### PR TITLE
Let call classification see through a `satisfies` constraint

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -36,6 +36,7 @@ import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import { getCallArgumentPosition } from "./call-arguments.ts";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
 import {
@@ -1522,26 +1523,21 @@ function isMultiApplicationChain(outerCall: ts.CallExpression): boolean {
   return ts.isCallExpression(innerCalleeCallee);
 }
 
+/**
+ * Peels the non-semantic wrappers that can stand between a call site and the
+ * expression it is really about — parentheses, `as T`, `<T>x`, `satisfies T`,
+ * and `!`. Classification asks what an expression *is*, and none of these
+ * change that, so all of them come off before any node-kind test runs.
+ *
+ * Delegates to the shared {@link unwrapExpression} so the wrapper list has a
+ * single definition and a wrapper spelling cannot be handled in one resolver
+ * and missed in another. `includePartiallyEmitted` stays off: a
+ * PartiallyEmittedExpression marks a node the emit pipeline has already
+ * rewritten, which is a different question from the authored shapes classified
+ * here.
+ */
 function stripWrappers(expression: ts.Expression): ts.Expression {
-  let current: ts.Expression = expression;
-
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    break;
-  }
-
-  return current;
+  return unwrapExpression(expression, { includePartiallyEmitted: false });
 }
 
 function stripInitializerAccess(expression: ts.Expression): ts.Expression {

--- a/packages/ts-transformers/test/ast/call-kind.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind.test.ts
@@ -10,6 +10,7 @@ import {
   getCapabilitySummaryCallbackArgument,
   getLiftAppliedInputAndCallback,
   getPatternBuilderCallbackArgument,
+  resolveCallbackFunctionExpression,
 } from "../../src/ast/mod.ts";
 import { getWithPatternHoistablePatternCall } from "../../src/ast/call-kind.ts";
 
@@ -71,6 +72,27 @@ function findInitializer(
 
   if (!found) {
     throw new Error(`Initializer for ${declarationName} not found`);
+  }
+
+  return found;
+}
+
+function findFirstArrowFunction(sourceFile: ts.SourceFile): ts.ArrowFunction {
+  let found: ts.ArrowFunction | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isArrowFunction(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  if (!found) {
+    throw new Error("Arrow function not found");
   }
 
   return found;
@@ -484,4 +506,50 @@ Deno.test("detectCallKind ignores a builder-named import from a foreign module",
   }
 
   assertEquals(detectCallKind(expression, checker), undefined);
+});
+
+Deno.test("resolveCallbackFunctionExpression sees through a `satisfies` cast", () => {
+  // `satisfies T` states a constraint and leaves the value alone, so it hides
+  // a callback no more than `as T` or parentheses do. Callers that ask "is
+  // this argument the callback?" must answer yes through every one of those
+  // spellings, and callers that go on to use the returned node as an anchor
+  // need the authored arrow itself, not a wrapper standing in front of it.
+  const { sourceFile, checker } = createProgram(`
+    type Handler = (event: { word: string }, state: { count: number }) => void;
+
+    const value = ((event, state) => {}) satisfies Handler;
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isSatisfiesExpression(expression)) {
+    throw new Error("Expected satisfies expression initializer");
+  }
+
+  assertEquals(
+    resolveCallbackFunctionExpression(expression, checker),
+    findFirstArrowFunction(sourceFile),
+  );
+});
+
+Deno.test("resolveCallbackFunctionExpression sees through a `satisfies`-wrapped alias initializer", () => {
+  // The alias is annotated `any`, so the type carries no call signatures and
+  // the only route to the callback is the syntactic one: identifier to
+  // variable initializer, then through the wrapper.
+  const { sourceFile, checker } = createProgram(`
+    type Handler = (event: { word: string }, state: { count: number }) => void;
+
+    const callback: any = ((event, state) => {}) satisfies Handler;
+
+    const value = callback;
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isIdentifier(expression)) {
+    throw new Error("Expected identifier initializer");
+  }
+
+  assertEquals(
+    resolveCallbackFunctionExpression(expression, checker),
+    findFirstArrowFunction(sourceFile),
+  );
 });

--- a/packages/ts-transformers/test/schema-first-imported-callback.test.ts
+++ b/packages/ts-transformers/test/schema-first-imported-callback.test.ts
@@ -22,6 +22,11 @@ export const echoAny: any = ((event: Ping) => ({
   echoed: event.word,
   // deno-lint-ignore no-explicit-any
 })) as any;
+export type EchoHandler = (event: Ping) => PingResult;
+// deno-lint-ignore no-explicit-any
+export const echoSatisfies: any = ((event: Ping) => ({
+  echoed: event.word,
+})) satisfies EchoHandler;
 `;
 
 const MAIN = `import { cell, handler, pattern, Stream } from "commonfabric";
@@ -94,6 +99,30 @@ describe("schema-first-imported-callback", () => {
     expect(call).toBeDefined();
     expect(call.arguments.length).toBe(4);
     expect(call.arguments[2].getText(module)).toBe("echoAny");
+    expect(call.arguments[3].getText(module)).toContain("resultSchema");
+  });
+
+  it("recognizes an imported `any` callback behind a `satisfies` constraint", async () => {
+    // `satisfies T` checks the value against T and leaves it exactly as
+    // written, so it is transparent for the same reason parentheses and `as`
+    // are. With the alias annotated `any` the wrapper is the only thing
+    // between the declaration fallback and the function it needs to see.
+    const main = MAIN.replace(
+      "import { echoImported, type Ping, type PingResult }",
+      "import { echoSatisfies, echoImported, type Ping, type PingResult }",
+    ).replace(
+      "  echoImported,\n);",
+      "  echoSatisfies,\n);",
+    );
+    const output = await transformFiles({
+      "/main.tsx": main,
+      "/helpers.ts": HELPERS,
+    }, { types: COMMONFABRIC_TYPES });
+    const module = parseModule(output["/main.tsx"]);
+    const [call] = callsNamed(module, "handler");
+    expect(call).toBeDefined();
+    expect(call.arguments.length).toBe(4);
+    expect(call.arguments[2].getText(module)).toBe("echoSatisfies");
     expect(call.arguments[3].getText(module)).toContain("resultSchema");
   });
 });


### PR DESCRIPTION
## What

`stripWrappers` in `packages/ts-transformers/src/ast/call-kind.ts` stripped
`ParenthesizedExpression`, `AsExpression`, `TypeAssertionExpression`, and
`NonNullExpression` — but not `SatisfiesExpression`. `satisfies T` checks a
value against a type and leaves the value exactly as written, so it is
transparent for the same reason the other four are.

A probe over every wrapper spelling on `main`, through
`resolveCallbackFunctionExpression`:

```
direct / parens / asCast / nonNull / aliasAs   -> ARROW
satisfiesCast                                   -> undefined
aliasSatisfies                                  -> undefined
```

Exactly the two `satisfies` shapes failed — the wrapper on a callback
argument, and the wrapper on an aliased callback's initializer.

## Why it matters

`resolveCallbackFunctionExpression` is what `isCallbackReference` and
schema-first handler recognition are built on. A schema-first
`handler(eventSchema, stateSchema, callback)` whose callback is an `any`-typed
alias behind `satisfies` was not recognized as schema-first, so injection
prepended two generated schemas and displaced the callback out of the argument
positions the runtime dispatch and the sandbox verifier accept — the emitted
call carried **six arguments where the authored form has four**. That is the
assertion the new integration test pins.

## Approach

Rather than adding a fifth wrapper case, `stripWrappers` now delegates to the
shared `unwrapExpression`, which already handles all five. The wrapper list
gets one definition, so a spelling cannot be handled in one resolver and
missed in another — which is how this gap arose.

`includePartiallyEmitted` stays off, holding behavior otherwise exactly
constant. Whether classification should see through a `PartiallyEmittedExpression`
(a node the emit pipeline has already rewritten) is a real question, but a
separate one — it touches ~20 call sites, and a passing suite is not a
structural argument for changing it. Left as-is deliberately.

## Verification

Each new test was confirmed to **fail without the source change**, not merely
to pass with it:

- `test/ast/call-kind.test.ts` — two unit tests asserting the resolver returns
  the *authored arrow node itself* (identity, so a caller using it as an anchor
  lands on the right node), for the `satisfies`-wrapped argument and the
  `satisfies`-wrapped `any` alias initializer.
- `test/schema-first-imported-callback.test.ts` — an imported `any` callback
  behind `satisfies`, covering the declaration-fallback branch of
  `isCallbackReference`. Without the fix: 6 arguments instead of 4.

Gates, all green on deno 2.9.4:

| Gate | Result |
| --- | --- |
| `deno fmt --check` | 4812 files clean |
| `deno lint` | 4731 files clean |
| `deno task check` | all packages ok |
| ts-transformers suite | 1155 passed, 0 failed |
| `UPDATE_GOLDENS=1` | no golden changes |

No goldens moved: recognition widens only for shapes that previously failed to
resolve at all.

## Spec

No behavior-spec edit. §10.3's documented shape list does not enumerate wrapper
spellings, and the `unwrapExpression` list the spec already describes names
`satisfies`. `wish-result-lowering-spec.md` §3 deliberately *preserves*
`satisfies`, but that is `stripSyntacticWrappers` — a rewrite pre-pass keeping
type information in emitted output, not a read-only classifier; `stripWrappers`
already strips `as T`. The specs were right and the code was wrong.
`spec-sync.test.ts` passes.

## Relationship to CT-1870 (#6003, #6026)

Surfaced by cubic on #6026 (comment 3810863205), answered there as
"pre-existing, follow-up filed". This is that follow-up, and it is
semantically independent — neither PR touches `stripWrappers`.

One mechanical note for whoever merges second: both #6003 and #6026 add the
line `import { unwrapExpression } from "../utils/expression.ts";` to
`call-kind.ts`, because both move `isCallbackReference` into that file. This PR
adds the same import at the **same position with identical context**, so git
will dedupe or conflict visibly rather than silently producing two identical
imports and a redeclaration error. Worth a glance at the import block on
whichever rebase lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

