### PR TITLE
perf(runner): let a view's child-schema lookups reach the cache

### DIFF
--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -42,14 +42,15 @@ export {
 type IFCAtom = JSONValue;
 
 // schemaAtPath derivations per deep-frozen schema identity. The derivation is
-// pure given (schema, path, boolean default flags) when no extra
-// confidentiality is passed — instance state never enters it (`lub` delegates
-// to a static and has no subclasses) — and it runs per array element / object
-// property on read and write-diff paths, so identical lookups repeat
-// constantly. Module-level rather than per-instance: several hot paths create
-// a fresh ContextualFlowControl per call (storage pull/watch, traversal
-// contexts), which would leave a per-instance cache permanently cold.
-// Mutable schemas are never cached (in-place edits must be observed).
+// pure given (schema, path, the two defaults) when no extra confidentiality is
+// passed — instance state never enters it (`lub` delegates to a static and has
+// no subclasses) — and it runs per array element / object property on read and
+// write-diff paths, so identical lookups repeat constantly. Module-level
+// rather than per-instance: several hot paths create a fresh
+// ContextualFlowControl per call (storage pull/watch, traversal contexts),
+// which would leave a per-instance cache permanently cold. Mutable schemas are
+// never cached (in-place edits must be observed), and neither is a mutable
+// default (see `defaultSchemaTag`).
 let schemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
 // Path derivations can embed registry content; the registry clear (last
 // lease out) swaps the cache so an epoch's derivations do not outlive it.
@@ -225,11 +226,41 @@ const symbolicSchemaAtPathPart = (
     : classifier(part);
 };
 
+/**
+ * A stable token for one of `schemaAtPath`'s two default schemas, or
+ * `undefined` where the default cannot take part in a cache key.
+ *
+ * The defaults are usually the booleans `true` and `false`, which name
+ * themselves. A caller can also pass a schema object instead — that is how a
+ * reader asks to be TOLD that a property was not selected rather than handed
+ * something indistinguishable from a selected one, which is what
+ * `schema-view.ts` does for every property and every element it reads. Such a
+ * default is a module-level frozen constant, so its identity is stable for the
+ * life of the process and a tag minted once names it ever after.
+ *
+ * Deep-frozen is the condition, not a convenience: a mutable object could be
+ * changed after a result was cached under it, and the entry would then answer
+ * for a default it no longer describes.
+ */
+const defaultSchemaTags = new WeakMap<object, string>();
+let nextDefaultSchemaTag = 0;
+
+const defaultSchemaTag = (schema: JSONSchema): string | undefined => {
+  if (typeof schema === "boolean") return String(schema);
+  if (!isObjectOrArray(schema) || !isDeepFrozen(schema)) return undefined;
+  let tag = defaultSchemaTags.get(schema);
+  if (tag === undefined) {
+    tag = `#${++nextDefaultSchemaTag}`;
+    defaultSchemaTags.set(schema, tag);
+  }
+  return tag;
+};
+
 const schemaAtPathKey = (
   schema: JSONSchemaObj,
   path: readonly string[],
-  defaultEmptyProperties: boolean,
-  defaultMissingProperty: boolean,
+  defaultEmptyProperties: string,
+  defaultMissingProperty: string,
 ): string => {
   let key = `${defaultEmptyProperties}|${defaultMissingProperty}`;
   if (path.length === 1) {
@@ -525,9 +556,17 @@ export class ContextualFlowControl {
     const defs = isObjectOrArray(schema) && schema.$defs
       ? schema.$defs
       : undefined;
+    // Both defaults take part in the cache key, whether each is a boolean or
+    // a frozen sentinel schema. Refusing to cache the sentinel case turned the
+    // cache off for the whole of `schema-view.ts`, which passes sentinels on
+    // every property and every element it reads — so a view re-derived each
+    // child's schema from scratch, and handed the caller a fresh object that
+    // then cost a content hash to intern. That is the hot path, not a corner
+    // of one: reading a list of N references narrows N times per pass.
+    const emptyTag = defaultSchemaTag(defaultEmptyProperties);
+    const missingTag = defaultSchemaTag(defaultMissingProperty);
     const cacheable = extraConfidentiality === undefined &&
-      typeof defaultEmptyProperties === "boolean" &&
-      typeof defaultMissingProperty === "boolean" &&
+      emptyTag !== undefined && missingTag !== undefined &&
       isObjectOrArray(schema) && isDeepFrozen(schema);
     if (!cacheable) {
       return ContextualFlowControl.schemaAtPathInternal(
@@ -544,12 +583,7 @@ export class ContextualFlowControl {
       byKey = new Map();
       schemaAtPathCache.set(schema, byKey);
     }
-    const key = schemaAtPathKey(
-      schema,
-      path,
-      defaultEmptyProperties,
-      defaultMissingProperty,
-    );
+    const key = schemaAtPathKey(schema, path, emptyTag, missingTag);
     let result = byKey.get(key);
     if (result === undefined) {
       // Intern the derivation so the cached result is the canonical frozen

--- a/packages/runner/test/link-scan-dereference.bench.ts
+++ b/packages/runner/test/link-scan-dereference.bench.ts
@@ -1,0 +1,208 @@
+/**
+ * What it costs to walk a list of links through a materialized view.
+ *
+ * This is the shape a derivation takes when it reads a list whose elements are
+ * references: the view materializes an element on access, materializing it
+ * resolves the link the element is, and resolving a link records a dereference
+ * hop on the transaction. So the cost of the walk is the cost of one hop times
+ * the number of them, and a derivation declared over a whole list pays it
+ * again on every change to any element of that list.
+ *
+ * The fixture is a row list of the shape a pivot table has: each element is a
+ * link to a row document, and each row names its subject with a second link.
+ * Touching a row therefore costs two hops, which is what makes a scan's hop
+ * count a property of the list rather than of the walk that reads it.
+ *
+ * Three groups, each measuring the same walk against a different state of the
+ * transaction it runs on:
+ *
+ *   - **first**: the walk that pulls each row document into the transaction
+ *     for the first time. The floor for a view that has to load.
+ *   - **repeat**: the same walk again on the same transaction, where every hop
+ *     is one this transaction has already resolved and already recorded. What
+ *     separates it from **first** is what a resolution keeps.
+ *   - **past a write**: the same walk with a write in front of it, which is
+ *     the shape a board is actually read in — something is always being
+ *     written — and drops the resolution memo the repeat walk hits.
+ *
+ * One runtime and one seeded list serve the whole file, and every iteration
+ * aborts its transaction, so no iteration pays for a runtime, a store, or a
+ * document write, and none leaves state behind for the next. Each body walks
+ * once untimed before the bracket, so the timed window is never the one paying
+ * for the transaction's first look at a document.
+ *
+ * Environment controls:
+ * - LINK_SCAN_ROWS: rows in the list, default 50
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { type JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { benchDiagnostic } from "./bench-diagnostics.ts";
+
+const signer = await Identity.fromPassphrase("bench link scan");
+const space = signer.did();
+
+/**
+ * Rows in the list.
+ *
+ * Fifty is the size a board reaches while still feeling like one screen of
+ * work, and the size at which a per-row derivation over the whole list already
+ * costs a person real time.
+ */
+const ROWS = Number(Deno.env.get("LINK_SCAN_ROWS") ?? "50");
+
+/**
+ * What a reader of the list declares.
+ *
+ * Both reference fields are declared `unknown`: they hold links that a reader
+ * compares by identity and never reads through, and declaring them any wider
+ * would expand the subject document into the walk and measure that instead.
+ * That is also what a pattern declaring `unknown` compiles to, which matters
+ * more than it looks — the empty schema `{}` narrows to the `true` schema on
+ * every child, and a fixture written that way measures the cost of THAT and
+ * reports it as the cost of walking a list.
+ */
+const ROW_LIST_SCHEMA = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      subject: { type: "unknown" },
+      mentionedBy: { type: "array", items: { type: "unknown" } },
+    },
+  },
+} as const satisfies JSONSchema;
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+
+const LIST_CAUSE = "link-scan-row-list";
+const SCRATCH_CAUSE = "link-scan-scratch";
+
+{
+  const tx = runtime.edit();
+  const subjects = Array.from({ length: ROWS }, (_, index) => {
+    const cell = runtime.getCell<{ title: string }>(
+      space,
+      `link-scan-subject-${index}`,
+      undefined,
+      tx,
+    );
+    cell.set({ title: `Subject ${index}` });
+    return cell;
+  });
+  // `setRaw` with an explicit link, so each row holds a reference to its
+  // subject rather than a copy of it. A row read through the schema above then
+  // resolves that reference, which is the second hop each row costs.
+  const rows = subjects.map((subject, index) => {
+    const cell = runtime.getCell<unknown>(
+      space,
+      `link-scan-row-${index}`,
+      undefined,
+      tx,
+    );
+    cell.setRaw({ subject: subject.getAsLink(), mentionedBy: [] });
+    return cell;
+  });
+  runtime.getCell<unknown>(space, LIST_CAUSE, undefined, tx)
+    .setRaw(rows.map((row) => row.getAsLink()));
+  runtime.getCell<{ epoch: number }>(space, SCRATCH_CAUSE, undefined, tx)
+    .set({ epoch: 0 });
+  await tx.commit();
+}
+
+/**
+ * Open a transaction that materializes lazily, which is what puts an element
+ * read on the view path a derivation's argument takes.
+ */
+const open = () => {
+  const tx = runtime.edit();
+  tx.markLazyMaterialize(true);
+  return {
+    tx,
+    list: runtime.getCell(space, LIST_CAUSE, ROW_LIST_SCHEMA, tx),
+    scratch: runtime.getCell<{ epoch: number }>(
+      space,
+      SCRATCH_CAUSE,
+      undefined,
+      tx,
+    ),
+  };
+};
+
+/**
+ * Touch every row's subject reference, which is what materializes the row and
+ * resolves both of its links. Returns a count so the walk cannot be optimized
+ * away, and so a fixture that stopped resolving fails loudly rather than
+ * reporting a fast empty walk.
+ */
+const walk = (list: ReturnType<typeof open>["list"]): number => {
+  const view = list.get() as { subject: unknown }[];
+  let touched = 0;
+  for (let index = 0; index < view.length; index++) {
+    if (view[index].subject !== undefined) touched++;
+  }
+  if (touched !== ROWS) {
+    throw new Error(`walk resolved ${touched} of ${ROWS} rows`);
+  }
+  return touched;
+};
+
+Deno.bench({
+  name: `walk ${ROWS} rows - first`,
+  group: "link scan",
+  baseline: true,
+  fn(b) {
+    const { tx, list } = open();
+    b.start();
+    walk(list);
+    b.end();
+    tx.abort("bench");
+  },
+});
+
+Deno.bench({
+  name: `walk ${ROWS} rows - repeat`,
+  group: "link scan",
+  fn(b) {
+    const { tx, list } = open();
+    // Untimed: the timed walk below finds every row already in the
+    // transaction, so what it measures is what a resolution keeps rather than
+    // what a load costs.
+    walk(list);
+    b.start();
+    walk(list);
+    b.end();
+    tx.abort("bench");
+  },
+});
+
+Deno.bench({
+  name: `walk ${ROWS} rows - past a write`,
+  group: "link scan",
+  fn(b) {
+    const { tx, list, scratch } = open();
+    walk(list);
+    // A write to an unrelated document, which is enough to drop the
+    // transaction's resolution memo: the walk below re-resolves every link it
+    // just resolved.
+    scratch.withTx(tx).key("epoch").set(1);
+    b.start();
+    walk(list);
+    b.end();
+    tx.abort("bench");
+  },
+});
+
+// Hops are what the walk actually costs, and the count is a property of the
+// fixture rather than of any one iteration. Reported once, outside every timed
+// window, so the timings can be read per hop.
+benchDiagnostic(
+  `[link-scan] ${ROWS} rows, 2 link hops each: ${ROWS * 2} hops per walk`,
+);

--- a/packages/runner/test/link-scan-dereference.bench.ts
+++ b/packages/runner/test/link-scan-dereference.bench.ts
@@ -27,9 +27,13 @@
  *
  * One runtime and one seeded list serve the whole file, and every iteration
  * aborts its transaction, so no iteration pays for a runtime, a store, or a
- * document write, and none leaves state behind for the next. Each body walks
- * once untimed before the bracket, so the timed window is never the one paying
- * for the transaction's first look at a document.
+ * document write, and none leaves state behind for the next.
+ *
+ * **repeat** and **past a write** each walk once untimed before the bracket,
+ * so their timed window finds every row already in the transaction and
+ * measures only what the interlude cost. **first** times its only walk, which
+ * is what makes it the cold baseline: the load is the thing it is there to
+ * report.
  *
  * Environment controls:
  * - LINK_SCAN_ROWS: rows in the list, default 50


### PR DESCRIPTION
## What

Two commits: a benchmark for what a walk over a list of links costs per dereference hop, and the fix that benchmark was built to measure.

## Why

Creating fifty topics on a board costs ~37s off screen, and the per-create cost grows with the board. Attributing that walk with a V8 sampling profile put **21.8% of it in schema interning and content hashing** — hashing a schema to find the canonical instance already in the table. 99.93% of interning's identity misses resolved to something already interned.

The cause: `schemaAtPath` caches its derivations per deep-frozen schema identity, and declined to cache whenever either default schema was not a boolean. A caller can pass a schema object there instead — that is how a reader asks to be *told* a property was not selected rather than handed something it cannot tell from a selected one — and `schema-view.ts` passes exactly that, on every property and every element it reads.

So the cache was off for the whole of the view read path. Each child narrow re-derived the subschema from scratch and returned a fresh object, which the caller then interned: a content hash and a deep-freeze walk to arrive at the instance already in the table.

## Fix

Both defaults now take part in the cache key. A boolean names itself; a frozen schema object gets an identity tag minted once, which is sound because its identity is stable and its content cannot change under the entry. A mutable default still refuses to cache, as a mutable schema does.

## Evidence

| measurement | before | after |
|---|---|---|
| seeding 50 topics — schema intern identity misses | 230,790 | **45,326** |
| `link scan` bench — repeat walk | 1.3 ms | **0.65 ms** |
| `link scan` bench — past a write | 1.7 ms | **1.1 ms** |
| `link scan` bench — first walk | 2.0 ms | **1.5 ms** |

Timings are the min of three alternated runs on an Apple M3 Max; every individual pair favoured the fix. The miss counts are deterministic and independent of machine load.

Re-profiling after the fix puts schema interning at 1.9% of the same walk, down from 24%.

## Checks

- `packages/runner` tests: 1240 passed, 0 failed
- `deno task check`: passes tree-wide
- `packages/patterns/topics` pattern tests: 45 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

