### PR TITLE
fix(ts-transformers): verify plain-array map provenance

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -707,11 +707,12 @@ pattern-owned sites outright; the compute-owned boundaries (`computed`,
 
 `plain-array-value` carries them only for the callback role that can hold
 them, which `isCollectingPlainArrayMethodCallback` (`ast/call-kind.ts`)
-decides. It admits a callback that is argument zero of an
-`Array`/`ReadonlyArray` method named in `COLLECTING_ARRAY_METHOD_NAMES` —
-today `map` alone — over a plain receiver no reactive lowering owns. `map`
-stores each result without reading it, so a result that is a cell stays a
-cell. Every other callback-taking array method reads the result as it runs:
+decides. It admits a callback that is argument zero of a standard-library
+`Array`/`ReadonlyArray` method named in `COLLECTING_ARRAY_METHOD_NAMES` — today
+`map` alone — over a plain receiver no reactive lowering owns. A source-defined
+type merely named `Array` or `ReadonlyArray` is not a standard array. `map`
+stores each result without reading it, so a result that is a cell stays a cell.
+Every other callback-taking array method reads the result as it runs:
 `filter`, `find`, `some`, and `every` as a boolean, `sort` as a number,
 `flatMap` as an array test, `reduce` as the next accumulator. A cell reaching
 any of those is an object, which is truthy, not a number, and not an array, so

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -707,12 +707,13 @@ pattern-owned sites outright; the compute-owned boundaries (`computed`,
 
 `plain-array-value` carries them only for the callback role that can hold
 them, which `isCollectingPlainArrayMethodCallback` (`ast/call-kind.ts`)
-decides. It admits a callback that is argument zero of a standard-library
-`Array`/`ReadonlyArray` method named in `COLLECTING_ARRAY_METHOD_NAMES` — today
-`map` alone — over a plain receiver no reactive lowering owns. A source-defined
-type merely named `Array` or `ReadonlyArray` is not a standard array. `map`
-stores each result without reading it, so a result that is a cell stays a cell.
-Every other callback-taking array method reads the result as it runs:
+decides. It admits a callback that is argument zero of TypeScript's
+declaration-file-backed global `Array`/`ReadonlyArray` type and names a method
+in `COLLECTING_ARRAY_METHOD_NAMES` — today `map` alone — over a plain receiver
+no reactive lowering owns. A source-defined type merely named `Array` or
+`ReadonlyArray` is not a standard array. `map` stores each result without
+reading it, so a result that is a cell stays a cell. Every other
+callback-taking array method reads the result as it runs:
 `filter`, `find`, `some`, and `every` as a boolean, `sort` as a number,
 `flatMap` as an array test, `reduce` as the next accumulator. A cell reaching
 any of those is an object, which is truthy, not a number, and not an array, so

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -707,13 +707,13 @@ pattern-owned sites outright; the compute-owned boundaries (`computed`,
 
 `plain-array-value` carries them only for the callback role that can hold
 them, which `isCollectingPlainArrayMethodCallback` (`ast/call-kind.ts`)
-decides. It admits a callback that is argument zero of TypeScript's
-declaration-file-backed global `Array`/`ReadonlyArray` type and names a method
-in `COLLECTING_ARRAY_METHOD_NAMES` — today `map` alone — over a plain receiver
-no reactive lowering owns. A source-defined type merely named `Array` or
+decides. It admits a callback that is argument zero of the configured
+default-library `Array`/`ReadonlyArray` type and names a method in
+`COLLECTING_ARRAY_METHOD_NAMES` — today `map` alone — over a plain receiver no
+reactive lowering owns. A source or ambient type merely named `Array` or
 `ReadonlyArray` is not a standard array. `map` stores each result without
-reading it, so a result that is a cell stays a cell. Every other
-callback-taking array method reads the result as it runs:
+reading it, so a result that is a cell stays a cell. Every other callback-taking
+array method reads the result as it runs:
 `filter`, `find`, `some`, and `every` as a boolean, `sort` as a number,
 `flatMap` as an array test, `reduce` as the next accumulator. A cell reaching
 any of those is an object, which is truthy, not a number, and not an array, so

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -106,8 +106,8 @@ the callback returns while it runs — as a boolean, a number, an array test, or
 the next accumulator. `map` is the one that merely collects. A lift returned to
 a predicate is an object, so `filter` keeps every element and `find` matches
 the first; those callbacks therefore keep the diagnostic. The test that admits
-a callback also requires it to be argument zero of a method whose owner symbol
-includes the standard-library `Array`/`ReadonlyArray` declaration, so a
+a callback also requires it to be argument zero of a method whose owner is
+TypeScript's declaration-file-backed global `Array`/`ReadonlyArray` type, so a
 comparator in a later argument position, a same-named source type, and a `map`
 belonging to some other type are all excluded.
 

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -106,9 +106,10 @@ the callback returns while it runs — as a boolean, a number, an array test, or
 the next accumulator. `map` is the one that merely collects. A lift returned to
 a predicate is an object, so `filter` keeps every element and `find` matches
 the first; those callbacks therefore keep the diagnostic. The test that admits
-a callback also requires it to be argument zero of a method resolved on
-`Array`/`ReadonlyArray`, so a comparator in a later argument position and a
-`map` belonging to some other type are both excluded.
+a callback also requires it to be argument zero of a method whose owner symbol
+includes the standard-library `Array`/`ReadonlyArray` declaration, so a
+comparator in a later argument position, a same-named source type, and a `map`
+belonging to some other type are all excluded.
 
 Two behaviors change:
 

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -106,10 +106,10 @@ the callback returns while it runs — as a boolean, a number, an array test, or
 the next accumulator. `map` is the one that merely collects. A lift returned to
 a predicate is an object, so `filter` keeps every element and `find` matches
 the first; those callbacks therefore keep the diagnostic. The test that admits
-a callback also requires it to be argument zero of a method whose owner is
-TypeScript's declaration-file-backed global `Array`/`ReadonlyArray` type, so a
-comparator in a later argument position, a same-named source type, and a `map`
-belonging to some other type are all excluded.
+a callback also requires it to be argument zero of a method whose owner symbol
+includes the configured default-library `Array`/`ReadonlyArray` declaration, so
+a comparator in a later argument position, a same-named source or ambient type,
+and a `map` belonging to some other type are all excluded.
 
 Two behaviors change:
 

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -110,7 +110,7 @@ Those container kinds appear to authors in three main buckets:
    property values, variable initializers, call arguments, array elements, and
    direct function return expressions
 3. callback-local value-expression sites inside supported collection
-   callbacks, both the reactive operators and plain-array value callbacks
+   callbacks, both the reactive operators and plain-array `map` callbacks
 
 Explicit computation callbacks such as `computed`, `action`, `lift`, and
 `handler` are important boundaries, but their bodies are **not** blanket

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -129,6 +129,36 @@ async function resolveAndCompileToModules(
 }
 
 describe("TypeScriptCompiler", () => {
+  it("registers virtual environment types as default libraries", async () => {
+    const compiler = new TypeScriptCompiler(types);
+    const resolved = await compiler.resolveProgram(
+      new InMemoryProgram("/main.ts", {
+        "/main.ts": "export const values = [1, 2, 3];",
+      }),
+    );
+    let classifications: Record<string, boolean> | undefined;
+
+    compiler.compileToModules(resolved, {
+      beforeTransformers: (program) => {
+        classifications = Object.fromEntries(
+          program.getSourceFiles()
+            .filter((sourceFile) => sourceFile.fileName.startsWith("$types/"))
+            .map((sourceFile) => [
+              sourceFile.fileName,
+              program.isSourceFileDefaultLibrary(sourceFile),
+            ]),
+        );
+        return [];
+      },
+    });
+
+    expect(classifications).toEqual({
+      "$types/dom.d.ts": true,
+      "$types/es2023.d.ts": true,
+      "$types/jsx.d.ts": true,
+    });
+  });
+
   it("compileToModules emits per-module CommonJS for each source", async () => {
     const compiler = new TypeScriptCompiler(types);
     const program = new InMemoryProgram("/main.tsx", {

--- a/packages/js-compiler/typescript/options.ts
+++ b/packages/js-compiler/typescript/options.ts
@@ -88,8 +88,11 @@ export const getCompilerOptions = (): CompilerOptions => {
     jsxFragmentFactory: "__cfHelpers.h.fragment",
     target: TARGET,
     // `lib` should autoapply, but we need to manage default libraries since
-    // we are running outside of node. Ensure this lib matches `target`.
-    lib: [TARGET_TYPE_LIB, "dom", "jsx"],
+    // we are running outside of node. The Compiler API needs the actual file
+    // names to register these virtual files as default libraries; extensionless
+    // names load, but `Program.isSourceFileDefaultLibrary()` rejects them.
+    // Ensure the target lib matches `target`.
+    lib: [`${TARGET_TYPE_LIB}.d.ts`, "dom.d.ts", "jsx.d.ts"],
     // Dynamic import/requires and `<reference` pragmas
     // should not be respected.
     noResolve: true,

--- a/packages/ts-transformers/docs/array-method-callback-pipeline.md
+++ b/packages/ts-transformers/docs/array-method-callback-pipeline.md
@@ -54,6 +54,16 @@ passes, not first. By the time it fires, expression-site lowering during
 `key()`-substitution prologue it generates is downstream of the analyzer-driven
 decisions about wrapping.
 
+This document focuses on reactive collection calls that `ClosureTransformer`
+rewrites. An ordinary eager `Array.map()` or `ReadonlyArray.map()` call remains
+plain JavaScript, but a callback in a pattern body can still carry pattern-owned
+value sites that stage 13 lowers. That permission is narrower than the
+`plain-array-value` callback boundary: `isCollectingPlainArrayMethodCallback`
+admits only argument zero of a `map` whose owner symbol includes the configured
+TypeScript default-library `Array`/`ReadonlyArray` declaration. Same-named
+source and ambient types do not qualify, and neither do result-interpreting
+methods such as `filter`, `find`, `sort`, `flatMap`, or `reduce`.
+
 ## What `ClosureTransformer` does for `.map`s
 
 `ClosureTransformer` walks the source tree and delegates each visited expression
@@ -191,6 +201,7 @@ See `src/core/mod.ts` for the full registry contract.
 | Per-callback closure transform                             | `src/closures/strategies/array-method-transform.ts`                                          |
 | Element binding analysis (identifier vs destructured)      | `src/closures/strategies/array-method-utils.ts`                                              |
 | Synthesized pattern callback's typed shape                 | `src/closures/utils/schema-factory.ts`                                                       |
+| Plain-array `map` callback value-site permission           | `src/policy/callback-boundary.ts` + `src/ast/call-kind.ts`                                   |
 | `ClosureTransformer` per-callback expression-site lowering | `src/transformers/expression-site-lowering.ts` (`rewriteArrayMethodCallbackExpressionSites`) |
 | The defer-to-late-lowering gate                            | `src/transformers/expression-site-lowering.ts` (`shouldDeferToLateInPlaceLowering`)          |
 | Dataflow analyzer identifier + property-access branches    | `src/ast/dataflow.ts` (around lines 700-900)                                                 |

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -900,16 +900,15 @@ const COLLECTING_ARRAY_METHOD_NAMES = new Set(["map"]);
  * Three things must hold, and each rules out a shape that would otherwise slip
  * through method-name matching alone: the callback is argument zero, so a
  * comparator or an `initialValue` in another position does not qualify; the
- * resolved owner symbol includes the standard-library `Array`/`ReadonlyArray`
- * declaration, so a same-named source type or a `map` of some other type does
- * not qualify; and the receiver is a plain array that no reactive lowering
- * owns, so the reactive collection operators keep their own structural
- * treatment.
+ * resolved owner is TypeScript's declaration-file-backed global
+ * `Array`/`ReadonlyArray` type, so a same-named source type or a `map` of some
+ * other type does not qualify; and the receiver is a plain array that no
+ * reactive lowering owns, so the reactive collection operators keep their own
+ * structural treatment.
  */
 export function isCollectingPlainArrayMethodCallback(
   callback: ts.ArrowFunction | ts.FunctionExpression,
   checker: ts.TypeChecker,
-  isSourceFileDefaultLibrary: (sourceFile: ts.SourceFile) => boolean,
 ): boolean {
   const position = getCallArgumentPosition(callback);
   if (!position || position.index !== 0) {
@@ -935,8 +934,9 @@ export function isCollectingPlainArrayMethodCallback(
   const ownerSymbol = checker.getSymbolAtLocation(owner.name);
   if (
     !ownerSymbol ||
+    !checker.isArrayType(checker.getDeclaredTypeOfSymbol(ownerSymbol)) ||
     !(ownerSymbol.declarations ?? []).some((candidate) =>
-      isSourceFileDefaultLibrary(candidate.getSourceFile())
+      candidate.getSourceFile().isDeclarationFile
     )
   ) {
     return false;

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -900,14 +900,16 @@ const COLLECTING_ARRAY_METHOD_NAMES = new Set(["map"]);
  * Three things must hold, and each rules out a shape that would otherwise slip
  * through method-name matching alone: the callback is argument zero, so a
  * comparator or an `initialValue` in another position does not qualify; the
- * resolved signature is declared on `Array`/`ReadonlyArray`, so a `map` of some
- * other type does not qualify; and the receiver is a plain array that no
- * reactive lowering owns, so the reactive collection operators keep their own
- * structural treatment.
+ * resolved owner symbol includes the standard-library `Array`/`ReadonlyArray`
+ * declaration, so a same-named source type or a `map` of some other type does
+ * not qualify; and the receiver is a plain array that no reactive lowering
+ * owns, so the reactive collection operators keep their own structural
+ * treatment.
  */
 export function isCollectingPlainArrayMethodCallback(
   callback: ts.ArrowFunction | ts.FunctionExpression,
   checker: ts.TypeChecker,
+  isSourceFileDefaultLibrary: (sourceFile: ts.SourceFile) => boolean,
 ): boolean {
   const position = getCallArgumentPosition(callback);
   if (!position || position.index !== 0) {
@@ -925,8 +927,18 @@ export function isCollectingPlainArrayMethodCallback(
     return false;
   }
 
-  const owner = findOwnerName(declaration);
-  if (!owner || !ARRAY_OWNER_NAMES.has(owner)) {
+  const owner = findOwnerDeclaration(declaration);
+  if (!owner?.name || !ARRAY_OWNER_NAMES.has(owner.name.text)) {
+    return false;
+  }
+
+  const ownerSymbol = checker.getSymbolAtLocation(owner.name);
+  if (
+    !ownerSymbol ||
+    !(ownerSymbol.declarations ?? []).some((candidate) =>
+      isSourceFileDefaultLibrary(candidate.getSourceFile())
+    )
+  ) {
     return false;
   }
 
@@ -2340,7 +2352,14 @@ function isMethodDeclarationOwnedBy(
   return !!owner && ownerNames.has(owner);
 }
 
-function findOwnerName(node: ts.Node): string | undefined {
+/** Finds the nearest named type declaration containing `node`. */
+function findOwnerDeclaration(
+  node: ts.Node,
+):
+  | ts.InterfaceDeclaration
+  | ts.ClassDeclaration
+  | ts.TypeAliasDeclaration
+  | undefined {
   let current: ts.Node | undefined = node.parent;
   while (current) {
     if (
@@ -2348,12 +2367,16 @@ function findOwnerName(node: ts.Node): string | undefined {
       ts.isClassDeclaration(current) ||
       ts.isTypeAliasDeclaration(current)
     ) {
-      if (current.name) return current.name.text;
+      return current;
     }
     if (ts.isSourceFile(current)) break;
     current = current.parent;
   }
   return undefined;
+}
+
+function findOwnerName(node: ts.Node): string | undefined {
+  return findOwnerDeclaration(node)?.name?.text;
 }
 
 function hasIdentifierName(

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -900,15 +900,16 @@ const COLLECTING_ARRAY_METHOD_NAMES = new Set(["map"]);
  * Three things must hold, and each rules out a shape that would otherwise slip
  * through method-name matching alone: the callback is argument zero, so a
  * comparator or an `initialValue` in another position does not qualify; the
- * resolved owner is TypeScript's declaration-file-backed global
- * `Array`/`ReadonlyArray` type, so a same-named source type or a `map` of some
- * other type does not qualify; and the receiver is a plain array that no
- * reactive lowering owns, so the reactive collection operators keep their own
- * structural treatment.
+ * resolved owner symbol includes the configured default-library
+ * `Array`/`ReadonlyArray` declaration, so a same-named source or ambient type
+ * and a `map` of some other type do not qualify; and the receiver is a plain
+ * array that no reactive lowering owns, so the reactive collection operators
+ * keep their own structural treatment.
  */
 export function isCollectingPlainArrayMethodCallback(
   callback: ts.ArrowFunction | ts.FunctionExpression,
   checker: ts.TypeChecker,
+  isSourceFileDefaultLibrary: (sourceFile: ts.SourceFile) => boolean,
 ): boolean {
   const position = getCallArgumentPosition(callback);
   if (!position || position.index !== 0) {
@@ -934,9 +935,8 @@ export function isCollectingPlainArrayMethodCallback(
   const ownerSymbol = checker.getSymbolAtLocation(owner.name);
   if (
     !ownerSymbol ||
-    !checker.isArrayType(checker.getDeclaredTypeOfSymbol(ownerSymbol)) ||
     !(ownerSymbol.declarations ?? []).some((candidate) =>
-      candidate.getSourceFile().isDeclarationFile
+      isSourceFileDefaultLibrary(candidate.getSourceFile())
     )
   ) {
     return false;

--- a/packages/ts-transformers/src/ast/reactive-context.ts
+++ b/packages/ts-transformers/src/ast/reactive-context.ts
@@ -25,7 +25,6 @@ export interface ReactiveContextInfo {
 
 export interface ReactiveContextLookup {
   isArrayMethodCallback(node: ts.Node): boolean;
-  isSourceFileDefaultLibrary?(sourceFile: ts.SourceFile): boolean;
   isSyntheticComputeCallback?(node: ts.Node): boolean;
   isSyntheticComputeOwnedNode?(node: ts.Node): boolean;
 }
@@ -217,8 +216,6 @@ export function classifyReactiveContext(
           {
             isArrayMethodCallback: (node) =>
               lookup?.isArrayMethodCallback(node) ?? false,
-            isSourceFileDefaultLibrary: (sourceFile) =>
-              lookup?.isSourceFileDefaultLibrary?.(sourceFile) ?? false,
           },
         );
         const bodyContext = boundarySemantics.bodyContext;

--- a/packages/ts-transformers/src/ast/reactive-context.ts
+++ b/packages/ts-transformers/src/ast/reactive-context.ts
@@ -25,6 +25,7 @@ export interface ReactiveContextInfo {
 
 export interface ReactiveContextLookup {
   isArrayMethodCallback(node: ts.Node): boolean;
+  isSourceFileDefaultLibrary?(sourceFile: ts.SourceFile): boolean;
   isSyntheticComputeCallback?(node: ts.Node): boolean;
   isSyntheticComputeOwnedNode?(node: ts.Node): boolean;
 }
@@ -216,6 +217,8 @@ export function classifyReactiveContext(
           {
             isArrayMethodCallback: (node) =>
               lookup?.isArrayMethodCallback(node) ?? false,
+            isSourceFileDefaultLibrary: (sourceFile) =>
+              lookup?.isSourceFileDefaultLibrary?.(sourceFile) ?? false,
           },
         );
         const bodyContext = boundarySemantics.bodyContext;

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -167,6 +167,11 @@ export class TransformationContext {
     return this.state.isArrayMethodCallback(node);
   }
 
+  /** Whether `sourceFile` belongs to TypeScript's loaded default library. */
+  isSourceFileDefaultLibrary(sourceFile: ts.SourceFile): boolean {
+    return this.program.isSourceFileDefaultLibrary(sourceFile);
+  }
+
   /**
    * Mark a synthetic callback introduced by a compute wrapper so later phases
    * can classify its contents as compute-owned even when they originate from

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -167,11 +167,6 @@ export class TransformationContext {
     return this.state.isArrayMethodCallback(node);
   }
 
-  /** Whether `sourceFile` belongs to TypeScript's loaded default library. */
-  isSourceFileDefaultLibrary(sourceFile: ts.SourceFile): boolean {
-    return this.program.isSourceFileDefaultLibrary(sourceFile);
-  }
-
   /**
    * Mark a synthetic callback introduced by a compute wrapper so later phases
    * can classify its contents as compute-owned even when they originate from

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -12,7 +12,6 @@ import { isEventHandlerJsxAttribute } from "../ast/event-handlers.ts";
 
 export interface CallbackBoundaryLookup {
   isArrayMethodCallback(node: ts.Node): boolean;
-  isSourceFileDefaultLibrary(sourceFile: ts.SourceFile): boolean;
 }
 
 export type SupportedCallbackBoundaryKind =
@@ -407,12 +406,7 @@ export function getCallbackBoundarySemantics(
     supportsPatternOwnedWrapperCallbackSite: supportedKind ===
         "reactive-array-method" ||
       (supportedKind === "plain-array-value" &&
-        !!lookup &&
-        isCollectingPlainArrayMethodCallback(
-          callback,
-          checker,
-          (sourceFile) => lookup.isSourceFileDefaultLibrary(sourceFile),
-        )) ||
+        isCollectingPlainArrayMethodCallback(callback, checker)) ||
       supportedKind === "pattern-builder" ||
       supportedKind === "render-builder",
     supportsPatternOwnedStatements: supportedKind === "reactive-array-method" ||

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -12,6 +12,7 @@ import { isEventHandlerJsxAttribute } from "../ast/event-handlers.ts";
 
 export interface CallbackBoundaryLookup {
   isArrayMethodCallback(node: ts.Node): boolean;
+  isSourceFileDefaultLibrary(sourceFile: ts.SourceFile): boolean;
 }
 
 export type SupportedCallbackBoundaryKind =
@@ -406,7 +407,12 @@ export function getCallbackBoundarySemantics(
     supportsPatternOwnedWrapperCallbackSite: supportedKind ===
         "reactive-array-method" ||
       (supportedKind === "plain-array-value" &&
-        isCollectingPlainArrayMethodCallback(callback, checker)) ||
+        !!lookup &&
+        isCollectingPlainArrayMethodCallback(
+          callback,
+          checker,
+          (sourceFile) => lookup.isSourceFileDefaultLibrary(sourceFile),
+        )) ||
       supportedKind === "pattern-builder" ||
       supportedKind === "render-builder",
     supportsPatternOwnedStatements: supportedKind === "reactive-array-method" ||

--- a/packages/ts-transformers/test/policy/callback-support.test.ts
+++ b/packages/ts-transformers/test/policy/callback-support.test.ts
@@ -8,7 +8,10 @@ import {
   getCallbackBoundarySemantics,
 } from "../../src/policy/callback-boundary.ts";
 
-function createProgramAndContext(source: string): {
+function createProgramAndContext(
+  source: string,
+  options: { withDefaultLibrary?: boolean } = {},
+): {
   sourceFile: ts.SourceFile;
   checker: ts.TypeChecker;
   context: TransformationContext;
@@ -19,7 +22,7 @@ function createProgramAndContext(source: string): {
     module: ts.ModuleKind.ESNext,
     jsx: ts.JsxEmit.Preserve,
     strict: true,
-    noLib: true,
+    noLib: !options.withDefaultLibrary,
     skipLibCheck: true,
   };
 
@@ -32,11 +35,17 @@ function createProgramAndContext(source: string): {
   );
 
   const host = ts.createCompilerHost(compilerOptions, true);
-  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  const getSourceFile = host.getSourceFile.bind(host);
+  const fileExists = host.fileExists.bind(host);
+  const readFile = host.readFile.bind(host);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNew) =>
+    name === fileName
+      ? sourceFile
+      : getSourceFile(name, languageVersion, onError, shouldCreateNew);
   host.getCurrentDirectory = () => "/";
   host.getDirectories = () => [];
-  host.fileExists = (name) => name === fileName;
-  host.readFile = (name) => name === fileName ? source : undefined;
+  host.fileExists = (name) => name === fileName || fileExists(name);
+  host.readFile = (name) => name === fileName ? source : readFile(name);
   host.writeFile = () => {};
   host.useCaseSensitiveFileNames = () => true;
   host.getCanonicalFileName = (name) => name;
@@ -82,16 +91,13 @@ function findFirstNode<T extends ts.Node>(
 Deno.test(
   "Callback support policy: plain array map callbacks stay plain-array value callbacks",
   () => {
-    // The harness compiles with `noLib`, so the Array members a test relies on
-    // are declared by the test itself.
-    const { sourceFile, checker, context } = createProgramAndContext(`
-      interface Array<T> {
-        map<U>(callback: (value: T) => U): U[];
-      }
-
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
       const items = [1, 2, 3];
       const result = items.map((item) => item + 1);
-    `);
+    `,
+      { withDefaultLibrary: true },
+    );
 
     const callback = findFirstNode(sourceFile, ts.isArrowFunction);
     const semantics = getCallbackBoundarySemantics(callback, checker, context);
@@ -198,16 +204,38 @@ Deno.test(
 );
 
 Deno.test(
-  "Callback support policy: a callback past argument zero carries no wrapper site",
+  "Callback support policy: a source-defined `Array.map()` carries no wrapper site",
   () => {
     const { sourceFile, checker, context } = createProgramAndContext(`
+      class Array<T> {
+        map<U>(callback: (value: T) => U): U[] { return []; }
+      }
+
+      const items = new Array<number>();
+      const result = items.map((item) => item + 1);
+    `);
+
+    const callback = findFirstNode(sourceFile, ts.isArrowFunction);
+    const semantics = getCallbackBoundarySemantics(callback, checker, context);
+
+    assertEquals(semantics.supportsPatternOwnedWrapperCallbackSite, false);
+  },
+);
+
+Deno.test(
+  "Callback support policy: a callback past argument zero carries no wrapper site",
+  () => {
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
       interface Array<T> {
         map<U>(callback: (value: T) => U, andThen: (value: U) => U): U[];
       }
 
       const items = [1, 2, 3];
       const result = items.map((item) => item + 1, (item) => item * 2);
-    `);
+    `,
+      { withDefaultLibrary: true },
+    );
 
     const callbacks: ts.ArrowFunction[] = [];
     const visit = (node: ts.Node): void => {

--- a/packages/ts-transformers/test/policy/callback-support.test.ts
+++ b/packages/ts-transformers/test/policy/callback-support.test.ts
@@ -16,12 +16,14 @@ const virtualLibrarySource = `
 
   interface Array<T> extends ReadonlyArray<T> {}
 `;
+const ambientArrayFileName = "/ambient/array.d.ts";
 
 function createProgramAndContext(
   source: string,
   options: {
     withDefaultLibrary?: boolean;
     withVirtualLibrary?: boolean;
+    withAmbientArrayDeclaration?: boolean;
   } = {},
 ): {
   sourceFile: ts.SourceFile;
@@ -35,7 +37,8 @@ function createProgramAndContext(
     module: ts.ModuleKind.ESNext,
     jsx: ts.JsxEmit.Preserve,
     strict: true,
-    noLib: !options.withDefaultLibrary,
+    noLib: !options.withDefaultLibrary && !options.withVirtualLibrary,
+    ...(options.withVirtualLibrary ? { lib: ["es2023.d.ts"] } : {}),
     skipLibCheck: true,
   };
 
@@ -46,45 +49,52 @@ function createProgramAndContext(
     true,
     ts.ScriptKind.TSX,
   );
-  const virtualLibraryFile = options.withVirtualLibrary
-    ? ts.createSourceFile(
-      virtualLibraryFileName,
-      virtualLibrarySource,
-      compilerOptions.target!,
-      true,
-      ts.ScriptKind.TS,
-    )
-    : undefined;
+  const injectedFiles = new Map<string, string>();
+  if (options.withVirtualLibrary) {
+    injectedFiles.set(virtualLibraryFileName, virtualLibrarySource);
+  }
+  if (options.withAmbientArrayDeclaration) {
+    injectedFiles.set(ambientArrayFileName, virtualLibrarySource);
+  }
+  const injectedSourceFiles = new Map(
+    [...injectedFiles].map(([name, text]) => [
+      name,
+      ts.createSourceFile(
+        name,
+        text,
+        compilerOptions.target!,
+        true,
+        ts.ScriptKind.TS,
+      ),
+    ]),
+  );
 
   const host = ts.createCompilerHost(compilerOptions, true);
   const getSourceFile = host.getSourceFile.bind(host);
   const fileExists = host.fileExists.bind(host);
   const readFile = host.readFile.bind(host);
-  host.getSourceFile = (name, languageVersion, onError, shouldCreateNew) =>
-    name === fileName
-      ? sourceFile
-      : name === virtualLibraryFileName
-      ? virtualLibraryFile
-      : getSourceFile(name, languageVersion, onError, shouldCreateNew);
+  host.getSourceFile = (name, languageVersion, onError, shouldCreateNew) => {
+    if (name === fileName) return sourceFile;
+    return injectedSourceFiles.get(name) ??
+      getSourceFile(name, languageVersion, onError, shouldCreateNew);
+  };
   host.getCurrentDirectory = () => "/";
   host.getDirectories = () => [];
   host.fileExists = (name) =>
-    name === fileName ||
-    (name === virtualLibraryFileName && !!virtualLibraryFile) ||
+    name === fileName || injectedFiles.has(name) ||
     fileExists(name);
   host.readFile = (name) =>
-    name === fileName
-      ? source
-      : name === virtualLibraryFileName
-      ? virtualLibrarySource
-      : readFile(name);
+    name === fileName ? source : injectedFiles.get(name) ?? readFile(name);
   host.writeFile = () => {};
   host.useCaseSensitiveFileNames = () => true;
   host.getCanonicalFileName = (name) => name;
   host.getNewLine = () => "\n";
+  if (options.withVirtualLibrary) {
+    host.getDefaultLibLocation = () => "/virtual";
+  }
 
-  const rootNames = virtualLibraryFile
-    ? [virtualLibraryFileName, fileName]
+  const rootNames = options.withAmbientArrayDeclaration
+    ? [ambientArrayFileName, fileName]
     : [fileName];
   const program = ts.createProgram(rootNames, compilerOptions, host);
   const context = new TransformationContext({
@@ -183,13 +193,37 @@ Deno.test(
     if (!virtualLibraryFile) {
       throw new Error("Expected virtual library source file");
     }
-    assertEquals(program.isSourceFileDefaultLibrary(virtualLibraryFile), false);
+    assertEquals(program.isSourceFileDefaultLibrary(virtualLibraryFile), true);
 
     const callback = findFirstNode(sourceFile, ts.isArrowFunction);
     const semantics = getCallbackBoundarySemantics(callback, checker, context);
 
     assertEquals(semantics.isPlainArrayValueCallback, true);
     assertEquals(semantics.supportsPatternOwnedWrapperCallbackSite, true);
+  },
+);
+
+Deno.test(
+  "Callback support policy: ambient Array declarations carry no wrapper site",
+  () => {
+    const { sourceFile, checker, context, program } = createProgramAndContext(
+      `
+      const items = [1, 2, 3];
+      const result = items.map((item) => item + 1);
+    `,
+      { withAmbientArrayDeclaration: true },
+    );
+    const ambientArrayFile = program.getSourceFile(ambientArrayFileName);
+    if (!ambientArrayFile) {
+      throw new Error("Expected ambient Array declaration");
+    }
+    assertEquals(program.isSourceFileDefaultLibrary(ambientArrayFile), false);
+
+    const callback = findFirstNode(sourceFile, ts.isArrowFunction);
+    const semantics = getCallbackBoundarySemantics(callback, checker, context);
+
+    assertEquals(semantics.isPlainArrayValueCallback, true);
+    assertEquals(semantics.supportsPatternOwnedWrapperCallbackSite, false);
   },
 );
 

--- a/packages/ts-transformers/test/policy/callback-support.test.ts
+++ b/packages/ts-transformers/test/policy/callback-support.test.ts
@@ -8,13 +8,26 @@ import {
   getCallbackBoundarySemantics,
 } from "../../src/policy/callback-boundary.ts";
 
+const virtualLibraryFileName = "/virtual/es2023.d.ts";
+const virtualLibrarySource = `
+  interface ReadonlyArray<T> {
+    map<U>(callback: (value: T) => U): U[];
+  }
+
+  interface Array<T> extends ReadonlyArray<T> {}
+`;
+
 function createProgramAndContext(
   source: string,
-  options: { withDefaultLibrary?: boolean } = {},
+  options: {
+    withDefaultLibrary?: boolean;
+    withVirtualLibrary?: boolean;
+  } = {},
 ): {
   sourceFile: ts.SourceFile;
   checker: ts.TypeChecker;
   context: TransformationContext;
+  program: ts.Program;
 } {
   const fileName = "/test.tsx";
   const compilerOptions: ts.CompilerOptions = {
@@ -33,6 +46,15 @@ function createProgramAndContext(
     true,
     ts.ScriptKind.TSX,
   );
+  const virtualLibraryFile = options.withVirtualLibrary
+    ? ts.createSourceFile(
+      virtualLibraryFileName,
+      virtualLibrarySource,
+      compilerOptions.target!,
+      true,
+      ts.ScriptKind.TS,
+    )
+    : undefined;
 
   const host = ts.createCompilerHost(compilerOptions, true);
   const getSourceFile = host.getSourceFile.bind(host);
@@ -41,17 +63,30 @@ function createProgramAndContext(
   host.getSourceFile = (name, languageVersion, onError, shouldCreateNew) =>
     name === fileName
       ? sourceFile
+      : name === virtualLibraryFileName
+      ? virtualLibraryFile
       : getSourceFile(name, languageVersion, onError, shouldCreateNew);
   host.getCurrentDirectory = () => "/";
   host.getDirectories = () => [];
-  host.fileExists = (name) => name === fileName || fileExists(name);
-  host.readFile = (name) => name === fileName ? source : readFile(name);
+  host.fileExists = (name) =>
+    name === fileName ||
+    (name === virtualLibraryFileName && !!virtualLibraryFile) ||
+    fileExists(name);
+  host.readFile = (name) =>
+    name === fileName
+      ? source
+      : name === virtualLibraryFileName
+      ? virtualLibrarySource
+      : readFile(name);
   host.writeFile = () => {};
   host.useCaseSensitiveFileNames = () => true;
   host.getCanonicalFileName = (name) => name;
   host.getNewLine = () => "\n";
 
-  const program = ts.createProgram([fileName], compilerOptions, host);
+  const rootNames = virtualLibraryFile
+    ? [virtualLibraryFileName, fileName]
+    : [fileName];
+  const program = ts.createProgram(rootNames, compilerOptions, host);
   const context = new TransformationContext({
     program,
     sourceFile,
@@ -61,7 +96,7 @@ function createProgramAndContext(
     },
   });
 
-  return { sourceFile, checker: program.getTypeChecker(), context };
+  return { sourceFile, checker: program.getTypeChecker(), context, program };
 }
 
 function findFirstNode<T extends ts.Node>(
@@ -116,16 +151,58 @@ Deno.test(
 );
 
 Deno.test(
+  "Callback support policy: readonly array map callbacks carry a wrapper site",
+  () => {
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
+      const items: readonly number[] = [1, 2, 3];
+      const result = items.map((item) => item + 1);
+    `,
+      { withDefaultLibrary: true },
+    );
+
+    const callback = findFirstNode(sourceFile, ts.isArrowFunction);
+    const semantics = getCallbackBoundarySemantics(callback, checker, context);
+
+    assertEquals(semantics.isPlainArrayValueCallback, true);
+    assertEquals(semantics.supportsPatternOwnedWrapperCallbackSite, true);
+  },
+);
+
+Deno.test(
+  "Callback support policy: virtual library array map callbacks carry a wrapper site",
+  () => {
+    const { sourceFile, checker, context, program } = createProgramAndContext(
+      `
+      const items = [1, 2, 3];
+      const result = items.map((item) => item + 1);
+    `,
+      { withVirtualLibrary: true },
+    );
+    const virtualLibraryFile = program.getSourceFile(virtualLibraryFileName);
+    if (!virtualLibraryFile) {
+      throw new Error("Expected virtual library source file");
+    }
+    assertEquals(program.isSourceFileDefaultLibrary(virtualLibraryFile), false);
+
+    const callback = findFirstNode(sourceFile, ts.isArrowFunction);
+    const semantics = getCallbackBoundarySemantics(callback, checker, context);
+
+    assertEquals(semantics.isPlainArrayValueCallback, true);
+    assertEquals(semantics.supportsPatternOwnedWrapperCallbackSite, true);
+  },
+);
+
+Deno.test(
   "Callback support policy: plain array find callbacks stay plain-array value callbacks",
   () => {
-    const { sourceFile, checker, context } = createProgramAndContext(`
-      interface Array<T> {
-        find(callback: (value: T) => boolean): T | undefined;
-      }
-
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
       const items = [1, 2, 3];
       const result = items.find((item) => item > 1);
-    `);
+    `,
+      { withDefaultLibrary: true },
+    );
 
     const callback = findFirstNode(sourceFile, ts.isArrowFunction);
     const semantics = getCallbackBoundarySemantics(callback, checker, context);
@@ -148,14 +225,13 @@ Deno.test(
 Deno.test(
   "Callback support policy: a plain filter callback carries no wrapper site",
   () => {
-    const { sourceFile, checker, context } = createProgramAndContext(`
-      interface Array<T> {
-        filter(callback: (value: T) => boolean): T[];
-      }
-
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
       const items = [1, 2, 3];
       const result = items.filter((item) => item > 1);
-    `);
+    `,
+      { withDefaultLibrary: true },
+    );
 
     const callback = findFirstNode(sourceFile, ts.isArrowFunction);
     const semantics = getCallbackBoundarySemantics(callback, checker, context);
@@ -168,14 +244,13 @@ Deno.test(
 Deno.test(
   "Callback support policy: a sort comparator carries no wrapper site",
   () => {
-    const { sourceFile, checker, context } = createProgramAndContext(`
-      interface Array<T> {
-        toSorted(compare: (a: T, b: T) => number): T[];
-      }
-
+    const { sourceFile, checker, context } = createProgramAndContext(
+      `
       const items = [1, 2, 3];
-      const result = items.toSorted((a, b) => a - b);
-    `);
+      const result = items.sort((a, b) => a - b);
+    `,
+      { withDefaultLibrary: true },
+    );
 
     const callback = findFirstNode(sourceFile, ts.isArrowFunction);
     const semantics = getCallbackBoundarySemantics(callback, checker, context);

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3556,6 +3556,39 @@ Deno.test("Reactive .get() Validation", async (t) => {
   );
 
   await t.step(
+    "still errors inside a source-defined `Array.map()` callback",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      class Array<T> {
+        constructor(readonly value: T) {}
+
+        map(callback: (value: T) => unknown): T[] {
+          return callback(this.value) ? [this.value] : [];
+        }
+      }
+
+      const VALUES = new Array("a");
+
+      export default pattern<{ target: Writable<string> }>(({ target }) => {
+        const t = target.get();
+        const selected = VALUES.map((value) => {
+          const matches = value === t;
+          return matches;
+        });
+        return { selected };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertHasErrorType(errors, "pattern-context:computation");
+    },
+  );
+
+  await t.step(
     "allows a parenthesized method call over a .get() binding",
     async () => {
       const source = `      import { pattern, Writable } from "commonfabric";


### PR DESCRIPTION
## Summary

Follow-up hardening for #6016:

- grant plain-array `map()` callbacks pattern-owned wrapper sites only when the resolved owner symbol includes TypeScript’s actual default-library `Array` or `ReadonlyArray` declaration;
- reject source-defined classes or interfaces merely named `Array`/`ReadonlyArray`;
- add policy-level and end-to-end validation regressions;
- clarify the target-language, current-behavior, and design-delta specifications.

## Root cause

#6016 correctly narrowed the new permission to callback argument zero, `map()` alone, and a plain non-reactive receiver. Its standard-array check, however, compared only the resolved declaration owner’s name.

A valid module-local type such as:

```ts
class Array<T> {
  map(callback: (value: T) => unknown): T[] {
    return callback(this.value) ? [this.value] : [];
  }
}
```

therefore passed as an ordinary JavaScript array. If that custom map() interpreted its callback result, lowering a reactive callback-local into a cell could silently change its semantics.

##Behavior

Built-in Array.prototype.map() and ReadonlyArray.map() retain the behavior introduced by #6016.
A source-defined same-named type now remains outside the wrapper-site permission and receives the existing pattern-context:computation diagnostic when its callback contains an unsupported reactive computation.

The symbol-level check still permits ordinary standard-library declaration merging: the owner qualifies when any declaration belonging to that symbol comes from TypeScript’s loaded default library.

## Specification audit

#6016 updated the correct primary specifications. This follow-up also fixes one overly broad target-language sentence that referred to all “plain-array value callbacks,” even though result-interpreting callbacks such as filter() and find() remain unsupported. It now names plain-array map() callbacks specifically.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

