### PR TITLE
Read one wrapper set in call classification, not a subset of one

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -1531,13 +1531,14 @@ function isMultiApplicationChain(outerCall: ts.CallExpression): boolean {
  *
  * Delegates to the shared {@link unwrapExpression} so the wrapper list has a
  * single definition and a wrapper spelling cannot be handled in one resolver
- * and missed in another. `includePartiallyEmitted` stays off: a
- * PartiallyEmittedExpression marks a node the emit pipeline has already
- * rewritten, which is a different question from the authored shapes classified
- * here.
+ * and missed in another. It takes that helper's full wrapper set, including
+ * PartiallyEmittedExpression: the pipeline runs over authored source through
+ * `ts.transform`, never as part of TypeScript's emit, so a partially emitted
+ * node cannot reach classification and there is nothing here for a narrower
+ * set to protect.
  */
 function stripWrappers(expression: ts.Expression): ts.Expression {
-  return unwrapExpression(expression, { includePartiallyEmitted: false });
+  return unwrapExpression(expression);
 }
 
 function stripInitializerAccess(expression: ts.Expression): ts.Expression {

--- a/packages/ts-transformers/test/ast/call-kind.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind.test.ts
@@ -553,3 +553,20 @@ Deno.test("resolveCallbackFunctionExpression sees through a `satisfies`-wrapped 
     findFirstArrowFunction(sourceFile),
   );
 });
+
+Deno.test("resolveCallbackFunctionExpression takes the shared helper's whole wrapper set", () => {
+  // A PartiallyEmittedExpression cannot arise here — the pipeline transforms
+  // authored source through `ts.transform`, never as part of TypeScript's
+  // emit — so this pins a choice rather than guards a reachable path:
+  // classification reads the same wrapper set as every other resolver in the
+  // package, and narrowing it back to a local subset fails here first. The
+  // node is built directly because nothing in the corpus produces one.
+  const { sourceFile, checker } = createProgram(`
+    const value = (event, state) => {};
+  `);
+
+  const arrow = findFirstArrowFunction(sourceFile);
+  const wrapped = ts.factory.createPartiallyEmittedExpression(arrow);
+
+  assertEquals(resolveCallbackFunctionExpression(wrapped, checker), arrow);
+});


### PR DESCRIPTION
Follow-up to #6050, which noted this as a deliberately unanswered question.

## The short version

`stripWrappers` asked the shared `unwrapExpression` for its wrapper list *minus*
`PartiallyEmittedExpression`. I went looking for whether that exclusion was
load-bearing. **It is not** — it is a behavioral no-op, and this PR drops it so
call classification reads the same wrapper set as every other resolver in the
package.

This is a consistency change, not a bug fix. No behavior moves.

## Why the exclusion protects nothing

Three independent lines, because "the tests still pass" would not have settled
it — a passing suite says nothing about whether the case is reachable.

**Structural.** The pipeline transforms authored source via
`ts.transform(sourceFile, factories)`. That is not TypeScript's emit pipeline,
and `PartiallyEmittedExpression` is produced by TypeScript's *own* type-erasure
transforms, which never run here. `createPartiallyEmittedExpression` appears
nowhere in `src/`, so no stage builds one either. There is no route in.

**Empirical.** I instrumented `unwrapExpression` itself — all 129 call sites,
PEE-stripping on by default — and ran the full corpus. Exactly two partially
emitted nodes were observed across 1155 tests, and both came from
`test/utils/expression.test.ts`, the unit test that manufactures one with
`ts.factory` precisely to cover that wrapper. Pipeline-produced: **zero**.

**Instrument validated.** I did not trust that null on its own. Forcing the case
with a synthetic node confirmed the logger fires. The zero is a real zero rather
than a probe that never worked.

Worth stating the other half plainly: a partially emitted node *would* block
resolution if one ever arrived (verified — it resolves to `undefined` under the
narrow set). The handling the rest of the package carries is not wrong to want.
It is simply unreachable, which is why the seven other modules that strip it are
defensive rather than load-bearing.

## What the exclusion did cost

Nothing at runtime — only the standing risk that call classification and every
other resolver in this package disagree about what "transparent" means. That
divergence is exactly what hid a `satisfies`-wrapped callback until #6050. One
set, one answer.

## The test

The new test pins a choice rather than guarding a reachable path, and its
comment says so — it builds the node with `ts.factory` because nothing in the
corpus produces one. Verified to fail under the narrow set, so it holds the
decision rather than decorating it.

## Gates

| Gate | Result |
| --- | --- |
| `deno fmt --check` | 4832 files clean |
| `deno lint` | 4748 files clean |
| `deno task check` | all packages ok |
| ts-transformers suite | 1156 passed, 0 failed |
| `UPDATE_GOLDENS=1` | no golden changes |

## Follow-up, deliberately not in this PR

The investigation turned up roughly **eight independent definitions of
"transparent wrapper"** in this package — `unwrapExpression`, `stripWrappers`,
`unwrapStructuralDataFlowExpression`, inline loops in `opaque-roots` and
`pattern-body-reactive-root-lowering`, and predicates in
`reactive-variable-for`, `rewrite-expression`, and `binary-expression`. They
mostly agree on the same five or six node kinds, and #6050 happened because one
drifted. Unifying them is worth doing and is its own PR; keeping it out of this
one leaves this diff mechanical.

One outlier I checked and cleared: `fallback-array-method-rewrite.ts` walks
*parents* through only parens and PEE, omitting `as`/`satisfies`/`!`.
Structurally that is the #6050 shape, but probing five spellings of a
fallback-map receiver produced identical `mapWithPattern` emission in every
case. Not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

