### PR TITLE
docs(verbs): the verb session gets a tour, and the walkthrough says what it is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,8 +243,9 @@ Each of these gates fails CI on its own, and none of them run as part of
 - `deno task check-skill-facts` — a path or import cited by a skill, an
   `AGENTS.md`, or a rule that stopped resolving
 - `deno task check-verb-session-sync` — a `cf` command or act reference in
+  `docs/common/verbs/the-verb-session.md` or
   `docs/common/verbs/session-walkthrough.md` that its demo script does not back;
-  the walkthrough quotes commands, never composes them
+  both documents quote commands, never compose them
 - `deno task check-single-copy-deps`, `check-unused-deps`, `check-deno-pins` —
   dependency declarations across the workspace
 - `deno task check-package-cycles` — two packages that import each other, the

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -91,13 +91,15 @@ on the Common Fabric runtime.
 
 ### verbs/ — driving a deployed piece through `cf`
 
-Read in this order: what a verb hands back, then a whole session using it,
-then where an author's words go. Arriving without a piece id, start with the
-agent's entry instead.
+Start with the tour if the vocabulary is new; it assumes nothing. Arriving
+without a piece id, start with the agent's entry instead. The other three
+answer narrower questions, and the README says which is which.
 
+- [verbs/README.md](verbs/README.md) — which of the five to read, by the question you are asking
+- [verbs/the-verb-session.md](verbs/the-verb-session.md) — the tour: what a pattern, piece, space and verb are, and a whole session driven through `cf` in thirteen acts. Assumes nothing; read it first
 - [verbs/agents-over-the-cli.md](verbs/agents-over-the-cli.md) — reaching a piece with no id in hand: the discovery surfaces and what bounds each, orienting on an unfamiliar piece, and the conclusions an empty answer does not support
+- [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — the same session priced: byte measurements, the code behind each answer, the caveats, and what the surface still owes. Its companion script under `packages/cli/integration/` runs every step
 - [verbs/over-the-cli.md](verbs/over-the-cli.md) — what a verb hands back: declared results, piece references, idempotent retries, and a runnable walkthrough
-- [verbs/session-walkthrough.md](verbs/session-walkthrough.md) — a whole session driven through `cf`: discovery, help, completion, refusals, and carrying an address from one call into the next. Its companion script under `packages/cli/integration/` runs every step
 - [verbs/prose-over-the-cli.md](verbs/prose-over-the-cli.md) — how an author's doc comments reach a caller, and which of the two documents `cf` reads carries what
 
 [INTRODUCTION.md](INTRODUCTION.md) is a stub kept for older links; this README

--- a/docs/common/verbs/README.md
+++ b/docs/common/verbs/README.md
@@ -1,0 +1,23 @@
+# Verbs
+
+A **verb** is an operation a pattern declares — a `Stream` property, an event
+type in and a result type out — and the only way a piece's state ever changes.
+These five documents cover driving one from the command line. They divide by
+the question they answer, so start with the one that matches yours.
+
+| Document | Answers |
+| --- | --- |
+| [The Verb Session](the-verb-session.md) | *What is this, and why is it shaped this way?* The tour: it defines pattern, piece, space, verb, handler and invocation, then walks a whole session against a real fixture in thirteen acts. Read it start to finish; it assumes nothing. |
+| [An agent's entry](agents-over-the-cli.md) | *I have a space and a key, but no piece id — where do I start?* The discovery surfaces, what bounds each, and the conclusions an empty answer does not support. |
+| [A verb session, measured](session-walkthrough.md) | *What does it cost, and what does it still owe?* The tour's session priced step by step — byte measurements, the code behind each answer, the caveats, and the gap list. Written for someone building on the surface or reviewing it. |
+| [Verbs over the CLI](over-the-cli.md) | *What does a verb hand back?* The reference for declared results, piece references, and what a retry does and does not guarantee. |
+| [An author's prose, over the CLI](prose-over-the-cli.md) | *How does a doc comment reach a caller?* The reference for which of the two documents a caller's tools read carries which sentence. |
+
+The tour and the walkthrough describe one session, driven by one script.
+`packages/cli/integration/verb-session-demo.sh` runs it,
+`verb-session-gaps.sh` asserts the same surface as pass/fail in CI, and
+`deno task check-verb-session-sync` holds both documents to the demo: a `cf`
+command either quotes a line the demo runs or carries a `# not in the demo`
+comment saying why it cannot, and an act number must name an act the demo has.
+The agent's entry is not yet held to a script, so its commands are checked by
+review rather than by CI.

--- a/docs/common/verbs/session-walkthrough.md
+++ b/docs/common/verbs/session-walkthrough.md
@@ -1,19 +1,17 @@
-# A verb session, end to end
+# A verb session, measured
 
-What driving a pattern entirely through `cf` looks like when the verb surface is
-complete: discovery, documentation, help, completion, and carrying an address
-from one call into the next.
+What a whole session driven through `cf` costs and guarantees: the measurement
+behind each step, the caveats each one carries, and what the surface still
+owes. It assumes the vocabulary rather than teaching it.
 
-[Verbs over the CLI](over-the-cli.md) explains what a verb hands back.
-This walks a whole session using it.
+**Not met a pattern or a piece before?** Read
+[The Verb Session](the-verb-session.md) first. That is the tour of this same
+session — it defines pattern, piece, space, verb, handler and invocation,
+walks the thirteen acts, and reads start to finish. This document is where
+those acts are priced and their limits stated.
 
-**Not met a pattern or a piece before?** [The Verb Session][overview] is an
-illustrated tour of this same session that defines the vocabulary this
-document assumes — pattern, piece, space, verb, handler, invocation — and
-reads start to finish. Come back here for the measurements, the caveats, and
-what the surface still owes. Note which copy is authoritative: this one is
-gated by CI against the scripts it describes, while that page is a snapshot
-kept by hand.
+[Verbs over the CLI](over-the-cli.md) explains what a verb hands back; this
+document is where that behavior is priced against a session that exercises it.
 
 The subject is a work-item tracker — items in a tree, plus typed cross-links.
 It is a real pattern: [`packages/cli/integration/pattern/tracker.tsx`][tracker],
@@ -41,17 +39,17 @@ not run one-for-one — a step is a theme, an act is a beat, and a theme can
 take several beats to show. Watching the transcript and wanting the reasoning
 behind a particular act, read across:
 
-| Demo act | Explained here in |
+| Demo act | Explained in |
 | --- | --- |
 | 1 · Arrive by name | step 1 |
 | 2 · Ask what it is, and what it can do | step 2 |
 | 3 · Ask what a verb wants | step 3 |
 | 4 · Create, and act on what you were handed | step 5 |
-| 5 · Read addresses instead of contents | step 6, and "Why this pattern" on what an unshaped read costs |
+| 5 · Read addresses instead of contents | step 6, and "What you are driving" on what an unshaped read costs |
 | 6 · Ask the same question twice | step 6, on why a read may be asked twice and a call may not |
-| 7 · A verb returns what only the pattern could compute, and its receipt reads that outcome back | the verb-shapes table under "Why this pattern", and step 6 on the receipt |
-| 8 · Finishing reports what the caller could not know | the verb-shapes table under "Why this pattern" |
-| 9 · A verb that declares no result | the verb-shapes table, and step 5's closing read |
+| 7 · A verb returns what only the pattern could compute, and its receipt reads that outcome back | the [tour's verb-shapes table](the-verb-session.md#three-design-decisions-each-aimed-at-a-hard-case), and step 6 on the receipt |
+| 8 · Finishing reports what the caller could not know | the [tour's verb-shapes table](the-verb-session.md#three-design-decisions-each-aimed-at-a-hard-case) |
+| 9 · A verb that declares no result | the [tour's verb-shapes table](the-verb-session.md#three-design-decisions-each-aimed-at-a-hard-case), and step 5's closing read |
 | 10 · Step back and read the board | step 6 |
 | 11 · Ask for something that is not there | step 7 |
 | 12 · Relate two items | step 8 |
@@ -75,39 +73,16 @@ Section headers inside the help output below are the literal strings
 `renderPieceCallHelp` emits ([`packages/cli/lib/exec-schema.ts`][exec-schema]). Their contents
 are illustrative.
 
-## Why this pattern
+## What you are driving
 
 A fixture exists to be driven, and this one is shaped so that driving it is hard
-in the particular ways the verb surface has to be good at.
-
-**A tree with cross-links.** An item is filed under one item and can be waited
-on by any other, so the same item is reachable by two different paths. That is
-where an address stops being a convenience: handing a caller the item's contents
-twice says nothing about whether they are looking at one item or two, and only
-an address answers it.
-
-**State a caller cannot set.** `title` is the only field supplied at creation.
-`status`, `notes`, `children` and `blockedOn` belong to the pattern and change
-only when a verb is called, which is what makes the verb surface the whole
-interface rather than a convenience laid over a writable document.
-
-**Six verbs, five shapes.** They are not six features. Each shape is a
-different question a caller asks about what comes back, and the tracker carries
-every one of them so that none goes undemonstrated. Only the first shape has two
-verbs, and they differ in nothing but what the new item is filed under:
-
-| Verb | The shape it exercises | Where |
-| --- | --- | --- |
-| `addItem`, `addChild` | returns a piece — an address the next command takes as its target, and a value that can be reached from inside itself | acts 4 and 8 |
-| `recordNote` | returns what only the pattern could compute: the clock is a handler capability, so the stamp cannot come from the caller | act 7 |
-| `finish` | returns a derived fact — `openBelow` takes a walk of the whole subtree, which a caller would pay N reads for | act 8 |
-| `archive` | declares no result: the invocation settles carrying no `result` at all, and what it changed is a separate read | act 9 |
-| `blockOn` | takes an address as an **argument** rather than as the receiver | act 12 — the address as printed, standing where the verb declares a reference |
-
-Those act numbers name acts in the demo script, which the table at the top of
-this document maps against its steps.
-
-## What you are driving
+in the particular ways the verb surface has to be good at. The three decisions
+behind that shape — a tree with cross-links, state a caller cannot set, and six
+verbs covering five result shapes — are laid out in the tour's
+[The program under the demo](the-verb-session.md#the-program-under-the-demo),
+along with the table pairing each shape against the act that demonstrates it.
+What belongs here is the cost of driving it, which the sections below carry
+step by step.
 
 Two patterns. A **board** holds root items; an **item** holds its own subtree,
 its own graph edges, and its own verbs — so the thing a create hands back is
@@ -438,18 +413,10 @@ needs.
 
 ## 5. Create, and carry the address forward
 
-This is where `--select` starts carrying the narrative, so here is the whole
-of the grammar the session uses. A selection names the shape of the answer;
-everything not named is left out.
-
-| Spelling | What comes back |
-| --- | --- |
-| `title,status` | those two fields and nothing else |
-| `item.title` | walks into `item` and keeps `title` — it prunes rather than flattens, so the answer is still shaped like the result |
-| `@` | the address of the position being read, in place of its contents |
-| `item@` | the address `item` holds, rather than following the link and copying what is behind it |
-| `children@` | applied across an array: each element's own address |
-| `@,title` | both — the address beside the field |
+This is where `--select` starts carrying the narrative. The grammar the session
+uses is set out in the tour's
+[act 4](the-verb-session.md#act-4--create-and-act-on-what-you-were-handed): a
+selection names the shape of the answer, and everything not named is left out.
 
 An address always arrives under the key `$link`, which is why that key is
 everywhere in the output below. The full account of the suffix — marking
@@ -887,4 +854,3 @@ argument, with the detached-copy refusal standing guard beside it (step 8).
 [exec-schema]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/exec-schema.ts
 [piece-lib]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/piece.ts
 [completion]: https://github.com/commontoolsinc/labs/blob/main/packages/cli/lib/completion/providers.ts
-[overview]: https://claude.ai/code/artifact/74bd43c3-4672-4e6c-9af4-34513e5bedaa

--- a/docs/common/verbs/the-verb-session.md
+++ b/docs/common/verbs/the-verb-session.md
@@ -1,0 +1,690 @@
+# The Verb Session
+
+A running program is deployed, inspected, driven and re-read entirely from the
+command line — with no tooling written for it. Everything the terminal knows,
+it derived from the program's own TypeScript.
+
+This is the tour: it defines the vocabulary, states what the verb surface is
+for, and walks a whole session against a real pattern. Read it start to
+finish. [A verb session, end to end](session-walkthrough.md) reports the same
+session's measurements, its caveats, and what the surface still owes; come
+here first and go there for the evidence.
+
+## What this is for
+
+The goal is narrow and testable: everything you can do to a running program,
+you can do from the command line — and nothing had to be written per program
+to make it so.
+
+### Three words, and then the CLI makes sense
+
+The system runs user-written programs. Three terms carry almost all of the
+vocabulary, and they map cleanly onto ideas you already have.
+
+| Term | What it is | The nearest familiar thing |
+| --- | --- | --- |
+| **Pattern** | A TypeScript module declaring some reactive state and the operations allowed on it. | A class definition — or a component, if you know Solid.js. |
+| **Piece** | A running instance of a pattern, with durable state. Deploying a pattern makes one. | An object; a row; a live process with an address. |
+| **Space** | The shared durable place pieces live in, named by a cryptographic identifier. | A database, or a tenant. |
+
+The fourth term is the one this work is named for. A **verb** is an operation a
+pattern declares — the only way its state ever changes. In the source it is a
+typed stream: an event type in, a result type out.
+
+Every example from here on comes from one program: a work-item tracker,
+written to be driven and nothing else. Items sit in a tree on a **board**, and
+any item can be blocked by any other. The next section takes it apart; for
+now, one of its verbs is enough to show the shape of a declaration.
+
+```tsx
+// Shown for illustration only.
+
+/** Record that this item waits on another. The blocker may be anywhere on
+ *  the board — this is the edge that makes the tree a graph. */
+blockOn: Stream<BlockOnEvent, BlockOnResult>;
+```
+
+That single declaration is the whole contract. The event type says what a
+caller may send, the result type says what comes back, and the doc comment
+says what it is for. Everything in the session below — flags, help pages,
+listings, validation, error messages — is derived from declarations like this
+one, at the moment you ask.
+
+Two more words show up in the output later and are worth having now. The
+function behind a verb is its **handler** — the only code that changes the
+piece's state, and the only place with privileges a caller lacks, such as
+reading the clock. Calling a verb creates an **invocation**: a record that
+settles, carrying the result if the verb declares one. A call returns that
+record, not a bare value.
+
+### The claim being tested
+
+A system where programs are user-written has an awkward problem: someone
+deploys a program you have never seen, and you need to operate it. The usual
+answers are a bespoke UI per program, or a hand-written client per program.
+Both mean that operating a piece requires someone to have anticipated you.
+
+The verb surface is the other answer. A caller arrives knowing nothing, asks
+the piece what it is and what it can do, and drives it. The test of whether
+that works is not a design document; it is a transcript, and the session below
+is that transcript.
+
+**The thing to watch for.** Nothing in the session was authored for the
+tracker. Every flag name, type, required-ness mark, man page, listing row,
+error message and result field was computed from the pattern's TypeScript.
+Swap in a different pattern and the same commands describe that one instead.
+
+### What "fully functional" has to include
+
+Six capabilities, because a surface missing any one of them sends you back to
+writing a client:
+
+- **Discovery** — arrive at a piece and learn what it is and what it can do, without being told.
+- **Documentation** — read the author's own words about a verb and its parameters, at the terminal.
+- **Invocation** — call a verb, with flags derived from its event type.
+- **Reading** — ask for exactly the shape of answer you want, and no more.
+- **Composition** — take an address one command printed and hand it to the next, unedited.
+- **Refusal** — be told precisely what was wrong, before anything happens.
+
+The last two are where the difficulty concentrated, and the session spends its
+final acts there.
+
+## The program under the demo
+
+A work-item tracker, about 260 lines of TypeScript. It exists only to be
+driven, and it is shaped to be awkward in exactly the ways the verb surface
+has to be good at.
+
+The fixture is
+[`packages/cli/integration/pattern/tracker.tsx`](../../../packages/cli/integration/pattern/tracker.tsx).
+It belongs to this demonstration and nothing else, so no product change can
+quietly break the story — and no story pressure can bend a shipped pattern.
+
+### Two patterns, and the second one is the interesting one
+
+A **board** holds root items. An **item** holds its own subtree, its own graph
+edges, and its own verbs — so the thing a create hands back is itself a fully
+callable piece, with no separate lookup and no schema shipped alongside.
+
+```tsx
+// Shown for illustration only.
+
+/** One work item: what it holds, and what it can do. */
+interface ItemOutput {
+  title: string;
+  /** "open" until a verb changes it — "done" or "archived". */
+  status: string;
+  /** Append-only. Each entry carries a time the pattern stamped,
+   *  not the caller: reading the clock is a handler capability. */
+  notes: { body: string; at: number }[];
+  /** The tree. */
+  children: ItemOutput[];
+  /** The graph. A blocker is any item anywhere on the board, not a
+   *  descendant — which is what makes one item reachable by two paths. */
+  blockedOn: ItemOutput[];
+
+  addChild: Stream<AddChildEvent, AddChildResult>;
+  recordNote: Stream<RecordNoteEvent, RecordNoteResult>;
+  finish: Stream<FinishEvent, FinishResult>;
+  blockOn: Stream<BlockOnEvent, BlockOnResult>;
+  archive: Stream<void>;
+}
+```
+
+Fields and verbs sit in one interface because that is what an item *is*. A
+child in `children` is a full item; declaring it any narrower would be a claim
+the runtime contradicts. The walkthrough's
+[What you are driving](session-walkthrough.md#what-you-are-driving) carries the
+full declaration, both patterns and every event and result type.
+
+### Three design decisions, each aimed at a hard case
+
+**A tree with cross-links.** An item is filed under one parent and can be
+blocked by any other item anywhere on the board. So the same item is reachable
+by two different paths — and that is where an address stops being a
+convenience. Handing a caller the item's contents twice says nothing about
+whether they are looking at one item or two copies. Only an address answers
+that, which is why the session ends where it does.
+
+**State a caller cannot set.** `title` is the only field supplied at creation.
+Everything else — `status`, `notes`, `children`, `blockedOn` — belongs to the
+pattern and changes only when a verb is called. That is what makes the verb
+surface the whole interface rather than a convenience laid over a writable
+document.
+
+**Six verbs, five shapes.** The verbs are not six features. Each exercises a
+different question a caller asks about what comes back, and the tracker
+carries every one so that none goes undemonstrated.
+
+| Verb | The shape it exercises | Where |
+| --- | --- | --- |
+| `addItem`, `addChild` | Returns a piece — an address the next command takes as its target, and a value that can be reached from inside itself. | acts 4 and 8 |
+| `recordNote` | Returns what only the pattern could compute: the clock is a handler capability, so the timestamp cannot come from the caller. | act 7 |
+| `finish` | Returns a derived fact — counting what is still open below takes a walk of the whole subtree, which a caller would pay N reads for. | act 8 |
+| `archive` | Declares no result at all. The invocation settles carrying nothing, and what changed is a separate read. | act 9 |
+| `blockOn` | Takes an address as an **argument** rather than as the receiver — the case a tree hides and a graph forces. | act 12 |
+
+**Why a doc comment is load-bearing here.** Each comment above is not
+decoration — it is the only source for what the terminal prints when someone
+asks what a verb is for. An author writes it where the thing it describes is
+declared, and the CLI reads it back out of the compiled pattern.
+[An author's prose, over the CLI](prose-over-the-cli.md) is the full account of
+which document carries which sentence.
+
+## The session, act by act
+
+Thirteen beats against a space that starts empty. Every block below is real
+output from a run — the demo prints each command before running it, so the
+transcript is the artifact.
+
+Two environment variables are exported (the server URL and an identity key);
+`-s` names the space. Everything else you see is the whole command. Addresses
+are long content hashes — they are shortened with `…` below for width, and
+printed in full by the real run.
+
+### Acts 1–3 · Arrive knowing nothing
+
+#### Act 1 · Arrive by name
+
+Deploying the pattern makes a piece. A **slug** gives it a name in the space,
+so the identifier this command prints is never typed again. The name is
+discoverable rather than folklore: the space keeps a slug index, so someone
+landing in a space another person populated starts from a listing.
+
+**Deploy, and name it.**
+
+```console
+$ cf piece new packages/cli/integration/pattern/tracker.tsx -s demo --slug board
+fid1:QX-ZJYrB8ynVZvX5Ne_nWlvOaeOcfehraVa2-6et5tk
+
+$ cf piece slugs -s demo
+SLUG  PIECE
+board fid1:QX-ZJYrB8ynVZvX5Ne_nWlvOaeOcfehraVa2-6et5tk
+```
+
+#### Act 2 · Ask what it is, and what it can do
+
+One command is the piece's man page. Every sentence on it is a doc comment
+from the source, compiled with the pattern and read back out of it. `STATE` and
+`INPUTS` are split by who writes them: inputs are what a caller supplies, state
+belongs to the pattern and moves only when a verb runs.
+
+**The piece's own page.**
+
+```console
+$ cf piece describe -s demo --piece board
+NAME    Work tracker
+PATTERN cf:module/85fQFjnFuBYjduHt…#default (/tracker.tsx)
+
+  A work-item tracker: root items on a board, everything deeper under an
+  item's `children`. State changes only through verbs — a caller files,
+  notes, finishes, archives, and relates items; nothing here is written
+  directly.
+
+STATE
+  items  ItemOutput[]
+      Root items only. The tree hangs off each one's `children`.
+
+INPUTS
+  items  ItemOutput[]
+
+VERBS
+  addItem
+      File a new root item on the board.
+```
+
+The board declares one verb, so the listing has one row. `items` is data, and
+data is not callable — so it is never offered as something to call.
+
+#### Act 3 · Ask what a verb wants
+
+The help page is assembled from two sources: the structure comes from the event
+type, the sentences come from the author's doc comments. Neither was written
+for the CLI.
+
+**A verb's own help page.**
+
+```console
+$ cf call -s demo --piece board addItem -- --help
+File a new root item on the board.
+
+JSON input:
+  Pass inline JSON as one positional argument or after `--json`.
+  {
+    title: string
+  }
+
+Flags after `--`:
+  --title <string>  Required. One line naming the work.
+
+Output:
+  The invocation's `result`:
+    item <json>  The root item this call created.
+```
+
+`--title <string> Required.` falls out of `{ title: string }`. *One line naming
+the work* is the comment on that field. The `Output:` section appears only
+because this verb declares a result — a verb that declares none has no such
+section, rather than an empty one.
+
+### Acts 4–6 · Create, and carry the address forward
+
+#### Act 4 · Create, and act on what you were handed
+
+The create returns the piece it made, as an address. That address is the whole
+of what later commands need — and it goes into the next command exactly as
+printed, standing bare in the first position. An address begins with `/` and a
+relative path never does, so the two cannot collide.
+
+`--select` appears here for the first time and carries the rest of the session,
+so it is worth stating in full. A selection names the shape of the answer;
+anything not named is left out.
+
+| Spelling | What comes back |
+| --- | --- |
+| `title,status` | Those two fields and nothing else. |
+| `item.title` | Walks into `item` and keeps `title`. It prunes rather than flattens — the answer is still shaped like the result. |
+| `@` | The **address** of the position being read, in place of its contents. |
+| `item@` | The address `item` holds — rather than following that link and copying whatever is behind it. |
+| `children@` | Applied across an array: each element's own address. |
+| `@,title` | Both — the address beside the field. |
+
+An address always arrives under the key `$link`, which is why that key is
+everywhere in the output from here on. So `--select item@` below asks for
+*where the new item lives*, not a copy of it. The full account of the suffix —
+marking positions deeper than a link, the `{"$link": true}` spelling a JSON
+Schema uses, and escaping a literal `@` — is in
+[verbs over the CLI](over-the-cli.md#asking-a-read-for-an-address).
+
+**A create hands back an address.**
+
+```console
+$ cf call -s demo --piece board --select item@ addItem -- --title 'Login rewrite'
+{
+  "invocation": "74c9fde6-bdee-4163-9775-b2f7f38add94",
+  "status": "settled",
+  "receipt": "/of:fid1:sE-3T7t35uBkvKndib5FzQuaGnBRPhwhWPPvLPMIPbU",
+  "result": {
+    "item": {
+      "$link": "/of:fid1:i4v6HTLQqLO4a7cDo9Vzexxs8fb5zZK0vLRrDogTIQs"
+    }
+  }
+}
+```
+
+Reading that address off the screen is fine by hand. To keep it in a script you
+pipe the response through [jq](https://jqlang.github.io/jq/), the standard
+command-line JSON tool: `-r` asks for the raw string rather than a quoted one,
+and the path walks the response — `.result`, then `.item`, then the `$link` the
+`@` produced. The quotes around `$link` are load-bearing: jq reads a bare
+`.$link` as one of its own variables, so the unquoted form fails to compile at
+all.
+
+**The same call, captured — and the address goes into the next command unedited.**
+
+```bash
+EPIC=$(cf call -s demo --piece board --select item@ addItem -- --title 'Login rewrite' \
+       | jq -r '.result.item."$link"')
+
+cf piece verbs -s demo --piece "$EPIC"
+```
+
+```text
+PATTERN cf:module/85fQFjnFuBYjduHt…#Item
+NAME       KIND    ON     MARKS
+addChild   handler result
+    File a new item beneath this one.
+archive    handler result
+    Mark this item archived. Declares no result — the value-less shape.
+blockOn    handler result
+    Record that this item waits on another. The blocker may be anywhere on
+    the board — this is the edge that makes the tree a graph.
+finish     handler result
+    Mark this item done. Descendants are left alone — finishing a parent
+    says nothing about its children.
+recordNote handler result
+    Append a progress note. Notes are append-only; nothing rewrites one.
+```
+
+Every verb an item has, and not the board's one. The listing was derived from
+the piece in front of you, so an address alone is enough to discover a surface
+you were never told about.
+
+#### Act 5 · Read addresses instead of contents
+
+A read is a query: you name the shape you want. An unshaped read follows every
+link and carries everything — measured at 3183 bytes for a single child on this
+pattern. Naming what you want brings it to 51. Here the `@` from act 4 crosses
+an array, so each child answers with its own address, and `title` rides beside
+it.
+
+**Projection: names and addresses only.**
+
+```console
+$ cf get -s demo /of:fid1:i4v6HTL…gTIQs children --select @,title
+[
+  { "$link": "/of:fid1:SKf22px…N5UfM", "title": "Session cookies" },
+  { "$link": "/of:fid1:d4ppvfP…Pqsls", "title": "CSRF tokens" }
+]
+```
+
+#### Act 6 · Ask the same question twice
+
+The demo runs the identical command a second time, deliberately — because the
+first thing anyone watching a live system says is *show me that again*. Asking
+again changes nothing.
+
+That is the read/call dividing line the whole session rests on. A read is a
+question, and asking it has no effect — which is what makes reads safe to
+script. It is not a promise that two reads agree: a read answers from the state
+it finds, so anything written in between shows up the second time. These two
+agree because nothing else is writing to this fixture, which is also why the
+addresses the later acts drive can come out of this read rather than a hidden
+second one.
+
+A call is the opposite of effect-free: it runs the handler body, so asking
+twice does the work twice. Act 7 shows what a caller does instead.
+
+### Acts 7–9 · What a verb hands back
+
+#### Act 7 · A verb returns what only the pattern could compute
+
+The note's timestamp is the pattern's. Reading the clock is a capability a
+handler has and a caller does not, so this value could not have been supplied
+from outside.
+
+**A stamp the caller could not have sent.**
+
+```console
+$ cf call -s demo /of:fid1:2zR3_Jo…mC84 recordNote -- --body 'blocked on the cookie spec'
+{
+  "invocation": "58cb83ba-51c0-453d-87a4-b53e9ec9537d",
+  "status": "settled",
+  "receipt": "/of:fid1:5dl-nOAgrKiU39qtTtfaBRZnR7DJCmAkxvMX1lrpz_4",
+  "result": {
+    "note": { "at": 1787075808000, "body": "blocked on the cookie spec" },
+    "noteCount": 1
+  }
+}
+```
+
+The `at` field is the one to watch: `1787075808000` came from the handler, and
+nothing in the command carries it.
+
+Act 6 asked a read twice. A call cannot be asked twice — it would run the
+handler again — but it does not need to be. That `receipt` is the address of
+the cell this handling wrote its outcome to, and reading it is an ordinary read.
+
+**The outcome, without calling anything again.**
+
+```console
+$ cf get -s demo /of:fid1:5dl-nOA…pz_4 --select note,noteCount
+{
+  "note": {
+    "at": 1787075808000,
+    "body": "blocked on the cookie spec"
+  },
+  "noteCount": 1
+}
+```
+
+The same `at` comes back, off the receipt rather than off a second call.
+
+**What that does not prove.** A receipt is a frozen snapshot of the outcome its
+handling committed, so it reports that outcome whether or not anything has
+happened since. Reading it back cannot, on its own, tell you the handler did
+not run again — the numbers inside would look the same either way. Only the
+piece can settle it, and this act reads it at the end.
+
+**That route needs the address.** When a caller never got one — a dropped
+connection, a response nobody saw — the invocation id is the handle instead.
+Name a call with `--invocation`, and replaying that id hands the original
+outcome back. The second payload below is deliberately different text.
+
+**The same id, a different payload.**
+
+```console
+$ cf call -s demo --invocation note-retry /of:fid1:3bSpAHm…JIRk recordNote -- --body 'first attempt'
+$ cf call -s demo --invocation note-retry /of:fid1:3bSpAHm…JIRk recordNote -- --body 'a different body entirely'
+{
+  "invocation": "note-retry",
+  "status": "settled",
+  "deduplicated": true,
+  "receipt": "/of:fid1:tdSLj9QyZFgmSQ53SFqN31lZz2yieuP1pWTW7nCeum0",
+  "result": {
+    "note": { "at": 1787082752000, "body": "first attempt" },
+    "noteCount": 2
+  }
+}
+```
+
+Two things in that envelope are the answer: `"deduplicated": true`, and a
+`body` reading `first attempt` rather than the second call's text. But the same
+caution applies: a replay is *defined* to hand the original snapshot back, so
+this envelope would read the same whether or not a second note actually landed.
+The board is what settles it.
+
+**Where a second note would have shown up.**
+
+```console
+$ cf get -s demo /of:fid1:akNXtBX…JfUU notes --select body
+[
+  { "body": "blocked on the cookie spec" },
+  { "body": "first attempt" }
+]
+```
+
+Two entries, from the two calls that committed, and the replay's text is not
+among them. That is the proof; the envelopes could not have given it.
+
+An id is only half the handle — it is scoped to an **invocation session**, so
+one agent's `note-retry` is not another's. Mint one per run and keep it in
+`CF_INVOCATION_SESSION`: out of argv means out of shell history and the default
+process listing, which reduces casual exposure rather than making it a secret
+store.
+
+**A retry is still not free.** Read the guarantee precisely: at-most-once
+*commit*, not at-most-once *execution*. The redelivered event re-runs the
+handler body and then loses the race for the receipt, so a verb that reaches
+outside its transaction — an LLM call, a fetch, a message sent — repeats those
+effects on every retry. Retry freely for a verb that only writes its own space;
+prefer the receipt for one that reaches beyond it.
+
+#### Act 8 · Finishing reports what the caller could not know
+
+`finish` hands back how many items are still open beneath this one. That takes
+a walk of the whole subtree — a caller computing it would pay one read per
+level. One call, one answer.
+
+#### Act 9 · A verb that declares no result
+
+`archive` is `Stream<void>`: nothing to supply, nothing handed back. The call
+is the verb's name alone, and the invocation settles carrying no `result` key
+at all — not an empty one. What changed is a read away, and the address may
+carry the path, so one word names the piece and the field in it.
+
+**The value-less shape.**
+
+```console
+$ cf call -s demo /of:fid1:SKf22px…N5UfM archive
+{
+  "invocation": "cf78ac78-75d8-4d4b-a461-c341b9f41534",
+  "status": "settled",
+  "receipt": "/of:fid1:0u1OqcMyuo2Zo7JK1XgqNL03xHUtEDI_Ur9ug6tsRW0"
+}
+
+$ cf get -s demo /of:fid1:SKf22px…N5UfM/status
+"archived"
+```
+
+### Act 10 · Step back
+
+#### Act 10 · Read the board
+
+Every change so far was seen one call at a time. One read from the name the
+session started with shows the tree they add up to — and a filter decides
+membership before projection, so a field can select without appearing in the
+output.
+
+**Depth is a call; breadth is a read.**
+
+```console
+$ cf get -s demo --piece board items --select title,status,children@
+[
+  {
+    "status": "done",
+    "title": "Login rewrite",
+    "children": [
+      { "$link": "/of:fid1:SKf22px…N5UfM" },
+      { "$link": "/of:fid1:d4ppvfP…Pqsls" }
+    ]
+  }
+]
+
+$ cf get -s demo /of:fid1:i4v6HTL…gTIQs children --select title --filter '.status == "open"'
+[ { "title": "CSRF tokens" } ]
+```
+
+### Act 11 · Being told no
+
+#### Act 11 · Ask for something that is not there
+
+Every act so far named something the pattern declares. Getting it wrong is the
+other half of a surface that knows its own vocabulary — and the answers come
+from two entirely different pieces of code, in one voice.
+
+**A typo on a call, and a typo on a read. Both blocks below are refusals.**
+
+```console
+$ cf call -s demo --piece board addItem '{"title":"Ship it","titel":"typo"}'
+Invalid input for "addItem": "titel" at <event> is not a field this verb
+declares. Did you mean "title"? <event> takes "title"
+
+$ cf get -s demo /of:fid1:i4v6HTL…gTIQs children --schema '{"type":"array","items":{"type":"object","propertes":{"title":true}}}'
+Invalid --schema at <root>[]: "propertes" is not a projection schema keyword.
+Did you mean "properties"? Projection reads "type", "properties", "items",
+"additionalProperties", "$link"
+```
+
+Each names what was wrong, the position it sat at, what that position accepts,
+and the nearest thing you probably meant.
+
+**A refusal is a capability, not a failure.** What it replaces is worse than an
+error. A payload carrying `titel` used to be accepted, the unknown field
+dropped on the way in, and the caller told the call settled — a silent strip
+that a hand-written or model-written JSON payload hits and a TypeScript author
+never does. Both refusals land before an invocation exists, so nothing is
+spent.
+
+### Acts 12–13 · The graph, and the payoff
+
+#### Act 12 · Relate two items
+
+Here the address stops being a receiver and becomes an **argument**. A tree
+hides this case — you call the verb *on* the parent, so the receiver carries
+the relationship. A graph forces it: two items must be related to each other,
+and the second one has to be named.
+
+**The address as printed, standing as an argument.**
+
+```console
+$ cf call -s demo --select blocked@,on@,blockedOnCount /of:fid1:SKf22px…N5UfM blockOn -- --on /of:fid1:d4ppvfP…Pqsls
+"result": {
+  "blocked":         { "$link": "/of:fid1:xIWrhn5…nWsK4" },
+  "blockedOnCount":  1,
+  "on":              { "$link": "/of:fid1:d4ppvfP…Pqsls" }
+}
+```
+
+The `on` address that came back is `d4ppvfP…Pqsls` — the same string that went
+in. What landed is an *edge to that item*, not a copy of its contents.
+
+Two payloads could only ever be mistakes at a position like this, and both are
+refused by name.
+
+**Guarding a reference position. Both blocks below are refusals.**
+
+```console
+$ cf call -s demo /of:fid1:SKf22px…N5UfM blockOn -- --on not-an-address
+"not-an-address" at <event>.on is not an address — the position declares a
+reference, and takes the /of:… form a read prints
+
+$ cf call -s demo /of:fid1:SKf22px…N5UfM blockOn '{"on":{"title":"a copy"}}'
+<event>.on declares a reference, and an inline copy would store a detached
+document rather than an edge — send the address a read printed
+```
+
+**The second refusal is the one worth understanding.** A payload shaped like
+the target validates perfectly against the schema — so it used to be accepted,
+stored as a detached copy inside the caller's own item, and reported as
+success. Nothing pointed at anything. Refusing it required the CLI to know
+which positions declare a reference, which is a fact only the compiled pattern
+still carries by the time a schema reaches the wire.
+
+#### Act 13 · One item, two paths, one address
+
+The closing read is the point of the whole session. The same item appears twice
+— once as a child in its own right, once inside the `blockedOn` of the item
+waiting on it — and it is *the same string* in both places.
+
+**An edge, not a copy.**
+
+```console
+$ cf get -s demo /of:fid1:i4v6HTL…gTIQs children --select @,title,blockedOn@
+[
+  {
+    "$link": "/of:fid1:SKf22px…N5UfM",
+    "title": "Session cookies",
+    "blockedOn": [
+      { "$link": "/of:fid1:d4ppvfP…Pqsls" }
+    ]
+  },
+  {
+    "$link": "/of:fid1:d4ppvfP…Pqsls",
+    "title": "CSRF tokens",
+    "blockedOn": []
+  }
+]
+```
+
+`d4ppvfP…Pqsls` is the address to follow: it stands inside the first item's
+`blockedOn`, and again as the second item's own `$link`. Had the tracker stored
+contents instead of addresses, this output would show two objects that happen
+to look alike, and a caller could not tell one item from two. The matching
+address is the proof.
+
+## How the story is kept honest
+
+A demo that drifts from the system it describes is worse than no demo. Three
+artifacts check each other, and two of them run in CI:
+
+| Artifact | What it guarantees |
+| --- | --- |
+| [`verb-session-demo.sh`](../../../packages/cli/integration/verb-session-demo.sh) | Prints each command and runs that same command — there is no second, prettier spelling. An act claiming a refusal that no longer happens fails the run, and so does one claiming a success it does not get. |
+| [`verb-session-gaps.sh`](../../../packages/cli/integration/verb-session-gaps.sh) | Asserts the same surface as pass/fail in CI. It also carries a `gap` assertion for a capability that is deliberately absent, which fails loudly the day that capability arrives — so a gap closing gets noticed rather than aging into a stale document. |
+| [`check-verb-session-sync`](../../../tasks/check-verb-session-sync.ts) | Every command quoted in this page and in the walkthrough must be a command the demo actually runs, and every act number must name a real act. Prose cannot invent a command that was never executed. |
+
+Read the harness's summary line carefully: a count of zero open gaps means
+nothing is currently asserting one, which is not the same as the surface being
+complete. What the surface still owes is tracked in prose, in the walkthrough's
+[What the session is waiting on](session-walkthrough.md#what-the-session-is-waiting-on).
+
+## Running it yourself
+
+Start the local servers, then run the demo against them. It deploys into a
+fresh throwaway space and needs nothing set up first, and takes about thirty
+seconds end to end.
+
+```bash
+./scripts/start-local-dev.sh
+packages/cli/integration/verb-session-demo.sh
+
+# and the pass/fail version:
+packages/cli/integration/verb-session-gaps.sh
+```
+
+## Where to read further
+
+- [Verbs over the CLI](over-the-cli.md) — what a verb hands back: declared results, piece references, and what a retry does and does not guarantee.
+- [A verb session, end to end](session-walkthrough.md) — the same session's measurements, its caveats, and what the surface still owes.
+- [An author's prose, over the CLI](prose-over-the-cli.md) — how an author's doc comments reach a caller, and which of the two documents the CLI reads carries what.

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -25,6 +25,7 @@ import {
   joinContinuations,
   main,
   tokenize,
+  TOUR_PATH,
   WALKTHROUGH_PATH,
   walkthroughCommands,
 } from "./check-verb-session-sync.ts";
@@ -34,9 +35,11 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 describe("check-verb-session-sync", () => {
   let sh = "";
   let md = "";
+  let tour = "";
   beforeAll(async () => {
     sh = await Deno.readTextFile(join(REPO_ROOT, DEMO_PATH));
     md = await Deno.readTextFile(join(REPO_ROOT, WALKTHROUGH_PATH));
+    tour = await Deno.readTextFile(join(REPO_ROOT, TOUR_PATH));
   });
 
   describe("tokenize", () => {
@@ -107,6 +110,11 @@ describe("check-verb-session-sync", () => {
       expect(actReferences(md).length).toBeGreaterThanOrEqual(5);
     });
 
+    it("collects an act reference whatever its case", () => {
+      expect(actReferences("Act 12, then act 13").map((r) => r.act))
+        .toEqual([12, 13]);
+    });
+
     it("maps every demo act number to a nonempty section", () => {
       const acts = demoActs(sh);
       expect(acts.size).toBeGreaterThanOrEqual(13);
@@ -133,18 +141,43 @@ describe("check-verb-session-sync", () => {
     });
 
     it("catches an act reference the demo does not have", () => {
-      // The first "act 12" in the walkthrough, wherever it sits, renumbered
-      // past the demo's range.
-      const stale = md.replace("act 12", "act 99");
-      expect(stale).not.toEqual(md);
-      const found = findViolations(sh, stale);
+      // The first "act 12" in the tour, wherever it sits, renumbered past the
+      // demo's range. The tour carries the act narrative; the walkthrough
+      // references acts too, and either would exercise this.
+      const stale = tour.replace("act 12", "act 99");
+      expect(stale).not.toEqual(tour);
+      const found = findViolations(sh, stale, TOUR_PATH);
       expect(found.some((v) => v.includes("act 99"))).toBe(true);
     });
 
     it("catches a shape-table row paired with the wrong act", () => {
-      const mispaired = md.replace("| act 9 |", "| act 3 |");
-      expect(mispaired).not.toEqual(md);
-      expect(findViolations(sh, mispaired).length).toBeGreaterThanOrEqual(1);
+      // The verb shape table lives in the tour, beside the fixture it
+      // describes.
+      const mispaired = tour.replace("| act 9 |", "| act 3 |");
+      expect(mispaired).not.toEqual(tour);
+      expect(findViolations(sh, mispaired, TOUR_PATH).length)
+        .toBeGreaterThanOrEqual(1);
+    });
+
+    it("checks a console transcript, not only a bash block", () => {
+      const block = [
+        "```console",
+        "$ cf frobnicate --nothing-like-this",
+        "```",
+      ].join("\n");
+      expect(findViolations(sh, block).length).toBe(1);
+    });
+
+    it("drops an -s space pair before matching a transcript command", () => {
+      // A transcript shows the space it really ran against; the demo passes
+      // its own. Without the drop these differ by two tokens and no command
+      // in a transcript would ever match.
+      const block = [
+        "```console",
+        "$ cf get -s demo $EPIC children --select @,title",
+        "```",
+      ].join("\n");
+      expect(findViolations(sh, block)).toEqual([]);
     });
 
     it("lets an exempted line differ from every demo command", () => {

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -1,26 +1,32 @@
 #!/usr/bin/env -S deno run --allow-read
 /**
- * Fails when the verb-session walkthrough drifts from the demo that runs it.
+ * Fails when a verb-session document drifts from the demo that runs it.
  *
- * The walkthrough (`docs/common/verbs/session-walkthrough.md`) may QUOTE
- * commands but never compose them: every `cf` line in one of its bash blocks
- * must be a command `packages/cli/integration/verb-session-demo.sh` actually
- * runs, or sit under a `# not in the demo` comment saying why it cannot be.
- * Nothing executes a bash block in a document, so a composed example can be
- * wrong from the day it is written and stay wrong through every editing pass
- * — one shipped that way and survived four of them. The same document names
- * demo acts by number, and those references have gone stale twice as acts
- * were inserted. Both failure classes are mechanical to detect, and this is
- * where they are detected.
+ * Two documents describe the same session — the tour
+ * (`docs/common/verbs/the-verb-session.md`) and the walkthrough
+ * (`docs/common/verbs/session-walkthrough.md`) — and each may QUOTE commands
+ * but never compose them: every `cf` line in one of their command blocks must
+ * be a command `packages/cli/integration/verb-session-demo.sh` actually runs,
+ * or sit under a `# not in the demo` comment saying why it cannot be. Nothing
+ * executes a command block in a document, so a composed example can be wrong
+ * from the day it is written and stay wrong through every editing pass — one
+ * shipped that way and survived four of them. Both documents also name demo
+ * acts by number, and those references have gone stale twice as acts were
+ * inserted. Both failure classes are mechanical to detect, and this is where
+ * they are detected.
  *
- * Three checks:
- * - Every walkthrough `cf` command matches a demo command, token for token,
- *   after normalization: the demo's `-s "$SPACE"` pair is dropped (the
- *   walkthrough's examples run in a configured shell), quotes are stripped,
- *   and a token holding a `$variable` or a `<placeholder>` matches anything.
- * - Every "act N" reference names an act the demo has.
- * - Every row of the verb shape table pairs its verbs with acts whose demo
+ * Three checks, run over every document in `DOC_PATHS`:
+ * - Every `cf` command matches a demo command, token for token, after
+ *   normalization: an `-s <space>` pair is dropped from both sides, quotes
+ *   are stripped, and a token holding a `$variable` or a `<placeholder>`
+ *   matches anything. An address a transcript shortened for width needs no
+ *   rule of its own: the demo holds every address in a variable.
+ * - Every "act N" reference, in any case, names an act the demo has.
+ * - Every row of a verb shape table pairs its verbs with acts whose demo
  *   text actually mentions them.
+ *
+ * A `bash` block holds commands alone; a `console` block holds a transcript,
+ * and its output lines fall out because they carry no `cf` token.
  *
  * Usage: deno run --allow-read ./tasks/check-verb-session-sync.ts
  */
@@ -30,6 +36,11 @@ import { dirname, fromFileUrl, join } from "@std/path";
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
 export const WALKTHROUGH_PATH = "docs/common/verbs/session-walkthrough.md";
+export const TOUR_PATH = "docs/common/verbs/the-verb-session.md";
+
+/** Every document held to the demo. Both quote commands and name acts, and a
+ * command invented in either is wrong the same way. */
+export const DOC_PATHS = [TOUR_PATH, WALKTHROUGH_PATH];
 
 /** The comment that exempts the next `cf` line in a walkthrough bash block.
  * The marker alone is not enough: an exemption without a reason is one
@@ -85,13 +96,17 @@ export function tokenize(line: string): string[] {
 }
 
 /** A token that stands for "whatever the session had here": a shell variable
- * on the demo side, an angle-bracket placeholder on the walkthrough side. */
+ * on the demo side, an angle-bracket placeholder in a document. An address a
+ * transcript shortened for width needs nothing of its own — the demo holds
+ * every address in a variable, so the wildcard is already on that side. */
 function isWildcard(token: string): boolean {
   return token.includes("$") || (token.startsWith("<") && token.endsWith(">"));
 }
 
-/** Drops the demo's per-command space flag; the walkthrough's examples run in
- * a shell where the space is already configured. */
+/** Drops a command's per-space flag. The demo passes `-s "$SPACE"` and a
+ * transcript shows the space it really ran against, while the walkthrough's
+ * examples run in a shell where the space is already configured — so the flag
+ * is noise on every side of the comparison. */
 function dropSpaceFlag(tokens: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < tokens.length; i++) {
@@ -145,8 +160,10 @@ export function demoCommands(shText: string): string[][] {
   return commands;
 }
 
-/** Every `cf` command a walkthrough bash block shows, with its 1-indexed
- * line, minus the ones a `# not in the demo` comment exempts. */
+/** Every `cf` command a document's command block shows, with its 1-indexed
+ * line, minus the ones a `# not in the demo` comment exempts. A `bash` block
+ * holds commands alone; a `console` block holds a transcript, where the
+ * output lines carry no `cf` token and fall out on their own. */
 export function walkthroughCommands(
   mdText: string,
 ): Array<{ tokens: string[]; line: number }> {
@@ -157,7 +174,9 @@ export function walkthroughCommands(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
     if (!inBash) {
-      if (line.startsWith("```bash")) inBash = true;
+      if (line.startsWith("```bash") || line.startsWith("```console")) {
+        inBash = true;
+      }
       continue;
     }
     if (line.startsWith("```")) {
@@ -179,7 +198,7 @@ export function walkthroughCommands(
       exempt = false;
       continue;
     }
-    out.push({ tokens: tokenize(span), line: i + 1 });
+    out.push({ tokens: dropSpaceFlag(tokenize(span)), line: i + 1 });
   }
   return out;
 }
@@ -221,7 +240,7 @@ export function actReferences(
   const out: Array<{ act: number; line: number }> = [];
   const lines = mdText.split("\n");
   for (let i = 0; i < lines.length; i++) {
-    for (const match of lines[i]!.matchAll(/\bacts? (\d+)(?: and (\d+))?/g)) {
+    for (const match of lines[i]!.matchAll(/\bacts? (\d+)(?: and (\d+))?/gi)) {
       out.push({ act: Number(match[1]), line: i + 1 });
       if (match[2]) out.push({ act: Number(match[2]), line: i + 1 });
     }
@@ -241,7 +260,7 @@ export function shapeTableRows(
     if (!line.startsWith("| `")) continue;
     const cells = line.split("|").map((cell) => cell.trim());
     const last = cells[cells.length - 2] ?? "";
-    const acts = [...last.matchAll(/\bact[s]? (\d+)(?: and (\d+))?/g)]
+    const acts = [...last.matchAll(/\bact[s]? (\d+)(?: and (\d+))?/gi)]
       .flatMap((m) => m[2] ? [Number(m[1]), Number(m[2])] : [Number(m[1])]);
     if (acts.length === 0) continue;
     const verbs = [...(cells[1] ?? "").matchAll(/`(\w+)`/g)].map((m) => m[1]!);
@@ -250,14 +269,19 @@ export function shapeTableRows(
   return out;
 }
 
-/** Every way the two files disagree, as printable findings. */
-export function findViolations(shText: string, mdText: string): string[] {
+/** Every way a document and the demo disagree, as printable findings.
+ * `docPath` only labels the findings; it is the caller's name for the text. */
+export function findViolations(
+  shText: string,
+  mdText: string,
+  docPath: string = WALKTHROUGH_PATH,
+): string[] {
   const violations: string[] = [];
   const demo = demoCommands(shText);
   for (const { tokens, line } of walkthroughCommands(mdText)) {
     if (!demo.some((cmd) => commandMatches(tokens, cmd))) {
       violations.push(
-        `${WALKTHROUGH_PATH}:${line} shows a command the demo does not run: ` +
+        `${docPath}:${line} shows a command the demo does not run: ` +
           `\`${tokens.join(" ")}\` — quote a demo line, or mark the line ` +
           `with \`# not in the demo\` and a reason`,
       );
@@ -267,7 +291,7 @@ export function findViolations(shText: string, mdText: string): string[] {
   for (const { act, line } of actReferences(mdText)) {
     if (!acts.has(act)) {
       violations.push(
-        `${WALKTHROUGH_PATH}:${line} names act ${act}, which the demo does ` +
+        `${docPath}:${line} names act ${act}, which the demo does ` +
           `not have`,
       );
     }
@@ -278,7 +302,7 @@ export function findViolations(shText: string, mdText: string): string[] {
       if (body === undefined) continue; // already reported above
       if (!verbs.some((verb) => body.includes(verb))) {
         violations.push(
-          `${WALKTHROUGH_PATH}:${line} pairs ${verbs.join("/")} with act ` +
+          `${docPath}:${line} pairs ${verbs.join("/")} with act ` +
             `${act}, whose demo text mentions none of them`,
         );
       }
@@ -286,7 +310,7 @@ export function findViolations(shText: string, mdText: string): string[] {
     for (const verb of verbs) {
       if (!rowActs.some((act) => (acts.get(act) ?? "").includes(verb))) {
         violations.push(
-          `${WALKTHROUGH_PATH}:${line} lists \`${verb}\` under acts ` +
+          `${docPath}:${line} lists \`${verb}\` under acts ` +
             `${rowActs.join(", ")}, and none of those acts mentions it`,
         );
       }
@@ -309,16 +333,23 @@ export async function main(deps: {
   const shText = await Deno.readTextFile(
     deps.shPath ?? join(REPO_ROOT, DEMO_PATH),
   );
-  const mdText = await Deno.readTextFile(
-    deps.mdPath ?? join(REPO_ROOT, WALKTHROUGH_PATH),
-  );
-  const violations = findViolations(shText, mdText);
+  const docPaths = deps.mdPath === undefined ? DOC_PATHS : [deps.mdPath];
+  const violations: string[] = [];
+  for (const docPath of docPaths) {
+    const mdText = await Deno.readTextFile(
+      docPath.startsWith("/") ? docPath : join(REPO_ROOT, docPath),
+    );
+    violations.push(...findViolations(shText, mdText, docPath));
+  }
   if (violations.length > 0) {
     error(`verb-session sync: ${violations.length} violation(s)\n`);
     for (const violation of violations) error(`  ${violation}`);
     return 1;
   }
-  log("Walkthrough commands and act references all match the demo.");
+  log(
+    `Commands and act references in ${docPaths.length} document(s) all ` +
+      `match the demo.`,
+  );
   return 0;
 }
 


### PR DESCRIPTION
## Why

Someone meeting verbs for the first time had nowhere in the repository to
start. `session-walkthrough.md` reads as a tour — its title, its standfirst,
its thirteen steps — but its content is a completeness report: byte
measurements, implementation symbols, issue numbers, a composition-axis status
table, and a gap list. A newcomer hit `#5937` and `withDeclaredFieldProse` on
the way to learning what a piece is.

The document that did the newcomer's job lived outside the repository, as a
published artifact behind `go/verb-session`. Nothing coupled it to the scripts
and documents it describes, so it drifted by default and updating it was a
thing to remember rather than a thing CI caught. It also duplicated the
walkthrough silently: the `--select` grammar table was a straight copy, six
rows, same order and wording.

This brings the tour in beside its neighbors and gives each of the four
documents in `docs/common/verbs/` one stated purpose, so a change to the verb
surface has one obvious place to land.

## What Changed

**The four-way split**, stated in a new `docs/common/verbs/README.md`:

| Document | Answers |
| --- | --- |
| `the-verb-session.md` (new) | *What is this, and why is it shaped this way?* |
| `session-walkthrough.md` | *What does it cost, and what does it still owe?* |
| `over-the-cli.md` | *What does a verb hand back?* |
| `prose-over-the-cli.md` | *How does a doc comment reach a caller?* |

- **`the-verb-session.md`** — the tour, migrated in. Three parts, thirteen
  acts, the vocabulary, and the transcripts.
- **`session-walkthrough.md`** — retitled *A verb session, measured*, with a
  standfirst that declares the role. It hands the `--select` grammar, the
  fixture's three design decisions, and the verb-shapes table to the tour, and
  keeps the measurements, citations, composition axis, and gap table. Its
  filename is unchanged: two documents under `docs/history/` link to it, and
  history is never edited.
- **`check-verb-session-sync`** — now gates both documents rather than one. It
  reads `console` transcripts as well as `bash` blocks, drops the `-s <space>`
  pair from the document side, and collects act references in any case.
- `docs/common/README.md` and `AGENTS.md` described the old arrangement.

The published artifact is superseded; `go/verb-session` should point at
`docs/common/verbs/the-verb-session.md`.

### One thing deliberately not shipped

An earlier draft taught the gate to treat an elided address (`…`) as a
wildcard, so a transcript could shorten a hash for width. Mutation testing
killed it: removing the rule left its test green, because every demo command
holds its address in a `$VAR`, which already wildcards from the demo side. The
rule was never load-bearing, and an unexercised matching rule inside a
correctness gate later reads as a guarantee. The tour's elided addresses pass
without it.

## Test plan

- `deno task check-verb-session-sync` — passes over both documents; every `cf`
  command in the tour matches a demo command token for token.
- `deno test -A tasks/check-verb-session-sync.test.ts` — 28 steps. Three new
  cases cover the console-fence read, the `-s` drop, and case-insensitive act
  references; each was mutation-checked and goes red when its behavior is
  removed.
- `deno task check-docs common` — 121 blocks; the tour's two TypeScript blocks
  carry `// Shown for illustration only.`, matching the neighbor.
- `deno task check-docs-history-index`, `check-conflict-markers`,
  `check-skill-facts`, `deno fmt --check`, `deno lint` — all green.
- Every relative link and anchor in `docs/common/verbs/` resolves, including
  the incoming `#what-you-are-driving` from `concepts/self-reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

