### PR TITLE
fix(runner): build a node's cause from what names it, not what it reads

### DIFF
--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -121,7 +121,9 @@ lives in `hashStringForEntityAddress()`, which any other address intake shares.
 derived id follows is settled by whoever builds the cause. A node's cause is
 built from its bound inputs, and those links carry the schema the node reads
 through, so `causalFormOfBinding()` reduces each of them to the cell it names
-first. A link's identity is its address — what
+first — down to the addressing members alone (`LINK_ADDRESS_KEYS`), so that
+anything else riding a link, such as cfc's `cfcLabelView`, stays out along
+with the schema. A link's identity is its address — what
 [link equality](#internal-representation) compares — so an id derived through
 one stays put when a pattern's type signature widens, and the `$defs` closure a
 schema drags along stays out of the digest entirely. A deferred `$alias` keeps

--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -117,6 +117,17 @@ is not a complete identity to fall back on (see
 [Computed Cell Identity](../computed-cell-identity.md)). The reduction itself
 lives in `hashStringForEntityAddress()`, which any other address intake shares.
 
+`createRef()` hashes the preimage it is handed, links and all, so what a
+derived id follows is settled by whoever builds the cause. A node's cause is
+built from its bound inputs, and those links carry the schema the node reads
+through, so `causalFormOfBinding()` reduces each of them to the cell it names
+first. A link's identity is its address — what
+[link equality](#internal-representation) compares — so an id derived through
+one stays put when a pattern's type signature widens, and the `$defs` closure a
+schema drags along stays out of the digest entirely. A deferred `$alias` keeps
+its schema: it is a binding on its way to a nested pattern, part of that
+pattern's structure rather than of this node's cause.
+
 The underlying `hashOf()` function — see
 [Data Model](./1-data-model.md#hashing-and-content-addressing) for the hashing
 mechanism — is also used directly for:

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -106,6 +106,13 @@ export function createRef(
     // cell, recognized through the cell-rep / sigil chokepoint predicates rather
     // than the raw `{ "/": ... }` shape.
     //
+    // A link is hashed as it stands, schema and all. This walk takes what it
+    // is given: a caller deriving an id has to hand over a preimage that is
+    // causal, and reducing one here would only hide the difference between a
+    // caller that did and one that did not. `causalFormOfBinding()` does the
+    // reducing for a node's cause, at the seam that knows which links a bound
+    // tree holds and why they carry a schema at all.
+    //
     // TODO(danfuzz): the other data-model special-object type, `FabricInstance`
     // (a container that holds other values), is not handled here. Unlike a
     // primitive it *does* need descending into — but by its actual contents,

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -13,6 +13,8 @@ import {
 import { type MemorySpace } from "./cell.ts";
 import {
   type AliasBinding,
+  type CellLinkRefPayload,
+  LINK_ADDRESS_KEYS,
   type SigilLink,
   type SigilWriteRedirectLink,
   type URI,
@@ -308,30 +310,53 @@ export function areNormalizedLinksSameIgnoringScope(
 }
 
 /**
- * The same link with its `schema` dropped -- a link reduced to what it names,
- * for a caller that must not be sensitive to how the value there is read.
+ * The same link reduced to the cell it names: its {@link LINK_ADDRESS_KEYS}
+ * members and nothing else.
  *
  * A link's identity is its address, which is what
- * {@link areNormalizedLinksSame} compares: two links to one cell under
- * different schemas name the same cell. The schema is a read lens laid over
- * that address, so anything deriving from a link's identity has to leave it
- * out. `causalFormOfBinding()` is the caller that does, reducing a node's
- * bound inputs on the way into its cause; `WebhookCellLinkRefPayload` makes
- * the same cut for the wire.
+ * {@link areNormalizedLinksSame} compares. What a payload carries beyond the
+ * address describes how the value there is read or labeled -- `schema` is the
+ * reading lens, cfc's `cfcLabelView` a flow-control side channel its own
+ * module calls no part of addressing identity -- so anything deriving from a
+ * link's identity has to leave all of it out. `causalFormOfBinding()` is the
+ * caller that does, reducing a node's bound inputs on the way into its cause.
  *
- * A link carrying no schema is returned as it stands, so a caller pays an
- * allocation only where there is something to drop.
+ * Kept as a list of what to KEEP rather than what to drop, so the next member
+ * somebody hangs off a payload stays out of derived ids until someone decides
+ * it belongs in an address. That is the direction that fails safely here: a
+ * new addressing member has to be taught to `NormalizedLink` and
+ * {@link areNormalizedLinksSame} anyway and cannot arrive unnoticed, while
+ * metadata riding along on a link demonstrably can.
+ *
+ * A link already down to its address is returned as it stands, so a caller
+ * pays an allocation only where there is something to drop.
  */
-export function sigilLinkWithoutSchema(link: SigilLink): SigilLink {
+export function sigilLinkAddressOnly(link: SigilLink): SigilLink {
   const payload = linkRefPayload(link);
+
+  // A payload that is not a record carries no members to read. `isLinkRef()`
+  // vets the envelope rather than what sits inside it, so `{"/": {"link@1":
+  // null}}` reaches here as a link; it is data nothing addresses, and it
+  // passes through as it stands rather than throwing on the `in` below.
+  if (!isObjectNotArray(payload)) return link;
 
   // `in`, not `!== undefined`: a hash is over the members a value HAS, so a
   // key spelled `schema: undefined` is a member like any other and would
   // otherwise reach the digest as one.
-  if (!("schema" in payload)) return link;
+  const keys = Object.keys(payload);
+  if (
+    keys.every((key) => (LINK_ADDRESS_KEYS as readonly string[]).includes(key))
+  ) {
+    return link;
+  }
 
-  const { schema: _schema, ...rest } = payload;
-  return linkRefFrom(rest);
+  return linkRefFrom(
+    Object.fromEntries(
+      LINK_ADDRESS_KEYS
+        .filter((key) => key in payload)
+        .map((key) => [key, payload[key]]),
+    ) as CellLinkRefPayload,
+  );
 }
 
 /**

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,5 +1,9 @@
 import { isObjectNotArray } from "@commonfabric/utils/types";
-import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import {
+  isLinkRef,
+  linkRefFrom,
+  linkRefPayload,
+} from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
   type JSONSchema,
@@ -301,6 +305,33 @@ export function areNormalizedLinksSameIgnoringScope(
 ): boolean {
   return link1.id === link2.id && link1.space === link2.space &&
     arrayEqual(link1.path, link2.path);
+}
+
+/**
+ * The same link with its `schema` dropped -- a link reduced to what it names,
+ * for a caller that must not be sensitive to how the value there is read.
+ *
+ * A link's identity is its address, which is what
+ * {@link areNormalizedLinksSame} compares: two links to one cell under
+ * different schemas name the same cell. The schema is a read lens laid over
+ * that address, so anything deriving from a link's identity has to leave it
+ * out. `causalFormOfBinding()` is the caller that does, reducing a node's
+ * bound inputs on the way into its cause; `WebhookCellLinkRefPayload` makes
+ * the same cut for the wire.
+ *
+ * A link carrying no schema is returned as it stands, so a caller pays an
+ * allocation only where there is something to drop.
+ */
+export function sigilLinkWithoutSchema(link: SigilLink): SigilLink {
+  const payload = linkRefPayload(link);
+
+  // `in`, not `!== undefined`: a hash is over the members a value HAS, so a
+  // key spelled `schema: undefined` is a member like any other and would
+  // otherwise reach the digest as one.
+  if (!("schema" in payload)) return link;
+
+  const { schema: _schema, ...rest } = payload;
+  return linkRefFrom(rest);
 }
 
 /**

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -22,11 +22,13 @@ import {
   getMetaLink,
   isAliasBinding,
   isCellLink,
+  isSigilLink,
   isWriteRedirectLink,
   KeepAsCell,
   type NormalizedFullLink,
   parseLink,
   sanitizeSchemaForLinks,
+  sigilLinkWithoutSchema,
 } from "./link-utils.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
@@ -379,6 +381,76 @@ function sendValueToBindingInner<T>(
       throw new Error(`Got ${value} instead of ${binding}`);
     }
   }
+}
+
+/**
+ * The causal form of a bound binding tree: the same tree with every link in it
+ * reduced to the cell it names.
+ *
+ * `unwrapOneLevelAndBindToDoc()` emits its links with `includeSchema: true`,
+ * because a node reads through them and the schema is how it reads. A node's
+ * CAUSE is built from that same tree, and there the schema is wrong twice
+ * over. It is not causal: a link's identity is the address it carries (see
+ * `areNormalizedLinksSame`), so an id derived through one would be re-minted
+ * by a widened type signature or a renamed `$defs` entry, neither of which
+ * moves what the node reads or where it writes. And it is by far the largest
+ * thing in the tree: a schema drags its whole `$defs` closure along, running
+ * to kilobytes against a cause otherwise measured in hundreds of bytes.
+ *
+ * So the reduction happens here rather than in the binding itself, and the two
+ * trees part company at this call: what the node reads through keeps its
+ * schema, what names the node does not.
+ *
+ * A subtree holding nothing to reduce comes back by identity, so a cause built
+ * from schema-free links allocates nothing and hashes exactly as it did.
+ *
+ * A deferred `$alias` is left as it stands. It is not a link but a binding on
+ * its way to a nested pattern, and what it carries is that pattern's structure.
+ */
+export function causalFormOfBinding<T extends FabricExecValue>(binding: T): T {
+  function reduce(value: FabricExecValue): FabricExecValue {
+    if (isSigilLink(value)) return sigilLinkWithoutSchema(value);
+
+    // A `FabricPrimitive` is a leaf, and a `FabricInstance` holds its contents
+    // behind a codec this walk cannot read. Neither can hold a link the walk
+    // could reach, so both stand as they are. `unwrapOneLevelAndBindToDoc`
+    // throws on the latter, so a bound tree carries none to begin with.
+    if (value instanceof FabricPrimitive || value instanceof FabricInstance) {
+      return value;
+    }
+
+    // Copy lazily, and skip holes, exactly as `convert()` below does -- see
+    // there for why each of those is what it is. Each element is read once
+    // into a local, so an accessor-backed member is not run a second time by
+    // the comparison and does not land in the copy as a value the tree never
+    // held.
+    if (Array.isArray(value)) {
+      let reduced: FabricExecValue[] | undefined;
+      for (let i = 0; i < value.length; i++) {
+        if (!(i in value)) continue;
+        const element = value[i];
+        const next = reduce(element);
+        if (next === element) continue;
+        reduced ??= value.slice();
+        reduced[i] = next;
+      }
+      return reduced ?? value;
+    }
+
+    if (!isObjectOrArray(value)) return value;
+
+    let reduced: Record<string, FabricExecValue> | undefined;
+    for (const key of Object.keys(value)) {
+      const element = value[key];
+      const next = reduce(element);
+      if (next === element) continue;
+      reduced ??= { ...value };
+      reduced[key] = next;
+    }
+    return reduced ?? value;
+  }
+
+  return reduce(binding) as T;
 }
 
 /**

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -28,7 +28,7 @@ import {
   type NormalizedFullLink,
   parseLink,
   sanitizeSchemaForLinks,
-  sigilLinkWithoutSchema,
+  sigilLinkAddressOnly,
 } from "./link-utils.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
@@ -397,6 +397,10 @@ function sendValueToBindingInner<T>(
  * thing in the tree: a schema drags its whole `$defs` closure along, running
  * to kilobytes against a cause otherwise measured in hundreds of bytes.
  *
+ * The reduction is to the address, not away from the schema specifically, so
+ * anything else riding a link is left out too -- cfc's `cfcLabelView` being
+ * the one that exists today. See `sigilLinkAddressOnly()`.
+ *
  * So the reduction happens here rather than in the binding itself, and the two
  * trees part company at this call: what the node reads through keeps its
  * schema, what names the node does not.
@@ -409,7 +413,7 @@ function sendValueToBindingInner<T>(
  */
 export function causalFormOfBinding<T extends FabricExecValue>(binding: T): T {
   function reduce(value: FabricExecValue): FabricExecValue {
-    if (isSigilLink(value)) return sigilLinkWithoutSchema(value);
+    if (isSigilLink(value)) return sigilLinkAddressOnly(value);
 
     // A `FabricPrimitive` is a leaf, and a `FabricInstance` holds its contents
     // behind a codec this walk cannot read. Neither can hold a link the walk

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -74,6 +74,7 @@ import {
 } from "./link-utils.ts";
 import { isRawBuiltinResult, type RawBuiltinReturnType } from "./module.ts";
 import {
+  causalFormOfBinding,
   findAllWriteRedirectCells,
   opaqueArgumentKeys,
   sendValueToBinding,
@@ -5829,6 +5830,12 @@ export class Runner {
       streamLink,
     }: JavaScriptNodeContext & { streamLink: NormalizedFullLink },
   ): void {
+    // What names this node, as opposed to what it reads through: the bound
+    // inputs with every link reduced to the cell it names. Hoisted out of the
+    // handler because the bindings are fixed for the node, so the reduction
+    // runs once rather than per event.
+    const causalInputs = causalFormOfBinding(inputs) as Record<string, any>;
+
     const handler = (tx: IExtendedStorageTransaction, event: any) => {
       if (event?.preventDefault) event.preventDefault();
 
@@ -5857,7 +5864,7 @@ export class Runner {
       // collide on the receipt. The fallback covers non-dispatch invocations
       // (tests calling the handler directly).
       const cause = {
-        ...(inputs as Record<string, any>),
+        ...causalInputs,
         $event: tx.dispatchedEventId ?? crypto.randomUUID(),
       };
       const policyFacingIdentity = resolvePolicyFacingImplementationIdentity(
@@ -6141,12 +6148,18 @@ export class Runner {
     };
     let previouslyInvalidArgument = false;
     const fnSource = fn.toString();
+    // See the handler's counterpart above: what names the node, reduced once
+    // here rather than on every action invocation.
+    const resultFor = {
+      inputs: causalFormOfBinding(inputs),
+      outputs: causalFormOfBinding(outputs),
+      fn: fnSource,
+    };
 
     const action: Action & {
       ignoredSchedulingWrites?: NormalizedFullLink[];
     } = (tx: IExtendedStorageTransaction) => {
       action.ignoredSchedulingWrites = [];
-      const resultFor = { inputs, outputs, fn: fnSource };
       const policyFacingIdentity = resolvePolicyFacingImplementationIdentity(
         module,
         { implementation: fn },

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -44,7 +44,19 @@ export type CellLinkRefPayload = {
  */
 export type WebhookCellLinkRefPayload = Omit<CellLinkRefPayload, "schema">;
 
-const WEBHOOK_LINK_KEYS = [
+/**
+ * The payload members that address a cell: which document, in which space and
+ * scope, at which path, and whether a write there redirects. This is the whole
+ * of what a link says about where it points; everything else a payload may
+ * carry -- `schema`, cfc's `cfcLabelView` -- describes how the value there is
+ * read or labeled.
+ *
+ * Two consumers turn on that distinction, and share this list so they cannot
+ * drift apart on what "addressing" means. The webhook wire admits these and
+ * refuses the rest ({@link assertWebhookCellLinkRefPayload}), and a node's
+ * cause is reduced to them (`sigilLinkAddressOnly`).
+ */
+export const LINK_ADDRESS_KEYS = [
   "id",
   "space",
   "scope",
@@ -63,7 +75,7 @@ export function assertWebhookCellLinkRefPayload(
   payload: WireLinkRefPayload,
 ): asserts payload is WebhookCellLinkRefPayload {
   for (const key of Object.keys(payload)) {
-    if (!(WEBHOOK_LINK_KEYS as readonly string[]).includes(key)) {
+    if (!(LINK_ADDRESS_KEYS as readonly string[]).includes(key)) {
       throw new Error(`Unexpected cell-link field: "${key}".`);
     }
   }

--- a/packages/runner/test/node-cause-schema-stability.test.ts
+++ b/packages/runner/test/node-cause-schema-stability.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The ids a node mints do not move when a schema around it changes.
+ *
+ * A node's bound inputs carry links annotated with the schema the node reads
+ * through, and its cause is built from those same inputs. Only the addresses
+ * are causal, so `causalFormOfBinding()` reduces the links on the way into the
+ * cause. What that buys is checked here end to end: the same pattern under a
+ * widened argument schema anchors its array elements at the same entity ids,
+ * so a piece that gains an optional field keeps the documents it had.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import { type JSONSchema } from "../src/builder/types.ts";
+import { getMetaCell, parseLink } from "../src/link-utils.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+/**
+ * The element schema, and the same one with an optional field added. Widening
+ * is the change a piece actually undergoes between pattern versions, and it
+ * leaves every existing element valid -- so nothing about the elements written
+ * below has moved.
+ */
+const narrowElement = {
+  type: "object",
+  properties: { label: { type: "string" } },
+  required: ["label"],
+} as const satisfies JSONSchema;
+
+const widerElement = {
+  type: "object",
+  properties: { label: { type: "string" }, note: { type: "string" } },
+  required: ["label"],
+} as const satisfies JSONSchema;
+
+describe("node-cause-schema-stability", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let lift: ReturnType<typeof createBuilder>["commonfabric"]["lift"];
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+    ({ lift, pattern } = createTrustedBuilder(runtime).commonfabric);
+  });
+
+  async function commitTx() {
+    if (tx.status().status !== "ready") return;
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+  }
+
+  afterEach(async () => {
+    await commitTx();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Runs a pattern whose lift writes two objects into a writable array, and
+   * returns the entity id each element was anchored at. Writing objects into
+   * an array is what routes through `anchorValueAsEntity`, whose derivation
+   * folds in the frame cause -- the bound inputs of the lift doing the write.
+   */
+  async function anchoredIds(element: JSONSchema): Promise<string[]> {
+    const argumentSchema = {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: element,
+          default: [],
+          asCell: ["cell"],
+        },
+      },
+      required: ["items"],
+    } as const satisfies JSONSchema;
+
+    // The lift takes the array as a writable cell, which is what routes its
+    // write through the frame -- and so through the cause under test.
+    const seed = lift(
+      // deno-lint-ignore no-explicit-any
+      (state: any) => {
+        state.items.set([{ label: "first" }, { label: "second" }]);
+        return null;
+      },
+      argumentSchema,
+    );
+
+    const seeder = pattern(
+      // deno-lint-ignore no-explicit-any
+      ({ items }: any) => ({ seeded: seed({ items }) }),
+      argumentSchema,
+      { type: "object" } as const satisfies JSONSchema,
+    );
+
+    // A fixed cause, so the result cell is the same document across both runs
+    // and only the schema differs between them.
+    const resultCell = runtime.getCell(space, "seeder result", undefined, tx);
+    const result = runtime.run(tx, seeder, {}, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+    await result.pull();
+
+    // Read the argument's stored array RAW: each element is a link to the
+    // document it was anchored at, and resolving them would read through to
+    // the contents instead.
+    const items = getMetaCell(resultCell, "argument", tx).key("items");
+    const stored = items.getRaw() as unknown[] | undefined;
+    return (stored ?? []).map((entry) => parseLink(entry)?.id ?? "unlinked");
+  }
+
+  it("anchors array elements at the same ids under a widened element schema", async () => {
+    const narrow = await anchoredIds(narrowElement);
+    const wider = await anchoredIds(widerElement);
+
+    // Both runs actually anchored -- otherwise two empty lists would compare
+    // equal and the test would pass having checked nothing.
+    expect(narrow).toHaveLength(2);
+    expect(narrow.every((id) => id.startsWith("of:"))).toBe(true);
+
+    expect(wider).toEqual(narrow);
+  });
+});

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -17,6 +17,7 @@ import {
   parseLink,
 } from "../src/link-utils.ts";
 import {
+  causalFormOfBinding,
   findAllWriteRedirectCells,
   opaqueArgumentKeys,
   sendValueToBinding,
@@ -716,6 +717,81 @@ describe("pattern-binding", () => {
       lengths.length = 0;
       bind(binding);
       expect(lengths).toEqual(viaMap);
+    });
+  });
+
+  describe("causalFormOfBinding", () => {
+    /** Reduces `binding`, typed as the sibling `bind()` helper above is. */
+    const reduce = <T>(binding: T): T =>
+      causalFormOfBinding(binding as never) as T;
+
+    /** A link carrying a schema, as a bound binding holds one. */
+    const linkWithSchema = () =>
+      runtime.getCell(space, `causal ${crypto.randomUUID()}`, undefined, tx)
+        .asSchema({ type: "object", properties: { v: { type: "number" } } })
+        .getAsLink({ includeSchema: true });
+
+    it("returns a link naming the same cell with no schema on it", () => {
+      const link = linkWithSchema();
+      const before = parseLink(link)!;
+      expect(before.schema).not.toBeUndefined();
+
+      const after = parseLink(reduce({ x: link }).x)!;
+      expect(after.schema).toBeUndefined();
+      expect(areNormalizedLinksSame(after, before)).toBe(true);
+    });
+
+    it("reduces a link nested inside a binding", () => {
+      const binding = { $ctx: { deep: [{ items: linkWithSchema() }] } };
+      const reduced = reduce(binding);
+      expect(parseLink(reduced.$ctx.deep[0].items)!.schema).toBeUndefined();
+    });
+
+    it("returns a binding with no link schema to drop by identity", () => {
+      const binding = { x: 1, deep: { y: ["a", "b"] } };
+      expect(reduce(binding)).toBe(binding);
+    });
+
+    it("copies only the path to a reduced link, sharing its siblings", () => {
+      const untouched = { deep: [1, 2, 3] };
+      const binding = { changed: { inner: linkWithSchema() }, untouched };
+      const reduced = reduce(binding);
+
+      expect(reduced).not.toBe(binding);
+      expect(reduced.changed).not.toBe(binding.changed);
+      expect(reduced.untouched).toBe(untouched);
+      expect(reduced.untouched.deep).toBe(untouched.deep);
+    });
+
+    it("preserves holes when a sibling element reduces", () => {
+      // deno-lint-ignore no-sparse-arrays
+      const binding = [linkWithSchema(), , "third"] as unknown[];
+      const reduced = reduce(binding);
+
+      expect(reduced).not.toBe(binding);
+      expect(reduced.length).toBe(3);
+      expect(1 in reduced).toBe(false);
+      expect(reduced[2]).toBe("third");
+    });
+
+    it("leaves a deferred `$alias` as it stands", () => {
+      // An alias is a binding on its way to a nested pattern, not a link, and
+      // its schema is that pattern's structure rather than this node's cause.
+      const binding = {
+        a: {
+          $alias: { cell: "argument", defer: 1, path: ["v"], schema: true },
+        },
+      };
+      const reduced = reduce(binding);
+      expect(reduced).toBe(binding);
+      expect(isAliasBinding(reduced.a)).toBe(true);
+    });
+
+    it("leaves the binding it was handed unchanged", () => {
+      const binding = { x: linkWithSchema() };
+      const before = JSON.stringify(binding);
+      reduce(binding);
+      expect(JSON.stringify(binding)).toBe(before);
     });
   });
 

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -7,6 +7,10 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import {
+  linkCfcLabelView,
+  setLinkCfcLabelView,
+} from "../src/cfc/link-label-view.ts";
 import { isCell } from "../src/cell.ts";
 import {
   areLinksSame,
@@ -24,6 +28,7 @@ import {
   unwrapOneLevelAndBindToDoc,
 } from "../src/pattern-binding.ts";
 import { Runtime } from "../src/runtime.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
@@ -772,6 +777,38 @@ describe("pattern-binding", () => {
       expect(reduced.length).toBe(3);
       expect(1 in reduced).toBe(false);
       expect(reduced[2]).toBe("third");
+    });
+
+    it("returns a link carrying only addressing members by identity", () => {
+      const link = runtime
+        .getCell(space, `bare ${crypto.randomUUID()}`, undefined, tx)
+        .getAsLink();
+      const binding = { x: link };
+      expect(reduce(binding)).toBe(binding);
+    });
+
+    it("drops a cfc label view riding on a link", () => {
+      // The label view is a flow-control side channel, and cfc's own module
+      // calls it no part of a link's addressing identity -- so it is no part
+      // of what names a node either.
+      const link = runtime
+        .getCell(space, `labeled ${crypto.randomUUID()}`, undefined, tx)
+        .getAsLink();
+      setLinkCfcLabelView(link, {} as never);
+      expect(linkCfcLabelView(link)).not.toBeUndefined();
+
+      const reduced = reduce({ x: link }).x;
+      expect(linkCfcLabelView(reduced)).toBeUndefined();
+      expect(areNormalizedLinksSame(parseLink(reduced)!, parseLink(link)!))
+        .toBe(true);
+    });
+
+    it("returns a link envelope holding no payload record as it stands", () => {
+      // `isSigilLink()` vets the envelope, not what sits inside it, so a
+      // payload that is not a record reaches the reduction. It addresses
+      // nothing and there is nothing to read off it.
+      const binding = { x: { "/": { [LINK_V1_TAG]: null } } };
+      expect(reduce(binding)).toBe(binding);
     });
 
     it("leaves a deferred `$alias` as it stands", () => {


### PR DESCRIPTION
A node's bound inputs carry links annotated with the schema the node reads through — `unwrapOneLevelAndBindToDoc()` emits them that way on purpose — and its **cause** was built from that same tree. So the schema rode into every id derived in the node's frame, where it is wrong twice over.

## It is not causal

A link's identity is the address it carries (`areNormalizedLinksSame`), so an id derived through one was re-minted by a widened type signature or a renamed `$defs` entry — neither of which moves what the node reads or where it writes.

The case that bites is a lift seeding an array. Its elements anchor through `anchorValueAsEntity`, whose derivation folds in the frame cause, so editing the element schema handed the piece **new documents in place of the ones it had**. `record.tsx` seeding `subPieces` is a live instance.

## It is the largest thing in the tree

Instrumenting `createRef` over real pattern tests:

| workload | before | after |
|---|---|---|
| `shopping-list.test.tsx` | 5,450 bytes | **0** |
| `record.test.tsx` | 18,564 bytes | **18** |
| `type-picker.test.tsx` | 1,999 bytes | **0** |

Against a preimage otherwise averaging 139 bytes, the `$defs` closure a schema drags along was most of what got hashed. The 18 bytes left in `record.test.tsx` are one `schema:{"type":"unknown"}` on a `data:` link inside a runtime-synthesized result pattern — a per-event identity, and a builder-produced binding rather than a node cause.

## The change

`causalFormOfBinding()` makes the reduction, and it lives next to the binding walk that put the schemas there. The two trees part company at one visible seam: **what the node reads through keeps its schema; what names the node does not.**

Both cause sites build from it — the handler's `{...inputs, $event}` and the lift's `{inputs, outputs, fn}` — hoisted out of their closures so the reduction runs once per node rather than per event or per invocation. A subtree with nothing to reduce comes back by identity, so an already schema-free cause allocates nothing and hashes exactly as it did.

`createRef()` keeps hashing links as it is given them. Reducing there would have covered the same cases, but it would also have masked the difference between a caller that hands over a causal preimage and one that does not.

A deferred `$alias` is left as it stands: not a link, but a binding on its way to a nested pattern, carrying that pattern's structure.

## Compatibility

Ids at the affected sites are re-minted once. Stored data keeps its ids — they are stored as links; what changes is what a fresh derivation yields. For the lift case that means one hop now, in exchange for those ids no longer moving on every schema edit. Worth a `docs/development/space-clone-rehearsal.md` pass before this reaches a space holding real data.

## Verification

- **Unit** — `causalFormOfBinding` in `pattern-binding.test.ts`, beside the existing `unwrapOneLevelAndBindToDoc` structure-sharing block: reduction, sharing by identity, hole preservation, deferred `$alias` untouched, no mutation of the input.
- **Behavioural** — `node-cause-schema-stability.test.ts` runs a real pattern whose lift writes objects into a writable array, under an element schema and a widened version of it, and asserts the anchored entity ids match. Mutation-tested: drop `causalFormOfBinding` from the lift site and it fails with an id diff.
- `packages/runner`: 1241 passed, 0 failed. All 142 pattern tests passed.
- `deno task check`, `check-docs`, `check-skill-facts`, `check-package-cycles`, `check-no-waitfor`, `check-conflict-markers`, repo-wide `deno fmt --check` and `deno lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)