### PR TITLE
refactor(runtime-client): the protocol's shapes are type aliases

### DIFF
--- a/packages/runner/src/pattern-coverage.ts
+++ b/packages/runner/src/pattern-coverage.ts
@@ -7,7 +7,7 @@ import { FABRIC_MOUNT_ROOT } from "./sandbox/module-record-compiler.ts";
 
 export type { PatternCoverageKind, PatternCoverageSpan };
 
-export interface PatternCoverageFileReport {
+export type PatternCoverageFileReport = {
   path: string;
   spans: (PatternCoverageSpan & { count: number })[];
   totals: {
@@ -20,9 +20,9 @@ export interface PatternCoverageFileReport {
     coveredRuntime: number[];
     uncoveredRuntime: number[];
   };
-}
+};
 
-export interface PatternCoverageReport {
+export type PatternCoverageReport = {
   version: 1;
   generatedAt: string;
   files: PatternCoverageFileReport[];
@@ -31,12 +31,12 @@ export interface PatternCoverageReport {
     coveredRuntimeLines: number;
     uncoveredRuntimeLines: number;
   };
-}
+};
 
-export interface PatternCoverageReportOptions {
+export type PatternCoverageReportOptions = {
   root?: string;
   includeTestFiles?: boolean;
-}
+};
 
 /**
  * A collector's raw spans and per-span hit counts in a plain-JSON shape that
@@ -46,10 +46,10 @@ export interface PatternCoverageReportOptions {
  * {@link PatternCoverageCollector.ingest}ed into a collector in another (the
  * test process) with matching `(fileName, id)` keys.
  */
-export interface PatternCoverageData {
+export type PatternCoverageData = {
   spans: PatternCoverageSpan[];
   hits: { fileName: string; id: number; count: number }[];
-}
+};
 
 /** Default LCOV test name for pattern-coverage records (see {@link isPatternRuntimeTestName} in the gate). */
 export const PATTERN_COVERAGE_TEST_NAME = "pattern-runtime";

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -11,7 +11,7 @@ import type {
   SchedulerEventPreflightStats,
 } from "../telemetry.ts";
 
-export interface TelemetryAnnotations {
+export type TelemetryAnnotations = {
   pattern: Pattern;
   module: Module;
   reads: NormalizedFullLink[];
@@ -32,14 +32,14 @@ export interface TelemetryAnnotations {
     directOutputs: NormalizedFullLink[];
   };
   schedulerObservationIdentity?: SchedulerObservationIdentity;
-}
+};
 
-export interface SchedulerObservationIdentity {
+export type SchedulerObservationIdentity = {
   ownerSpace?: MemorySpace;
   branch?: string;
   pieceId: string;
   processGeneration?: number;
-}
+};
 
 export type Action = (tx: IExtendedStorageTransaction) => any;
 export type AnnotatedAction = Action & TelemetryAnnotations;
@@ -92,30 +92,30 @@ export type SpaceScopeURIAndType =
   `${MemorySpace}/${CellScope}/${URI}/${MediaType}`;
 
 /** Per-iteration stats captured during the settle loop. */
-export interface SettleIterationStats {
+export type SettleIterationStats = {
   workSetSize: number;
   orderSize: number;
   actionsRun: number;
   /** Action IDs in the work set (truncated to top entries) */
   actions: { id: string; type: "effect" | "computation" }[];
   durationMs: number;
-}
+};
 
 /** Stats for the entire settle loop of one execute() call. */
-export interface SettleStats {
+export type SettleStats = {
   iterations: SettleIterationStats[];
   totalDurationMs: number;
   settledEarly: boolean;
   initialSeedCount: number;
-}
+};
 
 /** One recorded settle stats entry from execute() history. */
-export interface SettleStatsHistoryEntry {
+export type SettleStatsHistoryEntry = {
   recordedAt: number;
   stats: SettleStats;
-}
+};
 
-export interface ActionRunTraceEntry {
+export type ActionRunTraceEntry = {
   recordedAt: number;
   actionId: string;
   actionType: "effect" | "computation";
@@ -123,13 +123,13 @@ export interface ActionRunTraceEntry {
   durationMs: number;
   declaredWrites: ActionRunTraceAddress[];
   actualWrites: ActionRunTraceAddress[];
-}
+};
 
-export interface ActionRunTraceAddress {
+export type ActionRunTraceAddress = {
   space: MemorySpace;
   entityId: URI;
   path: string[];
-}
+};
 
 export type TriggerTraceValueKind =
   | "undefined"
@@ -141,13 +141,13 @@ export type TriggerTraceValueKind =
   | "object"
   | "other";
 
-export interface TriggerTraceValueSummary {
+export type TriggerTraceValueSummary = {
   kind: TriggerTraceValueKind;
   size?: number;
   preview?: string | number | boolean | null;
-}
+};
 
-export interface TriggerTraceActionRecord {
+export type TriggerTraceActionRecord = {
   actionId: string;
   actionType: "effect" | "computation";
   mode: "pull";
@@ -160,9 +160,9 @@ export interface TriggerTraceActionRecord {
   pendingAfter: boolean;
   dirtyBefore: boolean;
   dirtyAfter: boolean;
-}
+};
 
-export interface TriggerTraceEntry {
+export type TriggerTraceEntry = {
   recordedAt: number;
   notificationType: string;
   changeIndex: number;
@@ -175,7 +175,7 @@ export interface TriggerTraceEntry {
   before: TriggerTraceValueSummary;
   after: TriggerTraceValueSummary;
   triggered: TriggerTraceActionRecord[];
-}
+};
 
 export type QueuedEvent = {
   /** Durable event id minted at send (spec §7.5). */

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -4,6 +4,7 @@
  * /!\ interfaces and utilities.
  */
 
+export { refuseFabricInstance } from "./fabric-special-object.ts";
 export {
   addressKey,
   CELL_SCOPE_VALUES,

--- a/packages/runner/src/storage/write-stack-trace.ts
+++ b/packages/runner/src/storage/write-stack-trace.ts
@@ -3,15 +3,15 @@ import type { IMemorySpaceAddress, MemorySpace, URI } from "./interface.ts";
 
 export type WriteStackTraceMatchMode = "exact" | "prefix";
 
-export interface WriteStackTraceMatcher {
+export type WriteStackTraceMatcher = {
   space?: MemorySpace;
   entityId?: URI;
   path?: string[];
   match?: WriteStackTraceMatchMode;
   label?: string;
-}
+};
 
-export interface WriteStackTraceEntry {
+export type WriteStackTraceEntry = {
   recordedAt: number;
   space: MemorySpace;
   entityId: URI;
@@ -31,13 +31,13 @@ export interface WriteStackTraceEntry {
     | "object"
     | "other";
   stack?: string;
-}
+};
 
-export interface WriteStackTraceOptions {
+export type WriteStackTraceOptions = {
   errorName?: string;
   scopeId?: string;
   writerActionId?: string;
-}
+};
 
 const writeTraceLogger = getLogger("storage.write-trace", {
   enabled: false,

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -2,21 +2,23 @@
 // to record events that can be subscribed to in other
 // contexts to visualize or log events inside the runtime.
 
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+
 import { IMemoryChange } from "./storage/interface.ts";
 
 /**
  * Statistics tracked for each action's execution performance.
  */
-export interface ActionStats {
+export type ActionStats = {
   runCount: number;
   totalTime: number;
   averageTime: number;
   lastRunTime: number;
   lastRunTimestamp: number; // When the action last ran (performance.now())
-}
+};
 
 // Types for scheduler graph visualization
-export interface SchedulerGraphNode {
+export type SchedulerGraphNode = {
   id: string; // actionId or "input:space/entity" for inputs
   type: "effect" | "computation" | "input" | "inactive"; // inactive = has stats but no longer registered
   stats?: ActionStats;
@@ -45,29 +47,29 @@ export interface SchedulerGraphNode {
   // retirement). `identity` is a module content hash; `symbol` distinguishes
   // co-located patterns of one module (the export vs hoisted sub-patterns).
   patternIdentity?: { identity: string; symbol: string };
-}
+};
 
-export interface SchedulerGraphEdge {
+export type SchedulerGraphEdge = {
   from: string; // actionId of source
   to: string; // actionId of target
   cells: string[]; // Cell IDs creating this dependency
   edgeType?: "data" | "parent"; // data = dependency, parent = parent-child relationship
-}
+};
 
-export interface SchedulerGraphSnapshot {
+export type SchedulerGraphSnapshot = {
   nodes: SchedulerGraphNode[];
   edges: SchedulerGraphEdge[];
   timestamp: number;
-}
+};
 
-export interface SchedulerActionInfo {
+export type SchedulerActionInfo = {
   patternName?: string;
   moduleName?: string;
   reads?: string[];
   writes?: string[];
-}
+};
 
-export interface SchedulerEventPreflightStats {
+export type SchedulerEventPreflightStats = {
   visitCount: number;
   dirtyInputCount: number;
   resultTrueCount: number;
@@ -82,9 +84,9 @@ export interface SchedulerEventPreflightStats {
   hotActions?: SchedulerEventPreflightActionSummary[];
   hotFanoutActions?: SchedulerEventPreflightActionSummary[];
   rootDirectWriters?: SchedulerEventPreflightActionSummary[];
-}
+};
 
-export interface SchedulerEventPreflightActionSummary {
+export type SchedulerEventPreflightActionSummary = {
   actionId: string;
   actionType: "effect" | "computation" | "unknown";
   visitCount: number;
@@ -97,7 +99,7 @@ export interface SchedulerEventPreflightActionSummary {
   readCount: number;
   shallowReadCount: number;
   writeCount: number;
-}
+};
 
 // ============================================================
 // Diagnosis types for non-settling / non-idempotent detection
@@ -107,35 +109,35 @@ export interface SchedulerEventPreflightActionSummary {
  * Report for a single action detected as non-idempotent.
  * Same inputs (reads) produced different outputs (writes) across runs.
  */
-export interface NonIdempotentReport {
+export type NonIdempotentReport = {
   actionId: string;
   actionInfo?: SchedulerActionInfo;
   runs: {
     timestamp: number;
-    reads: Record<string, unknown>;
-    writes: Record<string, unknown>;
+    reads: Record<string, FabricValue>;
+    writes: Record<string, FabricValue>;
   }[];
   differingWriteKeys: string[];
-}
+};
 
 /**
  * A cycle found in the causal chain of action triggers.
  * e.g. A writes cell X -> triggers B, B writes cell Y -> triggers A.
  */
-export interface CycleReport {
+export type CycleReport = {
   cycle: { actionId: string; writesCell: string }[];
   timestamp: number;
-}
+};
 
 /**
  * Aggregated result from a diagnosis run.
  */
-export interface SchedulerDiagnosisResult {
+export type SchedulerDiagnosisResult = {
   nonIdempotent: NonIdempotentReport[];
   cycles: CycleReport[];
   duration: number;
   busyTime: number;
-}
+};
 
 // Types of markers that can be submitted by the runtime.
 export type RuntimeTelemetryMarker = {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -2862,6 +2862,21 @@ describe("runtime-client CellRef conversion", () => {
       (mapCellRefsToSigilLinks({ b: bytes }) as { b: unknown }).b,
     ).toBe(bytes);
   });
+
+  it("refuses a `FabricInstance`, naming the class and the situation", () => {
+    // A tripwire, not a limitation to route around: an instance's codec
+    // contents can hold a link that this walk cannot reach, so refusing beats
+    // the `{}` the record branch would otherwise produce.
+    const error = FabricError.fromNativeError(new Error("boom"));
+    const message =
+      "Cannot yet handle `FabricError` (a `FabricInstance`) when mapping " +
+      "cell refs to sigil links.";
+
+    expect(() => mapCellRefsToSigilLinks(error)).toThrow(message);
+    // Nested too, the walk reaching it through the container rebuild.
+    expect(() => mapCellRefsToSigilLinks({ e: error })).toThrow(message);
+    expect(() => mapCellRefsToSigilLinks([error])).toThrow(message);
+  });
 });
 
 describe("RuntimeProcessor VDom event label-view ingress", () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -2845,6 +2845,23 @@ describe("runtime-client CellRef conversion", () => {
     expect(payload.id).toBe("of:cfc-raw-link");
     expect("cfcLabelView" in payload).toBe(false);
   });
+
+  it("hands back a `FabricPrimitive` whole, nested or not", () => {
+    // A fabric class keeps its state in private fields and has no enumerable
+    // own properties, so the record branch would rebuild one as `{}`. A
+    // primitive is atomic and holds no link, so passing it through is the
+    // whole answer.
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+    expect(mapCellRefsToSigilLinks(bytes)).toBe(bytes);
+    expect(mapCellRefsToSigilLinks({ b: bytes })).toEqual({ b: bytes });
+    expect(mapCellRefsToSigilLinks([bytes])).toEqual([bytes]);
+    // Identity through a container too: the walk rebuilds the container, and
+    // what it puts back has to be the value rather than a copy of it.
+    expect(
+      (mapCellRefsToSigilLinks({ b: bytes }) as { b: unknown }).b,
+    ).toBe(bytes);
+  });
 });
 
 describe("RuntimeProcessor VDom event label-view ingress", () => {

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -26,11 +26,8 @@ import { CellRef, PageRef } from "../protocol/types.ts";
  * writes: every `CellRef` in it becomes a `SigilLink`, and every raw
  * `SigilLink` loses its label view.
  *
- * A cell's value is a `FabricValue`, so that is the domain both ways, and a
- * `CellRef` is one too -- the conversion moves within the type rather than
- * across it. That the result holds no `CellRef` is therefore a fact about this
- * function and not something its return type states; a narrower name for the
- * result would only seem to exclude them.
+ * A cell's value is a `FabricValue`, as are a `CellRef` and a `SigilLink`, so
+ * the conversion moves within that type. The result holds no `CellRef`.
  */
 export function mapCellRefsToSigilLinks(value: FabricValue): FabricValue {
   if (
@@ -55,21 +52,20 @@ export function mapCellRefsToSigilLinks(value: FabricValue): FabricValue {
     // link payload it finds, so given a link it returns one.
     return stripSigilCfcLabelViews(value) as SigilLink;
   } else if (value instanceof FabricPrimitive) {
-    // Atomic, so there is nothing under it to map and handing it back whole is
-    // the complete answer rather than a deferral. It goes _before_ the record
+    // Atomic, so there is nothing under it to map. It goes _before_ the record
     // branch: one is also a record, and that branch rebuilds from enumerable
     // own properties a fabric class does not have, which would put `{}` here in
     // place of the value.
     return value;
   } else if (typeof value === "object" && value) {
     // TODO(danfuzz): descend a `FabricInstance` by its codec contents, at
-    // which point this becomes a walk rather than a silent flattening. This is
-    // the one arm of the declared domain that is not yet served: an instance
-    // reaches here and the rebuild below reads enumerable own properties it
-    // does not have, so it leaves as `{}`. Handing one back whole instead is
-    // no better, unlike the primitive above -- an instance can hold a link in
-    // its contents, which would then go unmapped -- so which disposition to
-    // take meanwhile is open. What keeps it from arising today is
+    // which point this becomes a walk rather than a silent flattening. It is
+    // the one arm of the domain above not yet served: an instance reaching
+    // here meets a rebuild that reads enumerable own properties it does not
+    // have, and leaves as `{}`. Passing it through untouched is the other
+    // available disposition, and drops any link in its contents instead;
+    // neither is right, and which to take meanwhile is open. What keeps it
+    // from arising today is
     // `CellHandle.serialize()` in `../cell-handle.ts`, which refuses a
     // `FabricSpecialObject` before it can reach this walk; the marker on
     // `WireCellValue` in `../protocol/types.ts` states the same gap at the

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -1,3 +1,4 @@
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import {
   Cell,
   JSONSchema,
@@ -35,16 +36,24 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
     // ref's (inv-12 Stage 0) — drop it so it never becomes a link-write
     // policy input.
     return stripSigilCfcLabelViews(value);
+  } else if (value instanceof FabricPrimitive) {
+    // Atomic, so there is nothing under it to map and handing it back whole is
+    // the complete answer rather than a deferral. It goes _before_ the record
+    // branch: one is also a record, and that branch rebuilds from enumerable
+    // own properties a fabric class does not have, which would put `{}` here in
+    // place of the value.
+    return value;
   } else if (typeof value === "object" && value) {
     // TODO(danfuzz): descend a `FabricInstance` by its codec contents, at
-    // which point this becomes a walk rather than a silent flattening. The
-    // rebuild below reads own enumerable properties, which for a fabric class
-    // are not its contents -- a `FabricBytes` arriving here leaves as `{}`,
-    // neither refused nor carried. What keeps that from happening today is
-    // `CellHandle.serialize()` in `../cell-handle.ts`, which refuses a
-    // `FabricSpecialObject` before it can reach this walk; the marker on
-    // `WireCellValue` in `../protocol/types.ts` states the same gap at the
-    // type.
+    // which point this becomes a walk rather than a silent flattening. Unlike
+    // the primitive above, an instance can hold a link in its contents, so
+    // handing one back whole would leave that link unmapped -- and the rebuild
+    // below reads enumerable own properties it does not have, so it leaves as
+    // `{}` instead. Neither disposition is right, and which to take meanwhile
+    // is open. What keeps it from arising today is `CellHandle.serialize()` in
+    // `../cell-handle.ts`, which refuses a `FabricSpecialObject` before it can
+    // reach this walk; the marker on `WireCellValue` in `../protocol/types.ts`
+    // states the same gap at the type.
     return Object.entries(value).reduce((acc: Record<string, any>, [k, v]) => {
       acc[k] = mapCellRefsToSigilLinks(v);
       return acc;

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -36,6 +36,15 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
     // policy input.
     return stripSigilCfcLabelViews(value);
   } else if (typeof value === "object" && value) {
+    // TODO(danfuzz): descend a `FabricInstance` by its codec contents, at
+    // which point this becomes a walk rather than a silent flattening. The
+    // rebuild below reads own enumerable properties, which for a fabric class
+    // are not its contents -- a `FabricBytes` arriving here leaves as `{}`,
+    // neither refused nor carried. What keeps that from happening today is
+    // `CellHandle.serialize()` in `../cell-handle.ts`, which refuses a
+    // `FabricSpecialObject` before it can reach this walk; the marker on
+    // `WireCellValue` in `../protocol/types.ts` states the same gap at the
+    // type.
     return Object.entries(value).reduce((acc: Record<string, any>, [k, v]) => {
       acc[k] = mapCellRefsToSigilLinks(v);
       return acc;

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -1,4 +1,5 @@
 import {
+  FabricInstance,
   FabricPrimitive,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -16,7 +17,11 @@ import {
   redactCaveatSourcesForDisplay,
   stripSigilCfcLabelViews,
 } from "@commonfabric/runner/cfc";
-import { isSigilLink, linkRefFrom } from "@commonfabric/runner/shared";
+import {
+  isSigilLink,
+  linkRefFrom,
+  refuseFabricInstance,
+} from "@commonfabric/runner/shared";
 
 import { isCellRef } from "../protocol/mod.ts";
 import { CellRef, PageRef } from "../protocol/types.ts";
@@ -57,19 +62,24 @@ export function mapCellRefsToSigilLinks(value: FabricValue): FabricValue {
     // own properties a fabric class does not have, which would put `{}` here in
     // place of the value.
     return value;
+  } else if (value instanceof FabricInstance) {
+    // A `FabricInstance` is refused. Its codec contents can carry a link, and
+    // those contents are not reachable by property name -- so the record
+    // branch below would rebuild one from enumerable own properties it does
+    // not have, yielding `{}` and losing whatever it holds, and passing it
+    // through whole would leave any link inside it unmapped.
+    //
+    // Nothing reaches this in production today, de facto rather than by
+    // construction: no flag gates it. The two callers pass a value that
+    // arrived by structured cloning, which strips a fabric class, so one
+    // cannot reach them as an instance at all; what would reach this is a
+    // direct caller, and there is none. `CellHandle.serialize()` in
+    // `../cell-handle.ts` refuses a `FabricSpecialObject` earlier still.
+    //
+    // TODO(danfuzz): descend by codec-mediated traversal into instance state,
+    // at which point this becomes a walk rather than a refusal.
+    refuseFabricInstance(value, "when mapping cell refs to sigil links");
   } else if (typeof value === "object" && value) {
-    // TODO(danfuzz): descend a `FabricInstance` by its codec contents, at
-    // which point this becomes a walk rather than a silent flattening. It is
-    // the one arm of the domain above not yet served: an instance reaching
-    // here meets a rebuild that reads enumerable own properties it does not
-    // have, and leaves as `{}`. Passing it through untouched is the other
-    // available disposition, and drops any link in its contents instead;
-    // neither is right, and which to take meanwhile is open. What keeps it
-    // from arising today is
-    // `CellHandle.serialize()` in `../cell-handle.ts`, which refuses a
-    // `FabricSpecialObject` before it can reach this walk; the marker on
-    // `WireCellValue` in `../protocol/types.ts` states the same gap at the
-    // type.
     return Object.entries(value).reduce(
       (acc: Record<string, FabricValue>, [k, v]) => {
         acc[k] = mapCellRefsToSigilLinks(v);

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -1,4 +1,7 @@
-import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
+import {
+  FabricPrimitive,
+  type FabricValue,
+} from "@commonfabric/data-model/fabric-value";
 import {
   Cell,
   JSONSchema,
@@ -18,7 +21,18 @@ import { isSigilLink, linkRefFrom } from "@commonfabric/runner/shared";
 import { isCellRef } from "../protocol/mod.ts";
 import { CellRef, PageRef } from "../protocol/types.ts";
 
-export function mapCellRefsToSigilLinks(value: unknown): any {
+/**
+ * Converts a value arriving over the connection into the form the worker
+ * writes: every `CellRef` in it becomes a `SigilLink`, and every raw
+ * `SigilLink` loses its label view.
+ *
+ * A cell's value is a `FabricValue`, so that is the domain both ways, and a
+ * `CellRef` is one too -- the conversion moves within the type rather than
+ * across it. That the result holds no `CellRef` is therefore a fact about this
+ * function and not something its return type states; a narrower name for the
+ * result would only seem to exclude them.
+ */
+export function mapCellRefsToSigilLinks(value: FabricValue): FabricValue {
   if (
     typeof value === "string" || typeof value === "number" ||
     typeof value === "boolean"
@@ -35,7 +49,11 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
     // via toJSON). Its label view is a main-thread display artifact like a
     // ref's (inv-12 Stage 0) — drop it so it never becomes a link-write
     // policy input.
-    return stripSigilCfcLabelViews(value);
+    //
+    // `stripSigilCfcLabelViews()` reports `unknown`, being general over what it
+    // walks. Narrowed here by what it does: it removes a property from each
+    // link payload it finds, so given a link it returns one.
+    return stripSigilCfcLabelViews(value) as SigilLink;
   } else if (value instanceof FabricPrimitive) {
     // Atomic, so there is nothing under it to map and handing it back whole is
     // the complete answer rather than a deferral. It goes _before_ the record
@@ -45,19 +63,24 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
     return value;
   } else if (typeof value === "object" && value) {
     // TODO(danfuzz): descend a `FabricInstance` by its codec contents, at
-    // which point this becomes a walk rather than a silent flattening. Unlike
-    // the primitive above, an instance can hold a link in its contents, so
-    // handing one back whole would leave that link unmapped -- and the rebuild
-    // below reads enumerable own properties it does not have, so it leaves as
-    // `{}` instead. Neither disposition is right, and which to take meanwhile
-    // is open. What keeps it from arising today is `CellHandle.serialize()` in
-    // `../cell-handle.ts`, which refuses a `FabricSpecialObject` before it can
-    // reach this walk; the marker on `WireCellValue` in `../protocol/types.ts`
-    // states the same gap at the type.
-    return Object.entries(value).reduce((acc: Record<string, any>, [k, v]) => {
-      acc[k] = mapCellRefsToSigilLinks(v);
-      return acc;
-    }, {});
+    // which point this becomes a walk rather than a silent flattening. This is
+    // the one arm of the declared domain that is not yet served: an instance
+    // reaches here and the rebuild below reads enumerable own properties it
+    // does not have, so it leaves as `{}`. Handing one back whole instead is
+    // no better, unlike the primitive above -- an instance can hold a link in
+    // its contents, which would then go unmapped -- so which disposition to
+    // take meanwhile is open. What keeps it from arising today is
+    // `CellHandle.serialize()` in `../cell-handle.ts`, which refuses a
+    // `FabricSpecialObject` before it can reach this walk; the marker on
+    // `WireCellValue` in `../protocol/types.ts` states the same gap at the
+    // type.
+    return Object.entries(value).reduce(
+      (acc: Record<string, FabricValue>, [k, v]) => {
+        acc[k] = mapCellRefsToSigilLinks(v);
+        return acc;
+      },
+      {},
+    );
   }
   return value;
 }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -3,6 +3,7 @@ import type { RealmEncodedValue } from "@commonfabric/data-model/codec-realm";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { DID, KeyPairRaw } from "@commonfabric/identity";
 import { type Program } from "@commonfabric/js-compiler/interface";
+import type { CfcConfClause } from "@commonfabric/runner/cfc";
 import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type {
   ActionRunTraceEntry,
@@ -218,8 +219,8 @@ export type InitializationData = {
   // (display-dischargeable classes). Undefined = no ceiling (current
   // behavior).
   renderConfidentialityCeiling?: {
-    atoms?: unknown[];
-    caveatKinds?: string[];
+    atoms?: readonly CfcConfClause[];
+    caveatKinds?: readonly string[];
   };
   // Static trust snapshot applied to worker-owned transactions.
   trustSnapshot?: {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -121,10 +121,10 @@ export enum NotificationType {
   PendingWritesChanged = "callback:pending-writes",
 }
 
-export interface IPCClientMessage {
+export type IPCClientMessage = {
   msgId: MessageId;
   data: IPCClientRequest;
-}
+};
 
 export enum RuntimeErrorCode {
   CompilerStackLoadFailed = "compiler-stack-load-failed",
@@ -152,11 +152,11 @@ export type IPCRemoteMessage = IPCRemoteNotification | IPCRemoteResponse;
  * That is a requirement on whatever delivers a request, not a property of any
  * particular transport -- see `RuntimeTransport.send()`.
  */
-export interface BaseRequest {
+export type BaseRequest = {
   type: RequestType;
-}
+};
 
-export interface InitializationData {
+export type InitializationData = {
   // URL of backend server. Also the default host for spaces absent from
   // `spaceHostMap`.
   apiUrl: string;
@@ -245,18 +245,18 @@ export interface InitializationData {
   // effect on the next runtime (reload), not live. Off by default; the shell
   // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
   concurrentWatchRefresh?: boolean;
-}
+};
 
-export interface InitializeRequest extends BaseRequest {
+export type InitializeRequest = BaseRequest & {
   type: RequestType.Initialize;
   data: InitializationData;
-}
+};
 
-export interface DisposeRequest extends BaseRequest {
+export type DisposeRequest = BaseRequest & {
   type: RequestType.Dispose;
-}
+};
 
-export interface CellGetRequest extends BaseRequest {
+export type CellGetRequest = BaseRequest & {
   type: RequestType.CellGet;
   cell: CellRef;
   meta?: MetaField;
@@ -270,7 +270,7 @@ export interface CellGetRequest extends BaseRequest {
   // and its schema carries the declarations (e.g. stream fields) that the
   // value alone does not.
   includeRef?: boolean;
-}
+};
 
 /**
  * A cell's value as this connection carries it: the data a cell holds, with a
@@ -302,29 +302,29 @@ export type WireCellValue =
   | { readonly [key: string]: WireCellValue }
   | CellRef;
 
-export interface CellSetRequest extends BaseRequest {
+export type CellSetRequest = BaseRequest & {
   type: RequestType.CellSet;
   cell: CellRef;
   value: WireCellValue;
-}
+};
 
 // A read-modify-write append (`CellHandle.push`). Same wire shape as CellSet —
 // it carries the whole already-appended array — but routed as its own request so
 // the runtime keeps the read-target as a commit precondition (compare-and-set),
 // rather than the blind last-write-wins of CellSet.
-export interface CellPushRequest extends BaseRequest {
+export type CellPushRequest = BaseRequest & {
   type: RequestType.CellPush;
   cell: CellRef;
   value: WireCellValue;
-}
+};
 
-export interface CellSendRequest extends BaseRequest {
+export type CellSendRequest = BaseRequest & {
   type: RequestType.CellSend;
   cell: CellRef;
   event: WireCellValue;
-}
+};
 
-export interface CellSubscribeRequest extends BaseRequest {
+export type CellSubscribeRequest = BaseRequest & {
   type: RequestType.CellSubscribe;
   cell: CellRef;
   // Opt in to reactive CFC-label delivery: each CellUpdate then carries the
@@ -332,58 +332,58 @@ export interface CellSubscribeRequest extends BaseRequest {
   // dependency of the sink, so a label-only write (value unchanged) re-fires
   // the subscription. Off by default — only label-displaying callers pay it.
   includeCfcLabel?: boolean;
-}
+};
 
-export interface CellUnsubscribeRequest extends BaseRequest {
+export type CellUnsubscribeRequest = BaseRequest & {
   type: RequestType.CellUnsubscribe;
   cell: CellRef;
-}
+};
 
-export interface CellResolveAsCellRequest extends BaseRequest {
+export type CellResolveAsCellRequest = BaseRequest & {
   type: RequestType.CellResolveAsCell;
   cell: CellRef;
-}
+};
 
-export interface CellGetCfcLabelRequest extends BaseRequest {
+export type CellGetCfcLabelRequest = BaseRequest & {
   type: RequestType.CellGetCfcLabel;
   cell: CellRef;
-}
+};
 
 // unused?
-export interface GetCellRequest extends BaseRequest {
+export type GetCellRequest = BaseRequest & {
   type: RequestType.GetCell;
   space: DID;
   cause: FabricValue;
   schema?: JSONSchema;
-}
+};
 
-export interface GetHomeSpaceCellRequest extends BaseRequest {
+export type GetHomeSpaceCellRequest = BaseRequest & {
   type: RequestType.GetHomeSpaceCell;
-}
+};
 
-export interface EnsureHomePatternRunningRequest extends BaseRequest {
+export type EnsureHomePatternRunningRequest = BaseRequest & {
   type: RequestType.EnsureHomePatternRunning;
-}
+};
 
-export interface IdleRequest extends BaseRequest {
+export type IdleRequest = BaseRequest & {
   type: RequestType.Idle;
-}
+};
 
 /**
  * Await storage/piece-manager convergence for EVERY space this worker
  * has opened. Genuinely spaceless — like Idle — unlike PageSynced,
  * which awaits one named space's piece context.
  */
-export interface RuntimeSyncedRequest extends BaseRequest {
+export type RuntimeSyncedRequest = BaseRequest & {
   type: RequestType.RuntimeSynced;
-}
+};
 
 /** Resolve a legacy named space inside the worker so its derived identity can
  * be retained as fresh-space ACL bootstrap authority. */
-export interface ResolveSpaceNameRequest extends BaseRequest {
+export type ResolveSpaceNameRequest = BaseRequest & {
   type: RequestType.ResolveSpaceName;
   name: string;
-}
+};
 
 /**
  * Record a runtime-learned HTTP or HTTPS host hint for a space (site-table v0).
@@ -400,11 +400,11 @@ export interface ResolveSpaceNameRequest extends BaseRequest {
  * accepted site-table route can reject a conflicting IPC hint. The IPC does
  * not override a seed or route already accepted for the session.
  */
-export interface RegisterSpaceHostRequest extends BaseRequest {
+export type RegisterSpaceHostRequest = BaseRequest & {
   type: RequestType.RegisterSpaceHost;
   space: DID;
   host: string;
-}
+};
 
 /**
  * Await all in-flight compile-cache write-backs (persistence durability), as
@@ -412,146 +412,146 @@ export interface RegisterSpaceHostRequest extends BaseRequest {
  * assert a precompiled pattern loads without an in-client recompile: the cache
  * write must be durable before a subsequent load reads it.
  */
-export interface FlushCompileCacheWritesRequest extends BaseRequest {
+export type FlushCompileCacheWritesRequest = BaseRequest & {
   type: RequestType.FlushCompileCacheWrites;
-}
+};
 
-export interface GetGraphSnapshotRequest extends BaseRequest {
+export type GetGraphSnapshotRequest = BaseRequest & {
   type: RequestType.GetGraphSnapshot;
-}
+};
 
-export interface GetLoggerCountsRequest extends BaseRequest {
+export type GetLoggerCountsRequest = BaseRequest & {
   type: RequestType.GetLoggerCounts;
-}
+};
 
-export interface GetPatternCoverageRequest extends BaseRequest {
+export type GetPatternCoverageRequest = BaseRequest & {
   type: RequestType.GetPatternCoverage;
-}
+};
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
-export interface SetLoggerLevelRequest extends BaseRequest {
+export type SetLoggerLevelRequest = BaseRequest & {
   type: RequestType.SetLoggerLevel;
   /** Logger name. If not provided, sets level for all loggers. */
   loggerName?: string;
   level: LogLevel;
-}
+};
 
-export interface SetLoggerEnabledRequest extends BaseRequest {
+export type SetLoggerEnabledRequest = BaseRequest & {
   type: RequestType.SetLoggerEnabled;
   /** Logger name. If not provided, sets enabled for all loggers. */
   loggerName?: string;
   enabled: boolean;
-}
+};
 
-export interface SetTelemetryEnabledRequest extends BaseRequest {
+export type SetTelemetryEnabledRequest = BaseRequest & {
   type: RequestType.SetTelemetryEnabled;
   enabled: boolean;
-}
+};
 
-export interface SetForwardWorkerConsoleRequest extends BaseRequest {
+export type SetForwardWorkerConsoleRequest = BaseRequest & {
   type: RequestType.SetForwardWorkerConsole;
   enabled: boolean;
-}
+};
 
-export interface ResetLoggerBaselinesRequest extends BaseRequest {
+export type ResetLoggerBaselinesRequest = BaseRequest & {
   type: RequestType.ResetLoggerBaselines;
-}
+};
 
-export interface GetSettleStatsRequest extends BaseRequest {
+export type GetSettleStatsRequest = BaseRequest & {
   type: RequestType.GetSettleStats;
-}
+};
 
-export interface SetSettleStatsEnabledRequest extends BaseRequest {
+export type SetSettleStatsEnabledRequest = BaseRequest & {
   type: RequestType.SetSettleStatsEnabled;
   enabled: boolean;
-}
+};
 
-export interface GetSettleStatsHistoryRequest extends BaseRequest {
+export type GetSettleStatsHistoryRequest = BaseRequest & {
   type: RequestType.GetSettleStatsHistory;
-}
+};
 
-export interface GetActionRunTraceRequest extends BaseRequest {
+export type GetActionRunTraceRequest = BaseRequest & {
   type: RequestType.GetActionRunTrace;
-}
+};
 
-export interface SetActionRunTraceEnabledRequest extends BaseRequest {
+export type SetActionRunTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetActionRunTraceEnabled;
   enabled: boolean;
-}
+};
 
-export interface GetTriggerTraceRequest extends BaseRequest {
+export type GetTriggerTraceRequest = BaseRequest & {
   type: RequestType.GetTriggerTrace;
-}
+};
 
-export interface SetTriggerTraceEnabledRequest extends BaseRequest {
+export type SetTriggerTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetTriggerTraceEnabled;
   enabled: boolean;
-}
+};
 
-export interface GetWriteStackTraceRequest extends BaseRequest {
+export type GetWriteStackTraceRequest = BaseRequest & {
   type: RequestType.GetWriteStackTrace;
-}
+};
 
-export interface SetWriteStackTraceMatchersRequest extends BaseRequest {
+export type SetWriteStackTraceMatchersRequest = BaseRequest & {
   type: RequestType.SetWriteStackTraceMatchers;
   matchers: WriteStackTraceMatcher[];
-}
+};
 
-export interface DetectNonIdempotentRequest extends BaseRequest {
+export type DetectNonIdempotentRequest = BaseRequest & {
   type: RequestType.DetectNonIdempotent;
   durationMs?: number;
-}
+};
 
-export interface SettleStatsResponse {
+export type SettleStatsResponse = {
   stats: SettleStats | null;
-}
+};
 
-export interface SettleStatsHistoryResponse {
+export type SettleStatsHistoryResponse = {
   history: SettleStatsHistoryEntry[];
-}
+};
 
-export interface ActionRunTraceResponse {
+export type ActionRunTraceResponse = {
   trace: ActionRunTraceEntry[];
-}
+};
 
-export interface TriggerTraceResponse {
+export type TriggerTraceResponse = {
   trace: TriggerTraceEntry[];
-}
+};
 
-export interface WriteStackTraceResponse {
+export type WriteStackTraceResponse = {
   trace: WriteStackTraceEntry[];
-}
+};
 
-export interface DetectNonIdempotentResponse {
+export type DetectNonIdempotentResponse = {
   result: SchedulerDiagnosisResult;
-}
+};
 
-export interface GetPatternSourcesRequest extends BaseRequest {
+export type GetPatternSourcesRequest = BaseRequest & {
   type: RequestType.GetPatternSources;
-}
+};
 
-export interface PatternSourceFile {
+export type PatternSourceFile = {
   name: string;
   contents: string;
-}
+};
 
-export interface PatternSourceInfo {
+export type PatternSourceInfo = {
   /** Content identity of the pattern's entry module (`cf:module/<hash>`). */
   identity: string;
   files: PatternSourceFile[];
-}
+};
 
-export interface PatternSourcesResponse {
+export type PatternSourcesResponse = {
   patterns: PatternSourceInfo[];
-}
+};
 
-export interface SetBreakpointsRequest extends BaseRequest {
+export type SetBreakpointsRequest = BaseRequest & {
   type: RequestType.SetBreakpoints;
   actionIds: string[];
-}
+};
 
-export interface UploadBlobRequest extends BaseRequest {
+export type UploadBlobRequest = BaseRequest & {
   type: RequestType.UploadBlob;
   /** The space the blob belongs to — uploads target ITS host. */
   space: DID;
@@ -565,21 +565,21 @@ export interface UploadBlobRequest extends BaseRequest {
    */
   body: RealmEncodedValue;
   suffix?: string;
-}
+};
 
-export interface UploadBlobResponse {
+export type UploadBlobResponse = {
   id: string;
   url: string;
-}
+};
 
 // Logger count types for IPC (matches @commonfabric/utils/logger types)
-export interface LogCounts {
+export type LogCounts = {
   debug: number;
   info: number;
   warn: number;
   error: number;
   total: number;
-}
+};
 
 export type LoggerBreakdown = {
   [messageKey: string]: LogCounts;
@@ -591,20 +591,20 @@ export type LoggerCountsData = Record<string, LoggerBreakdown> & {
   total: number;
 };
 
-export interface LoggerInfo {
+export type LoggerInfo = {
   enabled: boolean;
   level: LogLevel;
-}
+};
 
 export type LoggerMetadata = Record<string, LoggerInfo>;
 
 // Timing stats types for IPC (matches @commonfabric/utils/logger types)
-export interface CDFPoint {
+export type CDFPoint = {
   x: number; // Latency in ms
   y: number; // Cumulative probability (0-1)
-}
+};
 
-export interface TimingStats {
+export type TimingStats = {
   count: number; // Total measurements
   min: number; // Minimum time (ms)
   max: number; // Maximum time (ms)
@@ -616,7 +616,7 @@ export interface TimingStats {
   lastTimestamp: number; // When last recorded
   cdf: CDFPoint[]; // CDF of all samples since start
   cdfSinceBaseline: CDFPoint[] | null; // CDF of samples since baseline reset
-}
+};
 
 export type LoggerTimingData = Record<
   string,
@@ -628,7 +628,7 @@ export type LoggerFlagsData = Record<
   Record<string, Record<string, Record<string, unknown> | null>>
 >;
 
-export interface PageCreateRequest extends BaseRequest {
+export type PageCreateRequest = BaseRequest & {
   type: RequestType.PageCreate;
   /** The space the piece is created in — part of its address. */
   space: DID;
@@ -645,7 +645,7 @@ export interface PageCreateRequest extends BaseRequest {
   argument?: JSONValue;
   cause?: string;
   run?: boolean;
-}
+};
 
 /**
  * Page operations resolve against one space's piece context, and every
@@ -653,100 +653,100 @@ export interface PageCreateRequest extends BaseRequest {
  * space at this layer. The worker lazily builds a piece context per
  * space, sharing the one runtime/storage connection.
  */
-export interface PageGetSpaceDefault extends BaseRequest {
+export type PageGetSpaceDefault = BaseRequest & {
   type: RequestType.GetSpaceRootPattern;
   space: DID;
-}
+};
 
-export interface RecreateSpaceRootPatternRequest extends BaseRequest {
+export type RecreateSpaceRootPatternRequest = BaseRequest & {
   type: RequestType.RecreateSpaceRootPattern;
   space: DID;
-}
+};
 
-export interface PageGetRequest extends BaseRequest {
+export type PageGetRequest = BaseRequest & {
   type: RequestType.PageGet;
   pageId: string;
   runIt?: boolean;
   space: DID;
-}
+};
 
-export interface PageGetSlugRequest extends BaseRequest {
+export type PageGetSlugRequest = BaseRequest & {
   type: RequestType.PageGetSlug;
   pageId: string;
   space: DID;
-}
+};
 
-export interface PageRemoveRequest extends BaseRequest {
+export type PageRemoveRequest = BaseRequest & {
   type: RequestType.PageRemove;
   pageId: string;
   space: DID;
-}
+};
 
-export interface PageStartRequest extends BaseRequest {
+export type PageStartRequest = BaseRequest & {
   type: RequestType.PageStart;
   pageId: string;
   space: DID;
-}
+};
 
-export interface PageStopRequest extends BaseRequest {
+export type PageStopRequest = BaseRequest & {
   type: RequestType.PageStop;
   pageId: string;
   space: DID;
-}
+};
 
-export interface PageGetAllRequest extends BaseRequest {
+export type PageGetAllRequest = BaseRequest & {
   type: RequestType.PageGetAll;
   space: DID;
-}
+};
 
-export interface PageSyncedRequest extends BaseRequest {
+export type PageSyncedRequest = BaseRequest & {
   type: RequestType.PageSynced;
   space: DID;
-}
+};
 
 /**
  * Read one piece's source state: the pattern it runs, the origin it tracks, the
  * history metadata it carries, and its authored source files. See
  * `docs/specs/piece-source-lifecycle.md`.
  */
-export interface PieceGetSourceRequest extends BaseRequest {
+export type PieceGetSourceRequest = BaseRequest & {
   type: RequestType.PieceGetSource;
   space: DID;
   pieceId: string;
-}
+};
 
 /** Read the authored files retained for one recorded source revision. */
-export interface PieceGetSourceRevisionRequest extends BaseRequest {
+export type PieceGetSourceRevisionRequest = BaseRequest & {
   type: RequestType.PieceGetSourceRevision;
   space: DID;
   pieceId: string;
   revisionId: string;
-}
+};
 
 /** Create a copy of a piece in another space. */
-export interface PieceCloneRequest extends BaseRequest {
+export type PieceCloneRequest = BaseRequest & {
   type: RequestType.PieceClone;
   sourceSpace: DID;
   pieceId: string;
   destinationSpace: DID;
   /** Seed the clone with snapshots of the source piece's durable data. */
   copyData?: boolean;
-}
+};
 
 /** How a piece's origin URL resolves. */
 export type PieceOriginKind = "web" | "fabric-piece" | "fabric-pattern";
 
-export interface PieceOriginView {
+export type PieceOriginView = {
   url: string;
   kind: PieceOriginKind;
   /** The URL as recorded on the piece, when normalization changed it. */
   recorded?: string;
-}
+};
 
-export interface PiecePatternRefView {
+export type PiecePatternRefView = {
   identity: string;
   symbol: string;
-}
+};
 
 export type PieceSourceRevisionOperation =
   | "baseline"
@@ -758,16 +758,16 @@ export type PieceSourceRevisionOperation =
   | "follow"
   | "repoint";
 
-export interface PieceSourceRevisionView {
+export type PieceSourceRevisionView = {
   revisionId: string;
   timestamp: number;
   pattern: PiecePatternRefView;
   origin?: PieceOriginView;
   operation: PieceSourceRevisionOperation;
   selectedRevisionId?: string;
-}
+};
 
-export interface PieceSourceView {
+export type PieceSourceView = {
   space: DID;
   pieceId: string;
   name?: string;
@@ -780,87 +780,87 @@ export interface PieceSourceView {
   files: PatternSourceFile[];
   history: PieceSourceRevisionView[];
   currentRevisionId?: string;
-}
+};
 
-export interface PieceSourceResponse {
+export type PieceSourceResponse = {
   source: PieceSourceView;
-}
+};
 
-export interface PieceSourceRevisionSourceView {
+export type PieceSourceRevisionSourceView = {
   pattern: PiecePatternRefView;
   files: PatternSourceFile[];
-}
+};
 
-export interface PieceSourceRevisionResponse {
+export type PieceSourceRevisionResponse = {
   source: PieceSourceRevisionSourceView;
-}
+};
 
 export type PieceSourceAction =
   | { kind: "detach" }
   | { kind: "restore"; revisionId: string }
   | { kind: "follow"; revisionId: string };
 
-export interface PieceUpdateSourceRequest extends BaseRequest {
+export type PieceUpdateSourceRequest = BaseRequest & {
   type: RequestType.PieceUpdateSource;
   space: DID;
   pieceId: string;
   action: PieceSourceAction;
   /** Opaque token returned with an incompatibility warning. */
   confirmationToken?: string;
-}
+};
 
-export interface PieceUpdateSourceResponse extends PieceSourceResponse {
+export type PieceUpdateSourceResponse = PieceSourceResponse & {
   compatibilityWarning?: string;
   confirmationToken?: string;
   executionWarning?: string;
-}
+};
 
 /** One access level in a space ACL. */
 export type SpaceAclCapability = "READ" | "WRITE" | "OWNER";
 
 /** The space ACL and the current principal's ability to administer it. */
-export interface SpaceAclView {
+export type SpaceAclView = {
   space: DID;
   principal: DID;
   acl: Record<string, SpaceAclCapability>;
   canEdit: boolean;
-}
+};
 
 /** Response carrying a space's access-control view. */
-export interface SpaceAclResponse {
+export type SpaceAclResponse = {
   access: SpaceAclView;
-}
+};
 
 /** Reads the ACL for one space. */
-export interface SpaceGetAclRequest extends BaseRequest {
+export type SpaceGetAclRequest = BaseRequest & {
   type: RequestType.SpaceGetAcl;
   space: DID;
-}
+};
 
 /** Adds or replaces one explicit ACL entry in a space. */
-export interface SpaceSetAclEntryRequest extends BaseRequest {
+export type SpaceSetAclEntryRequest = BaseRequest & {
   type: RequestType.SpaceSetAclEntry;
   space: DID;
   user: string;
   capability: SpaceAclCapability;
-}
+};
 
 /** Removes one explicit ACL entry from a space. */
-export interface SpaceRemoveAclEntryRequest extends BaseRequest {
+export type SpaceRemoveAclEntryRequest = BaseRequest & {
   type: RequestType.SpaceRemoveAclEntry;
   space: DID;
   user: string;
-}
+};
 
 /** Common shape for one-way main -> worker notifications. */
-export interface BaseClientNotification {
+export type BaseClientNotification = {
   type: ClientNotificationType;
-}
+};
 
 /**
  * VDOM event message sent from main thread to worker when a DOM event fires.
  */
-export interface VDomEventNotification extends BaseClientNotification {
+export type VDomEventNotification = BaseClientNotification & {
   type: ClientNotificationType.VDomEvent;
   /** The mount ID that this event belongs to */
   mountId: number;
@@ -870,12 +870,12 @@ export interface VDomEventNotification extends BaseClientNotification {
   event: SerializedDomEvent;
   /** The node ID where the event occurred */
   nodeId: number;
-}
+};
 
 /**
  * Serialized DOM event data for IPC.
  */
-export interface SerializedDomEvent {
+export type SerializedDomEvent = {
   type: string;
   provenance?: {
     origin?: string;
@@ -899,12 +899,12 @@ export interface SerializedDomEvent {
   buttons?: number;
   target?: SerializedEventTarget;
   detail?: JSONValue;
-}
+};
 
 /**
  * Serialized event target data for IPC.
  */
-export interface SerializedEventTarget {
+export type SerializedEventTarget = {
   name?: string;
   value?: string;
   checked?: boolean;
@@ -912,39 +912,39 @@ export interface SerializedEventTarget {
   selectedIndex?: number;
   selectedOptions?: { value: string }[];
   dataset?: Record<string, string>;
-}
+};
 
 /**
  * Request to start VDOM rendering for a cell.
  * The worker will subscribe to the cell and send VDomBatch notifications.
  */
-export interface VDomMountRequest extends BaseRequest {
+export type VDomMountRequest = BaseRequest & {
   type: RequestType.VDomMount;
   /** Unique ID for this mount instance (used to match unmount) */
   mountId: number;
   /** The cell to render as VDOM */
   cell: CellRef;
-}
+};
 
 /**
  * Request to stop VDOM rendering for a mount.
  */
-export interface VDomUnmountRequest extends BaseRequest {
+export type VDomUnmountRequest = BaseRequest & {
   type: RequestType.VDomUnmount;
   /** The mount ID to stop */
   mountId: number;
-}
+};
 
 /**
  * Notification sent after the main thread applies a VDOM batch.
  */
-export interface VDomBatchAppliedNotification extends BaseClientNotification {
+export type VDomBatchAppliedNotification = BaseClientNotification & {
   type: ClientNotificationType.VDomBatchApplied;
   /** The mount ID that received the batch */
   mountId: number;
   /** The applied batch ID */
   batchId: number;
-}
+};
 
 /** Union of all one-way main -> worker notifications. */
 export type IPCClientNotification =
@@ -954,10 +954,10 @@ export type IPCClientNotification =
 /**
  * Response to VDomMount with the root node ID.
  */
-export interface VDomMountResponse {
+export type VDomMountResponse = {
   /** The root node ID for this mount */
   rootId: number;
-}
+};
 
 /**
  * TODO(danfuzz): This type should be made compatible with `FabricValue`, for
@@ -1036,9 +1036,9 @@ export type NullResponse = null;
 
 export type EmptyResponse = undefined;
 
-export interface BooleanResponse {
+export type BooleanResponse = {
   value: boolean;
-}
+};
 
 /**
  * A cell's value on its way _out_ of the worker, which `WireCellValue` is on
@@ -1052,51 +1052,51 @@ export interface BooleanResponse {
  * `codec-realm` is the mechanism, and closing this gap and `WireCellValue`'s
  * is one change.
  */
-export interface JSONValueResponse {
+export type JSONValueResponse = {
   value: JSONValue | undefined;
-}
+};
 
-export interface CellGetResponse extends JSONValueResponse {
+export type CellGetResponse = JSONValueResponse & {
   // Present only when the request set `includeCfcLabel`. `undefined` is a valid
   // value (the cell carries no label); the field is omitted when not requested.
   cfcLabel?: CfcLabelView | undefined;
   // Present only when the request set `includeRef` and the read resolved to a
   // cell (a raw-metadata read has no cell to reference).
   cell?: CellRef;
-}
+};
 
-export interface CellResponse {
+export type CellResponse = {
   cell: CellRef;
-}
+};
 
-export interface CfcLabelViewResponse {
+export type CfcLabelViewResponse = {
   cfcLabel: CfcLabelView | undefined;
-}
+};
 
-export interface PageResponse {
+export type PageResponse = {
   page: PageRef;
-}
+};
 
-export interface SlugResponse {
+export type SlugResponse = {
   slug: string | undefined;
-}
+};
 
-export interface SpaceResponse {
+export type SpaceResponse = {
   space: DID;
-}
+};
 
-export interface GraphSnapshotResponse {
+export type GraphSnapshotResponse = {
   snapshot: SchedulerGraphSnapshot;
-}
+};
 
-export interface LoggerCountsResponse {
+export type LoggerCountsResponse = {
   counts: LoggerCountsData;
   metadata: LoggerMetadata;
   timing: LoggerTimingData;
   flags: LoggerFlagsData;
-}
+};
 
-export interface PatternCoverageResponse {
+export type PatternCoverageResponse = {
   /**
    * The worker collector's spans and hit counts, or `null` when this worker was
    * built without a collector. Null and empty are kept apart on purpose: a
@@ -1105,9 +1105,9 @@ export interface PatternCoverageResponse {
    * makes the first invisible.
    */
   data: PatternCoverageData | null;
-}
+};
 
-export interface CellUpdateNotification {
+export type CellUpdateNotification = {
   type: NotificationType.CellUpdate;
   cell: CellRef;
   // TODO(danfuzz): the same gap `JSONValueResponse` is marked with. This is
@@ -1117,9 +1117,9 @@ export interface CellUpdateNotification {
   // the cell's current display label so the client re-renders on label changes
   // without a separate getCfcLabel round-trip.
   cfcLabel?: CfcLabelView | undefined;
-}
+};
 
-export interface ConsoleNotification {
+export type ConsoleNotification = {
   type: NotificationType.ConsoleMessage;
   metadata?: { pieceId?: string; patternId?: string; space?: string };
   method: string;
@@ -1130,14 +1130,14 @@ export interface ConsoleNotification {
   // what lets the fabric among them cross whole; see the marker at the producer
   // for what else has to move first.
   args: JSONValue[];
-}
+};
 
-export interface NavigateRequestNotification {
+export type NavigateRequestNotification = {
   type: NotificationType.NavigateRequest;
   targetCellRef: CellRef;
-}
+};
 
-export interface ErrorNotification {
+export type ErrorNotification = {
   type: NotificationType.ErrorReport;
   message: string;
   code?: RuntimeErrorCode;
@@ -1146,12 +1146,12 @@ export interface ErrorNotification {
   patternId?: string;
   spellId?: string;
   stackTrace?: string;
-}
+};
 
-export interface TelemetryNotification {
+export type TelemetryNotification = {
   type: NotificationType.Telemetry;
   marker: RuntimeTelemetryMarkerResult;
-}
+};
 
 /**
  * Worker-to-page mirror of the storage manager's durability barrier: `pending`
@@ -1159,10 +1159,10 @@ export interface TelemetryNotification {
  * once the pending set drains. The shell consults the latest value from its
  * beforeunload handler so a reload with unconfirmed writes prompts the user.
  */
-export interface PendingWritesNotification {
+export type PendingWritesNotification = {
   type: NotificationType.PendingWritesChanged;
   pending: boolean;
-}
+};
 
 /**
  * The vocabulary of DOM mutations carried by a VDOM batch. The worker
@@ -1177,7 +1177,7 @@ export type { VDomOp };
 /**
  * VDOM batch notification sent from worker to main thread.
  */
-export interface VDomBatchNotification {
+export type VDomBatchNotification = {
   type: NotificationType.VDomBatch;
   /** Identifier for this batch (for debugging/logging) */
   batchId: number;
@@ -1187,7 +1187,7 @@ export interface VDomBatchNotification {
   rootId?: number;
   /** The mount ID this batch belongs to */
   mountId?: number;
-}
+};
 
 export type RemoteResponse =
   | EmptyResponse


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

The mechanical half of making the IPC payload types compatible with `FabricValue`, plus a marker for a bug found while measuring for it.

## Why the declaration form is the blocker

TypeScript grants an implicit index signature to an anonymous object type and never to an `interface`. So an interface cannot satisfy `Readonly<Record<string, FabricValue>>` — cannot be a `FabricValue` — however fabric-shaped its fields are. Before this change, **none** of the 92 arms across `IPCClientRequest`, `IPCClientNotification`, `RemoteResponse` and `IPCRemoteNotification` satisfied `FabricValue`, and for 89 of them the reason had nothing to do with the values they carry.

All 109 interfaces in `protocol/types.ts` become type aliases, `extends B` becoming `B & { ... }`. An intersection keeps the implicit index signature provided the base is converted too, so `BaseRequest` stays a shared base rather than being inlined 58 times.

## That it is purely mechanical is checked, not asserted

Inverting the transformation reproduces the previous file **byte for byte**. So the only lines that changed are the 109 declaration headers and their terminators, and every body line is untouched. The check has a control: corrupting one body line makes the inversion stop matching.

The three things an interface can do that an alias cannot are all unused here — nothing is merged into these declarations, nothing extends them from outside the file, nothing implements them. Verified rather than assumed.

## What it buys, and what is left

**86 of 92 arms now satisfy `FabricValue`, up from 0** — 78 from
`protocol/types.ts` alone, and the rest once `runner`'s share is converted too.

The conversion reaches `runner` because the arms carry its types: a response
arm holding an `interface` cannot be a `FabricValue` however fabric-shaped its
own declaration is. Four files, 27 declarations — `scheduler/types.ts`,
`telemetry.ts`, `pattern-coverage.ts`, `storage/write-stack-trace.ts` — under
the same byte-for-byte inversion check.

The six that remain are each attributable, and none waits on this PR:

| blocked on | arms | where |
| --- | --- | --- |
| an `interface` in a package this does not reach | 3 | `Program` (`js-compiler`), `VDomOp`'s arms (`html`), `PatternCoverageSpan` (`ts-transformers`) |
| a value with no fabric representation | 3 | `CryptoKeyPair` in `InitializeRequest`; the realm-encoded body in `UploadBlobRequest`; `LoggerFlagsData` |

The first three are the same conversion again and are worth doing together, in
their own change.

`UploadBlobRequest`'s entry is expected and correct: a realm-*encoded* value is
the transport form and deliberately not a `FabricValue`. It resolves by
reverting that field to a `FabricBytes` once an envelope-level encoding exists.

`LoggerFlagsData` is the one that is *not* a straggler. It mirrors
`Logger.flags` in `@commonfabric/utils`, where a flag's metadata is an
arbitrary `Record<string, unknown>` from any caller — narrowing the protocol
side alone would claim more than the producer gives.

## Two `unknown`s that were narrowable

Unlike that one, these had producers already giving more than the declaration
admitted.

`SchedulerDiagnosisResult.nonIdempotent[].runs[].reads`/`.writes` are built by
`Object.fromEntries()` of maps their producer types `Map<string, FabricValue>`
— `captureCommittedReads()` and `captureTransactionWrites()` in
`scheduler/diagnosis.ts`, with no cast anywhere in the path. The declaration was
simply wider than what fills it.

`InitializeRequest`'s render ceiling carried `atoms?: unknown[]`, a loose
restatement of `RenderConfidentialityCeiling` in `html`'s worker types, whose
`atoms` are CFC clauses. It now says `CfcConfClause`, which is what the consumer
reads them as.

## The rest of the commits: `mapCellRefsToSigilLinks()`

The marker's subject turned out to be answerable rather than only markable, and the walk now handles its whole declared domain.

**A `FabricPrimitive` is handed back whole.** Atomic, so there is nothing under it to map. The branch goes before the record test, one being also a record — the same ordering `CellHandle.serialize()` states for its own refusal. Tested by identity at top level, in an object, and in an array; control: removing the branch turns the test red.

**A `FabricInstance` is refused**, rather than falling through to a rebuild that would yield `{}` and lose whatever it held, including any link nested inside it. That is the disposition the runner's binding walks take at the same hazard, through the same `refuseFabricInstance()` helper, so it is the same throw and the same message rather than a second one shaped like it — the helper is now exported from `@commonfabric/runner/shared`, the entry for what both threads use. `docs/development/EXPERIMENTAL_OPTIONS.md`'s "Flag-gated tripwires" governs these, and asks each caller to say which strength of the invariant it has: de facto here, no flag gating it, with the callers passing structured-cloned values that cannot arrive as an instance at all. Tested at top level and nested; control: removing the refusal turns the test red.

The `TODO` rides on the refusal, where the family keeps it — descend by codec-mediated traversal into instance state, at which point it becomes a walk rather than a refusal.

**The signature says `FabricValue` both ways.** It was `unknown -> any`, which let the walk say nothing about what it takes or gives. A cell's value is a `FabricValue`, and so are a `CellRef` and a `SigilLink`, so the conversion moves within the type. The result holding no `CellRef` is a fact about the function rather than something a narrower return type could state — `CellRef` being a `FabricValue` too.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





