### PR TITLE
fix(runner): a stored schema that constrains nothing yields to the reader's

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -1,5 +1,7 @@
 import { getLogger } from "@commonfabric/utils/logger";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import {
   linkPayloadAtProbe,
@@ -23,7 +25,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress, CfcDereferenceTrace } from "./cfc/types.ts";
 import { canFollowScopedLink, narrowerScopeCap } from "./scope.ts";
-import type { SchemaScope } from "./builder/types.ts";
+import type { JSONSchema, SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
 
@@ -38,6 +40,17 @@ export type ResolvedFullLink = NormalizedFullLink & {
   // type-script only marker, doesn't appear in actual data
   [resolvedFullLinkBrand]: true;
 };
+
+/**
+ * Whether `schema` constrains nothing at all: absent, JSON Schema `true`, or
+ * an empty object. Such a schema selects every value, so it says nothing the
+ * schema a resolution is already carrying does not, and a hop onto a link
+ * bearing one keeps carrying rather than adopting it. `false` is not one of
+ * these — it selects nothing, which is information.
+ */
+const schemaConstrainsNothing = (schema: JSONSchema | undefined): boolean =>
+  schema === undefined || schema === true ||
+  (isObjectOrArray(schema) && !isNontrivialSchema(schema));
 
 const MAX_PATH_RESOLUTION_LENGTH = 100;
 
@@ -286,6 +299,12 @@ const resolutionMemoVariant = (
  * Links can point to another (document, path) pair, and may appear either at
  * leaf nodes or in the middle of a document. This resolver transparently
  * follows such links and detects cycles.
+ *
+ * The resolved link carries a schema. A followed link's own stored schema
+ * describes the value at its target, where the caller's describes the value at
+ * the source, so the stored one replaces what the resolution carried in. One
+ * that constrains nothing describes nothing, so the caller's schema keeps
+ * traveling instead; see `schemaConstrainsNothing()`.
  *
  * A cycle is detected if the exact (document, path) pair is visited more than
  * once. This detects cycles like:
@@ -579,7 +598,9 @@ export function resolveLinkTracingDereferences(
         // so the shift reduces to target-path length minus our own.
         nextHop.link.path.length - link.path.length,
       );
-      if (nextLink.schema === undefined && link.schema !== undefined) {
+      if (
+        schemaConstrainsNothing(nextLink.schema) && link.schema !== undefined
+      ) {
         link = {
           ...nextLink,
           schema: link.schema,

--- a/packages/runner/test/stored-link-schema-precedence.test.ts
+++ b/packages/runner/test/stored-link-schema-precedence.test.ts
@@ -1,0 +1,165 @@
+/**
+ * What a link's own stored schema decides for a reader that declared one.
+ *
+ * A link stored in a document may carry a schema, and link resolution adopts
+ * it in place of the schema the reader carries in: the stored one describes
+ * the value at the link's target, where the reader's describes the value at
+ * the source. A schema that constrains nothing — JSON Schema `true`, or an
+ * empty object — describes neither, so the reader's schema keeps traveling
+ * and governs the projection, which is what makes an element read by its own
+ * path project the same as that element read within its array. A stored
+ * schema that does constrain still governs, and a stored `false` still
+ * selects nothing.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import "@commonfabric/utils/equal-ignoring-symbols";
+
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { CellLinkRefPayload } from "../src/sigil-types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("stored link schema precedence");
+const space = signer.did();
+
+type Row = { title: string };
+type Holder = { rows: Row[] };
+
+/** What a row declares: one required property, out of a wider stored value. */
+const rowSchema = {
+  type: "object",
+  properties: { title: { type: "string" } },
+  required: ["title"],
+} as const satisfies JSONSchema;
+
+const holderSchema = {
+  type: "object",
+  properties: { rows: { type: "array", items: rowSchema } },
+} as const satisfies JSONSchema;
+
+/** The value a row link points at, wider than the row schema selects. */
+const storedRow = { title: "cruller", glaze: "maple" };
+
+describe("stored-link-schema-precedence", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let seq = 0;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    tx = runtime.edit();
+    seq++;
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * A stored link to `cell` carrying `schema`. Built rather than minted:
+   * `getAsLink({ includeSchema: true })` leaves out a schema that constrains
+   * nothing, so it cannot produce one of these.
+   */
+  const linkCarrying = (cell: Cell<unknown>, schema: JSONSchema) => {
+    const link = cell.getAsNormalizedFullLink();
+    return linkRefFrom<CellLinkRefPayload>({
+      id: link.id,
+      space: link.space,
+      scope: link.scope,
+      path: [...link.path],
+      schema,
+    });
+  };
+
+  /** A one-row array whose single element link carries `storedSchema`. */
+  const holderOverLinkCarrying = (storedSchema: JSONSchema): Cell<Holder> => {
+    const row = runtime.getCell(space, `row-${seq}`, undefined, tx);
+    row.setRaw(storedRow);
+    const holder = runtime.getCell<Holder>(
+      space,
+      `holder-${seq}`,
+      holderSchema,
+      tx,
+    );
+    holder.setRaw({ rows: [linkCarrying(row, storedSchema)] } as never);
+    return holder;
+  };
+
+  const elementByPath = (holder: Cell<Holder>) =>
+    holder.key("rows").key(0).get();
+
+  const elementWithinArray = (holder: Cell<Holder>) =>
+    holder.key("rows").get()[0];
+
+  /**
+   * A read's own enumerable properties. An unconstrained projection hands back
+   * a live query-result proxy, which a structural diff renders as `{}`; the
+   * spread makes what a read exposes both comparable and printable whichever
+   * form it took.
+   */
+  const projectionOf = (value: unknown) => ({ ...(value as object) });
+
+  describe("a stored schema that constrains nothing", () => {
+    it("projects an element by path the same way as within its array", () => {
+      const holder = holderOverLinkCarrying(true);
+
+      expect(projectionOf(elementByPath(holder)))
+        .toEqual(projectionOf(elementWithinArray(holder)));
+    });
+
+    it("projects an element by path through the reader's row schema", () => {
+      const holder = holderOverLinkCarrying(true);
+
+      expect(projectionOf(elementByPath(holder))).toEqual({ title: "cruller" });
+    });
+
+    it("projects an empty stored schema the same way as `true`", () => {
+      const holder = holderOverLinkCarrying({});
+
+      expect(projectionOf(elementByPath(holder)))
+        .toEqual(projectionOf(elementWithinArray(holder)));
+      expect(projectionOf(elementByPath(holder))).toEqual({ title: "cruller" });
+    });
+
+    it("resolves the element link to the schema the reader carried in", () => {
+      const holder = holderOverLinkCarrying(true);
+      const readerLink = {
+        ...holder.getAsNormalizedFullLink(),
+        path: ["rows", "0"],
+        schema: rowSchema as JSONSchema,
+      };
+
+      expect(resolveLink(runtime, tx, readerLink).schema).toEqual(rowSchema);
+    });
+  });
+
+  describe("a stored schema that constrains", () => {
+    it("governs the projection in place of the reader's row schema", () => {
+      const holder = holderOverLinkCarrying({
+        type: "object",
+        properties: { glaze: { type: "string" } },
+      });
+
+      expect(projectionOf(elementByPath(holder))).toEqual({ glaze: "maple" });
+    });
+
+    it("selects nothing when the stored schema is `false`", () => {
+      const holder = holderOverLinkCarrying(false);
+
+      expect(elementByPath(holder)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
A stored link may carry its own schema. Link resolution adopted that schema in place of the one the resolution was carrying whenever it was present **at all** — including `true` and `{}`, which select every value and therefore describe nothing. Adopting one dropped the reader's declaration at that hop.

From there `validateAndTransform` takes the resolved link's schema as its selector, so an element read **by its own path** projected permissively — the whole stored value, whatever the reader declared. Read as part of **its array**, the same element goes through `followPointer`, whose `combineOptionalSchema` already discards a trivially-permissive link schema, so the declared item type governed. One element, two projections, two answers.

Measured on plain fixtures — stored row `{title:"cruller", glaze:"maple"}`, element link carrying `schema: true`, reader row schema `{title}` required:

| read | before | after |
| --- | --- | --- |
| `holder.key("rows").key(0).get()` | `{title:"cruller", glaze:"maple"}` | `{title:"cruller"}` |
| `holder.key("rows").get()[0]` | `{title:"cruller"}` | `{title:"cruller"}` |
| `resolveLink(readerLink).schema` | `true` | the row schema |

**What changed:** link resolution now treats a stored schema that constrains nothing the way it already treats an absent one — the schema the resolution carried in keeps traveling. A stored schema that *does* constrain still replaces it, and a stored `false` (which selects nothing, and so is information) still wins. The predicate is deliberately narrower than `ContextualFlowControl.isTrueSchema`, which also swallows `{asCell:…}`, `{default:…}` and `{ifc:…}` — all informative.

**Behavior change worth reviewing carefully:** this makes by-path reads through such links *narrower* than before. That is the correct direction — the reader's declaration should bound what it gets — but any consumer that was relying on the accidental over-permissiveness will now see only its declared fields. The full `packages/runner` suite (1241 tests / 6874 steps) is green, as are `packages/piece` and `packages/data-model`.

**Not a fix for stale non-trivial schemas.** This was found while diagnosing a live board whose links carry a large *stale* schema frozen in by a repair write; that case is untouched here by design, since such a schema does constrain and the reader has no basis to override it. Filed separately.

The write side does not mint schema-less-but-permissive links (`createSigilLinkFromParsedLink` omits a schema failing `isNontrivialSchema`), so what this repairs is reads of data already stored.

`stored-link-schema-precedence.test.ts` pins the invariant that an element read by its own path projects the same as that element read within its array — for `true` and for `{}` — alongside the two cases that must not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

