### PR TITLE
docs(profiling): the procedure for turning "this is slow" into a named source

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -141,10 +141,15 @@ logger row and a worker CPU profile answer different questions, and the causes
 this runtime has actually produced. It is live documentation — as those answers
 change, it changes with them.
 
+[`debugging/profiling.md`](debugging/profiling.md) is the walkthrough that goes
+with it: read the timings already being collected, find the phase, bracket it so
+a CPU profile can be read for exactly that window, split until a call explosion
+has an origin, and pin the result with a benchmark that correlates.
+
 The server side is the half still undocumented: attaching to a running
 toolshed's Deno process, and recording OTEL traces against a collector. Whoever
-profiles the server first should write those steps down the same way, under
-`docs/development/debugging/`, so that path stops being tribal knowledge too.
+profiles the server first should write those steps into that same document, so
+that path stops being tribal knowledge too.
 
 ### Making the Loop Fast
 

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -105,6 +105,9 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
 ### Diagnosis
 
 - [Non-Idempotent Detection](non-idempotent-detection.md) - Detect non-settling computations, cycles, and non-idempotent actions
+- [Profiling a Slowness](profiling.md) - Turning "this is slow" into a named
+  source and a benchmark that correlates: phase timings, `performance.mark`
+  brackets, worker CPU profiles, subphase splitting
 - [Debugging Settle Waves](settle-wave-investigation.md) - Workflow for tracing worker fan-out: baselines, settle stats, trigger/action-run/write traces
   - Dated findings from the March 2026 investigation are archived in [settle-wave-2026-03-findings](../../history/development/debugging/settle-wave-2026-03-findings.md)
 - [Browser Integration Test Diagnostics](integration-test-diagnostics.md) - Integration-test failures are self-diagnosing: fill phase ledger, host bound-cell probe, pending-IPC table, worker request ledger, console tail — read the failure output before instrumenting

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -33,9 +33,11 @@ deno task cf test packages/patterns/<pattern>/<name>.test.tsx --verbose --stats-
 No browser, no shell, no rendering — the cheapest rung that can see a read count
 explode. Each row carries `count`, `average`, `p95`, `max` and `total`.
 
-Read `count` against `average` before forming any theory. A row whose `total`
-grew because it ran more often is a different defect from one whose every call
-got slower, and the two have disjoint fixes.
+Each row prints `n`, `total`, `avg` and `p95`. Read the count against the
+average before forming any theory: a row whose `total` grew because it ran more
+often is a different defect from one whose every call got slower, and the two
+have disjoint fixes. (`max` and `p50` exist in the statistics but this command
+does not render them; the browser summary in step 3 does.)
 
 Two traps in the output itself:
 
@@ -49,24 +51,33 @@ Two traps in the output itself:
 `--storage-stats` adds the storage rows; `--stats-action-limit` controls how
 many per-step scheduler action deltas print.
 
-## 2. Bracket the phase so a profile can be read for it
+## 2. Bracket the phase — in the process you are going to profile
 
 A CPU profile is samples over a window. It has no idea what a phase is, so
 attributing one means knowing its exact interval.
 
-Wrap the phase the way
-[`packages/cli/lib/test-runner.ts`](../../../packages/cli/lib/test-runner.ts)
-does in its `withPhase` helper, which is the shape to copy:
+**Which process emits the marks decides whether they are any use.** `cf test`
+runs patterns in a Deno process with no browser in it; a worker CPU profile
+comes out of a browser worker over CDP. Marks emitted on one side of that
+boundary never appear in a profile taken on the other, so pick the bracket that
+matches the capture:
 
-- hierarchical keys, so subphases nest under their parent;
-- `logger.timeStart()` / `logger.timeEnd()` around the body;
-- `performance.mark()` at both boundaries and `performance.measure()` across the
-  pair, which gives the interval;
-- `console.timeStamp()` at each boundary, which puts the marker on a DevTools
-  timeline so zooming to the phase is a drag rather than arithmetic.
+- **Profiling the `cf test` process.** Wrap the phase the way
+  [`packages/cli/lib/test-runner.ts`](../../../packages/cli/lib/test-runner.ts)
+  does in its `withPhase` helper: hierarchical keys so subphases nest,
+  `logger.timeStart()` / `logger.timeEnd()` around the body, `performance.mark()`
+  at both boundaries with a `performance.measure()` across the pair, and a
+  `console.timeStamp()` at each. Run the process under `--inspect` and the marks
+  and timestamps land on the DevTools timeline beside the samples, so zooming to
+  the phase is a drag rather than arithmetic.
+- **Profiling the browser worker.** The interval has to come from the capture
+  itself: start the profiler when the phase starts and stop it when the phase
+  ends, so the profile *is* the phase. That is what the phase-scoped capture in
+  step 3 is for. Marks emitted inside the worker also work; marks emitted by the
+  test driving it do not.
 
-This is cheap to add and it is what makes the next descent possible. Add it to
-the phase you are narrowing, not to everything.
+Either way, add the bracket to the phase you are narrowing rather than to
+everything.
 
 ## 3. Attribute the phase to functions
 
@@ -74,7 +85,10 @@ Step wall-clock says how long; it does not say where the time went, and the
 scheduler's own spans account for only a fraction of the span they sit inside. A
 V8 sampling profile of the runtime worker attributes all of it, by function.
 
-Capture one around exactly the phase from step 2, using the seams in
+Start the capture when the phase starts and stop it when the phase ends. The
+profile is then the phase, and its ranking answers a question about that phase
+rather than about the whole run — which is the whole reason to bother scoping
+it. The seams are in
 [`packages/integration/cdp-profiler.ts`](../../../packages/integration/cdp-profiler.ts):
 
 - `attachWorkerProfiler(wsEndpoint)` — connects and waits for the runtime
@@ -89,6 +103,13 @@ Capture one around exactly the phase from step 2, using the seams in
 is the maintained example to lift the gating and naming from. Read the ranked
 report first; open the `.cpuprofile` in Chrome DevTools or speedscope when the
 ranking is not enough.
+
+For the logger's own view of the same run, `collectBrowserLoadSummary` in
+[`packages/patterns/integration/cfc-browser-helpers.ts`](../../../packages/patterns/integration/cfc-browser-helpers.ts)
+reads the worker's scheduler, runner and storage rows plus main-thread IPC, with
+`count`, `p50`, `p95` and `max` per row. It keeps the top rows by total, so a row
+recording set sizes rather than milliseconds will evict real timings — read
+those by name instead of widening the summary.
 
 ## 4. Split until an explosion has an origin
 

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -1,0 +1,135 @@
+# Profiling a Slowness
+
+Use this when something takes longer than it should, or grows worse as the data
+grows, and you need to know why rather than guess. The goal is to turn "this is
+slow" into "this function, called this many times, from here" — and then into a
+benchmark that moves when the real thing moves.
+
+[`skills/perf-investigation/SKILL.md`](../../../skills/perf-investigation/SKILL.md)
+is the map: which instrument reaches what, what each is blind to, the causes
+this runtime has actually produced, and how to keep a measurement honest. This
+document is the walkthrough — the order the steps go in, and the commands.
+
+The steps below descend. Each one narrows the window the next one looks at, and
+stopping early produces a fix aimed at a symptom.
+
+## 0. Read what is already being measured
+
+Timing is always on. `logger.timeStart()`, `logger.timeEnd()` and
+`logger.time()` record into per-key statistics whether or not the logger they
+belong to is enabled — `enabled: false` silences log lines, not measurement, and
+the counts behind `logger.debug()` and friends increment before that check too.
+A logger constructed disabled is quiet, not inert.
+
+So the first move is reading, not instrumenting. The phase timings and call
+counts for anything already wrapped exist before you touch the code.
+
+## 1. Find the phase
+
+```bash
+deno task cf test packages/patterns/<pattern>/<name>.test.tsx --verbose --stats-threshold 0
+```
+
+No browser, no shell, no rendering — the cheapest rung that can see a read count
+explode. Each row carries `count`, `average`, `p95`, `max` and `total`.
+
+Read `count` against `average` before forming any theory. A row whose `total`
+grew because it ran more often is a different defect from one whose every call
+got slower, and the two have disjoint fixes.
+
+Two traps in the output itself:
+
+- `--stats-threshold` gates whether a step reports at all. A step faster than
+  the threshold prints nothing; `0` means every step.
+- `--stats-include <prefixes>` rescues named categories from the **top-ten
+  truncation**, not from the threshold. It cannot make a fast step report.
+- Rows are ranked by `total`, so a row that records set sizes rather than
+  milliseconds sorts above every real timing and evicts it. Read those by name.
+
+`--storage-stats` adds the storage rows; `--stats-action-limit` controls how
+many per-step scheduler action deltas print.
+
+## 2. Bracket the phase so a profile can be read for it
+
+A CPU profile is samples over a window. It has no idea what a phase is, so
+attributing one means knowing its exact interval.
+
+Wrap the phase the way
+[`packages/cli/lib/test-runner.ts`](../../../packages/cli/lib/test-runner.ts)
+does in its `withPhase` helper, which is the shape to copy:
+
+- hierarchical keys, so subphases nest under their parent;
+- `logger.timeStart()` / `logger.timeEnd()` around the body;
+- `performance.mark()` at both boundaries and `performance.measure()` across the
+  pair, which gives the interval;
+- `console.timeStamp()` at each boundary, which puts the marker on a DevTools
+  timeline so zooming to the phase is a drag rather than arithmetic.
+
+This is cheap to add and it is what makes the next descent possible. Add it to
+the phase you are narrowing, not to everything.
+
+## 3. Attribute the phase to functions
+
+Step wall-clock says how long; it does not say where the time went, and the
+scheduler's own spans account for only a fraction of the span they sit inside. A
+V8 sampling profile of the runtime worker attributes all of it, by function.
+
+Capture one around exactly the phase from step 2, using the seams in
+[`packages/integration/cdp-profiler.ts`](../../../packages/integration/cdp-profiler.ts):
+
+- `attachWorkerProfiler(wsEndpoint)` — connects and waits for the runtime
+  worker, returning `undefined` rather than throwing;
+- `startWorkerProfile(profiler, context, { samplingIntervalUs })` — the
+  default period suits a single interaction; a window of minutes needs a
+  coarser one to stay inside the CDP message limit;
+- `writeWorkerProfile(profiler, { pathPrefix, label })` — writes the
+  `.cpuprofile` and the ranked self-time report.
+
+[`packages/patterns/integration/default-app.test.ts`](../../../packages/patterns/integration/default-app.test.ts)
+is the maintained example to lift the gating and naming from. Read the ranked
+report first; open the `.cpuprofile` in Chrome DevTools or speedscope when the
+ranking is not enough.
+
+## 4. Split until an explosion has an origin
+
+A count that is too high is visible at the top level. The caller that multiplies
+it is not.
+
+Keep splitting the phase into subphases and comparing counts between adjacent
+levels. The level where a count stops being proportional to the work and starts
+being proportional to the work squared is the level that introduced the
+multiplication — that is the caller to fix, and it is frequently not the
+function the profile ranked first.
+
+## 5. Isolate, then pin it with a benchmark
+
+You are done narrowing when you can write a benchmark. That is the honest test:
+a source you understand can be provoked directly, and one you cannot provoke is
+still a hypothesis.
+
+Write it before the fix, and confirm it **correlates** — that it moves with the
+real measurement rather than merely being fast. A benchmark that does not track
+the thing users feel defends nothing. [`BENCHMARKS.md`](../BENCHMARKS.md) owns
+that lane: where bench files live, which ones CI runs, and how the trend reads
+them.
+
+Keep it. A benchmark that pins a fix usually lands as part of it.
+
+## 6. Decide where the fix belongs
+
+Every finding has two fixes available — make the work cheaper, or ask for it
+less — and both exist at every level of the stack. A leaf at the edge can often
+be made cheaper for every caller at once; a caller can often stop asking. A
+pattern investigation usually surfaces the second, while the first is usually a
+runtime change.
+
+Look for both before choosing. The perf skill carries the causes this runtime
+has actually produced, and the reasons an investigation that ends at the pattern
+has often stopped early.
+
+## The server side
+
+Not covered here yet. A toolshed is a Deno process, so `--inspect` and the
+DevTools profiler reach it, and OTEL spans exist behind `OTEL_ENABLED` with a
+collector to receive them. Whoever profiles the server first should write the
+concrete steps into this document, the way the steps above are written.

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -31,7 +31,7 @@ deno task cf test packages/patterns/<pattern>/<name>.test.tsx --verbose --stats-
 ```
 
 No browser, no shell, no rendering — the cheapest rung that can see a read count
-explode. Each row carries `count`, `average`, `p95`, `max` and `total`.
+explode.
 
 Each row prints `n`, `total`, `avg` and `p95`. Read the count against the
 average before forming any theory: a row whose `total` grew because it ran more
@@ -64,17 +64,19 @@ matches the capture:
 
 - **Profiling the `cf test` process.** Wrap the phase the way
   [`packages/cli/lib/test-runner.ts`](../../../packages/cli/lib/test-runner.ts)
-  does in its `withPhase` helper: hierarchical keys so subphases nest,
-  `logger.timeStart()` / `logger.timeEnd()` around the body, `performance.mark()`
-  at both boundaries with a `performance.measure()` across the pair, and a
-  `console.timeStamp()` at each. Run the process under `--inspect` and the marks
-  and timestamps land on the DevTools timeline beside the samples, so zooming to
-  the phase is a drag rather than arithmetic.
-- **Profiling the browser worker.** The interval has to come from the capture
-  itself: start the profiler when the phase starts and stop it when the phase
-  ends, so the profile *is* the phase. That is what the phase-scoped capture in
-  step 3 is for. Marks emitted inside the worker also work; marks emitted by the
-  test driving it do not.
+  does in its `withPhase` helper: multi-segment keys, `logger.timeStart()` /
+  `logger.timeEnd()` around the body, `performance.mark()` at both boundaries
+  with a `performance.measure()` across the pair, and a `console.timeStamp()` at
+  each. The key segments are joined into one path and recorded against that path
+  alone — they read as a hierarchy and sort together, but nothing rolls up, so a
+  parent's total is its own span rather than the sum of its children's. Run the
+  process under `--inspect` and the marks and timestamps land on the DevTools
+  timeline beside the samples, so zooming to the phase is a drag rather than
+  arithmetic. - **Profiling the browser worker.** The interval has to come from
+  the capture itself: start the profiler when the phase starts and stop it when
+  the phase ends, so the profile *is* the phase. That is what the phase-scoped
+  capture in step 3 is for. Marks emitted inside the worker also work; marks
+  emitted by the test driving it do not.
 
 Either way, add the bracket to the phase you are narrowing rather than to
 everything.
@@ -107,8 +109,8 @@ ranking is not enough.
 For the logger's own view of the same run, `collectBrowserLoadSummary` in
 [`packages/patterns/integration/cfc-browser-helpers.ts`](../../../packages/patterns/integration/cfc-browser-helpers.ts)
 reads the worker's scheduler, runner and storage rows plus main-thread IPC, with
-`count`, `p50`, `p95` and `max` per row. It keeps the top rows by total, so a row
-recording set sizes rather than milliseconds will evict real timings — read
+`count`, `p50`, `p95` and `max` per row. It keeps the top rows by total, so a
+row recording set sizes rather than milliseconds will evict real timings — read
 those by name instead of widening the summary.
 
 ## 4. Split until an explosion has an origin
@@ -117,9 +119,12 @@ A count that is too high is visible at the top level. The caller that multiplies
 it is not.
 
 Keep splitting the phase into subphases and comparing counts between adjacent
-levels. The level where a count stops being proportional to the work and starts
-being proportional to the work squared is the level that introduced the
-multiplication — that is the caller to fix, and it is frequently not the
+levels. Compare the counts, not shares of a total: each key is timed
+independently and nothing aggregates, so a child's contribution cannot be
+inferred by subtracting it from its parent. The level where a count stops being
+proportional to the work and starts being proportional to the work squared is
+the level that introduced the multiplication — that is the caller to fix, and it
+is frequently not the
 function the profile ranked first.
 
 ## 5. Isolate, then pin it with a benchmark

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -114,59 +114,39 @@ that differ costs less than a seam every future scenario has to be bent through.
 A phase is a place to look, never an answer. "The seed phase costs four minutes"
 is where an investigation starts being useful, and stopping there produces a fix
 aimed at a symptom. Keep going until you can name the thing doing the work — a
-function, a read, a derivation that re-runs — and can say whether it is
-expensive or merely frequent.
+function, a read, a derivation that re-runs — and say whether it is expensive or
+merely frequent.
 
-The instruments hand off to each other at each step down, and the handoff is the
-part worth knowing:
+`docs/development/debugging/profiling.md` has the steps and the commands. Two
+things about them are worth knowing before you start, because they decide where
+you begin and what you can trust:
 
-- **Logger phases say which phase.** Hierarchical keys are what make this a
-  descent rather than a single reading: a phase that costs four minutes splits
-  into named subphases, and one of those is usually most of it.
-- **`performance.mark` and `performance.measure` say where that phase sits in
-  the profile.** A CPU profile is samples over a window; it has no idea what a
-  phase is. Bracketing a phase with marks gives you its exact interval, so the
-  profile can be read for that window instead of averaged over the whole run —
-  which is the difference between "resolveLink is 30% of the run" and
-  "resolveLink is 90% of the phase that regressed". `console.timeStamp` at the
-  same boundaries puts the marker on a DevTools timeline, where the zoom is a
-  drag rather than an arithmetic exercise.
-- **Subphases say where a call explosion begins.** A count that is too high is
-  visible at the top, but the caller that multiplies it is not. Splitting the
-  phase until the count changes shape between two adjacent levels locates the
-  multiplication — the level where a count goes from proportional to the work to
-  proportional to the work squared is the one that introduced it.
+- **The timings already exist.** A logger constructed with `enabled: false` is
+  quiet, not inert: `timeStart`, `timeEnd` and `time` record into per-key
+  statistics without consulting that flag, and the counts behind the logging
+  methods increment before it is checked. Read what is accumulating before
+  instrumenting anything.
+- **Marks only help in the process that emits them.** `cf test` runs in a Deno
+  process with no browser; a worker CPU profile comes from a different process
+  over CDP. Bracketing a phase is what gives a profile its interval, but the
+  bracket has to be on the same side of that boundary as the samples.
 
-`withPhase` in `packages/cli/lib/test-runner.ts` is the worked example of the
-whole shape: hierarchical keys, a logger timer around the body, a mark at each
-boundary, a measure across the pair, and a `console.timeStamp` at each. Copy it
-into whatever you are narrowing.
-
-A logger constructed with `enabled: false` is quiet, not inert, and the
-difference decides where an investigation starts. `timeStart`, `timeEnd` and
-`time` record into per-key statistics without consulting that flag, and the
-counts behind the logging methods increment before it is checked — only the log
-lines are suppressed. So the timings for anything already wrapped are
-accumulating right now, and the first move is reading them rather than turning
-anything on.
-
-**You are done narrowing when you can write a benchmark.** That is the honest
-test, and it is worth holding to: a source you understand can be provoked
-directly, and one you cannot provoke is still a hypothesis. Build the benchmark
-before the fix, confirm it moves with the real measurement rather than merely
-being fast, and keep it — a benchmark that correlates with the thing users feel
-is what defends the fix afterwards, and it often lands as part of it. Where a
-source genuinely cannot be isolated that way, say so rather than skipping the
-step quietly.
+**You are done narrowing when you can write a benchmark.** A source you
+understand can be provoked directly; one you cannot provoke is still a
+hypothesis. Confirm it correlates — that it moves with the real measurement
+rather than merely being fast — and keep it, because that is what defends the
+fix afterwards.
 
 ## Count against average
 
-Every logger row carries `count`, `average`, `p95`, `max`, and `total`, and the
-first two are the whole diagnosis: a row whose `total` grew because `count` grew
-is a different bug from one whose `average` grew, and they have disjoint fixes.
-Read them before forming a theory. Rows are ranked by `total` and truncated, so
-a row that measures set sizes rather than milliseconds will sort above real
-timings and evict them — read those by name instead of widening the summary.
+Every logger row carries a count and a set of durations — the `cf test` stats
+print `n`, `total`, `avg` and `p95`, and the browser summary adds `p50` and
+`max` — and the count against the average is the whole diagnosis: a row whose
+`total` grew because `count` grew is a different bug from one whose `average`
+grew, and they have disjoint fixes. Read them before forming a theory. Rows are
+ranked by `total` and truncated, so a row that measures set sizes rather than
+milliseconds will sort above real timings and evict them — read those by name
+instead of widening the summary.
 
 ## Two ways to be slow, at every level
 

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -5,9 +5,12 @@ description: Investigate Common Fabric slowness end to end — measure it, attri
 
 # Performance Investigation
 
-For why we spend this time at all, and what we consider worth speeding up, read
-`docs/development/PERFORMANCE_PROGRAM.md`. This skill is the other half: how the
-investigation is actually run here, and what the answers have historically been.
+Two neighbours carry the halves this does not.
+`docs/development/PERFORMANCE_PROGRAM.md` is why we spend this time at all and
+what we consider worth speeding up. `docs/development/debugging/profiling.md` is
+the walkthrough — the steps in order, with the commands. This skill is the map
+they are read against: what each instrument reaches, what it is blind to, and
+what the answers here have historically turned out to be.
 
 ## A slow pattern is an instrument, not the defect
 
@@ -106,6 +109,56 @@ reading. A perf harness is otherwise throwaway — built for one investigation,
 driven by knobs nobody else needs, and not committed — so duplicating the parts
 that differ costs less than a seam every future scenario has to be bent through.
 
+## Narrowing, until a phase becomes a source
+
+A phase is a place to look, never an answer. "The seed phase costs four minutes"
+is where an investigation starts being useful, and stopping there produces a fix
+aimed at a symptom. Keep going until you can name the thing doing the work — a
+function, a read, a derivation that re-runs — and can say whether it is
+expensive or merely frequent.
+
+The instruments hand off to each other at each step down, and the handoff is the
+part worth knowing:
+
+- **Logger phases say which phase.** Hierarchical keys are what make this a
+  descent rather than a single reading: a phase that costs four minutes splits
+  into named subphases, and one of those is usually most of it.
+- **`performance.mark` and `performance.measure` say where that phase sits in
+  the profile.** A CPU profile is samples over a window; it has no idea what a
+  phase is. Bracketing a phase with marks gives you its exact interval, so the
+  profile can be read for that window instead of averaged over the whole run —
+  which is the difference between "resolveLink is 30% of the run" and
+  "resolveLink is 90% of the phase that regressed". `console.timeStamp` at the
+  same boundaries puts the marker on a DevTools timeline, where the zoom is a
+  drag rather than an arithmetic exercise.
+- **Subphases say where a call explosion begins.** A count that is too high is
+  visible at the top, but the caller that multiplies it is not. Splitting the
+  phase until the count changes shape between two adjacent levels locates the
+  multiplication — the level where a count goes from proportional to the work to
+  proportional to the work squared is the one that introduced it.
+
+`withPhase` in `packages/cli/lib/test-runner.ts` is the worked example of the
+whole shape: hierarchical keys, a logger timer around the body, a mark at each
+boundary, a measure across the pair, and a `console.timeStamp` at each. Copy it
+into whatever you are narrowing.
+
+A logger constructed with `enabled: false` is quiet, not inert, and the
+difference decides where an investigation starts. `timeStart`, `timeEnd` and
+`time` record into per-key statistics without consulting that flag, and the
+counts behind the logging methods increment before it is checked — only the log
+lines are suppressed. So the timings for anything already wrapped are
+accumulating right now, and the first move is reading them rather than turning
+anything on.
+
+**You are done narrowing when you can write a benchmark.** That is the honest
+test, and it is worth holding to: a source you understand can be provoked
+directly, and one you cannot provoke is still a hypothesis. Build the benchmark
+before the fix, confirm it moves with the real measurement rather than merely
+being fast, and keep it — a benchmark that correlates with the thing users feel
+is what defends the fix afterwards, and it often lands as part of it. Where a
+source genuinely cannot be isolated that way, say so rather than skipping the
+step quietly.
+
 ## Count against average
 
 Every logger row carries `count`, `average`, `p95`, `max`, and `total`, and the
@@ -114,6 +167,26 @@ is a different bug from one whose `average` grew, and they have disjoint fixes.
 Read them before forming a theory. Rows are ranked by `total` and truncated, so
 a row that measures set sizes rather than milliseconds will sort above real
 timings and evict them — read those by name instead of widening the summary.
+
+## Two ways to be slow, at every level
+
+A call costs what it costs and happens as often as it happens, so every finding
+has two fixes available: make the work cheaper, or ask for it less. They are not
+alternatives to choose between up front — which one is available is a fact about
+the code you have not read yet, and investigations that assume one skip the
+larger win about half the time.
+
+Both live at every level of the stack, and neither level is the natural home of
+this work. A leaf at the edge — resolving a link, walking a schema, hashing a
+value — can often be made cheaper for every caller at once, which is the widest
+possible fix and the one that closes a footgun rather than an instance. The
+caller can often stop asking: hoist the read, declare a narrower one, split a
+derivation so the half that cannot have changed does not re-run. A pattern
+usually surfaces the second; the first is usually a runtime change, and is the
+reason this work does not end at the pattern.
+
+Look for both before choosing. The cheapest real fix is frequently the one at
+the other end of the stack from where the symptom appeared.
 
 ## Where cost comes from in this runtime
 


### PR DESCRIPTION
The skill said which instruments exist and what each is blind to. It stopped short of what an investigation actually needs: the order to use them in. `docs/development/debugging/profiling.md` is that walkthrough, and the skill now reads as the map it is against.

This is also the document `PERFORMANCE_PROGRAM.md` has been asking for — it said profiling documentation did not exist and named a file that did not either.

## Three steps that were missing entirely

**Bracketing a phase so a profile can be read for it.** A CPU profile is samples over a window and knows nothing about phases, so attributing one means knowing its exact interval. `performance.mark` at both boundaries and a `measure` across the pair supply it; a `console.timeStamp` beside them puts the boundary on a DevTools timeline, where zooming to the phase is a drag rather than arithmetic. This is the difference between "resolveLink is 30% of the run" and "resolveLink is 90% of the phase that regressed".

`withPhase` in `packages/cli/lib/test-runner.ts` already does all of it behind hierarchical keys and is the shape to copy.

**Subphases locate a call explosion.** The count is visible at the top level; the caller that multiplies it is not. The level where a count stops being proportional to the work and starts being proportional to its square is the one that introduced it — frequently not the function the profile ranked first.

**An investigation is finished when it can produce a benchmark**, not when it can name a phase. A source you cannot provoke directly is still a hypothesis. Write the benchmark before the fix, confirm it *correlates* rather than merely being fast, and keep it — it usually lands as part of the fix.

## A correction

The skill had one point backwards. It said `withPhase`'s phase logger being constructed disabled meant that instrumentation "costs nothing until someone wants it".

A logger constructed with `enabled: false` is quiet, not inert. `timeStart`, `timeEnd` and `time` record into per-key statistics without consulting that flag, and the counts behind the logging methods increment before it is checked — only the log lines are suppressed. The practical consequence is the opposite of what the old text implied: the timings are accumulating already, and the first move is reading them rather than hunting for a switch. That is now step 0.

## Both fixes, at every level

Every finding has two available fixes — make the work cheaper, or ask for it less — and both exist at every level of the stack. A leaf at the edge can often be made cheaper for every caller at once, which closes a footgun rather than an instance; a caller can often stop asking. A pattern investigation surfaces the second; the first is usually a runtime change, and is why this work does not end at the pattern.

## Gates

`fmt`, `lint`, `check-docs` (561 blocks) and `check-skill-facts` (46 documents) all pass. `docs/` is excluded from `deno fmt`, so prose width there is manual — the new document's only over-80 lines are links and one command, matching its neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

