### PR TITLE
docs(skills): a performance investigation is a probe into the stack, not a pattern fix

### DIFF
--- a/.agents/skills/perf-investigation
+++ b/.agents/skills/perf-investigation
@@ -1,0 +1,1 @@
+../../skills/perf-investigation

--- a/.claude/skills/perf-investigation
+++ b/.claude/skills/perf-investigation
@@ -1,0 +1,1 @@
+../../skills/perf-investigation

--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -135,14 +135,16 @@ rather than one-off flame charts.
 
 #### Documenting the Process
 
-We don't have profiling documentation yet (the debugging docs cover logging
-and pattern-level tips, but not runtime profiling). Whoever does the first
-client or server profile should document the concrete steps — which pattern
-to use, how to start the local dev server, how to record the trace, how to
-attach to the Deno process, what to look for — in
-`docs/development/debugging/profiling.md` so the next person can repeat it.
-This is something we'll need to do periodically; it shouldn't require tribal
-knowledge.
+`skills/perf-investigation/SKILL.md` carries the process for a slowness that
+surfaces in a pattern or in the browser: which instrument reaches what, why a
+logger row and a worker CPU profile answer different questions, and the causes
+this runtime has actually produced. It is live documentation — as those answers
+change, it changes with them.
+
+The server side is the half still undocumented: attaching to a running
+toolshed's Deno process, and recording OTEL traces against a collector. Whoever
+profiles the server first should write those steps down the same way, under
+`docs/development/debugging/`, so that path stops being tribal knowledge too.
 
 ### Making the Loop Fast
 

--- a/packages/integration/cdp-profiler.ts
+++ b/packages/integration/cdp-profiler.ts
@@ -323,3 +323,97 @@ export function renderProfileReport(
   }
   return report;
 }
+
+/**
+ * The runtime worker's script URL fragment.
+ *
+ * A property of how the runtime names its worker, not of any one measurement,
+ * which is why it is here rather than restated by each scenario that profiles.
+ */
+export const RUNTIME_WORKER_URL = "worker-runtime";
+
+/**
+ * Connect a profiler to a running browser and wait for its runtime worker.
+ *
+ * Resolves to `undefined` rather than throwing when anything goes wrong, and
+ * closes the half-open connection on the way out. Profiling is instrumentation:
+ * a scenario that cannot be profiled still has a scenario to run, so every seam
+ * here degrades to unprofiled instead of failing the caller.
+ */
+export async function attachWorkerProfiler(
+  wsEndpoint: string,
+  workerUrl = RUNTIME_WORKER_URL,
+): Promise<CdpWorkerProfiler | undefined> {
+  let profiler: CdpWorkerProfiler | undefined;
+  try {
+    profiler = await CdpWorkerProfiler.connect(wsEndpoint);
+    await profiler.waitForWorker(workerUrl);
+    return profiler;
+  } catch (error) {
+    console.warn("Worker CPU profiler setup failed, disabling:", error);
+    profiler?.close();
+    return undefined;
+  }
+}
+
+/**
+ * Start a profile, reporting whether it actually started.
+ *
+ * `context` names the thing being profiled in the warning, so a run that loses
+ * one capture out of many says which. The sampling interval is the caller's:
+ * the profiler's own default suits a single interaction, while a window of
+ * minutes needs a coarser period to stay inside the CDP message limit.
+ */
+export async function startWorkerProfile(
+  profiler: CdpWorkerProfiler,
+  context: string,
+  options: { workerUrl?: string; samplingIntervalUs?: number } = {},
+): Promise<boolean> {
+  try {
+    await profiler.start(
+      options.workerUrl ?? RUNTIME_WORKER_URL,
+      options.samplingIntervalUs ?? 250,
+    );
+    return true;
+  } catch (error) {
+    console.warn(`Worker CPU profile start failed (${context}):`, error);
+    return false;
+  }
+}
+
+/**
+ * Stop a profile and write both artifacts: `<pathPrefix>.cpuprofile`, which
+ * Chrome DevTools and speedscope load, and `<pathPrefix>.report.txt`, the
+ * ranked self-time report.
+ *
+ * `pathPrefix` and `label` carry the scenario's own parameters — the board
+ * size, the iteration, the phase — so they are the caller's to compose. Set
+ * `logReport` to put the ranked report in the run's output, which is what makes
+ * a headless run answer the question without opening a file.
+ */
+export async function writeWorkerProfile(
+  profiler: CdpWorkerProfiler,
+  options: {
+    pathPrefix: string;
+    label: string;
+    context?: string;
+    logReport?: boolean;
+  },
+): Promise<void> {
+  const context = options.context ?? options.label;
+  try {
+    const profile = await profiler.stop();
+    await Deno.writeTextFile(
+      `${options.pathPrefix}.cpuprofile`,
+      JSON.stringify(profile),
+    );
+    const report = renderProfileReport(profile, options.label);
+    await Deno.writeTextFile(`${options.pathPrefix}.report.txt`, report);
+    if (options.logReport) console.log(report);
+    console.log(
+      `Worker CPU profile written: ${options.pathPrefix}.cpuprofile`,
+    );
+  } catch (error) {
+    console.warn(`Worker CPU profile capture failed (${context}):`, error);
+  }
+}

--- a/packages/integration/index.ts
+++ b/packages/integration/index.ts
@@ -6,7 +6,14 @@ export type {
   ScreencastFrame,
   SelectorOptions,
 } from "./astral-adapter.ts";
-export { CdpWorkerProfiler, renderProfileReport } from "./cdp-profiler.ts";
+export {
+  attachWorkerProfiler,
+  CdpWorkerProfiler,
+  renderProfileReport,
+  RUNTIME_WORKER_URL,
+  startWorkerProfile,
+  writeWorkerProfile,
+} from "./cdp-profiler.ts";
 export { dismissDialogs, Page, pipeConsole } from "./page.ts";
 export * from "./presentation/mod.ts";
 export * as env from "./env.ts";

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1,12 +1,14 @@
 import {
+  attachWorkerProfiler,
   awaitViewSettled,
-  CdpWorkerProfiler,
+  type CdpWorkerProfiler,
   env,
   Page,
   type ProbeApi,
-  renderProfileReport,
+  startWorkerProfile,
   waitFor,
   waitForCondition,
+  writeWorkerProfile,
 } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import {
@@ -314,15 +316,7 @@ describe("default-app flow test", () => {
     let cpuProfiler: CdpWorkerProfiler | undefined;
     if (CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES > 0) {
       console.log("Connect CDP worker profiler...");
-      try {
-        cpuProfiler = await CdpWorkerProfiler.connect(shell.wsEndpoint());
-        await cpuProfiler.waitForWorker("worker-runtime");
-      } catch (error) {
-        // Profiling is best-effort instrumentation; never fail the test.
-        console.warn("Worker CPU profiler setup failed, disabling:", error);
-        cpuProfiler?.close();
-        cpuProfiler = undefined;
-      }
+      cpuProfiler = await attachWorkerProfiler(shell.wsEndpoint());
     }
 
     if (CAPTURE_HOME_LOAD_SERIES > 0) {
@@ -382,15 +376,10 @@ describe("default-app flow test", () => {
         noteIndex <= 1 + CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES;
       if (profileThisNote) {
         console.log(`Start worker CPU profile (note ${noteIndex})...`);
-        try {
-          await cpuProfiler!.start("worker-runtime");
-        } catch (error) {
-          console.warn(
-            `Worker CPU profile start failed (note ${noteIndex}):`,
-            error,
-          );
-          profileThisNote = false;
-        }
+        profileThisNote = await startWorkerProfile(
+          cpuProfiler!,
+          `note ${noteIndex}`,
+        );
       }
 
       console.log(`Click notes drop down (note ${noteIndex})...`);
@@ -538,26 +527,11 @@ describe("default-app flow test", () => {
       );
 
       if (profileThisNote) {
-        try {
-          const profile = await cpuProfiler!.stop();
-          const outPrefix = `${CPUPROFILE_DIR}/default-app-note-${noteIndex}`;
-          await Deno.writeTextFile(
-            `${outPrefix}.cpuprofile`,
-            JSON.stringify(profile),
-          );
-          const report = renderProfileReport(
-            profile,
-            `note-create iteration ${noteIndex}`,
-          );
-          await Deno.writeTextFile(`${outPrefix}.report.txt`, report);
-          console.log(`Worker CPU profile written: ${outPrefix}.cpuprofile`);
-        } catch (error) {
-          // Profiling is best-effort instrumentation; don't fail the test.
-          console.warn(
-            `Worker CPU profile capture failed (note ${noteIndex}):`,
-            error,
-          );
-        }
+        await writeWorkerProfile(cpuProfiler!, {
+          pathPrefix: `${CPUPROFILE_DIR}/default-app-note-${noteIndex}`,
+          label: `note-create iteration ${noteIndex}`,
+          context: `note ${noteIndex}`,
+        });
       }
 
       if (noteIndex <= CAPTURE_NOTE_CREATE_PROFILE_SERIES) {

--- a/skills/pattern-test-to-integration/SKILL.md
+++ b/skills/pattern-test-to-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-test-to-integration
-description: Convert Common Fabric pattern unit tests (`*.test.tsx` driven by actions and assertions) into browser integration tests (`packages/patterns/integration/*.test.ts`) that exercise the rendered UI and can be recorded with `deno task demo`. Use when asked to promote, mirror, spot-check, browser-test, or make a video demo from an existing pattern test, including multi-user pattern tests.
+description: Convert Common Fabric pattern unit tests (`*.test.tsx` driven by actions and assertions) into browser integration tests (`packages/patterns/integration/*.test.ts`) that exercise the rendered UI, scale to a chosen size, and can be recorded with `deno task demo`. Use when asked to promote, mirror, spot-check, browser-test, or make a video demo from an existing pattern test, including multi-user pattern tests.
 ---
 
 # Pattern Test to Integration
@@ -124,6 +124,41 @@ they already encode shadow traversal, one trusted interaction, view settling,
 commit semantics, or an effect wait. Prefer accessible names and stable
 product-facing selectors. Do not select by transient DOM structure when the UI
 offers a semantic role, label, or explicit stable id.
+
+## Make the scenario's scale a knob
+
+A browser test written at one fixed size answers whether the feature works. The
+same test with its size parameterized also answers how the feature behaves as
+data grows, which is a different and usually more valuable question — and it
+costs one constant to keep both. Read the size from the environment with a small
+default, so CI keeps paying the small number while an investigation can ask for
+a large one.
+
+Three distinctions are worth building in, because retrofitting them later means
+rewriting the scenario:
+
+- **Composed versus seeded.** A couple of items driven through the real composer
+  are what make the test a regression test; the rest exist only to establish
+  size and should be created through the verb. Keep the two counts separate and
+  derive the seeded count from the total. Presentation mode animates every
+  keystroke, so a large board built through the composer is also an unwatchable
+  recording.
+- **Where the bulk is created.** Seeding before the view is ever opened and
+  seeding while it is on screen measure different things — the first is the cost
+  with nothing rendering, the second is the cost of the live view keeping up.
+  Make that a knob too rather than picking one.
+- **Extra timed operations after the bulk exists.** What a regression actually
+  cares about is what _one more_ costs on a board of that size, which is not
+  recoverable by dividing the time it took to build it.
+
+Emit measurements as parseable single lines carrying the size they were taken
+at, rather than only as step durations, so a sweep across sizes can be collected
+without re-reading logs by eye.
+
+`packages/patterns/integration/topic-board-scale.bench.ts` is the same idea in
+the benchmark lane, including how it declares sizes it cannot yet run. When the
+task is measurement rather than conversion, `skills/perf-investigation/SKILL.md`
+picks up from here.
 
 ## Keep correctness timing separate from presentation
 

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -40,8 +40,10 @@ question needs, and stop as soon as an instrument answers it.
 
 **Pattern test.** `deno task cf test <file> --verbose --stats-threshold 0`
 prints the logger's timing and count rows per step with no browser, no shell,
-and no rendering. `--stats-include` keeps named categories regardless of
-threshold, `--stats-action-limit` controls how many per-step scheduler action
+and no rendering. `--stats-include` rescues named categories from the top-ten
+truncation rather than from the threshold — a step faster than the threshold
+still prints nothing at all, so keep `--stats-threshold 0` when every step has
+to report — `--stats-action-limit` controls how many per-step scheduler action
 deltas print, and `--storage-stats` adds the storage rows. This is the fastest
 way to see a read count explode, and it needs no conversion work.
 

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -88,6 +88,16 @@ profile inside the CDP message limit while still resolving a millisecond-scale
 action. Treat profiling as instrumentation: a capture that fails should report
 and let the phase run unprofiled, never fail the scenario.
 
+Copy that wiring rather than abstracting it.
+`packages/patterns/integration/default-app.test.ts` is the maintained example to
+lift from, and keeping it worth copying is exactly why its connect / wait /
+start / stop / write-both-artifacts sequence stays inline there instead of
+moving behind a helper. A perf harness is usually throwaway — built for one
+investigation, driven by environment knobs nobody else needs, and not committed.
+Thirty duplicated lines of setup per investigation cost less than a shared seam
+that every future scenario has to be bent through, and the duplication is
+visible where a reader is already looking.
+
 ## Count against average
 
 Every logger row carries `count`, `average`, `p95`, `max`, and `total`, and the

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -88,15 +88,21 @@ profile inside the CDP message limit while still resolving a millisecond-scale
 action. Treat profiling as instrumentation: a capture that fails should report
 and let the phase run unprofiled, never fail the scenario.
 
-Copy that wiring rather than abstracting it.
+Share the parts of that wiring nobody varies; copy the rest.
+`attachWorkerProfiler`, `startWorkerProfile` and `writeWorkerProfile` (same
+module) are the invariant half — finding the worker, degrading to unprofiled
+rather than failing, and writing both artifacts — and no measurement has a
+reason to spell any of them differently. Everything that encodes the question
+stays in the scenario, written out: which iterations or phases to capture, the
+sampling interval, the output prefix and label that carry the board size or the
+phase, and the environment knob that turns capture on.
+
 `packages/patterns/integration/default-app.test.ts` is the maintained example to
-lift from, and keeping it worth copying is exactly why its connect / wait /
-start / stop / write-both-artifacts sequence stays inline there instead of
-moving behind a helper. A perf harness is usually throwaway — built for one
-investigation, driven by environment knobs nobody else needs, and not committed.
-Thirty duplicated lines of setup per investigation cost less than a shared seam
-that every future scenario has to be bent through, and the duplication is
-visible where a reader is already looking.
+lift from, and that is the reason for the split rather than a full helper: the
+half a measurer edits every time has to stay visible where they are already
+reading. A perf harness is otherwise throwaway — built for one investigation,
+driven by knobs nobody else needs, and not committed — so duplicating the parts
+that differ costs less than a seam every future scenario has to be bent through.
 
 ## Count against average
 

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: perf-investigation
+description: Investigate Common Fabric slowness end to end — measure it, attribute it to a phase and then to a cause, and land the fix wherever it turns out to belong. Use when something is slow, when it gets slower as the data grows, when asked to profile, benchmark, or measure a scaling curve, or when a performance fix needs proving rather than asserting. A slow pattern is the usual entry point; the cause is as often in the runtime.
+---
+
+# Performance Investigation
+
+For why we spend this time at all, and what we consider worth speeding up, read
+`docs/development/PERFORMANCE_PROGRAM.md`. This skill is the other half: how the
+investigation is actually run here, and what the answers have historically been.
+
+## A slow pattern is an instrument, not the defect
+
+The pattern in front of you is where the investigation starts, not where it
+ends. On the board work this skill is drawn from, the wins split roughly evenly
+between pattern changes and runtime changes — and which one a given symptom
+would turn out to be was not knowable before measuring. Several runtime fixes
+closed a footgun the pattern had merely been first to step in.
+
+So expect any of three outcomes, often more than one from a single
+investigation:
+
+- the pattern changes;
+- the runtime changes — usually spun off as its own task, so a pattern PR does
+  not quietly grow a runtime refactor;
+- `skills/pattern-dev/SKILL.md` or `skills/pattern-critic/SKILL.md` gains a
+  rule, when the pattern was written the way anyone would have written it and
+  the cost was invisible at authoring time.
+
+That third outcome is the highest-value one and the easiest to skip, because by
+then you understand the problem and it no longer looks like a trap. If an
+investigation ends with only a pattern fix, ask what made the cost invisible —
+the answer is usually a rule worth writing down, and sometimes a runtime change
+that makes the cheap spelling the natural one.
+
+## Instruments, cheapest first
+
+Each rung sees something the rung below cannot. Climb only as far as the
+question needs, and stop as soon as an instrument answers it.
+
+**Pattern test.** `deno task cf test <file> --verbose --stats-threshold 0`
+prints the logger's timing and count rows per step with no browser, no shell,
+and no rendering. `--stats-include` keeps named categories regardless of
+threshold, `--stats-action-limit` controls how many per-step scheduler action
+deltas print, and `--storage-stats` adds the storage rows. This is the fastest
+way to see a read count explode, and it needs no conversion work.
+
+**Browser integration test.** What the pattern test cannot see: rendering, the
+main-thread/worker split, IPC, cold load, and anything about how cost scales
+with what is on screen. Promote the test using
+`skills/pattern-test-to-integration/SKILL.md`, which owns that conversion and
+the scale knob the measurement below depends on. Then instrument it from
+`packages/patterns/integration/cfc-browser-helpers.ts`: `StepTimer` and
+`logStepTimings` for phase wall-clock, and `collectBrowserLoadSummary` for the
+worker's scheduler/runner/storage rows plus main-thread IPC.
+
+**Benchmarks.** For anything that must stay fast, a bench file is how it is
+defended; `docs/development/BENCHMARKS.md` owns that lane, including
+`packages/patterns/integration/topic-board-scale.bench.ts`, which measures a
+board's cold load across sizes and documents why its larger sizes are declared
+but skipped. Read it before adding a bench rather than inventing a shape.
+
+**The transformer's emitted schema.** A derivation's cost often starts with how
+much it declared it would read. `deno task cf check <file> --show-transformed`
+shows what the pattern actually compiles to, and the emitted schema's size is a
+usable proxy for read width — a board derivation that reads the whole space and
+one that reads a length differ by orders of magnitude in emitted characters.
+This catches a class the timers only see downstream of.
+
+## The logger names it; the profiler weighs it
+
+Use both, because neither is sufficient and the failure is asymmetric.
+
+The logger's spans attribute only a fraction of the time inside the span they
+sit in — on the board work, the scheduler's own spans accounted for roughly a
+tenth of `scheduler/run/action`. Elapsed wall-clock on a loaded machine varies
+by more than the differences under test. So logger rows tell you **which key,
+and how many times**; they do not reliably tell you where the time went.
+
+A V8 sampling profile of the runtime worker does. `CdpWorkerProfiler` and
+`renderProfileReport` (`packages/integration/cdp-profiler.ts`, exported from
+`@commonfabric/integration`) attach to the worker and produce both a
+`.cpuprofile` that Chrome DevTools and speedscope load, and a ranked self-time
+report. Two things about using it here: the profiler picks the worker out of the
+page's targets by its script URL, and its default sampling period is tuned for a
+single interaction — over a window of minutes, a coarser period keeps the
+profile inside the CDP message limit while still resolving a millisecond-scale
+action. Treat profiling as instrumentation: a capture that fails should report
+and let the phase run unprofiled, never fail the scenario.
+
+## Count against average
+
+Every logger row carries `count`, `average`, `p95`, `max`, and `total`, and the
+first two are the whole diagnosis: a row whose `total` grew because `count` grew
+is a different bug from one whose `average` grew, and they have disjoint fixes.
+Read them before forming a theory. Rows are ranked by `total` and truncated, so
+a row that measures set sizes rather than milliseconds will sort above real
+timings and evict them — read those by name instead of widening the summary.
+
+## Where cost comes from in this runtime
+
+Seed list, not a boundary — these are the causes this codebase has actually
+produced, and the point is the shape of each, so you recognize a sixth.
+`packages/patterns/topics/main.tsx` carries several of them as comments on the
+code that resolves them.
+
+- **The read is too wide.** The transformer shrinks a derivation's input schema
+  to the paths it can see the body reach, and gives up when it cannot see — a
+  helper call or a dynamic index makes it declare everything, so one derived
+  value reads the whole space. The fix is making the read declarable: a
+  module-scope `lift` whose parameter type is the bound, iteration that the
+  analysis can follow.
+- **The read is too often.** A read placed inside a scan materializes its value
+  once per iteration. Hoisting it out changes nothing semantically and removes a
+  factor of N.
+- **Each access costs more than it looks.** Reading an element through a
+  reactive array resolves a link every time, so a quadratic scan over one pays a
+  link resolution per element per pass. Taking a plain array first is the same
+  scan at a fraction of the cost.
+- **The invalidation shape is wrong.** A derivation declared over a whole list
+  re-runs for every element on any change to any of them. Splitting it so each
+  half depends only on what can actually change it — and sampling, where a read
+  should register no dependency at all — turns N re-runs per write into one.
+- **The work is fine but keeps being thrown away.** Mapped sub-patterns track
+  their elements by normalized link address, which is stable across position
+  changes for a cell and includes the positional index for an inline value — so
+  an inline element makes identity equal position, and any reorder or prepend
+  re-addresses every downstream cell and rebuilds its subtree.
+  `packages/runner/src/builtins/map.ts` states the rule at its source. The
+  symptom is churn rather than slowness in any one place, and no timer shows it
+  — the work is fast every time, there is just N times more of it than there
+  should be. What shows it is snapshotting the rendered tree across successive
+  appends and counting how many addresses survive: a carried element should keep
+  all of them and mint none. Nothing shared captures that today, so expect to
+  build it: it has to walk the persisted VDOM as cells, so every node carries
+  the entity id and path it lives at, and run on each append so consecutive
+  snapshots diff as the same tree plus one element, modulo ids.
+
+## Off screen and on screen
+
+Measure the same operation twice — once with nothing rendering the result, once
+with it on screen. The pair is what makes the numbers mean something:
+
+- the **difference between them** is the rendering cost;
+- the **difference between an early operation and a late one** is how the cost
+  scales;
+- an operation measured only on screen conflates the two, and one measured only
+  off screen can look flat while the product feels unusable.
+
+Time individual operations against a board that already exists, rather than
+inferring per-operation cost by dividing the time to build one — building is a
+different curve, and the number you want for a regression is what one more costs
+at a given size.
+
+## Measuring honestly
+
+The gap between a real change and machine noise is narrower than it looks, and
+this repo has been burned by it.
+
+- **A mean hides a stall.** One stalled sample inside a run is enough to invent
+  a regression the dashboard then reports. Compare trimmed against untrimmed,
+  and check whether an elevated reading arrives with a `max` an order of
+  magnitude above its typical sample and a reduced sample count. The worked case
+  is
+  `docs/history/development/performance/2026-08-benchmark-headline-machine-noise.md`.
+- **Alternate, don't batch.** Interleave the two sides and take a min-of-five
+  rather than running all of one then all of the other; background load drifts
+  over minutes. Where the harness allows it, normalize against an untouched
+  control measured in the same run.
+- **Never sleep to stabilize a measurement.** A sleep sets a floor on the number
+  you are trying to reduce and makes it depend on scheduling luck.
+  `docs/development/waiting-in-tests.md` is binding here, and the waits in
+  `packages/patterns/integration/cfc-browser-helpers.ts` are the event-driven
+  primitives to reach for.
+- **State the board size, the machine, and which side is which** in any number
+  you report. A ratio without a size is not reproducible.
+
+## Landing it
+
+A performance change needs its evidence attached: the measurement, the size it
+was taken at, and what moved. Point at the mechanism rather than the number
+alone — a number without a cause is indistinguishable from noise that happened
+to persist.
+
+Where the investigation produced a finding worth keeping but no longer describes
+the current system — a decomposition, a ruled-out hypothesis, a noise analysis —
+it is a point-in-time record: `docs/history/development/performance/` is its
+home, under the rules in `docs/README.md`.


### PR DESCRIPTION
The technique for finding and attributing slowness here lived in one branch's untracked harness, a series of commit messages, and the heads of whoever had run it. None of that survives a worktree being cleaned — and the commits it was reasoned out in were squashed on landing, so even the reasoning is not where you would look for it.

## `skills/perf-investigation/SKILL.md`

Written to `docs/development/skill-authoring.md`'s bar — map, not procedure — so the generic "profile, then narrow" advice is absent and what is left is the part a capable agent cannot derive:

- **The framing leads.** A slow pattern is the instrument, not the defect. Roughly half of what this has found so far was in the runtime rather than in the pattern that surfaced it, and the third outcome — a rule in `pattern-dev` or `pattern-critic` so the next author does not step in the same hole — is the one most easily skipped, because by the time you understand a footgun it stops looking like one.
- **The instrument ladder**, each rung with what it is *blind to*: `cf test --stats-threshold 0` (no browser) → browser integration test → benches → `--show-transformed` for read width.
- **Why both logger and profiler.** The scheduler's own spans account for roughly a tenth of `scheduler/run/action`, so logger rows tell you which key and how often, never where the time went.
- **`count` against `average`** as the too-often/too-slow discriminator, including that rows are ranked by `total` and truncated, so size-valued rows evict real timings.
- **Five causes this runtime has actually produced**, marked as seed rather than boundary — read too wide because the transformer could not see through a helper, reads repeated inside a scan, an element access that resolves a link every time, an invalidation declared over a whole list, and work that is fine but keeps being re-addressed and thrown away.
- **Off-screen against on-screen** as differencing: the gap between them is render cost, the gap between an early and a late operation is the curve.
- **Measuring honestly**, including the stalled-sample-in-a-mean failure that has already produced a phantom regression on this dashboard.

## Scale moved to where the test is written

`pattern-test-to-integration` grows the knob — composed against seeded, where the bulk is created, and timing one more operation on a board that already exists — because that is a property of the conversion, not of the measurement. The perf skill invokes it and picks up after.

## The profiler wiring, split on volatility

`attachWorkerProfiler`, `startWorkerProfile` and `writeWorkerProfile` take the half nobody varies: finding the worker, degrading to unprofiled rather than failing, and writing both artifacts. Everything encoding the question stays written out at the call site — which iterations to capture and why note 1 is skipped, the sampling interval, the prefix and label carrying the scenario's parameters.

That split is the point rather than the line count. `packages/patterns/integration/default-app.test.ts` is what the next investigation lifts its harness from, so the half a measurer edits has to stay visible where they are already reading, and the half that never varies is noise in the way.

## Verification

`deno task check-skill-facts` passes (46 documents), so every path the skill cites resolves. The two claims a reader would otherwise have to trust are cited to the source that states them: `--show-transformed` exists, and `packages/runner/src/builtins/map.ts` states the normalized-link keying rule.

**CI does not cover the refactored code.** The capture path is off unless `CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES` is set, so a green pipeline is not evidence here. Run locally with it set to 1: all three seams execute, both artifacts are written with the right label, and the suite passes. The failure branches remain unexercised. Warning text and the written-path log are unchanged and the report is logged only when a caller asks, so the maintained test's output is byte-identical.

## Deliberately not here

The topics harness itself is dropped rather than committed — it would rot as topics evolves, and it is recreatable from the conversion skill. Its knowledge is in the skill instead of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

