### PR TITLE
docs(data-model): `FabricEpochNsec` cites its own spec section

### DIFF
--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -24,7 +24,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 /**
  * Temporal type representing nanoseconds from the POSIX Epoch
  * (1970-01-01T00:00:00Z). Wraps a `bigint` value. Used for high-precision
- * timestamps. See Section 1.4.6 of the formal spec.
+ * timestamps. See Section 1.4.7 of the formal spec.
  */
 export class FabricEpochNsec extends BaseFabricPrimitive
   implements ApiFabricEpochNsec {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

One line. The `FabricEpochNsec` class doc pointed at Section 1.4.6 of the
formal spec, which is the base-class section (`FabricSpecialObject` and
`FabricPrimitive`). `FabricEpochNsec` is Section 1.4.7.

This is the sibling of the off-by-one fixed in #6044, which corrected
`FabricEpochDay`'s citation from 1.4.7 to 1.4.8. Both were one section low, in
the way an insertion above them would produce.

## Neighbors I checked and left alone

Every `Section <n>` citation in `packages/` was compared against the actual
headings. Three are worth naming, none of them a defect this change should
absorb:

- `FabricError` and `FabricRegExp` both cite **1.4.1**, the Wrapper Class
  Summary, rather than their own sections (1.4.2 and 1.4.5). Two classes
  agreeing on it reads as a deliberate pointer to the summary table rather
  than an error, so it stands.
- `FabricPrimitive` in `data-model/src/interface.ts` cites **"Section 1.4.5
  and 1.4.6"**. 1.4.6 is right -- it is the base-class section. 1.4.5 is
  `FabricRegExp`, which has nothing to do with the freeze protocol the comment
  describes. Suspicious, but which section the pair meant to name is a
  judgment call rather than an arithmetic one, so it is left for a decision.
- `JsonCodecEngine` cites **"the formal spec (Section 5)"**. Section 5 still
  exists at `1-fabric-values.md:3087` after the JSON encoding was extracted to
  its own document, so this one resolves and is fine.

## Verification

`fmt --check` and `lint` clean; `data-model` suite 56 passed / 0 failed. The
cited heading was confirmed present at `1-fabric-values.md:928`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

