### PR TITLE
docs: mark every realm crossing that carries a value it cannot represent

### DIFF
--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -13,8 +13,8 @@ export type InitializationData = {
   // TODO(danfuzz): this is one of the two crossings the `InsecureCryptoKeyPair`
   // marker in `@commonfabric/identity`'s `interface.ts` is about. The key
   // material is a plain `Uint8Array` pair because that is what structured
-  // clone carries; `RealmCodecEngine` carries a `FabricBytes`, which would
-  // make the bytes immutable end to end rather than only within a signer.
+  // clone carries; `codec-realm` carries a `FabricBytes`, which would make the
+  // bytes immutable end to end rather than only within a signer.
   rawIdentity: KeyPairRaw;
   experimental?: {
     modernCellRep?: boolean;

--- a/packages/background-piece-service/src/worker-ipc.ts
+++ b/packages/background-piece-service/src/worker-ipc.ts
@@ -10,6 +10,11 @@ export enum WorkerIPCMessageType {
 export type InitializationData = {
   did: string;
   toolshedUrl: string;
+  // TODO(danfuzz): this is one of the two crossings the `InsecureCryptoKeyPair`
+  // marker in `@commonfabric/identity`'s `interface.ts` is about. The key
+  // material is a plain `Uint8Array` pair because that is what structured
+  // clone carries; `RealmCodecEngine` carries a `FabricBytes`, which would
+  // make the bytes immutable end to end rather than only within a signer.
   rawIdentity: KeyPairRaw;
   experimental?: {
     modernCellRep?: boolean;

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -113,7 +113,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
  * constructor, after all fields are initialized. (Freezing in the base
  * constructor would prevent subclass field assignment.)
  *
- * See Section 1.4.5 and 1.4.6 of the formal spec.
+ * See Section 1.4.6 of the formal spec.
  */
 export abstract class FabricPrimitive extends FabricSpecialObject {
   /** Constructs an instance. */

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -194,10 +194,10 @@ export function serializeEvent(event: Event): SerializedEvent {
   // `bigint` throws out of `JSON.stringify()` and lands in the `catch`, which
   // replaces the entire detail with `String(detail)`, and a `FabricBytes`
   // stringifies to `{}`. The crossing is `postMessage`, not JSON text, so
-  // `RealmCodecEngine` (`@commonfabric/data-model/codecs`) carries the whole
-  // domain here; what has to stay is the separate job this does of turning an
-  // unencodable detail into something rather than failing the event. The
-  // outbound half of this seam is marked on `SetPropOp` in `../vdom-ops.ts`.
+  // `codec-realm` carries the whole domain here; what has to stay is the
+  // separate job this does of turning an unencodable detail into something
+  // rather than failing the event. The outbound half of this seam is marked on
+  // `SetPropOp` in `../vdom-ops.ts`.
   if ("detail" in event && (event as CustomEvent).detail !== undefined) {
     const detail = (event as CustomEvent).detail;
     try {

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -187,6 +187,17 @@ export function serializeEvent(event: Event): SerializedEvent {
   }
 
   // Handle CustomEvent detail - ensure it's JSON-serializable
+  //
+  // TODO(danfuzz): a `detail` is a whole value a component chose to hand the
+  // pattern, and the pattern's handler receives it as a `FabricValue`. This
+  // JSON round-trip narrows it to the JSON-compatible subset on the way in: a
+  // `bigint` throws out of `JSON.stringify()` and lands in the `catch`, which
+  // replaces the entire detail with `String(detail)`, and a `FabricBytes`
+  // stringifies to `{}`. The crossing is `postMessage`, not JSON text, so
+  // `RealmCodecEngine` (`@commonfabric/data-model/codecs`) carries the whole
+  // domain here; what has to stay is the separate job this does of turning an
+  // unencodable detail into something rather than failing the event. The
+  // outbound half of this seam is marked on `SetPropOp` in `../vdom-ops.ts`.
   if ("detail" in event && (event as CustomEvent).detail !== undefined) {
     const detail = (event as CustomEvent).detail;
     try {

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -54,8 +54,8 @@ export interface SetPropOp {
   // JSON-compatible subset. The producer (`transformPropValue()` in
   // `worker/reconciler.ts`) does not narrow to match: it hands over a
   // `FabricPrimitive` whole, and structured clone strips one to `{}` on the
-  // way here. `RealmCodecEngine` (`@commonfabric/data-model/codecs`) is the
-  // mechanism, this batch crossing by `postMessage` rather than as JSON text.
+  // way here. `codec-realm` is the mechanism, this batch crossing by
+  // `postMessage` rather than as JSON text.
   value: JSONValue;
 }
 

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -49,6 +49,13 @@ export interface SetPropOp {
   op: "set-prop";
   nodeId: number;
   key: string;
+  // TODO(danfuzz): a prop is whatever a pattern put on a render node, so its
+  // value is a `FabricValue`, and `JSONValue` narrows that to the
+  // JSON-compatible subset. The producer (`transformPropValue()` in
+  // `worker/reconciler.ts`) does not narrow to match: it hands over a
+  // `FabricPrimitive` whole, and structured clone strips one to `{}` on the
+  // way here. `RealmCodecEngine` (`@commonfabric/data-model/codecs`) is the
+  // mechanism, this batch crossing by `postMessage` rather than as JSON text.
   value: JSONValue;
 }
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3158,6 +3158,12 @@ export class WorkerReconciler {
    */
   // deno-lint-ignore no-explicit-any
   private transformPropValue(key: string, value: unknown): any {
+    // TODO(danfuzz): what this returns is not in fact cloneable without loss.
+    // `convertCellsToLinks()` below preserves a `FabricPrimitive` by identity,
+    // and structured clone strips one to `{}` between here and the applicator,
+    // silently. Encoding with `RealmCodecEngine` is what makes the doc comment
+    // above true; see the marker on `SetPropOp` in `../vdom-ops.ts`.
+    //
     // TODO(danfuzz): the `typeof` gate admits a `FabricSpecialObject`, so a
     // fabric-valued `style` prop is routed into the `Object.entries` walk of
     // `styleObjectToCssString` — yielding an empty CSS string, silently —

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3161,7 +3161,7 @@ export class WorkerReconciler {
     // TODO(danfuzz): what this returns is not in fact cloneable without loss.
     // `convertCellsToLinks()` below preserves a `FabricPrimitive` by identity,
     // and structured clone strips one to `{}` between here and the applicator,
-    // silently. Encoding with `RealmCodecEngine` is what makes the doc comment
+    // silently. Encoding with `codec-realm` is what makes the doc comment
     // above true; see the marker on `SetPropOp` in `../vdom-ops.ts`.
     //
     // TODO(danfuzz): the `typeof` gate admits a `FabricSpecialObject`, so a

--- a/packages/identity/src/interface.ts
+++ b/packages/identity/src/interface.ts
@@ -110,9 +110,9 @@ export interface AuthorizationError extends Error {
  * payload, and structured cloning does not preserve a class.
  *
  * TODO(danfuzz): Change these properties to `FabricBytes`, carried across the
- * boundary by `RealmCodecEngine` (`@commonfabric/data-model/codecs`), which
- * encodes one as a bare `ArrayBuffer` a send can transfer. The bytes would
- * then be immutable end to end, instead of only within a signer.
+ * boundary by `codec-realm`, which encodes one as a bare `ArrayBuffer` a send
+ * can transfer. The bytes would then be immutable end to end, instead of only
+ * within a signer.
  */
 export type InsecureCryptoKeyPair = {
   privateKey: Uint8Array;

--- a/packages/identity/src/interface.ts
+++ b/packages/identity/src/interface.ts
@@ -109,9 +109,10 @@ export interface AuthorizationError extends Error {
  * byte type: a value of this shape crosses worker boundaries as an IPC
  * payload, and structured cloning does not preserve a class.
  *
- * TODO(danfuzz): Change these properties to `FabricBytes` once `codec-realm`
- * exists and is used to carry this across that boundary. The bytes would then
- * be immutable end to end, instead of only within a signer.
+ * TODO(danfuzz): Change these properties to `FabricBytes`, carried across the
+ * boundary by `RealmCodecEngine` (`@commonfabric/data-model/codecs`), which
+ * encodes one as a bare `ArrayBuffer` a send can transfer. The bytes would
+ * then be immutable end to end, instead of only within a signer.
  */
 export type InsecureCryptoKeyPair = {
   privateKey: Uint8Array;

--- a/packages/iframe-sandbox/src/context.ts
+++ b/packages/iframe-sandbox/src/context.ts
@@ -13,8 +13,9 @@ export type Context = unknown;
 // TODO(danfuzz): every `unknown` below that stands for a cell's value -- the
 // `read()` result, `write()`'s `value`, and the `callback` argument -- is a
 // `FabricValue`, and typing it so is what would let this seam carry the whole
-// domain. The values cross to the guest as themselves; see the markers on
-// `HostMessage` and `GuestMessage` in `./ipc.ts` for what that costs.
+// domain, `codec-realm` being the mechanism. The values cross to the guest as
+// themselves; see the markers on `HostMessage` and `GuestMessage` in
+// `./ipc.ts` for what that costs.
 export interface IframeContextHandler {
   read(
     element: CommonIframeSandboxElement,

--- a/packages/iframe-sandbox/src/context.ts
+++ b/packages/iframe-sandbox/src/context.ts
@@ -9,6 +9,12 @@ export type Context = unknown;
 
 // An `IframeContextHandler` is used by consumers to
 // register how read/writing values from frames are handled.
+//
+// TODO(danfuzz): every `unknown` below that stands for a cell's value -- the
+// `read()` result, `write()`'s `value`, and the `callback` argument -- is a
+// `FabricValue`, and typing it so is what would let this seam carry the whole
+// domain. The values cross to the guest as themselves; see the markers on
+// `HostMessage` and `GuestMessage` in `./ipc.ts` for what that costs.
 export interface IframeContextHandler {
   read(
     element: CommonIframeSandboxElement,

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -115,6 +115,17 @@ export enum HostMessageType {
   Update = "update",
 }
 
+/**
+ * A message the host passes through to the guest. `data` is a key and the
+ * value read for it.
+ *
+ * TODO(danfuzz): the value is a `FabricValue` -- it comes from a cell, by way
+ * of the registered `IframeContextHandler` -- and crosses to the guest by
+ * `postMessage()` as itself, so structured clone strips a `FabricPrimitive`
+ * to `{}` on the way. `RealmCodecEngine`
+ * (`@commonfabric/data-model/codecs`) encodes for exactly this crossing;
+ * `GuestMessage`'s `Write` arm is the same value going the other way.
+ */
 export type HostMessage = {
   type: HostMessageType.Update;
   data: [string, unknown];
@@ -133,6 +144,11 @@ export type GuestMessage =
   | { type: GuestMessageType.Subscribe; data: string | string[] }
   | { type: GuestMessageType.Unsubscribe; data: string | string[] }
   | { type: GuestMessageType.Read; data: string }
+  // TODO(danfuzz): the `Write` value is the inbound half of the gap marked on
+  // `HostMessage`, and closed by the same mechanism. It is the weaker half:
+  // the guest is untrusted, so what arrives is whatever it sent, and an
+  // encoded form gives the host a decode that refuses rather than a value it
+  // has to vet by hand.
   | { type: GuestMessageType.Write; data: [string, unknown] };
 
 export function isGuestMessage(message: unknown): message is GuestMessage {

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -122,8 +122,7 @@ export enum HostMessageType {
  * TODO(danfuzz): the value is a `FabricValue` -- it comes from a cell, by way
  * of the registered `IframeContextHandler` -- and crosses to the guest by
  * `postMessage()` as itself, so structured clone strips a `FabricPrimitive`
- * to `{}` on the way. `RealmCodecEngine`
- * (`@commonfabric/data-model/codecs`) encodes for exactly this crossing;
+ * to `{}` on the way. `codec-realm` encodes for exactly this crossing;
  * `GuestMessage`'s `Write` arm is the same value going the other way.
  */
 export type HostMessage = {

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -92,9 +92,8 @@ function sanitizeForTransfer(value: unknown): unknown {
   // cell, and this narrows it to the JSON-compatible subset -- a
   // `FabricPrimitive` becomes `{}`, a `bigint` becomes its own decimal text.
   // A test that asserted on either would be asserting on the damage. The
-  // crossing is `postMessage`, so `RealmCodecEngine`
-  // (`@commonfabric/data-model/codecs`) carries the whole domain, and the
-  // harness decodes on the other side.
+  // crossing is `postMessage`, so `codec-realm` carries the whole domain, and
+  // the harness decodes on the other side.
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value, (_key, entry) => {
     if (typeof entry === "function") return undefined;

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -88,6 +88,13 @@ async function attachPiece(next: PieceController): Promise<void> {
  * stringify bigints (JSON.stringify throws on them).
  */
 function sanitizeForTransfer(value: unknown): unknown {
+  // TODO(danfuzz): most of what reaches here is a `FabricValue` read from a
+  // cell, and this narrows it to the JSON-compatible subset -- a
+  // `FabricPrimitive` becomes `{}`, a `bigint` becomes its own decimal text.
+  // A test that asserted on either would be asserting on the damage. The
+  // crossing is `postMessage`, so `RealmCodecEngine`
+  // (`@commonfabric/data-model/codecs`) carries the whole domain, and the
+  // harness decodes on the other side.
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value, (_key, entry) => {
     if (typeof entry === "function") return undefined;

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -450,12 +450,12 @@ function sanitizedBody(
   // receiver wants. These args land in `console.log()` on the main thread
   // (`RuntimeInternals.#onConsole` in `lib-shell`), so the reader is a
   // devtools object inspector -- which renders a live `FabricBytes` as an
-  // expandable value and this string as a string. `RealmCodecEngine` carries
-  // the instance across whole, and the receiver decodes before logging.
+  // expandable value and this string as a string. `codec-realm` carries the
+  // instance across whole, and the receiver decodes before logging.
   //
-  // Two things stand in the way, and neither is this arm's doing. Encoding
-  // refuses a cycle today, where this walk reports one and carries on, so the
-  // memo `RealmCodecEngine` is marked for is a prerequisite. And a
+  // Two things stand in the way, and neither is this arm's doing.
+  // `codec-realm` refuses a cycle today, where this walk reports one and
+  // carries on, so its own memo `TODO` is a prerequisite. And a
   // `console.log()` argument is whatever pattern code passed, which need not
   // be a `FabricValue` at all -- so what replaces this is a walk that encodes
   // the fabric it finds and goes on naming the functions, cells and cycles it
@@ -943,7 +943,7 @@ export class RuntimeProcessor {
     // (`CellHandle.serialize`; see the `WireCellValue` marker in
     // `protocol/types.ts`) — this outbound direction loses silently. The
     // subscription-update path below posts the same conversion.
-    // `RealmCodecEngine` is the mechanism for both directions.
+    // `codec-realm` is the mechanism for both directions.
     const converted = redactSigilCfcLabelViewsForDisplay(
       convertCellsToLinks(value, {
         includeSchema: true,

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -445,6 +445,21 @@ function sanitizedBody(
   // and has nothing to descend into, and an instance's codec contents are not
   // reachable by property name. Naming beats refusing here, because what a
   // debug dump was handed is the very thing being debugged.
+  //
+  // TODO(danfuzz): naming it is what the transport forces, not what the
+  // receiver wants. These args land in `console.log()` on the main thread
+  // (`RuntimeInternals.#onConsole` in `lib-shell`), so the reader is a
+  // devtools object inspector -- which renders a live `FabricBytes` as an
+  // expandable value and this string as a string. `RealmCodecEngine` carries
+  // the instance across whole, and the receiver decodes before logging.
+  //
+  // Two things stand in the way, and neither is this arm's doing. Encoding
+  // refuses a cycle today, where this walk reports one and carries on, so the
+  // memo `RealmCodecEngine` is marked for is a prerequisite. And a
+  // `console.log()` argument is whatever pattern code passed, which need not
+  // be a `FabricValue` at all -- so what replaces this is a walk that encodes
+  // the fabric it finds and goes on naming the functions, cells and cycles it
+  // finds, not an encode in place of a walk.
   if (obj instanceof FabricSpecialObject) {
     return toCompactDebugString(obj);
   }
@@ -928,6 +943,7 @@ export class RuntimeProcessor {
     // (`CellHandle.serialize`; see the `WireCellValue` marker in
     // `protocol/types.ts`) — this outbound direction loses silently. The
     // subscription-update path below posts the same conversion.
+    // `RealmCodecEngine` is the mechanism for both directions.
     const converted = redactSigilCfcLabelViewsForDisplay(
       convertCellsToLinks(value, {
         includeSchema: true,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -554,8 +554,8 @@ export class CellHandle<T = unknown> {
     //
     // TODO(danfuzz): carry the whole `FabricValue` domain across this
     // connection, at which point this becomes a conversion rather than a
-    // refusal. `RealmCodecEngine` is the mechanism, and the gap it closes is
-    // the one marked on `WireCellValue` in `protocol/types.ts`.
+    // refusal. `codec-realm` is the mechanism, and the gap it closes is the
+    // one marked on `WireCellValue` in `protocol/types.ts`.
     if (value instanceof FabricSpecialObject) {
       throw new Error(
         `Cannot yet handle \`${value.constructor.name}\` (a ` +

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -554,8 +554,8 @@ export class CellHandle<T = unknown> {
     //
     // TODO(danfuzz): carry the whole `FabricValue` domain across this
     // connection, at which point this becomes a conversion rather than a
-    // refusal. `JsonCodecEngine` is the mechanism, and the gap it closes is the one
-    // marked on `WireCellValue` in `protocol/types.ts`.
+    // refusal. `RealmCodecEngine` is the mechanism, and the gap it closes is
+    // the one marked on `WireCellValue` in `protocol/types.ts`.
     if (value instanceof FabricSpecialObject) {
       throw new Error(
         `Cannot yet handle \`${value.constructor.name}\` (a ` +

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -284,11 +284,10 @@ export interface CellGetRequest extends BaseRequest {
  * `bigint` or a `symbol`, both of which are `FabricValue` arms. The transport
  * is `postMessage` rather than JSON, so that is a gap rather than a limit --
  * though structured clone alone does not close it, a class instance arriving
- * with its prototype and private fields gone. `RealmCodecEngine` is the
- * mechanism -- `realmFromFabricValue()` and `fabricFromRealmValue()` from
- * `@commonfabric/data-model/codecs` -- being the format written for this
- * crossing: a `bigint` travels as itself, a `symbol` under a tag, and a
- * `FabricBytes` as an `ArrayBuffer` a send can transfer. Until then
+ * with its prototype and private fields gone. `codec-realm` is the mechanism,
+ * being the format written for this crossing: a `bigint` travels as itself, a
+ * `symbol` under a tag, and a `FabricBytes` as an `ArrayBuffer` a send can
+ * transfer. Until then
  * `CellHandle.serialize()` refuses all three, so what the gap costs is a throw
  * rather than silent loss.
  */
@@ -561,7 +560,7 @@ export interface UploadBlobRequest extends BaseRequest {
    * IPC payload: a class does not survive the crossing, where a typed array
    * does and carries whole rather than element by element.
    *
-   * TODO(danfuzz): this wants to be a `FabricBytes`, which `RealmCodecEngine`
+   * TODO(danfuzz): this wants to be a `FabricBytes`, which `codec-realm`
    * carries across as a bare `ArrayBuffer` the send can transfer. The bytes
    * would then be immutable end to end rather than a view a sender still
    * holds.
@@ -644,7 +643,7 @@ export interface PageCreateRequest extends BaseRequest {
   // narrows it to the JSON-compatible subset with nothing carrying the rest.
   // The same gap `WireCellValue` is marked with, at the other request that
   // sends a value into the worker, and closed by the same mechanism
-  // (`RealmCodecEngine`).
+  // (`codec-realm`).
   argument?: JSONValue;
   cause?: string;
   run?: boolean;
@@ -1039,8 +1038,8 @@ export interface BooleanResponse {
  * direction loses where the inbound one throws: the producer hands over a
  * value with its `FabricPrimitive`s intact and structured clone strips each to
  * `{}` (see `handleCellGet` in `backends/runtime-processor.ts`).
- * `RealmCodecEngine` is the mechanism, and closing this gap and
- * `WireCellValue`'s is one change.
+ * `codec-realm` is the mechanism, and closing this gap and `WireCellValue`'s
+ * is one change.
  */
 export interface JSONValueResponse {
   value: JSONValue | undefined;
@@ -1116,9 +1115,9 @@ export interface ConsoleNotification {
   // TODO(danfuzz): these arrive pre-flattened to text by
   // `sanitizeForPostMessage()` (`backends/runtime-processor.ts`), and the
   // receiver hands them to `console.log()` -- a devtools inspector, which can
-  // show more of a value than a string of it can. A `RealmCodecValue` arm here
-  // is what lets the fabric among them cross whole; see the marker at the
-  // producer for what else has to move first.
+  // show more of a value than a string of it can. A `codec-realm` arm here is
+  // what lets the fabric among them cross whole; see the marker at the producer
+  // for what else has to move first.
   args: JSONValue[];
 }
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -166,6 +166,11 @@ export interface InitializationData {
   // IPC boundary. Fixed for the connection's lifetime.
   spaceHostMap?: Record<string, string>;
   // Signer.
+  //
+  // TODO(danfuzz): this and `spaceIdentity` below are the other crossing the
+  // `InsecureCryptoKeyPair` marker in `@commonfabric/identity`'s
+  // `interface.ts` is about, and want the same `FabricBytes` for the same
+  // reason.
   identity: KeyPairRaw;
   // Identity of space.
   spaceDid: DID;
@@ -279,9 +284,11 @@ export interface CellGetRequest extends BaseRequest {
  * `bigint` or a `symbol`, both of which are `FabricValue` arms. The transport
  * is `postMessage` rather than JSON, so that is a gap rather than a limit --
  * though structured clone alone does not close it, a class instance arriving
- * with its prototype and private fields gone. `JsonCodecEngine`
- * (`@commonfabric/data-model/codec-json`) is the mechanism, already used for
- * blob-upload bodies in `backends/runtime-processor.ts`. Until then
+ * with its prototype and private fields gone. `RealmCodecEngine` is the
+ * mechanism -- `realmFromFabricValue()` and `fabricFromRealmValue()` from
+ * `@commonfabric/data-model/codecs` -- being the format written for this
+ * crossing: a `bigint` travels as itself, a `symbol` under a tag, and a
+ * `FabricBytes` as an `ArrayBuffer` a send can transfer. Until then
  * `CellHandle.serialize()` refuses all three, so what the gap costs is a throw
  * rather than silent loss.
  */
@@ -553,6 +560,11 @@ export interface UploadBlobRequest extends BaseRequest {
    * The blob's bytes. The type has to stay structured-clone-able, this being an
    * IPC payload: a class does not survive the crossing, where a typed array
    * does and carries whole rather than element by element.
+   *
+   * TODO(danfuzz): this wants to be a `FabricBytes`, which `RealmCodecEngine`
+   * carries across as a bare `ArrayBuffer` the send can transfer. The bytes
+   * would then be immutable end to end rather than a view a sender still
+   * holds.
    */
   body: Uint8Array;
   suffix?: string;
@@ -628,6 +640,11 @@ export interface PageCreateRequest extends BaseRequest {
   } | {
     program: Program;
   };
+  // TODO(danfuzz): a piece's argument is a `FabricValue`, and `JSONValue`
+  // narrows it to the JSON-compatible subset with nothing carrying the rest.
+  // The same gap `WireCellValue` is marked with, at the other request that
+  // sends a value into the worker, and closed by the same mechanism
+  // (`RealmCodecEngine`).
   argument?: JSONValue;
   cause?: string;
   run?: boolean;
@@ -1013,6 +1030,18 @@ export interface BooleanResponse {
   value: boolean;
 }
 
+/**
+ * A cell's value on its way _out_ of the worker, which `WireCellValue` is on
+ * its way in.
+ *
+ * TODO(danfuzz): the two directions want the same type and do not have it.
+ * `JSONValue` cannot carry the whole `FabricValue` domain either, and this
+ * direction loses where the inbound one throws: the producer hands over a
+ * value with its `FabricPrimitive`s intact and structured clone strips each to
+ * `{}` (see `handleCellGet` in `backends/runtime-processor.ts`).
+ * `RealmCodecEngine` is the mechanism, and closing this gap and
+ * `WireCellValue`'s is one change.
+ */
 export interface JSONValueResponse {
   value: JSONValue | undefined;
 }
@@ -1071,6 +1100,8 @@ export interface PatternCoverageResponse {
 export interface CellUpdateNotification {
   type: NotificationType.CellUpdate;
   cell: CellRef;
+  // TODO(danfuzz): the same gap `JSONValueResponse` is marked with. This is
+  // the push form of the same read, produced by the same conversion.
   value: JSONValue;
   // Present only for subscriptions that opted in via `includeCfcLabel`. Carries
   // the cell's current display label so the client re-renders on label changes
@@ -1082,6 +1113,12 @@ export interface ConsoleNotification {
   type: NotificationType.ConsoleMessage;
   metadata?: { pieceId?: string; patternId?: string; space?: string };
   method: string;
+  // TODO(danfuzz): these arrive pre-flattened to text by
+  // `sanitizeForPostMessage()` (`backends/runtime-processor.ts`), and the
+  // receiver hands them to `console.log()` -- a devtools inspector, which can
+  // show more of a value than a string of it can. A `RealmCodecValue` arm here
+  // is what lets the fabric among them cross whole; see the marker at the
+  // producer for what else has to move first.
   args: JSONValue[];
 }
 

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -194,7 +194,8 @@ function toDisplay(
   // Note this is the second place such a value is lost, not the first: it
   // reaches the client through `postMessage`, and structured clone drops the
   // prototype and private fields on the way. Fixing this alone changes a `{}`
-  // into a `{}` until the wire carries one.
+  // into a `{}` until the wire carries one, which `RealmCodecEngine`
+  // (`@commonfabric/data-model/codecs`) is the mechanism for.
   if (typeof value === "object" && value !== null) {
     const out: Record<string, unknown> = {};
     for (const [key, item] of Object.entries(value)) {

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -194,8 +194,8 @@ function toDisplay(
   // Note this is the second place such a value is lost, not the first: it
   // reaches the client through `postMessage`, and structured clone drops the
   // prototype and private fields on the way. Fixing this alone changes a `{}`
-  // into a `{}` until the wire carries one, which `RealmCodecEngine`
-  // (`@commonfabric/data-model/codecs`) is the mechanism for.
+  // into a `{}` until the wire carries one, which `codec-realm` is the
+  // mechanism for.
   if (typeof value === "object" && value !== null) {
     const out: Record<string, unknown> = {};
     for (const [key, item] of Object.entries(value)) {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`codec-realm` is the format for a value crossing a realm boundary, and nothing
outside `data-model` uses it yet. This is a survey of the sites that want it,
left in the code as markers — so the next change to any of them starts from the
whole picture rather than rediscovering one seam at a time.

**Comments only.** No non-comment line is added or removed anywhere in the diff.

## The seams

**`runtime-client` worker IPC.** Inbound `WireCellValue` *throws* on the three
arms it cannot carry. Outbound `JSONValueResponse` and
`CellUpdateNotification.value` *lose silently*: `convertCellsToLinks()` hands
over a `FabricPrimitive` whole, and structured clone strips it to `{}`.
`PageCreateRequest.argument` (a piece's argument is a `FabricValue`) and
`UploadBlobRequest.body` (wants `FabricBytes`) are the same gap at two more
requests.

**The `html` VDOM seam.** `SetPropOp.value` outbound — same
`convertCellsToLinks()` defect. `CustomEvent.detail` inbound is a
`JSON.parse(JSON.stringify(detail))` whose `catch` replaces the **entire**
detail with `String(detail)` when a `bigint` throws out of the stringify.

**`iframe-sandbox` host and guest.** `HostMessage` and `GuestMessage` carry
`data: [string, unknown]` across the frame `postMessage`, and
`IframeContextHandler` types a cell's value as `unknown` at four positions.

**The debug path.** `sanitizeForPostMessage()` names a `FabricSpecialObject`
rather than carrying it. The receiver is `console.log()` in
`RuntimeInternals.#onConsole` — a devtools object inspector, which renders a
live value more fully than a string of one, so the flattening is forced by the
transport rather than chosen for the display. Two things have to move first and
the marker says so: encoding refuses a cycle today (where this walk reports one
and carries on), and a `console.log()` argument need not be a `FabricValue` at
all. What replaces it is a walk that encodes the fabric it finds and goes on
naming the functions, cells and cycles — not an encode in place of a walk.

**`multi-runtime-worker.ts`'s `sanitizeForTransfer()`.** Another JSON
round-trip, applied to `cell.get()` and `getRaw()`. A test asserting on a
`FabricBytes` there would be asserting on the damage.

## Markers that already existed

Four named `JsonCodecEngine` as the mechanism, decided before this format
existed. The transport is structured clone rather than JSON text, so they name
`codec-realm` instead.

Every marker here names `codec-realm` and nothing else — not
`RealmCodecEngine`, not a module path, not the entry-point functions. One name
means one `grep` finds all eighteen mentions across the twelve files:

```
$ grep -rn 'codec-realm' --include='*.ts' packages/ | grep -v 'packages/data-model/'
```

`InsecureCryptoKeyPair` in `identity` was written waiting for `codec-realm` to
exist, and named no site. Its two actual crossings —
`background-piece-service`'s `InitializationData.rawIdentity` and
`runtime-client`'s `InitializationData.identity`/`spaceIdentity` — now point
back at it.

## What was ruled out

`cli/lib/multi-user-test-worker.ts` passes indices and markers, and
`assertionOutcome()` returns strings. `agents-host`, `cf-harness` and
`spec-model` use `structuredClone()` for same-realm defensive copies of plain
config records, so they are not realm crossings at all.

`cf-piece-menu.ts` is downstream of the first seam and already marked; it gains
only the mechanism's name. Its existing note that fixing it alone "changes a
`{}` into a `{}`" is an ordering constraint — both halves are needed — not a
claim that the panel is indifferent to fidelity.

## One unrelated commit

`Tiny spec-ref fix.` (@danfuzz) corrects a citation in
`packages/data-model/src/interface.ts` from "Section 1.4.5 and 1.4.6" to
"Section 1.4.6" — §1.4.5 is `FabricRegExp`, which has nothing to do with the
freezing rule the doc comment states, while §1.4.6 is the base-classes section
that does. It rides along here rather than as a PR of its own. It is the
thirteenth file, and the only one from a package this survey does not otherwise
touch.

## Verification

Whole-diff property: `git diff -U0` filtered for non-comment added *or* removed
lines is empty in both directions, with the filter control-checked against a
real code line so the emptiness has grip.

Green locally at this head: `deno task check`, `deno lint`, `deno fmt --check`,
`deno task check-docs` (exit codes asserted, not tail-inspected), and
`deno task test` in `html` (39 passed), `runtime-client` (60 passed) and
`background-piece-service` (14 passed). The `identity`, `iframe-sandbox` and
part of the `ui` suites run under `deno-web-test` and launch a browser; I left
those to CI and did not run them locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



