### PR TITLE
fix(state-inspector,cli): a capped listing says so, and --kind counts what it keeps

### DIFF
--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -60,9 +60,12 @@ is the migration manifest: run it before pass one, check the output in, and diff
 against it before the live attempt.
 
 ```bash
-# every piece in the space, with the pattern identity it currently carries
-deno task cf inspect entities $DB --kind piece --require-complete --json \
-  | jq -r '.[].id' \
+# every piece in the space, with the pattern identity it currently carries.
+# The scan is captured on its own, NOT piped: a pipeline reports its LAST
+# command's status, so a refusal in the first stage would leave `sort` writing
+# an empty manifest and reporting success.
+pieces=$(deno task cf inspect entities $DB --kind piece --require-complete --json) &&
+  jq -r '.[].id' <<<"$pieces" \
   | while read -r id; do
       deno task cf inspect piece $DB "$id" --json \
         | jq -r '[.id, (.pattern.identity // "unresolved"), (.pattern.filename // "-")] | @tsv'
@@ -75,8 +78,11 @@ grep -E 'PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY|-85Wmyd9iwUjbpwnTYR2YolxkMU
 
 `--require-complete` is load-bearing, not decoration: the piece listing is
 capped like every space-wide scan, and a manifest short by a topic reads exactly
-like a complete one. The flag makes a capped scan exit nonzero, so a truncated
-manifest is never written.
+like a complete one. The flag makes a capped scan exit nonzero — but an exit
+status only travels as far as the shell carries it, which is why the scan runs
+on its own line and the manifest is written under `&&`. A refused scan then
+never reaches the redirect, so it leaves the previous manifest untouched rather
+than replacing it with an empty one.
 
 The count check is the point: the space holds 319 pieces across 150 identities,
 so "did I migrate the right 74?" is a question the manifest answers and a

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -61,7 +61,7 @@ against it before the live attempt.
 
 ```bash
 # every piece in the space, with the pattern identity it currently carries
-deno task cf inspect entities $DB --kind piece --json \
+deno task cf inspect entities $DB --kind piece --require-complete --json \
   | jq -r '.[].id' \
   | while read -r id; do
       deno task cf inspect piece $DB "$id" --json \
@@ -72,6 +72,11 @@ deno task cf inspect entities $DB --kind piece --json \
 grep -E 'PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY|-85Wmyd9iwUjbpwnTYR2YolxkMUHup9WHY6YsRUDA1E|WpIRvAWL_WW45Q89ekZAlHWLObhQ16NDmQzvv_q2aI8' \
   topics-manifest.tsv | cut -f2 | sort | uniq -c   # expect 39 / 34 / 1
 ```
+
+`--require-complete` is load-bearing, not decoration: the piece listing is
+capped like every space-wide scan, and a manifest short by a topic reads exactly
+like a complete one. The flag makes a capped scan exit nonzero, so a truncated
+manifest is never written.
 
 The count check is the point: the space holds 319 pieces across 150 identities,
 so "did I migrate the right 74?" is a question the manifest answers and a

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -92,7 +92,7 @@ function out(
 }
 
 /**
- * Report a capped result on stderr.
+ * Report a capped result on stderr, before any of it reaches stdout.
  *
  * A capped listing is a SUBSET that looks exactly like a complete one, so it
  * has to announce itself — and stderr is the one channel that reaches both
@@ -100,14 +100,31 @@ function out(
  * without the parsed bytes on stdout changing shape, which is what an envelope
  * around the array would have cost every caller for a condition most runs
  * never hit. Silence on stderr means the result IS the whole set.
+ *
+ * A notice only reaches a reader who is looking. `--require-complete` is for
+ * the caller who cannot afford to miss it — a script whose output is a backup
+ * or a rollback payload — and turns the same condition into a nonzero exit with
+ * nothing written to stdout at all.
  */
-function noteTruncation(extent: ScanExtent, what: string): void {
+function noteTruncation(
+  extent: ScanExtent,
+  what: string,
+  requireComplete?: boolean,
+): void {
   if (!extent.truncated) return;
-  console.error(
-    `NOTE: capped at --limit ${extent.limit} ${what}; the space holds ` +
-      `${extent.total} entities. Raise --limit for the rest.`,
-  );
+  const capped = `capped at --limit ${extent.limit} ${what}; the space holds ` +
+    `${extent.total} entities in all`;
+  if (requireComplete) {
+    throw new Error(`${capped}. --require-complete refuses a partial result.`);
+  }
+  console.error(`NOTE: ${capped}. Raise --limit for the rest.`);
 }
+
+/** The flag that turns a capped result into a failure. Shared by every scan. */
+const requireCompleteOption = [
+  "--require-complete",
+  "Exit nonzero instead of returning a capped result.",
+] as const;
 
 function splitPath(p?: string): string[] {
   return p ? p.split("/").filter(Boolean) : [];
@@ -995,6 +1012,7 @@ export const inspect = new Command()
     "Max entities to return; a capped result is noted on stderr.",
     { default: DEFAULT_SCAN_LIMIT },
   )
+  .option(...requireCompleteOption)
   .action(async (options, space) => {
     const kind = options.kind;
     if (kind !== undefined && !isEntityKind(kind)) {
@@ -1010,6 +1028,11 @@ export const inspect = new Command()
         kind,
       });
       const rows = listing.entities;
+      noteTruncation(
+        listing.extent,
+        kind ? `${kind} entities` : "entities",
+        options.requireComplete,
+      );
       out(!!options.json, rows, () => {
         if (rows.length === 0) {
           console.log("(no entities)");
@@ -1035,7 +1058,6 @@ export const inspect = new Command()
           ]).toString(),
         );
       });
-      noteTruncation(listing.extent, kind ? `${kind} entities` : "entities");
     } finally {
       s.close();
     }
@@ -1117,6 +1139,7 @@ export const inspect = new Command()
     "Max entities to reconstruct; a capped result is noted on stderr.",
     { default: DEFAULT_SCAN_LIMIT },
   )
+  .option(...requireCompleteOption)
   .action(async (options, space) => {
     const s = await openByToken(space, options);
     try {
@@ -1127,9 +1150,9 @@ export const inspect = new Command()
         includeLinks: options.links !== false,
       });
       if (options.root) g = subgraphAround(g, options.root, options.depth);
+      noteTruncation(g.extent, "entities", options.requireComplete);
       if (options.dot) {
         console.log(graphToDot(g));
-        noteTruncation(g.extent, "entities");
         return;
       }
       out(!!options.json, g, () => {
@@ -1194,7 +1217,6 @@ export const inspect = new Command()
           );
         }
       });
-      noteTruncation(g.extent, "entities");
     } finally {
       s.close();
     }
@@ -1216,6 +1238,7 @@ export const inspect = new Command()
     "Max entities to reconstruct; a capped result is noted on stderr.",
     { default: DEFAULT_SCAN_LIMIT },
   )
+  .option(...requireCompleteOption)
   .action(async (options, space) => {
     if (options.json) {
       throw new ValidationError(
@@ -1231,6 +1254,7 @@ export const inspect = new Command()
         liveBase: options.appUrl,
         limit: options.limit,
       });
+      noteTruncation(bundle.extent, "entities", options.requireComplete);
       const html = renderInspectorHtml(bundle);
       if (options.out) {
         Deno.writeTextFileSync(options.out, html);
@@ -1241,7 +1265,6 @@ export const inspect = new Command()
       } else {
         console.log(html);
       }
-      noteTruncation(bundle.extent, "entities");
     } finally {
       s.close();
     }

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -21,6 +21,7 @@ import {
   contendedEntities,
   convergenceExact,
   convergenceScanExact,
+  DEFAULT_SCAN_LIMIT,
   // Remote acquisition (`cf inspect --remote` / `pull`).
   defaultCacheDir,
   describeIdentity,
@@ -29,6 +30,7 @@ import {
   discoverSpaceDbs,
   entityConflicts,
   entityHistory,
+  entityKinds,
   entityTimeline,
   escapeTerminalText,
   type ExactConvergenceResult,
@@ -38,6 +40,7 @@ import {
   groupDiscoveredSpaces,
   type GroupedSpace,
   hotEntities,
+  isEntityKind,
   listCommits,
   listEntityModels,
   listRemoteSpaces,
@@ -50,6 +53,7 @@ import {
   renderInspectorHtml,
   type RequestSigner,
   resolveSpace,
+  type ScanExtent,
   type Scope,
   scopeOverlay,
   type SpaceGraph,
@@ -85,6 +89,24 @@ function out(
 ): void {
   if (json) console.log(stringify(data));
   else render();
+}
+
+/**
+ * Report a capped result on stderr.
+ *
+ * A capped listing is a SUBSET that looks exactly like a complete one, so it
+ * has to announce itself — and stderr is the one channel that reaches both
+ * readers. A human sees it beside the table; a `--json` consumer sees it
+ * without the parsed bytes on stdout changing shape, which is what an envelope
+ * around the array would have cost every caller for a condition most runs
+ * never hit. Silence on stderr means the result IS the whole set.
+ */
+function noteTruncation(extent: ScanExtent, what: string): void {
+  if (!extent.truncated) return;
+  console.error(
+    `NOTE: capped at --limit ${extent.limit} ${what}; the space holds ` +
+      `${extent.total} entities. Raise --limit for the rest.`,
+  );
 }
 
 function splitPath(p?: string): string[] {
@@ -964,20 +986,30 @@ export const inspect = new Command()
   )
   .option(
     "--kind <kind:string>",
-    "Filter: piece | module | stream | schema | owned-cell | free-cell | unknown.",
+    `Filter: ${entityKinds.join(" | ")}. --limit then counts entities of ` +
+      `this kind, not entities scanned to find them.`,
   )
   .option("--branch <branch:string>", "Branch (default: '').")
-  .option("--limit <n:number>", "Max entities to reconstruct.", {
-    default: 5000,
-  })
+  .option(
+    "--limit <n:number>",
+    "Max entities to return; a capped result is noted on stderr.",
+    { default: DEFAULT_SCAN_LIMIT },
+  )
   .action(async (options, space) => {
+    const kind = options.kind;
+    if (kind !== undefined && !isEntityKind(kind)) {
+      throw new ValidationError(
+        `Unknown --kind "${kind}". Expected one of: ${entityKinds.join(", ")}.`,
+      );
+    }
     const s = await openByToken(space, options);
     try {
-      let rows = listEntityModels(s, {
+      const listing = listEntityModels(s, {
         limit: options.limit,
         branch: options.branch,
+        kind,
       });
-      if (options.kind) rows = rows.filter((r) => r.kind === options.kind);
+      const rows = listing.entities;
       out(!!options.json, rows, () => {
         if (rows.length === 0) {
           console.log("(no entities)");
@@ -1003,6 +1035,7 @@ export const inspect = new Command()
           ]).toString(),
         );
       });
+      noteTruncation(listing.extent, kind ? `${kind} entities` : "entities");
     } finally {
       s.close();
     }
@@ -1079,9 +1112,11 @@ export const inspect = new Command()
   .option("--dot", "Emit Graphviz DOT (pipe to: dot -Tsvg).", {
     conflicts: ["json"],
   })
-  .option("--limit <n:number>", "Max entities to reconstruct.", {
-    default: 5000,
-  })
+  .option(
+    "--limit <n:number>",
+    "Max entities to reconstruct; a capped result is noted on stderr.",
+    { default: DEFAULT_SCAN_LIMIT },
+  )
   .action(async (options, space) => {
     const s = await openByToken(space, options);
     try {
@@ -1094,6 +1129,7 @@ export const inspect = new Command()
       if (options.root) g = subgraphAround(g, options.root, options.depth);
       if (options.dot) {
         console.log(graphToDot(g));
+        noteTruncation(g.extent, "entities");
         return;
       }
       out(!!options.json, g, () => {
@@ -1158,6 +1194,7 @@ export const inspect = new Command()
           );
         }
       });
+      noteTruncation(g.extent, "entities");
     } finally {
       s.close();
     }
@@ -1174,6 +1211,11 @@ export const inspect = new Command()
     "--app-url <url:string>",
     "Live shell base origin for deep links (e.g. https://host).",
   )
+  .option(
+    "--limit <n:number>",
+    "Max entities to reconstruct; a capped result is noted on stderr.",
+    { default: DEFAULT_SCAN_LIMIT },
+  )
   .action(async (options, space) => {
     if (options.json) {
       throw new ValidationError(
@@ -1187,6 +1229,7 @@ export const inspect = new Command()
         scope: options.scope,
         generatedAt: new Date().toISOString(),
         liveBase: options.appUrl,
+        limit: options.limit,
       });
       const html = renderInspectorHtml(bundle);
       if (options.out) {
@@ -1198,6 +1241,7 @@ export const inspect = new Command()
       } else {
         console.log(html);
       }
+      noteTruncation(bundle.extent, "entities");
     } finally {
       s.close();
     }

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -40,6 +40,7 @@ import {
   groupDiscoveredSpaces,
   type GroupedSpace,
   hotEntities,
+  isCompleteScan,
   isEntityKind,
   listCommits,
   listEntityModels,
@@ -106,18 +107,49 @@ function out(
  * or a rollback payload — and turns the same condition into a nonzero exit with
  * nothing written to stdout at all.
  */
-function noteTruncation(
+function noteIncompleteScan(
   extent: ScanExtent,
   what: string,
   requireComplete?: boolean,
 ): void {
-  if (!extent.truncated) return;
-  const capped = `capped at --limit ${extent.limit} ${what}; the space holds ` +
-    `${extent.total} entities in all`;
-  if (requireComplete) {
-    throw new Error(`${capped}. --require-complete refuses a partial result.`);
+  if (isCompleteScan(extent)) return;
+  const reasons: string[] = [];
+  if (extent.truncated) {
+    reasons.push(
+      `capped at --limit ${extent.limit} ${what}; the space holds ` +
+        `${extent.total} entities in all — raise --limit for the rest`,
+    );
   }
-  console.error(`NOTE: ${capped}. Raise --limit for the rest.`);
+  if (extent.unreadable > 0) {
+    // Named apart from the cap, because the remedy is different: a raised
+    // limit does not recover an entity whose payload will not decode.
+    reasons.push(
+      `${extent.unreadable} of ${extent.total} entities could not be ` +
+        `reconstructed and are absent from this result — raising --limit ` +
+        `will not recover them`,
+    );
+  }
+  if (requireComplete) {
+    throw new Error(
+      `${reasons.join("; ")}. --require-complete refuses a partial result.`,
+    );
+  }
+  for (const reason of reasons) console.error(`NOTE: ${reason}.`);
+}
+
+/**
+ * The cap a scan will apply, refusing anything an entity count could not reach.
+ * A fractional `--limit` is a typo with a silent failure mode — entities are
+ * counted one at a time, so a cap of 1.5 is a cap nothing ever equals — and a
+ * negative one asks for a listing that cannot exist.
+ */
+function validatedLimit(limit: number): number {
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new ValidationError(
+      `\`--limit\` must be a whole number of entities, not ${limit}.`,
+    );
+  }
+  return limit;
 }
 
 /** The flag that turns a capped result into a failure. Shared by every scan. */
@@ -1020,15 +1052,16 @@ export const inspect = new Command()
         `Unknown --kind "${kind}". Expected one of: ${entityKinds.join(", ")}.`,
       );
     }
+    const limit = validatedLimit(options.limit);
     const s = await openByToken(space, options);
     try {
       const listing = listEntityModels(s, {
-        limit: options.limit,
+        limit,
         branch: options.branch,
         kind,
       });
       const rows = listing.entities;
-      noteTruncation(
+      noteIncompleteScan(
         listing.extent,
         kind ? `${kind} entities` : "entities",
         options.requireComplete,
@@ -1141,16 +1174,17 @@ export const inspect = new Command()
   )
   .option(...requireCompleteOption)
   .action(async (options, space) => {
+    const limit = validatedLimit(options.limit);
     const s = await openByToken(space, options);
     try {
       let g: SpaceGraph = buildSpaceGraph(s, {
         branch: options.branch,
         scope: options.scope,
-        limit: options.limit,
+        limit,
         includeLinks: options.links !== false,
       });
       if (options.root) g = subgraphAround(g, options.root, options.depth);
-      noteTruncation(g.extent, "entities", options.requireComplete);
+      noteIncompleteScan(g.extent, "entities", options.requireComplete);
       if (options.dot) {
         console.log(graphToDot(g));
         return;
@@ -1240,6 +1274,7 @@ export const inspect = new Command()
   )
   .option(...requireCompleteOption)
   .action(async (options, space) => {
+    const limit = validatedLimit(options.limit);
     if (options.json) {
       throw new ValidationError(
         'Option "--json" and the "html" command are mutually exclusive.',
@@ -1252,9 +1287,9 @@ export const inspect = new Command()
         scope: options.scope,
         generatedAt: new Date().toISOString(),
         liveBase: options.appUrl,
-        limit: options.limit,
+        limit,
       });
-      noteTruncation(bundle.extent, "entities", options.requireComplete);
+      noteIncompleteScan(bundle.extent, "entities", options.requireComplete);
       const html = renderInspectorHtml(bundle);
       if (options.out) {
         Deno.writeTextFileSync(options.out, html);

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -291,6 +291,39 @@ describe("cf inspect capped listings", () => {
     });
   });
 
+  it("refuses a `--kind` scan that dropped a row it could not classify", async () => {
+    await withStore(async (path) => {
+      const db = new Database(path);
+      db.prepare(
+        `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+         VALUES ('of:corrupt', 9002, 0, 'set', '<<<not a document>>>', 1)`,
+      ).run();
+      db.close();
+
+      // The shape `scripts/topics-export.ts` runs to guard a rollback payload.
+      // A filtered scan drops what it cannot classify, so the omission has to
+      // reach the exit code — the notice alone never reaches `cfJson`.
+      const refused = await cf(
+        `inspect entities ${path} --kind piece --require-complete --json`,
+      );
+      expect(refused.code).not.toBe(0);
+      expect(refused.stdout.join("").trim()).toBe("");
+      expect(stripAnsi(refused.stderr.join("\n"))).toContain(
+        "could not be reconstructed",
+      );
+
+      // Unfiltered, the same store is complete: the row is returned `unknown`.
+      const kept = await cf(
+        `inspect entities ${path} --require-complete --json`,
+      );
+      expect(kept.code).toBe(0);
+      expect(
+        (JSON.parse(kept.stdout.join("\n")) as { id: string }[])
+          .some((e) => e.id === "of:corrupt"),
+      ).toBe(true);
+    });
+  });
+
   it("rejects a fractional `--limit` rather than applying a cap no count can reach", async () => {
     await withStore(async (path) => {
       const result = await cf(`inspect entities ${path} --limit 1.5`);

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -113,7 +113,7 @@ describe("cf inspect capped listings", () => {
       expect(result.code).toBe(0);
       expect(notices(result)).toEqual([
         `NOTE: capped at --limit 3 entities; the space holds ${TOTAL} ` +
-        `entities in all. Raise --limit for the rest.`,
+        `entities in all — raise --limit for the rest.`,
       ]);
     });
   });
@@ -167,7 +167,7 @@ describe("cf inspect capped listings", () => {
       expect(result.code).toBe(0);
       expect(notices(result)).toEqual([
         `NOTE: capped at --limit 2 piece entities; the space holds ${TOTAL} ` +
-        `entities in all. Raise --limit for the rest.`,
+        `entities in all — raise --limit for the rest.`,
       ]);
     });
   });
@@ -204,9 +204,19 @@ describe("cf inspect capped listings", () => {
       const result = await cf(`inspect graph ${path} --limit 3 --json`);
       expect(result.code).toBe(0);
       const graph = JSON.parse(result.stdout.join("\n")) as {
-        extent: { limit: number; total: number; truncated: boolean };
+        extent: {
+          limit: number;
+          total: number;
+          truncated: boolean;
+          unreadable: number;
+        };
       };
-      expect(graph.extent).toEqual({ limit: 3, total: TOTAL, truncated: true });
+      expect(graph.extent).toEqual({
+        limit: 3,
+        total: TOTAL,
+        truncated: true,
+        unreadable: 0,
+      });
     });
   });
 
@@ -248,6 +258,44 @@ describe("cf inspect capped listings", () => {
       );
       expect(html.code).not.toBe(0);
       expect(html.stdout.join("").trim()).toBe("");
+    });
+  });
+
+  it("refuses a result missing an entity it could not read, which no higher limit recovers", async () => {
+    await withStore(async (path) => {
+      // A payload that will not decode is dropped by the graph pass, and the
+      // cap was never reached — so without its own count the scan would report
+      // itself complete over a smaller set.
+      const db = new Database(path);
+      db.prepare(
+        `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+         VALUES ('of:corrupt', 9001, 0, 'set', '<<<not a document>>>', 1)`,
+      ).run();
+      db.close();
+
+      const noted = await cf(`inspect graph ${path}`);
+      expect(noted.code).toBe(0);
+      expect(notices(noted).join("")).toContain(
+        "could not be reconstructed and are absent",
+      );
+      // Not the cap notice: the remedies differ, and a raised limit recovers
+      // nothing here.
+      expect(notices(noted).join("")).not.toContain("capped at --limit");
+
+      const refused = await cf(`inspect graph ${path} --require-complete`);
+      expect(refused.code).not.toBe(0);
+      expect(refused.stdout.join("").trim()).toBe("");
+      expect(stripAnsi(refused.stderr.join("\n"))).toContain(
+        "--require-complete refuses a partial result",
+      );
+    });
+  });
+
+  it("rejects a fractional `--limit` rather than applying a cap no count can reach", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect entities ${path} --limit 1.5`);
+      expect(result.code).not.toBe(0);
+      expect(stripAnsi(result.stderr.join("\n"))).toContain("--limit");
     });
   });
 

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -1,0 +1,223 @@
+// The capped-listing surface of `cf inspect`, through the real CLI process.
+//
+// A capped result is a subset that renders exactly like a complete one, so
+// these tests pin where the cap becomes visible: on stderr for every command
+// that scans a space, in BOTH modes, while `--json` keeps writing the same
+// bare array to stdout that its consumers parse. The scan semantics themselves
+// are pinned in packages/state-inspector/test/scan-extent.test.ts.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+
+import { cf, type CliResult, stripAnsi } from "./utils.ts";
+
+const SESSION = "session:did%3Akey%3AzAlice:s1";
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+/** Six busy free cells, one module, three quiet pieces. */
+const ENTITIES = [
+  ...Array.from({ length: 6 }, (_, i) => ({
+    id: `of:cell-${i + 1}`,
+    document: { value: `cell ${i + 1}` },
+    revisions: 5,
+  })),
+  {
+    id: "of:mod",
+    document: {
+      value: {
+        kind: "source",
+        identity: MODULE_IDENTITY,
+        code: "export default () => null;\n",
+        filename: "/api/patterns/notes/notebook.tsx",
+        imports: [],
+      },
+    },
+    revisions: 2,
+  },
+  ...Array.from({ length: 3 }, (_, i) => ({
+    id: `of:piece-${i + 1}`,
+    document: {
+      value: { $NAME: `Topic ${i + 1}` },
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+    },
+    revisions: 1,
+  })),
+];
+
+const TOTAL = ENTITIES.length;
+
+function seed(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(`
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 39, 'active');`);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{"seq":0}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  for (const entity of ENTITIES) {
+    for (let n = 0; n < entity.revisions; n++) {
+      seq++;
+      commit.run(seq, SESSION, seq);
+      rev.run(entity.id, seq, JSON.stringify(entity.document), seq);
+    }
+  }
+  db.close();
+}
+
+async function withStore(run: (path: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "cf-inspect-truncation-" });
+  try {
+    const path = `${dir}/space.sqlite`;
+    seed(path);
+    await run(path);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/**
+ * The cap notices among the process's stderr, which also carries the task
+ * runner's own echo and whatever Deno warns about on the day.
+ */
+const notices = (result: CliResult): string[] =>
+  result.stderr.map(stripAnsi).filter((line) => line.includes("NOTE:"));
+
+describe("cf inspect capped listings", () => {
+  it("names the cap, the space's size, and the flag that lifts it", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect entities ${path} --limit 3`);
+      expect(result.code).toBe(0);
+      expect(notices(result)).toEqual([
+        `NOTE: capped at --limit 3 entities; the space holds ${TOTAL} ` +
+        `entities. Raise --limit for the rest.`,
+      ]);
+    });
+  });
+
+  it("says nothing when the limit covers the whole space", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect entities ${path} --limit ${TOTAL}`);
+      expect(result.code).toBe(0);
+      expect(notices(result)).toEqual([]);
+      // The whole space is there to be silent about.
+      expect(stripAnsi(result.stdout.join("\n"))).toContain("of:piece-1");
+    });
+  });
+
+  it("writes the same bare array to stdout under `--json` while noting the cap", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect entities ${path} --limit 3 --json`);
+      expect(result.code).toBe(0);
+      const parsed = JSON.parse(result.stdout.join("\n"));
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(3);
+      expect(notices(result).length).toBe(1);
+    });
+  });
+
+  it("returns every piece under `--kind piece` where the limit reaches only cells", async () => {
+    await withStore(async (path) => {
+      // Six cells outrank every piece, so the same limit without `--kind`
+      // reaches no piece at all — which is what this composition has to beat.
+      const cellsOnly = await cf(`inspect entities ${path} --limit 6 --json`);
+      const scanned = JSON.parse(cellsOnly.stdout.join("\n")) as {
+        kind: string;
+      }[];
+      expect(scanned.filter((e) => e.kind === "piece")).toEqual([]);
+
+      const result = await cf(
+        `inspect entities ${path} --kind piece --limit 6 --json`,
+      );
+      expect(result.code).toBe(0);
+      const pieces = JSON.parse(result.stdout.join("\n")) as { kind: string }[];
+      expect(pieces.map((p) => p.kind)).toEqual(["piece", "piece", "piece"]);
+      expect(notices(result)).toEqual([]);
+    });
+  });
+
+  it("names the kind in the notice when a kind outruns the limit", async () => {
+    await withStore(async (path) => {
+      const result = await cf(
+        `inspect entities ${path} --kind piece --limit 2`,
+      );
+      expect(result.code).toBe(0);
+      expect(notices(result)).toEqual([
+        `NOTE: capped at --limit 2 piece entities; the space holds ${TOTAL} ` +
+        `entities. Raise --limit for the rest.`,
+      ]);
+    });
+  });
+
+  it("rejects a `--kind` no entity classifies as, before opening the space", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect entities ${path} --kind pieces`);
+      expect(result.code).not.toBe(0);
+      const stderr = stripAnsi(result.stderr.join("\n"));
+      expect(stderr).toContain('Unknown --kind "pieces"');
+      expect(stderr).toContain("owned-cell");
+    });
+  });
+
+  it("notes the cap on a capped graph, rendered or as DOT", async () => {
+    await withStore(async (path) => {
+      const rendered = await cf(`inspect graph ${path} --limit 3`);
+      expect(rendered.code).toBe(0);
+      expect(notices(rendered).length).toBe(1);
+
+      const dot = await cf(`inspect graph ${path} --limit 3 --dot`);
+      expect(dot.code).toBe(0);
+      expect(dot.stdout.join("\n")).toContain("digraph");
+      expect(notices(dot).length).toBe(1);
+
+      const whole = await cf(`inspect graph ${path} --limit ${TOTAL}`);
+      expect(whole.code).toBe(0);
+      expect(notices(whole)).toEqual([]);
+    });
+  });
+
+  it("carries the cap into the graph's `--json`, where the shape can hold it", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect graph ${path} --limit 3 --json`);
+      expect(result.code).toBe(0);
+      const graph = JSON.parse(result.stdout.join("\n")) as {
+        extent: { limit: number; total: number; truncated: boolean };
+      };
+      expect(graph.extent).toEqual({ limit: 3, total: TOTAL, truncated: true });
+    });
+  });
+
+  it("notes the cap on a capped HTML explorer and marks the page itself", async () => {
+    await withStore(async (path) => {
+      const result = await cf(`inspect html ${path} --limit 3`);
+      expect(result.code).toBe(0);
+      expect(notices(result).length).toBe(1);
+      expect(result.stdout.join("\n")).toContain(
+        `capped at 3 of ${TOTAL} entities`,
+      );
+    });
+  });
+});

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -113,7 +113,7 @@ describe("cf inspect capped listings", () => {
       expect(result.code).toBe(0);
       expect(notices(result)).toEqual([
         `NOTE: capped at --limit 3 entities; the space holds ${TOTAL} ` +
-        `entities. Raise --limit for the rest.`,
+        `entities in all. Raise --limit for the rest.`,
       ]);
     });
   });
@@ -167,7 +167,7 @@ describe("cf inspect capped listings", () => {
       expect(result.code).toBe(0);
       expect(notices(result)).toEqual([
         `NOTE: capped at --limit 2 piece entities; the space holds ${TOTAL} ` +
-        `entities. Raise --limit for the rest.`,
+        `entities in all. Raise --limit for the rest.`,
       ]);
     });
   });
@@ -207,6 +207,47 @@ describe("cf inspect capped listings", () => {
         extent: { limit: number; total: number; truncated: boolean };
       };
       expect(graph.extent).toEqual({ limit: 3, total: TOTAL, truncated: true });
+    });
+  });
+
+  it("refuses a capped result under `--require-complete`, with nothing on stdout", async () => {
+    await withStore(async (path) => {
+      const result = await cf(
+        `inspect entities ${path} --limit 3 --json --require-complete`,
+      );
+      expect(result.code).not.toBe(0);
+      // A partial payload written before the failure is the whole hazard: a
+      // pipeline that redirects stdout would keep the subset it was refused.
+      expect(result.stdout.join("").trim()).toBe("");
+      expect(stripAnsi(result.stderr.join("\n"))).toContain(
+        "--require-complete refuses a partial result",
+      );
+    });
+  });
+
+  it("returns the whole listing under `--require-complete` when the limit covers the space", async () => {
+    await withStore(async (path) => {
+      const result = await cf(
+        `inspect entities ${path} --limit ${TOTAL} --json --require-complete`,
+      );
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout.join("\n")).length).toBe(TOTAL);
+    });
+  });
+
+  it("refuses a capped graph and a capped HTML explorer under `--require-complete`", async () => {
+    await withStore(async (path) => {
+      const graph = await cf(
+        `inspect graph ${path} --limit 3 --require-complete`,
+      );
+      expect(graph.code).not.toBe(0);
+      expect(graph.stdout.join("").trim()).toBe("");
+
+      const html = await cf(
+        `inspect html ${path} --limit 3 --require-complete`,
+      );
+      expect(html.code).not.toBe(0);
+      expect(html.stdout.join("").trim()).toBe("");
     });
   });
 

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -127,7 +127,7 @@ deno task cf inspect conflicts z6Mkqa41 of:fid1:…        # writer timeline + A
 
 # what's in a space
 deno task cf inspect summary  z6Mkqa41
-deno task cf inspect entities z6Mkqa41 [--kind piece]
+deno task cf inspect entities z6Mkqa41 [--kind piece] [--limit 5000]
 deno task cf inspect piece    z6Mkqa41 of:fid1:… [--code]   # pattern source, input, owned cells
 deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
@@ -136,14 +136,14 @@ deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count [--seq N]
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --full-depth # every nested value, every link schema
 
 # the entity graph (relationships between pieces/cells/modules)
-deno task cf inspect graph    z6Mkqa41 [--root of:fid1:… --depth 2] [--dot]
+deno task cf inspect graph    z6Mkqa41 [--root of:fid1:… --depth 2] [--dot] [--limit 5000]
 
 # time travel
 deno task cf inspect diff     z6Mkqa41 of:fid1:… --from 7 --to 12
 deno task cf inspect timeline z6Mkqa41 [of:fid1:…]          # how a space / one entity grew
 
 # a self-contained HTML explorer (tree + graph + detail) to open in a browser
-deno task cf inspect html     z6Mkqa41 --out /tmp/space.html [--app-url https://host]
+deno task cf inspect html     z6Mkqa41 --out /tmp/space.html [--app-url https://host] [--limit 5000]
 
 # cross-space convergence (--all discovered, or --spaces a,b, or --dir)
 deno task cf inspect converge      of:fid1:… --all --path value
@@ -209,9 +209,16 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   watermark machinery (serving-loop.md §3b). The summary surface reports its
   presence and row count; a pre-migration snapshot without the table degrades
   gracefully — absence is a store from before the migration, not a broken DB.
-- **Lists and the HTML bundle are capped** for cost; un-analyzed cells are
-  marked rather than shown as clean. A count at a round cap may be truncated —
-  narrow with flags or a per-entity command.
+- **Space-wide scans are capped** at `--limit` (5,000 by default) for cost, and
+  every one of them says so: `entities`, `graph`, and `html` note a capped
+  result on stderr in both human and `--json` mode, `graph --json` also carries
+  an `extent`, and the HTML header marks the page. Silence means the result IS
+  the whole set. `entities --kind` selects during the scan, so `--limit` counts
+  the entities of that kind rather than the entities scanned to find them.
+- **The other caps are silent**: `history` / `hot` / `conflicts` row limits, and
+  the HTML stale-read pass, which caps per bundle and marks un-analyzed cells
+  rather than showing them clean. There a count at a round cap may be truncated
+  — narrow with flags or a per-entity command.
 - **Reads DBs it didn't write**: cross-space comparisons identify an unavailable
   view and return `unknown`. Per-entity diffs stop with the reconstruction error
   instead of reporting the value as absent.

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -222,12 +222,16 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   applies.
 - **Not every gap is a cap.** A scan that enumerates an entity it cannot
   reconstruct reports it as `extent.unreadable` rather than folding it into
-  `truncated`, because raising `--limit` does not recover one. An unfiltered
-  `entities` never has any — it returns a row for an unreadable entity rather
-  than dropping it — but `entities --kind` counts what the filter had to drop
-  for want of a kind it could not determine. The HTML explorer banners both,
-  because a generated page is a file that outlives the stderr notice — it gets
-  opened later and shared with someone who never ran the command.
+  `truncated`, because raising `--limit` does not recover one. It counts
+  reconstruction FAILURES only. An unfiltered `entities` never has any — it
+  returns a row for an unreadable entity rather than dropping it — while
+  `entities --kind` counts the rows the filter dropped because they would not
+  reconstruct. A row the filter drops on a kind it did determine is not one of
+  them: a tombstone and a document whose shape classifies as `unknown` are both
+  definitively not a `piece`, and neither is a gap in the answer. The HTML
+  explorer banners both, because a generated page is a file that outlives the
+  stderr notice — it gets opened later and shared with someone who never ran the
+  command.
 - **A scan sees what a read sees.** `visibleRevisionRows` is the one enumeration
   of what a branch can see, attributing each (scope, entity) to the nearest
   branch holding it; `visibleEntityRows`, `listScopes`, `scopeOverlay`, the HTML

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -127,7 +127,7 @@ deno task cf inspect conflicts z6Mkqa41 of:fid1:…        # writer timeline + A
 
 # what's in a space
 deno task cf inspect summary  z6Mkqa41
-deno task cf inspect entities z6Mkqa41 [--kind piece] [--limit 5000]
+deno task cf inspect entities z6Mkqa41 [--kind piece] [--limit 5000] [--require-complete]
 deno task cf inspect piece    z6Mkqa41 of:fid1:… [--code]   # pattern source, input, owned cells
 deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
@@ -215,6 +215,16 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   an `extent`, and the HTML header marks the page. Silence means the result IS
   the whole set. `entities --kind` selects during the scan, so `--limit` counts
   the entities of that kind rather than the entities scanned to find them.
+  `--require-complete` turns a capped result into a nonzero exit with nothing on
+  stdout, for a caller whose output is a backup or a rollback payload and who
+  cannot afford to miss a notice.
+- **A scan sees what a read sees.** Every space-wide scan enumerates through
+  `visibleEntityRows`, which walks branch ancestry the way `reconstructDocument`
+  does — a child branch lists the entities it inherited at the fork, not only
+  the ones written on it — and drops entities whose visible head is a `delete`.
+  `entities` is the exception that keeps tombstones, because it describes the
+  space's records; that is why its `extent.total` can exceed `graph`'s over the
+  same space.
 - **The other caps are silent**: `history` / `hot` / `conflicts` row limits, and
   the HTML stale-read pass, which caps per bundle and marks un-analyzed cells
   rather than showing them clean. There a count at a round cap may be truncated

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -224,15 +224,21 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   reconstruct reports it as `extent.unreadable` rather than folding it into
   `truncated`, because raising `--limit` does not recover one. `entities` never
   has any: it returns a row for an unreadable entity rather than dropping it.
-- **A scan sees what a read sees.** Every space-wide scan enumerates through
-  `visibleEntityRows`, and `listScopes` and `contentFingerprint` read through
-  the same branch chain — a fingerprint hashes the values ITS branch reads, or
-  it certifies a parent's content under a child's name. `visibleEntityRows`
-  walks branch ancestry the way `reconstructDocument` does — a child branch
-  lists the entities it inherited at the fork, not only the ones written on it —
-  and drops entities whose visible head is a `delete`. `entities` is the
-  exception that keeps tombstones, because it describes the space's records;
-  that is why its `extent.total` can exceed `graph`'s over the same space.
+  The HTML explorer banners both, because a generated page is a file that
+  outlives the stderr notice — it gets opened later and shared with someone who
+  never ran the command.
+- **A scan sees what a read sees.** `visibleRevisionRows` is the one enumeration
+  of what a branch can see, attributing each (scope, entity) to the nearest
+  branch holding it; `visibleEntityRows`, `listScopes`, `scopeOverlay`, the HTML
+  bundle's overlay discovery, and `contentFingerprint` all read through it, so
+  no view can report one domain while describing another — a fingerprint hashes
+  the values ITS branch reads, or it certifies a parent's content under a
+  child's name. `visibleEntityRows` walks branch ancestry the way
+  `reconstructDocument` does — a child branch lists the entities it inherited at
+  the fork, not only the ones written on it — and drops entities whose visible
+  head is a `delete`. `entities` is the exception that keeps tombstones, because
+  it describes the space's records; that is why its `extent.total` can exceed
+  `graph`'s over the same space.
 - **The other caps are silent**: `history` / `hot` / `conflicts` row limits, and
   the HTML stale-read pass, which caps per bundle and marks un-analyzed cells
   rather than showing them clean. There a count at a round cap may be truncated

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -222,11 +222,12 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   applies.
 - **Not every gap is a cap.** A scan that enumerates an entity it cannot
   reconstruct reports it as `extent.unreadable` rather than folding it into
-  `truncated`, because raising `--limit` does not recover one. `entities` never
-  has any: it returns a row for an unreadable entity rather than dropping it.
-  The HTML explorer banners both, because a generated page is a file that
-  outlives the stderr notice — it gets opened later and shared with someone who
-  never ran the command.
+  `truncated`, because raising `--limit` does not recover one. An unfiltered
+  `entities` never has any — it returns a row for an unreadable entity rather
+  than dropping it — but `entities --kind` counts what the filter had to drop
+  for want of a kind it could not determine. The HTML explorer banners both,
+  because a generated page is a file that outlives the stderr notice — it gets
+  opened later and shared with someone who never ran the command.
 - **A scan sees what a read sees.** `visibleRevisionRows` is the one enumeration
   of what a branch can see, attributing each (scope, entity) to the nearest
   branch holding it; `visibleEntityRows`, `listScopes`, `scopeOverlay`, the HTML

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -215,16 +215,24 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   an `extent`, and the HTML header marks the page. Silence means the result IS
   the whole set. `entities --kind` selects during the scan, so `--limit` counts
   the entities of that kind rather than the entities scanned to find them.
-  `--require-complete` turns a capped result into a nonzero exit with nothing on
-  stdout, for a caller whose output is a backup or a rollback payload and who
-  cannot afford to miss a notice.
+  `--require-complete` turns an incomplete result into a nonzero exit with
+  nothing on stdout, for a caller whose output is a backup or a rollback payload
+  and who cannot afford to miss a notice. A `--limit` that is not a whole number
+  of entities is refused, since a cap no count can reach is a cap that never
+  applies.
+- **Not every gap is a cap.** A scan that enumerates an entity it cannot
+  reconstruct reports it as `extent.unreadable` rather than folding it into
+  `truncated`, because raising `--limit` does not recover one. `entities` never
+  has any: it returns a row for an unreadable entity rather than dropping it.
 - **A scan sees what a read sees.** Every space-wide scan enumerates through
-  `visibleEntityRows`, which walks branch ancestry the way `reconstructDocument`
-  does — a child branch lists the entities it inherited at the fork, not only
-  the ones written on it — and drops entities whose visible head is a `delete`.
-  `entities` is the exception that keeps tombstones, because it describes the
-  space's records; that is why its `extent.total` can exceed `graph`'s over the
-  same space.
+  `visibleEntityRows`, and `listScopes` and `contentFingerprint` read through
+  the same branch chain — a fingerprint hashes the values ITS branch reads, or
+  it certifies a parent's content under a child's name. `visibleEntityRows`
+  walks branch ancestry the way `reconstructDocument` does — a child branch
+  lists the entities it inherited at the fork, not only the ones written on it —
+  and drops entities whose visible head is a `delete`. `entities` is the
+  exception that keeps tombstones, because it describes the space's records;
+  that is why its `extent.total` can exceed `graph`'s over the same space.
 - **The other caps are silent**: `history` / `hot` / `conflicts` row limits, and
   the HTML stale-read pass, which caps per bundle and marks un-analyzed cells
   rather than showing them clean. There a count at a round cap may be truncated

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -25,7 +25,7 @@ import {
   parseSigilLink,
   summarize,
 } from "./decode.ts";
-import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
+import { reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
@@ -543,11 +543,14 @@ export function buildAllDetails(
 
   const ctx: DetailContext = { ownDid, labelOf, nameOf, moduleIndex, docs };
 
-  // Pass 3: per-entity detail + version log. The log spans the same branch
-  // ancestry the rows came from — an entity a child branch INHERITED has its
-  // writes on the parent, and reading only local rows would describe it with an
-  // empty history.
-  const chain = branchReadChain(space, branch);
+  // Pass 3: per-entity detail + version log, read from the branch that OWNS the
+  // entity's visible row. An entity a child branch INHERITED has its writes on
+  // the parent, so local-only rows would describe it with no history at all;
+  // one the child OVERRODE has a parent log the child's value never came
+  // through, and reporting it would credit this entity with revisions no read
+  // from here can reach. Both are the same rule — nearest branch wins — which
+  // `visibleEntityRows` already resolved, so each row carries its own link.
+  const ownerOf = new Map(scanned.map((r) => [r.id, r.link]));
   const versionStmt = space.db.prepare(
     `SELECT r.seq, r.op, c.session_id, c.created_at
      FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
@@ -556,13 +559,10 @@ export function buildAllDetails(
   );
   const out: EntityDetail[] = [];
   for (const [id, doc] of docs) {
-    const versions = chain
-      .flatMap((link) =>
-        versionStmt.all<
-          { seq: number; op: string; session_id: string; created_at: string }
-        >(link.branch, id, scope, link.atSeq)
-      )
-      .sort((a, b) => a.seq - b.seq)
+    const owner = ownerOf.get(id);
+    const versions = (owner === undefined ? [] : versionStmt.all<
+      { seq: number; op: string; session_id: string; created_at: string }
+    >(owner.branch, id, scope, owner.atSeq))
       .map((v) => ({
         seq: v.seq,
         op: v.op,

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -25,16 +25,16 @@ import {
   parseSigilLink,
   summarize,
 } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
-  countEntities,
   DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   type ModuleEntry,
   type ScanExtent,
+  visibleEntityRows,
 } from "./model.ts";
 
 /** A resolved reference to another entity (or a cross-space target). */
@@ -471,23 +471,19 @@ export function buildAllDetails(
   const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
   const ownDid = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
-  // One row past the limit is asked for and dropped: getting it is what proves
-  // the space holds entities this pass does not describe.
-  const rows = space.db
-    .prepare(
-      `SELECT id, count(*) revisions FROM revision
-       WHERE branch = ? AND scope_key = ?
-       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
-    )
-    .all<{ id: string; revisions: number }>(branch, scope, limit + 1);
+  // The entities a read on this branch can see, tombstones already dropped —
+  // the same set the pass below describes, so `extent.total` counts what a
+  // complete pass would return and truncation is a fact rather than an
+  // inference from a count landing on the cap.
+  const rows = visibleEntityRows(space, { branch, scope });
   const truncated = rows.length > limit;
-  if (truncated) rows.pop();
+  const scanned = truncated ? rows.slice(0, limit) : rows;
 
   // Pass 1: reconstruct + module index + base labels.
   const docs = new Map<string, EntityDocument>();
   const moduleIndex = new Map<string, ModuleEntry>();
   const labelOf = new Map<string, { kind: EntityKind; label: string }>();
-  for (const r of rows) {
+  for (const r of scanned) {
     let doc: EntityDocument | undefined;
     try {
       doc = reconstructDocument(space, { id: r.id, branch, scope });
@@ -541,21 +537,26 @@ export function buildAllDetails(
 
   const ctx: DetailContext = { ownDid, labelOf, nameOf, moduleIndex, docs };
 
-  // Pass 3: per-entity detail + version log.
+  // Pass 3: per-entity detail + version log. The log spans the same branch
+  // ancestry the rows came from — an entity a child branch INHERITED has its
+  // writes on the parent, and reading only local rows would describe it with an
+  // empty history.
+  const chain = branchReadChain(space, branch);
   const versionStmt = space.db.prepare(
     `SELECT r.seq, r.op, c.session_id, c.created_at
      FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
      ORDER BY r.seq ASC, r.op_index ASC`,
   );
   const out: EntityDetail[] = [];
   for (const [id, doc] of docs) {
-    const versions = versionStmt
-      .all<{ seq: number; op: string; session_id: string; created_at: string }>(
-        branch,
-        id,
-        scope,
+    const versions = chain
+      .flatMap((link) =>
+        versionStmt.all<
+          { seq: number; op: string; session_id: string; created_at: string }
+        >(link.branch, id, scope, link.atSeq)
       )
+      .sort((a, b) => a.seq - b.seq)
       .map((v) => ({
         seq: v.seq,
         op: v.op,
@@ -580,7 +581,7 @@ export function buildAllDetails(
     ),
     extent: {
       limit,
-      total: countEntities(space, { branch, scope }),
+      total: rows.length,
       truncated,
     },
   };

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -29,11 +29,11 @@ import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
-  DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   type ModuleEntry,
   type ScanExtent,
+  scanLimit,
   visibleEntityRows,
 } from "./model.ts";
 
@@ -468,7 +468,7 @@ export function buildAllDetails(
 ): DetailListing {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
+  const limit = scanLimit(opts.limit);
   const ownDid = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
   // The entities a read on this branch can see, tombstones already dropped —
@@ -478,6 +478,7 @@ export function buildAllDetails(
   const rows = visibleEntityRows(space, { branch, scope });
   const truncated = rows.length > limit;
   const scanned = truncated ? rows.slice(0, limit) : rows;
+  let unreadable = 0;
 
   // Pass 1: reconstruct + module index + base labels.
   const docs = new Map<string, EntityDocument>();
@@ -490,7 +491,12 @@ export function buildAllDetails(
     } catch {
       doc = undefined;
     }
-    if (!doc) continue;
+    if (!doc) {
+      // Enumerated but not described: counted, never silently dropped, or a pass
+      // that skipped it would report itself complete over a smaller set.
+      unreadable++;
+      continue;
+    }
     docs.set(r.id, doc);
     const v = doc.value;
     if (isModuleValue(v)) {
@@ -583,6 +589,7 @@ export function buildAllDetails(
       limit,
       total: rows.length,
       truncated,
+      unreadable,
     },
   };
 }

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -29,9 +29,12 @@ import { reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
+  countEntities,
+  DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   type ModuleEntry,
+  type ScanExtent,
 } from "./model.ts";
 
 /** A resolved reference to another entity (or a cross-space target). */
@@ -448,6 +451,13 @@ function roleFor(kind: EntityKind, owned: boolean): string {
   }
 }
 
+/** A capped detail pass over a space, with how far its scan reached. */
+export interface DetailListing {
+  /** The entities detailed, at most `extent.limit` of them. */
+  details: EntityDetail[];
+  extent: ScanExtent;
+}
+
 /**
  * Build rich details for every entity in a space — one reconstruction pass,
  * resolving link-target labels and owner→child context names space-wide.
@@ -455,19 +465,23 @@ function roleFor(kind: EntityKind, owned: boolean): string {
 export function buildAllDetails(
   space: SpaceDb,
   opts: { branch?: string; scope?: string; limit?: number } = {},
-): EntityDetail[] {
+): DetailListing {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = opts.limit ?? 5000;
+  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
   const ownDid = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
+  // One row past the limit is asked for and dropped: getting it is what proves
+  // the space holds entities this pass does not describe.
   const rows = space.db
     .prepare(
       `SELECT id, count(*) revisions FROM revision
        WHERE branch = ? AND scope_key = ?
        GROUP BY id ORDER BY revisions DESC LIMIT ?`,
     )
-    .all<{ id: string; revisions: number }>(branch, scope, limit);
+    .all<{ id: string; revisions: number }>(branch, scope, limit + 1);
+  const truncated = rows.length > limit;
+  if (truncated) rows.pop();
 
   // Pass 1: reconstruct + module index + base labels.
   const docs = new Map<string, EntityDocument>();
@@ -560,7 +574,14 @@ export function buildAllDetails(
     "free-cell": 5,
     unknown: 6,
   };
-  return out.sort(
-    (a, b) => order[a.kind] - order[b.kind] || (b.revisions - a.revisions),
-  );
+  return {
+    details: out.sort(
+      (a, b) => order[a.kind] - order[b.kind] || (b.revisions - a.revisions),
+    ),
+    extent: {
+      limit,
+      total: countEntities(space, { branch, scope }),
+      truncated,
+    },
+  };
 }

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -157,6 +157,7 @@ export function generatedInternalCellIds(
     const doc = reconstructDocument(space, {
       id: model.id,
       scope: model.scope,
+      branch: options.branch ?? "",
     });
     const internal = (doc as Record<string, unknown> | undefined)?.internal;
     if (!Array.isArray(internal)) continue;
@@ -216,9 +217,13 @@ export function contentFingerprint(
       excludedGenerated++;
       continue;
     }
+    // The models come from this branch, so the values must too — reading the
+    // default branch here would hash a parent's content under a child's name
+    // and certify two different spaces as identical.
     const doc = reconstructDocument(space, {
       id: model.id,
       scope: model.scope,
+      branch,
     });
     const value = (doc as Record<string, unknown> | undefined)?.value;
     let hash: string | null = null;

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -119,9 +119,10 @@ export interface FingerprintReport {
 export interface FingerprintOptions {
   branch?: string;
   /**
-   * Refuse rather than fingerprint a space whose scope enumerates at or above
-   * this many entities, since the enumeration may have been truncated. Defaults
-   * to 1,000,000 — far above any real space; raise it only knowingly.
+   * Refuse rather than fingerprint a space whose scope enumerates more than
+   * this many entities, since the enumeration was truncated. A scope holding
+   * exactly the cap is complete and accepted. Defaults to 1,000,000 — far above
+   * any real space; raise it only knowingly.
    */
   enumerationCap?: number;
   /**

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -30,8 +30,8 @@ import { listScopes } from "./scopes.ts";
  * `listEntityModels` caps at 5,000 by default — a real Estuary space already
  * exceeds that. A fingerprint computed over a truncated enumeration would still
  * return a confident-looking hash, which is the exact failure this whole module
- * exists to prevent, so we raise the cap and REFUSE when even that is reached
- * rather than hash a partial space.
+ * exists to prevent, so we raise the cap and REFUSE the listing that reports
+ * itself truncated rather than hash a partial space.
  */
 const ENUMERATION_CAP = 1_000_000;
 
@@ -70,19 +70,18 @@ function allEntities(
 ): EntityModel[] {
   const out: EntityModel[] = [];
   for (const scope of listScopes(space, { branch })) {
-    const models = listEntityModels(space, {
+    const listing = listEntityModels(space, {
       branch,
       scope: scope.raw,
       limit: cap,
     });
-    if (models.length >= cap) {
+    if (listing.extent.truncated) {
       throw new Error(
-        `scope ${scope.raw} enumerates ${models.length}+ entities, at or above ` +
-          `the ${cap} cap; refusing to fingerprint a possibly truncated ` +
-          `enumeration.`,
+        `scope ${scope.raw} holds ${listing.extent.total} entities, past the ` +
+          `${cap} cap; refusing to fingerprint a truncated enumeration.`,
       );
     }
-    out.push(...models);
+    out.push(...listing.entities);
   }
   return out;
 }

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -20,13 +20,13 @@ import { reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
-  countEntities,
   DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   modelFromDocument,
   type ModuleEntry,
   type ScanExtent,
+  visibleEntityRows,
 } from "./model.ts";
 
 export type EdgeKind = "pattern" | "argument" | "owns" | "link";
@@ -92,22 +92,18 @@ export function buildSpaceGraph(
   const includeLinks = opts.includeLinks ?? true;
   const own = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
-  // One row past the limit is asked for and dropped: getting it is what proves
-  // the space holds more entities than this graph covers.
-  const rows = space.db
-    .prepare(
-      `SELECT id, count(*) revisions FROM revision
-       WHERE branch = ? AND scope_key = ?
-       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
-    )
-    .all<{ id: string; revisions: number }>(branch, scope, limit + 1);
+  // The entities a read on this branch can see, tombstones already dropped —
+  // the same set this graph is built from, so `extent.total` counts what a
+  // complete graph would hold and truncation is a fact rather than an inference
+  // from a count landing on the cap.
+  const rows = visibleEntityRows(space, { branch, scope });
   const truncated = rows.length > limit;
-  if (truncated) rows.pop();
+  const scanned = truncated ? rows.slice(0, limit) : rows;
 
   // Pass 1: reconstruct + build the module index (identity → module entity).
   const docs = new Map<string, EntityDocument>();
   const moduleIndex = new Map<string, ModuleEntry>();
-  for (const r of rows) {
+  for (const r of scanned) {
     let doc: EntityDocument | undefined;
     try {
       doc = reconstructDocument(space, { id: r.id, branch, scope });
@@ -237,7 +233,7 @@ export function buildSpaceGraph(
     stats: { nodesByKind, edgesByKind, externalEdges },
     extent: {
       limit,
-      total: countEntities(space, { branch, scope }),
+      total: rows.length,
       truncated,
     },
   };

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -20,10 +20,13 @@ import { reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
+  countEntities,
+  DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   modelFromDocument,
   type ModuleEntry,
+  type ScanExtent,
 } from "./model.ts";
 
 export type EdgeKind = "pattern" | "argument" | "owns" | "link";
@@ -61,6 +64,8 @@ export interface SpaceGraph {
     edgesByKind: Record<EdgeKind, number>;
     externalEdges: number;
   };
+  /** How far the entity scan this graph was built from reached. */
+  extent: ScanExtent;
 }
 
 function shortPath(p?: readonly string[]): string | undefined {
@@ -83,17 +88,21 @@ export function buildSpaceGraph(
 ): SpaceGraph {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = opts.limit ?? 5000;
+  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
   const includeLinks = opts.includeLinks ?? true;
   const own = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
+  // One row past the limit is asked for and dropped: getting it is what proves
+  // the space holds more entities than this graph covers.
   const rows = space.db
     .prepare(
       `SELECT id, count(*) revisions FROM revision
        WHERE branch = ? AND scope_key = ?
        GROUP BY id ORDER BY revisions DESC LIMIT ?`,
     )
-    .all<{ id: string; revisions: number }>(branch, scope, limit);
+    .all<{ id: string; revisions: number }>(branch, scope, limit + 1);
+  const truncated = rows.length > limit;
+  if (truncated) rows.pop();
 
   // Pass 1: reconstruct + build the module index (identity → module entity).
   const docs = new Map<string, EntityDocument>();
@@ -226,6 +235,11 @@ export function buildSpaceGraph(
     nodes: [...nodes.values()],
     edges: deduped,
     stats: { nodesByKind, edgesByKind, externalEdges },
+    extent: {
+      limit,
+      total: countEntities(space, { branch, scope }),
+      truncated,
+    },
   };
 }
 
@@ -280,6 +294,9 @@ export function subgraphAround(
     nodes,
     edges,
     stats: { nodesByKind, edgesByKind, externalEdges },
+    // A neighborhood inherits the cap of the scan it was cut from: narrowing
+    // to one root does not restore the entities the scan never reached.
+    extent: graph.extent,
   };
 }
 

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -20,12 +20,12 @@ import { reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
   classifyDocument,
-  DEFAULT_SCAN_LIMIT,
   type EntityKind,
   isModuleValue,
   modelFromDocument,
   type ModuleEntry,
   type ScanExtent,
+  scanLimit,
   visibleEntityRows,
 } from "./model.ts";
 
@@ -88,7 +88,7 @@ export function buildSpaceGraph(
 ): SpaceGraph {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
+  const limit = scanLimit(opts.limit);
   const includeLinks = opts.includeLinks ?? true;
   const own = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
@@ -99,6 +99,7 @@ export function buildSpaceGraph(
   const rows = visibleEntityRows(space, { branch, scope });
   const truncated = rows.length > limit;
   const scanned = truncated ? rows.slice(0, limit) : rows;
+  let unreadable = 0;
 
   // Pass 1: reconstruct + build the module index (identity → module entity).
   const docs = new Map<string, EntityDocument>();
@@ -110,7 +111,12 @@ export function buildSpaceGraph(
     } catch {
       doc = undefined;
     }
-    if (!doc) continue;
+    if (!doc) {
+      // Enumerated but not placed in the graph: counted, never silently dropped, or a pass
+      // that skipped it would report itself complete over a smaller set.
+      unreadable++;
+      continue;
+    }
     docs.set(r.id, doc);
     const v = doc.value;
     if (isModuleValue(v)) {
@@ -235,6 +241,7 @@ export function buildSpaceGraph(
       limit,
       total: rows.length,
       truncated,
+      unreadable,
     },
   };
 }

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -17,6 +17,7 @@ import { buildSpaceGraph, type SpaceGraph } from "./graph.ts";
 import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
 import { buildAllDetails, type EntityDetail } from "./detail.ts";
 import type { ScanExtent } from "./model.ts";
+import { visibleRevisionRows } from "./reconstruct.ts";
 import {
   listScopes,
   type Participant,
@@ -70,16 +71,21 @@ export function buildInspectorBundle(
 
   // Entities that carry per-user/session state (in a non-space scope, or in
   // more than one scope) get a full scope overlay so the explorer can show the
-  // per-identity divergence the space-scope view hides.
-  const overlayIds = space.db
-    .prepare(
-      `SELECT id FROM revision WHERE branch = ?
-       GROUP BY id
-       HAVING count(DISTINCT scope_key) > 1
-           OR sum(CASE WHEN scope_key != 'space' THEN 1 ELSE 0 END) > 0`,
+  // per-identity divergence the space-scope view hides. Discovered over the
+  // same branch-visible domain the tree and the scope list use — a child branch
+  // inherits its parent's per-user state, and a page that named a user scope
+  // while finding no cells in it would report the divergence as absent.
+  const scoped = new Map<string, Set<string>>();
+  for (const row of visibleRevisionRows(space, { branch })) {
+    const scopes = scoped.get(row.id) ?? new Set<string>();
+    scopes.add(row.scope);
+    scoped.set(row.id, scopes);
+  }
+  const overlayIds = [...scoped.entries()]
+    .filter(([, scopes]) =>
+      scopes.size > 1 || [...scopes].some((scope) => scope !== "space")
     )
-    .all<{ id: string }>(branch)
-    .map((r) => r.id);
+    .map(([id]) => id);
   const overlays = overlayIds.map((id) => scopeOverlay(space, id, { branch }));
 
   const listing = buildAllDetails(space, { branch, scope, limit });
@@ -688,9 +694,31 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
     : "";
   // The header's entity count is the whole space, while the tree and graph hold
   // only what the scan reached. Say so, or the two read as one number.
-  const capLine = bundle.extent.truncated
-    ? `<span class="stats" style="color:var(--piece)">⚠ capped at ${bundle.extent.limit} of ${bundle.extent.total} entities · rebuild with a higher --limit for the rest</span>`
-    : "";
+  //
+  // Both kinds of shortfall have to appear ON THE PAGE. A capped or partial
+  // explorer is a FILE — opened days later, shared with someone who never ran
+  // the command — so the notice `cf` wrote to stderr at generation time is not
+  // there to be read, and this banner is the only thing that survives.
+  const warnings: string[] = [];
+  if (bundle.extent.truncated) {
+    warnings.push(
+      `⚠ capped at ${bundle.extent.limit} of ${bundle.extent.total} entities · rebuild with a higher --limit for the rest`,
+    );
+  }
+  if (bundle.extent.unreadable > 0) {
+    // Named apart from the cap: a higher limit does not recover an entity whose
+    // stored payload will not decode.
+    warnings.push(
+      `⚠ ${bundle.extent.unreadable} of ${bundle.extent.total} entities could not be reconstructed and are missing below · a higher --limit will not recover them`,
+    );
+  }
+  const capLine = warnings
+    .map((text) =>
+      `<span class="stats" style="color:var(--piece)">${
+        escapeHtml(text)
+      }</span>`
+    )
+    .join("\n  ");
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -74,7 +74,9 @@ export function buildInspectorBundle(
   // per-identity divergence the space-scope view hides. Discovered over the
   // same branch-visible domain the tree and the scope list use — a child branch
   // inherits its parent's per-user state, and a page that named a user scope
-  // while finding no cells in it would report the divergence as absent.
+  // while finding no cells in it would report the divergence as absent. Records
+  // rather than readable entities, so an entity deleted in one scope and live
+  // in another still reaches the overlay that exists to show that.
   const scoped = new Map<string, Set<string>>();
   for (const row of visibleRevisionRows(space, { branch })) {
     const scopes = scoped.get(row.id) ?? new Set<string>();

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -16,6 +16,7 @@ import { type SpaceSummary, summarizeSpace } from "./queries.ts";
 import { buildSpaceGraph, type SpaceGraph } from "./graph.ts";
 import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
 import { buildAllDetails, type EntityDetail } from "./detail.ts";
+import type { ScanExtent } from "./model.ts";
 import {
   listScopes,
   type Participant,
@@ -37,6 +38,8 @@ export interface InspectorBundle {
   liveBase: string;
   summary: SpaceSummary;
   details: EntityDetail[];
+  /** How far the entity scan behind `details` and `graph` reached. */
+  extent: ScanExtent;
   graph: SpaceGraph;
   timeline: SpaceTimelineEntry[];
   /** Per-identity scopes present (space / user:<DID> / session:<DID>:*). */
@@ -57,10 +60,12 @@ export function buildInspectorBundle(
     scope?: string;
     generatedAt?: string;
     liveBase?: string;
+    limit?: number;
   } = {},
 ): InspectorBundle {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
+  const limit = opts.limit;
   const did = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
 
   // Entities that carry per-user/session state (in a non-space scope, or in
@@ -77,13 +82,15 @@ export function buildInspectorBundle(
     .map((r) => r.id);
   const overlays = overlayIds.map((id) => scopeOverlay(space, id, { branch }));
 
+  const listing = buildAllDetails(space, { branch, scope, limit });
   return {
     space: did,
     generatedAt: opts.generatedAt ?? "",
     liveBase: opts.liveBase ?? "",
     summary: summarizeSpace(space),
-    details: buildAllDetails(space, { branch, scope }),
-    graph: buildSpaceGraph(space, { branch, scope }),
+    details: listing.details,
+    extent: listing.extent,
+    graph: buildSpaceGraph(space, { branch, scope, limit }),
     timeline: spaceTimeline(space, { branch, scope }),
     scopes: listScopes(space, { branch }),
     overlays,
@@ -679,6 +686,11 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
       multiUser ? `, ${multiUser} multi-user ⚔` : ""
     }`
     : "";
+  // The header's entity count is the whole space, while the tree and graph hold
+  // only what the scan reached. Say so, or the two read as one number.
+  const capLine = bundle.extent.truncated
+    ? `<span class="stats" style="color:var(--piece)">⚠ capped at ${bundle.extent.limit} of ${bundle.extent.total} entities · rebuild with a higher --limit for the rest</span>`
+    : "";
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -694,6 +706,7 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
     escapeHtml(opsLine)
   }${bundle.generatedAt ? ` · ${bundle.generatedAt.slice(0, 10)}` : ""}</span>
   <span class="stats" style="color:var(--stream)">${idLine}${xLine}${cfLine}</span>
+  ${capLine}
   <span class="live">app URL <input id="live-input" placeholder="https://host (for live links)" size="22"></span>
 </header>
 <nav>

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -445,30 +445,110 @@ const KIND_ORDER: Record<EntityKind, number> = {
   unknown: 6,
 };
 
+/** Every kind an entity classifies as, in the order a listing presents them. */
+export const entityKinds: readonly EntityKind[] = Object.keys(
+  KIND_ORDER,
+) as EntityKind[];
+
+/** Whether a string names one of the kinds an entity classifies as. */
+export function isEntityKind(value: string): value is EntityKind {
+  return (entityKinds as readonly string[]).includes(value);
+}
+
 /**
- * Model every entity in a space — the fluent "what is in here?" view. One
+ * How many entities a space-wide scan reconstructs before it stops. Every scan
+ * is capped, because reconstruction is per-entity work and a space can hold
+ * more entities than anyone wants to wait for.
+ */
+export const DEFAULT_SCAN_LIMIT = 5000;
+
+/**
+ * How far a capped space-wide scan reached. A scan that stops at its cap
+ * returns a SUBSET, and a caller that cannot tell a capped result from a
+ * complete one will read the subset as the whole space — so every capped scan
+ * reports this alongside its result.
+ */
+export interface ScanExtent {
+  /** The cap the scan applied. */
+  limit: number;
+  /** Entities the space holds on this branch and scope, before any filter. */
+  total: number;
+  /** True when the space holds more of what was asked for than `limit`. */
+  truncated: boolean;
+}
+
+/** Entities present on one branch and scope — the set a capped scan walks. */
+export function countEntities(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string } = {},
+): number {
+  const row = space.db
+    .prepare(
+      `SELECT count(DISTINCT id) n FROM revision
+       WHERE branch = ? AND scope_key = ?`,
+    )
+    .get<{ n: number }>(opts.branch ?? "", opts.scope ?? "space");
+  return row?.n ?? 0;
+}
+
+/** An entity's kind without modeling it; `unknown` when it cannot be read. */
+function kindOf(doc: EntityDocument | undefined): EntityKind {
+  return doc === undefined ? "unknown" : classifyDocument(doc).kind;
+}
+
+/** A capped listing of a space's entities, with how far its scan reached. */
+export interface EntityListing {
+  /** The entities modeled, at most `extent.limit` of them. */
+  entities: EntityModel[];
+  extent: ScanExtent;
+}
+
+/**
+ * Model the entities in a space — the fluent "what is in here?" view. One
  * reconstruction pass: collect documents, build the module index from them,
  * then classify each. Sorted pieces → modules → streams → schemas → cells.
- * Replaces the old value-shape-only `listEntities` (which undercounted pieces).
+ *
+ * `limit` bounds what the caller asked for, so `kind` selects DURING the scan
+ * rather than over its result: filtering afterwards would yield "the pieces
+ * among the first `limit` entities" rather than "up to `limit` pieces", which
+ * reads the same and is a different set. A `kind` scan therefore walks the
+ * space until it has enough matches, and costs more than an unfiltered one.
  */
 export function listEntityModels(
   space: SpaceDb,
-  opts: { branch?: string; scope?: string; limit?: number } = {},
-): EntityModel[] {
+  opts: {
+    branch?: string;
+    scope?: string;
+    limit?: number;
+    kind?: EntityKind;
+  } = {},
+): EntityListing {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = opts.limit ?? 5000;
-  const rows = space.db
-    .prepare(
-      `SELECT id, count(*) revisions FROM revision
+  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
+  const kind = opts.kind;
+
+  // Unfiltered, SQL bounds the scan; filtered, only reconstruction can tell a
+  // match from a miss, so the whole space is walked and the loop below stops
+  // itself. Either way the scan reaches for one row past `limit` — finding it
+  // is what proves more remain.
+  const ordered = `SELECT id, count(*) revisions FROM revision
        WHERE branch = ? AND scope_key = ?
-       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
-    )
-    .all<{ id: string; revisions: number }>(branch, scope, limit);
+       GROUP BY id ORDER BY revisions DESC`;
+  const rows = kind === undefined
+    ? space.db
+      .prepare(`${ordered} LIMIT ?`)
+      .all<{ id: string; revisions: number }>(branch, scope, limit + 1)
+    : space.db
+      .prepare(ordered)
+      .all<{ id: string; revisions: number }>(branch, scope);
 
   // Single reconstruction pass: cache docs + build the module index inline.
+  // Only matching documents are cached; a `kind` scan may pass over far more
+  // entities than it keeps, and holding every value would cost the space.
   const docs = new Map<string, EntityDocument | undefined>();
   const moduleIndex = new Map<string, ModuleEntry>();
+  const kept: { id: string; revisions: number }[] = [];
   for (const r of rows) {
     let doc: EntityDocument | undefined;
     try {
@@ -476,7 +556,6 @@ export function listEntityModels(
     } catch {
       doc = undefined;
     }
-    docs.set(r.id, doc);
     const v = doc?.value;
     if (isModuleValue(v)) {
       const existing = moduleIndex.get(v.identity);
@@ -488,9 +567,15 @@ export function listEntityModels(
         });
       }
     }
+    if (kind !== undefined && kindOf(doc) !== kind) continue;
+    docs.set(r.id, doc);
+    kept.push(r);
+    if (kept.length > limit) break;
   }
+  const truncated = kept.length > limit;
+  if (truncated) kept.pop();
 
-  const out: EntityModel[] = rows.map((r): EntityModel => {
+  const out: EntityModel[] = kept.map((r): EntityModel => {
     const doc = docs.get(r.id);
     if (doc === undefined) {
       return {
@@ -513,11 +598,18 @@ export function listEntityModels(
     return m;
   });
 
-  return out.sort(
-    (a, b) =>
-      KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
-      (b.revisions ?? 0) - (a.revisions ?? 0),
-  );
+  return {
+    entities: out.sort(
+      (a, b) =>
+        KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
+        (b.revisions ?? 0) - (a.revisions ?? 0),
+    ),
+    extent: {
+      limit,
+      total: countEntities(space, { branch, scope }),
+      truncated,
+    },
+  };
 }
 
 export interface PieceCellRef {

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -55,7 +55,11 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
-import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
+import {
+  branchReadChain,
+  reconstructDocument,
+  visibleRevisionRows,
+} from "./reconstruct.ts";
 import type { EntityDocument, ReconstructOptions } from "./reconstruct.ts";
 
 export type EntityKind =
@@ -541,50 +545,46 @@ export function visibleEntityRows(
   } = {},
 ): EntityScanRow[] {
   const scope = opts.scope ?? "space";
-  // Revisions per entity on ONE branch, up to that branch's cut.
-  const perBranch = space.db.prepare(
-    `SELECT id, count(*) revisions FROM revision
-     WHERE branch = ? AND scope_key = ? AND seq <= ?
-     GROUP BY id`,
-  );
+  const branch = opts.branch ?? "";
+  const rows = visibleRevisionRows(space, { branch, scope });
+
   // Entities on ONE branch whose LAST row up to the cut is a delete. Asked for
   // the other way round — find the deletes, then ask which are final — because
   // deletes are a sliver of a space's rows, where deriving every entity's head
-  // op reads all of them.
-  const tombstoned = space.db.prepare(
-    `SELECT r.id FROM revision r
-     WHERE r.branch = ? AND r.scope_key = ? AND r.op = 'delete' AND r.seq <= ?
-       AND NOT EXISTS (
-         SELECT 1 FROM revision h
-         WHERE h.branch = r.branch AND h.id = r.id AND h.scope_key = r.scope_key
-           AND h.seq <= ?
-           AND (h.seq > r.seq OR (h.seq = r.seq AND h.op_index > r.op_index))
-       )`,
-  );
-
-  const rows: EntityScanRow[] = [];
-  const claimed = new Set<string>();
-  for (const link of branchReadChain(space, opts.branch ?? "")) {
-    const gone = new Set(
-      tombstoned
-        .all<{ id: string }>(link.branch, scope, link.atSeq, link.atSeq)
-        .map((r) => r.id),
+  // op reads all of them. Keyed by the branch that OWNS the entity: a delete on
+  // a farther link is hidden by the nearer branch that claimed it.
+  const gone = new Set<string>();
+  if (!opts.includeDeleted) {
+    const tombstoned = space.db.prepare(
+      `SELECT r.id FROM revision r
+       WHERE r.branch = ? AND r.scope_key = ? AND r.op = 'delete' AND r.seq <= ?
+         AND NOT EXISTS (
+           SELECT 1 FROM revision h
+           WHERE h.branch = r.branch AND h.id = r.id
+             AND h.scope_key = r.scope_key AND h.seq <= ?
+             AND (h.seq > r.seq OR (h.seq = r.seq AND h.op_index > r.op_index))
+         )`,
     );
-    for (
-      const row of perBranch.all<EntityScanRow>(link.branch, scope, link.atSeq)
-    ) {
-      // Nearest link wins, exactly as a read resolves it: a nearer branch that
-      // holds ANY row for an entity owns it, including when that row is the
-      // delete that hides what the parent still holds.
-      if (claimed.has(row.id)) continue;
-      claimed.add(row.id);
-      if (gone.has(row.id) && !opts.includeDeleted) continue;
-      rows.push(row);
+    for (const link of branchReadChain(space, branch)) {
+      for (
+        const r of tombstoned.all<{ id: string }>(
+          link.branch,
+          scope,
+          link.atSeq,
+          link.atSeq,
+        )
+      ) {
+        gone.add(`${link.branch}\u0000${r.id}`);
+      }
     }
   }
-  return rows.sort((a, b) =>
-    b.revisions - a.revisions || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
-  );
+
+  return rows
+    .filter((r) => !gone.has(`${r.link.branch}\u0000${r.id}`))
+    .map((r) => ({ id: r.id, revisions: r.revisions }))
+    .sort((a, b) =>
+      b.revisions - a.revisions || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+    );
 }
 
 /**

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -52,6 +52,7 @@
 // └────────────────────────────────────────────────────────────────────────────┘
 
 import { isObjectNotArray } from "@commonfabric/utils/types";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 
 import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
@@ -539,8 +540,8 @@ export interface EntityScanRow {
  *    describes — inflating the total and raising a truncation notice for a
  *    result that was never truncated.
  *
- * Ties on `revisions` break by id, so which entities a cap admits is a property
- * of the space rather than of the day's query plan.
+ * Ties on `revisions` break by id through `utf8Compare`, so which entities a
+ * cap admits is a property of the space rather than of the day's query plan.
  */
 export function visibleEntityRows(
   space: SpaceDb,
@@ -589,9 +590,11 @@ export function visibleEntityRows(
   return rows
     .filter((r) => !gone.has(`${r.link.branch}\u0000${r.id}`))
     .map((r) => ({ id: r.id, revisions: r.revisions, link: r.link }))
-    .sort((a, b) =>
-      b.revisions - a.revisions || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
-    );
+    // `utf8Compare` rather than `<`, matching `fingerprint.ts` and every other
+    // id ordering in the tree. The tie-break exists to make the order a
+    // property of the space; a hand-rolled comparison is a second definition of
+    // string order in the one domain that already has a shared one.
+    .sort((a, b) => b.revisions - a.revisions || utf8Compare(a.id, b.id));
 }
 
 /**

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -460,6 +460,17 @@ export function isEntityKind(value: string): value is EntityKind {
 export const DEFAULT_SCAN_LIMIT = 5000;
 
 /**
+ * The cap a scan will actually apply, for a limit that may be anything a caller
+ * passed. Entities are counted one at a time, so a cap has to be a whole
+ * number: a fractional one no integer count can ever equal is a cap that never
+ * takes effect, and the three scans disagreed about which way to round it.
+ */
+export function scanLimit(limit: number | undefined): number {
+  if (limit === undefined || Number.isNaN(limit)) return DEFAULT_SCAN_LIMIT;
+  return Math.max(0, Math.floor(limit));
+}
+
+/**
  * How far a capped space-wide scan reached. A scan that stops at its cap
  * returns a SUBSET, and a caller that cannot tell a capped result from a
  * complete one will read the subset as the whole space — so every capped scan
@@ -476,6 +487,20 @@ export interface ScanExtent {
   total: number;
   /** True when the scan reached more of what was asked for than `limit`. */
   truncated: boolean;
+  /**
+   * Entities the scan enumerated and could NOT describe — a payload that would
+   * not decode, or a reconstruction that threw. A separate count from
+   * `truncated` because it is a separate kind of incompleteness: raising
+   * `limit` does not recover one. Zero where a pass returns a row for every
+   * entity it reached, as `listEntityModels` does by modeling an unreadable
+   * entity `unknown`.
+   */
+  unreadable: number;
+}
+
+/** Whether a scan returned less than the whole set, for any reason. */
+export function isCompleteScan(extent: ScanExtent): boolean {
+  return !extent.truncated && extent.unreadable === 0;
 }
 
 /** One entity a scan can reach, and how many of its revisions it can see. */
@@ -620,7 +645,7 @@ export function listEntityModels(
 ): EntityListing {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
+  const limit = scanLimit(opts.limit);
   const kind = opts.kind;
 
   // A listing describes the space's RECORDS, so it keeps tombstones (they model
@@ -745,6 +770,10 @@ export function listEntityModels(
       limit,
       total: rows.length,
       truncated,
+      // A listing returns a row for every entity it reached: one that would not
+      // decode is modeled `unknown` rather than dropped, so nothing is missing
+      // from the result for this pass to report.
+      unreadable: 0,
     },
   };
 }

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -55,7 +55,7 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
 import type { EntityDocument, ReconstructOptions } from "./reconstruct.ts";
 
 export type EntityKind =
@@ -371,12 +371,9 @@ export function buildModuleIndex(
 ): Map<string, ModuleEntry> {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const ids = space.db
-    .prepare(
-      `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
-    )
-    .all<{ id: string }>(branch, scope)
-    .map((r) => r.id);
+  // Same enumeration every space-wide scan walks: branch-visible, and without
+  // the tombstones that could never reconstruct into a module anyway.
+  const ids = visibleEntityRows(space, { branch, scope }).map((r) => r.id);
 
   const index = new Map<string, ModuleEntry>();
   for (const id of ids) {
@@ -471,29 +468,127 @@ export const DEFAULT_SCAN_LIMIT = 5000;
 export interface ScanExtent {
   /** The cap the scan applied. */
   limit: number;
-  /** Entities the space holds on this branch and scope, before any filter. */
+  /**
+   * Entities this branch and scope can see, before any `kind` filter — the
+   * size of the set the scan walked (`visibleEntityRows`), so a complete pass
+   * describes exactly this many.
+   */
   total: number;
-  /** True when the space holds more of what was asked for than `limit`. */
+  /** True when the scan reached more of what was asked for than `limit`. */
   truncated: boolean;
 }
 
-/** Entities present on one branch and scope — the set a capped scan walks. */
+/** One entity a scan can reach, and how many of its revisions it can see. */
+export interface EntityScanRow {
+  id: string;
+  revisions: number;
+}
+
+/**
+ * Every entity a read on this branch and scope can see, busiest-first.
+ *
+ * This is the DOMAIN of every space-wide scan, and the set `ScanExtent.total`
+ * counts — one enumeration so that a scan's rows and its own report of how far
+ * it reached can never describe different sets. Two properties earn it:
+ *
+ *  - It reads through branch ancestry, not just the rows written ON `branch`.
+ *    A child branch inherits every entity its parent held at the fork
+ *    (`branchReadChain`), and a scan that enumerated only local rows would
+ *    report a listing complete while omitting entities the same branch reads
+ *    fine. `revisions` counts the history on the branch that OWNS the visible
+ *    row, which is the history a read from here can reach.
+ *  - It drops entities whose visible head is a `delete`, unless
+ *    `includeDeleted`. A tombstone reconstructs to nothing, so a pass that
+ *    describes reconstructed entities would otherwise count rows it never
+ *    describes — inflating the total and raising a truncation notice for a
+ *    result that was never truncated.
+ *
+ * Ties on `revisions` break by id, so which entities a cap admits is a property
+ * of the space rather than of the day's query plan.
+ */
+export function visibleEntityRows(
+  space: SpaceDb,
+  opts: {
+    branch?: string;
+    scope?: string;
+    /** Include entities whose visible head is a `delete`. Default false. */
+    includeDeleted?: boolean;
+  } = {},
+): EntityScanRow[] {
+  const scope = opts.scope ?? "space";
+  // Revisions per entity on ONE branch, up to that branch's cut.
+  const perBranch = space.db.prepare(
+    `SELECT id, count(*) revisions FROM revision
+     WHERE branch = ? AND scope_key = ? AND seq <= ?
+     GROUP BY id`,
+  );
+  // Entities on ONE branch whose LAST row up to the cut is a delete. Asked for
+  // the other way round — find the deletes, then ask which are final — because
+  // deletes are a sliver of a space's rows, where deriving every entity's head
+  // op reads all of them.
+  const tombstoned = space.db.prepare(
+    `SELECT r.id FROM revision r
+     WHERE r.branch = ? AND r.scope_key = ? AND r.op = 'delete' AND r.seq <= ?
+       AND NOT EXISTS (
+         SELECT 1 FROM revision h
+         WHERE h.branch = r.branch AND h.id = r.id AND h.scope_key = r.scope_key
+           AND h.seq <= ?
+           AND (h.seq > r.seq OR (h.seq = r.seq AND h.op_index > r.op_index))
+       )`,
+  );
+
+  const rows: EntityScanRow[] = [];
+  const claimed = new Set<string>();
+  for (const link of branchReadChain(space, opts.branch ?? "")) {
+    const gone = new Set(
+      tombstoned
+        .all<{ id: string }>(link.branch, scope, link.atSeq, link.atSeq)
+        .map((r) => r.id),
+    );
+    for (
+      const row of perBranch.all<EntityScanRow>(link.branch, scope, link.atSeq)
+    ) {
+      // Nearest link wins, exactly as a read resolves it: a nearer branch that
+      // holds ANY row for an entity owns it, including when that row is the
+      // delete that hides what the parent still holds.
+      if (claimed.has(row.id)) continue;
+      claimed.add(row.id);
+      if (gone.has(row.id) && !opts.includeDeleted) continue;
+      rows.push(row);
+    }
+  }
+  return rows.sort((a, b) =>
+    b.revisions - a.revisions || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+  );
+}
+
+/**
+ * How many entities a read on this branch and scope can see — the size of
+ * `visibleEntityRows`, and by construction the same set a scan walks.
+ */
 export function countEntities(
   space: SpaceDb,
-  opts: { branch?: string; scope?: string } = {},
+  opts: { branch?: string; scope?: string; includeDeleted?: boolean } = {},
 ): number {
-  const row = space.db
-    .prepare(
-      `SELECT count(DISTINCT id) n FROM revision
-       WHERE branch = ? AND scope_key = ?`,
-    )
-    .get<{ n: number }>(opts.branch ?? "", opts.scope ?? "space");
-  return row?.n ?? 0;
+  return visibleEntityRows(space, opts).length;
 }
 
 /** An entity's kind without modeling it; `unknown` when it cannot be read. */
 function kindOf(doc: EntityDocument | undefined): EntityKind {
   return doc === undefined ? "unknown" : classifyDocument(doc).kind;
+}
+
+/**
+ * The pattern identity a document's `moduleId` would resolve through — the
+ * same `patternIdentity.identity` `classifyDocument` reads into
+ * `lineage.pattern`, without paying for a full classification.
+ */
+function patternIdentityOf(
+  doc: EntityDocument | undefined,
+): string | undefined {
+  if (doc === undefined || !isObjectNotArray(doc.patternIdentity)) return;
+  const identity = (doc.patternIdentity as { identity?: unknown }).identity;
+  return typeof identity === "string" ? identity : undefined;
 }
 
 /** A capped listing of a space's entities, with how far its scan reached. */
@@ -528,52 +623,89 @@ export function listEntityModels(
   const limit = Math.max(0, opts.limit ?? DEFAULT_SCAN_LIMIT);
   const kind = opts.kind;
 
-  // Unfiltered, SQL bounds the scan; filtered, only reconstruction can tell a
-  // match from a miss, so the whole space is walked and the loop below stops
-  // itself. Either way the scan reaches for one row past `limit` — finding it
-  // is what proves more remain.
-  const ordered = `SELECT id, count(*) revisions FROM revision
-       WHERE branch = ? AND scope_key = ?
-       GROUP BY id ORDER BY revisions DESC`;
-  const rows = kind === undefined
-    ? space.db
-      .prepare(`${ordered} LIMIT ?`)
-      .all<{ id: string; revisions: number }>(branch, scope, limit + 1)
-    : space.db
-      .prepare(ordered)
-      .all<{ id: string; revisions: number }>(branch, scope);
+  // A listing describes the space's RECORDS, so it keeps tombstones (they model
+  // as `unknown`) — which also keeps `extent.total` counting exactly the set
+  // this pass returns.
+  const rows = visibleEntityRows(space, {
+    branch,
+    scope,
+    includeDeleted: true,
+  });
 
   // Single reconstruction pass: cache docs + build the module index inline.
   // Only matching documents are cached; a `kind` scan may pass over far more
   // entities than it keeps, and holding every value would cost the space.
   const docs = new Map<string, EntityDocument | undefined>();
   const moduleIndex = new Map<string, ModuleEntry>();
-  const kept: { id: string; revisions: number }[] = [];
-  for (const r of rows) {
-    let doc: EntityDocument | undefined;
-    try {
-      doc = reconstructDocument(space, { id: r.id, branch, scope });
-    } catch {
-      doc = undefined;
-    }
+  const indexModule = (id: string, doc: EntityDocument | undefined): void => {
     const v = doc?.value;
-    if (isModuleValue(v)) {
-      const existing = moduleIndex.get(v.identity);
-      if (!existing || v.kind === "source") {
-        moduleIndex.set(v.identity, {
-          id: r.id,
-          filename: v.filename,
-          kind: v.kind,
-        });
-      }
+    if (!isModuleValue(v)) return;
+    const existing = moduleIndex.get(v.identity);
+    // First wins, but a `source` entity always supersedes a `compiled` one.
+    if (!existing || v.kind === "source") {
+      moduleIndex.set(v.identity, { id, filename: v.filename, kind: v.kind });
     }
+  };
+  const read = (id: string): EntityDocument | undefined => {
+    try {
+      return reconstructDocument(space, { id, branch, scope });
+    } catch {
+      return undefined;
+    }
+  };
+
+  const kept: EntityScanRow[] = [];
+  let truncated = false;
+  let scanned = 0;
+  // Collect: one entity past the limit is kept and dropped, because HOLDING it
+  // is what proves more remain — truncation is never inferred from a count that
+  // happened to land on the cap.
+  for (; scanned < rows.length; scanned++) {
+    const r = rows[scanned];
+    const doc = read(r.id);
+    indexModule(r.id, doc);
     if (kind !== undefined && kindOf(doc) !== kind) continue;
+    if (kept.length === limit) {
+      truncated = true;
+      scanned++;
+      break;
+    }
     docs.set(r.id, doc);
     kept.push(r);
-    if (kept.length > limit) break;
   }
-  const truncated = kept.length > limit;
-  if (truncated) kept.pop();
+
+  // Resolve: a piece's `moduleId` comes from a module that can sit ANYWHERE in
+  // the order — modules are written once, so they rank last among busiest-first
+  // rows, and a `kind` scan that stopped at the cap can hold pieces whose module
+  // it never reached. Their `moduleId` would come back `undefined`, which reads
+  // as "this piece has no pattern" rather than "the scan stopped early".
+  //
+  // A `kind` scan is where that matters: the module is a DIFFERENT kind, so it
+  // could never be in the result and the caller has no way to resolve the
+  // identity themselves. An unfiltered capped listing is a prefix that says so,
+  // and its unresolved ids point outside the prefix the same way `lineage.owner`
+  // and `lineage.argument` already do — so it keeps its cheap scan.
+  const wanted = new Set<string>();
+  if (kind !== undefined) {
+    for (const doc of docs.values()) {
+      const identity = patternIdentityOf(doc);
+      if (
+        identity !== undefined && moduleIndex.get(identity)?.kind !== "source"
+      ) {
+        wanted.add(identity);
+      }
+    }
+  }
+  // The walk ends the moment nothing is still wanted.
+  for (; wanted.size > 0 && scanned < rows.length; scanned++) {
+    const r = rows[scanned];
+    const doc = read(r.id);
+    indexModule(r.id, doc);
+    const v = doc?.value;
+    // A `source` entity supersedes a `compiled` one, so a want is only settled
+    // once source is seen — or the rows run out.
+    if (isModuleValue(v) && v.kind === "source") wanted.delete(v.identity);
+  }
 
   const out: EntityModel[] = kept.map((r): EntityModel => {
     const doc = docs.get(r.id);
@@ -605,8 +737,13 @@ export function listEntityModels(
         (b.revisions ?? 0) - (a.revisions ?? 0),
     ),
     extent: {
+      // `rows`, not a second count: the listing and its own report of how far
+      // it reached are the same enumeration, so they cannot drift. It counts
+      // tombstones because this listing returns them, which is also why a
+      // `graph` or `html` total over the same space is smaller — those describe
+      // reconstructed entities, and a tombstone reconstructs to nothing.
       limit,
-      total: countEntities(space, { branch, scope }),
+      total: rows.length,
       truncated,
     },
   };

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -745,6 +745,13 @@ export function listEntityModels(
       }
     }
   }
+  // Reachable only when collection stopped at the cap — the loop above runs to
+  // `rows.length` otherwise — so a failure this walk meets is already covered by
+  // `truncated`, and counting it under `unreadable` would contradict the notice
+  // that goes with it: raising `--limit` DOES bring these rows into the pass
+  // above, which reports them. Pinned by a test, since the invariant lives in
+  // the loop bounds rather than anywhere it can be read off.
+  //
   // The walk ends the moment nothing is still wanted.
   for (; wanted.size > 0 && scanned < rows.length; scanned++) {
     const r = rows[scanned];

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -57,6 +57,7 @@ import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
 import {
   branchReadChain,
+  type BranchReadLink,
   reconstructDocument,
   visibleRevisionRows,
 } from "./reconstruct.ts";
@@ -511,6 +512,12 @@ export function isCompleteScan(extent: ScanExtent): boolean {
 export interface EntityScanRow {
   id: string;
   revisions: number;
+  /**
+   * The chain link that owns the visible row. A pass describing an entity's
+   * history has to read THIS branch and no other: nearest-branch ownership
+   * hides a parent's log exactly as it hides the parent's value.
+   */
+  link: BranchReadLink;
 }
 
 /**
@@ -581,7 +588,7 @@ export function visibleEntityRows(
 
   return rows
     .filter((r) => !gone.has(`${r.link.branch}\u0000${r.id}`))
-    .map((r) => ({ id: r.id, revisions: r.revisions }))
+    .map((r) => ({ id: r.id, revisions: r.revisions, link: r.link }))
     .sort((a, b) =>
       b.revisions - a.revisions || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
     );
@@ -671,25 +678,42 @@ export function listEntityModels(
       moduleIndex.set(v.identity, { id, filename: v.filename, kind: v.kind });
     }
   };
-  const read = (id: string): EntityDocument | undefined => {
+  // A throw and a tombstone both yield no document, and only one of them is an
+  // error: a deleted entity is definitively not a `piece`, while an entity that
+  // would not decode might have been one. A `kind` filter drops both, so the
+  // two have to stay distinguishable or the dropped error goes unreported.
+  const read = (
+    id: string,
+  ): { doc: EntityDocument | undefined; failed: boolean } => {
     try {
-      return reconstructDocument(space, { id, branch, scope });
+      return {
+        doc: reconstructDocument(space, { id, branch, scope }),
+        failed: false,
+      };
     } catch {
-      return undefined;
+      return { doc: undefined, failed: true };
     }
   };
 
   const kept: EntityScanRow[] = [];
   let truncated = false;
   let scanned = 0;
+  // Rows a `kind` filter dropped BECAUSE they would not reconstruct. An
+  // unfiltered listing keeps every row it reaches — an unreadable one included,
+  // modeled `unknown` — so it never has any; a filtered one silently omits what
+  // it cannot classify, and `--require-complete` has to hear about it.
+  let unreadable = 0;
   // Collect: one entity past the limit is kept and dropped, because HOLDING it
   // is what proves more remain — truncation is never inferred from a count that
   // happened to land on the cap.
   for (; scanned < rows.length; scanned++) {
     const r = rows[scanned];
-    const doc = read(r.id);
+    const { doc, failed } = read(r.id);
     indexModule(r.id, doc);
-    if (kind !== undefined && kindOf(doc) !== kind) continue;
+    if (kind !== undefined && kindOf(doc) !== kind) {
+      if (failed) unreadable++;
+      continue;
+    }
     if (kept.length === limit) {
       truncated = true;
       scanned++;
@@ -724,7 +748,7 @@ export function listEntityModels(
   // The walk ends the moment nothing is still wanted.
   for (; wanted.size > 0 && scanned < rows.length; scanned++) {
     const r = rows[scanned];
-    const doc = read(r.id);
+    const { doc } = read(r.id);
     indexModule(r.id, doc);
     const v = doc?.value;
     // A `source` entity supersedes a `compiled` one, so a want is only settled
@@ -770,10 +794,7 @@ export function listEntityModels(
       limit,
       total: rows.length,
       truncated,
-      // A listing returns a row for every entity it reached: one that would not
-      // decode is modeled `unknown` rather than dropped, so nothing is missing
-      // from the result for this pass to report.
-      unreadable: 0,
+      unreadable,
     },
   };
 }

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -176,16 +176,23 @@ export interface VisibleRevisionRow {
 }
 
 /**
- * Every (scope, entity) a read on this branch can see, each attributed to the
+ * Every (scope, entity) this branch has RECORDS for, each attributed to the
  * nearest branch holding it — `resolveBranchRow`'s rule applied to a whole
  * space instead of one entity.
+ *
+ * Records, not readable entities: an entity whose head is a `delete` is
+ * enumerated here, because a tombstone is something the branch holds and
+ * several callers need to know about it. `visibleEntityRows` is the read-
+ * visible set, and drops them. Do not mistake one for the other — the reason
+ * this function exists is that the ancestry rule was being written once per
+ * caller and drifting one caller at a time, and a caller that reads this as
+ * "what a read returns" reintroduces exactly that.
  *
  * Enumeration and reading have to agree about what a branch can see, or a view
  * reports one domain while describing another: a listing that covers inherited
  * entities beside a scope list that does not, or a page naming a per-user scope
- * while showing no cells in it. This is the enumeration those callers share.
- * Narrow with `scope` or `id` when only part of the space is wanted; the
- * remaining shape is identical either way.
+ * while showing no cells in it. Narrow with `scope` or `id` when only part of
+ * the space is wanted; the remaining shape is identical either way.
  */
 export function visibleRevisionRows(
   space: SpaceDb,

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -165,6 +165,59 @@ export function branchReadChain(
   return chain;
 }
 
+/** One (scope, entity) a read on a branch can see, and where it comes from. */
+export interface VisibleRevisionRow {
+  scope: string;
+  id: string;
+  /** Revisions on the branch that OWNS it — the history a read can reach. */
+  revisions: number;
+  /** The chain link that owns it. */
+  link: BranchReadLink;
+}
+
+/**
+ * Every (scope, entity) a read on this branch can see, each attributed to the
+ * nearest branch holding it — `resolveBranchRow`'s rule applied to a whole
+ * space instead of one entity.
+ *
+ * Enumeration and reading have to agree about what a branch can see, or a view
+ * reports one domain while describing another: a listing that covers inherited
+ * entities beside a scope list that does not, or a page naming a per-user scope
+ * while showing no cells in it. This is the enumeration those callers share.
+ * Narrow with `scope` or `id` when only part of the space is wanted; the
+ * remaining shape is identical either way.
+ */
+export function visibleRevisionRows(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; id?: string } = {},
+): VisibleRevisionRow[] {
+  const conditions = ["branch = ?", "seq <= ?"];
+  if (opts.scope !== undefined) conditions.push("scope_key = ?");
+  if (opts.id !== undefined) conditions.push("id = ?");
+  const stmt = space.db.prepare(
+    `SELECT scope_key, id, count(*) revs FROM revision
+     WHERE ${conditions.join(" AND ")} GROUP BY scope_key, id`,
+  );
+  const rows: VisibleRevisionRow[] = [];
+  const claimed = new Set<string>();
+  for (const link of branchReadChain(space, opts.branch ?? "")) {
+    const params: (string | number)[] = [link.branch, link.atSeq];
+    if (opts.scope !== undefined) params.push(opts.scope);
+    if (opts.id !== undefined) params.push(opts.id);
+    for (
+      const r of stmt.all<{ scope_key: string; id: string; revs: number }>(
+        ...params,
+      )
+    ) {
+      const key = `${r.scope_key}\u0000${r.id}`;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      rows.push({ scope: r.scope_key, id: r.id, revisions: r.revs, link });
+    }
+  }
+  return rows;
+}
+
 /**
  * Resolve the single revision row visible for `id` at `atSeq` on `branch`,
  * replicating the engine's `readRowForBranch` (`engine.ts`): take the latest

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -106,11 +106,70 @@ function hasTable(space: SpaceDb, name: string): boolean {
     .get<{ 1: number }>(name);
 }
 
+/** One branch a read consults, and the seq its rows are visible up to. */
+export interface BranchReadLink {
+  branch: string;
+  /** Rows with `seq <= atSeq` on this branch are visible from the read. */
+  atSeq: number;
+}
+
+// A chain depends on the `branch` table, which an offline space file does not
+// gain while we hold it open read-only, so it is derived once per (space,
+// branch, seq) and reused. Without this a space-wide scan would re-derive the
+// same chain for every entity it reconstructs.
+const chainCache = new WeakMap<SpaceDb, Map<string, BranchReadLink[]>>();
+
+/**
+ * The branches a read on `branch` at `atSeq` consults, nearest first, each with
+ * the seq it is read at — the engine's `readRowForBranch` ancestry (`engine.ts`)
+ * resolved as a list instead of walked per entity.
+ *
+ * This is the ONE encoding of "what can a read on this branch see". A read
+ * resolves the first link that holds a row; a space-wide scan enumerates the
+ * union across links. Both have to agree, or a listing reports itself complete
+ * while omitting entities the same branch reads fine.
+ */
+export function branchReadChain(
+  space: SpaceDb,
+  branch: string,
+  atSeq: number = MAX_SEQ,
+): BranchReadLink[] {
+  let perSpace = chainCache.get(space);
+  if (!perSpace) chainCache.set(space, perSpace = new Map());
+  const key = `${atSeq}\u0000${branch}`;
+  const hit = perSpace.get(key);
+  if (hit) return hit;
+
+  const chain: BranchReadLink[] = [];
+  const seen = new Set<string>();
+  let current = branch;
+  let cut = atSeq;
+  // `seen` guards a malformed cycle in `parent_branch`; without it a space
+  // whose branch table points back at itself would recur forever.
+  while (!seen.has(current)) {
+    seen.add(current);
+    chain.push({ branch: current, atSeq: cut });
+    if (!hasTable(space, "branch")) break;
+    const b = space.db
+      .prepare("SELECT parent_branch, fork_seq FROM branch WHERE name = ?")
+      .get<{ parent_branch: string | null; fork_seq: number | null }>(current);
+    // The default branch is named "" (falsy) — test for null/undefined, not truthiness.
+    if (!b || b.parent_branch === null || b.parent_branch === undefined) break;
+    // Inherit at min(seq, fork_seq), with `?? 0` matching the engine's fallback
+    // exactly (engine.ts) — a malformed null fork_seq must not leak the parent's
+    // post-fork head into the child.
+    cut = Math.min(cut, b.fork_seq ?? 0);
+    current = b.parent_branch;
+  }
+  perSpace.set(key, chain);
+  return chain;
+}
+
 /**
  * Resolve the single revision row visible for `id` at `atSeq` on `branch`,
  * replicating the engine's `readRowForBranch` (`engine.ts`): take the latest
  * local row at/before `atSeq`; if the branch has NONE, inherit the parent's row
- * at `min(atSeq, fork_seq)`, recursively to the root. Inheritance resolves WHICH
+ * at `min(atSeq, fork_seq)`, on up to the root. Inheritance resolves WHICH
  * branch owns the visible row — it does NOT merge logs.
  */
 function resolveBranchRow(
@@ -119,40 +178,17 @@ function resolveBranchRow(
   scope: string,
   id: string,
   atSeq: number,
-  seen: Set<string> = new Set(),
 ): { row: RevRow; branch: string } | undefined {
-  if (seen.has(branch)) return undefined;
-  seen.add(branch);
-
-  const row = space.db
-    .prepare(
-      `SELECT seq, op_index, op, data FROM revision
-       WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ?
-       ORDER BY seq DESC, op_index DESC LIMIT 1`,
-    )
-    .get<RevRow>(branch, id, scope, atSeq);
-  if (row) return { row, branch };
-
-  if (!hasTable(space, "branch")) return undefined;
-  const b = space.db
-    .prepare("SELECT parent_branch, fork_seq FROM branch WHERE name = ?")
-    .get<{ parent_branch: string | null; fork_seq: number | null }>(branch);
-  // The default branch is named "" (falsy) — test for null/undefined, not truthiness.
-  if (!b || b.parent_branch === null || b.parent_branch === undefined) {
-    return undefined;
-  }
-  // Inherit at min(seq, fork_seq), with `?? 0` matching the engine's fallback
-  // exactly (engine.ts) — a malformed null fork_seq must not leak the parent's
-  // post-fork head into the child.
-  const inheritedSeq = Math.min(atSeq, b.fork_seq ?? 0);
-  return resolveBranchRow(
-    space,
-    b.parent_branch,
-    scope,
-    id,
-    inheritedSeq,
-    seen,
+  const stmt = space.db.prepare(
+    `SELECT seq, op_index, op, data FROM revision
+     WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ?
+     ORDER BY seq DESC, op_index DESC LIMIT 1`,
   );
+  for (const link of branchReadChain(space, branch, atSeq)) {
+    const row = stmt.get<RevRow>(link.branch, id, scope, link.atSeq);
+    if (row) return { row, branch: link.branch };
+  }
+  return undefined;
 }
 
 /**

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -100,6 +100,9 @@ export function listScopes(
   space: SpaceDb,
   opts: { branch?: string } = {},
 ): Scope[] {
+  // Counts cover every entity the branch holds records for, tombstoned ones
+  // included: a scope is a fact about what the store contains, and one whose
+  // entities were all deleted is still a scope that was written to.
   const totals = new Map<string, { entities: number; revisions: number }>();
   for (const row of visibleRevisionRows(space, { branch: opts.branch })) {
     const total = totals.get(row.scope) ?? { entities: 0, revisions: 0 };
@@ -358,9 +361,11 @@ export function scopeOverlay(
   opts: { branch?: string } = {},
 ): ScopeOverlay {
   const branch = opts.branch ?? "";
-  // The scopes this branch can SEE for the entity, not only those written on
-  // it: an inherited entity's per-user variants live on the parent, and an
-  // overlay that missed them would report no divergence where there is some.
+  // The scopes this branch holds records for, not only those written on it: an
+  // inherited entity's per-user variants live on the parent, and an overlay
+  // that missed them would report no divergence where there is some. Tombstoned
+  // heads are wanted here too — an entity present in one scope and DELETED in
+  // another is a divergence, and `(absent)` below is its own class of one.
   const rows = visibleRevisionRows(space, { branch, id })
     .map((r) => ({ scope_key: r.scope, revs: r.revisions }));
   // Content-key each variant from the RAW reconstructed value (hashStringOf is

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -29,10 +29,10 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import { annotate, summarize } from "./decode.ts";
 import {
-  branchReadChain,
   type EntityDocument,
   reconstructDocument,
   selectAtPath,
+  visibleRevisionRows,
 } from "./reconstruct.ts";
 
 export type ScopeKind = "space" | "user" | "session" | "other";
@@ -100,30 +100,15 @@ export function listScopes(
   space: SpaceDb,
   opts: { branch?: string } = {},
 ): Scope[] {
-  const stmt = space.db.prepare(
-    `SELECT scope_key, id, count(*) revs FROM revision
-     WHERE branch = ? AND seq <= ? GROUP BY scope_key, id`,
-  );
   const totals = new Map<string, { entities: number; revisions: number }>();
-  const claimed = new Set<string>();
-  for (const link of branchReadChain(space, opts.branch ?? "")) {
-    for (
-      const r of stmt.all<{ scope_key: string; id: string; revs: number }>(
-        link.branch,
-        link.atSeq,
-      )
-    ) {
-      const key = `${r.scope_key}\u0000${r.id}`;
-      if (claimed.has(key)) continue;
-      claimed.add(key);
-      const total = totals.get(r.scope_key) ?? { entities: 0, revisions: 0 };
-      total.entities += 1;
-      total.revisions += r.revs;
-      totals.set(r.scope_key, total);
-    }
+  for (const row of visibleRevisionRows(space, { branch: opts.branch })) {
+    const total = totals.get(row.scope) ?? { entities: 0, revisions: 0 };
+    total.entities += 1;
+    total.revisions += row.revisions;
+    totals.set(row.scope, total);
   }
   return [...totals.entries()]
-    .map(([scope_key, total]) => ({ ...parseScope(scope_key), ...total }))
+    .map(([scope, total]) => ({ ...parseScope(scope), ...total }))
     .sort((a, b) =>
       KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || b.revisions - a.revisions
     );
@@ -373,12 +358,11 @@ export function scopeOverlay(
   opts: { branch?: string } = {},
 ): ScopeOverlay {
   const branch = opts.branch ?? "";
-  const rows = space.db
-    .prepare(
-      `SELECT scope_key, count(*) revs FROM revision
-       WHERE branch = ? AND id = ? GROUP BY scope_key`,
-    )
-    .all<{ scope_key: string; revs: number }>(branch, id);
+  // The scopes this branch can SEE for the entity, not only those written on
+  // it: an inherited entity's per-user variants live on the parent, and an
+  // overlay that missed them would report no divergence where there is some.
+  const rows = visibleRevisionRows(space, { branch, id })
+    .map((r) => ({ scope_key: r.scope, revs: r.revisions }));
   // Content-key each variant from the RAW reconstructed value (hashStringOf is
   // already fabric-aware and depth-complete). Hashing the *annotated* value
   // would falsely converge — depth-8 truncation collapses values that differ

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -29,6 +29,7 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import { annotate, summarize } from "./decode.ts";
 import {
+  branchReadChain,
   type EntityDocument,
   reconstructDocument,
   selectAtPath,
@@ -82,24 +83,47 @@ const KIND_ORDER: Record<ScopeKind, number> = {
   other: 3,
 };
 
-/** Enumerate the scopes present in a space, with entity/revision counts. */
+/**
+ * Enumerate the scopes a read on this branch can see, with entity/revision
+ * counts.
+ *
+ * Reads through branch ancestry, because a child branch inherits its parent's
+ * per-user and per-session state along with everything else: enumerating only
+ * the scopes written ON the branch drops those, and a caller that walks this
+ * list to cover "every scope" would cover a subset without knowing. Each
+ * (scope, entity) is attributed to the nearest branch holding it, exactly as a
+ * read resolves it, so counts describe what is visible from here rather than
+ * summing a parent's history into a child's. A space with no child branches
+ * has a one-link chain, where this is the query it always was.
+ */
 export function listScopes(
   space: SpaceDb,
   opts: { branch?: string } = {},
 ): Scope[] {
-  const branch = opts.branch ?? "";
-  const rows = space.db
-    .prepare(
-      `SELECT scope_key, count(DISTINCT id) ents, count(*) revs
-       FROM revision WHERE branch = ? GROUP BY scope_key`,
-    )
-    .all<{ scope_key: string; ents: number; revs: number }>(branch);
-  return rows
-    .map((r) => ({
-      ...parseScope(r.scope_key),
-      entities: r.ents,
-      revisions: r.revs,
-    }))
+  const stmt = space.db.prepare(
+    `SELECT scope_key, id, count(*) revs FROM revision
+     WHERE branch = ? AND seq <= ? GROUP BY scope_key, id`,
+  );
+  const totals = new Map<string, { entities: number; revisions: number }>();
+  const claimed = new Set<string>();
+  for (const link of branchReadChain(space, opts.branch ?? "")) {
+    for (
+      const r of stmt.all<{ scope_key: string; id: string; revs: number }>(
+        link.branch,
+        link.atSeq,
+      )
+    ) {
+      const key = `${r.scope_key}\u0000${r.id}`;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      const total = totals.get(r.scope_key) ?? { entities: 0, revisions: 0 };
+      total.entities += 1;
+      total.revisions += r.revs;
+      totals.set(r.scope_key, total);
+    }
+  }
+  return [...totals.entries()]
+    .map(([scope_key, total]) => ({ ...parseScope(scope_key), ...total }))
     .sort((a, b) =>
       KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || b.revisions - a.revisions
     );

--- a/packages/state-inspector/test/db.test.ts
+++ b/packages/state-inspector/test/db.test.ts
@@ -81,7 +81,7 @@ Deno.test("scope_key shim: a DB without scope_key still inspects", async () => {
       const snapDoc = reconstructDocument(space, { id: "of:b" });
       assertEquals((snapDoc?.value as { n: number }).n, 2);
 
-      const models = listEntityModels(space);
+      const models = listEntityModels(space).entities;
       assertEquals(models.length, 2); // of:a, of:b
       assertEquals(models.map((m) => m.id).sort(), ["of:a", "of:b"]);
     } finally {

--- a/packages/state-inspector/test/declared-schema.test.ts
+++ b/packages/state-inspector/test/declared-schema.test.ts
@@ -155,7 +155,7 @@ async function details(): Promise<Map<string, EntityDetail>> {
   seed(dbPath);
   const space = openSpace(dbPath);
   try {
-    return new Map(buildAllDetails(space).map((d) => [d.id, d]));
+    return new Map(buildAllDetails(space).details.map((d) => [d.id, d]));
   } finally {
     space.close();
     await Deno.remove(dir, { recursive: true });

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -133,7 +133,7 @@ Deno.test("unified entity model + encoded commit decode", async (t) => {
       );
 
       await t.step("entities classify by path-set, not value shape", () => {
-        const ents = listEntityModels(space);
+        const ents = listEntityModels(space).entities;
         const byId = Object.fromEntries(ents.map((e) => [e.id, e]));
 
         assertEquals(byId["of:mod"].kind, "module");

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -20,7 +20,9 @@ import {
   entityKinds,
   isEntityKind,
   listEntityModels,
+  visibleEntityRows,
 } from "../model.ts";
+import { reconstructDocument } from "../reconstruct.ts";
 import { buildAllDetails } from "../detail.ts";
 import { buildSpaceGraph, subgraphAround } from "../graph.ts";
 import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
@@ -44,7 +46,6 @@ CREATE TABLE branch (
   fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
   head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
 );
-INSERT INTO branch (name, head_seq, status) VALUES ('', 39, 'active');
 `;
 
 const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
@@ -55,6 +56,10 @@ interface SeedEntity {
   /** The stored document, written once per revision. */
   document: Record<string, unknown>;
   revisions: number;
+  /** Branch the revisions are written on. Defaults to the space branch. */
+  branch?: string;
+  /** Written after the revisions: the entity's visible head is a tombstone. */
+  deleted?: boolean;
 }
 
 /** Six busy cells, one module, three quiet pieces — busiest scanned first. */
@@ -90,27 +95,68 @@ const ENTITIES: SeedEntity[] = [
 const TOTAL = ENTITIES.length;
 const PIECES = ENTITIES.filter((e) => e.id.startsWith("of:piece-")).length;
 
-function seed(path: string): void {
+function seed(
+  path: string,
+  entities: SeedEntity[] = ENTITIES,
+  branches: { name: string; parent?: string; forkSeq?: number }[] = [],
+): void {
   const db = new Database(path, { create: true });
   db.exec(SCHEMA);
+  const branchRow = db.prepare(
+    `INSERT INTO branch (name, parent_branch, fork_seq, head_seq)
+     VALUES (?, ?, ?, 9999)`,
+  );
+  for (const b of branches) {
+    branchRow.run(b.name, b.parent ?? null, b.forkSeq ?? null);
+  }
   const commit = db.prepare(
-    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
-     VALUES (?, ?, ?, '{}', '{}')`,
+    `INSERT INTO "commit" (seq, branch, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, ?, '{}', '{}')`,
   );
   const rev = db.prepare(
-    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
-     VALUES (?, ?, 0, 'set', ?, ?)`,
+    `INSERT INTO revision (branch, id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 0, ?, ?, ?)`,
   );
   let seq = 0;
-  for (const entity of ENTITIES) {
+  const write = (entity: SeedEntity, op: string, data: string | null) => {
+    seq++;
+    const branch = entity.branch ?? "";
+    commit.run(seq, branch, SESSION, seq);
+    rev.run(branch, entity.id, seq, op, data, seq);
+  };
+  for (const entity of entities) {
     for (let n = 0; n < entity.revisions; n++) {
-      seq++;
-      commit.run(seq, SESSION, seq);
-      rev.run(entity.id, seq, JSON.stringify(entity.document), seq);
+      write(entity, "set", JSON.stringify(entity.document));
     }
+    if (entity.deleted) write(entity, "delete", null);
   }
   db.close();
 }
+
+/** Open a space seeded for one test, and clean it up after. */
+async function withSeeded(
+  entities: SeedEntity[],
+  branches: { name: string; parent?: string; forkSeq?: number }[],
+  run: (space: SpaceDb) => void,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-scan-" });
+  seed(`${dir}/space.sqlite`, entities, branches);
+  const space = openSpace(`${dir}/space.sqlite`);
+  try {
+    run(space);
+  } finally {
+    space.close();
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+const cells = (n: number, revisions: number, opts: Partial<SeedEntity> = {}) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `of:cell-${i + 1}`,
+    document: { value: `cell ${i + 1}` },
+    revisions,
+    ...opts,
+  }));
 
 describe("scan-extent", () => {
   let dir: string;
@@ -118,7 +164,7 @@ describe("scan-extent", () => {
 
   beforeAll(async () => {
     dir = await Deno.makeTempDir({ prefix: "state-inspector-scan-extent-" });
-    seed(`${dir}/space.sqlite`);
+    seed(`${dir}/space.sqlite`, ENTITIES, [{ name: "" }]);
     space = openSpace(`${dir}/space.sqlite`);
   });
 
@@ -280,6 +326,229 @@ describe("scan-extent", () => {
         buildInspectorBundle(space, { limit: TOTAL }),
       );
       expect(html).not.toContain("capped at");
+    });
+  });
+
+  describe("visibleEntityRows()", () => {
+    it("returns the entities a child branch inherited from its parent, not only the ones written on it", async () => {
+      await withSeeded(
+        [
+          ...cells(3, 2),
+          {
+            id: "of:kid",
+            document: { value: "kid" },
+            revisions: 1,
+            branch: "kid",
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 6 }],
+        (kidSpace) => {
+          // The parent's entities are readable from the child (that is what
+          // `reconstructDocument` resolves), so the scan has to enumerate them.
+          expect(
+            reconstructDocument(kidSpace, { id: "of:cell-1", branch: "kid" }),
+          ).toEqual({ value: "cell 1" });
+          expect(
+            visibleEntityRows(kidSpace, { branch: "kid" }).map((r) => r.id),
+          ).toEqual(["of:cell-1", "of:cell-2", "of:cell-3", "of:kid"]);
+        },
+      );
+    });
+
+    it("omits an entity a child branch deleted, while the parent still lists it", async () => {
+      await withSeeded(
+        [
+          ...cells(2, 1),
+          {
+            id: "of:cell-1",
+            document: { value: "cell 1" },
+            revisions: 0,
+            branch: "kid",
+            deleted: true,
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 2 }],
+        (space) => {
+          // The child's delete is the nearest row, so it hides the entity the
+          // parent still holds — the same resolution a read makes.
+          expect(
+            reconstructDocument(space, { id: "of:cell-1", branch: "kid" }),
+          ).toBeUndefined();
+          expect(
+            visibleEntityRows(space, { branch: "kid" }).map((r) => r.id),
+          ).toEqual(["of:cell-2"]);
+          expect(visibleEntityRows(space).map((r) => r.id)).toEqual([
+            "of:cell-1",
+            "of:cell-2",
+          ]);
+        },
+      );
+    });
+
+    it("omits an entity whose visible head is a delete, and returns it under `includeDeleted`", async () => {
+      await withSeeded(
+        [
+          ...cells(2, 1),
+          {
+            id: "of:gone",
+            document: { value: "gone" },
+            revisions: 1,
+            deleted: true,
+          },
+        ],
+        [{ name: "" }],
+        (deleted) => {
+          expect(visibleEntityRows(deleted).map((r) => r.id)).toEqual([
+            "of:cell-1",
+            "of:cell-2",
+          ]);
+          expect(
+            visibleEntityRows(deleted, { includeDeleted: true }).map((r) =>
+              r.id
+            ),
+          ).toContain("of:gone");
+        },
+      );
+    });
+  });
+
+  describe("a child branch's scans", () => {
+    /** Three inherited entities and one written on the child itself. */
+    const inherited = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          ...cells(3, 2),
+          {
+            id: "of:kid",
+            document: { value: "kid" },
+            revisions: 1,
+            branch: "kid",
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 6 }],
+        run,
+      );
+
+    it("counts the inherited entities in the extent rather than reporting a complete listing", async () => {
+      await inherited((kidSpace) => {
+        const listing = listEntityModels(kidSpace, { branch: "kid", limit: 2 });
+        expect(listing.extent).toEqual({ limit: 2, total: 4, truncated: true });
+      });
+    });
+
+    it("describes an inherited entity with the version log of the branch that holds its writes", async () => {
+      await inherited((kidSpace) => {
+        const listing = buildAllDetails(kidSpace, { branch: "kid" });
+        expect(listing.extent.total).toBe(4);
+        const detail = listing.details.find((d) => d.id === "of:cell-1");
+        // Two writes, both on the parent before the fork — an empty log here
+        // would describe an entity the child reads fine as having no history.
+        expect(detail?.versions.map((v) => v.seq)).toEqual([1, 2]);
+      });
+    });
+  });
+
+  describe("a space holding a deleted entity", () => {
+    /** Two live cells and one whose visible head is a tombstone. */
+    const withTombstone = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          ...cells(2, 2),
+          {
+            id: "of:gone",
+            document: { value: "gone" },
+            revisions: 1,
+            deleted: true,
+          },
+        ],
+        [{ name: "" }],
+        run,
+      );
+
+    it("counts only the entities a detail pass describes, so a limit above them reports no truncation", async () => {
+      await withTombstone((space) => {
+        const listing = buildAllDetails(space, { limit: 2 });
+        expect(listing.details.map((d) => d.id)).toEqual([
+          "of:cell-1",
+          "of:cell-2",
+        ]);
+        // Counting the tombstone would make this 3 of a 2-entity limit, and
+        // announce a cap over a pass that described everything it could.
+        expect(listing.extent).toEqual({
+          limit: 2,
+          total: 2,
+          truncated: false,
+        });
+      });
+    });
+
+    it("counts only the entities a graph holds", async () => {
+      await withTombstone((space) => {
+        expect(buildSpaceGraph(space, { limit: 2 }).extent).toEqual({
+          limit: 2,
+          total: 2,
+          truncated: false,
+        });
+      });
+    });
+
+    it("keeps the tombstone in the entity listing, which describes the space's records", async () => {
+      await withTombstone((space) => {
+        const listing = listEntityModels(space);
+        expect(listing.entities.map((e) => e.id)).toContain("of:gone");
+        expect(listing.extent.total).toBe(3);
+      });
+    });
+  });
+
+  describe("a module that ranks below the pieces pointing at it", () => {
+    /** Three busy pieces; their module written once, so it sorts last. */
+    const PIECE_DOC = {
+      value: { $NAME: "Topic" },
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+    };
+    const quietModule = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          ...Array.from({ length: 3 }, (_, i) => ({
+            id: `of:piece-${i + 1}`,
+            document: PIECE_DOC,
+            revisions: 3,
+          })),
+          {
+            id: "of:mod",
+            document: {
+              value: {
+                kind: "source",
+                identity: MODULE_IDENTITY,
+                code: "export default () => null;\n",
+                filename: "/api/patterns/notes/notebook.tsx",
+                imports: [],
+              },
+            },
+            revisions: 1,
+          },
+        ],
+        [{ name: "" }],
+        run,
+      );
+
+    it("resolves the pattern of every piece a capped `kind` scan returns", async () => {
+      await quietModule((space) => {
+        // The module sorts last, so a scan that stopped at the cap never
+        // reached it. Assert that first: it is what keeps the assertion below
+        // from passing vacuously.
+        expect(
+          listEntityModels(space, { limit: 2 }).entities.map((e) => e.kind),
+        ).toEqual(["piece", "piece"]);
+
+        const listing = listEntityModels(space, { kind: "piece", limit: 2 });
+        expect(listing.extent.truncated).toBe(true);
+        expect(listing.entities.map((e) => e.lineage.pattern?.moduleId))
+          .toEqual(
+            ["of:mod", "of:mod"],
+          );
+      });
     });
   });
 });

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../model.ts";
 import { reconstructDocument } from "../reconstruct.ts";
 import { contentFingerprint } from "../fingerprint.ts";
-import { listScopes } from "../scopes.ts";
+import { listScopes, scopeOverlay } from "../scopes.ts";
 import { buildAllDetails } from "../detail.ts";
 import { buildSpaceGraph, subgraphAround } from "../graph.ts";
 import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
@@ -708,6 +708,69 @@ describe("scan-extent", () => {
         expect(shared(kid)).not.toBe(shared(root));
         expect(kid.perEntity.map((e) => e.scope)).toContain(MINE);
       });
+    });
+  });
+
+  describe("the standalone HTML explorer", () => {
+    it("marks a page missing an entity it could not reconstruct, not only a capped one", async () => {
+      await withSeeded(
+        [
+          { id: "of:good", document: { value: "readable" }, revisions: 1 },
+          { id: "of:bad", document: UNDECODABLE, revisions: 1 },
+        ],
+        [{ name: "" }],
+        (space) => {
+          const bundle = buildInspectorBundle(space);
+          // The cap was never reached, so the cap banner stays away — and
+          // before this the page said nothing at all, while its tree omitted an
+          // entity. A generated page outlives the stderr notice: it gets opened
+          // days later and shared with someone who never ran the command.
+          expect(bundle.extent).toMatchObject({
+            truncated: false,
+            unreadable: 1,
+          });
+          const html = renderInspectorHtml(bundle);
+          expect(html).not.toContain("capped at");
+          expect(html).toContain("could not be reconstructed");
+          expect(html).toContain("a higher --limit will not recover them");
+        },
+      );
+    });
+
+    it("shows the per-user cells of an entity a child branch inherited", async () => {
+      const MINE = "user:did:key:zBob";
+      await withSeeded(
+        [
+          { id: "of:shared", document: { value: "space value" }, revisions: 1 },
+          {
+            id: "of:shared",
+            document: { value: "bob's value" },
+            revisions: 1,
+            scope: MINE,
+          },
+          {
+            id: "of:kidonly",
+            document: { value: "kid" },
+            revisions: 1,
+            branch: "kid",
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 2 }],
+        (space) => {
+          // The scope list and the overlays have to describe one domain: a page
+          // naming a per-user scope while finding no cells in it reports the
+          // divergence as absent rather than as unreached.
+          const bundle = buildInspectorBundle(space, { branch: "kid" });
+          expect(bundle.scopes.map((s) => s.raw)).toContain(MINE);
+          expect(bundle.overlays.map((o) => o.id)).toEqual(["of:shared"]);
+          const overlay = scopeOverlay(space, "of:shared", { branch: "kid" });
+          expect(overlay.variants.map((v) => v.scope)).toEqual([
+            "space",
+            MINE,
+          ]);
+          expect(overlay.divergent).toBe(true);
+        },
+      );
     });
   });
 });

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -856,10 +856,14 @@ describe("scan-extent", () => {
           expect(capped.extent.truncated).toBe(true);
           expect(isCompleteScan(capped.extent)).toBe(false);
 
-          const whole = listEntityModels(space, { kind: "piece" });
-          expect(whole.extent.truncated).toBe(false);
-          expect(whole.extent.unreadable).toBe(1);
-          expect(isCompleteScan(whole.extent)).toBe(false);
+          // Still `kind: "piece"` — uncapped, not unfiltered. The distinction
+          // decides the expected count: a FILTERED scan drops the undecodable
+          // row and counts it, where an unfiltered one would keep it as
+          // `unknown` and report zero.
+          const uncapped = listEntityModels(space, { kind: "piece" });
+          expect(uncapped.extent.truncated).toBe(false);
+          expect(uncapped.extent.unreadable).toBe(1);
+          expect(isCompleteScan(uncapped.extent)).toBe(false);
         },
       );
     });

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -1,0 +1,285 @@
+/**
+ * A capped space-wide scan returns a SUBSET that looks exactly like a complete
+ * one. These tests pin the two properties that tell them apart: every capped
+ * scan reports how far it reached, and a `kind` filter selects DURING the scan
+ * so the limit counts the entities the caller asked for.
+ *
+ * The seeded space makes the two orders disagree on purpose — six busy free
+ * cells sort ahead of the three quiet pieces — because that is the shape where
+ * filtering after the scan returns "the pieces among the first N entities"
+ * rather than pieces, and the two are indistinguishable from the result.
+ */
+
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+
+import { openSpace, type SpaceDb } from "../db.ts";
+import {
+  countEntities,
+  entityKinds,
+  isEntityKind,
+  listEntityModels,
+} from "../model.ts";
+import { buildAllDetails } from "../detail.ts";
+import { buildSpaceGraph, subgraphAround } from "../graph.ts";
+import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 39, 'active');
+`;
+
+const SESSION = "session:did:key:zSpaceAAAA:11111111-2222-3333";
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+interface SeedEntity {
+  id: string;
+  /** The stored document, written once per revision. */
+  document: Record<string, unknown>;
+  revisions: number;
+}
+
+/** Six busy cells, one module, three quiet pieces — busiest scanned first. */
+const ENTITIES: SeedEntity[] = [
+  ...Array.from({ length: 6 }, (_, i) => ({
+    id: `of:cell-${i + 1}`,
+    document: { value: `cell ${i + 1}` },
+    revisions: 5,
+  })),
+  {
+    id: "of:mod",
+    document: {
+      value: {
+        kind: "source",
+        identity: MODULE_IDENTITY,
+        code: "export default () => null;\n",
+        filename: "/api/patterns/notes/notebook.tsx",
+        imports: [],
+      },
+    },
+    revisions: 2,
+  },
+  ...Array.from({ length: 3 }, (_, i) => ({
+    id: `of:piece-${i + 1}`,
+    document: {
+      value: { $NAME: `Topic ${i + 1}` },
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+    },
+    revisions: 1,
+  })),
+];
+
+const TOTAL = ENTITIES.length;
+const PIECES = ENTITIES.filter((e) => e.id.startsWith("of:piece-")).length;
+
+function seed(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  for (const entity of ENTITIES) {
+    for (let n = 0; n < entity.revisions; n++) {
+      seq++;
+      commit.run(seq, SESSION, seq);
+      rev.run(entity.id, seq, JSON.stringify(entity.document), seq);
+    }
+  }
+  db.close();
+}
+
+describe("scan-extent", () => {
+  let dir: string;
+  let space: SpaceDb;
+
+  beforeAll(async () => {
+    dir = await Deno.makeTempDir({ prefix: "state-inspector-scan-extent-" });
+    seed(`${dir}/space.sqlite`);
+    space = openSpace(`${dir}/space.sqlite`);
+  });
+
+  afterAll(async () => {
+    space.close();
+    await Deno.remove(dir, { recursive: true });
+  });
+
+  describe("countEntities()", () => {
+    it("returns every entity on the branch and scope, however busy each is", () => {
+      expect(countEntities(space)).toBe(TOTAL);
+    });
+
+    it("returns 0 for a scope the space stores nothing under", () => {
+      expect(countEntities(space, { scope: "user:did:key:zNobody" })).toBe(0);
+    });
+  });
+
+  describe("entityKinds", () => {
+    it("names every kind a listing presents, in the order it presents them", () => {
+      expect(entityKinds).toEqual([
+        "piece",
+        "module",
+        "stream",
+        "schema",
+        "owned-cell",
+        "free-cell",
+        "unknown",
+      ]);
+    });
+  });
+
+  describe("isEntityKind()", () => {
+    it("returns true for a name a listing presents", () => {
+      expect(isEntityKind("owned-cell")).toBe(true);
+    });
+
+    it("returns false for a plural spelling of one", () => {
+      expect(isEntityKind("pieces")).toBe(false);
+    });
+  });
+
+  describe("listEntityModels()", () => {
+    it("returns the entities the limit allowed and reports the result truncated", () => {
+      const listing = listEntityModels(space, { limit: 3 });
+      expect(listing.entities.length).toBe(3);
+      expect(listing.extent).toEqual({
+        limit: 3,
+        total: TOTAL,
+        truncated: true,
+      });
+    });
+
+    it("reports truncation one below the entity count and not at it", () => {
+      expect(listEntityModels(space, { limit: TOTAL - 1 }).extent.truncated)
+        .toBe(true);
+      const whole = listEntityModels(space, { limit: TOTAL });
+      expect(whole.entities.length).toBe(TOTAL);
+      expect(whole.extent.truncated).toBe(false);
+    });
+
+    it("returns up to `limit` entities OF the requested kind, not the kinds among the first `limit` entities", () => {
+      // The scan runs busiest-first, and at this limit it reaches only cells,
+      // so a filter applied to its RESULT would return nothing. Assert that
+      // first: it is what keeps the assertion below from passing vacuously.
+      const unfiltered = listEntityModels(space, { limit: 6 });
+      expect(unfiltered.entities.filter((e) => e.kind === "piece")).toEqual([]);
+
+      const listing = listEntityModels(space, { kind: "piece", limit: 6 });
+      expect(listing.entities.map((e) => e.kind)).toEqual(
+        Array(PIECES).fill("piece"),
+      );
+      expect(listing.extent.truncated).toBe(false);
+    });
+
+    it("reports truncation when the space holds more of the requested kind than the limit", () => {
+      const listing = listEntityModels(space, { kind: "piece", limit: 2 });
+      expect(listing.entities.length).toBe(2);
+      expect(listing.extent).toEqual({
+        limit: 2,
+        total: TOTAL,
+        truncated: true,
+      });
+    });
+
+    it("resolves a piece's pattern module across the entities the filter dropped", () => {
+      const listing = listEntityModels(space, { kind: "piece" });
+      expect(listing.entities.map((e) => e.lineage.pattern?.moduleId)).toEqual(
+        Array(PIECES).fill("of:mod"),
+      );
+    });
+
+    it("returns no entities for a kind the space holds none of", () => {
+      const listing = listEntityModels(space, { kind: "schema" });
+      expect(listing.entities).toEqual([]);
+      expect(listing.extent.truncated).toBe(false);
+    });
+
+    it("returns nothing but reports truncation for a limit below one", () => {
+      const listing = listEntityModels(space, { limit: 0 });
+      expect(listing.entities).toEqual([]);
+      expect(listing.extent).toEqual({
+        limit: 0,
+        total: TOTAL,
+        truncated: true,
+      });
+    });
+  });
+
+  describe("buildSpaceGraph()", () => {
+    it("returns the cap it applied and that the space outran it", () => {
+      const graph = buildSpaceGraph(space, { limit: 3 });
+      expect(graph.extent).toEqual({ limit: 3, total: TOTAL, truncated: true });
+    });
+
+    it("returns `truncated` false for a limit the whole space fits inside", () => {
+      const graph = buildSpaceGraph(space, { limit: TOTAL });
+      expect(graph.extent.truncated).toBe(false);
+    });
+  });
+
+  describe("subgraphAround()", () => {
+    it("returns the extent of the scan the neighborhood was cut from", () => {
+      const graph = buildSpaceGraph(space, { limit: 3 });
+      expect(subgraphAround(graph, "of:cell-1", 2).extent).toEqual(
+        graph.extent,
+      );
+    });
+  });
+
+  describe("buildAllDetails()", () => {
+    it("returns the details the limit allowed and reports the pass truncated", () => {
+      const listing = buildAllDetails(space, { limit: 3 });
+      expect(listing.details.length).toBe(3);
+      expect(listing.extent).toEqual({
+        limit: 3,
+        total: TOTAL,
+        truncated: true,
+      });
+    });
+
+    it("returns `truncated` false for a limit the whole space fits inside", () => {
+      expect(buildAllDetails(space, { limit: TOTAL }).extent.truncated).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("renderInspectorHtml()", () => {
+    it("names the cap and the space's entity count in a truncated explorer", () => {
+      const html = renderInspectorHtml(
+        buildInspectorBundle(space, { limit: 3 }),
+      );
+      expect(html).toContain(`capped at 3 of ${TOTAL} entities`);
+    });
+
+    it("says nothing about a cap in an explorer that covers the space", () => {
+      const html = renderInspectorHtml(
+        buildInspectorBundle(space, { limit: TOTAL }),
+      );
+      expect(html).not.toContain("capped at");
+    });
+  });
+});

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -793,6 +793,77 @@ describe("scan-extent", () => {
       );
     });
 
+    it("does not count a document whose shape classifies as `unknown`", async () => {
+      await withSeeded(
+        [
+          {
+            id: "of:piece-1",
+            document: {
+              value: { $NAME: "Topic" },
+              patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+            },
+            revisions: 1,
+          },
+          // Decodes fine; its shape is simply not one the model names. Its kind
+          // WAS determined — `unknown` — so dropping it is an answer, not a gap.
+          { id: "of:odd", document: { cfc: {}, slug: "x" }, revisions: 1 },
+        ],
+        [{ name: "" }],
+        (space) => {
+          const listing = listEntityModels(space, { kind: "piece" });
+          expect(listing.entities.map((e) => e.id)).toEqual(["of:piece-1"]);
+          expect(listing.extent.unreadable).toBe(0);
+          expect(isCompleteScan(listing.extent)).toBe(true);
+        },
+      );
+    });
+
+    it("already reports itself truncated whenever the module walk runs past the cap", async () => {
+      const MODULE = {
+        value: {
+          kind: "source",
+          identity: MODULE_IDENTITY,
+          code: "export default () => null;\n",
+          filename: "/api/patterns/notes/notebook.tsx",
+          imports: [],
+        },
+      };
+      await withSeeded(
+        [
+          ...Array.from({ length: 2 }, (_, i) => ({
+            id: `of:piece-${i + 1}`,
+            document: {
+              value: { $NAME: "Topic" },
+              patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+            },
+            revisions: 3,
+          })),
+          // Both sit past a cap of 1, so only the module walk reaches them.
+          { id: "of:bad", document: UNDECODABLE, revisions: 2 },
+          { id: "of:mod", document: MODULE, revisions: 1 },
+        ],
+        [{ name: "" }],
+        (space) => {
+          // The walk resolves the module and passes an undecodable row on the
+          // way, which it does not count. It does not have to: the walk is
+          // reachable ONLY after collection stopped at the cap, so the result
+          // already reports itself incomplete, and raising the limit hands the
+          // same row to the pass that DOES count it. Both halves asserted here,
+          // because the invariant lives in the loop bounds and nothing else
+          // would notice if an edit broke it.
+          const capped = listEntityModels(space, { kind: "piece", limit: 1 });
+          expect(capped.entities[0].lineage.pattern?.moduleId).toBe("of:mod");
+          expect(capped.extent.truncated).toBe(true);
+          expect(isCompleteScan(capped.extent)).toBe(false);
+
+          const whole = listEntityModels(space, { kind: "piece" });
+          expect(whole.extent.truncated).toBe(false);
+          expect(whole.extent.unreadable).toBe(1);
+          expect(isCompleteScan(whole.extent)).toBe(false);
+        },
+      );
+    });
+
     it("does not count a tombstone the filter dropped, which is no error", async () => {
       await withSeeded(
         [

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -711,6 +711,52 @@ describe("scan-extent", () => {
     });
   });
 
+  describe("an entity deleted in one scope and live in another", () => {
+    const MINE = "user:did:key:zBob";
+    /** Shared value kept; the per-user copy written and then deleted. */
+    const halfDeleted = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          { id: "of:x", document: { value: "shared" }, revisions: 1 },
+          {
+            id: "of:x",
+            document: { value: "bob's" },
+            revisions: 1,
+            scope: MINE,
+            deleted: true,
+          },
+        ],
+        [{ name: "" }],
+        run,
+      );
+
+    it("reports the deletion as divergence rather than dropping the scope", async () => {
+      await halfDeleted((space) => {
+        // `visibleRevisionRows` enumerates RECORDS, so a tombstoned head still
+        // reaches the overlay. Filtering tombstones there would leave one
+        // variant and report `divergent: false` — erasing the very difference
+        // an overlay is for. `visibleEntityRows` is the read-visible set.
+        const overlay = scopeOverlay(space, "of:x");
+        expect(overlay.variants.map((v) => `${v.scope}=${v.summary}`)).toEqual([
+          `space="shared"`,
+          `${MINE}=(absent)`,
+        ]);
+        expect(overlay.divergent).toBe(true);
+      });
+    });
+
+    it("keeps the scope out of the read-visible entity rows", async () => {
+      await halfDeleted((space) => {
+        expect(visibleEntityRows(space, { scope: MINE })).toEqual([]);
+        expect(
+          visibleEntityRows(space, { scope: MINE, includeDeleted: true }).map((
+            r,
+          ) => r.id),
+        ).toEqual(["of:x"]);
+      });
+    });
+  });
+
   describe("the standalone HTML explorer", () => {
     it("marks a page missing an entity it could not reconstruct, not only a capped one", async () => {
       await withSeeded(

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -757,6 +757,113 @@ describe("scan-extent", () => {
     });
   });
 
+  describe("a `kind` scan meeting a row it cannot classify", () => {
+    it("counts the unclassifiable row it dropped, so strictness can refuse", async () => {
+      await withSeeded(
+        [
+          {
+            id: "of:piece-1",
+            document: {
+              value: { $NAME: "Topic" },
+              patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+            },
+            revisions: 1,
+          },
+          { id: "of:bad", document: UNDECODABLE, revisions: 1 },
+        ],
+        [{ name: "" }],
+        (space) => {
+          // The filter drops the undecodable row because its kind cannot be
+          // determined — which is precisely why the omission has to be
+          // reported. `topics-export.ts` runs this exact scan under
+          // `--require-complete` to guard a rollback payload.
+          const listing = listEntityModels(space, { kind: "piece" });
+          expect(listing.entities.map((e) => e.id)).toEqual(["of:piece-1"]);
+          expect(listing.extent.unreadable).toBe(1);
+          expect(isCompleteScan(listing.extent)).toBe(false);
+
+          // Unfiltered keeps it, modeled `unknown`, so nothing is missing.
+          const all = listEntityModels(space);
+          expect(all.entities.map((e) => e.id).sort()).toEqual([
+            "of:bad",
+            "of:piece-1",
+          ]);
+          expect(isCompleteScan(all.extent)).toBe(true);
+        },
+      );
+    });
+
+    it("does not count a tombstone the filter dropped, which is no error", async () => {
+      await withSeeded(
+        [
+          {
+            id: "of:piece-1",
+            document: {
+              value: { $NAME: "Topic" },
+              patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+            },
+            revisions: 1,
+          },
+          {
+            id: "of:gone",
+            document: { value: "was here" },
+            revisions: 1,
+            deleted: true,
+          },
+        ],
+        [{ name: "" }],
+        (space) => {
+          // A deleted entity is definitively not a piece. Only a row whose kind
+          // could not be DETERMINED is a gap in the answer.
+          const listing = listEntityModels(space, { kind: "piece" });
+          expect(listing.entities.map((e) => e.id)).toEqual(["of:piece-1"]);
+          expect(listing.extent.unreadable).toBe(0);
+          expect(isCompleteScan(listing.extent)).toBe(true);
+        },
+      );
+    });
+  });
+
+  describe("a detail pass over a branch's own and inherited entities", () => {
+    /** `of:kept` inherited untouched; `of:override` rewritten on the child. */
+    const forked = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          { id: "of:kept", document: { value: "p1" }, revisions: 2 },
+          { id: "of:override", document: { value: "parent" }, revisions: 1 },
+          {
+            id: "of:override",
+            document: { value: "child" },
+            revisions: 1,
+            branch: "kid",
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 3 }],
+        run,
+      );
+
+    it("reports only the overriding branch's history for an entity the child rewrote", async () => {
+      await forked((space) => {
+        const detail = buildAllDetails(space, { branch: "kid" }).details
+          .find((d) => d.id === "of:override");
+        // The value came from the child alone — `reconstructWithinBranch` never
+        // composes across the fork — so crediting this entity with the parent's
+        // writes would report revisions no read from here can reach.
+        expect(detail?.versions.map((v) => v.seq)).toEqual([4]);
+        expect(detail?.revisions).toBe(1);
+      });
+    });
+
+    it("reports the parent's history for an entity the child only inherited", async () => {
+      await forked((space) => {
+        const detail = buildAllDetails(space, { branch: "kid" }).details
+          .find((d) => d.id === "of:kept");
+        expect(detail?.versions.map((v) => v.seq)).toEqual([1, 2]);
+        expect(detail?.revisions).toBe(2);
+      });
+    });
+  });
+
   describe("the standalone HTML explorer", () => {
     it("marks a page missing an entity it could not reconstruct, not only a capped one", async () => {
       await withSeeded(

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -17,12 +17,17 @@ import { Database } from "@db/sqlite";
 import { openSpace, type SpaceDb } from "../db.ts";
 import {
   countEntities,
+  DEFAULT_SCAN_LIMIT,
   entityKinds,
+  isCompleteScan,
   isEntityKind,
   listEntityModels,
+  scanLimit,
   visibleEntityRows,
 } from "../model.ts";
 import { reconstructDocument } from "../reconstruct.ts";
+import { contentFingerprint } from "../fingerprint.ts";
+import { listScopes } from "../scopes.ts";
 import { buildAllDetails } from "../detail.ts";
 import { buildSpaceGraph, subgraphAround } from "../graph.ts";
 import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
@@ -60,7 +65,15 @@ interface SeedEntity {
   branch?: string;
   /** Written after the revisions: the entity's visible head is a tombstone. */
   deleted?: boolean;
+  /** Scope the revisions are written under. Defaults to the shared scope. */
+  scope?: string;
 }
+
+/** A stored payload `decodeStored` cannot read, standing in for a bad write. */
+const UNDECODABLE = "<<< not a document >>>" as unknown as Record<
+  string,
+  unknown
+>;
 
 /** Six busy cells, one module, three quiet pieces — busiest scanned first. */
 const ENTITIES: SeedEntity[] = [
@@ -114,19 +127,25 @@ function seed(
      VALUES (?, ?, ?, ?, '{}', '{}')`,
   );
   const rev = db.prepare(
-    `INSERT INTO revision (branch, id, seq, op_index, op, data, commit_seq)
-     VALUES (?, ?, ?, 0, ?, ?, ?)`,
+    `INSERT INTO revision (branch, id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, ?, 0, ?, ?, ?)`,
   );
   let seq = 0;
   const write = (entity: SeedEntity, op: string, data: string | null) => {
     seq++;
     const branch = entity.branch ?? "";
     commit.run(seq, branch, SESSION, seq);
-    rev.run(branch, entity.id, seq, op, data, seq);
+    rev.run(branch, entity.id, entity.scope ?? "space", seq, op, data, seq);
   };
   for (const entity of entities) {
     for (let n = 0; n < entity.revisions; n++) {
-      write(entity, "set", JSON.stringify(entity.document));
+      write(
+        entity,
+        "set",
+        entity.document === UNDECODABLE
+          ? (UNDECODABLE as unknown as string)
+          : JSON.stringify(entity.document),
+      );
     }
     if (entity.deleted) write(entity, "delete", null);
   }
@@ -215,6 +234,7 @@ describe("scan-extent", () => {
         limit: 3,
         total: TOTAL,
         truncated: true,
+        unreadable: 0,
       });
     });
 
@@ -247,6 +267,7 @@ describe("scan-extent", () => {
         limit: 2,
         total: TOTAL,
         truncated: true,
+        unreadable: 0,
       });
     });
 
@@ -270,6 +291,7 @@ describe("scan-extent", () => {
         limit: 0,
         total: TOTAL,
         truncated: true,
+        unreadable: 0,
       });
     });
   });
@@ -277,7 +299,12 @@ describe("scan-extent", () => {
   describe("buildSpaceGraph()", () => {
     it("returns the cap it applied and that the space outran it", () => {
       const graph = buildSpaceGraph(space, { limit: 3 });
-      expect(graph.extent).toEqual({ limit: 3, total: TOTAL, truncated: true });
+      expect(graph.extent).toEqual({
+        limit: 3,
+        total: TOTAL,
+        truncated: true,
+        unreadable: 0,
+      });
     });
 
     it("returns `truncated` false for a limit the whole space fits inside", () => {
@@ -303,6 +330,7 @@ describe("scan-extent", () => {
         limit: 3,
         total: TOTAL,
         truncated: true,
+        unreadable: 0,
       });
     });
 
@@ -432,7 +460,12 @@ describe("scan-extent", () => {
     it("counts the inherited entities in the extent rather than reporting a complete listing", async () => {
       await inherited((kidSpace) => {
         const listing = listEntityModels(kidSpace, { branch: "kid", limit: 2 });
-        expect(listing.extent).toEqual({ limit: 2, total: 4, truncated: true });
+        expect(listing.extent).toEqual({
+          limit: 2,
+          total: 4,
+          truncated: true,
+          unreadable: 0,
+        });
       });
     });
 
@@ -478,6 +511,7 @@ describe("scan-extent", () => {
           limit: 2,
           total: 2,
           truncated: false,
+          unreadable: 0,
         });
       });
     });
@@ -488,6 +522,7 @@ describe("scan-extent", () => {
           limit: 2,
           total: 2,
           truncated: false,
+          unreadable: 0,
         });
       });
     });
@@ -548,6 +583,130 @@ describe("scan-extent", () => {
           .toEqual(
             ["of:mod", "of:mod"],
           );
+      });
+    });
+  });
+
+  describe("scanLimit()", () => {
+    it("floors a fractional limit, which no entity count could ever equal", () => {
+      expect(scanLimit(1.5)).toBe(1);
+      expect(scanLimit(-3)).toBe(0);
+      expect(scanLimit(undefined)).toBe(DEFAULT_SCAN_LIMIT);
+      expect(scanLimit(NaN)).toBe(DEFAULT_SCAN_LIMIT);
+    });
+  });
+
+  describe("a fractional limit", () => {
+    it("caps every scan the same way rather than passing through one of them", async () => {
+      await withSeeded(cells(2, 1), [{ name: "" }], (space) => {
+        // Before normalizing, `kept.length === limit` could never hold against
+        // 1.5, so the entity listing returned BOTH entities while detail and
+        // graph returned one — three scans disagreeing on one input.
+        expect(listEntityModels(space, { limit: 1.5 }).entities.length).toBe(1);
+        expect(buildAllDetails(space, { limit: 1.5 }).details.length).toBe(1);
+        expect(buildSpaceGraph(space, { limit: 1.5 }).extent).toEqual({
+          limit: 1,
+          total: 2,
+          truncated: true,
+          unreadable: 0,
+        });
+      });
+    });
+  });
+
+  describe("a space holding an entity that will not decode", () => {
+    /** One readable entity and one whose stored payload is not decodable. */
+    const withCorrupt = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          { id: "of:good", document: { value: "readable" }, revisions: 1 },
+          { id: "of:bad", document: UNDECODABLE, revisions: 1 },
+        ],
+        [{ name: "" }],
+        run,
+      );
+
+    it("counts the entity a detail pass could not describe rather than dropping it silently", async () => {
+      await withCorrupt((space) => {
+        const listing = buildAllDetails(space);
+        expect(listing.details.map((d) => d.id)).toEqual(["of:good"]);
+        // `truncated` stays false — the cap was never reached — so without a
+        // count of its own this pass would report itself complete over one of
+        // two entities, and `--require-complete` would exit 0.
+        expect(listing.extent.truncated).toBe(false);
+        expect(listing.extent.unreadable).toBe(1);
+        expect(isCompleteScan(listing.extent)).toBe(false);
+      });
+    });
+
+    it("counts the entity a graph could not place", async () => {
+      await withCorrupt((space) => {
+        const graph = buildSpaceGraph(space);
+        expect(graph.extent.unreadable).toBe(1);
+        expect(isCompleteScan(graph.extent)).toBe(false);
+      });
+    });
+
+    it("reports the entity listing complete, because it returns a row for one it cannot read", async () => {
+      await withCorrupt((space) => {
+        const listing = listEntityModels(space);
+        expect(listing.entities.map((e) => e.id).sort()).toEqual([
+          "of:bad",
+          "of:good",
+        ]);
+        expect(listing.extent.unreadable).toBe(0);
+        expect(isCompleteScan(listing.extent)).toBe(true);
+      });
+    });
+  });
+
+  describe("a fingerprint of a child branch", () => {
+    const MINE = "user:did:key:zBob";
+    /** A parent entity the child overrides, and a parent-only user scope. */
+    const forked = (run: (space: SpaceDb) => void) =>
+      withSeeded(
+        [
+          { id: "of:shared", document: { value: "PARENT" }, revisions: 1 },
+          {
+            id: "of:mine",
+            document: { value: "parent user state" },
+            revisions: 1,
+            scope: MINE,
+          },
+          {
+            id: "of:shared",
+            document: { value: "CHILD" },
+            revisions: 1,
+            branch: "kid",
+          },
+        ],
+        [{ name: "" }, { name: "kid", parent: "", forkSeq: 2 }],
+        run,
+      );
+
+    it("enumerates the per-user scope the child inherited rather than only its own", async () => {
+      await forked((space) => {
+        expect(listScopes(space, { branch: "kid" }).map((s) => s.raw)).toEqual(
+          listScopes(space).map((s) => s.raw),
+        );
+        expect(listScopes(space, { branch: "kid" }).map((s) => s.raw))
+          .toContain(MINE);
+      });
+    });
+
+    it("hashes the value the branch reads, not the parent's", async () => {
+      await forked((space) => {
+        // The read resolves the child's override; a fingerprint that hashed the
+        // default branch would certify two different contents as identical —
+        // the one failure this module exists to prevent.
+        expect(reconstructDocument(space, { id: "of:shared", branch: "kid" }))
+          .toEqual({ value: "CHILD" });
+        const kid = contentFingerprint(space, { branch: "kid" });
+        const root = contentFingerprint(space);
+        const shared = (r: typeof kid) =>
+          r.perEntity.find((e) => e.id === "of:shared")?.hash;
+        expect(shared(kid)).not.toBe(shared(root));
+        expect(kid.perEntity.map((e) => e.scope)).toContain(MINE);
       });
     });
   });

--- a/scripts/topics-export.ts
+++ b/scripts/topics-export.ts
@@ -76,10 +76,12 @@ const didMatch = /(did:key:[A-Za-z0-9]+)\.sqlite$/.exec(snapshot);
 const spaceDid = didMatch ? didMatch[1] : null;
 
 // A capped listing would hand the export a subset of the space's pieces, and a
-// rollback payload missing topics reads exactly like a complete one. A `--kind`
-// scan walks the whole space whenever the space holds fewer pieces than the
-// limit, so naming a limit past any plausible piece count costs nothing and
-// removes the cliff entirely.
+// rollback payload missing topics reads exactly like a complete one. The limit
+// is named past any plausible piece count so the cap never bites in practice —
+// but a finite cap is still a cliff, and `cfJson` reads only stdout, so the
+// notice `cf` writes to stderr would go by unseen. `--require-complete` turns
+// the same condition into a nonzero exit, which `cf()` DOES raise: the export
+// either covers every piece in the space or it does not get written.
 const PIECE_LIMIT = 1_000_000;
 
 const pieces = await cfJson<EntityRow[]>([
@@ -90,6 +92,7 @@ const pieces = await cfJson<EntityRow[]>([
   "piece",
   "--limit",
   String(PIECE_LIMIT),
+  "--require-complete",
   "--json",
 ]);
 

--- a/scripts/topics-export.ts
+++ b/scripts/topics-export.ts
@@ -75,12 +75,21 @@ if (!snapshot || positional.length > 1 || !outPath) usage();
 const didMatch = /(did:key:[A-Za-z0-9]+)\.sqlite$/.exec(snapshot);
 const spaceDid = didMatch ? didMatch[1] : null;
 
+// A capped listing would hand the export a subset of the space's pieces, and a
+// rollback payload missing topics reads exactly like a complete one. A `--kind`
+// scan walks the whole space whenever the space holds fewer pieces than the
+// limit, so naming a limit past any plausible piece count costs nothing and
+// removes the cliff entirely.
+const PIECE_LIMIT = 1_000_000;
+
 const pieces = await cfJson<EntityRow[]>([
   "inspect",
   "entities",
   snapshot,
   "--kind",
   "piece",
+  "--limit",
+  String(PIECE_LIMIT),
   "--json",
 ]);
 

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -214,8 +214,10 @@ fixed recipe. The recurring debugging questions and where they resolve:
   `entities --kind` selects _during_ the scan, so `--limit` counts entities of
   that kind, not entities walked to find them. **Scripting a backup or rollback
   payload? Pass `--require-complete`** — a capped scan then exits nonzero with
-  nothing on stdout, so an incomplete payload cannot be written by a pipeline
-  that only checks the exit code. The other caps stay silent —
+  nothing on stdout. Check that status where it is produced: a shell pipeline
+  reports its LAST command's status, so a scan piped into `jq` and a redirect
+  refuses, and the redirect still writes an empty file and reports success.
+  Capture the scan on its own, or set `pipefail`. The other caps stay silent —
   history/hot/contention row limits, and the HTML stale-read pass, which caps
   per bundle and _marks_ un-analyzed cells rather than showing them clean. There
   a count equal to a round cap is still the tell.

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -217,7 +217,9 @@ fixed recipe. The recurring debugging questions and where they resolve:
   nothing on stdout. Check that status where it is produced: a shell pipeline
   reports its LAST command's status, so a scan piped into `jq` and a redirect
   refuses, and the redirect still writes an empty file and reports success.
-  Capture the scan on its own, or set `pipefail`. The other caps stay silent —
+  Capture the scan on its own, or set `pipefail`. It refuses for either kind of
+  incompleteness — a cap reached, or an entity that would not reconstruct, which
+  a higher `--limit` never recovers. The other caps stay silent —
   history/hot/contention row limits, and the HTML stale-read pass, which caps
   per bundle and _marks_ un-analyzed cells rather than showing them clean. There
   a count equal to a round cap is still the tell.

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -207,10 +207,15 @@ fixed recipe. The recurring debugging questions and where they resolve:
   v2 stage C.2, and the tool no longer reads them even from an old snapshot that
   still contains them. The entity-history surface always works; the basis table
   absent (pre-migration store) or empty is normal, not a broken DB.
-- **Lists and the bundle are capped** (e.g. history/hot/graph/contention have
-  limits; the HTML stale-read pass caps per bundle and _marks_ un-analyzed cells
-  rather than showing them clean). When a count equals a round cap, suspect
-  truncation and narrow with flags or a per-entity command.
+- **A capped result announces itself — and the caps that don't are the ones to
+  watch.** The space-wide scans (`entities`, `graph`, `html`) print a cap notice
+  on stderr in _both_ modes, so silence there means you hold the whole set; a
+  `--json` consumer that discards stderr discards the only warning it gets.
+  `entities --kind` selects _during_ the scan, so `--limit` counts entities of
+  that kind, not entities walked to find them. The other caps stay silent —
+  history/hot/contention row limits, and the HTML stale-read pass, which caps
+  per bundle and _marks_ un-analyzed cells rather than showing them clean. There
+  a count equal to a round cap is still the tell.
 - **`--json` is the agent path.** Human output elides; for anything you parse or
   chain, pass `--json`.
 - **It reads DBs it didn't write.** A corrupt/partial row degrades that one

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -212,7 +212,10 @@ fixed recipe. The recurring debugging questions and where they resolve:
   on stderr in _both_ modes, so silence there means you hold the whole set; a
   `--json` consumer that discards stderr discards the only warning it gets.
   `entities --kind` selects _during_ the scan, so `--limit` counts entities of
-  that kind, not entities walked to find them. The other caps stay silent —
+  that kind, not entities walked to find them. **Scripting a backup or rollback
+  payload? Pass `--require-complete`** — a capped scan then exits nonzero with
+  nothing on stdout, so an incomplete payload cannot be written by a pipeline
+  that only checks the exit code. The other caps stay silent —
   history/hot/contention row limits, and the HTML stale-read pass, which caps
   per bundle and _marks_ un-analyzed cells rather than showing them clean. There
   a count equal to a round cap is still the tell.


### PR DESCRIPTION
`cf inspect entities` caps at `--limit` (5,000 by default) and said nothing about it. Measured against a real space: a store whose clone manifest reports **44,596 entities** returned exactly **5,000 rows** under a kind-count legend and table that read like the whole space. An operator scripting `--json` got a subset shaped exactly like a complete answer.

`--kind` compounded it. The action called `listEntityModels(s, {limit, branch})` and only then did `rows.filter(r => r.kind === options.kind)` — so `--kind piece` meant "the pieces among the first N entities of any kind," not "up to N pieces." On that space, owned cells took **4,351 of the first 5,000**, and the piece listing came back with **225**. The space actually holds **9,420 pieces**; the listing was showing 2.4% of them, and silently omitted **27 topic pieces that the board's own argument links to**.

That is not a cosmetic gap. `scripts/topics-export.ts` discovers topics through exactly this call, and its output is the **rollback payload** for live pattern migrations; the manifest recipe in `docs/plans/topics-migration-rehearsal.md` has the same shape. A rollback payload missing topics reads exactly like a complete one.

## What changed

Every space-wide scan now returns a `ScanExtent` — the cap it applied, the entities the space holds, and whether more remain. `truncated` is proven by reaching for one row past the limit, not inferred from a count landing on a round number.

- `entities`, `graph`, and `html` announce a capped result **on stderr in both modes**. stdout is untouched, so `--json` consumers keep parsing the same bare array — an envelope would have broken `topics-export.ts`, the rehearsal doc's `jq` recipe, and every ad-hoc pipeline, permanently, for a condition most runs never hit. Silence on stderr now means the result IS the whole set.
- `graph --json` also carries `extent` in-band, where the shape already had room; the HTML header marks a capped page (and `inspect html` gains the `--limit` it never had, so a capped explorer is now fixable as well as visible).
- **`--kind` selects during the scan**, so `--limit` governs the filtered set. The scan walks until it has enough matches — costlier than an unfiltered scan, and it returns the set the flag reads like. A kind no entity classifies as is refused before the space opens.
- `fingerprint.ts` drops its `models.length >= cap` heuristic for the exact flag, losing a false alarm on a space that holds exactly `cap` entities.
- `topics-export.ts` names a limit past any plausible piece count and passes `--require-complete`; if that finite ceiling is ever reached, the export exits nonzero before writing a rollback payload.

**Left alone, deliberately:** the `history` / `hot` / `conflicts` row limits and the HTML stale-read pass stay silent — different in kind, and the stale-read pass already marks un-analyzed cells rather than showing them clean. Both README and SKILL now say which caps announce themselves and which do not.

Tests cover truncation firing at the cap and not one below it, `--kind` + limit composition (asserting first that the unfiltered scan at that limit reaches *no* piece, so the test cannot pass vacuously), the `--json` stdout shape, and the decline paths.

Verified end-to-end against the space that exposed the bug: the notice fires, and an uncapped `--kind piece` scan now returns all 9,420 pieces with **zero** board-linked topics missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

