### PR TITLE
revert: authored-position binding annotations (#6003)

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1576,15 +1576,13 @@ no originals, so the `schemaInjected` flag's deliberate lack of a
 including `sourceMapRange` — verified on TS 5.9.2 and 6.0.3).
 
 Recovery precedence is: own text range → explicit source-map range →
-original-chain terminal (`recoverAuthoredPosition`, `src/ast/utils.ts`).
-`test/lineage-regression.test.ts` pins it end to end: it drives the full
-pipeline over a five-origin fixture and asserts every builder call AND
-callback recovers to its distinctive authored snippet (content is the ground
-truth, not merely `pos >= 0`). This is the read path for transform-time source
-annotation — the stage-25 `position` / `bindingName` metadata of §17.3 — and
-the same fallback family §16.2's coverage spans use. Rationale, per-site
-table, and the probe rig:
-`packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
+original-chain terminal. `test/lineage-regression.test.ts` pins it end to end:
+it drives the full pipeline over a five-origin fixture and asserts every
+builder call AND callback recovers to its distinctive authored snippet
+(content is the ground truth, not merely `pos >= 0`). This is the read path
+for transform-time source annotation (A′, CT-1870), and the same fallback
+family §16.2's coverage spans use. Rationale, per-site table, and the probe
+rig: `packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
 
 ## 12. Schema Generation
 
@@ -2644,9 +2642,8 @@ counters.
 
 `ModuleScopeFunctionHardeningTransformer` (stage 25, **last**) rewrites a
 module's top level so that every surviving module-scope function value is
-frozen at module-evaluation time, so that CFC trusted bindings carry a
-machine-readable binding identity, and so that every function-bearing builder
-artifact carries where its function was AUTHORED. It emits up to two module-local helper
+frozen at module-evaluation time, and so that CFC trusted bindings carry a
+machine-readable binding identity. It emits up to two module-local helper
 function declarations and wraps or annotates top-level bindings with calls to
 them (`src/transformers/module-scope-function-hardening.ts`). It extends the
 base `Transformer` with no `filter` override, so it runs on every source file
@@ -2768,17 +2765,14 @@ Four shapes are rewritten:
    `export default __cfHardenFn((x: number) => x + 1);` (verified by direct
    pipeline run).
 
-Everything else at top level is exempt from HARDENING: builder-call
-initializers (`const h = handler(…)` — the builder layer hardens
-implementations at runtime instead, `packages/runner/src/builder/module.ts`),
-`__cf_data` wrappers and other call results, literals, classes,
-interfaces/type aliases (erased at emit), `export default pattern(…)` (a call,
-not a direct function), and the stage-16 hoisted
-`const __cfLift_N = __cfHelpers.lift(…)` consts (call initializers; see the
-negative assertions in `test/closures/module-scope-helper-hoisting.test.ts`).
-The builder-call shapes among those — authored builder consts, the hoisted
-consts, and `export default <builder call>` — do receive the verified-binding
-ANNOTATION when they carry a function argument (§17.3).
+Everything else at top level is exempt: builder-call initializers
+(`const h = handler(…)` — the builder layer hardens implementations at
+runtime instead, `packages/runner/src/builder/module.ts`), `__cf_data`
+wrappers and other call results, literals, classes, interfaces/type aliases
+(erased at emit), `export default pattern(…)` (a call, not a direct
+function), and the stage-16 hoisted `const __cfLift_N = __cfHelpers.lift(…)`
+consts (call initializers; see the negative assertions in
+`test/closures/module-scope-helper-hoisting.test.ts`).
 
 Helper emission is demand-driven: each helper declaration is prepended (in
 order: binding-identity helper, then hardening helper) **before every other
@@ -2795,20 +2789,11 @@ Helper names are `createUniqueName`-minted, so they print as bare
 `__cfHardenFn`/`__cfBindVerifiedBinding` unless the printer must
 disambiguate — and a suffixed name would no longer verify (§17.6).
 
-### 17.3 Verified-binding annotation (CT-1665, CT-1870)
+### 17.3 Verified-binding annotation (CT-1665)
 
-The same stage stamps two overlapping sets of module-scope values with a
-`__cfBindVerifiedBinding(value, metadata)` call:
-
-- CFC **trusted bindings**, with their authoring identity, so a
-  `WriteAuthorizedBy` claim embedded in a schema can later be matched to the
-  live handler that performs the write (CT-1665);
-- every top-level **function-bearing builder artifact**, with where its
-  function was authored, so debug source resolution reads a transform-time
-  constant instead of walking runtime stack frames (CT-1870).
-
-A value in both sets takes ONE annotation carrying the union of the two
-metadata sets.
+The same stage stamps CFC **trusted bindings** with their authoring identity,
+so a `WriteAuthorizedBy` claim embedded in a schema can later be matched to
+the live handler that performs the write.
 
 **Which bindings are trusted.** `collectWriteAuthorizedByBindingNames` scans
 the stage-22 AST for type references to `WriteAuthorizedBy`,
@@ -2829,98 +2814,33 @@ pipeline run — such a module gets a plain `__cfHardenFn` wrap and no
 annotation), whereas references surviving in `interface`/type-alias
 declarations or un-lowered type arguments do.
 
-**Which builder artifacts are annotated.** `resolveBuilderArtifact` accepts a
-top-level value whose initializer — seen through `unwrapExpression`'s
-parenthesis / `as` / `satisfies` / assertion / non-null wrappers — is a call
-that `detectCallKind` classifies as `kind: "builder"` AND that is
-function-bearing: some argument names a callback per `isCallbackReference`
-(`src/ast/call-kind.ts`) — the checker's call signatures, never a syntax list,
-the same semantic predicate schema injection uses for the schema-first
-`handler` form. That is the same builder test
-`collectTopLevelBuilderArtifactNames` uses for `__cfReg` registration (§11.4),
-and on this stage's fully lowered AST it covers the stage-16 hoisted
-`__cfLift_N` / `__cfHandler_N` / `__cfPattern_N` consts as well as authored
-builder consts, because `detectCallKind` recognizes the pipeline's
-`__cfHelpers.*` spelling alongside the authored imports. `export default
-<builder call>` is annotated on the exported expression
-(`transformExportAssignment`); `export = …` is not. A builder call with no
-function-bearing argument has no authored function whose position to report,
-and is left alone.
-
-The **position anchor** is resolved per argument, first match wins: an inline
-arrow / function expression, an identifier whose same-file initializer chain
-resolves through `resolveCallbackFunctionExpression` (wrapper strips and the
-hardening helper included), or a same-file `function` declaration
-(declarations hoist, so the use may precede it —
-`resolveSameFileFunctionDeclaration`). A callback none of these reach —
-property access, or an import (a position is same-file by contract:
-`sourceFile` names this module) — leaves the artifact anchor-less, and its
-annotation reports the builder call's own authored site
-(`resolveAuthoredSite`).
-
-**What is emitted.** The transformer emits
+**What is emitted.** For a trusted binding whose initializer is a call
+expression or a direct function (`isTrustedCallable`), the transformer emits
 `__cfBindVerifiedBinding(value, metadata)` where metadata is
 
 ```ts
 // Shown for illustration only.
 {
-    sourceFile: "/test.tsx",         // normalizeWriterIdentityFile(fileName)
-    bindingPath: ["saveTitle"],      // trusted bindings ONLY
-    position: { line: 21, col: 59 }, // where the function was authored
-    bindingName: "saveTitle"         // the name it was declared under
+    sourceFile: "/test.tsx",       // normalizeWriterIdentityFile(fileName)
+    bindingPath: ["saveTitle"]     // single-element: the binding name
 }
 ```
 
-(`annotateBindingIdentifier` / `createBindingIdentityMetadata`). Field by
-field:
-
-- `sourceFile` is always present.
-- `bindingPath` — the binding's own name as a one-element path — is present
-  ONLY for a trusted binding. Together with `sourceFile` it IS the verified
-  binding identity that authorizes writes (`readBindingIdentity` requires
-  both), so an artifact annotated only for its position must not carry it.
-- `position` is `{ line, col }` with `line` 1-based and `col` 0-based —
-  TypeScript's own line/character pair with 1 added to the line, taken at the
-  first authored character of the construct (leading trivia skipped). Both
-  index into the file the pipeline transformed, which is the authored file
-  plus the one-line helper-import prelude the pre-transform injects (§2.1);
-  a reader wanting authored coordinates subtracts that prelude's line, which
-  the runner computes from the authored bytes (`helperInjectionLineOffset`,
-  `packages/runner/src/harness/engine.ts` — the same correction §16.2's
-  coverage spans take). The position is recovered through §11.5's lineage
-  channels (`recoverAuthoredPosition`, `src/ast/utils.ts`) from the builder's
-  FUNCTION argument when one anchors the artifact, falling back to the
-  builder call as a whole (dropped function lineage, or an anchor-less
-  artifact); it is omitted when neither recovers.
-- `bindingName` is the authored name enclosing that position: the nearest
-  variable or function declaration reached by walking the parsed authored file
-  down to it, dropped on the way down through a function
-  (`findAuthoredNodeAt`). So a lift hoisted out of
-  `const doubled = computed(() => count * 2)` reports `doubled`, while one
-  hoisted out of a JSX expression in the same pattern's body reports nothing —
-  the declaration a pattern is assigned to does not name what is written
-  inside its callback. The field is omitted when no such declaration exists.
-
-Placement depends on export-ness (`transformVariableStatement`, guarded by
+(`annotateBindingIdentifier` / `createBindingIdentityMetadata`). Placement
+depends on export-ness (`transformVariableStatement`, guarded by
 `test/cfc-authoring.test.ts`):
 
-- **Exported** binding — annotated **inline**, and when the initializer is a
-  direct function the hardener nests outermost:
+- **Exported** trusted binding — annotated **inline**, and when the
+  initializer is a direct function the hardener nests outermost:
   `export const writeFn = __cfHardenFn(__cfBindVerifiedBinding((value:
   string) => value, {…}));` (verified by direct pipeline run; builder-call
-  case asserted in "lowers exported trusted builder bindings inline"). Inline
-  is not a preference for exported bindings but a requirement: CommonJS emit
-  turns a reference to an exported binding into `exports.<name>`, and the
-  verifier's statement grammar admits only a bare identifier target (§17.6).
-  `export default <builder call>` is annotated inline for the same reason it
-  has no alternative — there is no local binding to name.
-- **Non-exported** binding — declaration left untouched, followed by a
-  statement-form annotation `__cfBindVerifiedBinding(saveTitle, {…});`, and,
-  for direct-function initializers, a statement-form `__cfHardenFn(writeFn);`
-  **after** the annotation. Named function declarations that are trusted get
-  the same post-statement pair (declaration, annotation, hardening — verified
-  by direct pipeline run). Every hoisted builder artifact takes this form, so
-  its initializer text — and its inferred type — are untouched.
+  case asserted in "lowers exported trusted builder bindings inline").
+- **Non-exported** trusted binding — declaration left untouched, followed by
+  a statement-form annotation `__cfBindVerifiedBinding(saveTitle, {…});`,
+  and, for direct-function initializers, a statement-form
+  `__cfHardenFn(writeFn);` **after** the annotation. Named function
+  declarations that are trusted get the same post-statement pair
+  (declaration, annotation, hardening — verified by direct pipeline run).
 
 The annotation-before-hardening order is load-bearing: the emitted binding
 helper only stamps `Object.isExtensible` values
@@ -3005,12 +2925,9 @@ non-exported case reaches provenance through the `__cfReg` registration sink
 > unstamped-adoption branch in `reconcileWriterClaimStamp`, the `bundleId`
 > arm, and this note. (Berni's ask on the labs#4871 review.)
 
-The annotation appears in essentially every fixture that declares a builder
-artifact (344 of the 376 `*.expected.*` files; the remainder declare none),
-so the emitted shapes are pinned by the golden corpus. The trusted-binding
-paths are additionally covered by `test/cfc-authoring.test.ts` and the runner
-tests above; the position and `bindingName` fields are pinned per authored
-origin by `test/lineage-regression.test.ts`.
+No fixture in `test/fixtures/**` exercises `__cfBindVerifiedBinding` as of
+this writing; the annotation paths are covered by `test/cfc-authoring.test.ts`
+and the runner tests above.
 
 ### 17.4 Before/after example
 
@@ -3060,17 +2977,9 @@ const saveTitle = handler(/* …injected schemas… */, (_event, { title, savedT
 });
 __cfBindVerifiedBinding(saveTitle, {
     sourceFile: "/test.tsx",
-    bindingPath: ["saveTitle"],
-    position: { line: 6, col: 8 },
-    bindingName: "saveTitle"
+    bindingPath: ["saveTitle"]
 });
 ```
-
-`saveTitle` is in both sets — a trusted binding AND a function-bearing builder
-artifact — so its one annotation carries all four fields. A hoisted lift, in
-the same statement form, carries `sourceFile`, `position`, and (where the
-authored expression sits under a declaration) `bindingName`, but no
-`bindingPath`.
 
 ### 17.5 Why it runs last
 
@@ -3089,11 +2998,9 @@ The stage-22 slot (after everything, and specifically after
   (`isPatternCoverageHitStatement`, `compiled-bundle-verifier.ts`).
 - **After hoisting (stage 16) and schema generation (stage 17):** the
   module-scope surface it freezes/annotates is final — hoisted
-  `__cfLift_N`/`__cfPattern_N` consts exist (unhardened, being call
-  initializers, and each followed by its own binding annotation), and
-  trusted-name discovery sees the post-lowering AST (§17.3). Running last is
-  also what makes the authored positions available: every builder call and
-  callback reaches this stage carrying the §11.5 lineage.
+  `__cfLift_N`/`__cfPattern_N` consts exist (and stay unwrapped, being call
+  initializers), and trusted-name discovery sees the post-lowering AST
+  (§17.3).
 - **Nothing downstream re-analyzes wrapped functions.** Within one pipeline
   run no stage follows it; for analysis code that may encounter hardened
   output, call-kind resolution can see through `__cfHardenFn*(…)` wrappers

--- a/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -413,30 +413,7 @@ patterns) and the full fixture suite green.
 ## 9. The A′ line proper — shape of remaining work (post-lineage)
 
 1. **Lineage fix lands** (§5–§8). Everything below reads positions through it.
-2. **Transform-time injection design — DECIDED (Option D) and PR-1 SHIPPED**
-   (CT-1870, approved by the runner owner 2026-08-18; emit-side implemented on
-   the `gideon/ct-1870-…` branch): the module-scope hardening stage's CT-1665
-   `__cfBindVerifiedBinding` metadata gained `position: {line, col}` (line
-   1-based, col 0-based; indexes the transformed file = authored file + the
-   one-line helper-import prelude — readers subtract via the runner's
-   `helperInjectionLineOffset`) and `bindingName` (authored declaration name,
-   absent for inline-expression origins), and its coverage widened from the
-   trusted-binding set to every function-bearing builder artifact (hoisted,
-   authored, exported, export-default). Function-bearing is semantic
-   (`isCallbackReference` — the checker's call signatures, shared with schema
-   injection); a callback no same-file function anchors (property access, an
-   import) annotates anchor-less, its position reporting the builder call's own
-   authored site. The helper stamps the metadata onto the value; the
-   implementation-stamp branch is skipped for builders whose implementations
-   `hardenVerifiedFunction` froze during the call, so the read path in step 3
-   goes through the value. Security guard: `bindingPath` stays
-   trusted-scope-only (with `sourceFile` it mints verified binding identity —
-   `cfc/implementation-identity.ts`). No sandbox-verifier change was needed (it
-   checks the helper's canonical source and matches wrapper calls by
-   name/classification, never metadata fields — probe-verified through
-   `Engine.compileToRecordGraph`). Behavior-spec §17.3 carries the field
-   contract; the lineage-regression test pins per-origin position + name. The
-   original design conversation, for the record:
+2. **Transform-time injection design** (the next design conversation):
    - _Where to inject_: at `BuilderCallHoistingTransformer`, which already
      visits every hoisted builder AND every in-place/authored builder
      (`collectTopLevelBuilderArtifactNames`) AND `export default pattern(…)`;
@@ -456,23 +433,9 @@ patterns) and the full fixture suite green.
      rendezvous.
    - _What content_: file + line:col of the authored callback (and the authored
      binding name — closes the empty-`fn.name` debug-name gap).
-3. **Runtime read side (PR-2, NEXT)**: `fn.src` lazy getter reads the annotation
-   instead of eval-frame resolution (CT-1754 machinery in `harness/engine.ts`
-   becomes dead on this path). Read the metadata off the annotated VALUE (the
-   factory), not the implementation function: `hardenVerifiedFunction` freezes
-   implementations during the builder call (`runner/src/builder/module.ts`,
-   createNodeFactory + handlerInternal), which runs before the annotation
-   statement, so the helper's implementation-stamp is skipped for those builders
-   (`Object.isExtensible` guard). The design-note shape stands: a
-   `readBindingIdentity(value)`-style read in `recordModuleProvenance`'s walk,
-   feeding a debug-only WeakMap keyed by the implementation. Apply the
-   `helperInjectionLineOffset` line correction on this side (the transformer
-   cannot — a legacy stored envelope is byte-indistinguishable from a fresh
-   injection at transform time). Re-verify the `recordModuleProvenance` region
-   against #5927's engine rework before wiring. Context note: stack traces never
-   needed this — emitted sourcemaps were already line-correct pre-1868 (verified
-   empirically, 2026-07-21); the annotation exists because `fn.src` needs
-   function→position, which maps cannot answer.
+3. **Runtime read side**: `fn.src` lazy getter reads injected data instead of
+   eval-frame resolution (CT-1754 machinery in `harness/engine.ts` becomes dead
+   on this path).
 4. **Delete the dev-build eager resolution**:
    `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` and `setEagerSourceAnnotation` gate
    (~25ms dev cold-boot, historical — re-derive).

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -36,7 +36,6 @@ import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
-import { unwrapExpression } from "../utils/expression.ts";
 import { getCallArgumentPosition } from "./call-arguments.ts";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
 import {
@@ -717,47 +716,6 @@ function unwrapHardenedCallbackExpression(
   }
 
   return expression.arguments[0];
-}
-
-/**
- * Whether `expression` names a callback.
- *
- * Callback-ness is SEMANTIC — the checker's call signatures — never a
- * whitelist of spellings. Four review rounds each found the spelling the
- * previous round's syntax list missed (inline arrow, const reference,
- * function declaration, property access); asking the type ends the family,
- * because a schema is never callable and a callback always is, however it
- * is written. Two backstops cover the type information going missing
- * rather than a spelling: the syntactic resolver catches a local
- * `any`-typed callback (no call signatures to ask), and the declaration
- * fallback catches an IMPORTED one — the resolver cannot cross modules,
- * but the aliased symbol's declaration still says what the value is.
- */
-export function isCallbackReference(
-  expression: ts.Expression | undefined,
-  checker: ts.TypeChecker,
-): boolean {
-  if (!expression) return false;
-  if (resolveCallbackFunctionExpression(expression, checker)) return true;
-  const unwrapped = unwrapExpression(expression);
-  const type = checker.getTypeAtLocation(unwrapped);
-  if (type.getCallSignatures().length > 0) return true;
-  if (!ts.isIdentifier(unwrapped)) return false;
-  let symbol = checker.getSymbolAtLocation(unwrapped);
-  if (symbol !== undefined && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
-    symbol = checker.getAliasedSymbol(symbol);
-  }
-  const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-  if (declaration === undefined) return false;
-  if (ts.isFunctionDeclaration(declaration)) return true;
-  // The initializer goes through the wrapper-stripping resolver rather than
-  // a node-kind test: an assertion (`as any`), parentheses, or the hardening
-  // helper around the function must not hide it. The resolver works on a
-  // foreign file's node — the checker is program-wide.
-  return ts.isVariableDeclaration(declaration) &&
-    declaration.initializer !== undefined &&
-    resolveCallbackFunctionExpression(declaration.initializer, checker) !==
-      undefined;
 }
 
 export function isWildcardTraversalCall(

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -29,7 +29,6 @@ export {
   getLoweredArrayMethodName,
   getPatternBuilderCallbackArgument,
   hasReactiveCollectionProvenance,
-  isCallbackReference,
   isConsumedByTerminalChainCall,
   isPatternBuilderCall,
   isReactiveOriginCall,
@@ -82,7 +81,6 @@ export {
   isSyntheticNode,
   preserveLineage,
   preserveSourceMapRange,
-  recoverAuthoredPosition,
   setParentPointers,
   visitEachChildWithJsx,
 } from "./utils.ts";

--- a/packages/ts-transformers/src/ast/utils.ts
+++ b/packages/ts-transformers/src/ast/utils.ts
@@ -394,51 +394,6 @@ export function preserveSourceMapRange<T extends ts.Node>(
   return ts.setSourceMapRange(node, ts.getSourceMapRange(origin));
 }
 
-/**
- * The best-available AUTHORED text range for a node that may be synthetic —
- * the read side of {@link preserveLineage} / {@link preserveSourceMapRange}.
- * Precedence, widest channel last:
- *
- *   1. the node's own text range, when it has one;
- *   2. its explicit `sourceMapRange` — the channel the lineage helpers carry,
- *      and the only one present at most rebuild sites;
- *   3. the terminal of its original-node chain.
- *
- * Returns undefined when none of the three yields a real (`>= 0`) position:
- * the node reached here with no lineage at all.
- *
- * The range indexes into the text of the source file the pipeline is
- * transforming (`TransformationContext.sourceFile.text`), which every stage
- * carries unchanged, so `text.slice(pos, end)` is the authored snippet. Like
- * every TypeScript node range it starts at `pos`, i.e. BEFORE any leading
- * trivia; callers that want the first authored character of the construct
- * itself must skip that trivia (`node.getStart(sourceFile)` on the parsed
- * node covering the range).
- *
- * `sourceMapRange` is the load-bearing channel: original chains are dropped
- * deliberately at most rebuild sites, so a walk that consults only
- * `getOriginalNode` sees nothing.
- */
-export function recoverAuthoredPosition(
-  node: ts.Node,
-): ts.TextRange | undefined {
-  if (node.pos >= 0) return { pos: node.pos, end: node.end };
-
-  // ts.getSourceMapRange returns the node itself when no explicit range is set.
-  const sourceMapRange = ts.getSourceMapRange(node);
-  if (
-    (sourceMapRange as unknown) !== (node as unknown) && sourceMapRange.pos >= 0
-  ) {
-    return { pos: sourceMapRange.pos, end: sourceMapRange.end };
-  }
-
-  const original = ts.getOriginalNode(node);
-  if (original !== node && original.pos >= 0) {
-    return { pos: original.pos, end: original.end };
-  }
-  return undefined;
-}
-
 // Import and re-export shared checks from schema-generator
 import {
   isDefaultAliasSymbol,

--- a/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-function-hardening.ts
@@ -4,12 +4,6 @@ import {
   FUNCTION_HARDENING_HELPER_NAME,
   VERIFIED_BINDING_METADATA_FIELD,
 } from "@commonfabric/utils/sandbox-contract";
-import {
-  detectCallKind,
-  isCallbackReference,
-  resolveCallbackFunctionExpression,
-} from "../ast/call-kind.ts";
-import { recoverAuthoredPosition } from "../ast/utils.ts";
 import { TransformationContext, Transformer } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
@@ -37,8 +31,6 @@ export class ModuleScopeFunctionHardeningTransformer extends Transformer {
         bindingHelperName: bindingHelperName.text,
         trustedBindingNames,
         sourceFileName,
-        checker: context.checker,
-        authoredSourceFile: context.program.getSourceFile(sourceFile.fileName),
         useHelper: () => {
           helperNeeded = true;
         },
@@ -74,13 +66,6 @@ interface HardeningState {
   readonly bindingHelperName: string;
   readonly trustedBindingNames: ReadonlySet<string>;
   readonly sourceFileName: string;
-  readonly checker: ts.TypeChecker;
-  /**
-   * The parsed AUTHORED file. Recovered lineage ranges index into its text, so
-   * it is what resolves them to a line/column and to the authored binding name
-   * that encloses them. Absent only if the file left the program.
-   */
-  readonly authoredSourceFile: ts.SourceFile | undefined;
   readonly useHelper: () => void;
   readonly useBindingHelper: () => void;
 }
@@ -90,35 +75,20 @@ function transformTopLevelStatement(
   context: TransformationContext,
   state: HardeningState,
 ): ts.Statement[] {
-  const { factory } = context;
+  const { factory, sourceFile } = context;
 
   if (ts.isFunctionDeclaration(statement)) {
-    return transformFunctionDeclaration(statement, factory, state);
+    return transformFunctionDeclaration(statement, sourceFile, factory, state);
   }
 
   if (ts.isVariableStatement(statement)) {
-    return transformVariableStatement(statement, factory, state);
+    return transformVariableStatement(statement, sourceFile, factory, state);
   }
 
-  if (ts.isExportAssignment(statement)) {
-    return transformExportAssignment(statement, factory, state);
-  }
-
-  return [statement];
-}
-
-/**
- * `export default <expression>`: hardened when the expression is a function,
- * binding-annotated when it is a function-bearing builder call. The exported
- * expression is annotated in place — a default export has no local binding a
- * trailing annotation statement could name.
- */
-function transformExportAssignment(
-  statement: ts.ExportAssignment,
-  factory: ts.NodeFactory,
-  state: HardeningState,
-): ts.Statement[] {
-  if (isDirectFunctionExpression(statement.expression)) {
+  if (
+    ts.isExportAssignment(statement) &&
+    isDirectFunctionExpression(statement.expression)
+  ) {
     state.useHelper();
     return [
       factory.updateExportAssignment(
@@ -133,32 +103,12 @@ function transformExportAssignment(
     ];
   }
 
-  if (statement.isExportEquals) {
-    return [statement];
-  }
-
-  const artifact = resolveBuilderArtifact(statement.expression, state.checker);
-  if (!artifact) {
-    return [statement];
-  }
-
-  state.useBindingHelper();
-  return [
-    factory.updateExportAssignment(
-      statement,
-      statement.modifiers,
-      annotateBindingIdentifier(
-        statement.expression,
-        { artifact },
-        factory,
-        state,
-      ),
-    ),
-  ];
+  return [statement];
 }
 
 function transformFunctionDeclaration(
   statement: ts.FunctionDeclaration,
+  _sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   state: HardeningState,
 ): ts.Statement[] {
@@ -175,7 +125,7 @@ function transformFunctionDeclaration(
         factory.createExpressionStatement(
           annotateBindingIdentifier(
             factory.createIdentifier(statement.name.text),
-            { trustedBindingName: statement.name.text, site: statement },
+            statement.name.text,
             factory,
             state,
           ),
@@ -224,6 +174,7 @@ function transformFunctionDeclaration(
 
 function transformVariableStatement(
   statement: ts.VariableStatement,
+  _sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   state: HardeningState,
 ): ts.Statement[] {
@@ -245,33 +196,20 @@ function transformVariableStatement(
       const isDirectFunction = isDirectFunctionExpression(initializer);
       const isTrustedCallable = isTrustedBinding &&
         (ts.isCallExpression(initializer) || isDirectFunction);
-      const artifact = resolveBuilderArtifact(
-        declaration.initializer,
-        state.checker,
-      );
 
-      if (!isTrustedCallable && !isDirectFunction && !artifact) {
+      if (!isTrustedCallable && !isDirectFunction) {
         return declaration;
       }
 
       changed = true;
-      // A binding that is both trusted and a builder artifact takes ONE
-      // annotation carrying both sets of metadata.
-      const annotateBinding = isTrustedCallable || artifact !== undefined;
-      const inlineBindingAnnotation = annotateBinding && exported;
+      const inlineBindingAnnotation = isTrustedCallable && exported;
       let rewritten = declaration.initializer;
-      if (annotateBinding) {
+      if (isTrustedCallable) {
         state.useBindingHelper();
-        const metadata: BindingIdentityMetadataInput = {
-          ...(isTrustedCallable
-            ? { trustedBindingName: declaration.name.text }
-            : {}),
-          ...(artifact ? { artifact } : { site: initializer }),
-        };
         if (inlineBindingAnnotation) {
           rewritten = annotateBindingIdentifier(
             rewritten,
-            metadata,
+            declaration.name.text,
             factory,
             state,
           );
@@ -280,7 +218,7 @@ function transformVariableStatement(
             factory.createExpressionStatement(
               annotateBindingIdentifier(
                 factory.createIdentifier(declaration.name.text),
-                metadata,
+                declaration.name.text,
                 factory,
                 state,
               ),
@@ -351,115 +289,9 @@ function wrapWithFunctionHardener(
   );
 }
 
-/**
- * A top-level function-bearing builder artifact: the builder call itself,
- * plus — when one resolves in this file — the function-valued argument whose
- * authored site the annotation reports. `pattern`, `handler`, `lift`,
- * `computed`, `action` and the rest of the builder family qualify; a builder
- * call with no function-bearing argument carries no authored function to name
- * and is left alone.
- */
-interface BuilderArtifact {
-  readonly call: ts.CallExpression;
-  /**
-   * The position anchor. Absent for a callback no same-file function
-   * resolves — reached through property access, or imported (a position is
-   * same-file by contract) — and the annotation then anchors at `call`.
-   */
-  readonly fn?:
-    | ts.ArrowFunction
-    | ts.FunctionExpression
-    | ts.FunctionDeclaration;
-}
-
-/**
- * The function-bearing builder artifact an expression denotes, if any. Type
- * wrappers are stripped first, so a cast-typed artifact
- * (`const x = handler(...) as XFactory`) resolves like a bare one — the same
- * unwrap `__cfReg` registration performs, and for the same reason.
- *
- * This runs on the fully lowered tree, where synthetic hoists
- * (`__cfLift_N`, `__cfHandler_N`, `__cfPattern_N`) and authored builder consts
- * both present as builder calls: `detectCallKind` recognizes the pipeline's
- * `__cfHelpers.*` spelling as well as the authored imports, so one predicate
- * covers both.
- */
-function resolveBuilderArtifact(
-  expression: ts.Expression,
-  checker: ts.TypeChecker,
-): BuilderArtifact | undefined {
-  const call = unwrapExpression(expression);
-  if (!ts.isCallExpression(call)) return undefined;
-  if (detectCallKind(call, checker)?.kind !== "builder") return undefined;
-  // Resolve the callback through identifiers and type wrappers, not just
-  // direct function syntax: `handler(onReset)` names an authored function the
-  // annotation should locate exactly as `handler((e, s) => …)` does. The
-  // resolved declaration's function is the position anchor, so the metadata
-  // reports where the callback was WRITTEN, and its enclosing declaration
-  // (`onReset`) supplies the binding name.
-  for (const argument of call.arguments) {
-    const fn = resolveCallbackFunctionExpression(argument, checker);
-    if (fn) return { call, fn };
-    const declaration = resolveSameFileFunctionDeclaration(argument, checker);
-    if (declaration) return { call, fn: declaration };
-  }
-  // A callback can be function-bearing with no resolvable anchor — reached
-  // through property access, or imported from another module. The artifact
-  // still qualifies; it annotates anchor-less, and the annotation reports the
-  // call's own authored site. Callback-ness is the checker's call signatures
-  // (`isCallbackReference`), so qualification cannot lag the spellings the
-  // builder families accept.
-  if (
-    call.arguments.some((argument) => isCallbackReference(argument, checker))
-  ) {
-    return { call };
-  }
-  return undefined;
-}
-
-/**
- * The same-file `function` declaration an identifier argument names, if any —
- * `lift(sanitizeTickets)` with `function sanitizeTickets(…)` below it (the
- * declaration may follow the use; function declarations hoist). Resolved here
- * rather than in the shared callback resolver so its other callers keep their
- * behavior. An identifier whose declaration lives in ANOTHER file resolves to
- * nothing: a position is same-file by contract (`sourceFile` names this
- * module), so an imported callback cannot anchor a position — its builder
- * call annotates anchor-less instead.
- */
-function resolveSameFileFunctionDeclaration(
-  argument: ts.Expression,
-  checker: ts.TypeChecker,
-): ts.FunctionDeclaration | undefined {
-  const target = unwrapExpression(argument);
-  if (!ts.isIdentifier(target)) return undefined;
-  const symbol = checker.getSymbolAtLocation(target);
-  const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-  if (!declaration || !ts.isFunctionDeclaration(declaration)) return undefined;
-  if (
-    declaration.getSourceFile().fileName !== target.getSourceFile().fileName
-  ) {
-    return undefined;
-  }
-  return declaration;
-}
-
-/** What a binding-identity annotation describes. */
-interface BindingIdentityMetadataInput {
-  /**
-   * The binding's own name, present only when it is in the trusted
-   * (`WriteAuthorizedBy`) scope. It is what becomes `bindingPath`.
-   */
-  readonly trustedBindingName?: string;
-  /** The builder artifact being annotated, when the value is one. */
-  readonly artifact?: BuilderArtifact;
-  /** The annotated node, for values that are not builder artifacts. */
-  readonly site?: ts.Node;
-}
-
 function annotateBindingIdentifier(
   identifier: ts.Expression,
-  input: BindingIdentityMetadataInput,
+  bindingName: string,
   factory: ts.NodeFactory,
   state: HardeningState,
 ): ts.CallExpression {
@@ -468,185 +300,28 @@ function annotateBindingIdentifier(
     undefined,
     [
       identifier,
-      createBindingIdentityMetadata(input, factory, state),
+      createBindingIdentityMetadata(bindingName, factory, state),
     ],
   );
 }
 
-/**
- * The metadata object the binding-identity helper stamps onto an annotated
- * value (and onto its `implementation`, when it has one). Fields:
- *
- * - `sourceFile` — the module's normalized writer-identity file name. Always
- *   present.
- * - `bindingPath` — the binding's name, as a one-element path. Present ONLY
- *   for a binding in the trusted (`WriteAuthorizedBy`) scope: together with
- *   `sourceFile` it forms the verified binding identity that authorizes writes,
- *   so a value outside that scope must not carry it.
- * - `position` — where the annotated function was AUTHORED, as
- *   `{ line, col }`. `line` is 1-based and `col` is 0-based, i.e. TypeScript's
- *   own line/character pair with 1 added to the line. Both index into the file
- *   the pipeline transformed, which is the authored file plus the one-line
- *   helper-import prelude injection prepends, so a reader that wants authored
- *   coordinates subtracts that prelude's line (the runner's
- *   `helperInjectionLineOffset` computes it from the authored bytes). Absent
- *   when the value's lineage reaches this stage with no recoverable authored
- *   position.
- * - `bindingName` — the authored name the function was declared under, for
- *   debug display. Absent when it was authored as an inline expression under no
- *   declaration, such as a lifted JSX expression or a `.map` callback.
- *
- * The position describes the artifact's FUNCTION — the callback a builder was
- * given — falling back to the builder call as a whole when the callback's
- * lineage was dropped, or when no same-file function anchors it (property
- * access, an imported callback).
- */
 function createBindingIdentityMetadata(
-  input: BindingIdentityMetadataInput,
+  bindingName: string,
   factory: ts.NodeFactory,
   state: HardeningState,
 ): ts.ObjectLiteralExpression {
-  const properties: ts.PropertyAssignment[] = [
+  return factory.createObjectLiteralExpression([
     factory.createPropertyAssignment(
       factory.createIdentifier("sourceFile"),
       factory.createStringLiteral(state.sourceFileName),
     ),
-  ];
-
-  if (input.trustedBindingName !== undefined) {
-    properties.push(
-      factory.createPropertyAssignment(
-        factory.createIdentifier("bindingPath"),
-        factory.createArrayLiteralExpression([
-          factory.createStringLiteral(input.trustedBindingName),
-        ]),
-      ),
-    );
-  }
-
-  const site = resolveAuthoredSite(input, state);
-  if (site) {
-    properties.push(
-      factory.createPropertyAssignment(
-        factory.createIdentifier("position"),
-        factory.createObjectLiteralExpression([
-          factory.createPropertyAssignment(
-            factory.createIdentifier("line"),
-            factory.createNumericLiteral(site.line),
-          ),
-          factory.createPropertyAssignment(
-            factory.createIdentifier("col"),
-            factory.createNumericLiteral(site.col),
-          ),
-        ]),
-      ),
-    );
-    if (site.bindingName !== undefined) {
-      properties.push(
-        factory.createPropertyAssignment(
-          factory.createIdentifier("bindingName"),
-          factory.createStringLiteral(site.bindingName),
-        ),
-      );
-    }
-  }
-
-  return factory.createObjectLiteralExpression(properties, true);
-}
-
-/** Where an annotated value was authored, in the shape the metadata reports. */
-interface AuthoredSite {
-  /** 1-based. */
-  readonly line: number;
-  /** 0-based. */
-  readonly col: number;
-  readonly bindingName: string | undefined;
-}
-
-/**
- * Resolve the authored line/column — and the authored binding name enclosing
- * it — for the value an annotation describes. The candidates are tried in
- * order, so a builder artifact reports its callback's site and falls back to
- * the whole call when the callback arrived with no lineage or no same-file
- * function anchors it at all.
- */
-function resolveAuthoredSite(
-  input: BindingIdentityMetadataInput,
-  state: HardeningState,
-): AuthoredSite | undefined {
-  const authoredSourceFile = state.authoredSourceFile;
-  if (!authoredSourceFile) return undefined;
-
-  const candidates = input.artifact
-    ? input.artifact.fn
-      ? [input.artifact.fn, input.artifact.call]
-      : [input.artifact.call]
-    : input.site
-    ? [input.site]
-    : [];
-
-  for (const candidate of candidates) {
-    const range = recoverAuthoredPosition(candidate);
-    if (!range) continue;
-    const enclosing = findAuthoredNodeAt(authoredSourceFile, range.pos);
-    // A recovered range starts before the construct's leading trivia; the
-    // parsed node covering it reports where its first real token begins.
-    const start = enclosing?.node.getStart(authoredSourceFile) ?? range.pos;
-    const position = authoredSourceFile.getLineAndCharacterOfPosition(
-      start >= range.pos && start < range.end ? start : range.pos,
-    );
-    return {
-      line: position.line + 1,
-      col: position.character,
-      bindingName: enclosing?.bindingName,
-    };
-  }
-  return undefined;
-}
-
-/**
- * Descend the authored tree to the innermost node covering `pos`, carrying the
- * name of the nearest declaration that encloses it.
- *
- * The name is dropped on the way down through a function, because the
- * declaration a function is assigned to does not name what is written INSIDE
- * it: a lift hoisted out of `const doubled = computed(() => count * 2)` is
- * `doubled`, while one hoisted out of a JSX expression in the same pattern's
- * body is anonymous.
- */
-function findAuthoredNodeAt(
-  sourceFile: ts.SourceFile,
-  pos: number,
-): { node: ts.Node; bindingName: string | undefined } | undefined {
-  let node: ts.Node = sourceFile;
-  let bindingName: string | undefined;
-  let found = false;
-
-  for (;;) {
-    const child = ts.forEachChild(
-      node,
-      (candidate) =>
-        candidate.pos <= pos && pos < candidate.end ? candidate : undefined,
-    );
-    if (!child) break;
-    if (ts.isFunctionLike(node)) bindingName = undefined;
-    bindingName = authoredDeclarationName(child) ?? bindingName;
-    node = child;
-    found = true;
-  }
-
-  return found ? { node, bindingName } : undefined;
-}
-
-/** The name a declaration binds its value under, for the debug binding name. */
-function authoredDeclarationName(node: ts.Node): string | undefined {
-  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-    return node.name.text;
-  }
-  if (ts.isFunctionDeclaration(node) && node.name) {
-    return node.name.text;
-  }
-  return undefined;
+    factory.createPropertyAssignment(
+      factory.createIdentifier("bindingPath"),
+      factory.createArrayLiteralExpression([
+        factory.createStringLiteral(bindingName),
+      ]),
+    ),
+  ], true);
 }
 
 function createFunctionHardeningHelper(

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -16,13 +16,13 @@ import {
   inferParameterType,
   inferReturnType,
   isAnyOrUnknownType,
-  isCallbackReference,
   isCellLikeType,
   isFunctionLikeExpression,
   isSyntheticNode,
   isUnresolvedSchemaType,
   preserveSourceMapRange,
   registerSyntheticCallType,
+  resolveCallbackFunctionExpression,
   typeToSchemaTypeNode,
   unwrapCellLikeType,
   widenLiteralType,
@@ -2592,6 +2592,49 @@ function resolveLiftAppliedInputAndCallback(
     return undefined;
   }
   return { input, callback };
+}
+
+/**
+ * Whether `expression` names a callback, for recognizing the schema-first
+ * `handler` form and for keeping the trailing-options check from
+ * spread-replacing a callback with the injected result options.
+ *
+ * Callback-ness is SEMANTIC — the checker's call signatures — never a
+ * whitelist of spellings. Four review rounds each found the spelling the
+ * previous round's syntax list missed (inline arrow, const reference,
+ * function declaration, property access); asking the type ends the family,
+ * because a schema is never callable and a callback always is, however it
+ * is written. Two backstops cover the type information going missing
+ * rather than a spelling: the syntactic resolver catches a local
+ * `any`-typed callback (no call signatures to ask), and the declaration
+ * fallback catches an IMPORTED one — the resolver cannot cross modules,
+ * but the aliased symbol's declaration still says what the value is.
+ */
+function isCallbackReference(
+  expression: ts.Expression | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!expression) return false;
+  if (resolveCallbackFunctionExpression(expression, checker)) return true;
+  const unwrapped = unwrapExpression(expression);
+  const type = checker.getTypeAtLocation(unwrapped);
+  if (type.getCallSignatures().length > 0) return true;
+  if (!ts.isIdentifier(unwrapped)) return false;
+  let symbol = checker.getSymbolAtLocation(unwrapped);
+  if (symbol !== undefined && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    symbol = checker.getAliasedSymbol(symbol);
+  }
+  const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
+  if (declaration === undefined) return false;
+  if (ts.isFunctionDeclaration(declaration)) return true;
+  // The initializer goes through the wrapper-stripping resolver rather than
+  // a node-kind test: an assertion (`as any`), parentheses, or the hardening
+  // helper around the function must not hide it. The resolver works on a
+  // foreign file's node — the checker is program-wide.
+  return ts.isVariableDeclaration(declaration) &&
+    declaration.initializer !== undefined &&
+    resolveCallbackFunctionExpression(declaration.initializer, checker) !==
+      undefined;
 }
 
 function resolveFunctionLikeExpression(

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,11 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 16 },
-    bindingName: "upper"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     count: number;
 }, number>(({ count }) => count + 1, {
@@ -61,10 +38,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 24 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     cell: __cfHelpers.Writable<number>;
 }, number>(({ cell }) => cell.get(), {
@@ -79,10 +52,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 28 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim(), {
@@ -96,10 +65,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 26 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim(), {
@@ -113,10 +78,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 17 }
-});
 // FIXTURE: authored-ifelse-reactive-roots
 // Verifies: authored ifElse outside JSX and top-level receiver-method roots lower reactively
 //   ifElse(show, count + 1, 0)         → compute-wrapped branch
@@ -124,7 +85,7 @@ __cfBindVerifiedBinding(__cfLift_5, {
 //   ifElse(show, name.trim(), "x")     → reactive receiver-method branch
 //   name.trim()                        → top-level receiver-method root lowered to lift-applied
 //   identity(name.trim())             → lift-applied local-helper root
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     const show = __cf_pattern_input.key("show");
     const name = __cf_pattern_input.key("name");
@@ -199,10 +160,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["value", "cellValue", "trimmed", "upper", "upperDirect"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-hoisted-nullish-selection.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -71,11 +53,6 @@ const join = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, { myName, profile }) => {
     const resolved = profile?.get();
     myName.set(resolved ? resolved.name : event.name);
-});
-__cfBindVerifiedBinding(join, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 2 },
-    bindingName: "join"
 });
 interface CardState {
     myName: Default<string, "">;
@@ -139,11 +116,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 48, col: 24 },
-    bindingName: "activeProfile"
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -160,10 +132,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["boundJoin"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { boundJoin }) => boundJoin.send({ name: "guest" }));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 56, col: 28 }
-});
 // FIXTURE: builder-arg-hoisted-nullish-selection
 // Verifies: the remedy the `reactive:call-argument-computation` diagnostic
 //   advises — a reactive `??` selection hoisted to a body-level const and
@@ -178,7 +146,7 @@ __cfBindVerifiedBinding(__cfHandler_1, {
 //   the hoist diagnostic (see fixtures/bug-repro/ and
 //   test/builder-argument-computation-diagnostic.test.ts); this golden pins
 //   that the advised hoisted form compiles, and what it compiles to.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const myName = __cf_pattern_input.key("myName");
     const profile = __cf_pattern_input.key("profile");
     const profileWish = wish<Profile>({ query: "#profile" }, {
@@ -262,10 +230,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 34 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-arg-ternary-label.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,11 +31,6 @@ const join = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, { myName }) => {
     myName.set(event.name);
 });
-__cfBindVerifiedBinding(join, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 2 },
-    bindingName: "join"
-});
 interface CardState {
     myName: Default<string, "">;
     users: Default<string[], [
@@ -80,11 +57,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 11 },
-    bindingName: "boundJoin"
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -101,10 +73,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["boundJoin"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { boundJoin }) => boundJoin.send({ name: "guest" }));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 28 }
-});
 // FIXTURE: builder-arg-ternary-label
 // Verifies: a ternary over a reactive comparison written inline in a
 //   bound-handler's builder args lowers via the conditional emitter's ifElse
@@ -116,7 +84,7 @@ __cfBindVerifiedBinding(__cfHandler_1, {
 //   at the same position, which is rejected with the
 //   `reactive:call-argument-computation` hoist diagnostic — pinned in
 //   test/builder-argument-computation-diagnostic.test.ts.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const myName = __cf_pattern_input.key("myName");
     const users = __cf_pattern_input.key("users");
     const boundJoin = join({
@@ -187,10 +155,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 34 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,16 +36,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 9 }
-});
 // FIXTURE: builder-conditional
 // Verifies: ternary in JSX is transformed to ifElse() with a lift-applied condition
 //   state.count > 0 ? <p>A</p> : <p>B</p> → __cfHelpers.ifElse(...schemas, lift(...)({...}), <p>A</p>, <p>B</p>)
 //   pattern<PatternState>                  → pattern(..., inputSchema, outputSchema)
 //   state.label                            → state.key("label")
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [NAME]: state.key("label"),
         [UI]: (<section>
@@ -134,10 +112,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -33,10 +15,6 @@ const __cfAmdHooks = undefined;
 // Verifies: stable const aliases to `computed()` still lower to `derive()`.
 const alias = computed;
 const __cfLift_1 = __cfHelpers.lift(() => 1, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 21 }
-});
 export default __cfLift_1();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const __cfLift_1 = lift((value: string) => value, {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 29 },
-    bindingName: "normalizedStage"
-});
 // FIXTURE: computed-object-literal-input
 // Verifies: cell(), lift(), and computed() all get schemas injected from type annotations
 //   cell<string>("initial")             → cell<string>("initial", { type: "string" })
@@ -63,41 +40,21 @@ const __cfLift_2 = lift((count: number) => count, {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 22 },
-    bindingName: "attempts"
-});
 const attempts = __cfHelpers.__cf_data(__cfLift_2(attemptCount).for("attempts", true));
 const __cfLift_3 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 22 },
-    bindingName: "accepted"
-});
 const accepted = __cfHelpers.__cf_data(__cfLift_3(acceptedCount).for("accepted", true));
 const __cfLift_4 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 22 },
-    bindingName: "rejected"
-});
 const rejected = __cfHelpers.__cf_data(__cfLift_4(rejectedCount).for("rejected", true));
 const __cfLift_5 = __cfHelpers.lift(() => `stage:${normalizedStage} attempts:${attempts}` +
     ` accepted:${accepted} rejected:${rejected}`, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 26 },
-    bindingName: "_summary"
-});
 const _summary = __cfHelpers.__cf_data(__cfLift_5().for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,11 +31,6 @@ const increment = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_e, state) => {
     state.value.set(state.value.get() + 1);
 });
-__cfBindVerifiedBinding(increment, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 49 },
-    bindingName: "increment"
-});
 const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -67,11 +44,6 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     value: Cell<number>;
 }) => {
     state.value.set(state.value.get() - 1);
-});
-__cfBindVerifiedBinding(decrement, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 26 },
-    bindingName: "decrement"
 });
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
@@ -94,10 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 42 }
-});
 // FIXTURE: counter-pattern-no-name
 // Verifies: same transforms as counter-pattern apply even when the file has no unique name
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)
@@ -105,7 +73,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   pattern<PatternState>(fn)          → pattern(fn, inputSchema, outputSchema)
 //   state.value ? a : b (in JSX)      → __cfHelpers.ifElse(...schemas, state.key("value"), lift(...)({...}), "unknown")
 // Context: Identical to counter-pattern; verifies no-name patterns still transform correctly
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [NAME]: str `Simple counter: ${state.key("value")}`,
         [UI]: (<div>
@@ -171,10 +139,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,11 +31,6 @@ const increment = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_e, state) => {
     state.value.set(state.value.get() + 1);
 });
-__cfBindVerifiedBinding(increment, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 49 },
-    bindingName: "increment"
-});
 const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -67,11 +44,6 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     value: Cell<number>;
 }) => {
     state.value.set(state.value.get() - 1);
-});
-__cfBindVerifiedBinding(decrement, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 26 },
-    bindingName: "decrement"
 });
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
@@ -94,10 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 42 }
-});
 // FIXTURE: counter-pattern
 // Verifies: full pattern with handlers, ternary, str template, and schema generation
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)
@@ -106,7 +74,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   state.value ? a : b (in JSX)      → __cfHelpers.ifElse(...schemas, state.key("value"), lift(...)({...}), "unknown")
 //   state.value                        → state.key("value")
 // Context: Combines handler schema injection, pattern schema generation, ternary-to-ifElse, and str template transforms
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [NAME]: str `Simple counter: ${state.key("value")}`,
         [UI]: (<div>
@@ -172,10 +140,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const handleClick = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
 });
-__cfBindVerifiedBinding(handleClick, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 2 },
-    bindingName: "handleClick"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     count: Default<number, 0>;
 }, number>(({ count }) => count + 1, {
@@ -69,10 +46,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 24 }
-});
 // FIXTURE: event-handler-no-compute-wrap
 // Verifies: handler invocations in JSX are NOT wrapped in a reactive compute
 // wrapper (formerly derive, now lift-applied post-CT-1615), while
@@ -83,7 +56,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   pattern<{ count: Default<number, 0> }>   → pattern(fn, inputSchema, outputSchema)
 // Context: Negative test ensuring handler calls in event attributes and
 // inside .map() are not wrapped as reactive compute.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         [UI]: (<div>
@@ -143,10 +116,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,18 +28,13 @@ const myHandler = handler(false as const satisfies __cfHelpers.JSONSchema, {
 } as const satisfies __cfHelpers.JSONSchema, (_, state: State) => {
     state.value.set(state.value.get() + 1);
 });
-__cfBindVerifiedBinding(myHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 26 },
-    bindingName: "myHandler"
-});
 // FIXTURE: handler-object-literal
 // Verifies: handler gets schema from inline param type; handler invocations use state.key()
 //   handler((_, state: State) => ...)          → handler(false, stateSchema, fn)
 //   myHandler({ value: state.value, ... })     → myHandler({ value: state.key("value"), ... })
 //   myHandler(state)                           → myHandler(state) (unchanged)
 // Context: Pattern already has explicit schemas; only handler schema injection and property access transforms apply
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         // Test case 1: Object literal with all properties from state
         onClick1: myHandler({ value: state.key("value"), name: state.key("name") }).for({ stream: ["__patternResult", "onClick1"] }, true),
@@ -96,10 +73,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["onClick1", "onClick2", "onClick3"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,11 +47,6 @@ const logPiecesList = lift(({ piecesList }) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(logPiecesList, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 2 },
-    bindingName: "logPiecesList"
-});
 const getStatus = lift(({ status }) => status, {
     type: "object",
     properties: {
@@ -86,11 +63,6 @@ const getStatus = lift(({ status }) => status, {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(getStatus, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 2 },
-    bindingName: "getStatus"
-});
 // FIXTURE: lift-explicit-toschema
 // Verifies: lift() with explicit toSchema<T>() is replaced by the generated JSON schema
 //   lift(fn, toSchema<{ piecesList: Cell<PieceEntry[]> }>()) → lift(fn, generatedSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -74,10 +56,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 14 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -114,10 +92,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 8 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -154,10 +128,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 10 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -197,13 +167,9 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 11 }
-});
 // FIXTURE: non-jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole call roots outside JSX
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     serialized: __cfLift_1({ state: {
             wishes: state.key("wishes")
         } }).for(["__patternResult", "serialized"], true),
@@ -265,10 +231,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
         }
     },
     required: ["serialized", "keys", "values", "entries"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-destructure-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-destructure-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -32,7 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: pattern-array-destructure-param
 // Verifies: top-level array destructuring in pattern params lowers to index-based key access
 //   ([first]) => <div>{first}</div> → const first = __cf_pattern_input.key("0")
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const first = __cf_pattern_input.key("0");
     return <div>{first}</div>;
 }, {
@@ -60,10 +42,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 33 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.values.push(Math.random().toString(36).substring(2, 15));
 });
-__cfBindVerifiedBinding(adder, {
-    sourceFile: "/test.tsx",
-    position: { line: 4, col: 22 },
-    bindingName: "adder"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     values: unknown[];
 }, void>(({ values }) => {
@@ -69,10 +46,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 13 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -111,10 +84,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 24 }
-});
 // FIXTURE: pattern-array-map
 // Verifies: .map() on a reactive array is transformed to .mapWithPattern()
 //   values.map((value, index) => JSX)  → values.mapWithPattern(pattern(fn, elementSchema, outputSchema), {})
@@ -122,7 +91,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   handler((_, state: {...}) => ...)  → handler(false, stateSchema, fn)
 //   pattern<{ values: string[] }>      → pattern(fn, inputSchema, outputSchema)
 // Context: Destructured pattern parameter; combines array map transform with computed and handler schemas
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const values = __cf_pattern_input.key("values");
     __cfLift_1({ values: values });
     return {
@@ -184,10 +153,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,17 +33,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 16 },
-    bindingName: "label"
-});
 // FIXTURE: pattern-call-arg-conditional
 // Verifies: top-level ordinary helper calls with reactive arguments are lifted
 //   as whole calls rather than lowering only the inner argument expression.
 //   const label = identity(state.done ? "Done" : "Pending")
 //   → const label = lift(({ state }) => identity(state.done ? "Done" : "Pending"))({ state })
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const label = __cfLift_1({ state: {
             done: state.key("done")
         } }).for("label", true);
@@ -82,10 +59,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["label"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,11 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 11 },
-    bindingName: "view"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         done: boolean;
@@ -77,11 +54,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 11 },
-    bindingName: "view"
-});
 // FIXTURE: pattern-call-root-containers
 // Verifies: top-level ordinary call roots whole-wrap consistently across
 //   non-JSX container kinds instead of lowering only their nested conditional
@@ -92,7 +64,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   → [lift(({ state }) => identity(state.done ? "Done" : "Pending"))({ state })]
 //   return identity(state.done ? "Done" : "Pending")
 //   → return lift(({ state }) => identity(state.done ? "Done" : "Pending"))({ state })
-export const objectAndArray = __cfBindVerifiedBinding(pattern((state) => {
+export const objectAndArray = pattern((state) => {
     const view = {
         value: __cfLift_1({ state: {
                 done: state.key("done")
@@ -124,11 +96,7 @@ export const objectAndArray = __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["value", "list"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 57 },
-    bindingName: "objectAndArray"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         done: boolean;
@@ -150,11 +118,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 2 }
-});
-export default __cfBindVerifiedBinding(pattern((state) => __cfLift_3({ state: {
+export default pattern((state) => __cfLift_3({ state: {
         done: state.key("done")
     } }).for("__patternResult", true), {
     type: "object",
@@ -166,10 +130,7 @@ export default __cfBindVerifiedBinding(pattern((state) => __cfLift_3({ state: {
     required: ["done"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 50 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,16 +33,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 11 }
-});
 // FIXTURE: pattern-local-helper-call-roots
 // Verifies: top-level ordinary local helper calls with reactive inputs are
 //   lifted as whole calls, while plain inputs stay plain.
 //   double(2)                 -> unchanged plain JS call
 //   double(state.count + 1)   -> lift(({ state }) => double(state.count + 1))({ state })
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     staticDoubled: double(2),
     doubled: __cfLift_1({ state: {
             count: state.key("count")
@@ -84,10 +62,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
         }
     },
     required: ["staticDoubled", "doubled"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,17 +32,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 8 }
-});
 // FIXTURE: pattern-object-binary-add
 // Verifies: top-level non-JSX arithmetic in an object property is lowered after
 //   closure normalization into a direct lift-applied computation rather than left
 //   as raw arithmetic over opaque values.
 //   return { next: state.count + 1 }
 //   → return { next: lift(({ state }) => state.count + 1)({ state }) }
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     next: __cfLift_1({ state: {
             count: state.key("count")
         } }).for(["__patternResult", "next"], true)
@@ -80,10 +58,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
         }
     },
     required: ["next"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-logical-or.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -34,7 +16,7 @@ const __cfAmdHooks = undefined;
 //   closure normalization rather than being left as raw JS short-circuiting.
 //   return { label: state.label || "Pending" }
 //   → return { label: unless(state.label, "Pending") }
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     label: __cfHelpers.unless({
         type: ["string", "undefined"]
     } as const satisfies __cfHelpers.JSONSchema, {
@@ -57,10 +39,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
         }
     },
     required: ["label"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 43 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,16 +32,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 10 }
-});
 // FIXTURE: pattern-object-prefix-not
 // Verifies: top-level non-JSX unary boolean negation in an object property is
 //   lowered after closure normalization into a direct lift-applied computation.
 //   return { hidden: !state.done }
 //   → return { hidden: lift(({ state }) => !state.done)({ state }) }
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     hidden: __cfLift_1({ state: {
             done: state.key("done")
         } }).for(["__patternResult", "hidden"], true)
@@ -79,10 +57,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
         }
     },
     required: ["hidden"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,11 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 16 },
-    bindingName: "label"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         maybeUser?: { name: string; } | undefined;
@@ -90,11 +67,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 21 },
-    bindingName: "maybeLabel"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -120,10 +92,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 14 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         float: string;
@@ -145,10 +113,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 17 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
@@ -169,10 +133,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 19 }
-});
 // FIXTURE: pattern-top-level-root-lowering
 // Verifies: top-level non-JSX ordinary helper calls with reactive inputs are
 //   lifted as whole calls instead of lowering only inner argument expressions.
@@ -182,7 +142,7 @@ __cfBindVerifiedBinding(__cfLift_5, {
 //   parseInt(state.float)         -> lift-applied free-function root
 //   state.label ?? "Pending"      -> lift-applied nullish root
 //   state.items?.[0]              -> lowered optional element access
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const label = __cfLift_1({ state: {
             user: {
                 name: state.key("user", "name")
@@ -274,10 +234,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["label", "maybeLabel", "maxValue", "parsedValue", "fallbackLabel", "firstItem"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,16 +32,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 24 }
-});
 // FIXTURE: pattern-two-schemas
 // Verifies: pattern with both input and output schemas already present preserves them
 //   pattern<Input, Result>(fn, inputSchema, outputSchema) → pattern(fn, inputSchema, outputSchema) (schemas kept)
 //   ({ count }) destructuring                              → __cf_pattern_input.key("count")
 // Context: Schemas are user-provided, not generated; type args are stripped but schemas remain
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         doubled: __cfLift_1({ count: count }).for(["__patternResult", "doubled"], true)
@@ -80,10 +58,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["doubled"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,16 +35,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 21 }
-});
 // FIXTURE: pattern-with-name-and-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)
 //   input.value                        → input.key("value")
 // Context: Type comes from inline parameter annotation, not generic type argument
-export default __cfBindVerifiedBinding(pattern((input: MyInput) => {
+export default pattern((input: MyInput) => {
     return {
         result: __cfLift_1({ input: {
                 value: input.key("value")
@@ -84,10 +62,7 @@ export default __cfBindVerifiedBinding(pattern((input: MyInput) => {
         }
     },
     required: ["result"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,16 +35,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 21 }
-});
 // FIXTURE: pattern-with-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)
 //   input.value                        → input.key("value")
 // Context: Identical structure to pattern-with-name-and-type; confirms consistent behavior
-export default __cfBindVerifiedBinding(pattern((input: MyInput) => {
+export default pattern((input: MyInput) => {
     return {
         result: __cfLift_1({ input: {
                 value: input.key("value")
@@ -84,10 +62,7 @@ export default __cfBindVerifiedBinding(pattern((input: MyInput) => {
         }
     },
     required: ["result"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,11 +40,6 @@ const addTodo = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.items.push(event.add);
 });
-__cfBindVerifiedBinding(addTodo, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 62 },
-    bindingName: "addTodo"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -99,16 +76,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 27 }
-});
 // FIXTURE: schema-generation-builders
 // Verifies: handler with generic type args generates event+state schemas; .map() becomes .mapWithPattern()
 //   handler<TodoEvent, { items: Cell<string[]> }>(fn) → handler(eventSchema, stateSchema, fn)
 //   state.items.map((item, index) => JSX)             → state.key("items").mapWithPattern(pattern(...), {})
 //   pattern<TodoState>(fn)                            → pattern(fn, inputSchema, outputSchema)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <button type="button" onClick={addTodo({ items: state.key("items") })}>
@@ -160,10 +133,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 34 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,11 +21,6 @@ declare const state: AliasInput;
 const __cfLift_1 = __cfHelpers.lift((): AliasResult => ({
     length: state.text.length,
 }), false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 40 },
-    bindingName: "textLength"
-});
 // FIXTURE: schema-generation-computed-alias
 // Verifies: a reactive builder imported under an alias still gets schema injection
 //   computedAlias((): AliasResult => ...) → captures `state` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -31,11 +13,6 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const value: number;
 const __cfLift_1 = __cfHelpers.lift(() => value * 2, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 14 },
-    bindingName: "result"
-});
 // FIXTURE: schema-generation-computed-inside-jsx
 // Verifies: a reactive builder inside a JSX expression still gets schemas injected
 //   computed(() => value * 2) → captures `value` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -36,11 +18,6 @@ const __cfLift_1 = __cfHelpers.lift(() => {
     }
     return 42;
 }, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 36 },
-    bindingName: "multiReturn"
-});
 // FIXTURE: schema-generation-computed-multiple-returns
 // Verifies: a reactive builder with multiple return paths infers a union output schema
 //   computed(() => { ... }) → output schema is an enum union of the returned literals

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -31,11 +13,6 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const total: number;
 const __cfLift_1 = __cfHelpers.lift(() => total * 2, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 32 },
-    bindingName: "doubled"
-});
 // FIXTURE: schema-generation-computed-untyped
 // Verifies: a reactive builder with no generic type args infers schemas from captured values
 //   computed(() => total * 2) → captures `total` ({ type: "number" }) and infers output from the body

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,11 +21,6 @@ declare const source: DeriveInput;
 const __cfLift_1 = __cfHelpers.lift((): DeriveResult => ({
     doubled: source.count * 2,
 }), false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 37 },
-    bindingName: "doubledValue"
-});
 // FIXTURE: schema-generation-computed
 // Verifies: computed() closure-extracts a captured value into a lift() with input
 // (capture) and output schemas generated from type info

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-both-inline.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -40,7 +22,7 @@ interface CounterState {
 //   handler((event: IncrementEvent, state: CounterState) => ...) → handler(eventSchema, stateSchema, fn)
 // Context: Types come from inline parameter annotations, not generic type args
 // Both parameters typed inline (no generic type arguments)
-export const incrementer = __cfBindVerifiedBinding(handler({
+export const incrementer = handler({
     type: "object",
     properties: {
         amount: {
@@ -58,10 +40,6 @@ export const incrementer = __cfBindVerifiedBinding(handler({
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (event: IncrementEvent, state: CounterState) => {
     state.count += event.amount;
-}), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 2 },
-    bindingName: "incrementer"
 });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-handler-event-only.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -37,7 +19,7 @@ interface IncrementEvent {
 //   handler((event: IncrementEvent, _state) => ...) → handler(eventSchema, false, fn)
 // Context: Untyped state param gets `false` as its schema (unknown)
 // Only event is typed, state should get unknown schema
-export const incrementer = __cfBindVerifiedBinding(handler({
+export const incrementer = handler({
     type: "object",
     properties: {
         amount: {
@@ -47,10 +29,6 @@ export const incrementer = __cfBindVerifiedBinding(handler({
     required: ["amount"]
 } as const satisfies __cfHelpers.JSONSchema, false as const satisfies __cfHelpers.JSONSchema, (event: IncrementEvent, _state) => {
     console.log("increment by", event.amount);
-}), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 35 },
-    bindingName: "incrementer"
 });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -89,11 +71,6 @@ const logPiecesList = lift(({ piecesList }) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(logPiecesList, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 2 },
-    bindingName: "logPiecesList"
-});
 export default logPiecesList;
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,7 +21,7 @@ type LiftResult = {
 // Verifies: lift() with no generic type args infers schemas from inline param and return type
 //   lift((args: LiftArgs): LiftResult => ...) → lift(inputSchema, outputSchema, fn)
 // Context: Types come from function parameter and return type annotations, not generic args
-export const doubleValue = __cfBindVerifiedBinding(lift((args: LiftArgs): LiftResult => ({
+export const doubleValue = lift((args: LiftArgs): LiftResult => ({
     doubled: args.value * 2,
 }), {
     type: "object",
@@ -57,11 +39,7 @@ export const doubleValue = __cfBindVerifiedBinding(lift((args: LiftArgs): LiftRe
         }
     },
     required: ["doubled"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 32 },
-    bindingName: "doubleValue"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-typed-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-typed-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -34,15 +16,11 @@ const __cfAmdHooks = undefined;
 //   lift((value: number) => value * 2) → lift({ type: "number" }, { type: "number" }, fn)
 // Context: Single primitive param; output type inferred from expression body
 // Lift requires explicit type annotation for proper schema generation
-export const doubleValue = __cfBindVerifiedBinding(lift((value: number) => value * 2, {
+export const doubleValue = lift((value: number) => value * 2, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 32 },
-    bindingName: "doubleValue"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ type LiftResult = {
 // FIXTURE: schema-generation-lift
 // Verifies: lift() with generic type args generates input and output schemas
 //   lift<LiftArgs, LiftResult>(fn) → lift(inputSchema, outputSchema, fn)
-export const doubleValue = __cfBindVerifiedBinding(lift(({ value }) => ({
+export const doubleValue = lift(({ value }) => ({
     doubled: value * 2,
 }), {
     type: "object",
@@ -56,11 +38,7 @@ export const doubleValue = __cfBindVerifiedBinding(lift(({ value }) => ({
         }
     },
     required: ["doubled"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 54 },
-    bindingName: "doubleValue"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-unless.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ interface State {
 //   unless(value, defaultValue) → unless(conditionSchema, fallbackSchema, resultSchema, value, defaultValue)
 //   pattern<State>(fn)          → pattern(fn, inputSchema, outputSchema)
 // Context: unless(cond, fallback) returns cond if truthy, else fallback; schemas reflect the union type
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     const defaultValue = __cf_pattern_input.key("defaultValue");
     // unless(condition, fallback) - returns condition if truthy, else fallback
@@ -108,10 +90,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-when.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-injection-when.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ interface State {
 //   when(enabled, message) → when(conditionSchema, valueSchema, resultSchema, enabled, message)
 //   pattern<State>(fn)     → pattern(fn, inputSchema, outputSchema)
 // Context: when(cond, value) returns value if cond is truthy, else cond; result schema is union type
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const enabled = __cf_pattern_input.key("enabled");
     const message = __cf_pattern_input.key("message");
     // when(condition, value) - returns value if condition is truthy, else condition
@@ -96,10 +78,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -57,10 +39,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 42 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     cell: {
         value: number;
@@ -82,10 +60,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 6 }
-});
 // FIXTURE: str-template-call-interpolation
 // Verifies: reactive lowering of expressions interpolated into a str`` tagged template.
 //   The str runtime lifts its interpolation over the values it receives, so any value
@@ -98,7 +72,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 // Context: Regression for CT-1621 — derive(cell.value, String) migrated to bare
 //   String(cell.value) inside str`` silently dropped reactivity because interpolation
 //   call-expressions were never classified as lowerable expression sites.
-export default __cfBindVerifiedBinding(pattern((cell) => {
+export default pattern((cell) => {
     return {
         [NAME]: str `bare ${cell.key("value")} call ${__cfLift_1({ cell: {
                 value: cell.key("value")
@@ -126,10 +100,7 @@ export default __cfBindVerifiedBinding(pattern((cell) => {
         }
     },
     required: ["$NAME", "value"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,10 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 9 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -78,16 +56,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 27 }
-});
 // FIXTURE: ternary_computed
 // Verifies: ternary with expressions on both sides produces ifElse() with a lift-applied computation for each branch
 //   state.value + 1 ? state.value + 2 : "undefined" → ifElse(...schemas, lift(...)({...}), lift(...)({...}), "undefined")
 //   pattern<PatternState>(fn)                        → pattern(fn, inputSchema, outputSchema)
 // Context: Both condition and consequent contain state expressions that must be individually lift-applied
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [NAME]: "test ternary with computed",
         [UI]: (<div>
@@ -147,10 +121,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -42,14 +24,10 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 16 }
-});
 // FIXTURE: action-basic
 // Verifies: action() callback is extracted into a handler with captured state
 //   action(() => count.set(...)) → handler(eventSchema, captureSchema, (_, { count }) => count.set(...))({ count })
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         inc: __cfHandler_1({
@@ -73,10 +51,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["inc"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,15 +35,11 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 28 }
-});
 // FIXTURE: action-generic-event
 // Verifies: action<MyEvent>(fn) with a type parameter generates a typed event schema
 //   action<MyEvent>((e) => ...) → handler(MyEvent schema, captureSchema, (e, { value }) => ...)({ value })
 // Context: Event type comes from a generic type parameter, not an inline annotation
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
         // Test action<MyEvent>((e) => ...) variant (type parameter instead of inline annotation)
@@ -98,10 +76,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["data"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,11 +37,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
     isEditing.set(true);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 30 },
-    bindingName: "startEditing"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     card: {
         description: string;
@@ -84,18 +61,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": [false, true, ""]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 34 },
-    bindingName: "hasDescription"
-});
 // FIXTURE: action-in-ternary-branch
 // Verifies: action() result used in a ternary branch alongside computed() keeps
 //   local JSX rewrites instead of forcing a whole-branch lift-applied computation
 //   action(() => ...) → handler(eventSchema, captureSchema, (_, { isEditing }) => ...)({ isEditing })
 //   nested hasDescription ternary → local ifElse(...) inside the JSX branch
 // Context: Regression coverage for JSX-local rewriting with action references in the same branch
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const card = __cf_pattern_input.key("card");
     const isEditing = new Cell(false, {
         type: "boolean"
@@ -218,10 +190,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,11 +36,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     required: ["isEditing"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
     isEditing.set(true);
-});
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 30 },
-    bindingName: "startEditing"
 });
 const __cfLift_1 = __cfHelpers.lift<{
     card: {
@@ -106,16 +83,12 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 22 }
-});
 // FIXTURE: action-in-ternary-with-explicit-computed
 // Verifies: action() referenced inside an explicit computed() in JSX is captured in the lift-applied wrapper
 //   action(() => ...) → handler(...)({ isEditing })
 //   computed(() => JSX with action ref) → lift(fn)({ card, startEditing })
 // Context: Action referenced inside computed expression must appear in the lift-applied capture object
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const card = __cf_pattern_input.key("card");
     const isEditing = new Cell(false, {
         type: "boolean"
@@ -223,10 +196,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,10 +30,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 18 }
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -65,15 +43,11 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b));
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 18 }
-});
 // FIXTURE: action-partial
 // Verifies: Partial<BaseState> produces optional (anyOf undefined|type) capture schemas in handlers
 //   action(() => console.log(a)) → handler(false, { a: { anyOf: [undefined, string] } }, ...)({ a })
 // Context: Partial<> makes properties optional; capture schemas reflect this with anyOf union
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
@@ -107,10 +81,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["readA", "readB"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 34 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -45,10 +27,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["a"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -59,15 +37,11 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["b"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42));
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 17 }
-});
 // FIXTURE: action-required-partial
 // Verifies: Required<BaseState> makes originally-optional properties required in capture schemas
 //   action(() => a.set("hello")) → handler(false, { a: { type: "string", asCell, required } }, ...)({ a })
 // Context: BaseState.a is optional, but Required<> forces it to required in both input and capture schemas
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
@@ -102,10 +76,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["setA", "setB"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 33 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,11 +31,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 27 },
-    bindingName: "increment"
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -66,16 +43,11 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() - 1);
 });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 27 },
-    bindingName: "decrement"
-});
 // FIXTURE: action-result-not-opaque
 // Verifies: action() results used as JSX event handlers are not marked asOpaque in the output
 //   action(() => count.set(...)) → handler(false, { count: { asCell } }, (_, { count }) => ...)({ count })
 // Context: action() is an opaque origin, but handler results are used directly (no property access)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const label = __cf_pattern_input.key("label");
     const count = new Writable(0, {
         type: "number"
@@ -135,10 +107,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,11 +42,6 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { self }) => {
     console.log("self.title:", self.title);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 28 },
-    bindingName: "showSelf"
-});
 const __cfHandler_2 = __cfHelpers.handler({
     type: "object",
     properties: {},
@@ -105,17 +82,12 @@ const __cfHandler_2 = __cfHelpers.handler({
     console.log("self:", self);
     count.set(count.get() + 1);
 });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 37 },
-    bindingName: "incrementWithSelf"
-});
 // FIXTURE: action-self-closure
 // Verifies: action() closing over SELF captures self properties in the handler
 //   action(() => console.log(self.title)) → handler(eventSchema, { self: { title } }, (_, { self }) => ...)({ self: { title: self.key("title") } })
 //   action(() => { self; count.set(...) }) → handler(eventSchema, { self: TestOutput, count: asCell }, ...)({ self, count })
 // Context: SELF reference requires Default<> inputs so output schema is always satisfied
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const self = __cf_pattern_input[__cfHelpers.SELF];
     const count = new Writable(0, {
@@ -167,10 +139,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["title", "count", "$NAME", "$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,15 +35,11 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 19 }
-});
 // FIXTURE: action-with-event
 // Verifies: action() with an inline-annotated event parameter generates a typed event schema
 //   action((e: MyEvent) => value.set(e.data)) → handler(MyEvent schema, captureSchema, (e, { value }) => ...)({ value })
 // Context: Event type from inline annotation (e: MyEvent) rather than generic type parameter
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
         update: __cfHandler_1({
@@ -97,10 +75,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["data"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,10 +37,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 30 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return __cfLift_1({ r: {
@@ -101,10 +79,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 23 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     r: {
         active?: boolean | undefined;
@@ -129,10 +103,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 30 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return __cfLift_2({ r: {
@@ -175,10 +145,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 23 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return <i>{r.key("name")}</i>;
@@ -237,10 +203,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 52 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("primary") ?? r.key("fallback");
@@ -291,10 +253,6 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
             }
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 23 }
-});
 // FIXTURE: array-method-scalar-nullish-lift
 // Verifies (CT-1779): a SCALAR nullish-coalescing `??` with a reactive operand in the
 // return / predicate position of a reactive map/filter/flatMap callback is value-lifted,
@@ -309,7 +267,7 @@ __cfBindVerifiedBinding(__cfPattern_4, {
 // filter-flatmap-fallback-chain; here the heterogeneous `r.primary ?? r.fallback`
 // (`string[] | number[]`, a union of array members a bare isArrayType misses) stays
 // structural too.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     return {
         [UI]: (<div>
@@ -389,10 +347,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 40 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 27 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
@@ -105,10 +83,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 20 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <i>{v.key("voterName")}</i>;
@@ -155,10 +129,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 17 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     v: {
         optionId: string;
@@ -184,10 +154,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 31 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
@@ -231,10 +197,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 24 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     v: {
         optionId: string;
@@ -260,10 +222,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 36 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     const oid = __cf_pattern_input.key("params", "oid");
@@ -310,10 +268,6 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "boolean"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 28 }
-});
 // FIXTURE: array-method-value-lift
 // Verifies (CT-1777): a bare reactive VALUE-expression in the return position of a
 // reactive map/filter/flatMap callback is lifted to a value-level lift, so it runs on
@@ -325,7 +279,7 @@ __cfBindVerifiedBinding(__cfPattern_4, {
 //   - flatMap -> array-element compare → flatMapWithPattern(pattern(... return [lift(...)(...)]))
 // Collection-valued `??` fallbacks and logical `&&`/`||` stay structural / control-flow
 // lowered; see filter-flatmap-fallback-chain for the structural-collection counterpart.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const votes = __cf_pattern_input.key("votes");
     const oid = __cf_pattern_input.key("oid");
     return {
@@ -403,10 +357,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 55 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -115,10 +93,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 25 }
-});
 // FIXTURE: cell-map-with-captures
 // Verifies: Cell.map() with outer-scope captures is transformed to mapWithPattern with params
 //   typedValues.map((value) => <span>{value * state.multiplier}</span>)
@@ -126,7 +100,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   value * state.multiplier → lift(...)({ value, state: { multiplier } })
 // Context: The map callback captures `state.multiplier` from the outer scope,
 //   which must be threaded through as a mapWithPattern param and re-derived inside.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     // Explicitly type as Cell to ensure closure transformation
     const typedValues: Cell<number[]> = cell(state.key("values"), {
         type: "array",
@@ -186,10 +160,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,30 +25,16 @@ const internalHelper = lift((x: number) => x + 1, {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(internalHelper, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 28 },
-    bindingName: "internalHelper"
-});
-export const exportedLift = __cfBindVerifiedBinding(lift((x: number) => x * 2, {
+export const exportedLift = lift((x: number) => x * 2, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 33 },
-    bindingName: "exportedLift"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const reexportedLift = lift((x: number) => x - 1, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(reexportedLift, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 28 },
-    bindingName: "reexportedLift"
-});
 export { reexportedLift };
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
@@ -82,11 +50,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 16 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return ({
         vs: items.mapWithPattern(__cfPattern_1, {}).for(["__patternResult", "vs"], true)
@@ -113,10 +77,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["vs"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 44 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,17 +45,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 26 },
-    bindingName: "result"
-});
 // Test that all literal types are widened in closure captures
 // FIXTURE: computed-all-literal-types
 // Verifies: literal values (number, string, boolean, float) are captured and their types widened in schemas
 //   computed(() => expr) → lift(schema, schema)({ value, numLiteral, floatLiteral, boolLiteral, strLiteral }) with widened types
 // Context: each literal type maps to its widened JSON schema type (e.g., 42 → "number", "hello" → "string")
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -92,10 +69,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,16 +32,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-array-element-access
 // Verifies: an array variable accessed by index inside a computed is captured as a whole array
 //   computed(() => expr) → lift(schema, schema)({ value, factors })
 // Context: `factors[1]!` uses bracket access; the entire `factors` array is captured
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -71,10 +48,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -64,10 +46,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 21 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     pieceRegistry: {
         length: number;
@@ -89,10 +67,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 31 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     return (<li>{piece.key("name")}</li>);
@@ -139,17 +113,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 29 }
-});
 // FIXTURE: computed-array-length
 // Verifies: computed(() => expr) with .length access on a Reactive<T[]> is closure-extracted
 //   computed(() => pieceRegistry.length) → lift(({ pieceRegistry }) => pieceRegistry.length)({ pieceRegistry: { length: pieceRegistry.length } })
 //   pieceRegistry.map(fn) → pieceRegistry.mapWithPattern(pattern(fn, ...schemas), {})
 // Context: Regression test ensuring array .length produces the correct schema
 //   shape rather than an object schema with a length property.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const __cf_destructure_1 = wish<{
         pieceRegistry: Piece[];
     }>({ query: "/" }, {
@@ -223,10 +193,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,16 +30,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-basic-capture
 // Verifies: computed(() => expr) with two cell captures is closure-extracted into a lift-applied computation
 //   computed(() => value.get() * multiplier.get()) → lift(({ value, multiplier }) => value.get() * multiplier.get())({ value, multiplier })
 //   Captured cells are annotated with asCell: true in the capture schema.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -71,10 +48,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,17 +37,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["multiplier", "value"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-collision-property
 // Verifies: a captured cell named the same as a returned object property does not rename the property
 //   computed(() => ({ multiplier: multiplier.get(), value: ... })) → lift(...)({ multiplier })
 // Context: returned object literal `{ multiplier: ... }` property name stays unchanged while the
 //   captured variable reference resolves to the capture binding
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const multiplier = new Writable(2, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
@@ -84,10 +61,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
         }
     },
     required: ["multiplier", "value"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,16 +44,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["value", "data"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-collision-shorthand
 // Verifies: a shorthand property `{ multiplier }` over a captured cell expands correctly
 //   computed(() => ({ value, data: { multiplier } })) → lift(...)({ multiplier })
 // Context: shorthand must keep the property name while binding to the captured value
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const multiplier = new Writable(2, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("multiplier", true);
@@ -96,10 +73,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
         }
     },
     required: ["value", "data"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,16 +35,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-complex-expression
 // Verifies: computed(() => expr) with three cell captures in an arithmetic expression
 //   computed(() => (a.get() * b.get() + c.get()) / 2) → lift(({ a, b, c }) => ...)({ a, b, c })
 //   All three cells (a, b, c) are captured with asCell: true in the schema.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const a = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("a", true);
@@ -80,10 +57,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,16 +40,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-conditional-expression
 // Verifies: computed(() => expr) with four cell captures in a ternary expression
 //   computed(() => value.get() > threshold.get() ? a.get() : b.get()) → lift(({ value, threshold, a, b }) => ...)({ value, threshold, a, b })
 //   All four cells are captured with asCell: true in the schema.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -89,10 +66,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -93,11 +75,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 26 },
-    bindingName: "result"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     result: { tasks: Item[]; view: string; };
 }, __cfHelpers.JSXElement[]>(({ result }) => {
@@ -164,17 +141,13 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 18 }
-});
 // FIXTURE: computed-destructured-map
 // Verifies: .map() on a destructured property of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const { tasks } = result; return tasks.map(fn) }) → lift(({ result }) => { const { tasks } = result; return tasks.map(fn) })(...)
 // Context: Inside a lift-applied callback, Reactive values are unwrapped to plain JS,
 //   so destructured `tasks` is a plain array. The .map() must remain untransformed.
 //   This is a negative test for reactive .map() detection on derived values.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const result = __cfLift_1({ items: items }).for("result", true);
     return {
@@ -236,10 +209,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,16 +51,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-destructured-param
 // Verifies: a captured cell works alongside destructuring inside the computed body
 //   computed(() => { const { x, y } = point.get(); ... }) → lift(...)({ point, multiplier })
 // Context: `const { x, y } = point.get()` destructures inside the body, not a parameter
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const point = new Writable({ x: 10, y: 20 } as Point, {
         type: "object",
         properties: {
@@ -102,10 +79,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -76,17 +58,12 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 25 },
-    bindingName: "liked"
-});
 // FIXTURE: computed-filter-map-chain
 // Verifies: .filter() and .map() inside computed() are NOT transformed
 // Context: Inside computed(), Reactive auto-unwraps to plain array, so
 //   .filter() and .map() are standard Array methods — they must remain
 //   untransformed. This is a negative test for the reactive method detection.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const liked = __cfLift_1({ state: {
             preferences: state.key("preferences")
         } }).for("liked", true);
@@ -127,10 +104,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["liked"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -30,20 +12,10 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 25 },
-    bindingName: "foo"
-});
 const __cfLift_2 = __cfHelpers.lift(() => {
     const foo = __cfLift_1().for("foo", true);
     return foo.key("bar");
 }, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 25 },
-    bindingName: "outer"
-});
 // FIXTURE: computed-in-computed-property-access
 // Verifies: property access on a computed() result declared INSIDE another computed()
 //   gets transformed to .key() access
@@ -51,15 +23,12 @@ __cfBindVerifiedBinding(__cfLift_2, {
 // Context: Local variables holding Reactive values (from compute/lift-applied calls)
 //   inside a lift-applied callback need .key() rewriting even though they are not
 //   captured from an outer scope.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const outer = __cfLift_2().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -31,11 +13,6 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const config = __cfHelpers.__cf_data({ bar: "module-level" });
 const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 },
-    bindingName: "config"
-});
 const __cfLift_2 = __cfHelpers.lift(() => {
     const condition = 1 > 0;
     if (condition) {
@@ -44,11 +21,6 @@ const __cfLift_2 = __cfHelpers.lift(() => {
     }
     return config.bar;
 }, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 25 },
-    bindingName: "outer"
-});
 // FIXTURE: computed-in-computed-scoped-no-false-rewrite
 // Verifies: a block-scoped computed() result named `config` does NOT cause
 //   the module-level `config.bar` to be rewritten to `config.key("bar")`.
@@ -56,15 +28,12 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   but the outer `config.bar` (plain object) must remain untouched.
 // Context: The pre-scan collects opaque roots by name; it must not leak
 //   across lexical scopes and incorrectly rewrite unrelated same-named accesses.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const outer = __cfLift_2().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "string"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -86,10 +68,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 24 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
@@ -165,16 +143,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 25 }
-});
 // FIXTURE: computed-inside-map-with-method-chain
 // Verifies: a computed nested inside .map() correctly transforms outer .map() but leaves inner chains alone
 //   state.items.map(fn) → state.items.mapWithPattern(pattern(...))
 //   inner .filter().map() inside the computed callback → NOT transformed (plain array)
 // Context: computed is used inline in JSX within a mapWithPattern callback
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Edge case: explicit computed inside mapWithPattern with method chain.
@@ -260,10 +234,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,15 +45,11 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 18 }
-});
 // FIXTURE: computed-jsx-local-function
 // Verifies: computed() with a locally-defined function inside the callback is closure-extracted
 //   computed(() => { const format = ...; return <span>{format(count)}</span> }) → lift(({ count }) => { ... })({ count })
 //   The pattern param `count` is captured with asOpaque: true in the schema.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         [UI]: (<div>
@@ -115,10 +93,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -81,11 +63,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 28 },
-    bindingName: "filtered"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     filtered: {
         name: string;
@@ -137,17 +114,13 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 18 }
-});
 // FIXTURE: computed-local-var-map
 // Verifies: .map() on a local variable assigned from a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const localVar = filtered; return localVar.map(fn) }) → lift(({ filtered }) => { const localVar = filtered; return localVar.map(fn) })(...)
 // Context: Inside a lift-applied callback, Reactive values are unwrapped to plain JS,
 //   so `localVar` is a plain array. The .map() must remain untransformed.
 //   This is a negative test for reactive .map() detection on local aliases.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const filtered = __cfLift_1({ items: items }).for("filtered", true);
     return {
@@ -209,10 +182,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -56,16 +38,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-local-variable
 // Verifies: callback-local variables are not captured, but outer cells are
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(...)({ a, b, c })
 // Context: `sum` is a local const inside the callback and must not appear in captures
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const a = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("a", true);
@@ -83,10 +60,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 24 },
-    bindingName: "rows"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -111,11 +88,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 24 },
-    bindingName: "label"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {
@@ -162,17 +134,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 18 }
-});
 // FIXTURE: computed-map-call-arg-conditional
 // Verifies: callback-local ordinary call roots within a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations rather than
 //   lowering only the nested ternary argument site.
 //   const label = identity(row.done ? "Done" : "Pending")
 //   → const label = lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -232,10 +200,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 24 },
-    bindingName: "rows"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -111,11 +88,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 24 },
-    bindingName: "label"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {
@@ -162,17 +134,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 18 }
-});
 // FIXTURE: computed-map-call-arg-logical-and
 // Verifies: callback-local ordinary call roots within a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations rather than
 //   lowering only the nested && argument site.
 //   const label = identity(row.done && "Done")
 //   → const label = lift(({ row }) => identity(row.done && "Done"))(...)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -232,10 +200,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 24 },
-    bindingName: "rows"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -111,10 +88,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 11 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -136,10 +109,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 11 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return ({
@@ -184,11 +153,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["value", "list"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 25 },
-    bindingName: "views"
-});
 const __cfLift_4 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -210,10 +174,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 4 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfLift_4({ row: {
@@ -241,11 +201,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 26 },
-    bindingName: "labels"
-});
 // FIXTURE: computed-map-call-root-containers
 // Verifies: inside a computed-array .map() callback, callback-local ordinary
 //   call roots whole-wrap as callback-local lift-applied computations across
@@ -256,7 +211,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   → [lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)]
 //   row => identity(row.done ? "Done" : "Pending")
 //   → row => lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -314,10 +269,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["views", "labels"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 24 },
-    bindingName: "rows"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({
@@ -122,17 +99,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 18 }
-});
 // FIXTURE: computed-map-direct-return-conditional
 // Verifies: direct callback-return ternary on a computed array is lowered to ifElse()
 //   rows.map((row) => row.done ? "Done" : "Pending")
 //   → rows.mapWithPattern(pattern(... return ifElse(row.done, "Done", "Pending")))
 // Context: the conditional is the callback's root return expression, not nested
 //   inside returned JSX, which currently slips past the JSX-local rewrite pass.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -192,10 +165,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["name", "rank", "isFirst"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 29 },
-    bindingName: "adminData"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
@@ -107,11 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 25 },
-    bindingName: "count"
-});
 // FIXTURE: computed-map-in-derived-branch
 // Verifies: moving a reactive computation out of a JSX slot forces the whole
 //   branch into derive(), so nested maps run in compute context and stay plain
@@ -119,7 +91,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   adminData.map((entry) => <li>...) → stays plain .map() inside the derive callback
 // Context: opposite of computed-map-in-ternary-branch; no JSX-local rewrite is
 //   available for the hoisted `peopleCount` initializer.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const people = __cf_pattern_input.key("people");
     const showAdmin = new Writable(false, {
         type: "boolean"
@@ -214,10 +186,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["name", "rank", "isFirst"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 29 },
-    bindingName: "adminData"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
 }, number>(({ people }) => people.get().length, {
@@ -107,11 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 25 },
-    bindingName: "count"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     return (<span>{person.key("name")}</span>);
@@ -158,10 +130,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 20 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     count: number;
 }, string>(({ count }) => count + " people", {
@@ -175,10 +143,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 41, col: 21 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return (<li>
@@ -234,10 +198,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 31 }
-});
 // FIXTURE: computed-map-in-ternary-branch
 // Verifies: a computed array used inside a ternary JSX branch stays pattern-lowered
 //   const adminData = computed(() => [...people.get()].sort(...).map(...))
@@ -246,7 +206,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 // Context: The outer `people.map(...)` is over a pattern input cell, while the
 //   inner `adminData.map(...)` is over compute-owned data but still lowered in
 //   pattern context when rendered from the ternary branch.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const people = __cf_pattern_input.key("people");
     const showAdmin = new Writable(false, {
         type: "boolean"
@@ -336,10 +296,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -73,16 +55,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 25 },
-    bindingName: "count"
-});
 // FIXTURE: computed-map-input-no-captures
 // Verifies: a computed over a captured cell array uses a plain .map() (not .mapWithPattern)
 //   computed(() => items.get().map(...).length) → lift(...)({ items })
 // Context: tests schema injection for a computed whose result derives from a captured cell's array
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // items is a captured cell; .get() yields a plain array, so .map() stays plain.
     const count = __cfLift_1({ items: items }).for("count", true);
@@ -121,10 +98,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["count"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 48 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 24 },
-    bindingName: "rows"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     view: string[];
 }, string | undefined>(({ view }) => view[0], {
@@ -105,10 +82,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 24 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = [__cfHelpers.ifElse({
@@ -161,16 +134,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 18 }
-});
 // FIXTURE: computed-map-local-array-conditional
 // Verifies: nested ternary inside a callback-local array initializer within a
 //   computed-array .map() callback is lowered at the array element site.
 //   const view = [row.done ? "Done" : "Pending"]
 //   → const view = [ifElse(row.done, "Done", "Pending")]
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -230,10 +199,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 24 },
-    bindingName: "rows"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -111,11 +88,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 18 },
-    bindingName: "label"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {
@@ -144,18 +116,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 26 },
-    bindingName: "labels"
-});
 // FIXTURE: computed-map-local-call-root
 // Verifies: callback-local ordinary call roots in a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations even when
 //   introduced through a local variable initializer in non-JSX output code.
 //   const label = identity(row.done ? "Done" : "Pending")
 //   → const label = lift(({ row }) => identity(row.done ? "Done" : "Pending"))(...)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -194,10 +161,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["labels"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 52 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 24 },
-    bindingName: "rows"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.ifElse({
@@ -141,16 +118,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 18 }
-});
 // FIXTURE: computed-map-local-object-conditional
 // Verifies: nested ternary inside a callback-local object initializer within a
 //   computed-array .map() callback is lowered to ifElse().
 //   const view = { status: row.done ? "Done" : "Pending" }
 //   → const view = { status: ifElse(row.done, "Done", "Pending") }
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -210,10 +183,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 24 },
-    bindingName: "rows"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.unless({
@@ -139,16 +116,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 18 }
-});
 // FIXTURE: computed-map-local-object-logical-or
 // Verifies: nested || inside a callback-local object initializer within a
 //   computed-array .map() callback is lowered to unless().
 //   const view = { status: row.done || "Pending" }
 //   → const view = { status: unless(row.done, "Pending") }
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -208,10 +181,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -76,11 +58,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["done"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 24 },
-    bindingName: "rows"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({
@@ -109,17 +86,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 18 }
-});
 // FIXTURE: computed-map-pre-resolved-return-conditional
 // Verifies: pre-resolving a boolean inside the source computed does not avoid
 //   the need to lower the later direct callback-return ternary.
 //   computed(() => state.items.map((item) => ({ done: item.done })))
 //   rows.map((row) => row.done ? "Done" : "Pending")
 //   → rows.mapWithPattern(pattern(... return ifElse(row.done, "Done", "Pending")))
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
@@ -179,10 +152,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -124,17 +106,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             type: "null"
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 33 },
-    bindingName: "latestMessage"
-});
 // FIXTURE: computed-map-union-return
 // Verifies: a computed returning a union type (string | null) with a nested .map() infers the correct output schema
 //   computed(() => { ...; return content }) → lift(schema, anyOf[string, null])({ messages })
 //   inner .map() inside the computed callback → NOT transformed (plain array after unwrap)
 // Context: previously caused schema to fall back to `true` when the callback became synthetic
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     // This computed callback contains a nested map and returns string | null.
     // The callback becomes synthetic during transformation, which previously
     // caused type inference to fail, resulting in a 'true' schema instead of
@@ -223,10 +200,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,16 +50,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-method-call-capture
 // Verifies: a deep property access on a captured object is restructured into a nested capture object
 //   computed(() => value.get() + state.counter.value) → lift(...)({ value, state: { counter: { value } } })
 // Context: `state.counter.value` is captured as a nested object structure, not a flat binding
-export default __cfBindVerifiedBinding(pattern((state: State) => {
+export default pattern((state: State) => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -107,10 +84,7 @@ export default __cfBindVerifiedBinding(pattern((state: State) => {
     required: ["counter"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -56,16 +38,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-multiple-captures
 // Verifies: computed() with a multi-statement body capturing three cells is closure-extracted
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(({ a, b, c }) => { ... })({ a, b, c })
 //   All three cells (a, b, c) are captured with asCell: true in the schema.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const a = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("a", true);
@@ -83,10 +60,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,17 +36,12 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "number"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-nested-callback
 // Verifies: capture extraction works with a nested .map() over a captured cell's array value
 //   computed(() => numbers.get().map(n => n * multiplier.get())) → lift(...)({ numbers, multiplier })
 //   inner numbers.get().map(fn) runs on a plain array → NOT rewritten to mapWithPattern
 // Context: both `numbers` and `multiplier` are captured cells; the inner map reads `multiplier`
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const numbers = new Writable([1, 2, 3], {
         type: "array",
         items: {
@@ -85,10 +62,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -52,16 +34,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 27 },
-    bindingName: "doubled"
-});
 // FIXTURE: computed-nested-property
 // Verifies: computed() capturing a cell with an object value and accessing a nested property
 //   computed(() => { const current = counter.get(); return current.count * 2 }) → lift(({ counter }) => { ... })({ counter })
 //   The cell schema preserves the nested object shape { count: number } with asCell: true.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const counter = new Writable({ count: 0 }, {
         type: "object",
         properties: {
@@ -75,10 +52,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,11 +30,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 23 },
-    bindingName: "sum"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     sum: number;
 }, number>(({ sum }) => sum * 2, {
@@ -66,18 +43,13 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 27 },
-    bindingName: "doubled"
-});
 // FIXTURE: computed-nested
 // Verifies: chained computed() calls where the second captures the result of the first
 //   computed(() => a.get() + b.get()) → lift(({ a, b }) => a.get() + b.get())({ a, b })
 //   computed(() => sum * 2) → lift(({ sum }) => sum * 2)({ sum })
 // Context: The first lift-applied computation captures cells (asCell: true), the second captures
 //   the computed result (asOpaque: true) since it is a Reactive.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const a = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("a", true);
@@ -92,10 +64,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return doubled;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -30,23 +12,15 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift(() => 42, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-no-captures
 // Verifies: computed(() => expr) with no external captures is transformed to
 // lift(false, fn)() with no input object.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const result = __cfLift_1().for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,11 +21,6 @@ const __cfLift_1 = __cfHelpers.lift((): Question | null => {
     // In real code this would filter and return first match, or null
     return null;
 }, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 31 },
-    bindingName: "topQuestion"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     topQuestion: {
         question: string;
@@ -69,10 +46,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 40 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.question, {
@@ -107,10 +80,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 37 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     topQuestion: {
         category: string;
@@ -136,10 +105,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 42 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     topQuestion: Question | null;
 }, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.category, {
@@ -174,10 +139,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 42 }
-});
 // FIXTURE: computed-nullable-optional-chain
 // Verifies: computed() capturing a nullable computed result preserves anyOf [type, null] in schema
 //   computed(() => topQuestion?.question || "") → lift(({ topQuestion }) => topQuestion?.question || "")({ topQuestion })
@@ -185,7 +146,7 @@ __cfBindVerifiedBinding(__cfLift_5, {
 // Context: Tests both optional chaining (?.) and explicit null-check patterns on
 //   a nullable Reactive. The capture schema correctly uses anyOf [Question, null]
 //   with asOpaque: true for the topQuestion capture.
-export default __cfBindVerifiedBinding(pattern((_) => {
+export default pattern((_) => {
     // This computed can return null - simulates finding a question from a list
     const topQuestion = __cfLift_1().for("topQuestion", true);
     return {
@@ -237,10 +198,7 @@ export default __cfBindVerifiedBinding(pattern((_) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,16 +41,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-optional-chaining
 // Verifies: computed() with optional chaining and nullish coalescing on captured cells
 //   computed(() => value.get() * (config.get()?.multiplier ?? 1)) → lift(({ value, config }) => ...)({ value, config })
 //   The config cell has a nullable type (anyOf [object, null]) with asCell: true in the capture schema.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const config = new Writable<{
         multiplier?: number;
     } | null>({ multiplier: 2 }, {
@@ -93,10 +70,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,18 +50,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-pattern-param-mixed
 // Verifies: computed() capturing a mix of cells, pattern params, and plain locals
 //   computed(() => (value.get() + config.base + offset) * config.multiplier + threshold.get()) → lift(...)({ value, config: { base, multiplier }, offset, threshold })
 // Context: Captures four different variable types: cell (value, threshold with
 //   asCell), pattern param (config with .key() rewriting), and plain local
 //   (offset as plain number). All coexist in a single capture object.
-export default __cfBindVerifiedBinding(pattern((config: {
+export default pattern((config: {
     base: number;
     multiplier: number;
 }) => {
@@ -113,10 +90,7 @@ export default __cfBindVerifiedBinding(pattern((config: {
     required: ["base", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,18 +37,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-pattern-param
 // Verifies: computed() inside a pattern captures the pattern parameter as a structured object
 //   computed(() => value.get() * config.multiplier) → lift(({ value, config }) => ...)({ value, config: { multiplier: config.key("multiplier") } })
 // Context: The pattern parameter `config` is not destructured, so properties
 //   accessed on it (config.multiplier) are rewritten to config.key("multiplier")
 //   in the captures object.
-export default __cfBindVerifiedBinding(pattern((config: {
+export default pattern((config: {
     multiplier: number;
 }) => {
     const value = new Writable(10, {
@@ -89,10 +66,7 @@ export default __cfBindVerifiedBinding(pattern((config: {
     required: ["multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -47,18 +29,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-pattern-typed
 // Verifies: computed() inside a typed pattern with destructured params is closure-extracted
 //   computed(() => value.get() * multiplier) → lift(({ value, multiplier }) => value.get() * multiplier)({ value, multiplier })
 // Context: The pattern uses generic type params <{ multiplier: number }, number>.
 //   Destructured `multiplier` is captured with asOpaque: true (it is a Reactive
 //   from the pattern input), while `value` is captured with asCell: true.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const multiplier = __cf_pattern_input.key("multiplier");
     const value = new Writable(10, {
         type: "number"
@@ -78,10 +55,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
     required: ["multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 55 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -93,11 +75,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 26 },
-    bindingName: "result"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     result: {
         tasks: {
@@ -156,10 +133,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 18 }
-});
 // FIXTURE: computed-property-access-map
 // Verifies: .map() on a property access of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => result.tasks.map(fn)) → lift(({ result }) => result.tasks.map(fn))({ result: { tasks: result.key("tasks") } })
@@ -167,7 +140,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   so `result.tasks` is a plain array. The .map() must remain untransformed.
 //   This is a negative test for reactive .map() detection on property access paths.
 //   Note the captures use result.key("tasks") to extract the needed sub-property.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const result = __cfLift_1({ items: items }).for("result", true);
     return {
@@ -231,10 +204,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,16 +42,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-property-result
 // Verifies: computed property access with a dynamic key captures both the object and the key
 //   computed(() => expr) → lift(schema, schema)({ value, config, key })
 // Context: `config[key]` requires both `config` and `key` to be captured as plain values
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -83,10 +60,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,15 +30,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-reserved-names
 // Verifies: variables with __cf_ prefixed names are captured without special treatment
 //   computed(() => value.get() * __cf_reserved.get()) → lift(...)({ value, __cf_reserved })
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -71,10 +48,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["count", "total"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 25 },
-    bindingName: "stats"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     stats: {
         count: number;
@@ -114,10 +91,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 18 }
-});
 // FIXTURE: computed-result-in-derive-captures
 // Verifies: computed() result properties captured in a subsequent lift-applied computation use .key() access
 //   computed(() => `${stats.count} of ${stats.total} done`) → lift(({ stats }) => ...)({ stats: { count: stats.key("count"), total: stats.key("total") } })
@@ -125,7 +98,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   When the second computed() captures stats.count and stats.total, the
 //   transform rewrites them to stats.key("count") and stats.key("total") in
 //   the captures object because stats is a Reactive.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const stats = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("stats", true);
@@ -186,10 +159,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,11 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 27 },
-    bindingName: "summary"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     summary: {
         length: number;
@@ -88,17 +65,13 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 24 }
-});
 // FIXTURE: computed-result-property-in-return
 // Verifies: .length on a computed() string result is captured via .key("length") in a subsequent lift-applied computation
 //   computed(() => summary.length) → lift(({ summary }) => summary.length)({ summary: { length: summary.key("length") } })
 // Context: The first computed() returns a string Reactive (from .join()).
 //   When the second computed() accesses summary.length, the capture is rewritten
 //   to summary.key("length") because summary is a Reactive, not a plain value.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const summary = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("summary", true);
@@ -130,10 +103,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["summary", "charCount"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -42,11 +24,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 },
-    bindingName: "url"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     token: string;
 }, { headers: { Authorization: string; }; }>(({ token }) => ({
@@ -74,16 +51,11 @@ const __cfLift_2 = __cfHelpers.lift<{
     },
     required: ["headers"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 27 },
-    bindingName: "options"
-});
 // CT-1334: computed() with template literal capturing pattern parameter.
 // The `token` from pattern destructuring must be captured as an explicit
 // input to the lift-applied call, so the callback receives the
 // resolved value—not the Reactive proxy.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input: {
+export default pattern((__cf_pattern_input: {
     token: string;
 }) => {
     const token = __cf_pattern_input.key("token");
@@ -121,10 +93,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input: {
         }
     },
     required: ["url", "options"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,15 +30,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-template-literal
 // Verifies: captured cells used inside a template literal expression are extracted
 //   computed(() => `${prefix.get()}${value.get()}`) → lift(...)({ value, prefix })
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -70,10 +47,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,16 +30,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-type-assertion
 // Verifies: a type assertion (`as number`) in the callback body is preserved after capture extraction
 //   computed(() => (value.get() * multiplier.get()) as number) → lift(...)({ value, multiplier })
 // Context: the `as number` cast remains intact in the transformed callback expression
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -71,10 +48,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,16 +45,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 26 },
-    bindingName: "result"
-});
 // FIXTURE: computed-union-undefined
 // Verifies: captured properties with `number | undefined` union types produce correct schemas
 //   computed(() => ...) → lift(...)({ value, config: { required, unionUndefined } })
 // Context: `unionUndefined` schema is `type: ["number", "undefined"]`; `required` is plain `number`
-export default __cfBindVerifiedBinding(pattern((config: Config) => {
+export default pattern((config: Config) => {
     const value = new Writable(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("value", true);
@@ -97,10 +74,7 @@ export default __cfBindVerifiedBinding(pattern((config: Config) => {
     required: ["required", "unionUndefined"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -47,10 +29,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 50 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const n = __cf_pattern_input.key("element");
     const multiplier = __cf_pattern_input.key("params", "multiplier");
@@ -79,10 +57,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 45 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
@@ -110,18 +84,13 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "number"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 27 },
-    bindingName: "doubled"
-});
 // FIXTURE: computed-with-closed-over-cell-map
 // Verifies: .map() on a closed-over Cell inside computed() IS transformed to .mapWithPattern()
 //   computed(() => numbers.map(n => n * multiplier.get())) → lift(({ numbers, multiplier }) => numbers.mapWithPattern(pattern(fn, ...), { multiplier }))({ numbers, multiplier })
 // Context: Unlike Reactive arrays, Cell arrays still need reactive mapping even
 //   inside a lift-applied callback. The .map() callback's closed-over `multiplier` cell
 //   is passed as a params object to mapWithPattern.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const numbers = new Writable([1, 2, 3], {
         type: "array",
         items: {
@@ -145,10 +114,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -70,10 +52,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema, { materializerWriteInputPaths: [["processed"]], completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 11 }
-});
 // FIXTURE: computed-write-capability-materializer
 // Verifies: a computed() that WRITES to a captured cell (`.set(...)`) produces a
 //   write-capability capture, which the lift-applied strategy emits with a
@@ -83,7 +61,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   i.e. the options object stays LAST, after both schemas — NOT scrambled into
 //   the argumentSchema slot. (CT-1625 regression: the function-first reorder
 //   originally appended schemas after the options, corrupting the call.)
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const items = new Writable<Item[]>([{ title: "a" }], {
         type: "array",
         items: {
@@ -142,10 +120,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["title"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/fetch-json-result-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/fetch-json-result-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -75,11 +57,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 26 }
-});
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const __cf_destructure_1 = fetchJson<Item[]>({
         schema: {
             type: "array",
@@ -137,10 +115,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 46 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,10 +50,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 18 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>Item #{item.key("id")}: {item.key("name")}</div>);
@@ -121,17 +99,13 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 15 }
-});
 // FIXTURE: filter-basic
 // Verifies: .filter() + .map() chain on reactive arrays are both transformed
 //   .filter(fn) → .filterWithPattern(pattern(...), {})
 //   .map(fn)    → .mapWithPattern(pattern(...), {})
 // Context: No captured outer variables — params objects are empty {}. Basic
 //   filter-then-map chain where filter checks a boolean field and map renders.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {})}
@@ -194,10 +168,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -64,10 +46,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 18 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("tags") ?? [];
@@ -102,10 +80,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 19 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     return <span>{tag}</span>;
@@ -138,16 +112,12 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 15 }
-});
 // FIXTURE: filter-flatmap-fallback-chain
 // Verifies: fallback receiver chains keep structural array-method lowering
 //   (items ?? []).filter(fn).flatMap(fn).map(fn)
 //     → lift(...)(...).filterWithPattern(...).flatMapWithPattern(...).mapWithPattern(...)
 // Context: Top-level JSX fallback receiver with chained collection methods and a nested callback fallback
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
@@ -210,10 +180,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 43 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,10 +36,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 26 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const suffix = __cf_pattern_input.params.suffix;
@@ -99,10 +77,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 16 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         tags: string[];
@@ -134,10 +108,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 46 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.params.prefix;
@@ -197,10 +167,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 17 }
-});
 // FIXTURE: filter-flatmap-plain-captures
 // Verifies: plain lexical captures in reactive filter/flatMap chains become
 // params values, not reactive key(...) lookups
@@ -208,7 +174,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   items.filter(fn).flatMap(fn) -> filterWithPattern(...).flatMapWithPattern(...)
 // Context: the captures are plain strings, so the lowered callbacks should not
 // route them through key() ownership paths.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const suffix = "!";
     const prefix = "#";
@@ -253,10 +219,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["labels"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,10 +51,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 18 }
-});
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -106,10 +84,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 22 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -184,10 +158,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 15 }
-});
 // FIXTURE: filter-map-chain
 // Verifies: filter+map chain with captured outer variables
 //   .filter(fn) → .filterWithPattern(pattern(...), {})  — no captures
@@ -195,7 +165,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 // Context: The map callback captures state.taxRate from outer scope, so it
 //   appears in the params object and the map body uses a lift-applied
 //   computation for the reactive computation. The filter has no captures (only element properties).
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {
@@ -265,10 +235,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,15 +67,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 29 }
-});
 // FIXTURE: flatmap-basic
 // Verifies: .flatMap() on a reactive array is transformed
 //   .flatMap(fn) → .flatMapWithPattern(pattern(...), {})
 // Context: flatMap renders each item as JSX. No captured outer variables.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").flatMapWithPattern(__cfPattern_1, {})}
@@ -156,10 +134,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,14 +30,10 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.counter.set(state.counter.get() + 1));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 37 }
-});
 // FIXTURE: handler-basic
 // Verifies: inline arrow function in JSX onClick is extracted into a handler with captures
 //   onClick={() => state.counter.set(...)} → onClick={handler(false, { state: { counter: asCell } }, (_, { state }) => ...)({ state: { counter } })}
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
@@ -103,10 +81,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -52,15 +34,11 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["recordMap"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { recordMap }) => recordMap[nextKey()]!.set(counter));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 37 }
-});
 // FIXTURE: handler-computed-key
 // Verifies: handler capturing a Record with computed (dynamic) key access is transformed correctly
 //   onClick={() => recordMap[nextKey()]!.set(counter)) → handler(false, { recordMap: { additionalProperties, asOpaque } }, ...)({ recordMap })
 // Context: Dynamic property access via computed key; Record type uses additionalProperties in schema
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const recordMap = state.key("records");
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({
@@ -111,10 +89,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -81,15 +63,11 @@ const __cfHandler_1 = __cfHelpers.handler({
     state.selectedValue.set(value);
     state.lastItems.set(items.map(i => i.label).join(", "));
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 21 }
-});
 // FIXTURE: handler-destructured-params
 // Verifies: destructured event parameter in inline handler is preserved and schema-typed
 //   onct-change={({ detail: { value, items } }) => ...} → handler(event schema with detail.value + detail.items, capture schema, ({ detail: { value, items } }, { state }) => ...)({ state })
 // Context: Destructured event params retain structure; event schema reflects the destructured shape
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
@@ -143,10 +121,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,15 +50,11 @@ const __cfHandler_1 = __cfHelpers.handler({
     state.selectedValue.set(event.detail.value);
     state.changeCount.set(state.changeCount.get() + 1);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 21 }
-});
 // FIXTURE: handler-event-param
 // Verifies: inline handler with a named event parameter generates event + capture schemas
 //   onct-change={(event) => ...} → handler(event schema with detail.value, capture schema, (event, { state }) => ...)({ state })
 // Context: Typed cf-select event; event param is not destructured, used as event.detail.value
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
@@ -130,10 +108,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-existing-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-existing-reference.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,17 +45,12 @@ const existing = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     console.log(state.count);
 });
-__cfBindVerifiedBinding(existing, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 25 },
-    bindingName: "existing"
-});
 // FIXTURE: handler-existing-reference
 // Verifies: pre-declared handler() call site is NOT re-wrapped; only its schema is generated
 //   existing({ state }) → existing({ state }) (call site unchanged)
 //   handler(fn) at declaration → handler(false, captureSchema, fn) (schema injected at definition)
 // Context: handler() declared outside the pattern; the transform adds schemas but does not re-extract
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<cf-button onClick={existing({ state })}>
         Existing
@@ -116,10 +93,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,15 +47,11 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     const scaled = state.items.map((item) => item.value * state.multiplier);
     console.log(scaled);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
 // FIXTURE: handler-nested-map
 // Verifies: .map() inside a handler body is NOT transformed to .mapWithPattern()
 //   onClick={() => { state.items.map(...) }) → handler(..., (_, { state }) => { state.items.map(...) })
 // Context: .map() on a plain array inside a handler remains a normal JS .map(), not a reactive transform
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
@@ -133,10 +111,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -36,15 +18,11 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     type: "object",
     properties: {}
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => console.log("hi"));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 37 }
-});
 // FIXTURE: handler-no-captures
 // Verifies: inline handler with no captured outer variables still gets wrapped with empty captures
 //   onClick={() => console.log("hi")) → handler(false, { properties: {} }, (_, __cf_handler_params) => ...)({})
 // Context: No closed-over state; capture object is empty
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({})}>
         Log
@@ -88,10 +66,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -41,15 +23,11 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["__cf_handler_event"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event_1, { __cf_handler_event }) => __cf_handler_event);
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 37 }
-});
 // FIXTURE: handler-reserved-capture
 // Verifies: captured variable named __cf_handler_event is renamed to avoid collision with the synthetic event param
 //   onClick={() => __cf_handler_event) → handler(false, { __cf_handler_event: ... }, (__cf_handler_event_1, { __cf_handler_event }) => ...)
 // Context: Edge case -- user variable collides with internal __cf_handler_event name; event param gets suffixed
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const __cf_handler_event = state.key("label");
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({
@@ -95,10 +73,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,15 +32,11 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { state }) => state.counter.set(state.counter.get() + 1));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 37 }
-});
 // FIXTURE: handler-unused-event
 // Verifies: inline handler with an unused event param (_) still generates an event schema placeholder
 //   onClick={(_: unknown) => state.counter.set(...)) → handler(event schema, capture schema, (_, { state }) => ...)({ state })
 // Context: Event param is named _ (unused); transformer emits a generic event schema placeholder
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
@@ -106,10 +84,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -105,12 +87,7 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         flushLater(fileId, content, savedContent, onSaveFile);
     });
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 27 },
-    bindingName: "trigger"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const fileId = __cf_pattern_input.key("fileId");
     const content = __cf_pattern_input.key("content");
     const savedContent = __cf_pattern_input.key("savedContent");
@@ -163,10 +140,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["trigger"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -78,11 +60,6 @@ const Item = pattern((__cf_pattern_input) => {
     },
     required: ["id", "label", "$NAME"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(Item, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 2 },
-    bindingName: "Item"
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -121,11 +98,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     if (existing) {
         return navigateTo(existing);
     }
-});
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 24 },
-    bindingName: "read"
 });
 const __cfHandler_2 = __cfHelpers.handler({
     type: "object",
@@ -186,13 +158,8 @@ const __cfHandler_2 = __cfHelpers.handler({
     items.push(newItem as any);
     return newItem;
 });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 59, col: 6 },
-    bindingName: "write"
-});
 // FIXTURE: hoisted-handler-preserves-capture-schemas (CT-1585 regression)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const self = __cf_pattern_input[__cfHelpers.SELF];
     // `read` action: matches the shape of notebook.tsx's
@@ -257,10 +224,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["read", "write", "$NAME", "$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,11 +31,6 @@ const moduleHasSettings = lift(({ piece }: {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(moduleHasSettings, {
-    sourceFile: "/test.tsx",
-    position: { line: 4, col: 31 },
-    bindingName: "moduleHasSettings"
-});
 const selectMessage = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -70,11 +47,6 @@ const selectMessage = handler({
     required: ["selectedId", "msgId"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, { selectedId, msgId }) => {
     selectedId.set(msgId);
-});
-__cfBindVerifiedBinding(selectMessage, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 2 },
-    bindingName: "selectMessage"
 });
 interface Entry {
     piece: {
@@ -145,10 +117,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 23 }
-});
 const __cfLift_1 = __cfHelpers.lift<{
     msg: {
         type: string;
@@ -170,10 +138,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 14 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     const selectedId = __cf_pattern_input.key("params", "selectedId");
@@ -244,15 +208,11 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 24 }
-});
 // FIXTURE: ifelse-factory-boundaries
 // Verifies: authored ifElse keeps captured property access inside factory boundaries
 //   moduleHasSettings({ piece: entry.piece }) → piece capture stays structural inside lift() call
 //   selectMessage({ selectedId, msgId: msg.id }) → msg.id stays structural inside handler call branch
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const messages = __cf_pattern_input.key("messages");
     const selectedId = new Writable("", {
@@ -340,10 +300,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -61,10 +43,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.isEditing.set(true));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 34 }
-});
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         isEditing: __cfHelpers.ReadonlyCell<boolean>;
@@ -109,15 +87,11 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 22 }
-});
 // FIXTURE: inline-action-in-ternary-branch
 // Verifies: inline arrow handler inside explicit computed() in a ternary branch is extracted and captured in a lift-applied computation
 //   computed(() => <cf-button onClick={() => state.isEditing.set(true)} />) → lift(..., handler(...)(...))({ state: { isEditing: asCell } })
 // Context: Regression -- inline handler inside computed() must have its Cell ref captured in the lift-applied computation
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<cf-card>
         {__cfHelpers.ifElse({
@@ -219,10 +193,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,10 +42,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: lift-result-type-cf-ref-normalized
 // Verifies: a synthesized lift's RESULT type argument that is a commonfabric
 // type (here JSXElement, the type of the returned JSX) is emitted as the
@@ -75,7 +53,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 // (test/no-import-type-in-output.test.ts) guards every path globally; this
 // fixture pins the specific JSX-returning-computed shape with a legible,
 // minimal diff so a regression is obvious here too.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
         [UI]: <div>{__cfLift_1({ count: count })}</div>,
@@ -117,10 +95,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,10 +51,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 19 }
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -92,10 +70,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["index", "state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state, index }) => state.selectedIndex.set(index));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 43 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -175,10 +149,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 25 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
@@ -214,10 +184,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 21 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
@@ -257,16 +223,12 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 11 }
-});
 // FIXTURE: map-and-handler
 // Verifies: .map() in JSX is transformed to .mapWithPattern() and inline handler inside map body is extracted
 //   state.items.map((item, index) => JSX) → state.key("items").mapWithPattern(pattern(...), { state: { discount, selectedIndex } })
 //   onClick={() => state.selectedIndex.set(index)) → handler(false, { state: { selectedIndex: asCell }, index }, ...)
 // Context: Combines reactive array mapping with handler extraction; map callback becomes a sub-pattern
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -341,10 +303,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -79,15 +61,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 24 }
-});
 // FIXTURE: map-array-destructure-lowering
 // Verifies: array destructuring in .map() callback is lowered to index-based key access
 //   .map(([left, right]) => ...) → .mapWithPattern(pattern(...), {})
 //   [left, right] → key("element", "0"), key("element", "1")
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("rows").mapWithPattern(__cfPattern_1, {})}
@@ -141,10 +119,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -76,10 +58,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 19 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element", "0");
     const count = __cf_pattern_input.key("element", "1");
@@ -127,16 +105,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 19 }
-});
 // FIXTURE: map-array-destructure-shorthand
 // Verifies: array-destructured map params are not incorrectly captured as shorthand properties
 //   .map(([item]) => ...) → .mapWithPattern(pattern(...), {}) with key("element", "0")
 //   .map(([item, count], index) → key("element", "0"), key("element", "1"), key("index")
 // Context: Shorthand JSX usage like {item} must not cause array-destructured bindings to be captured
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
@@ -196,10 +170,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -80,10 +62,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 26 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const date = __cf_pattern_input.key("element", "0");
     const pizza = __cf_pattern_input.key("element", "1");
@@ -143,16 +121,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 26 }
-});
 // FIXTURE: map-array-destructured
 // Verifies: array destructuring in .map() is lowered, with and without captured outer state
 //   .map(([date, pizza]) => ...) → .mapWithPattern(pattern(...), {}) with index-based keys
 //   Closing over state.scale → captures { state: { scale: state.key("scale") } }
 // Context: Two map calls — one without captures (empty {}), one with a captured outer variable
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with array destructured parameter */}
@@ -217,10 +191,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,10 +66,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 27 }
-});
 const __cfLift_1 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
@@ -104,10 +82,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 17 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
@@ -124,10 +98,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 27 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const name = person.key("name"), spotPreferences = person.key("spotPreferences");
@@ -197,10 +167,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 28 }
-});
 // FIXTURE: map-body-destructure-cases
 // Verifies: body-local destructuring inside reactive .map() callbacks lowers to key() access
 //   const { spotNumber: sn } = spot        -> sn bound from spot.key("spotNumber")
@@ -208,7 +174,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   spotPreferences.length                 -> spotPreferences.key("length")
 //   spotPreferences.map(...).join(", ")    -> nested plain-array callback stays plain
 // Context: Covers destructuring aliases declared inside the callback body, not only in the parameter list
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<section>
         <ul>
@@ -292,10 +258,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,10 +65,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 27 }
-});
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -120,10 +98,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 19 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -193,10 +167,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 27 }
-});
 // FIXTURE: map-callback-schema-params
 // Verifies: mapWithPattern callback schemas omit params when captures are unused
 // and include params when captures are used
@@ -204,7 +174,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   state.items.map((item) => <span>{item.price * state.discount}</span>)
 //     -> required: ["element", "params"]
 // Context: Both callbacks are pattern-owned JSX maps over the same receiver; only the second closes over outer state
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <section data-kind="unused">
@@ -276,10 +246,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,15 +65,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-capture-cell-fn
 // Verifies: cell() variable closed over in .map() is captured with asCell schema annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { count: count })
 //   cell(0) capture → params.count with { type: "number", asCell: true }
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const count = cell(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
@@ -148,10 +126,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,15 +65,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-capture-cell-of
 // Verifies: new Cell() variable closed over in .map() is captured with asCell schema annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { counter: counter })
 //   new Cell(0) capture → params.counter with { type: "number", asCell: true }
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const counter = new Cell(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
@@ -148,10 +126,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,11 +49,6 @@ const removeItem = handler({
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
-});
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 2 },
-    bindingName: "removeItem"
 });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const _ = __cf_pattern_input.key("element");
@@ -139,16 +116,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 21 }
-});
 // FIXTURE: map-capture-cell-param-no-name
 // Verifies: pattern without generic type param still captures destructured bindings correctly
 //   .map(fn) → .mapWithPattern(pattern(...), { items: items })
 //   items capture → params.items (no asOpaque when schema is inferred from annotation)
 // Context: Same as map-capture-cell-param but uses inline type annotation instead of generic
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input: InputSchema) => {
+export default pattern((__cf_pattern_input: InputSchema) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
@@ -210,10 +183,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input: InputSchema)
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,11 +49,6 @@ const removeItem = handler({
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
-});
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 2 },
-    bindingName: "removeItem"
 });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const _ = __cf_pattern_input.key("element");
@@ -138,16 +115,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 21 }
-});
 // FIXTURE: map-capture-cell-param
 // Verifies: destructured pattern param closed over in .map() is captured as opaque
 //   .map(fn) → .mapWithPattern(pattern(...), { items: items })
 //   items (from pattern destructuring) → params.items with asOpaque: true
 // Context: Captures the parent array as opaque to pass to a handler alongside the map index
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
@@ -209,10 +182,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,10 +42,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const settings = __cf_pattern_input.key("params", "settings");
@@ -117,15 +95,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 25 }
-});
 // FIXTURE: map-capture-derived-from-param
 // Verifies: variable derived from state (const settings = state.settings) is captured correctly
 //   .map(fn) → .mapWithPattern(pattern(...), { settings: { multiplier: settings.key("multiplier") } })
 //   item * settings.multiplier → derive() keeps item as an explicit input and closes over the callback-owned settings param
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const settings = state.key("settings");
     return {
         [UI]: (<div>
@@ -185,10 +159,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -92,10 +74,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 25 }
-});
 // FIXTURE: map-capture-mixed-reactivity
 // Verifies: captures of different reactivity kinds are annotated distinctly in the schema
 //   label (plain string) → params.label (type: "string", accessed via .params)
@@ -104,7 +82,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //       `cell`. (The capture is created with cell(100) but never written here.)
 //   derived (state.threshold) → params.derived (asOpaque: true)
 // Context: Three capture kinds — plain value, cell, and state-derived — in one map callback
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const label = "Result";
     const limit = cell(100, {
         type: "number"
@@ -168,10 +146,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -91,15 +73,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-capture-object-literal
 // Verifies: plain object literal closed over in .map() is captured as a non-reactive param
 //   .map(fn) → .mapWithPattern(pattern(...), { style: style })
 //   style (object literal) → params.style accessed via .params (not .key) since it is non-reactive
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const style = { color: "red", fontSize: 14 };
     return {
         [UI]: (<div>
@@ -154,10 +132,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -87,15 +69,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-capture-writable-of
 // Verifies: new Writable() variable closed over in .map() is captured with asCell annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { selected: selected })
 //   new Writable<string | null>(null) → params.selected with { anyOf: [string, null], asCell: true }
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const selected = new Writable<string | null>(null, {
         anyOf: [{
                 type: "string"
@@ -156,10 +134,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,20 +35,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 39 }
-});
-export const fn = __cfBindVerifiedBinding(lift(() => items.mapWithPattern(__cfPattern_1, {}), false as const satisfies __cfHelpers.JSONSchema, {
+export const fn = lift(() => items.mapWithPattern(__cfPattern_1, {}), false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 },
-    bindingName: "fn"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,9 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_amount_key = nextKey();
@@ -94,16 +73,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 25 }
-});
 // FIXTURE: map-computed-alias-side-effect
 // Verifies: computed property key with side effects is hoisted and used via a lift-applied computation
 //   { [nextKey()]: amount } → __cf_amount_key = nextKey(); lift(...)(...element[__cf_amount_key])
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 // Context: nextKey() has side effects (keyCounter++), so the key expression is evaluated once and cached
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {})}
@@ -153,10 +128,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,9 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     foo: number;
     val: number;
@@ -73,10 +52,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey();
@@ -132,16 +107,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 25 }
-});
 // FIXTURE: map-computed-alias-with-plain-binding
 // Verifies: computed property key mixed with a static destructured binding in the same pattern
 //   { foo, [dynamicKey()]: val } → key binding for foo, lift-applied computation for val
 //   foo + val expression → lift(...)(...) combining both bindings
 // Context: Mixes static destructuring ({foo}) with dynamic computed key ([dynamicKey()]: val)
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {})}
@@ -201,10 +172,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -87,11 +69,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 44 },
-    bindingName: "messageReactions"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");
@@ -153,10 +130,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 36 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     const messageReactions = __cfLift_1({ msg: {
@@ -224,16 +197,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 22 }
-});
 // FIXTURE: map-computed-fallback-alias
 // Verifies: computed() inside a map callback creates a lift-applied computation and nested map is also transformed
 //   computed(() => (msg.reactions ?? [])) → lift(...)(...) with msg.reactions as input
 //   messageReactions.map(fn) → nested .mapWithPattern(pattern(...), { msg: { id: msg.key("id") } })
 // Context: Nested map — outer maps messages, inner maps computed reactions; inner captures msg.id
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
@@ -306,10 +275,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -71,10 +53,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 21 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -108,10 +86,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 16 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -201,16 +175,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 25 }
-});
 // FIXTURE: map-conditional-expression
 // Verifies: ternary expression in .map() callback is transformed to ifElse() with lift-applied branches
 //   item.price > state.threshold ? ... : ... → ifElse(lift(...)(condition), lift(...)(trueBranch), falseBranch)
 //   .map(fn) → .mapWithPattern(pattern(...), { state: { threshold, discount } })
 // Context: Captures state.threshold (for condition) and state.discount (for true branch) from outer scope
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Ternary with captures in map callback */}
@@ -282,10 +252,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -85,11 +67,6 @@ const castVote = handler({
         event,
     ]);
 });
-__cfBindVerifiedBinding(castVote, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 2 },
-    bindingName: "castVote"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     castVote: __cfHelpers.HandlerFactory<VoteEvent, { votes: __cfHelpers.Cell<VoteEvent[]>; }, void>;
     state: {
@@ -147,11 +124,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 24 },
-    bindingName: "boundCastVote"
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -188,10 +160,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     id: item.id,
     step: "single",
 }));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 27 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -294,10 +262,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 25 }
-});
 // FIXTURE: map-conditional-inline-handler-send
 // Verifies: inline onClick handlers inside conditional JSX branches retain
 // imperative handler semantics when nested in reactive map callbacks.
@@ -305,7 +269,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   not lift(...)(...boundCastVote.send(...))
 // Context: The conditional branch makes expression rewriting recurse into the
 // handler subtree; the authored handler arrow must be treated as safe context.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const boundCastVote = __cfLift_1({
         castVote: castVote,
         state: {
@@ -397,10 +361,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -79,16 +61,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 25 }
-});
 // FIXTURE: map-destructure-alias-action-collision
 // Verifies: destructured alias inside map callback body is lowered to explicit key() access
 //   const { spotNumber: sn } = spot → const sn = spot.key("spotNumber")
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 // Context: Body destructuring from opaque map elements becomes explicit key() bindings
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<ul>
         {state.key("spots").mapWithPattern(__cfPattern_1, {})}
@@ -145,10 +123,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,10 +42,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const cost = __cf_pattern_input.key("element", "price");
     const state = __cf_pattern_input.key("params", "state");
@@ -123,16 +101,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 25 }
-});
 // FIXTURE: map-destructured-alias
 // Verifies: object destructuring with alias in .map() param is lowered to key() on the original name
 //   .map(({ price: cost }) => ...) → key("element", "price") assigned to cost
 //   cost * state.discount → lift(...)(...) with both element key and captured state
 // Context: Captures state.discount from outer scope; alias uses the original property name for key access
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -191,10 +165,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,9 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey;
@@ -104,16 +83,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 25 }
-});
 // FIXTURE: map-destructured-computed-alias
 // Verifies: computed property key with a const-asserted identifier is lowered to lift-applied
 //   { [dynamicKey]: val } → __cf_val_key = dynamicKey; lift(...)(...element[__cf_val_key])
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 // Context: dynamicKey is a const-asserted string, not a function call — still uses the lift-applied pattern
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {})}
@@ -173,10 +148,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,15 +54,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 27 }
-});
 // FIXTURE: map-destructured-numeric-alias
 // Verifies: numeric property key destructuring in .map() param is lowered to key() with string index
 //   .map(({ 0: first }) => ...) → key("element", "0") assigned to first
 //   .map(fn) → .mapWithPattern(pattern(...), {})
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("entries").mapWithPattern(__cfPattern_1, {})}
@@ -132,10 +110,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -95,10 +77,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 30 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const tasks = section.key("tasks");
@@ -165,15 +143,11 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 26 }
-});
 // FIXTURE: map-destructured-opaque-local-capture
 // Verifies: destructured opaque locals captured by nested map callbacks stay reactive
 //   const { tasks } = section → const tasks = __cf_pattern_input.key("params", "tasks")
 //   nested tag callback reads tasks.length through key("length"), not plain params values
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     [UI]: (<div>
       {state.key("sections").mapWithPattern(__cfPattern_2, {})}
     </div>),
@@ -244,10 +218,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,10 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 21 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     y: number;
     state: {
@@ -91,10 +69,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 40 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element", "x");
     const y = __cf_pattern_input.key("element", "y");
@@ -165,16 +139,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 26 }
-});
 // FIXTURE: map-destructured-param
 // Verifies: object destructuring in .map() param is lowered to key() calls on each property
 //   .map(({ x, y }) => ...) → key("element", "x"), key("element", "y")
 //   x * state.scale, y * state.scale → lift(...)(...) calls with captured state
 // Context: Captures state.scale from outer scope; destructured element properties used in expressions
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with destructured parameter and capture */}
@@ -242,10 +212,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,15 +54,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 25 }
-});
 // FIXTURE: map-destructured-string-alias
 // Verifies: object destructuring with string-property alias in .map() param is lowered to key()
 //   .map(({ couponCode: code }) => ...) → key("element", "couponCode") assigned to code
 //   .map(fn) → .mapWithPattern(pattern(...), {})
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {})}
@@ -132,10 +110,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,10 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 20 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -125,16 +103,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
 // FIXTURE: map-element-access-opaque
 // Verifies: .map() on reactive array is transformed when callback uses bracket access on a captured opaque object
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {tagCounts: ...}})
 //   state.tagCounts[tag] → lift(...)(...) with opaque schema for dynamic key access
 // Context: Captures state.tagCounts for bracket-notation element access inside map
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("sortedTags").mapWithPattern(__cfPattern_1, {
@@ -191,10 +165,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 28 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -108,16 +86,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 25 }
-});
 // FIXTURE: map-element-computed
 // Verifies: .map() on reactive array is transformed with computed element property access
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 //   item.name.toUpperCase() → lift-applied computation wrapping the computed expression
 // Context: Uses index param; computation on element property triggers a lift-applied wrapper
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Performs computation on element property - should wrap in computed() */}
@@ -181,10 +155,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-generic-type-parameter.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-generic-type-parameter.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -108,12 +90,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["id", "type"]
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 18 },
-    bindingName: "results"
-});
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const results = __cfLift_1({ state: {
             emails: state.key("emails"),
             prompt: state.key("prompt")
@@ -167,10 +144,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["results"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const handleClick = handler({
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
-});
-__cfBindVerifiedBinding(handleClick, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 62 },
-    bindingName: "handleClick"
 });
 interface Item {
     id: number;
@@ -129,15 +106,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 25 }
-});
 // FIXTURE: map-handler-reference-no-name
 // Verifies: .map() transform works when pattern has inline type annotation instead of type arg
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
 // Context: pattern((state: State) => ...) form without <State> generic; handler not captured
-export default __cfBindVerifiedBinding(pattern((state: State) => {
+export default pattern((state: State) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
@@ -206,10 +179,7 @@ export default __cfBindVerifiedBinding(pattern((state: State) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const handleClick = handler({
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
-});
-__cfBindVerifiedBinding(handleClick, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 62 },
-    bindingName: "handleClick"
 });
 interface Item {
     id: number;
@@ -129,15 +106,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 25 }
-});
 // FIXTURE: map-handler-reference-with-type-arg-no-name
 // Verifies: .map() transform works with type arg on pattern but no export name
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
 // Context: Same as map-handler-reference but exercises the <State> type-arg-no-name path
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
@@ -206,10 +179,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const handleClick = handler({
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
-});
-__cfBindVerifiedBinding(handleClick, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 62 },
-    bindingName: "handleClick"
 });
 interface Item {
     id: number;
@@ -129,15 +106,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 25 }
-});
 // FIXTURE: map-handler-reference
 // Verifies: .map() on reactive array is transformed when callback references a module-level handler
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
 // Context: handler() at module scope is NOT captured; state.count is captured for handler args
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
@@ -206,10 +179,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -64,10 +46,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 19 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
@@ -118,16 +96,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 25 }
-});
 // FIXTURE: map-import-reference
 // Verifies: .map() on reactive array is transformed when callback references module-level constants and functions
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 //   formatPrice(item.price * (1 + TAX_RATE)) → lift-applied computation wrapping the expression
 // Context: Module-level constant (TAX_RATE) and function (formatPrice) are NOT captured as reactive params
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Should NOT capture module-level constant or function */}
@@ -188,10 +162,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,10 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 19 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -131,16 +109,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 25 }
-});
 // FIXTURE: map-index-param-used
 // Verifies: .map() on reactive array is transformed when index param is used with a capture
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {offset: ...}})
 //   index + state.offset → lift(...)(...) combining index and captured state
 // Context: Both index parameter and state.offset are used in an expression
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Uses both index parameter and captures state.offset */}
@@ -208,10 +182,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -80,10 +62,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 25 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
@@ -128,16 +106,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 25 }
-});
 // FIXTURE: map-index-shorthand
 // Verifies: .map() on reactive array is transformed when index param uses shorthand names (i, idx)
 //   .map((item, i) => ...) → .mapWithPattern(pattern(...), {})
 //   .map((item, idx) => ...) → .mapWithPattern(pattern(...), {})
 // Context: Two maps using different shorthand index names; no outer captures
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with common shorthand index parameter names */}
@@ -201,10 +175,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -107,10 +89,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 39 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");
@@ -170,10 +148,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 39 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     return (<section>
@@ -249,16 +223,12 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 22 }
-});
 // FIXTURE: map-inline-fallback-receivers
 // Verifies: inline fallback array-method receivers are transformed structurally
 //   (msg.reactions ?? []).map(fn) → lift(...)(...).mapWithPattern(pattern(...), { msg: { id: ... } })
 //   (msg.reactions || []).map(fn) → lift(...)(...).mapWithPattern(pattern(...), { msg: { id: ... } })
 // Context: Nested map — outer maps messages, inner fallback receivers capture msg.id and message-local reaction data
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
@@ -337,10 +307,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,11 +41,6 @@ const removeItem = handler({
     if (index >= 0) {
         items.set(currentItems.toSpliced(index, 1));
     }
-});
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 2 },
-    bindingName: "removeItem"
 });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
@@ -127,16 +104,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 25 }
-});
 // FIXTURE: map-inside-ifelse-with-handler
 // Verifies: .map() inside an ifElse branch is still transformed to mapWithPattern
 //   .map(fn) → .mapWithPattern(pattern(...), {items: ...})
 //   hasItems ternary → ifElse(...)
 // Context: Map nested inside ifElse; handler references both the items array and iterator variable
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const hasItems = __cf_pattern_input.key("hasItems");
     // CT-1035: Map inside ifElse branches should transform to mapWithPattern
@@ -219,10 +192,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -73,10 +55,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["name", "active"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 15 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return entry.key("active");
@@ -100,10 +78,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 18 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return <span>{entry.key("name")}</span>;
@@ -145,17 +119,13 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 15 }
-});
 // FIXTURE: map-jsx-map-filter-chain
 // Verifies: chained .map().filter().map() on reactive array all transform
 //   .map(fn)    → .mapWithPattern(pattern(...), {})
 //   .filter(fn) → .filterWithPattern(pattern(...), {})
 //   .map(fn)    → .mapWithPattern(pattern(...), {})
 // Context: Three-step chain; no outer captures in any callback
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const list = __cf_pattern_input.key("list");
     return {
         [UI]: (<div>
@@ -216,10 +186,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 41 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,10 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 22 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_1({ item: item }).for("__patternResult", true);
@@ -61,17 +39,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 12 }
-});
 // FIXTURE: map-local-helper-call-root
 // Verifies: non-JSX pattern-owned map callbacks lift ordinary local helper
 //   calls as whole callback-local lift-applied computations rather than lowering only the inner
 //   receiver-method argument expression.
 //   items.map((item) => identity(item.toUpperCase()))
 //   -> mapWithPattern(..., ({ item }) => lift(({ item }) => identity(item.toUpperCase()))(...))
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return items.mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
 }, {
@@ -90,10 +64,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 44 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,10 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 20 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -169,10 +147,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 25 }
-});
 // FIXTURE: map-multiple-captures
 // Verifies: .map() on reactive array captures multiple outer variables (state + local)
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount, taxRate}, multiplier})
@@ -183,7 +157,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   is also wired in as an explicit lift-applied input so the callback stays
 //   self-contained; module-level `shippingCost` is left lexical (module-scope
 //   bindings are stable across hoist boundaries).
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const multiplier = 2;
     return {
         [UI]: (<div>
@@ -256,10 +230,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -93,10 +75,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 13 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -180,16 +158,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 25 }
-});
 // FIXTURE: map-multiple-similar-captures
 // Verifies: .map() correctly captures multiple state properties with the same leaf name
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {checkout: {discount}, upsell: {discount}}})
 //   expression → lift(...)(...) with both discount paths distinguished
 // Context: state.checkout.discount and state.upsell.discount share the name "discount" but are separate captures
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -268,10 +242,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -104,10 +86,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 29 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -197,16 +175,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 25 }
-});
 // FIXTURE: map-nested-callback
 // Verifies: nested .map() calls on reactive arrays are each transformed independently
 //   outer .map(fn) → .mapWithPattern(pattern(...), {state: {prefix}})
 //   inner .map(fn) → .mapWithPattern(pattern(...), {item: {name}})
 // Context: Inner map captures item.name from the outer map callback scope
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Outer map captures state.prefix, inner map closes over item from outer callback */}
@@ -292,10 +266,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -114,15 +96,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 25 }
-});
 // FIXTURE: map-nested-property
 // Verifies: .map() on reactive array captures nested property access on state
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {currentUser: {firstName, lastName}}})
 // Context: Captures state.currentUser.firstName and state.currentUser.lastName as nested property paths
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -204,10 +182,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -82,15 +64,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 25 }
-});
 // FIXTURE: map-no-captures
 // Verifies: .map() on reactive array is transformed even with no captured outer variables
 //   .map(fn) → .mapWithPattern(pattern(...), {})
 // Context: Callback only references its own parameter (item); captures object is empty
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* No captures - just uses the callback parameter */}
@@ -151,10 +129,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -79,15 +61,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 25 }
-});
 // FIXTURE: map-outer-element
 // Verifies: .map() on reactive array captures a local variable aliased from state
 //   .map(fn) → .mapWithPattern(pattern(...), {element: ...})
 // Context: Local const "element" aliases state.highlight; captured as params.element inside the map pattern
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const element = state.key("highlight");
     return {
         [UI]: (<div>
@@ -139,10 +117,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-paren-wrapped-callback.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -57,18 +39,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 24 },
-    bindingName: "out"
-});
 // FIXTURE: map-paren-wrapped-callback
 // Verifies: a parenthesized inline map callback lowers exactly like its bare
 //   spelling — rows.map(((r) => r.label)) → rows.mapWithPattern(pattern(...))
 // Context: paren-invariance (target spec §5.7) at the extraction seam; a blind
 //   arguments[0] read here once skipped the lowering entirely, emitting a raw
 //   reactive .map that throws at runtime
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const out = rows.mapWithPattern(__cfPattern_1, {}).for("out", true);
     return { out };
@@ -105,10 +82,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["out"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 40 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -79,11 +61,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 37 },
-    bindingName: "isEditing"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         removePersonConfirmTarget: string | null;
@@ -113,11 +90,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 43 },
-    bindingName: "isRemoveConfirm"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         spots: {
@@ -175,11 +147,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         required: ["label", "value"]
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 55, col: 42 },
-    bindingName: "activeSpotOpts"
-});
 const __cfLift_4 = __cfHelpers.lift<{
     activeSpotOpts: {
         length: number;
@@ -201,10 +168,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 75, col: 15 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
@@ -221,10 +184,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 76, col: 15 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
@@ -241,10 +200,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 79, col: 30 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -504,17 +459,13 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 26 }
-});
 // FIXTURE: map-parking-style-join
 // Verifies: nested plain-array joins inside a reactive map callback stay plain in complex branches
 //   state.people.map(fn)                    -> state.key("people").mapWithPattern(pattern(...), ...)
 //   state.spots.filter(...).map(... )       -> lift(...)(...).filter(...).map(...) stays plain inside computed()
 //   spotPreferences.map((n) => "#" + n)     -> nested plain-array callback stays plain and does not capture n
 // Context: Realistic callback body mixing computed aliases, destructuring, conditional JSX, and joined plain-array labels
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("people").mapWithPattern(__cfPattern_1, {
@@ -636,10 +587,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,11 +65,6 @@ const EntryRow = pattern((input) => ({
     },
     required: ["rendered", "$UI", "$NAME"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(EntryRow, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 46 },
-    bindingName: "EntryRow"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const row = EntryRow({
@@ -139,10 +116,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["ui", "n"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 20 }
-});
 // FIXTURE: map-pattern-factory-result-key-access (CT-1586)
 // Verifies: `row[K]` where K is a well-known CF computed key (UI or NAME)
 // and row is a pattern-factory result inside a JSX-context map callback
@@ -153,7 +126,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 // lowering lets tracked-opaque static-key access take precedence over the
 // JSX dynamic-wrap heuristic. Covers both UI and NAME on the same row to
 // exercise the common well-known-key cases through the same fix path.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const filtered = __cf_pattern_input.key("filtered");
     return ({
         [UI]: (<div>
@@ -220,10 +193,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-callback-local-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-callback-local-comparison.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,11 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 26 },
-    bindingName: "isToday"
-});
 // FIXTURE: map-plain-array-callback-local-comparison
 // Verifies: a callback-local binding inside a plain-array .map() lowers like the
 // same binding in the pattern body
@@ -73,7 +50,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   isToday as a JSX ternary condition      -> ifElse over the lifted binding
 // Context: The fixed-column calendar shape — a plain index array mapped inside
 // JSX, with the per-column comparison named before it is used as a condition
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const weekDates = __cf_pattern_input.key("weekDates");
     const todayDate = __cf_pattern_input.key("todayDate");
     return {
@@ -139,10 +116,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-dynamic-checkbox.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-dynamic-checkbox.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -45,7 +27,7 @@ interface Input {
 //   Object.entries(...).map(fn)                     -> plain .map() remains plain
 //   selectedScopes[key as keyof SelectedScopes]     -> lift-applied binding with selectedScopes and key captures
 // Context: Dynamic property access in a plain array callback used as a cf-checkbox binding
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const selectedScopes = __cf_pattern_input.key("selectedScopes");
     return {
         [UI]: (<div>
@@ -107,10 +89,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -57,10 +39,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 17 }
-});
 // FIXTURE: map-plain-array-no-transform
 // Verifies: .map() on a plain (non-reactive) array is NOT transformed to mapWithPattern
 //   plainArray.map(fn) → plainArray.map(fn) (unchanged)
@@ -68,7 +46,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   lift-applied computation, with `n` (the plain-array element) wired in as an explicit
 //   lift-applied input so the callback stays self-contained.
 // Context: NEGATIVE TEST for callback-root ownership -- the array is a local literal [1,2,3,4,5], not a reactive Cell array
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const plainArray = [1, 2, 3, 4, 5];
     return {
         [UI]: (<div>
@@ -118,10 +96,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -97,11 +79,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 33 },
-    bindingName: "doneToday"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");
@@ -193,16 +170,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 27 }
-});
 // FIXTURE: map-plain-array-some-alias-in-computed
 // Verifies: aliasing the result of .get() inside computed() still keeps nested plain-array callbacks plain
 //   const logList = logs.get()
 //   logList.some(fn) -> plain JS some(fn), not callback-lowered
 // Context: Outer habits.map(...) is pattern-owned, but the inner some() runs on the aliased unwrapped array inside computed()
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const habits = __cf_pattern_input.key("habits");
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
@@ -288,10 +261,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -94,11 +76,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 33 },
-    bindingName: "doneToday"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");
@@ -190,16 +167,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 27 }
-});
 // FIXTURE: map-plain-array-some-in-computed
 // Verifies: plain-array callbacks nested inside computed() remain plain even inside a reactive outer map callback
 //   habits.map(fn) -> habits.mapWithPattern(...)
 //   computed(() => logs.get().some(fn)) -> lift(...)(...) whose inner some(fn) stays plain JS
 // Context: The outer callback is pattern-owned, but the inner some() callback runs on the unwrapped logs array inside computed()
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const habits = __cf_pattern_input.key("habits");
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
@@ -285,10 +258,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -57,10 +39,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 40 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("subItems").mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
@@ -98,10 +76,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 12 }
-});
 // FIXTURE: map-receiver-key-lowering
 // Verifies: nested .map() calls are both transformed, with receiver lowered to .key()
 //   items.map(fn) → items.mapWithPattern(pattern(...), {})
@@ -150,11 +124,6 @@ const _p = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(_p, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 26 },
-    bindingName: "_p"
-});
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,10 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 34 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{__cfLift_1({ item: item })}</span>;
@@ -79,10 +57,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 17 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => identity(item.toUpperCase()), {
@@ -96,10 +70,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 34 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{__cfLift_2({ item: item })}</span>;
@@ -132,15 +102,11 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 17 }
-});
 // FIXTURE: map-receiver-method-roots
 // Verifies: receiver-method roots inside pattern-owned map callbacks lower reactively
 //   item.toUpperCase()            → callback-local lift-applied computation
 //   identity(item.toUpperCase())  → call-argument receiver-method root lowered reactively
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return ({
         [UI]: (<div>
@@ -188,10 +154,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 44 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -40,11 +22,6 @@ const passthrough = lift((items: string[]) => items, {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(passthrough, {
-    sourceFile: "/test.tsx",
-    position: { line: 4, col: 25 },
-    bindingName: "passthrough"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -72,11 +49,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 25 },
-    bindingName: "inner"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
@@ -96,11 +68,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 25 },
-    bindingName: "foo"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -114,10 +81,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 29 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_3({ item: item }).for("__patternResult", true);
@@ -132,10 +95,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 19 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
@@ -158,11 +117,6 @@ const __cfLift_4 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 32 },
-    bindingName: "fromComputed"
-});
 const __cfLift_5 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -176,10 +130,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 29 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_5({ item: item }).for("__patternResult", true);
@@ -194,10 +144,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 19 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
@@ -220,11 +166,6 @@ const __cfLift_6 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 28 },
-    bindingName: "fromLift"
-});
 const __cfLift_7 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -238,10 +179,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 29 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_7({ item: item }).for("__patternResult", true);
@@ -256,10 +193,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 19 }
-});
 const __cfLift_8 = __cfHelpers.lift(() => {
     const foo = wish<Default<string[], [
     ]>>({ query: "#items" }, {
@@ -271,11 +204,6 @@ const __cfLift_8 = __cfHelpers.lift(() => {
     } as const satisfies __cfHelpers.JSONSchema).result!;
     return foo.mapWithPattern(__cfPattern_3, {});
 }, false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 28 },
-    bindingName: "fromWish"
-});
 const __cfLift_9 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
@@ -295,11 +223,6 @@ const __cfLift_9 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 25 },
-    bindingName: "foo"
-});
 const __cfLift_10 = __cfHelpers.lift<{
     item: {
         length: number;
@@ -321,10 +244,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 42 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_10({ item: {
@@ -341,11 +260,6 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 32 },
-    bindingName: "filtered"
-});
 const __cfLift_11 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item + "!", {
@@ -359,10 +273,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 34 }
-});
 const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_11({ item: item }).for("__patternResult", true);
@@ -377,10 +287,6 @@ const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 24 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
@@ -404,11 +310,6 @@ const __cfLift_12 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 32 },
-    bindingName: "fromFiltered"
-});
 const __cfLift_13 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
@@ -428,11 +329,6 @@ const __cfLift_13 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_13, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 25 },
-    bindingName: "foo"
-});
 const __cfLift_14 = __cfHelpers.lift<{
     item: {
         length: number;
@@ -454,10 +350,6 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_14, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 42 }
-});
 const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_14({ item: {
@@ -474,11 +366,6 @@ const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 32 },
-    bindingName: "filtered"
-});
 const __cfLift_15 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item.toUpperCase(), {
@@ -492,10 +379,6 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_15, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 34 }
-});
 const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_15({ item: item }).for("__patternResult", true);
@@ -510,10 +393,6 @@ const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 24 }
-});
 const __cfLift_16 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
@@ -537,11 +416,6 @@ const __cfLift_16 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_16, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 46 },
-    bindingName: "fromFilteredReceiverMethod"
-});
 // FIXTURE: map-regains-reactive-aliases
 // Verifies: compute-owned aliases that still resolve to reactive array roots
 // are rewritten back to mapWithPattern/filterWithPattern when used in pattern
@@ -554,7 +428,7 @@ __cfBindVerifiedBinding(__cfLift_16, {
 //                                                   -> receiver-method body still lowers to a lift-applied computation
 // Context: contrasts with the existing plain-array compute fixtures where the
 // callback receiver really is compute-owned plain JS data.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const inner = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("inner", true);
@@ -616,10 +490,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["fromComputed", "fromLift", "fromWish", "fromFiltered", "fromFilteredReceiverMethod"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 44 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-result-cell-preserved.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-result-cell-preserved.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -100,11 +82,6 @@ const Sub = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(Sub, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 47 },
-    bindingName: "Sub"
-});
 export interface Input {
     items: Item[];
 }
@@ -154,12 +131,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 25 },
-    bindingName: "subs"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const subs = items.mapWithPattern(__cfPattern_1, {}).for("subs", true);
     return { subs };
@@ -220,10 +192,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["title"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,10 +54,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 10 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
@@ -119,10 +97,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 27 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>(({ items }) => (items as Item[] | undefined) ?? [], {
@@ -163,10 +137,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 10 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
@@ -210,10 +180,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 51 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>(({ items }) => (items satisfies Item[] | undefined) ?? [], {
@@ -254,10 +220,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 10 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);
@@ -301,17 +263,13 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 58 }
-});
 // FIXTURE: map-root-fallback-wrappers
 // Verifies: top-level fallback receiver roots keep structural array-method lowering across wrapper forms
 //   (items ?? []).map(fn)                             -> lift(...)(...).mapWithPattern(...)
 //   ((items as Item[] | undefined) ?? []).map(fn)     -> cast-wrapped fallback still lowers
 //   ((items satisfies Item[] | undefined) ?? []).map  -> satisfies-wrapped fallback still lowers
 // Context: All three forms are direct JSX roots rather than nested property fallback receivers
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
@@ -370,10 +328,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 43 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,10 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -133,15 +111,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-single-capture-no-name
 // Verifies: .map() transform with single capture works when pattern uses inline type annotation
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
 // Context: pattern((state: State) => ...) form without <State> generic type arg
-export default __cfBindVerifiedBinding(pattern((state: State) => {
+export default pattern((state: State) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -200,10 +174,7 @@ export default __cfBindVerifiedBinding(pattern((state: State) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,10 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -133,15 +111,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-single-capture-with-type-arg-no-name
 // Verifies: .map() transform with single capture works with type arg on pattern
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
 // Context: Same as map-single-capture but exercises the type-arg-no-name code path
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -200,10 +174,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,10 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -133,15 +111,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 25 }
-});
 // FIXTURE: map-single-capture
 // Verifies: .map() on reactive array captures a single outer state property
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
 //   item.price * state.discount → lift(...)(...) combining element and captured state
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {state.key("items").mapWithPattern(__cfPattern_1, {
@@ -200,10 +174,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -73,10 +55,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["n", "u"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 12 }
-});
 // FIXTURE: map-symbol-key-access
 // Verifies: .map() on reactive array is transformed when callback uses symbol key access
 //   .map(fn) → .mapWithPattern(pattern(...), {})
@@ -125,11 +103,6 @@ const _p = pattern((__cf_pattern_input) => {
         required: ["n", "u"]
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(_p, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 26 },
-    bindingName: "_p"
-});
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -75,10 +57,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 16 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -152,16 +130,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 25 }
-});
 // FIXTURE: map-template-literal
 // Verifies: .map() on reactive array is transformed when callback uses a template literal with captures
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {prefix, suffix}})
 //   `${state.prefix} ${item.name} ${state.suffix}` → lift-applied computation wrapping the template
 // Context: Template literal interpolations reference both element and captured state properties
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Template literal with captures */}
@@ -233,10 +207,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,11 +51,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 28 },
-    bindingName: "hasItems"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         tags: {
@@ -103,10 +80,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 23 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");
@@ -183,10 +156,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 31 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");
@@ -279,10 +248,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 20 }
-});
 // FIXTURE: map-ternary-inside-nested-map
 // Verifies: ternaries inside nested .map() callbacks are transformed to ifElse
 //   outer ternary → ifElse(hasItems, items.mapWithPattern(...), <p>No items</p>)
@@ -290,7 +255,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   inner .map(fn) → .mapWithPattern(pattern(...), {showInactive})
 //   inner ternary → ifElse(tag.active, tag.name, ifElse(showInactive, `(${tag.name})`, ""))
 // Context: Nested maps with ternaries at both levels; captures showInactive through both map layers
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const showInactive = __cf_pattern_input.key("showInactive");
     const hasItems = __cfLift_1({ items: items }).for("hasItems", true);
@@ -393,10 +358,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,11 +51,6 @@ const removeItem = handler({
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, item }) => {
     items.remove(item);
-});
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 2 },
-    bindingName: "removeItem"
 });
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
@@ -140,16 +117,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 19 }
-});
 // FIXTURE: map-wish-default-handler-capture
 // Verifies: wish<Default<Array<T>, []>>().result maps still lower to mapWithPattern with handler captures
 //   wish<Default<Item[], []>>(...).result!.map(fn) -> mapWithPattern(pattern(...), { items: items })
 //   removeItem({ items, item })                    -> captures both the reactive array and the current element
 // Context: The array comes from wish().result rather than a pattern param or a local cell
-export default __cfBindVerifiedBinding(pattern((_) => {
+export default pattern((_) => {
     const __cf_destructure_1 = wish<Default<Item[], [
     ]>>({ query: "#items" }, {
         type: "array",
@@ -216,10 +189,7 @@ export default __cfBindVerifiedBinding(pattern((_) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 46 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -74,16 +56,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 19 }
-});
 // FIXTURE: map-with-array-param-no-name
 // Verifies: .map() with array param works when pattern uses inline type annotation
 //   .map((item, index, array) => ...) → .mapWithPattern(pattern(...), {})
 //   array.length → array.key("length")
 // Context: Same as map-with-array-param but with (_state: any) inline annotation instead of type arg
-export default __cfBindVerifiedBinding(pattern((_state: any) => {
+export default pattern((_state: any) => {
     const items = cell([1, 2, 3, 4, 5], {
         type: "array",
         items: {
@@ -124,10 +102,7 @@ export default __cfBindVerifiedBinding(pattern((_state: any) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -74,16 +56,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 19 }
-});
 // FIXTURE: map-with-array-param
 // Verifies: .map() on reactive array is transformed when the third parameter (array) is used
 //   .map((item, index, array) => ...) → .mapWithPattern(pattern(...), {})
 //   array.length → array.key("length")
 // Context: All three .map() callback params (element, index, array) are used; no outer captures
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell([1, 2, 3, 4, 5], {
         type: "array",
         items: {
@@ -124,10 +102,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,10 +45,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["background"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 29 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     secondToggle: __cfHelpers.ReadonlyCell<boolean>;
 }, { background: string; }>(({ secondToggle }) => {
@@ -91,10 +69,6 @@ const __cfLift_2 = __cfHelpers.lift<{
     },
     required: ["background"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 31 }
-});
 // FIXTURE: nested-computed-in-ifelse
 // Verifies: computed() inside ifElse branches transforms to the lift-applied form without double-wrapping .get()
 //   computed(() => { secondToggle.get(); ... }) → lift(({ secondToggle }) => { secondToggle.get(); ... })({ secondToggle })
@@ -102,7 +76,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 // Context: Regression test — .get() inside a computed() that is nested within
 //   an ifElse branch must NOT get an extra lift-applied wrapper, since computed is
 //   already a safe reactive context.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const showOuter = new Writable(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showOuter", true);
@@ -164,10 +138,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 51 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -141,11 +123,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 19 },
-    bindingName: "ranked"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     ranked: OptionTally[];
 }, OptionTally[]>(({ ranked }) => enrichTallies(ranked), {
@@ -229,11 +206,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 41, col: 21 },
-    bindingName: "enriched"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const voter = __cf_pattern_input.key("element");
     return <span>{voter.key("name")}</span>;
@@ -272,10 +244,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 37 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const tally = __cf_pattern_input.key("element");
     return (<div>{tally.key("voters").mapWithPattern(__cfPattern_1, {})}</div>);
@@ -340,10 +308,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 24 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const voter = __cf_pattern_input.key("element");
     return <span>{voter.key("name")}</span>;
@@ -382,10 +346,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 37 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const tally = __cf_pattern_input.key("element");
     return (<div>{tally.key("voters").mapWithPattern(__cfPattern_3, {})}</div>);
@@ -450,11 +410,7 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 51, col: 26 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const votes = __cf_pattern_input.key("votes");
     const options = __cf_pattern_input.key("options");
     const ranked = __cfLift_1({
@@ -541,10 +497,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,11 +42,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["assignName"]
 } as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name));
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 27 },
-    bindingName: "setAssign"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.PerSpace<__cfHelpers.Cell<Person[]>>;
 }, readonly Person[]>(({ people }) => people.get(), {
@@ -110,10 +87,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 14 }
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -139,10 +112,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["p", "setAssign"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }));
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 25 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const p = __cf_pattern_input.key("element");
     const setAssign = __cf_pattern_input.key("params", "setAssign");
@@ -210,10 +179,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 38 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const people = __cf_pattern_input.key("params", "people");
@@ -299,10 +264,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 18 }
-});
 // FIXTURE: nested-map-fallback-receiver
 // Verifies: a fallback-receiver array method — (reactiveCall() ?? []).map(...) —
 //   nested INSIDE another .map() callback is lowered to mapWithPattern, so its
@@ -317,7 +278,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   scope cannot be accessed via closure"). The `?? []` guard (correct for the
 //   scoped-cell-undefined-before-sync race) is exactly what hid the reactive
 //   receiver from the transformer.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const people = Writable.perSpace.of<Person[]>([], {
         type: "array",
@@ -402,10 +363,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-binding-key-destructure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-binding-key-destructure.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -33,7 +15,7 @@ const key = "foo" as const;
 // FIXTURE: pattern-computed-binding-key-destructure
 // Verifies: computed binding-name destructuring is lowered structurally
 //   ({ [key]: foo }) → const foo = __cf_pattern_input.key(key)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key(key);
     return <div>{foo}</div>;
 }, {
@@ -64,10 +46,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 40 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-literal-member-default.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-literal-member-default.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -32,7 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: pattern-computed-literal-member-default
 // Verifies: literal-member destructuring defaults survive into schema defaults
 //   ({ ["foo"]: foo = "fallback" }) → schema default on "foo"
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     return <div>{foo}</div>;
 }, {
@@ -67,10 +49,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-reactive-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,18 +30,13 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "number"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 27 },
-    bindingName: "doubled"
-});
 // FIXTURE: pattern-computed-reactive-map
 // Verifies: .map() on a Reactive inside computed() is NOT transformed to mapWithPattern
 //   computed(() => items.map((n) => n * 2)) → lift(({ items }) => items.map((n) => n * 2))({ items })
 // Context: Inside the lift-applied computation, Reactive auto-unwraps to a plain array, so
 //   .map() is a standard Array.prototype.map — it must remain untransformed.
 //   This is a negative test for reactive method detection.
-export default __cfBindVerifiedBinding(pattern((items) => {
+export default pattern((items) => {
     // items is Reactive<number[]> as a pattern parameter
     // Inside the computed callback (which becomes a lift-applied computation), items.map should NOT be transformed
     const doubled = __cfLift_1({ items: items }).for("doubled", true);
@@ -74,10 +51,7 @@ export default __cfBindVerifiedBinding(pattern((items) => {
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 33 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-interface-default-sibling-fields.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-interface-default-sibling-fields.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ interface Input {
 // Verifies: interface-backed destructuring defaults keep schema defaults and non-default sibling fields
 //   ({ foo = "fallback", count = 0 }) → schema defaults for foo/count
 //   enabled stays present in the input schema even though it is not destructured
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const count = __cf_pattern_input.key("count");
     return (<div>
@@ -80,10 +62,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,11 +51,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 28 },
-    bindingName: "hasItems"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     i: number;
     item: {
@@ -99,10 +76,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 21 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const i = __cf_pattern_input.key("index");
@@ -182,10 +155,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 31 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>
@@ -256,10 +225,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 20 }
-});
 // FIXTURE: pattern-nested-jsx-map
 // Verifies: nested .map() calls in JSX both become mapWithPattern, including inside ifElse
 //   items.map((item) => ...) → items.mapWithPattern(pattern(...))
@@ -269,7 +234,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 // Context: Inner map on item.tags captures `item.selectedIndex` from the outer
 //   mapWithPattern, so it must be passed as a param. Ternaries become ifElse at
 //   both the outer and inner levels.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const hasItems = __cfLift_1({ items: items }).for("hasItems", true);
     return {
@@ -365,10 +330,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -45,11 +27,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 27 },
-    bindingName: "preview"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     result?: any;
 }, any>(({ result }) => result?.title ?? "Untitled", {
@@ -58,17 +35,13 @@ const __cfLift_2 = __cfHelpers.lift<{
         result: true
     }
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 15 }
-});
 // FIXTURE: pattern-opaque-destructure-temporary-root-names
 // Verifies: destructured opaque temporaries preserve generated root suffixes
 //   const { result } = generateObject(...) uses the synthesized __cf_destructure_* binding consistently
 // NOTE (CT-1800): generateObject's `result` is declared optional, so the captured
 //   `result` is emitted optional (absent from `required`). The lift therefore
 //   fires while pending, keeping the `?? "Untitled"` fallback live.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     const preview = __cfLift_1({ messages: messages }).for("preview", true);
     const __cf_destructure_1 = generateObject({
@@ -113,10 +86,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 47 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -82,18 +64,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["req"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 24 },
-    bindingName: "body"
-});
 // FIXTURE: pattern-optional-destructured-capture
 // Verifies: an optional pattern input (`opt?`) destructured and captured in a
 //   closure is emitted optional in the derived lift's input schema (so it does
 //   not gate the lift), while `ud: T | undefined` (no `?`) stays required. A
 //   renamed binding tracks its source property's optionality whether the source
 //   key is an identifier (`ren: renamed`) or a string literal (`"q-opt": qOpt`).
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const req = __cf_pattern_input.key("req");
     const opt = __cf_pattern_input.key("opt");
     const ud = __cf_pattern_input.key("ud");
@@ -147,10 +124,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -61,17 +43,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 16 }
-});
 // FIXTURE: pattern-preserve-opaque-input
 // Verifies: Writable<T> pattern input is preserved as an opaque ref, with JSX .get() wrapped in a lift-applied computation
 //   input.key("foo").get() in JSX → lift(({ input }) => input.key("foo").get())({ input })
 // Context: When the pattern parameter is typed as Writable<State>, the input
 //   schema uses asOpaque: true. The .get() call inside JSX is not in a safe
 //   reactive context, so it gets wrapped in a lift-applied computation.
-export default __cfBindVerifiedBinding(pattern((input: Writable<State>) => {
+export default pattern((input: Writable<State>) => {
     return {
         [UI]: <div>{__cfLift_1({ input: input })}</div>,
     };
@@ -121,10 +99,7 @@ export default __cfBindVerifiedBinding(pattern((input: Writable<State>) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-self-computed-destructure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-self-computed-destructure.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,11 +35,6 @@ const _p = pattern((__cf_pattern_input) => {
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(_p, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 33 },
-    bindingName: "_p"
-});
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-static-default-destructure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-static-default-destructure.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,7 +21,7 @@ interface State {
 //   default values → schema: { title: { type: "string", default: "Untitled" }, count: { type: "number", default: 0 } }
 // Context: Static default values in the destructuring pattern are lifted into
 //   the JSON schema as "default" annotations rather than kept as JS defaults.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const count = __cf_pattern_input.key("count");
     return {
@@ -87,10 +69,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,10 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 20 }
-});
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;
@@ -90,18 +68,13 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 39 },
-    bindingName: "grepTool"
-});
 // FIXTURE: patternTool-basic-capture
 // Verifies: patternTool's first arg is a pattern() (CT-1655); `content` is a
 //   genuine pattern input supplied via extraParams.
 //   patternTool(pattern(({ query, content }) => …), { content })
 // Context: `content` appears in the pattern callback's destructured input and is
 //   pre-filled through extraParams.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const grepTool = patternTool(__cfPattern_1, { content: content.for(["grepTool", 1, "content"], true) });
     return { grepTool };
 }, {
@@ -150,10 +123,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 25 },
-    bindingName: "genResult"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     content: string;
 }, string>(({ content }) => content, {
@@ -68,11 +45,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 25 },
-    bindingName: "genResult"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     genResult: {
         pending: boolean;
@@ -102,10 +74,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 22 }
-});
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     language: string;
     content: string;
@@ -134,18 +102,13 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 12 },
-    bindingName: "tool"
-});
 // FIXTURE: patternTool-local-var
 // Verifies: patternTool's first arg is a pattern() (CT-1655); `content` is a
 //   genuine pattern input supplied via extraParams, while the pattern-local
 //   `genResult` (from generateText) stays a local binding (not pulled into
 //   extraParams).
 //   patternTool(pattern(({ language, content }) => …genResult…), { content })
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const tool = patternTool(__cfPattern_1, { content: content.for(["tool", 1, "content"], true) });
     return { tool };
 }, {
@@ -194,10 +157,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,10 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 20 }
-});
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
 }) => {
@@ -73,11 +51,6 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 35 },
-    bindingName: "tool"
-});
 // FIXTURE: patternTool-multiple-captures
 // Verifies: patternTool's first arg is an explicit pattern() (CT-1655) with no
 //   explicit extraParams. The free module-scoped reactive captures `prefix` and
@@ -87,7 +60,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   patternTool(pattern(({ value }) => …prefix.get()…multiplier.get()…))
 // Context: Both `prefix` and `multiplier` are module-scoped new Writable() values;
 //   `value` is the pattern's only per-call input.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const tool = patternTool(__cfPattern_1);
     return { tool };
 }, {
@@ -132,10 +105,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,10 +36,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 20 }
-});
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;
@@ -85,17 +63,12 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 35 },
-    bindingName: "tool"
-});
 // FIXTURE: patternTool-no-captures
 // Verifies: patternTool's first arg is a pattern() (CT-1655) with no extraParams.
 //   patternTool(pattern(({ query, content }) => …))
 // Context: The pattern callback only references its own parameters (query,
 //   content) and no module-scoped reactive variables, so no extraParams.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const tool = patternTool(__cfPattern_1);
     return { tool };
 }, {
@@ -140,10 +113,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,10 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 22 }
-});
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
     offset: number;
@@ -87,11 +65,6 @@ const __cfPattern_1 = pattern((__cf_pattern_input: {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 12 },
-    bindingName: "tool"
-});
 // FIXTURE: patternTool-with-existing-params
 // Verifies: patternTool's first arg is an explicit pattern() (CT-1655). The
 //   author supplies `offset` via extraParams (a genuine per-call input); the
@@ -100,7 +73,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   extraParams — auto-capture-into-extraParams was removed when patternTool
 //   began requiring an explicit pattern.
 //   patternTool(pattern(({ value, offset }) => …multiplier.get()…), { offset })
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const tool = patternTool(__cfPattern_1, { offset: offset.for(["tool", 1, "offset"], true) });
     return { tool };
 }, {
@@ -149,10 +122,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 54 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,10 +65,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 18 }
-});
 // FIXTURE: readonly-capture-named-alias-nested-cell
 // Verifies (BEHAVIOR LOCK): a by-reference, read-only-used capture of a bare
 //   `Cell<EntriesValue>` (EntriesValue = Entry[] | Default<[]>, Entry has a
@@ -105,7 +83,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   packages/patterns/cfc-group-chat-demo/main.test.tsx (the `profiles` capture).
 //   This fixture pins the intended single-file output with a legible diff so a
 //   future change to the readonly-rewrap path is obvious here too.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const entries = Writable.of<EntriesValue>([] as EntriesValue, {
         type: "array",
         items: {
@@ -134,10 +112,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
     return __cfLift_1({ entries: entries }).for("__patternResult", true);
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -87,10 +69,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 36 }
-});
 // FIXTURE: unless-with-map
 // Verifies: || operator becomes unless() with reactive map as fallback
 //   customContent || items.map(...) → unless(customContent, items.mapWithPattern(...))
@@ -98,7 +76,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 // Context: unless(condition, fallback) returns condition if truthy, else fallback.
 //   The fallback branch contains a reactive .map() that must be transformed to
 //   mapWithPattern with proper schema injection.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const customContent = __cf_pattern_input.key("customContent");
     const items = __cf_pattern_input.key("items");
     return {
@@ -170,10 +148,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -87,10 +69,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 32 }
-});
 // FIXTURE: when-with-map
 // Verifies: && operator becomes when() with reactive map as the value
 //   showItems && items.map(...) → when(showItems, items.mapWithPattern(...))
@@ -98,7 +76,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 // Context: when(condition, value) returns value if condition is truthy, else
 //   condition. The value branch contains a reactive .map() that must be
 //   transformed to mapWithPattern with proper schema injection.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const showItems = __cf_pattern_input.key("showItems");
     const items = __cf_pattern_input.key("items");
     return {
@@ -175,10 +153,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,11 +37,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     counter.set(0);
     label.set("Count");
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 23 },
-    bindingName: "reset"
-});
 // FIXTURE: writable-of-terminal-methods
 // Verifies: new Writable() gets schema annotation, and action() with .set() becomes handler()
 //   new Writable(0) → new Writable(0, { type: "number" })
@@ -68,7 +45,7 @@ __cfBindVerifiedBinding(__cfHandler_1, {
 // Context: new Writable() produces opaque cells. The .set() calls inside
 //   action() are terminal methods that require the action to be rewritten as a
 //   handler with captured cell references (counter, label) in its schema.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const counter = new Writable(0, {
         type: "number"
@@ -133,10 +110,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -69,11 +51,6 @@ const removeItem = handler({
         next.splice(index, 1);
     items.set(next);
 });
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 2 },
-    bindingName: "removeItem"
-});
 // alias-based intersection variant
 type ListStateWithIndex = ListState & {
     index: number;
@@ -111,11 +88,6 @@ const removeItemAlias = handler({
     if (index >= 0 && index < next.length)
         next.splice(index, 1);
     items.set(next);
-});
-__cfBindVerifiedBinding(removeItemAlias, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 2 },
-    bindingName: "removeItemAlias"
 });
 // FIXTURE: array-cell-remove-intersection
 // Verifies: handler context intersection types are flattened and Cell<T[]> generates array schema with asCell

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -114,11 +96,6 @@ const userHandler = handler({
     }
     state.lastAction.set(event.action);
 });
-__cfBindVerifiedBinding(userHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 50 },
-    bindingName: "userHandler"
-});
 const _updateTags = handler({
     type: "object",
     properties: {
@@ -151,11 +128,6 @@ const _updateTags = handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ detail }, state) => {
     state.tags.set(detail?.tags ?? []);
 });
-__cfBindVerifiedBinding(_updateTags, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 2 },
-    bindingName: "_updateTags"
-});
 export { userHandler };
 // FIXTURE: complex-nested-types
 // Verifies: handler with nested object types, string literal unions, and Cell-wrapped arrays generate correct schemas
@@ -163,7 +135,7 @@ export { userHandler };
 //   "create" | "update" | "delete" → { enum: ["create", "update", "delete"] }
 //   Cell<Array<{...}>> → { type: "array", items: { type: "object", ... }, asCell: true }
 // Context: also tests a second handler (_updateTags) with Cell<string[]>; pattern wraps handler as asStream output
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     return { userHandler };
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -173,10 +145,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
         }
     },
     required: ["userHandler"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 56, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -112,12 +94,7 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["count"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 46 },
-    bindingName: "add"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const add = __cfHandler_1({
         entries: entries
@@ -190,10 +167,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["name", "next"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-shapes.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-shapes.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -117,11 +99,6 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["ok"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 52 },
-    bindingName: "addUnion"
-});
 const __cfHandler_2 = __cfHelpers.handler({
     type: "array",
     items: {
@@ -141,11 +118,6 @@ const __cfHandler_2 = __cfHelpers.handler({
         },
         required: ["n"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 49 },
-    bindingName: "addArr"
-});
 const __cfHandler_3 = __cfHelpers.handler({
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -162,11 +134,6 @@ const __cfHandler_3 = __cfHelpers.handler({
         },
         required: ["n"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 47 },
-    bindingName: "addStr"
-});
 const __cfHandler_4 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -212,12 +179,7 @@ const __cfHandler_4 = __cfHelpers.handler({
         },
         required: ["ok"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 56 },
-    bindingName: "addSection"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const log = __cf_pattern_input.key("log");
     const addUnion = __cfHandler_1({
         log: log
@@ -320,10 +282,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
                 }]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 58 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-nested-unread-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-nested-unread-reference.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -110,12 +92,7 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["ok"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 42 },
-    bindingName: "add"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const log = __cf_pattern_input.key("log");
     const add = __cfHandler_1({
         log: log
@@ -186,10 +163,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["n"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 58 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,11 +36,6 @@ const timedHandler = handler({
     required: ["lastUpdate"]
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.lastUpdate.set(event.timestamp);
-});
-__cfBindVerifiedBinding(timedHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 53 },
-    bindingName: "timedHandler"
 });
 // FIXTURE: date-types
 // Verifies: Date type maps to JSON Schema string with format "date-time"

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -94,11 +76,6 @@ const removePiece = handler({
     const idx = current.findIndex((c) => equals(c, piece));
     if (idx >= 0)
         pieceRegistry.set(current.toSpliced(idx, 1));
-});
-__cfBindVerifiedBinding(removePiece, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 2 },
-    bindingName: "removePiece"
 });
 // FIXTURE: identity-only-handler-default-array
 // Verifies: a `Writable<T[] | Default<[]>>` array used only for identity removal

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -91,11 +73,6 @@ const addPiece = handler({
         pieceRegistry.push(piece);
     }
 });
-__cfBindVerifiedBinding(addPiece, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 2 },
-    bindingName: "addPiece"
-});
 const trackRecent = handler({
     type: "object",
     properties: {
@@ -148,11 +125,6 @@ const trackRecent = handler({
     const filtered = current.filter((c) => !equals(c, piece));
     const updated = [piece, ...filtered].slice(0, 10);
     recentPieces.set(updated);
-});
-__cfBindVerifiedBinding(trackRecent, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 2 },
-    bindingName: "trackRecent"
 });
 // FIXTURE: identity-only-handler-payload
 // Verifies: handler payloads and array items used only for identity/passthrough

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const stateSchema = __cfHelpers.__cf_data({
 const logHandler = handler(eventSchema, stateSchema, (event, state) => {
     // Use optional chaining and nullish coalescing since properties may be undefined
     state.log?.push(event.message ?? "no message");
-});
-__cfBindVerifiedBinding(logHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 53 },
-    bindingName: "logHandler"
 });
 // FIXTURE: preserve-explicit-schemas-optional
 // Verifies: explicit schemas without "required" arrays are preserved as-is (optional properties)

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const stateSchema = __cfHelpers.__cf_data({
 } as const);
 const logHandler = handler(eventSchema, stateSchema, (event, state) => {
     state.log.push(event.message);
-});
-__cfBindVerifiedBinding(logHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 53 },
-    bindingName: "logHandler"
 });
 // FIXTURE: preserve-explicit-schemas
 // Verifies: handler with user-provided schema literals passes them through unchanged (no type-based generation)

--- a/packages/ts-transformers/test/fixtures/handler-schema/schema-first-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/schema-first-declared-result.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,11 +47,6 @@ const ping = handler({
         },
         required: ["echoed"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(ping, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 2 },
-    bindingName: "ping"
-});
 // The named-callback spelling of the same form: recognition is
 // identifier-aware, so the call still passes through un-prepended and the
 // declared result still lands in the trailing options. (SES-mode loading
@@ -97,11 +74,6 @@ const pingNamed = handler({
         },
         required: ["echoed"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(pingNamed, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 18 },
-    bindingName: "echoNamed"
-});
 // A callback referenced as a function DECLARATION: no expression resolver can
 // return it, so recognition asks callback-ness instead — without this, the
 // prepend path ran and the trailing-options lowering spread-replaced the
@@ -129,11 +101,6 @@ const pingDeclared = handler({
         },
         required: ["echoed"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(pingDeclared, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 0 },
-    bindingName: "echoDeclared"
-});
 // A callback reached through property access — the spelling no syntax list
 // anticipated. Callback-ness is the checker's call signatures, so any
 // callable expression recognizes the form; a schema is never callable.
@@ -160,11 +127,6 @@ const pingViaProperty = handler({
         },
         required: ["echoed"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(pingViaProperty, {
-    sourceFile: "/test.tsx",
-    position: { line: 91, col: 24 },
-    bindingName: "pingViaProperty"
-});
 // The same form without a declared result: passed through untouched — no
 // generated schemas, no options object.
 const poke = handler({
@@ -175,12 +137,7 @@ const poke = handler({
     type: "object",
     properties: { count: { type: "number", asCell: ["cell"] } },
 }, (_event, _state) => { });
-__cfBindVerifiedBinding(poke, {
-    sourceFile: "/test.tsx",
-    position: { line: 116, col: 2 },
-    bindingName: "poke"
-});
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const count = cell(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
@@ -231,10 +188,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["word"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 119, col: 53 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: schema-first-declared-result
 // Verifies: the schema-first authored form handler<E, T[, R]>(eventSchema,
 //   stateSchema, callback) keeps its authored schemas and callback positions

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,11 +36,6 @@ const myHandler = handler({
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.value.set(state.value.get() + event.increment);
-});
-__cfBindVerifiedBinding(myHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 54 },
-    bindingName: "myHandler"
 });
 // FIXTURE: simple-handler-writable
 // Verifies: Writable<T> is treated identically to Cell<T> and generates asCell in the schema

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,11 +36,6 @@ const myHandler = handler({
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.value.set(state.value.get() + event.increment);
-});
-__cfBindVerifiedBinding(myHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 54 },
-    bindingName: "myHandler"
 });
 // FIXTURE: simple-handler
 // Verifies: basic handler type parameters are transformed into event and context JSON schemas

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,11 +41,6 @@ const writeNote = handler({
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { db }) => {
     db.exec("INSERT INTO notes (body) VALUES (?)", ["hi"]);
-});
-__cfBindVerifiedBinding(writeNote, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 44 },
-    bindingName: "writeNote"
 });
 export { writeNote };
 // @ts-ignore: Internals

--- a/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/stream-declared-result.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -77,11 +59,6 @@ const renameTopic = handler({
         },
         required: ["topic"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(renameTopic, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 2 },
-    bindingName: "renameTopic"
-});
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -117,11 +94,6 @@ const __cfHandler_1 = __cfHelpers.handler({
         },
         required: ["topic"]
     } as const satisfies __cfHelpers.JSONSchema });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 52 },
-    bindingName: "addTopic"
-});
 const __cfHandler_2 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -142,12 +114,7 @@ const __cfHandler_2 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, (_event, { count }) => {
     count.set(count.get() + 1);
 });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 23 },
-    bindingName: "touch"
-});
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const count = cell(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
@@ -200,10 +167,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["title"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 53 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: stream-declared-result
 // Verifies: a declared result on Stream's second parameter reaches the
 //   emitted module, and still satisfies the pattern's own Output annotation.

--- a/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,11 +36,6 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.items.get();
     state[event.key];
-});
-__cfBindVerifiedBinding(removeItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 2 },
-    bindingName: "removeItem"
 });
 // FIXTURE: unsupported-intersection-index
 // Verifies: dynamic key access keeps index-signature intersections open-ended

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -45,10 +27,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 8 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("name")}</span>;
@@ -92,10 +70,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 18 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.ReadonlyCell<number>;
 }, number>(({ count }) => count.get(), {
@@ -110,15 +84,11 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 23 }
-});
 // FIXTURE: authored-ifelse-jsx-branches
 // Verifies: authored ifElse in JSX lowers both conditions and reactive branches correctly
 //   ifElse(limit > 0, items.map(...), <span>Hidden</span>) → derived condition + pattern-lowered map branch
 //   ifElse(show, count.get(), 0) in JSX                     → derived reactive branch, not raw count.get()
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const limit = __cf_pattern_input.key("limit");
     const count = __cf_pattern_input.key("count");
@@ -233,10 +203,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/binding-attr-nullish-wish-fallback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/binding-attr-nullish-wish-fallback.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -92,10 +74,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 36 }
-});
 // FIXTURE: binding-attr-nullish-wish-fallback
 // Verifies: a nullish-coalescing binary at a bidirectional JSX binding
 //   position — optional pattern input falling back to a wish() result —
@@ -105,7 +83,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 // Context: regression companion to the builder-argument computation
 //   diagnostic — the JSX-attribute form is supported; only the builder-call
 //   argument form requires the hoist diagnostic.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const profileInput = __cf_pattern_input.key("profileInput");
     const profileWish = wish<Profile>({ query: "#profile" }, {
         type: "object",
@@ -179,10 +157,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 35 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,10 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 10 }
-});
 // Reproduction of bug: .get() called on Cell inside ifElse predicate
 // The transformer wraps predicates in a lift-applied computation, which unwraps Cells,
 // but fails to remove the .get() calls
@@ -62,7 +40,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 // Verifies: .get() calls on Cell refs inside ifElse predicates are preserved within the lift-applied computation
 //   showHistory && messageCount !== dismissedIndex.get() → lift(({...}) => showHistory && messageCount !== dismissedIndex.get())(...)
 // Context: Bug repro -- predicate wrapped in a lift-applied computation which unwraps Cells, but .get() must remain
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const showHistory = __cf_pattern_input.key("showHistory");
     const messageCount = __cf_pattern_input.key("messageCount");
     const dismissedIndex = __cf_pattern_input.key("dismissedIndex");
@@ -131,10 +109,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,10 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 24 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     price: number;
     discount: number;
@@ -76,15 +54,11 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 24 }
-});
 // FIXTURE: complex-expressions
 // Verifies: multi-variable arithmetic in JSX is wrapped in a lift-applied computation with captured refs
 //   {price - discount}             → lift((...) => price - discount)({ price, discount })
 //   {(price - discount) * (1+tax)} → lift((...) => ...)({ price, discount, tax })
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const price = __cf_pattern_input.key("price");
     const discount = __cf_pattern_input.key("discount");
     const tax = __cf_pattern_input.key("tax");
@@ -145,10 +119,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -42,15 +24,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["B", "C"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 24 }
-});
 // FIXTURE: computed-boundary-nested-ternaries
 // Verifies: outer branch lowering does not structurally lower nested ternaries inside computed callbacks
 //   show ? computed(() => bar ? "B" : "C") : "D" → outer branch lowers, inner ternary stays authored
 //   ifElse(show, computed(() => foo ? "A" : bar ? "B" : "C"), "D") → helper-owned branch lowering still preserves the inner ternaries
-export const OuterTernary = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const OuterTernary = pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const bar = __cf_pattern_input.key("bar");
     return (<div>{__cfHelpers.ifElse({
@@ -93,11 +71,7 @@ export const OuterTernary = __cfBindVerifiedBinding(pattern((__cf_pattern_input)
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 69 },
-    bindingName: "OuterTernary"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     foo: boolean;
     bar: boolean;
@@ -115,11 +89,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["A", "B", "C"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 24 }
-});
-export const AuthoredIfElse = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const AuthoredIfElse = pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");
@@ -151,11 +121,7 @@ export const AuthoredIfElse = __cfBindVerifiedBinding(pattern((__cf_pattern_inpu
     required: ["show", "foo", "bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["A", "B", "C", "D"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 3 },
-    bindingName: "AuthoredIfElse"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,15 +28,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 9 }
-});
 // FIXTURE: conditional-empty-check
 // Verifies: !cell.get().length && <JSX> is transformed to when() with a lift-applied predicate
 //   !items.get().length && <span> → when(lift(({items}) => !items.get().length)({items}), <span>)
 // Context: Negated length check on a cell array used as conditional guard
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const items = cell<string[]>([], {
         type: "array",
         items: {
@@ -113,10 +91,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -98,11 +80,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 37 },
-    bindingName: "itemsWithAisles"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     itemsWithAisles: { aisle: string; item: Item; }[];
 }, Record<string, Assignment[]>>(({ itemsWithAisles }) => {
@@ -186,11 +163,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 36 },
-    bindingName: "groupedByAisle"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
 }, string[]>(({ groupedByAisle }) => Object.keys(groupedByAisle).sort(), {
@@ -241,11 +213,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 32 },
-    bindingName: "aisleNames"
-});
 const __cfLift_4 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
     aisleName: string;
@@ -331,10 +298,6 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 15 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const assignment = __cf_pattern_input.key("element");
     return (<div>
@@ -397,10 +360,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 46 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const aisleName = __cf_pattern_input.key("element");
     const groupedByAisle = __cf_pattern_input.key("params", "groupedByAisle");
@@ -483,10 +442,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 54, col: 26 }
-});
 // CT-1036: Property access on derived grouped objects with derived keys
 // This pattern groups items by a property, then maps over the group keys
 // and accesses the grouped object with each key.
@@ -495,7 +450,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 //   aisleNames.map(...)            → aisleNames.mapWithPattern(pattern(...), {captures})
 //   groupedByAisle[aisleName].map  → lift over {groupedByAisle, aisleName} then .mapWithPattern(...)
 // Context: CT-1036 -- nested map with derived object indexed by derived key, two levels deep
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Create assignments with aisle data (whole-array map kept inside computed)
     const itemsWithAisles = __cfLift_1({ items: items }).for("itemsWithAisles", true);
@@ -569,10 +524,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,14 +33,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 27 }
-});
 // FIXTURE: element-access-both-opaque
 // Verifies: element access where both array and index are cell-backed Reactives is wrapped in a lift-applied computation
 //   items.get()[index.get()] → lift(({items, index}) => items.get()[index.get()])({ items, index })
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell(["apple", "banana", "cherry"], {
         type: "array",
         items: {
@@ -107,10 +85,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,10 +66,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 26 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         nested: {
@@ -131,10 +109,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 25 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -159,10 +133,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 11 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -187,10 +157,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 25 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -223,10 +189,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 51, col: 28 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -255,10 +217,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 54, col: 26 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -287,10 +245,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 21 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
@@ -335,10 +289,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 63, col: 11 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -370,10 +320,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 22 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -398,10 +344,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 70, col: 28 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         nested: {
@@ -441,10 +383,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 74, col: 19 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
@@ -485,10 +423,6 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 77, col: 30 }
-});
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -517,10 +451,6 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_13, {
-    sourceFile: "/test.tsx",
-    position: { line: 83, col: 11 }
-});
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -549,10 +479,6 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_14, {
-    sourceFile: "/test.tsx",
-    position: { line: 83, col: 38 }
-});
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
@@ -588,10 +514,6 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_15, {
-    sourceFile: "/test.tsx",
-    position: { line: 89, col: 12 }
-});
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -624,10 +546,6 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_16, {
-    sourceFile: "/test.tsx",
-    position: { line: 97, col: 21 }
-});
 const __cfLift_17 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -659,10 +577,6 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_17, {
-    sourceFile: "/test.tsx",
-    position: { line: 100, col: 20 }
-});
 const __cfLift_18 = __cfHelpers.lift<{
     state: {
         arr: number[];
@@ -687,17 +601,13 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_18, {
-    sourceFile: "/test.tsx",
-    position: { line: 103, col: 17 }
-});
 // FIXTURE: element-access-complex
 // Verifies: complex element-access patterns (nested, computed, chained, conditional) are wrapped in a lift-applied computation
 //   state.matrix[state.row]![state.col]         → lift(...)({ matrix, row, col })
 //   state.arr[state.a + state.b]                → lift(...)({ arr, a, b })
 //   state.users[state.selectedUser]!.scores[..] → lift(...)({ users, selectedUser, selectedScore })
 // Context: Covers nested indexing, computed indices, chained access, conditions, operators
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Nested Element Access</h3>
@@ -961,10 +871,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -64,10 +46,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 18 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -92,10 +70,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 18 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
@@ -131,16 +105,12 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 20 }
-});
 // FIXTURE: element-access-simple
 // Verifies: dynamic element access on reactive arrays is wrapped in a lift-applied computation
 //   state.items[state.index]            → lift(({state}) => state.items[state.index])({ items, index })
 //   state.items[state.items.length - 1] → lift(...)({ items })
 //   state.matrix[state.row]![state.col] → lift(...)({ matrix, row, col })
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Dynamic Element Access</h3>
@@ -221,10 +191,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,11 +45,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 29 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const isFolder = __cfLift_1({ file: {
@@ -99,10 +76,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 18 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     return <span>{file.key("name")}</span>;
@@ -149,11 +122,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 15 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -193,10 +162,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,10 +49,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 10 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     __cfLift_1({ file: {
@@ -127,11 +105,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 23 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -171,10 +145,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/generate-text-local-ternary.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/generate-text-local-ternary.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -35,7 +17,7 @@ const __cfAmdHooks = undefined;
 // Context: `text` is a local `generateText()` result rather than a pattern
 // input binding, so this exercises expression-site lowering on local reactive
 // aliases in JSX.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const text = generateText({ prompt: "hi" }).for("text", true);
     return {
         [UI]: <div>{__cfHelpers.ifElse({
@@ -77,10 +59,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -76,11 +58,6 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 26 },
-    bindingName: "pushPath"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
@@ -101,11 +78,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 20 },
-    bindingName: "p"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
@@ -126,11 +98,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 20 },
-    bindingName: "p"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
@@ -182,11 +149,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 26 },
-    bindingName: "visible"
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -212,10 +174,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["entry", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }));
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 62, col: 30 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const pushPath = __cf_pattern_input.key("params", "pushPath");
@@ -283,11 +241,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 59, col: 29 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
         type: "array",
@@ -376,10 +330,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 36 },
-    bindingName: "handleNavigateInto"
-});
 const __cfHandler_2 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -129,11 +106,6 @@ const __cfHandler_2 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
     void item;
 });
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 55, col: 32 },
-    bindingName: "handleOpenFile"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
@@ -154,11 +126,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 64, col: 21 },
-    bindingName: "p"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     unsorted: Entry[];
 }, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => {
@@ -234,11 +201,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 66, col: 24 },
-    bindingName: "items"
-});
 const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -266,10 +228,6 @@ const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleNavigateInto, item }) => handleNavigateInto.send({
     name: item.name,
 }));
-__cfBindVerifiedBinding(__cfHandler_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 83, col: 29 }
-});
 const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -318,10 +276,6 @@ const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleOpenFile, item }) => handleOpenFile.send({ item }));
-__cfBindVerifiedBinding(__cfHandler_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 89, col: 29 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const handleNavigateInto = __cf_pattern_input.key("params", "handleNavigateInto");
@@ -432,11 +386,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 71, col: 27 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
         type: "array",
@@ -586,10 +536,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,11 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 20 },
-    bindingName: "p"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
@@ -124,11 +101,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 26 },
-    bindingName: "visible"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -155,10 +127,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 12 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -200,11 +168,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 42 },
-    bindingName: "filtered"
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return <button type="button">{entry.key("name")}</button>;
@@ -248,11 +211,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 30 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
         type: "array",
@@ -323,10 +282,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -90,11 +72,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 24 },
-    bindingName: "visible"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -120,10 +97,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 10 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -182,11 +155,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 39 },
-    bindingName: "labels"
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const label = __cf_pattern_input.key("element");
     return <button type="button">{label}</button>;
@@ -219,11 +187,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 26 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
     const labelPrefix = __cf_pattern_input.key("labelPrefix");
@@ -312,10 +276,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,11 +54,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 48, col: 20 },
-    bindingName: "p"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
@@ -128,11 +105,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 26 },
-    bindingName: "visible"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -189,11 +161,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 29 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
         type: "array",
@@ -263,10 +231,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -90,11 +72,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 24 },
-    bindingName: "visible"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
@@ -150,11 +127,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 27 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
     const labelPrefix = __cf_pattern_input.key("labelPrefix");
@@ -242,10 +215,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
     path.push(name);
 });
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 26 },
-    bindingName: "pushPath"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>(({ path }) => path.get(), {
@@ -109,11 +86,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 61, col: 20 },
-    bindingName: "p"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     tree: __cfHelpers.Cell<Entry[]>;
     p: readonly string[];
@@ -187,11 +159,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 62, col: 27 },
-    bindingName: "unsorted"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     unsorted: readonly Entry[];
 }, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)), {
@@ -257,11 +224,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 63, col: 24 },
-    bindingName: "items"
-});
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -287,10 +249,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["item", "pushPath"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }));
-__cfBindVerifiedBinding(__cfHandler_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 71, col: 32 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const pushPath = __cf_pattern_input.key("params", "pushPath");
@@ -373,11 +331,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 27 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
         type: "array",
@@ -461,10 +415,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 13 },
-    bindingName: "output1"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     result: string;
 }, boolean>(({ result }) => !!result, {
@@ -64,11 +41,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 13 },
-    bindingName: "output2"
-});
 // Tests ifElse where ifTrue is explicitly undefined
 // This pattern is common: ifElse(pending, undefined, { result })
 // The transformer must handle this correctly - the undefined is a VALUE, not a missing argument
@@ -77,7 +49,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   ifElse(cond, undefined, {result}) → ifElse(schema, schema, schema, schema, lift(...)(...), undefined, {result})
 //   ifElse(cond, {data}, undefined)   → ifElse(schema, schema, schema, schema, lift(...)(...), {data}, undefined)
 // Context: undefined is a VALUE argument, not a missing argument
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const __cf_destructure_1 = fetchText({
         url: "/api/data",
     }), pending = __cf_destructure_1.key("pending").for("pending", true), result = __cf_destructure_1.key("result").for("result", true);
@@ -175,10 +147,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 46 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -56,10 +38,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 23 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -81,10 +59,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 23 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -106,10 +80,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 23 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -131,10 +101,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 23 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -156,10 +122,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 23 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -185,10 +147,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 30 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -214,10 +172,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 19 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -243,10 +197,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 27 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -281,10 +231,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 20 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -306,10 +252,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 20 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -331,10 +273,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 26 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -356,16 +294,12 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 48 }
-});
 // FIXTURE: jsx-arithmetic-operations
 // Verifies: arithmetic expressions with reactive refs in JSX are wrapped in a lift-applied computation
 //   {state.count + 1}                      → lift(({state}) => state.count + 1)({ count })
 //   {state.price * state.quantity * 1.08}   → lift(...)({ price, quantity })
 //   {state.count * state.count * state.count} → lift(...)({ count })
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Basic Arithmetic</h3>
@@ -464,10 +398,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,10 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 11 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -98,10 +76,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 11 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -130,10 +104,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 11 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -163,10 +133,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 11 }
-});
 // FIXTURE: jsx-array-method-sink-calls
 // Verifies: direct JSX sink receiver-methods over structural array-method chains can use the shared post-closure path
 //   state.items.filter(fn).join(", ")                        → shared post-closure lift-applied computation over the sink call
@@ -174,7 +140,7 @@ __cfBindVerifiedBinding(__cfLift_4, {
 //   state.items.filter(fn).join(", ").toUpperCase()          → shared post-closure lift-applied computation over the chained call
 //   state.items.filter(fn).join(", ").toUpperCase().trim()   → shared post-closure lift-applied computation over the recursive chained call
 // Context: Verifies recursive receiver-method chaining above a shareable array-method sink base
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <p>
@@ -254,10 +220,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -77,10 +59,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 20 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -114,10 +92,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 32 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -156,10 +130,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 18 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -256,10 +226,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 27 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -290,10 +256,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 56, col: 26 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         discount: number;
@@ -315,10 +277,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 59, col: 30 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         taxRate: number;
@@ -340,10 +298,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 60, col: 25 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -374,10 +328,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 63, col: 24 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -408,10 +358,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 64, col: 24 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -442,10 +388,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 11 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         filter: {
@@ -475,10 +417,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 73, col: 27 }
-});
 // FIXTURE: jsx-complex-mixed
 // Verifies: mixed transforms -- map, filter, arithmetic, ternary/ifElse, attribute bindings in one pattern
 //   .filter(fn)              → .filterWithPattern(pattern(...), {captures})
@@ -486,7 +424,7 @@ __cfBindVerifiedBinding(__cfLift_10, {
 //   ternary cond ? a : b     → ifElse(lift(...)(cond), a, b)
 //   {state.discount * 100}   → lift(...)({ discount })
 // Context: Comprehensive fixture combining array methods, conditionals, lift-applied computations, and attributes
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Array Operations</h3>
@@ -640,10 +578,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 15 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -83,10 +61,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 15 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -108,10 +82,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 41 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -133,10 +103,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 11 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -158,10 +124,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 14 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         userType: string;
@@ -183,10 +145,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 11 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         userType: string;
@@ -208,10 +166,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 14 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -233,10 +187,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 11 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -258,10 +208,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 30 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -283,10 +229,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 61, col: 30 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -308,16 +250,12 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 74, col: 10 }
-});
 // FIXTURE: jsx-conditional-rendering-no-name
 // Verifies: same conditional rendering transforms work when pattern has no NAME export
 //   cond ? a : b             → ifElse(schema..., cond, a, b)
 //   ifElse(cond, <jsx>, <jsx>) → ifElse(schema..., cond, <jsx>, <jsx>)
 // Context: Variant of jsx-conditional-rendering without [NAME], testing schema inference without name
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Basic Ternary</h3>
@@ -586,10 +524,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 15 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -83,10 +61,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 15 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -108,10 +82,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 41 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -133,10 +103,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 11 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -158,10 +124,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 14 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         userType: string;
@@ -183,10 +145,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 11 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         userType: string;
@@ -208,10 +166,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 14 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -233,10 +187,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 11 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -258,10 +208,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 30 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         score: number;
@@ -283,10 +229,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 61, col: 30 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -308,16 +250,12 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 74, col: 10 }
-});
 // FIXTURE: jsx-conditional-rendering
 // Verifies: ternary expressions and ifElse() calls in JSX are transformed to reactive ifElse()
 //   cond ? a : b             → ifElse(schema, schema, schema, schema, cond, a, b)
 //   ifElse(cond, <jsx>, <jsx>) → ifElse(schema..., cond, <jsx>, <jsx>)
 // Context: Basic, nested, and complex ternaries plus explicit ifElse calls
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Basic Ternary</h3>
@@ -586,10 +524,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 33 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
@@ -82,10 +60,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 10 }
-});
 // FIXTURE: jsx-direct-branch-roots
 // Verifies: direct JSX branch roots lower structurally without leaving raw
 //   child expressions in place.
@@ -93,7 +67,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //   primary ? "A" : secondary ? "B" : "C"        -> nested ternary lowering
 //   primary ? "A" : fallbackLabel || "C"         -> nested logical branch lowering
 //   label ?? "Pending"                           -> top-level JSX nullish lowering
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     [UI]: (<div>
       <p>{__cfHelpers.ifElse({
         type: "boolean"
@@ -212,10 +186,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -57,10 +39,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 10 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -89,10 +67,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 10 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -121,10 +95,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 9 }
-});
 // FIXTURE: jsx-filter-length-roots
 // Verifies: structural filter-length wrappers use the shared post-closure path
 //   instead of rewriting the filter callback itself to filterWithPattern().
@@ -132,7 +102,7 @@ __cfBindVerifiedBinding(__cfLift_3, {
 //   items.filter(fn).length > 0
 //   items.filter(fn).length > 0 ? "Yes" : "No"
 // Context: all three shapes should lower without leaking callback locals.
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     [UI]: (<div>
       <p>{__cfLift_1({ state: {
             items: state.key("items"),
@@ -200,10 +170,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 63 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,10 +45,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 17 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -88,10 +66,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 17 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -117,10 +91,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 17 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -142,10 +112,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 19 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -167,10 +133,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 19 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -192,10 +154,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 21 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -217,10 +175,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 25 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         name: string;
@@ -242,10 +196,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 23 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         name: string;
@@ -267,10 +217,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 23 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -292,10 +238,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 23 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -317,10 +259,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 21 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -342,10 +280,6 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 22 }
-});
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         name: string;
@@ -367,10 +301,6 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_13, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 25 }
-});
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -392,10 +322,6 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_14, {
-    sourceFile: "/test.tsx",
-    position: { line: 41, col: 22 }
-});
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         price: number;
@@ -417,10 +343,6 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_15, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 26 }
-});
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         float: string;
@@ -442,10 +364,6 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_16, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 23 }
-});
 const __cfLift_17 = __cfHelpers.lift<{
     state: {
         float: string;
@@ -467,10 +385,6 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_17, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 25 }
-});
 const __cfLift_18 = __cfHelpers.lift<{
     state: {
         values: number[];
@@ -495,10 +409,6 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_18, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 17 }
-});
 const __cfLift_19 = __cfHelpers.lift<{
     state: {
         values: number[];
@@ -523,10 +433,6 @@ const __cfLift_19 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_19, {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 23 }
-});
 const __cfLift_20 = __cfHelpers.lift<{
     state: {
         values: number[];
@@ -551,10 +457,6 @@ const __cfLift_20 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_20, {
-    sourceFile: "/test.tsx",
-    position: { line: 51, col: 20 }
-});
 const __cfLift_21 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -576,10 +478,6 @@ const __cfLift_21 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_21, {
-    sourceFile: "/test.tsx",
-    position: { line: 54, col: 27 }
-});
 const __cfLift_22 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -601,10 +499,6 @@ const __cfLift_22 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_22, {
-    sourceFile: "/test.tsx",
-    position: { line: 55, col: 26 }
-});
 const __cfLift_23 = __cfHelpers.lift<{
     state: {
         name: string;
@@ -626,10 +520,6 @@ const __cfLift_23 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_23, {
-    sourceFile: "/test.tsx",
-    position: { line: 56, col: 27 }
-});
 const __cfLift_24 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -655,16 +545,12 @@ const __cfLift_24 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_24, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 30 }
-});
 // FIXTURE: jsx-function-calls
 // Verifies: function/method calls with reactive args in JSX are wrapped in a lift-applied computation
 //   Math.max(state.a, state.b)     → lift(({state}) => Math.max(state.a, state.b))({ a, b })
 //   state.name.toUpperCase()       → lift(...)({ name })
 //   parseInt(state.float)          → lift(...)({ float })
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Math Functions</h3>
@@ -829,10 +715,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -89,10 +71,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 63, col: 21 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         user: {
@@ -122,10 +100,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 65, col: 28 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         user: {
@@ -163,10 +137,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 68, col: 11 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -195,10 +165,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 72, col: 27 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -223,10 +189,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 74, col: 23 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         numbers: number[];
@@ -255,10 +217,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 75, col: 29 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         config: {
@@ -296,10 +254,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 81, col: 22 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         user: {
@@ -341,10 +295,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 96, col: 12 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         config: {
@@ -382,17 +332,13 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 97, col: 27 }
-});
 // FIXTURE: jsx-property-access
 // Verifies: nested property access chains in JSX are converted to .key() or wrapped in a lift-applied computation
 //   state.user.name                → state.key("user", "name")  (simple access, no lift)
 //   state.user.age + 1             → lift(({state}) => state.user.age + 1)({ age })
 //   state.items[state.index]       → lift(...)({ items, index })
 // Context: Covers deep nesting, style bindings, array access, method calls on properties
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Basic Property Access</h3>
@@ -663,10 +609,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,10 +47,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 13 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -94,10 +72,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 12 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -119,10 +93,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 12 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -144,10 +114,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 12 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -173,10 +139,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 12 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         title: string;
@@ -206,10 +168,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 12 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -231,10 +189,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 23 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         title: string;
@@ -256,10 +210,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 23 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         message: string;
@@ -281,10 +231,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 23 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -310,10 +256,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 12 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         firstName: string;
@@ -339,10 +281,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 12 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -364,16 +302,12 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 29 }
-});
 // FIXTURE: jsx-string-operations
 // Verifies: string concatenation, template literals, and string methods in JSX are wrapped in a lift-applied computation
 //   state.title + ": " + state.firstName → lift(...)({ title, firstName })
 //   `Welcome, ${state.firstName}!`       → lift(...)({ firstName })
 //   state.firstName.toUpperCase()        → lift(...)({ firstName })
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>String Concatenation</h3>
@@ -479,10 +413,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -74,10 +56,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 10 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -114,10 +92,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 10 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -154,10 +128,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 10 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -197,13 +167,9 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 10 }
-});
 // FIXTURE: jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole JSX call roots
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     [UI]: (<div>
       <p>{__cfLift_1({ state: {
             wishes: state.key("wishes")
@@ -267,10 +233,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,10 +31,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 12 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string>(({ user }) => `Hello, ${user.get().name}!`, {
@@ -73,10 +51,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 42 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, boolean>(({ user }) => user.get().age > 18, {
@@ -97,10 +71,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 17 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, number>(({ user }) => user.get().age, {
@@ -121,16 +91,12 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 40 }
-});
 // FIXTURE: logical-and-non-jsx
 // Verifies: && with non-JSX right side still lowers through when(), with predicate/value derived separately
 //   user.get().name.length > 0 && `Hello...` → when(lift(...)(predicate), lift(...)(template))
 //   user.get().age > 18 && user.get().age    → when(lift(...)(predicate), lift(...)(number))
 // Context: JSX-local control flow still uses when(); non-JSX right-hand values become derived branch values
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const user = cell<{
         name: string;
         age: number;
@@ -196,10 +162,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-simple-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-simple-ref.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -33,7 +15,7 @@ const __cfAmdHooks = undefined;
 // Verifies: simple opaque ref && <JSX> is transformed to when() for short-circuit rendering
 //   showPanel && <div>Panel content</div> → when(showPanel, <div>Panel content</div>)
 //   userName && <span>Hello</span>        → when(userName, <span>Hello</span>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const showPanel = cell(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showPanel", true);
@@ -104,10 +86,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,10 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 9 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
     items: __cfHelpers.Cell<string[]>;
@@ -77,15 +55,11 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 9 }
-});
 // FIXTURE: logical-complex-expressions
 // Verifies: nested && and mixed || && with JSX are transformed to when() with lift-applied predicates
 //   a && b && <JSX>     → when(lift(...)({ a, b }), <JSX>)
 //   (a || b) && <JSX>   → when(lift(...)({ a, b }), <JSX>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell<string[]>([], {
         type: "array",
         items: {
@@ -170,10 +144,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -54,10 +36,6 @@ const __cfLift_1 = __cfHelpers.lift<{
             "enum": [false]
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 15 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     defaultMessage: __cfHelpers.Cell<string>;
 }, string>(({ defaultMessage }) => defaultMessage.get(), {
@@ -72,10 +50,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 66 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, boolean>(({ user }) => user.get().age > 18, {
@@ -96,10 +70,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 15 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string>(({ user }) => user.get().name, {
@@ -120,10 +90,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 39 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
 }, string | false>(({ user }) => (user.get().name.length > 0 && `Hello ${user.get().name}`) ||
@@ -153,10 +119,6 @@ const __cfLift_5 = __cfHelpers.lift<{
             "enum": [false]
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 11 }
-});
 // Tests mixed && and || operators: (a && b) || c
 // The && should use when, the || should use unless
 // FIXTURE: logical-mixed-and-or
@@ -164,7 +126,7 @@ __cfBindVerifiedBinding(__cfLift_5, {
 //   (cond && value) || fallback → lift-applied computation or nested when/unless
 //   cond && (value || fallback) → nested logical transforms
 //   (a && b) || (c && d) || e   → chained lift-applied expressions
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const user = cell<{
         name: string;
         age: number;
@@ -250,10 +212,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -53,10 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 24 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     config: __cfHelpers.Cell<{ timeout: number | null; retries: number | undefined; }>;
 }, boolean>(({ config }) => (config.get().retries ?? 3) > 0, {
@@ -76,10 +54,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 15 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, string | false>(({ items }) => items.get().length > 0 && (items.get()[0] ?? "empty"), {
@@ -102,10 +76,6 @@ const __cfLift_3 = __cfHelpers.lift<{
             "enum": [false]
         }]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 11 }
-});
 // Tests nullish coalescing (??) interaction with && and ||
 // ?? should NOT be transformed to when/unless (different semantics)
 // FIXTURE: logical-nullish-coalescing
@@ -113,7 +83,7 @@ __cfBindVerifiedBinding(__cfLift_3, {
 //   (config.get().timeout ?? 30) || "disabled" → lift(...)({ config })
 //   (config.get().retries ?? 3) > 0 && "text"  → lift(...)({ config })
 // Context: ?? has different semantics from || and must not be transformed to unless
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const config = cell<{
         timeout: number | null;
         retries: number | undefined;
@@ -203,10 +173,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,14 +28,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 9 }
-});
 // FIXTURE: logical-or-unless
 // Verifies: || with JSX fallback on right side is transformed to unless()
 //   items.get().length || <span>List is empty</span> → unless(lift(...)(...length), <span>List is empty</span>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell<string[]>([], {
         type: "array",
         items: {
@@ -109,10 +87,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -52,10 +34,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 9 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ active: boolean; verified: boolean; name: string; }>;
 }, string>(({ user }) => user.get().name, {
@@ -76,16 +54,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 69 }
-});
 // Tests triple && chain: a && b && c
 // Should produce nested when calls or lower the entire chain to a lift-applied computation
 // FIXTURE: logical-triple-and-chain
 // Verifies: triple && chain (a && b && <JSX>) is transformed to nested when() or a lift-applied computation
 //   user.get().active && user.get().verified && <span> → when(lift(...)({ user }), <span>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const user = cell<{
         active: boolean;
         verified: boolean;
@@ -154,10 +128,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,10 +30,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 15 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
 }, number | undefined>(({ items }) => items.get()[0]?.length || items.get()[1]?.length, {
@@ -69,16 +47,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 15 }
-});
 // Tests triple || chain: a || b || c
 // Should produce nested unless calls
 // FIXTURE: logical-triple-or-chain
 // Verifies: triple || chain (a || b || c) is transformed to nested unless() calls
 //   primary.get().length || secondary.get().length || "no content" → unless(unless(...), "no content")
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const primary = cell("", {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema).for("primary", true);
@@ -144,10 +118,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,10 +28,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 9 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
     return (<span>{name}</span>);
@@ -82,14 +60,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 22 }
-});
 // FIXTURE: map-array-length-conditional
 // Verifies: length-guard && map pattern is transformed to when() wrapping mapWithPattern()
 //   list.get().length > 0 && (<div>{list.map(...)}</div>) → when(lift(...)(...length), <div>{list.mapWithPattern(...)}</div>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const list = cell(["apple", "banana", "cherry"], {
         type: "array",
         items: {
@@ -146,10 +120,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,11 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
@@ -120,11 +97,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -166,10 +139,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,11 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const __cf_destructure_1 = file.key("tags"), kind = __cf_destructure_1.key("0");
@@ -126,11 +103,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -175,10 +148,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -94,11 +76,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -140,10 +118,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -115,10 +97,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 9 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     message: {
         author: string;
@@ -146,11 +124,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 25 },
-    bindingName: "isMine"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     message: {
         author: string;
@@ -172,11 +145,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 32 },
-    bindingName: "isKnownAuthor"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const message = __cf_pattern_input.key("element");
     const name = __cf_pattern_input.key("params", "name");
@@ -263,11 +231,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 42 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const name = __cf_pattern_input.key("name");
     const selectedRoom = __cf_pattern_input.key("selectedRoom");
     return {
@@ -325,10 +289,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,10 +54,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 10 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     __cfLift_1({ file: {
@@ -126,11 +104,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -172,10 +146,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -60,11 +42,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 24 },
-    bindingName: "label"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
@@ -113,11 +90,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -159,10 +132,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -68,11 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     file: {
         contentType: string;
@@ -94,11 +71,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 41 },
-    bindingName: "isOpenable"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const isFolder = __cfLift_1({ file: {
@@ -168,11 +140,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -217,10 +185,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,11 +49,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const meta = { kind: file.key("type") };
@@ -130,11 +107,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -176,10 +149,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -94,11 +76,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -140,10 +118,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -59,11 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");
@@ -120,11 +97,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -166,10 +139,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -62,11 +44,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "isFolder"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const info = [file.key("type"), file.key("name")] as const;
@@ -123,11 +100,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
@@ -169,10 +142,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,15 +65,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 23 }
-});
 // FIXTURE: map-nested-conditional-no-name
 // Verifies: same nested conditional map transforms work when pattern param is typed as any
 //   showList && <div>{items.map(...)}</div> → when(showList, <div>{items.mapWithPattern(...)}</div>)
 // Context: Variant of map-nested-conditional with _state: any instead of named pattern
-export default __cfBindVerifiedBinding(pattern((_state: any) => {
+export default pattern((_state: any) => {
     const items = cell([{ name: "apple" }, { name: "banana" }], {
         type: "array",
         items: {
@@ -156,10 +134,7 @@ export default __cfBindVerifiedBinding(pattern((_state: any) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -83,15 +65,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 23 }
-});
 // FIXTURE: map-nested-conditional
 // Verifies: when() guard around mapWithPattern() with nested when() inside the map body
 //   showList && <div>{items.map(item => <div>{item.name && <span>}</div>)}</div>
 //   → when(showList, <div>{items.mapWithPattern(pattern(... when(item.name, <span>)))}</div>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell([{ name: "apple" }, { name: "banana" }], {
         type: "array",
         items: {
@@ -156,10 +134,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-row-ternary-computed-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-row-ternary-computed-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -52,11 +34,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 22 },
-    bindingName: "me"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -82,10 +59,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 10 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const me = __cf_pattern_input.key("params", "me");
@@ -165,10 +138,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 19 }
-});
 // FIXTURE: map-row-ternary-computed-capture
 // Verifies: a binary comparison inside a JSX map-row ternary, comparing the
 //   element binding against a computed captured from the enclosing pattern
@@ -178,7 +147,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //     -> mapWithPattern row with an ifElse over a lifted comparison
 // Context: regression companion to the builder-argument computation
 //   diagnostic — this shape is supported and must keep lowering cleanly.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const links = __cf_pattern_input.key("links");
     const myName = __cf_pattern_input.key("myName");
     const me = __cfLift_1({ myName: myName }).for("me", true);
@@ -248,10 +217,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 35 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,10 +28,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 9 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -92,15 +70,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 24 }
-});
 // FIXTURE: map-single-capture-no-name
 // Verifies: same map + length guard transforms work with _state: any parameter
 //   people.get().length > 0 && <ul>{people.map(...)}</ul> → when(..., <ul>{mapWithPattern(...)}</ul>)
 // Context: Variant of map-single-capture with _state: any
-export default __cfBindVerifiedBinding(pattern((_state: any) => {
+export default pattern((_state: any) => {
     const people = cell([
         { id: "1", name: "Alice" },
         { id: "2", name: "Bob" },
@@ -169,10 +143,7 @@ export default __cfBindVerifiedBinding(pattern((_state: any) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,10 +28,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 9 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -92,15 +70,11 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 24 }
-});
 // FIXTURE: map-single-capture
 // Verifies: .map() with length guard is transformed to when() + mapWithPattern()
 //   people.get().length > 0 && <ul>{people.map((person, index) => <li>)}</ul>
 //   → when(lift(...)(...length), <ul>{people.mapWithPattern(pattern(...), {})}</ul>)
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const people = cell([
         { id: "1", name: "Alice" },
         { id: "2", name: "Bob" },
@@ -169,10 +143,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -72,10 +54,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 27 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -101,10 +79,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 11 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -126,10 +100,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 11 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -158,10 +128,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 53, col: 11 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     x: number;
     state: {
@@ -187,10 +153,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 37 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -226,10 +188,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 30 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     x: number;
     state: {
@@ -255,10 +213,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 59, col: 24 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -312,10 +266,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 58, col: 62 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -348,10 +298,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 66, col: 11 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -384,10 +330,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 74, col: 25 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         names: string[];
@@ -416,10 +358,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 80, col: 20 }
-});
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         names: string[];
@@ -448,10 +386,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_10, {
-    sourceFile: "/test.tsx",
-    position: { line: 85, col: 24 }
-});
 const __cfLift_11 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim().toLowerCase().replace(" ", "-"), {
@@ -465,10 +399,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_11, {
-    sourceFile: "/test.tsx",
-    position: { line: 92, col: 17 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
     return (<li>{__cfLift_11({ name: name })}</li>);
@@ -501,10 +431,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 91, col: 27 }
-});
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         prices: number[];
@@ -533,10 +459,6 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_12, {
-    sourceFile: "/test.tsx",
-    position: { line: 98, col: 32 }
-});
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -566,10 +488,6 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_13, {
-    sourceFile: "/test.tsx",
-    position: { line: 107, col: 11 }
-});
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         prices: number[];
@@ -598,10 +516,6 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_14, {
-    sourceFile: "/test.tsx",
-    position: { line: 114, col: 28 }
-});
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -627,10 +541,6 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_15, {
-    sourceFile: "/test.tsx",
-    position: { line: 120, col: 11 }
-});
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -657,10 +567,6 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_16, {
-    sourceFile: "/test.tsx",
-    position: { line: 126, col: 11 }
-});
 const __cfLift_17 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
@@ -698,10 +604,6 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_17, {
-    sourceFile: "/test.tsx",
-    position: { line: 134, col: 11 }
-});
 const __cfLift_18 = __cfHelpers.lift<{
     u: {
         name: string;
@@ -723,10 +625,6 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_18, {
-    sourceFile: "/test.tsx",
-    position: { line: 140, col: 28 }
-});
 const __cfLift_19 = __cfHelpers.lift<{
     u: {
         name: string;
@@ -748,10 +646,6 @@ const __cfLift_19 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_19, {
-    sourceFile: "/test.tsx",
-    position: { line: 140, col: 51 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const u = __cf_pattern_input.key("element");
     return (<li>{__cfHelpers.ifElse({
@@ -808,10 +702,6 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 139, col: 27 }
-});
 const __cfLift_20 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
@@ -846,10 +736,6 @@ const __cfLift_20 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_20, {
-    sourceFile: "/test.tsx",
-    position: { line: 147, col: 11 }
-});
 const __cfLift_21 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
@@ -880,10 +766,6 @@ const __cfLift_21 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_21, {
-    sourceFile: "/test.tsx",
-    position: { line: 149, col: 24 }
-});
 const __cfLift_22 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -909,10 +791,6 @@ const __cfLift_22 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_22, {
-    sourceFile: "/test.tsx",
-    position: { line: 154, col: 23 }
-});
 const __cfLift_23 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -938,10 +816,6 @@ const __cfLift_23 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_23, {
-    sourceFile: "/test.tsx",
-    position: { line: 159, col: 20 }
-});
 const __cfLift_24 = __cfHelpers.lift<{
     state: {
         words: string[];
@@ -970,17 +844,13 @@ const __cfLift_24 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_24, {
-    sourceFile: "/test.tsx",
-    position: { line: 163, col: 20 }
-});
 // FIXTURE: method-chains
 // Verifies: chained method calls and array method chains in JSX are wrapped in a lift-applied computation
 //   state.text.trim().toLowerCase()          → lift(...)({ text })
 //   state.items.filter(fn).map(fn)           → .filterWithPattern(...).mapWithPattern(...)
 //   state.prices.reduce(fn, 0)               → lift(...)({ prices, discount })
 // Context: Covers string chains, filter/map chains, reactive args, computed values, complex predicates
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Chained String Methods</h3>
@@ -1300,10 +1170,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/no-transform-simple-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/no-transform-simple-ref.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -35,7 +17,7 @@ const _element = <div>{count}</div>;
 // Verifies: a bare Reactive in JSX ({count}) is NOT wrapped in a lift-applied computation -- passed through as-is
 //   <div>{count}</div> → <div>{count}</div>  (unchanged)
 // Context: Negative test -- simple ref interpolation needs no transformation
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     return {
         [NAME]: "test",
     };
@@ -47,10 +29,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
         }
     },
     required: ["$NAME"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -66,10 +48,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 17 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span>{__cfLift_1({ item: {
@@ -120,16 +98,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 25 }
-});
 // FIXTURE: optional-chain-captures
 // Verifies: optional chaining (?.) in JSX is resolved to .key() or wrapped in a lift-applied computation
 //   state.maybe?.value         → state.key("maybe", "value")
 //   item.maybe?.value ?? 0     → lift(({item}) => item.maybe?.value ?? 0)({ item })
 // Context: Optional chaining with nullish coalescing inside a map body
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <span>{state.key("maybe", "value")}</span>
@@ -201,10 +175,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,15 +32,11 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 9 }
-});
 // FIXTURE: optional-element-access
 // Verifies: optional element access (?.[0]) in a negated && guard is transformed to when(lift(...)(...))
 //   !list.get()?.[0] && <span> → when(lift(({list}) => !list.get()?.[0])({ list }), <span>)
 // Context: Cell typed as string[] | undefined, with optional bracket access
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const list = cell<string[] | undefined>(undefined, {
         anyOf: [{
                 type: "undefined"
@@ -121,10 +99,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-method-calls.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,10 +40,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 14 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         maybeText?: string | undefined;
@@ -82,10 +60,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 12 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         maybeText?: string | undefined;
@@ -111,10 +85,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 10 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     item: string | undefined;
 }, string | undefined>(({ item }) => item?.trim?.(), {
@@ -127,10 +97,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 40 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{__cfLift_4({ item: item })}</span>;
@@ -162,10 +128,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 23 }
-});
 // FIXTURE: optional-method-calls
 // Verifies: receiver and invocation optionality lower as whole computations
 //   state.maybeText?.trim()                     → lift preserving receiver ?.
@@ -174,7 +136,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   format?.(state.maybeText ?? "")              → lift preserving lazy args
 // Context: Optionality modifies an otherwise supported call;
 //          the underlying call's provenance and lowering route stay unchanged.
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     normalized: __cfLift_1({ state: {
             maybeText: state.key("maybeText")
         } }).for(["__patternResult", "normalized"], true),
@@ -240,10 +202,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,17 +28,13 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 14 }
-});
 // FIXTURE: parameterized-inline-call-root
 // Verifies: helper-owned parameterized inline-function call roots lower as a
 // shared post-closure lift-applied computation around the whole call, not as a lift-applied computation inside the
 // inline function body that leaves the reactive argument outside.
 //   ((value) => prefix + value)(count)
 //     -> lift(({ prefix, count }) => ((value) => prefix + value)(count))({ prefix, count })
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const prefix = __cf_pattern_input.key("prefix");
     const count = __cf_pattern_input.key("count");
     return ({
@@ -105,10 +83,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 10, col: 58 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -150,10 +132,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 99, col: 11 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         user: {
@@ -183,10 +161,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 105, col: 28 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         user: {
@@ -216,10 +190,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 106, col: 11 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         user: {
@@ -262,10 +232,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 172, col: 14 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         user: {
@@ -295,10 +261,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 174, col: 14 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         config: {
@@ -354,10 +316,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 179, col: 25 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         user: {
@@ -387,10 +345,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 195, col: 22 }
-});
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         user: {
@@ -420,16 +374,12 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 196, col: 11 }
-});
 // FIXTURE: parent-suppression-edge
 // Verifies: property access suppression -- sibling properties share a captured parent in a lift-applied computation
 //   {state.user.name} ... {state.user.age} → individual .key() or shared lift(...)({ user: {...} })
 //   {state.config.theme.colors.primary}    → lift-applied computation with deeply nested capture
 // Context: Tests that the transformer correctly deduplicates and suppresses parent captures
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         [UI]: (<div>
         <h3>Same Base, Different Properties</h3>
@@ -1008,10 +958,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 85, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,11 +28,6 @@ const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() + 1);
 });
-__cfBindVerifiedBinding(increment, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 26 },
-    bindingName: "increment"
-});
 const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -64,11 +41,6 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
     value: Cell<number>;
 }) => {
     state.value.set(state.value.get() - 1);
-});
-__cfBindVerifiedBinding(decrement, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 26 },
-    bindingName: "decrement"
 });
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
@@ -91,10 +63,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 24 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -116,10 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 21 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -141,10 +105,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 20 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -166,17 +126,13 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 19 }
-});
 // FIXTURE: pattern-statements-vs-jsx
 // Verifies: only JSX-context expressions are transformed; statement-context expressions are left alone
 //   const next = state.value + 1    → NOT transformed (statement context)
 //   <p>{state.value + 1}</p>        → lift(({state}) => state.value + 1)({ value }) (JSX context)
 //   state.value > 10 ? "High":"Low" → ifElse(lift(...)(...), "High", "Low") (JSX context)
 // Context: Ensures the transformer distinguishes between statement and JSX expression contexts
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     return {
         // This template literal SHOULD be transformed (builder function context)
         [NAME]: str `Simple counter: ${state.key("value")}`,
@@ -258,10 +214,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -33,7 +15,7 @@ const __cfAmdHooks = undefined;
 // Verifies: top-level pattern JSX logical roots lower structurally, but computed-owned logical roots stay authored
 //   <div>{foo && name}</div> in a pattern body → __cfHelpers.when(...)
 //   <div>{computed(() => foo && bar)}</div> keeps the authored && inside the computed callback
-export const PatternLogicalAnd = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const PatternLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const name = __cf_pattern_input.key("user", "name");
     return (<div>{__cfHelpers.when({
@@ -80,11 +62,7 @@ export const PatternLogicalAnd = __cfBindVerifiedBinding(pattern((__cf_pattern_i
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 3 },
-    bindingName: "PatternLogicalAnd"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     foo: boolean;
     bar: string;
@@ -107,11 +85,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             "enum": [false]
         }]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 17 }
-});
-export const ComputedLogicalAnd = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");
     return (<div>{__cfLift_1({
@@ -149,11 +123,7 @@ export const ComputedLogicalAnd = __cfBindVerifiedBinding(pattern((__cf_pattern_
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 73 },
-    bindingName: "ComputedLogicalAnd"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,10 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 24 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     cell: {
         value: number;
@@ -75,16 +53,12 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 20 }
-});
 // FIXTURE: pattern-with-cells
 // Verifies: pattern input property access is transformed to .key() and arithmetic to a lift-applied computation
 //   cell.value       → cell.key("value")
 //   cell.value + 1   → lift(({cell}) => cell.value + 1)({ value: asOpaque })
 //   cell.value * 2   → lift(({cell}) => cell.value * 2)({ value: asOpaque })
-export default __cfBindVerifiedBinding(pattern((cell) => {
+export default pattern((cell) => {
     return {
         [UI]: (<div>
         <p>Current value: {cell.key("value")}</p>
@@ -137,10 +111,7 @@ export default __cfBindVerifiedBinding(pattern((cell) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-cell-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -66,11 +48,6 @@ const SimplePattern = pattern(() => ({
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(SimplePattern, {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 },
-    bindingName: "SimplePattern"
-});
 // Create a cell to store an array of pieces
 const createCellRef = lift(({ isInitialized, storedCellRef }) => {
     if (!isInitialized.get()) {
@@ -102,11 +79,6 @@ const createCellRef = lift(({ isInitialized, storedCellRef }) => {
     },
     required: ["isInitialized", "storedCellRef"],
 });
-__cfBindVerifiedBinding(createCellRef, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 2 },
-    bindingName: "createCellRef"
-});
 // Add a piece to the array and navigate to it
 // we get a new isInitialized passed in for each
 // piece we add to the list. this makes sure
@@ -133,11 +105,6 @@ const addPieceAndNavigate = lift(({ piece, cellRef, isInitialized }) => {
     },
     required: ["piece", "isInitialized"],
 });
-__cfBindVerifiedBinding(addPieceAndNavigate, {
-    sourceFile: "/test.tsx",
-    position: { line: 57, col: 2 },
-    bindingName: "addPieceAndNavigate"
-});
 // Create a new SimplePattern and add it to the array
 const createSimplePattern = handler({
     type: "unknown"
@@ -161,11 +128,6 @@ const createSimplePattern = handler({
     // Store the piece in the array and navigate
     return addPieceAndNavigate({ piece, cellRef, isInitialized });
 });
-__cfBindVerifiedBinding(createSimplePattern, {
-    sourceFile: "/test.tsx",
-    position: { line: 82, col: 2 },
-    bindingName: "createSimplePattern"
-});
 // Handler to navigate to a specific piece from the list
 const goToPiece = handler({
     type: "unknown"
@@ -181,11 +143,6 @@ const goToPiece = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { piece }) => {
     console.log("goToPiece clicked");
     return navigateTo(piece);
-});
-__cfBindVerifiedBinding(goToPiece, {
-    sourceFile: "/test.tsx",
-    position: { line: 96, col: 2 },
-    bindingName: "goToPiece"
 });
 const __cfLift_1 = __cfHelpers.lift<{
     cellRef: unknown[];
@@ -203,10 +160,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 123, col: 10 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     piece: any;
 }, any>(({ piece }) => piece[__cfHelpers.NAME], {
@@ -216,10 +169,6 @@ const __cfLift_2 = __cfHelpers.lift<{
     },
     required: ["piece"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 133, col: 42 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const piece = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -261,10 +210,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 126, col: 25 }
-});
 // FIXTURE: reactive-cell-map
 // Verifies: a reactive factory result still rewrites JSX ifElse predicates after
 //           the forbidden Reactive cast is removed
@@ -273,7 +218,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //     `as { cellRef: any[] }`, because the cast does not change the reactive origin
 // Context: Real-world pattern using Cell.for<any[]>(), handler, lift, and navigateTo
 // create the named cell inside the pattern body, so we do it just once
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     // cell to store array of pieces we created
     const __cf_destructure_1 = createCellRef({
         isInitialized: cell(false, {
@@ -346,10 +291,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 110, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/reactive-operations.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,10 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 18 }
-});
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
 }, number>(({ count }) => count.get() * 2, {
@@ -61,10 +39,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 20 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     price: __cfHelpers.Cell<number>;
 }, number>(({ price }) => price.get() * 1.1, {
@@ -79,16 +53,12 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 19 }
-});
 // FIXTURE: reactive-operations
 // Verifies: arithmetic on cell-backed Reactives in JSX is wrapped in a lift-applied computation with asCell schema
 //   {count}           → {count}  (bare ref, no transform)
 //   {count.get() + 1} → lift(({count}) => count.get() + 1)({ count: asCell })
 //   {price.get() * 1.1} → lift(...)({ price: asCell })
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const count = cell(10, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
@@ -132,10 +102,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,10 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 24 }
-});
 // FIXTURE: safe-context-and-jsx
 // Verifies: && and || with JSX inside handler callbacks are transformed to when()/unless()
 //   computed(() => show) && <span> → when(computed(() => show), <span>)
@@ -142,11 +120,6 @@ const MyHandler = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_event, { show }) => {
     return <div>{__cfLift_1({ show: show }) && <span>Content</span>}</div>;
 });
-__cfBindVerifiedBinding(MyHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 52 },
-    bindingName: "MyHandler"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     value: string | null;
 }, string | null>(({ value }) => value, {
@@ -168,10 +141,6 @@ const __cfLift_2 = __cfHelpers.lift<{
             type: "null"
         }]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 24 }
-});
 // Test: || with JSX inside handler callback should transform to unless()
 const MyHandler2 = handler({
     type: "object",
@@ -265,11 +234,6 @@ const MyHandler2 = handler({
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, { value }) => {
     return <div>{__cfLift_2({ value: value }) || <span>Fallback</span>}</div>;
-});
-__cfBindVerifiedBinding(MyHandler2, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 60 },
-    bindingName: "MyHandler2"
 });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-binary-condition-body-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-binary-condition-body-alias.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,10 +28,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 9 }
-});
 // FIXTURE: ternary-binary-condition-body-alias
 // Verifies: a JSX ternary whose condition is a binary comparison over a
 //   body-level alias of a reactive read lowers without crashing the
@@ -58,7 +36,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //     -> ifElse(<derived boolean>, <branch>, null)
 // Context: regression companion to the builder-argument computation
 //   diagnostic — this shape is supported and must keep lowering cleanly.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const users = __cf_pattern_input.key("users");
     const userCount = users.key("length");
     return {
@@ -123,10 +101,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 34 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -100,11 +82,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 33, col: 26 },
-    bindingName: "sorted"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
@@ -134,11 +111,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 25 },
-    bindingName: "count"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     state: any;
 }, boolean>(({ state }) => state.recentEvents.length === 0, {
@@ -150,10 +122,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 9 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
@@ -203,10 +171,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 38 }
-});
 // FIXTURE: ternary-branch-ownership
 // Verifies: ternary branches preserve the right ownership mode for lowered work
 //   state.user.settings.notifications ? "enabled" : "disabled"
@@ -215,7 +179,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //     -> single branch lift-applied computation + recentEvents.mapWithPattern(...)
 //   showList ? (() => { const itemCount = count + " items"; return <div>{sorted.map(...)}</div>; })() : ...
 //     -> whole branch compute-wrapped, so sorted.map(...) stays plain JS
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const showList = new Writable(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
@@ -369,10 +333,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 31, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -88,11 +70,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 26 },
-    bindingName: "sorted"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
@@ -122,11 +99,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 25 },
-    bindingName: "count"
-});
 // FIXTURE: ternary-hoisted-compute-plain-map-branch
 // Verifies: once a ternary JSX branch is wholly compute-wrapped, compute-owned
 // array maps inside that branch stay plain Array.map() calls.
@@ -134,7 +106,7 @@ __cfBindVerifiedBinding(__cfLift_2, {
 //     → ifElse(showList, lift(() => { const itemCount = ...; return <div>{sorted.map(...)}</div>; })(...), ...)
 // Context: the branch contains both a local compute-only alias and a map over
 //   a computed array result, so the whole branch should be handled as compute-owned.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const showList = new Writable(true, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("showList", true);
@@ -229,10 +201,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 42 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -48,10 +30,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 7 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");
@@ -101,10 +79,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
 // FIXTURE: ternary-pure-jsx-map-branch
 // Verifies: a plain reactive array map inside a ternary JSX branch stays
 // pattern-lowered without wrapping the whole branch in extra lift-applied noise.
@@ -112,7 +86,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //     → ifElse(lift(...)(length===0), <span>...</span>, <div>{recentEvents.mapWithPattern(...)}</div>)
 // Context: implicit JSX ternary branch selection with a pure pattern-owned map
 //   in the false branch.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const recentEvents = __cf_pattern_input.key("recentEvents");
     return ({
         [UI]: (<div>
@@ -189,10 +163,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 53 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -77,11 +59,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 18 },
-    bindingName: "a"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -107,11 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 18 },
-    bindingName: "b"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -137,11 +109,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 18 },
-    bindingName: "c"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.key("params", "prefix");
@@ -216,11 +183,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 19 }
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
     return ({
@@ -263,10 +226,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -52,11 +34,6 @@ const openNoteEditor = handler({
     },
     required: ["subPieces", "editingNoteIndex", "editingNoteText", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(openNoteEditor, {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 3 },
-    bindingName: "openNoteEditor"
-});
 const openSettings = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -71,11 +48,6 @@ const openSettings = handler({
     },
     required: ["settingsModuleIndex", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(openSettings, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 3 },
-    bindingName: "openSettings"
-});
 const toggleExpanded = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -90,11 +62,6 @@ const toggleExpanded = handler({
     },
     required: ["expandedIndex", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(toggleExpanded, {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 3 },
-    bindingName: "toggleExpanded"
-});
 const trashSubPiece = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -124,11 +91,6 @@ const trashSubPiece = handler({
     },
     required: ["subPieces", "trashedSubPieces", "expandedIndex", "settingsModuleIndex", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(trashSubPiece, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 3 },
-    bindingName: "trashSubPiece"
-});
 interface Item {
     note?: string;
     collapsed?: boolean;
@@ -218,11 +180,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 52, col: 30 },
-    bindingName: "allEntries"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         collapsed?: boolean | undefined;
@@ -247,10 +204,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 21 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
@@ -279,10 +232,6 @@ const __cfLift_3 = __cfHelpers.lift<{
     },
     required: ["fontWeight"]
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 79, col: 34 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
@@ -303,10 +252,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 82, col: 34 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     isExpanded: boolean;
 }, boolean>(({ isExpanded }) => !isExpanded, {
@@ -320,10 +265,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 88, col: 15 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     isExpanded: boolean;
 }, boolean>(({ isExpanded }) => !isExpanded, {
@@ -337,10 +278,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 105, col: 15 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element", "entry");
     const index = __cf_pattern_input.key("element", "index");
@@ -563,10 +500,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 65, col: 24 }
-});
 // FIXTURE: branch-lowered-capture-preservation
 // Verifies: branch-lowered UI chunks inside a computed-array map preserve captured
 // params needed by nested ifElse branches, inline computed() attributes, and handlers
@@ -576,7 +509,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //     -> params captures survive inside lowered branches
 //   computed(() => entry?.note ? "700" : "400") / title computed(...)
 //     -> authored compute wrappers still coexist with the preserved captures
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const subPieces = __cf_pattern_input.key("subPieces");
     const trashedSubPieces = __cf_pattern_input.key("trashedSubPieces");
@@ -677,10 +610,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -133,11 +115,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 38, col: 35 },
-    bindingName: "visibleProjects"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     memberIndex: number;
 }, boolean>(({ memberIndex }) => memberIndex === 0, {
@@ -151,10 +128,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 71, col: 15 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     project: {
         name: string;
@@ -180,10 +153,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 71, col: 35 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const member = __cf_pattern_input.key("element");
     const memberIndex = __cf_pattern_input.key("index");
@@ -251,10 +220,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 69, col: 31 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     visibleProjects: {
         name: string;
@@ -387,13 +352,8 @@ visibleProjects.map((project, projectIndex) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 24 },
-    bindingName: "rows"
-});
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected
     const fallbackMembers = new Writable(["ops", "sales"], {
         type: "array",
@@ -504,10 +464,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -84,11 +66,6 @@ const jumpToComment = handler({
     },
     required: ["selectedCommentId", "threadId", "commentId", "lane", "outerIndex", "innerIndex"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(jumpToComment, {
-    sourceFile: "/test.tsx",
-    position: { line: 51, col: 3 },
-    bindingName: "jumpToComment"
-});
 // [TRANSFORM] lift: input and output schemas injected
 const passthroughLabels = lift((labels: string[]) => labels, {
     type: "array",
@@ -101,11 +78,6 @@ const passthroughLabels = lift((labels: string[]) => labels, {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(passthroughLabels, {
-    sourceFile: "/test.tsx",
-    position: { line: 54, col: 31 },
-    bindingName: "passthroughLabels"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         threads: Thread[];
@@ -248,11 +220,6 @@ state.threads.map((thread, outerIndex) => ({
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 67, col: 34 },
-    bindingName: "visibleThreads"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     visibleComments: Comment[];
 }, Comment[]>(({ visibleComments }) => visibleComments, {
@@ -318,11 +285,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 88, col: 39 },
-    bindingName: "reboundComments"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     reboundIndex: number;
     outerIndex: number;
@@ -340,10 +302,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 130, col: 15 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         lane: string;
@@ -377,10 +335,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 131, col: 18 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const comment = __cf_pattern_input.key("element");
     const reboundIndex = __cf_pattern_input.key("index");
@@ -466,10 +420,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 128, col: 31 }
-});
 const __cfLift_5 = __cfHelpers.lift<{
     edgeIndex: number;
     outerIndex: number;
@@ -487,10 +437,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 139, col: 15 }
-});
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         lane: string;
@@ -516,10 +462,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 139, col: 42 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const edge = __cf_pattern_input.key("element");
     const edgeIndex = __cf_pattern_input.key("index");
@@ -594,10 +536,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 137, col: 32 }
-});
 const __cfLift_7 = __cfHelpers.lift<{
     visibleThreads: {
         thread: {
@@ -779,11 +717,6 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 79, col: 30 },
-    bindingName: "threadRows"
-});
 const __cfLift_8 = __cfHelpers.lift<{
     labelIndex: number;
 }, boolean>(({ labelIndex }) => labelIndex === 0, {
@@ -797,10 +730,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_8, {
-    sourceFile: "/test.tsx",
-    position: { line: 156, col: 13 }
-});
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         lane: string;
@@ -826,10 +755,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_9, {
-    sourceFile: "/test.tsx",
-    position: { line: 156, col: 32 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const label = __cf_pattern_input.key("element");
     const labelIndex = __cf_pattern_input.key("index");
@@ -897,10 +822,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 154, col: 24 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const rowIndex = __cf_pattern_input.key("index");
@@ -958,12 +879,8 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 160, col: 24 }
-});
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected; undefined default added for optional type
     const selectedCommentId = new Writable<string | undefined>(undefined, {
         type: ["string", "undefined"]
@@ -1085,10 +1002,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 61, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -81,11 +63,6 @@ const selectTask = handler({
     },
     required: ["selectedTaskId", "hoveredSectionId", "sectionId", "taskId", "sectionIndex", "taskIndex"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-__cfBindVerifiedBinding(selectTask, {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 3 },
-    bindingName: "selectTask"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         sections: __cfHelpers.ReadonlyCell<unknown[]>;
@@ -111,11 +88,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 53, col: 31 },
-    bindingName: "hasSections"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     task: {
         note?: string | undefined;
@@ -136,10 +108,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 97, col: 30 }
-});
 const __cfLift_3 = __cfHelpers.lift<{
     tagIndex: number;
     taskIndex: number;
@@ -157,10 +125,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 107, col: 29 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const tagIndex = __cf_pattern_input.key("index");
@@ -264,10 +228,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 105, col: 39 }
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const task = __cf_pattern_input.key("element");
     const taskIndex = __cf_pattern_input.key("index");
@@ -432,10 +392,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 80, col: 39 }
-});
 const __cfLift_4 = __cfHelpers.lift<{
     section: {
         tasks: {
@@ -493,10 +449,6 @@ section.tasks.length > 0
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 120, col: 18 }
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const sectionIndex = __cf_pattern_input.key("index");
@@ -661,12 +613,8 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 64, col: 32 }
-});
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected; undefined default added for optional type
     const selectedTaskId = new Writable<string | undefined>(undefined, {
         type: ["string", "undefined"]
@@ -816,10 +764,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/auth-availability-union-cell-preserved.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/auth-availability-union-cell-preserved.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -49,7 +31,7 @@ interface Input {
 // FIXTURE: auth-availability-union-cell-preserved
 // A discriminated union can represent loading auth separately from ready auth.
 // The ready variant keeps the nested auth value as a live writable cell.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const availability = __cf_pattern_input.key("availability");
     return {
         availability,
@@ -166,10 +148,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["token", "user"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -47,11 +29,6 @@ const liftWrapped = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftWrapped, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 25 },
-    bindingName: "liftWrapped"
-});
 const patternFullShape = pattern((input: Writable<{
     foo: string;
     bar: string;
@@ -71,11 +48,6 @@ const patternFullShape = pattern((input: Writable<{
     type: "string",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(patternFullShape, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 33 },
-    bindingName: "patternFullShape"
-});
 const patternExplicit = pattern((input) => input.key("foo"), {
     type: "object",
     properties: {
@@ -92,11 +64,6 @@ const patternExplicit = pattern((input) => input.key("foo"), {
     type: "string",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(patternExplicit, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 2 },
-    bindingName: "patternExplicit"
-});
 const liftPassthrough = lift((input: Writable<{
     foo: string;
     bar: string;
@@ -125,11 +92,6 @@ const liftPassthrough = lift((input: Writable<{
     required: ["foo", "bar"],
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftPassthrough, {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 29 },
-    bindingName: "liftPassthrough"
-});
 const helper = __cfHardenFn((value: Writable<{
     foo: string;
     bar: string;
@@ -153,11 +115,6 @@ const patternHelper = pattern((input: Writable<{
     type: "string",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(patternHelper, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 30 },
-    bindingName: "patternHelper"
-});
 const wildcardLift = lift((input: Writable<{
     foo: string;
     bar: string;
@@ -180,11 +137,6 @@ const wildcardLift = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(wildcardLift, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 26 },
-    bindingName: "wildcardLift"
-});
 export default __cfHelpers.__cf_data({
     liftWrapped,
     patternFullShape,

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -46,21 +28,11 @@ const liftOptional = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftOptional, {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 26 },
-    bindingName: "liftOptional"
-});
 const deriveInput: Writable<{
     foo: string;
     bar: string;
 }> = __cfHelpers.__cf_data({} as never);
 const __cfLift_1 = __cfHelpers.lift(() => deriveInput.key("foo").get(), false, undefined, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 13, col: 34 },
-    bindingName: "computedObserved"
-});
 const computedObserved = __cfHelpers.__cf_data(__cfLift_1().for("computedObserved", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -78,11 +50,6 @@ const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema,
     bar: string;
 }>) => {
     state.key("foo").get();
-});
-__cfBindVerifiedBinding(handlerObserved, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 2 },
-    bindingName: "handlerObserved"
 });
 const handlerExplicit = handler({
     type: "object",
@@ -114,11 +81,6 @@ const handlerExplicit = handler({
     event.detail.message;
     state.key("foo").get();
 });
-__cfBindVerifiedBinding(handlerExplicit, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 2 },
-    bindingName: "handlerExplicit"
-});
 const helper = __cfHardenFn((value: Writable<{
     foo: string;
     bar: string;
@@ -138,11 +100,6 @@ const liftInterprocedural = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftInterprocedural, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 33 },
-    bindingName: "liftInterprocedural"
-});
 const liftWriteOnly = lift((input: Writable<{
     foo: string;
     bar: string;
@@ -161,11 +118,6 @@ const liftWriteOnly = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftWriteOnly, {
-    sourceFile: "/test.tsx",
-    position: { line: 36, col: 27 },
-    bindingName: "liftWriteOnly"
-});
 const liftExplicit = lift((input) => input.key("foo").get(), {
     type: "object",
     properties: {
@@ -178,11 +130,6 @@ const liftExplicit = lift((input) => input.key("foo").get(), {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftExplicit, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 2 },
-    bindingName: "liftExplicit"
-});
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -199,11 +146,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get());
-__cfBindVerifiedBinding(__cfHandler_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 46, col: 19 },
-    bindingName: "a"
-});
 const actionPattern = pattern((input: Writable<{
     foo: string;
     bar: string;
@@ -227,11 +169,6 @@ const actionPattern = pattern((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["stream", "opaque"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(actionPattern, {
-    sourceFile: "/test.tsx",
-    position: { line: 45, col: 30 },
-    bindingName: "actionPattern"
-});
 export default __cfHelpers.__cf_data({
     liftOptional,
     computedObserved,

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -58,11 +40,6 @@ const readOnly = lift((input: Writable<State>) => input.key("foo").get(), {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(readOnly, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 22 },
-    bindingName: "readOnly"
-});
 const setOnly = lift((input: Writable<State>) => {
     input.key("foo").set("updated");
     return 1;
@@ -78,11 +55,6 @@ const setOnly = lift((input: Writable<State>) => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(setOnly, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 21 },
-    bindingName: "setOnly"
-});
 const updateOnly = lift((input: Writable<State>) => {
     input.key("profile").update({ name: "Ada" });
     return 1;
@@ -112,11 +84,6 @@ const updateOnly = lift((input: Writable<State>) => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(updateOnly, {
-    sourceFile: "/test.tsx",
-    position: { line: 32, col: 24 },
-    bindingName: "updateOnly"
-});
 const pushOnly = lift((input: Writable<State>) => {
     input.key("items").push({ id: "1", label: "First" });
     return 1;
@@ -149,11 +116,6 @@ const pushOnly = lift((input: Writable<State>) => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(pushOnly, {
-    sourceFile: "/test.tsx",
-    position: { line: 37, col: 22 },
-    bindingName: "pushOnly"
-});
 const readWrite = lift((input: Writable<State>) => {
     input.key("foo").set(input.key("foo").get().toUpperCase());
     return 1;
@@ -169,22 +131,12 @@ const readWrite = lift((input: Writable<State>) => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(readWrite, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 23 },
-    bindingName: "readWrite"
-});
 const comparable = lift((input: Writable<State>) => input.equals(input), {
     type: "unknown",
     asCell: ["comparable"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(comparable, {
-    sourceFile: "/test.tsx",
-    position: { line: 47, col: 24 },
-    bindingName: "comparable"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("id");
@@ -213,10 +165,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 50, col: 12 }
-});
 const opaqueMap = lift((input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_1, {}), {
     type: "array",
     items: {
@@ -243,11 +191,6 @@ const opaqueMap = lift((input: Writable<Item[]>) => input.mapWithPattern(__cfPat
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(opaqueMap, {
-    sourceFile: "/test.tsx",
-    position: { line: 49, col: 23 },
-    bindingName: "opaqueMap"
-});
 export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOnly, };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/collections-empty.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -33,7 +15,7 @@ const __cfAmdHooks = undefined;
 // Verifies: empty arrays and objects produce valid degenerate schemas
 //   cell([]) → cell([], { type: "array", items: false })
 //   cell({}) → cell({}, { type: "object", properties: {} })
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     // Empty array
     const _emptyArray = new Writable<string[]>([], {
         type: "array",
@@ -67,10 +49,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
         }
     },
     required: ["emptyArray", "emptyObject"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 8, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,11 +47,6 @@ const liftSummary = lift(({ primary, secondary }) => {
     },
     required: ["primary", "secondary", "difference"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftSummary, {
-    sourceFile: "/test.tsx",
-    position: { line: 6, col: 2 },
-    bindingName: "liftSummary"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     summary: {
         difference: any;
@@ -87,15 +64,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["summary"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 32 },
-    bindingName: "difference"
-});
 // FIXTURE: context-lift-result-property-projection-shorthand
 // Verifies: shorthand object returns preserve the projected computed() result type
 //   return { difference } → result schema difference: number
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
     const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
@@ -122,10 +94,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         difference: true
     },
     required: ["difference"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -65,11 +47,6 @@ const liftSummary = lift(({ primary, secondary }) => {
     },
     required: ["primary", "secondary", "difference"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(liftSummary, {
-    sourceFile: "/test.tsx",
-    position: { line: 6, col: 2 },
-    bindingName: "liftSummary"
-});
 const __cfLift_1 = __cfHelpers.lift<{
     summary: {
         difference: any;
@@ -87,18 +64,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["summary"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 32 },
-    bindingName: "difference"
-});
 // FIXTURE: context-lift-result-property-projection
 // Verifies: a reactive builder preserves projected property schemas when the captured
 // input comes from a typed lift() result rather than falling back to unknown
 //   computed(() => summary.difference) → captures { difference: number } and outputs number
 //   (KEEP computed: baring to `summary.difference` lowers to a plain .key() access with NO
 //    captured-input schema, defeating this fixture's projection-shrink coverage — verified)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const primary = __cf_pattern_input.key("primary");
     const secondary = __cf_pattern_input.key("secondary");
     const summary = liftSummary({ primary: primary.for(["summary", "primary"], true), secondary: secondary.for(["summary", "secondary"], true) }).for("summary", true);
@@ -129,10 +101,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         difference: true
     },
     required: ["summary", "difference"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,22 +49,12 @@ const testPattern = pattern(() => {
     type: "number",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(testPattern, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 28 },
-    bindingName: "testPattern"
-});
 // 6. Inside handler
 const testHandler = handler(false as const satisfies __cfHelpers.JSONSchema, false as const satisfies __cfHelpers.JSONSchema, () => {
     const _inHandler = cell(60, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("_inHandler", true);
     return _inHandler;
-});
-__cfBindVerifiedBinding(testHandler, {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 28 },
-    bindingName: "testHandler"
 });
 // FIXTURE: context-variations
 // Verifies: schema injection works in all code contexts and pattern/handler get their own schemas

--- a/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -93,12 +75,7 @@ const readAuthor = lift((qv: {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(readAuthor, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 2 },
-    bindingName: "readAuthor"
-});
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const db = sqliteDatabase().for("db", true);
     const q = db.query<{
         author_cf_link: Cell<User>;
@@ -150,10 +127,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -82,11 +64,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 41, col: 29 },
-    bindingName: "firstDone"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     items: {
         label: string | (string & { readonly [DEFAULT_MARKER]: ""; });
@@ -112,11 +89,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 42, col: 35 },
-    bindingName: "firstLabelEmpty"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     items: {
         rank: number | (number & { readonly [DEFAULT_MARKER]: 7; });
@@ -142,11 +114,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 43, col: 29 },
-    bindingName: "firstRank"
-});
 const __cfLift_4 = __cfHelpers.lift<{
     boxes: {
         note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
@@ -172,12 +139,7 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 44, col: 32 },
-    bindingName: "firstBoxNote"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const boxes = __cf_pattern_input.key("boxes");
     const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
@@ -249,10 +211,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["firstDone", "firstLabelEmpty", "firstRank", "firstBoxNote"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 40, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -71,11 +53,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 31 },
-    bindingName: "noteIsUnset"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     settings: {
         count: number | (number & { readonly [DEFAULT_MARKER]: 3; });
@@ -98,11 +75,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 33 },
-    bindingName: "countTimesTwo"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     settings: {
         enabled: boolean | (false & { readonly [DEFAULT_MARKER]: true; }) | (true & { readonly [DEFAULT_MARKER]: true; });
@@ -125,12 +97,7 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 29 },
-    bindingName: "isEnabled"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const settings = __cf_pattern_input.key("settings");
     const noteIsUnset = __cfLift_1({ settings: {
             note: settings.key("note")
@@ -184,10 +151,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["noteIsUnset", "countTimesTwo", "isEnabled"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -66,11 +48,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 31 },
-    bindingName: "extraIsNine"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     items: {
         label: string;
@@ -95,12 +72,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 32 },
-    bindingName: "labelIsGamma"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Extras key: only exists on some elements; must shrink to `priority?`.
     const extraIsNine = __cfLift_1({ items: items }).for("extraIsNine", true);
@@ -144,10 +116,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["extraIsNine", "labelIsGamma"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/result-cell-preserved.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/result-cell-preserved.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -86,12 +68,7 @@ const passThrough = lift((input: PassThroughInput) => input.cell, {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(passThrough, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 25 },
-    bindingName: "passThrough"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         items: items.for(["__patternResult", "items"], true),
@@ -150,10 +127,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["title"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/scoped-factory-assignment.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/scoped-factory-assignment.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -55,12 +37,7 @@ const Child = pattern((__cf_pattern_input) => {
     },
     required: ["label"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(Child, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 47 },
-    bindingName: "Child"
-});
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const label = __cf_pattern_input.key("label");
     const userChild: PerUser<ChildOutput> = Child.asScope("user")({ label });
     const sessionChild: PerSession<ChildOutput> = Child.asScope("session")({ label });
@@ -105,10 +82,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["label"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 35 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/scoped-sqlite-factory.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/scoped-sqlite-factory.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ interface Input {
 // `(...) => Reactive<SqliteDb>` plus an `asScope` method, with no
 // argumentSchema/resultSchema), so this exercises the asScope-method path of
 // the contextual-scope lowering.
-export default __cfBindVerifiedBinding(pattern(() => {
+export default pattern(() => {
     const userDb: PerUser<SqliteDb> = sqliteDatabase.asScope("user")({
         tables: { notes: table({ id: "integer primary key", body: "text" }) },
     }).for("userDb", true);
@@ -81,10 +63,7 @@ export default __cfBindVerifiedBinding(pattern(() => {
             properties: {}
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 21, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,14 +32,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 35 }
-});
 // FIXTURE: boolean-result-schema-normalization
 // Verifies: boolean result schemas stay normalized as `type: "boolean"` instead
 // of expanding into literal `true` / `false` enums.
-export default __cfBindVerifiedBinding(pattern((state: {
+export default pattern((state: {
     isPremium: boolean;
     score: number;
 }) => {
@@ -120,10 +98,7 @@ export default __cfBindVerifiedBinding(pattern((state: {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -43,11 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 14 },
-    bindingName: "len"
-});
 // FIXTURE: cell-get-binding-autowrap
 // Verifies: a `cell.get()` that feeds a chained computation at a
 //   variable-initializer binding is auto-wrapped into a lift, the same way it is
@@ -57,7 +34,7 @@ __cfBindVerifiedBinding(__cfLift_1, {
 //   expression even when the input is a Writable/Cell. The terminal-read
 //   spellings of the same binding are covered by
 //   `cell-get-terminal-binding-autowrap`.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const layout = __cf_pattern_input.key("layout");
     const len = __cfLift_1({ layout: layout }).for("len", true);
     return { len };
@@ -78,10 +55,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["len"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 3 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map-paren-builder.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -81,11 +63,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 15 },
-    bindingName: "view"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("keep");
@@ -114,11 +91,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 33 },
-    bindingName: "view"
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <li>{v.key("label")}</li>;
@@ -165,10 +137,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 18 }
-});
 // FIXTURE: cell-get-derived-collection-map-paren-builder
 // Verifies: parentheses around the pattern builder callback do not change the
 //   site-lifted-collection admission — the derived local still registers, and
@@ -177,7 +145,7 @@ __cfBindVerifiedBinding(__cfPattern_2, {
 // Context: the admission locates the builder call through
 //   getCallArgumentPosition, which reads argument positions through
 //   transparent parens (§5.7 paren-invariance).
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
     return {
@@ -259,10 +227,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 51 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-derived-collection-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -81,11 +63,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 15 },
-    bindingName: "view"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const r = __cf_pattern_input.key("element");
     return r.key("keep");
@@ -114,11 +91,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 33 },
-    bindingName: "view"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     view: Row[];
 }, boolean>(({ view }) => view.length > 0, {
@@ -135,11 +107,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 24, col: 17 },
-    bindingName: "hasAny"
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return v.key("label");
@@ -168,11 +135,6 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 26 },
-    bindingName: "labels"
-});
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <li>{v.key("label")}</li>;
@@ -219,10 +181,6 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 20 }
-});
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const v = __cf_pattern_input.key("element");
     return <em>{v.key("label")}</em>;
@@ -269,10 +227,6 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 35, col: 24 }
-});
 // FIXTURE: cell-get-derived-collection-map
 // Verifies: a local bound to a cell-read chain (`rows.get().filter(...)`) is a
 //   site-lifted reactive collection, and every array-method consumer of it
@@ -286,7 +240,7 @@ __cfBindVerifiedBinding(__cfPattern_4, {
 //   `*WithPattern` spelling structurally; the value-position map keeps its
 //   `.for()` naming on the rewritten chain. `hasAny` pins the
 //   boolean-consumer lift over the same local.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const view = __cfLift_1({ rows: rows }).filterWithPattern(__cfPattern_1, {}).for("view", true);
     const hasAny = __cfLift_2({ view: view }).for("hasAny", true);
@@ -379,10 +333,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 50 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-terminal-binding-autowrap.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -50,11 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 16 },
-    bindingName: "count"
-});
 const __cfLift_2 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
@@ -103,11 +80,6 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 26, col: 14 },
-    bindingName: "all"
-});
 const __cfLift_3 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, Row | undefined>(({ rows }) => rows.get()[0], {
@@ -157,11 +129,6 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_3, {
-    sourceFile: "/test.tsx",
-    position: { line: 27, col: 16 },
-    bindingName: "first"
-});
 const __cfLift_4 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, string>(({ rows }) => rows.get().join(","), {
@@ -193,11 +160,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_4, {
-    sourceFile: "/test.tsx",
-    position: { line: 28, col: 17 },
-    bindingName: "joined"
-});
 const __cfLift_5 = __cfHelpers.lift<{
     rows: __cfHelpers.Writable<Row[]>;
 }, readonly Row[]>(({ rows }) => rows.get(), {
@@ -246,11 +208,6 @@ const __cfLift_5 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_5, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 17 },
-    bindingName: "recent"
-});
 const __cfLift_6 = __cfHelpers.lift<{
     row: {
         sentAt: number;
@@ -272,10 +229,6 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_6, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 44 }
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfLift_6({ row: {
@@ -306,11 +259,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 29, col: 35 },
-    bindingName: "recent"
-});
 const __cfLift_7 = __cfHelpers.lift<{
     label?: __cfHelpers.Writable<string> | undefined;
 }, string | undefined>(({ label }) => label?.get(), {
@@ -328,11 +276,6 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_7, {
-    sourceFile: "/test.tsx",
-    position: { line: 30, col: 19 },
-    bindingName: "optional"
-});
 // FIXTURE: cell-get-terminal-binding-autowrap
 // Verifies: a cell read at a variable-initializer binding is auto-wrapped into a
 //   lift whether or not a computation sits on top of it — a bare `rows.get()`,
@@ -346,7 +289,7 @@ __cfBindVerifiedBinding(__cfLift_7, {
 //   reads. `label` pins the optional spelling: optionality rides through the
 //   lift rather than blocking the site, so the input schema carries `label` as
 //   an unrequired `anyOf` and the result widens to include `undefined`.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const rows = __cf_pattern_input.key("rows");
     const label = __cf_pattern_input.key("label");
     const count = __cfLift_1({ rows: rows }).for("count", true);
@@ -433,10 +376,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["sentAt", "body"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 22, col: 76 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-pattern-input-structure-recovery.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -32,7 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: cell-pattern-input-structure-recovery
 // Verifies: `cell(state.values)` preserves array/item structure when the source
 // comes from a typed pattern input.
-export default __cfBindVerifiedBinding(pattern((state) => {
+export default pattern((state) => {
     const typedValues = cell(state.key("values"), {
         type: "array",
         items: {
@@ -63,10 +45,7 @@ export default __cfBindVerifiedBinding(pattern((state) => {
         }
     },
     required: ["typedValues"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 45 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/default-union-syntax.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -114,7 +96,7 @@ const inputSchema = __cfHelpers.__cf_data({
 } as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: default-union-syntax
 // Verifies: union Default and DeepDefault syntax is preserved through schema-transform fixtures
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const subtitle = __cf_pattern_input.key("subtitle");
     const options = __cf_pattern_input.key("options");
@@ -232,10 +214,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["theme", "profile"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 34, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -34,7 +16,7 @@ const __cfAmdHooks = undefined;
 // fabric-primitive schema type (`{ type: "FabricBytes" }`, matched by
 // prototype at validation time), and the `FabricSpecialObject` nominal brand
 // -- a type-system-only key -- never reaches a generated schema.
-export default __cfBindVerifiedBinding(pattern((state: {
+export default pattern((state: {
     blob: FabricBytes;
 }) => {
     return {
@@ -77,10 +59,7 @@ export default __cfBindVerifiedBinding(pattern((state: {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 9, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,7 +33,7 @@ const inputSchema = __cfHelpers.__cf_data({
 // FIXTURE: negative-number-default
 // Verifies: negative numeric defaults are emitted as unary minus expressions
 // (the TS factory rejects negative numbers in createNumericLiteral)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const selectedIndex = __cf_pattern_input.key("selectedIndex");
     const threshold = __cf_pattern_input.key("threshold");
     return ({
@@ -86,10 +68,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["$NAME", "selectedIndex", "threshold"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -89,11 +71,6 @@ const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
     const counter = (branch.counter ?? 0) + 1;
     context.state.set({ nested: { branch: { counter } } });
 });
-__cfBindVerifiedBinding(increment, {
-    sourceFile: "/test.tsx",
-    position: { line: 23, col: 2 },
-    bindingName: "increment"
-});
 // FIXTURE: nested-default-optional
 // Verifies: nested optional interfaces with Default<> generate schemas with $ref/$defs and "default" values
 //   Default<NestedOptionalState, {}> → schema property with "default": {}
@@ -101,7 +78,7 @@ __cfBindVerifiedBinding(increment, {
 //   handler() → injects event/context schemas with asCell annotations
 //   pattern<Args>() → generates input schema, output schema (with asOpaque/asStream)
 // Context: deeply nested optional types (OptionalBranch inside OptionalNested inside NestedOptionalState)
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const state = __cf_pattern_input.key("state");
     return {
         state,
@@ -187,10 +164,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             }
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 39, col: 2 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nullable-boolean.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -38,7 +20,7 @@ interface Output {
 // FIXTURE: nullable-boolean
 // Verifies: pattern input and output schemas retain null in boolean unions.
 //   boolean | null → { anyOf: [{ type: "boolean" }, { type: "null" }] }
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const flag = __cf_pattern_input.key("flag");
     return ({ flag });
 }, {
@@ -65,10 +47,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["flag"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -44,17 +26,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["result", "prompt"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, { completeSchedulerScopeSummary: true });
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 18 }
-});
 // FIXTURE: pattern-any-result-override
 // Verifies: explicit Output type parameter overrides inferred `any` return type for schema generation
 //   pattern<Input, string>() → output schema { type: "string" } instead of inferred any
 //   pattern<Input, { [UI]: VNode }>() → output schema with $UI vnode $ref
 // Context: simulates `any` leaking through generic functions; two named exports, no default
 // Case 1: Explicit Output type overrides inferred `any` return
-export const TypedFromAny = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const TypedFromAny = pattern((__cf_pattern_input) => {
     const prompt = __cf_pattern_input.key("prompt");
     const result = fetchAny();
     return __cfLift_1({
@@ -71,16 +49,12 @@ export const TypedFromAny = __cfBindVerifiedBinding(pattern((__cf_pattern_input)
     required: ["prompt"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 64 },
-    bindingName: "TypedFromAny"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // Case 2: { [UI]: VNode } Output type instead of { [UI]: any }
 type Entry = {
     name: string;
 };
-export const TypedUIOutput = __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export const TypedUIOutput = pattern((__cf_pattern_input) => {
     const name = __cf_pattern_input.key("name");
     return {
         [UI]: (<div>{name}</div>),
@@ -101,11 +75,7 @@ export const TypedUIOutput = __cfBindVerifiedBinding(pattern((__cf_pattern_input
         }
     },
     required: ["$UI"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 25, col: 61 },
-    bindingName: "TypedUIOutput"
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-structural-recovery.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-structural-recovery.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -35,7 +17,7 @@ declare function fetchAny(): any;
 // `any` only appears in nested properties.
 //   pattern<Input>(fn) → pattern(fn, inputSchema, objectResultSchema)
 // Context: the top-level result stays structural, but `title` degrades to `true`.
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const prompt = __cf_pattern_input.key("prompt");
     return { title: fetchAny().title, prompt };
 }, {
@@ -55,10 +37,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["title", "prompt"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 11, col: 43 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-boolean-ifelse-predicate-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-boolean-ifelse-predicate-schema.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -39,7 +21,7 @@ type State = {
 // FIXTURE: pattern-boolean-ifelse-predicate-schema
 // Verifies: ternaries lowered from `.key(...)` reads keep a boolean predicate
 // schema instead of collapsing to `true`.
-export default __cfBindVerifiedBinding(pattern((state) => ({
+export default pattern((state) => ({
     [UI]: (<div>
       {__cfHelpers.ifElse({
         type: "boolean"
@@ -100,10 +82,7 @@ export default __cfBindVerifiedBinding(pattern((state) => ({
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 15, col: 30 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -63,15 +45,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["bar", "foo"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 20, col: 18 }
-});
 // FIXTURE: pattern-explicit-types
 // Verifies: explicit Input and Output type parameters generate separate input/output schemas
 //   pattern<Input, Output>() → input schema from Input, output schema from Output (includes inherited fields)
 //   Output extends Input → output schema includes both own (bar) and inherited (foo) properties
-export default __cfBindVerifiedBinding(pattern((input) => {
+export default pattern((input) => {
     return __cfLift_1({ input: input }).for("__patternResult", true);
 }, {
     type: "object",
@@ -92,10 +70,7 @@ export default __cfBindVerifiedBinding(pattern((input) => {
         }
     },
     required: ["bar", "foo"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 38 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-underscore-param-never-input-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-underscore-param-never-input-schema.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -32,7 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: pattern-underscore-param-never-input-schema
 // Verifies: underscore-prefixed authored pattern params still emit the `false`
 // / never input schema while preserving the result schema.
-export default __cfBindVerifiedBinding(pattern((_state: {
+export default pattern((_state: {
     name: string;
     count: number;
 }) => {
@@ -46,10 +28,7 @@ export default __cfBindVerifiedBinding(pattern((_state: {
         }
     },
     required: ["ok"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -152,11 +134,6 @@ const addItem = handler // <
 }) => {
     items.push({ text: event.detail.message });
 });
-__cfBindVerifiedBinding(addItem, {
-    sourceFile: "/test.tsx",
-    position: { line: 41, col: 2 },
-    bindingName: "addItem"
-});
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -205,10 +182,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 64, col: 21 }
-});
 // FIXTURE: pattern-with-types
 // Verifies: full pattern with toSchema, handler, JSX, and .map() all transform correctly together
 //   toSchema<T>() → inline JSON schema literal with Default<> mapped to "default" values
@@ -216,7 +189,7 @@ __cfBindVerifiedBinding(__cfPattern_1, {
 //   items.map((item, index) => JSX) → items.mapWithPattern(pattern(...), {})
 //   pattern<In, Out>() → uses pre-generated inputSchema/outputSchema passed as arguments
 // Context: kitchen-sink pattern with NAME, UI, handler, array .map(), and Default<> types
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const title = __cf_pattern_input.key("title");
     const items = __cf_pattern_input.key("items");
     const items_count = items.key("length");
@@ -294,10 +267,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
             required: ["text"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 53, col: 68 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -51,14 +33,10 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 12, col: 16 }
-});
 // FIXTURE: reactive-array-element-access-schema
 // Verifies: reactive array element access preserves `string | undefined` in the
 // emitted result schema.
-export default __cfBindVerifiedBinding(pattern((_state) => {
+export default pattern((_state) => {
     const items = cell(["apple", "banana", "cherry"], {
         type: "array",
         items: {
@@ -103,10 +81,7 @@ export default __cfBindVerifiedBinding(pattern((_state) => {
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 7, col: 23 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-map.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -61,11 +43,6 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 16, col: 27 },
-    bindingName: "mapped"
-});
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");
@@ -114,17 +91,12 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     },
     required: ["title", "done", "position"]
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfPattern_2, {
-    sourceFile: "/test.tsx",
-    position: { line: 19, col: 29 },
-    bindingName: "filtered"
-});
 // FIXTURE: reactive-map
 // Verifies: .map() on typed arrays is transformed to .mapWithPattern() with generated schemas
 //   items.map((item) => item.title) → items.mapWithPattern(pattern(...), {})
 //   items.map((item, index) => ({...})) → items.mapWithPattern(pattern(...), {}) with index param
 // Context: two .map() calls -- one returning a scalar, one returning an object with index
-export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
+export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Map on opaque ref arrays should be transformed to mapWithPattern
     const mapped = items.mapWithPattern(__cfPattern_1, {}).for("mapped", true);
@@ -185,10 +157,7 @@ export default __cfBindVerifiedBinding(pattern((__cf_pattern_input) => {
         }
     },
     required: ["mapped", "filtered"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 14, col: 46 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-reactive.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-reactive.expected.jsx
@@ -1,21 +1,3 @@
-function __cfBindVerifiedBinding(value: any, metadata: any) {
-    if (value && (typeof value === "object" || typeof value === "function") && Object.isExtensible(value)) {
-        Object.defineProperty(value, "__cfVerifiedBindingIdentity", {
-            value: metadata,
-            configurable: true
-        });
-    }
-    if (value && (typeof value === "object" || typeof value === "function") && typeof value.implementation === "function") {
-        var implementation = value.implementation;
-        if (implementation && (typeof implementation === "object" || typeof implementation === "function") && Object.isExtensible(implementation)) {
-            Object.defineProperty(implementation, "__cfVerifiedBindingIdentity", {
-                value: metadata,
-                configurable: true
-            });
-        }
-    }
-    return value;
-}
 function __cfHardenFn(fn: Function) {
     Object.freeze(fn);
     const prototype = fn.prototype;
@@ -67,17 +49,12 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-__cfBindVerifiedBinding(__cfLift_1, {
-    sourceFile: "/test.tsx",
-    position: { line: 18, col: 18 },
-    bindingName: "doubled"
-});
 // FIXTURE: with-reactive
 // Verifies: Cell<> fields generate asCell in schema and a reactive builder gets input/output schemas injected
 //   Cell<number> → { type: "number", asCell: true }
 //   toSchema<State>({default: ...}) → schema with "default" key preserved
 //   bare `cell.value.get() * 2` → auto-wraps, capturing cell.key("value") into lift(inputSchema, outputSchema, fn)
-export default __cfBindVerifiedBinding(pattern((cell) => {
+export default pattern((cell) => {
     const doubled = __cfLift_1({ cell: {
             value: cell.key("value")
         } }).for("doubled", true);
@@ -106,10 +83,7 @@ export default __cfBindVerifiedBinding(pattern((cell) => {
         }
     },
     required: ["value"]
-} as const satisfies __cfHelpers.JSONSchema), {
-    sourceFile: "/test.tsx",
-    position: { line: 17, col: 37 }
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -2,8 +2,6 @@ import { assert, assertEquals } from "@std/assert";
 
 import ts from "typescript";
 
-import { BINDING_IDENTITY_HELPER_NAME } from "@commonfabric/utils/sandbox-contract";
-import { recoverAuthoredPosition } from "../src/ast/mod.ts";
 import { CommonFabricTransformerPipeline } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { batchTypeCheckFixtures } from "./utils.ts";
@@ -37,14 +35,8 @@ import { batchTypeCheckFixtures } from "./utils.ts";
  *      full-`preserveLineage` sites (lift-applied outer, mapWithPattern) and
  *      the capture-scaffold outer carry.
  * Recovery mirrors the probe's precedence (own position → own sourceMapRange →
- * original-chain terminal, `recoverAuthoredPosition` in `src/ast/utils.ts`);
- * CONTENT is the ground truth — a position pointing at the wrong text is still
- * broken lineage.
- *
- * The fourth check is CT-1870's consumer of that lineage: the module-scope
- * hardening stage annotates every function-bearing builder artifact with
- * `__cfBindVerifiedBinding(value, { … position, bindingName })`, and each
- * annotation's `position` must land on the authored function it names.
+ * original-chain terminal); CONTENT is the ground truth — a position pointing
+ * at the wrong text is still broken lineage.
  *
  * Bite matrix (verified by reverting each fix file to its pre-fix state):
  * pattern-builder, capture-scaffold, array-method-transform and
@@ -70,9 +62,6 @@ import { batchTypeCheckFixtures } from "./utils.ts";
 //   ORIGIN-G  pattern-body binary over a dynamic opaque access → __cfLift
 //   ORIGIN-E  inline captured action in JSX          → handler scaffold → __cfHandler
 //   ORIGIN-D  .map with an element callback in JSX   → array-method → __cfPattern
-//   ORIGIN-H  handler over a referenced arrow const  → in-place, anchor = const
-//   ORIGIN-I  handler over a function declaration    → in-place, anchor = declaration
-//   ORIGIN-J  handler over a property-access callback → in-place, anchor = the call
 const FIXTURE = `import {
   action,
   computed,
@@ -97,30 +86,6 @@ const bump = handler<unknown, { count: Writable<number> }>((_, state) => {
   state.count.set(state.count.get() + 1);
 });
 
-// ORIGIN-H: builder whose callback is a REFERENCED authored function
-const onReset = (_: unknown, state: { count: Writable<number> }) => {
-  state.count.set(0);
-};
-const reset = handler<unknown, { count: Writable<number> }>(onReset);
-
-// ORIGIN-I: builder whose callback is a same-file FUNCTION DECLARATION,
-// declared below its use (declarations hoist — mirrors the live
-// generated-pattern form lift(sanitizeTickets)).
-const zero = handler<unknown, { count: Writable<number> }>(onZero);
-function onZero(_: unknown, state: { count: Writable<number> }) {
-  state.count.set(0 * 1);
-}
-
-// ORIGIN-J: builder whose callback arrives through PROPERTY ACCESS — no
-// same-file function anchors it, so the annotation anchors at the builder
-// call itself.
-const callbacks = {
-  echoTick(_: unknown, state: { count: Writable<number> }) {
-    state.count.set(state.count.get() + 10);
-  },
-};
-const viaProperty = handler<unknown, { count: Writable<number> }>(callbacks.echoTick);
-
 export default pattern<ProbeInput>(({ count, flag, label, items, task }) => {
   // ORIGIN-A: authored computed with a capture
   const doubled = computed(() => count * 2);
@@ -142,8 +107,6 @@ export default pattern<ProbeInput>(({ count, flag, label, items, task }) => {
           {items.map((item) => <li>{item}</li>)}
         </ul>
         <cf-button onClick={bump({ count })}>bump</cf-button>
-        <cf-button onClick={reset({ count })}>reset</cf-button>
-        <cf-button onClick={zero({ count })}>zero</cf-button>
         {/* ORIGIN-E: inline captured action */}
         <cf-button onClick={action(() => count * 4)}>quad</cf-button>
       </div>
@@ -158,20 +121,28 @@ export default pattern<ProbeInput>(({ count, flag, label, items, task }) => {
 `;
 
 /**
- * The value a binding-identity annotation wraps, or the expression itself when
- * it carries none. The hardening stage annotates an EXPORTED artifact in place
- * (`export default __cfBindVerifiedBinding(pattern(…), { … })`), so the builder
- * call the lineage checks are about sits one level in.
+ * Best-available authored position for a (possibly synthetic) node, mirroring
+ * the probe's recovery precedence: the node's own text range, else its explicit
+ * sourceMapRange, else the terminal of its original-node chain. Returns
+ * undefined when none of the three yields a real (`>= 0`) position — i.e.
+ * broken lineage.
  */
-function unwrapBindingAnnotation(expression: ts.Expression): ts.Expression {
-  if (
-    ts.isCallExpression(expression) &&
-    ts.isIdentifier(expression.expression) &&
-    expression.expression.text === BINDING_IDENTITY_HELPER_NAME
-  ) {
-    return expression.arguments[0]!;
+function recoverPosition(
+  node: ts.Node,
+): { pos: number; end: number } | undefined {
+  if (node.pos >= 0) return { pos: node.pos, end: node.end };
+
+  // ts.getSourceMapRange returns the node itself when no explicit range is set.
+  const smr = ts.getSourceMapRange(node);
+  if ((smr as unknown) !== (node as unknown) && smr.pos >= 0) {
+    return { pos: smr.pos, end: smr.end };
   }
-  return expression;
+
+  const original = ts.getOriginalNode(node);
+  if (original !== node && original.pos >= 0) {
+    return { pos: original.pos, end: original.end };
+  }
+  return undefined;
 }
 
 function findCallbackArgument(
@@ -213,10 +184,7 @@ function collectBuilderSites(root: ts.SourceFile): BuilderSite[] {
         ) {
           const name = decl.name.text;
           // Hoisted synthetics plus the authored module-scope `bump` handler.
-          if (
-            HOISTED_NAME.test(name) || name === "bump" || name === "reset" ||
-            name === "zero" || name === "viaProperty"
-          ) {
+          if (HOISTED_NAME.test(name) || name === "bump") {
             sites.push({
               tag: name,
               call: decl.initializer,
@@ -228,7 +196,7 @@ function collectBuilderSites(root: ts.SourceFile): BuilderSite[] {
     }
 
     if (ts.isExportAssignment(stmt) && !stmt.isExportEquals) {
-      let expr = unwrapBindingAnnotation(stmt.expression);
+      let expr = stmt.expression;
       while (
         ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) ||
         ts.isSatisfiesExpression(expr)
@@ -265,12 +233,6 @@ function collectRewrittenSites(
     if (ts.isCallExpression(node)) {
       if (
         ts.isIdentifier(node.expression) &&
-        node.expression.text === BINDING_IDENTITY_HELPER_NAME
-      ) {
-        // A binding-identity annotation names its target but is not a rewritten
-        // USE of it; it is checked separately, against its own metadata.
-      } else if (
-        ts.isIdentifier(node.expression) &&
         HOISTED_NAME.test(node.expression.text)
       ) {
         if (!sites.has(node.expression.text)) {
@@ -290,7 +252,7 @@ function collectRewrittenSites(
   return sites;
 }
 
-async function transformFixtureToAst(source = FIXTURE): Promise<{
+async function transformFixtureToAst(): Promise<{
   transformed: ts.SourceFile;
   /** The pre-transform source file, whose text the recovered positions index
    * into (it carries the `transformCfDirective` helper-import prelude). */
@@ -300,7 +262,7 @@ async function transformFixtureToAst(source = FIXTURE): Promise<{
   // Reuse the shared harness to build a program with the commonfabric + env
   // type definitions (and the `transformCfDirective` helper-import prelude).
   const { program } = await batchTypeCheckFixtures(
-    { [fileName]: source },
+    { [fileName]: FIXTURE },
     { types: COMMONFABRIC_TYPES },
   );
   const original = program.getSourceFile(fileName);
@@ -311,99 +273,8 @@ async function transformFixtureToAst(source = FIXTURE): Promise<{
   const transformed = result.transformed[0];
   assert(transformed, "pipeline returned a transformed source file");
   // NB: do NOT dispose the result yet — disposal can clear the emit-node data
-  // that holds sourceMapRange, which recoverAuthoredPosition reads.
+  // that holds sourceMapRange, which recoverPosition reads.
   return { transformed, original };
-}
-
-/** The `position` / `bindingName` a binding-identity annotation reports. */
-interface BindingAnnotation {
-  readonly position: { line: number; col: number } | undefined;
-  readonly bindingName: string | undefined;
-}
-
-function readNumericProperty(
-  literal: ts.ObjectLiteralExpression,
-  name: string,
-): number | undefined {
-  for (const property of literal.properties) {
-    if (
-      ts.isPropertyAssignment(property) && ts.isIdentifier(property.name) &&
-      property.name.text === name &&
-      ts.isNumericLiteral(property.initializer)
-    ) {
-      return Number(property.initializer.text);
-    }
-  }
-  return undefined;
-}
-
-function readBindingAnnotation(metadata: ts.Expression): BindingAnnotation {
-  assert(
-    ts.isObjectLiteralExpression(metadata),
-    "binding-identity metadata must be an object literal",
-  );
-  let position: { line: number; col: number } | undefined;
-  let bindingName: string | undefined;
-  for (const property of metadata.properties) {
-    if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
-      continue;
-    }
-    if (
-      property.name.text === "position" &&
-      ts.isObjectLiteralExpression(property.initializer)
-    ) {
-      const line = readNumericProperty(property.initializer, "line");
-      const col = readNumericProperty(property.initializer, "col");
-      assert(
-        line !== undefined && col !== undefined,
-        "position must carry numeric line and col",
-      );
-      position = { line, col };
-    }
-    if (
-      property.name.text === "bindingName" &&
-      ts.isStringLiteral(property.initializer)
-    ) {
-      bindingName = property.initializer.text;
-    }
-  }
-  return { position, bindingName };
-}
-
-/**
- * Every binding-identity annotation the hardening stage emitted, keyed the same
- * way {@link collectBuilderSites} keys artifacts: by the annotated binding's
- * name, and `export-default` for the annotated default export.
- */
-function collectBindingAnnotations(
-  root: ts.SourceFile,
-): Map<string, BindingAnnotation> {
-  const annotations = new Map<string, BindingAnnotation>();
-  const isAnnotation = (node: ts.Node): node is ts.CallExpression =>
-    ts.isCallExpression(node) && ts.isIdentifier(node.expression) &&
-    node.expression.text === BINDING_IDENTITY_HELPER_NAME;
-
-  for (const stmt of root.statements) {
-    if (
-      ts.isExpressionStatement(stmt) && isAnnotation(stmt.expression) &&
-      ts.isIdentifier(stmt.expression.arguments[0]!)
-    ) {
-      annotations.set(
-        (stmt.expression.arguments[0] as ts.Identifier).text,
-        readBindingAnnotation(stmt.expression.arguments[1]!),
-      );
-    }
-    if (
-      ts.isExportAssignment(stmt) && !stmt.isExportEquals &&
-      isAnnotation(stmt.expression)
-    ) {
-      annotations.set(
-        "export-default",
-        readBindingAnnotation(stmt.expression.arguments[1]!),
-      );
-    }
-  }
-  return annotations;
 }
 
 /** Distinctive authored markers for the hoisted-lift origins. Each hoisted
@@ -418,52 +289,6 @@ const LIFT_MARKERS = [
   'items[count] + "!"', // ORIGIN-G (pattern-body initializer)
 ];
 
-/**
- * What each origin's annotation must report: the authored text its `position`
- * points at, and the authored binding name it was declared under. Keyed by the
- * origin's marker rather than by hoist name, because which `__cfLift_N` an
- * origin becomes is an ordering detail this fixture deliberately does not pin.
- * An entry with no `bindingName` was authored as an inline expression under no
- * declaration, and the annotation must omit the field.
- */
-const ORIGIN_ANNOTATIONS = new Map<string, {
-  anchor: string;
-  bindingName?: string;
-}>([
-  ["count * 2", { anchor: "() => count * 2", bindingName: "doubled" }],
-  ["probe ${label}", { anchor: "() => `probe ${label}`" }],
-  ["count * 3", { anchor: "count * 3" }],
-  ["!task.done", { anchor: "!task.done" }],
-  [
-    'items[count] + "!"',
-    { anchor: 'items[count] + "!"', bindingName: "pick" },
-  ],
-  ["count * 4", { anchor: "() => count * 4" }], // ORIGIN-E, hoisted handler
-  ["(item) =>", { anchor: "(item) => <li>{item}</li>" }], // ORIGIN-D
-  ["state.count.set", { anchor: "(_, state) => {", bindingName: "bump" }],
-  // ORIGIN-H: the annotation locates the REFERENCED callback where it was
-  // written, named by its own declaration — not the builder binding.
-  ["state.count.set(0)", {
-    anchor: "(_: unknown, state: { count: Writable<number> }) => {",
-    bindingName: "onReset",
-  }],
-  // ORIGIN-I: a declaration-form callback anchors at the declaration itself.
-  ["state.count.set(0 * 1)", {
-    anchor: "function onZero",
-    bindingName: "onZero",
-  }],
-  // ORIGIN-J: no same-file function anchors a property-access callback, so
-  // the annotation anchors at the builder call, named by its declaration.
-  ["callbacks.echoTick", {
-    anchor: "handler<unknown, { count: Writable<number> }>(callbacks.echoTick)",
-    bindingName: "viaProperty",
-  }],
-  [
-    "count, flag, label, items, task",
-    { anchor: "({ count, flag, label, items, task }) => {" },
-  ],
-]);
-
 Deno.test(
   "CT-1868: builder lineage recovers authored positions at the hoisting stage",
   async () => {
@@ -472,7 +297,6 @@ Deno.test(
 
     const sites = collectBuilderSites(transformed);
     const rewritten = collectRewrittenSites(transformed);
-    const annotations = collectBindingAnnotations(transformed);
 
     // Sanity: the fixture must actually exercise every origin path, or a
     // silent pipeline change (e.g. a builder no longer hoisting) would
@@ -494,25 +318,13 @@ Deno.test(
     );
     assert(tags.includes("bump"), "expected the authored `bump` handler");
     assert(
-      tags.includes("reset"),
-      "expected the referenced-callback `reset` handler (ORIGIN-H)",
-    );
-    assert(
-      tags.includes("zero"),
-      "expected the declaration-callback `zero` handler (ORIGIN-I)",
-    );
-    assert(
-      tags.includes("viaProperty"),
-      "expected the property-access-callback `viaProperty` handler (ORIGIN-J)",
-    );
-    assert(
       tags.includes("export-default"),
       "expected the export-default pattern",
     );
 
     const recoveredByTag = new Map<string, string>();
     const recover = (tag: string, role: string, node: ts.Node): string => {
-      const pos = recoverAuthoredPosition(node);
+      const pos = recoverPosition(node);
       assert(
         pos,
         `${tag} ${role}: reached the hoisting stage with no recoverable ` +
@@ -521,60 +333,13 @@ Deno.test(
       return sourceText.slice(pos.pos, pos.end);
     };
 
-    // 4. The emitted annotation for one origin: its `position` must address the
-    // authored function it names, and `bindingName` must be the name that
-    // function was declared under (or absent, for an inline expression).
-    const checkAnnotation = (tag: string, marker: string): void => {
-      const expected = ORIGIN_ANNOTATIONS.get(marker);
-      assert(expected, `no annotation expectation for origin "${marker}"`);
-      const annotation = annotations.get(tag);
-      assert(annotation, `${tag}: the hardening stage emitted no annotation`);
-      assert(
-        annotation.position,
-        `${tag}: annotation carries no authored position`,
-      );
-      const lineStarts = original.getLineStarts();
-      assert(
-        annotation.position.line >= 1 &&
-          annotation.position.line <= lineStarts.length,
-        `${tag}: annotation line ${annotation.position.line} is outside the ` +
-          `authored file (${lineStarts.length} lines)`,
-      );
-      const offset = original.getPositionOfLineAndCharacter(
-        annotation.position.line - 1,
-        annotation.position.col,
-      );
-      const authored = sourceText.slice(
-        offset,
-        offset + expected.anchor.length,
-      );
-      assertEquals(
-        authored,
-        expected.anchor,
-        `${tag}: annotation position ${annotation.position.line}:${annotation.position.col} ` +
-          `addresses the wrong authored text`,
-      );
-      assertEquals(
-        annotation.bindingName,
-        expected.bindingName,
-        `${tag}: annotation reports the wrong authored binding name`,
-      );
-    };
-
     // 1 + 2. Per-{tag, role} recovery AND per-tag content binding.
     const claimedLiftMarkers = new Map<string, string>();
     for (const site of sites) {
       const callText = recover(site.tag, "call", site.call);
       recoveredByTag.set(site.tag, callText);
 
-      // ORIGIN-H's builder call carries its callback as an IDENTIFIER
-      // (`handler(…, onReset)`) and ORIGIN-J's as a PROPERTY ACCESS, so there
-      // is no function argument to recover here; their authored positions are
-      // pinned through the annotation check.
-      if (
-        site.tag !== "export-default" && site.tag !== "reset" &&
-        site.tag !== "zero" && site.tag !== "viaProperty"
-      ) {
+      if (site.tag !== "export-default") {
         assert(site.callback, `${site.tag}: expected a callback argument`);
       }
       const callbackText = site.callback
@@ -604,55 +369,29 @@ Deno.test(
               `origin marker "${marker}", got: ${callbackText}`,
           );
         }
-        checkAnnotation(site.tag, marker);
       } else if (site.tag.startsWith("__cfHandler_")) {
         assert(
           callText.includes("count * 4"),
           `${site.tag}: expected the ORIGIN-E action body, got: ${callText}`,
         );
-        checkAnnotation(site.tag, "count * 4");
       } else if (site.tag.startsWith("__cfPattern_")) {
         assert(
           callText.includes("(item) =>"),
           `${site.tag}: expected the ORIGIN-D map callback, got: ${callText}`,
         );
-        checkAnnotation(site.tag, "(item) =>");
-      } else if (site.tag === "zero") {
-        checkAnnotation(site.tag, "state.count.set(0 * 1)");
-      } else if (site.tag === "viaProperty") {
-        assert(
-          callText.includes("callbacks.echoTick"),
-          `viaProperty: expected the property-access callback call, got: ${callText}`,
-        );
-        checkAnnotation(site.tag, "callbacks.echoTick");
-      } else if (site.tag === "reset") {
-        assert(
-          callbackText === undefined ||
-            callbackText.includes("state.count.set(0)"),
-          `reset callback recovery: ${callbackText}`,
-        );
-        checkAnnotation(site.tag, "state.count.set(0)");
       } else if (site.tag === "bump") {
         assert(
           callbackText !== undefined &&
             callbackText.includes("state.count.set"),
           `bump callback: expected the authored handler body, got: ${callbackText}`,
         );
-        checkAnnotation(site.tag, "state.count.set");
       } else if (site.tag === "export-default") {
         assert(
           callText.includes("count, flag, label, items, task"),
           `export-default: expected the authored pattern call, got: ${callText}`,
         );
-        checkAnnotation(site.tag, "count, flag, label, items, task");
       }
     }
-    assertEquals(
-      annotations.size,
-      sites.length,
-      `every builder artifact must carry exactly one binding-identity ` +
-        `annotation; annotated: ${[...annotations.keys()].join(", ")}`,
-    );
     assertEquals(
       claimedLiftMarkers.size,
       LIFT_MARKERS.length,
@@ -682,56 +421,5 @@ Deno.test(
           `than its hoist (expected marker "${sharedMarker}"), got: ${siteText}`,
       );
     }
-  },
-);
-
-// A pattern authored as a NAMED module-scope const, whose body lifts an inline
-// JSX expression. The const's own artifact is named `named`; the lift hoisted
-// out of its body was authored under no declaration and must stay anonymous —
-// the declaration a pattern is assigned to does not name what is written inside
-// its callback.
-const NAMED_PATTERN_FIXTURE = `import {
-  Default,
-  pattern,
-  UI,
-} from "commonfabric";
-
-interface Input {
-  count: number | Default<0>;
-}
-
-const named = pattern<Input>(({ count }) => ({
-  [UI]: <span>{count + 7}</span>,
-}));
-
-export default named;
-`;
-
-Deno.test(
-  "CT-1870: an inline lift inside a named pattern const stays anonymous",
-  async () => {
-    const { transformed } = await transformFixtureToAst(NAMED_PATTERN_FIXTURE);
-    const annotations = collectBindingAnnotations(transformed);
-
-    assertEquals(
-      annotations.get("named")?.bindingName,
-      "named",
-      `the pattern const's own artifact is named after its declaration; ` +
-        `annotated: ${[...annotations.keys()].join(", ")}`,
-    );
-
-    const lifts = [...annotations].filter(([tag]) => HOISTED_NAME.test(tag));
-    assertEquals(
-      lifts.length,
-      1,
-      `expected the inline JSX expression to hoist to one lift, got: ${
-        lifts.map(([tag]) => tag).join(", ")
-      }`,
-    );
-    assertEquals(
-      lifts[0]![1].bindingName,
-      undefined,
-      `a lift hoisted out of the pattern callback carries no authored name`,
-    );
   },
 );


### PR DESCRIPTION
Reverts #6003 so we can reconsider the emitted metadata design before proceeding. The resulting tree is byte-identical to main immediately before #6003.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

