### PR TITLE
feat(logger): a recorded time span can put itself on the timeline

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -167,11 +167,35 @@ deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
   /tmp/measures.json --key=tx/read --chains     # the full chains
 ```
 
-Read the `--via` table for the ratio rather than the totals, because the two
-shapes it separates have different fixes: many parent spans doing a little each
-is a frequency problem, and few parent spans doing a great deal each is a width
-problem. A large root share is not a gap in the data — it says those spans ran
-outside every instrumented region, which is the next thing to wrap. The level where a count stops being
+### Keep asking until the shape stops changing
+
+Each answer here suggests the next question, and the investigation is not
+finished when one of them returns a number — it is finished when the shape stops
+changing. Drive it yourself rather than stopping at the first table:
+
+1. **What dominates?** Aggregate. If one key is most of the spans, it is the
+   subject.
+2. **Who calls it?** Attribute. A key that runs everywhere names no caller in
+   its own row.
+3. **Frequency or width?** Read `--via` for the ratio, not the totals. Many
+   callers doing a little each is a frequency problem, fixed by calling less.
+   Few doing a great deal each is a width problem, fixed by making one call ask
+   for less — and those live at opposite ends of the stack.
+4. **Is the unit cost flat?** Compare time per child across the buckets. Flat
+   means volume and nothing else; rising with size means a second defect inside
+   the heavy calls, and it is worth separating before either is fixed.
+5. **Who calls the heavy ones?** `--heavy=N`. This is the question most easily
+   skipped, and its answer is routinely different from step 2's — a call site
+   can be dominated by a handful of instances whose callers are nothing like the
+   typical one.
+6. **Repeat on whatever step 5 named**, until either a pattern repeats across
+   the heavy instances or the chain reaches uninstrumented ground.
+
+Reaching uninstrumented ground is a result, not a dead end. A large root share
+says those spans ran outside every wrapped region, and the next move is to wrap
+one level above the thing you were chasing and run again — which is step 2 of
+this list with a better vantage point. Say so explicitly rather than reporting
+the attributable fraction as though it were the whole. The level where a count stops being
 proportional to the work and starts being proportional to the work squared is
 the level that introduced the multiplication — that is the caller to fix, and it
 is frequently not the

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -144,13 +144,34 @@ deno task cf test <file> --timing-measures-out /tmp/measures.json
 deno run --allow-read skills/perf-investigation/scripts/aggregate-measures.ts /tmp/measures.json
 ```
 
-The script rolls every span up by key prefix and prints calls, total, and time
-per call at each level. That roll-up is precisely what the stored statistics
+`aggregate-measures.ts` rolls every span up by key prefix and prints calls,
+total, and time per call at each level. That roll-up is precisely what the stored statistics
 cannot give you — a logger records against its full joined path and nothing
 shorter, so the count at the level where multiplication begins is in no row.
 Scan down a branch: the level whose calls jump by a large factor over its
 parent's while its own time per call stays flat is the one that introduced the
-multiplication. The level where a count stops being
+multiplication.
+
+That answers where the time went. It does not answer who asked, and for a key
+that runs everywhere it cannot: a logger records against its own key no matter
+which caller reached it. `attribute-measures.ts` recovers the caller from the
+intervals — spans nest, so whichever span was open when another began is the one
+that called it:
+
+```bash
+deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
+  /tmp/measures.json --key=tx/read              # who calls it
+deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
+  /tmp/measures.json --key=tx/read --via=traverse   # and how many each does
+deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
+  /tmp/measures.json --key=tx/read --chains     # the full chains
+```
+
+Read the `--via` table for the ratio rather than the totals, because the two
+shapes it separates have different fixes: many parent spans doing a little each
+is a frequency problem, and few parent spans doing a great deal each is a width
+problem. A large root share is not a gap in the data — it says those spans ran
+outside every instrumented region, which is the next thing to wrap. The level where a count stops being
 proportional to the work and starts being proportional to the work squared is
 the level that introduced the multiplication — that is the caller to fix, and it
 is frequently not the

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -27,10 +27,16 @@ counts for anything already wrapped exist before you touch the code.
 What is *not* on by default is emission. `CF_TIMING_MEASURES=1` makes every
 recorded span also emit a `performance.measure`, which is what puts it on the
 timeline of the process that ran it and what step 4 aggregates. It is off
-because a measure costs several times what recording the span does, and the
-spans a logger wraps are the hot paths a profile is trying to describe — paying
-that always would distort the thing being measured. Turn it on for an
-investigation, not for a run you intend to trust the absolute numbers of.
+because the volume is meant for a tool rather than for a person: a topics
+pattern test emits more than 800,000 spans, and a human opening a timeline wants
+the phases someone deliberately named, not every span the runtime recorded. Turn
+it on for the length of an investigation and read it with something that
+aggregates.
+
+`CF_TIMING_MEASURES_CAP` raises the ceiling. It matters more than it looks:
+emission stops at the cap rather than sampling, so a run that hits it leaves an
+early-run prefix, and attributing a whole run from its setup is the mistake that
+invites.
 
 ## 1. Find the phase
 

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -156,10 +156,10 @@ show. `ms/call` says which level is expensive, and the two `self` columns
 separate a level that is itself slow from one that merely contains slow
 children.
 
-Note for a `cf test` capture: `withPhase` emits its own measure under a
-`cf-test/` prefix as well as recording the span through a logger, so those
-phases appear twice — once as `cf-test/<keys>` and once as `<keys>`. Read one
-branch or the other rather than summing across both.
+Only spans a logger recorded reach the file. `withPhase` also emits a measure
+of its own, under a `cf-test/` name and without the logger's prefix, and the
+capture leaves it on the timeline rather than writing it — so a phase appears
+once, under its logger keys, and the counts do not double.
 
 That answers where the time went. It does not answer who asked, and for a key
 that runs everywhere it cannot: a logger records against its own key no matter

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -145,12 +145,21 @@ deno run --allow-read skills/perf-investigation/scripts/aggregate-measures.ts /t
 ```
 
 `aggregate-measures.ts` rolls every span up by key prefix and prints calls,
-total, and time per call at each level. That roll-up is precisely what the stored statistics
-cannot give you — a logger records against its full joined path and nothing
-shorter, so the count at the level where multiplication begins is in no row.
-Scan down a branch: the level whose calls jump by a large factor over its
-parent's while its own time per call stays flat is the one that introduced the
-multiplication.
+total, time per call, and the spans recorded at exactly that level. That roll-up
+is what the stored statistics cannot give you — a logger records against its
+full joined path and nothing shorter, so no row holds a total for a prefix.
+
+Read it for where time concentrates, not for a call explosion. It groups keys by
+how they are NAMED, so `calls` counts every span at a prefix or below it and can
+only fall as you descend; a count that rises is not something this view can
+show. `ms/call` says which level is expensive, and the two `self` columns
+separate a level that is itself slow from one that merely contains slow
+children.
+
+Note for a `cf test` capture: `withPhase` emits its own measure under a
+`cf-test/` prefix as well as recording the span through a logger, so those
+phases appear twice — once as `cf-test/<keys>` and once as `<keys>`. Read one
+branch or the other rather than summing across both.
 
 That answers where the time went. It does not answer who asked, and for a key
 that runs everywhere it cannot: a logger records against its own key no matter

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -24,6 +24,14 @@ A logger constructed disabled is quiet, not inert.
 So the first move is reading, not instrumenting. The phase timings and call
 counts for anything already wrapped exist before you touch the code.
 
+What is *not* on by default is emission. `CF_TIMING_MEASURES=1` makes every
+recorded span also emit a `performance.measure`, which is what puts it on the
+timeline of the process that ran it and what step 4 aggregates. It is off
+because a measure costs several times what recording the span does, and the
+spans a logger wraps are the hot paths a profile is trying to describe — paying
+that always would distort the thing being measured. Turn it on for an
+investigation, not for a run you intend to trust the absolute numbers of.
+
 ## 1. Find the phase
 
 ```bash
@@ -118,10 +126,25 @@ those by name instead of widening the summary.
 A count that is too high is visible at the top level. The caller that multiplies
 it is not.
 
-Keep splitting the phase into subphases and comparing counts between adjacent
-levels. Compare the counts, not shares of a total: each key is timed
-independently and nothing aggregates, so a child's contribution cannot be
-inferred by subtracting it from its parent. The level where a count stops being
+Two ways to get there. By hand, keep splitting the phase into subphases and
+compare counts between adjacent levels — the counts themselves, not shares of a
+total, since each key is timed independently and a child's contribution cannot
+be inferred by subtracting it from its parent.
+
+Or let the measures do it. With emission on (step 0):
+
+```bash
+deno task cf test <file> --timing-measures-out /tmp/measures.json
+deno run --allow-read skills/perf-investigation/scripts/aggregate-measures.ts /tmp/measures.json
+```
+
+The script rolls every span up by key prefix and prints calls, total, and time
+per call at each level. That roll-up is precisely what the stored statistics
+cannot give you — a logger records against its full joined path and nothing
+shorter, so the count at the level where multiplication begins is in no row.
+Scan down a branch: the level whose calls jump by a large factor over its
+parent's while its own time per call stays flat is the one that introduced the
+multiplication. The level where a count stops being
 proportional to the work and starts being proportional to the work squared is
 the level that introduced the multiplication — that is the caller to fix, and it
 is frequently not the

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -76,6 +76,12 @@ export const test = new Command()
     "--pattern-coverage-dir <dir:string>",
     "Write pattern runtime coverage LCOV artifacts to this directory.",
   )
+  .option(
+    "--timing-measures-out <file:string>",
+    "Emit a performance.measure per logger time span and write them here as " +
+      "JSON. Aggregate with skills/perf-investigation/scripts/" +
+      "aggregate-measures.ts.",
+  )
   .arguments("<paths...:string>")
   .action(async (options, ...paths) => {
     const testFiles: string[] = [];
@@ -159,6 +165,9 @@ export const test = new Command()
       statsActionLimit: options.statsActionLimit,
       storageStats: options.storageStats,
       storageStatsLimit: options.storageStatsLimit,
+      timingMeasuresOut: options.timingMeasuresOut
+        ? resolve(Deno.cwd(), options.timingMeasuresOut)
+        : undefined,
       patternCoverageDir,
       continuousUI: Deno.env.get("CF_TEST_CONTINUOUS_UI") === "1",
     });

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -69,12 +69,15 @@ import {
   clearTimingMeasures,
   getLogger,
   getLoggerCountsBreakdown,
+  getTimingMeasuresState,
   getTimingStatsBreakdown,
   resetAllCountBaselines,
   resetAllLoggerCounts,
   resetAllTimingBaselines,
   resetAllTimingStats,
+  resetTimingMeasureBudget,
   setTimingMeasuresEnabled,
+  TIMING_MEASURE_PREFIX,
 } from "@commonfabric/utils/logger";
 import { timeout } from "@commonfabric/utils/sleep";
 
@@ -131,20 +134,36 @@ async function withPhase<T>(
   }
 }
 
+interface CapturedMeasure {
+  name: string;
+  startTime: number;
+  duration: number;
+}
+
 /**
- * Write every emitted timing measure out as JSON, then drop them.
+ * Take this file's emitted measures off the timeline.
  *
- * The entries are the only copy and nothing else clears them, so draining here
- * is what keeps a long run from growing its buffer without bound.
+ * Draining per file rather than reading once at the end is what makes a
+ * multi-file run work at all: each file starts by clearing the timeline, so
+ * anything not collected before the next one begins is gone.
  */
-async function writeTimingMeasures(path: string): Promise<void> {
-  const entries = performance.getEntriesByType("measure").map((entry) => ({
-    name: entry.name,
-    startTime: entry.startTime,
-    duration: entry.duration,
-  }));
-  await Deno.writeTextFile(path, JSON.stringify(entries));
+function drainTimingMeasures(into: CapturedMeasure[]): void {
+  for (const entry of performance.getEntriesByType("measure")) {
+    if (!entry.name.startsWith(TIMING_MEASURE_PREFIX)) continue;
+    into.push({
+      name: entry.name,
+      startTime: entry.startTime,
+      duration: entry.duration,
+    });
+  }
   clearTimingMeasures();
+}
+
+async function writeTimingMeasures(
+  path: string,
+  entries: readonly CapturedMeasure[],
+): Promise<void> {
+  await Deno.writeTextFile(path, JSON.stringify(entries));
   console.log(
     `\nWrote ${entries.length} timing measure(s) to ${path}. Aggregate with:` +
       `\n  deno run --allow-read ` +
@@ -992,6 +1011,9 @@ export async function runTestPattern(
   const startTime = performance.now();
   performance.clearMarks();
   performance.clearMeasures();
+  // The line above drops this run's emitted measures along with everything
+  // else, so the budget they were charged against has to come back too.
+  resetTimingMeasureBudget();
   resetAllLoggerCounts();
   resetAllTimingStats();
 
@@ -1985,6 +2007,13 @@ export async function runTests(
   results: TestRunResult[];
 }> {
   const paths = Array.isArray(pathOrPaths) ? pathOrPaths : [pathOrPaths];
+  // Emission is process-global, so a run that turns it on owes the process its
+  // previous state back — otherwise a later `runTests()` without the option
+  // keeps emitting into a buffer nobody will read.
+  const priorMeasureState = getTimingMeasuresState().enabled;
+  const captured: CapturedMeasure[] | undefined = options.timingMeasuresOut
+    ? []
+    : undefined;
   if (options.timingMeasuresOut) setTimingMeasuresEnabled(true);
   const allResults: TestRunResult[] = [];
   let totalPassed = 0;
@@ -2028,6 +2057,10 @@ export async function runTests(
       console.log(`  ✗ ${formatError(error)}`);
       recordFile(testPath, true, performance.now() - fileStarted);
       continue;
+    } finally {
+      // Before the next file clears the timeline, and on the failure path too:
+      // a file that wedged is often the one whose measures are wanted.
+      if (captured) drainTimingMeasures(captured);
     }
     allResults.push(result);
 
@@ -2171,9 +2204,10 @@ export async function runTests(
   }
   recordsFragment?.close();
 
-  if (options.timingMeasuresOut) {
-    await writeTimingMeasures(options.timingMeasuresOut);
+  if (options.timingMeasuresOut && captured) {
+    await writeTimingMeasures(options.timingMeasuresOut, captured);
   }
+  setTimingMeasuresEnabled(priorMeasureState);
 
   // Summary
   const totalTime = allResults.reduce((sum, r) => sum + r.totalDurationMs, 0);

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -2010,7 +2010,7 @@ export async function runTests(
   // Emission is process-global, so a run that turns it on owes the process its
   // previous state back — otherwise a later `runTests()` without the option
   // keeps emitting into a buffer nobody will read.
-  const priorMeasures = getTimingMeasuresState();
+  const priorMeasureState = getTimingMeasuresState().enabled;
   const captured: CapturedMeasure[] | undefined = options.timingMeasuresOut
     ? []
     : undefined;
@@ -2212,9 +2212,7 @@ export async function runTests(
   if (options.timingMeasuresOut && captured) {
     await writeTimingMeasures(options.timingMeasuresOut, captured);
   }
-  // Both halves of what was borrowed: the switch and the ceiling. Restoring
-  // only the switch would leave the raised cap behind for the whole process.
-  setTimingMeasuresEnabled(priorMeasures.enabled, { cap: priorMeasures.cap });
+  setTimingMeasuresEnabled(priorMeasureState);
 
   // Summary
   const totalTime = allResults.reduce((sum, r) => sum + r.totalDurationMs, 0);

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -2010,7 +2010,7 @@ export async function runTests(
   // Emission is process-global, so a run that turns it on owes the process its
   // previous state back — otherwise a later `runTests()` without the option
   // keeps emitting into a buffer nobody will read.
-  const priorMeasureState = getTimingMeasuresState().enabled;
+  const priorMeasures = getTimingMeasuresState();
   const captured: CapturedMeasure[] | undefined = options.timingMeasuresOut
     ? []
     : undefined;
@@ -2209,10 +2209,17 @@ export async function runTests(
   }
   recordsFragment?.close();
 
-  if (options.timingMeasuresOut && captured) {
-    await writeTimingMeasures(options.timingMeasuresOut, captured);
+  try {
+    if (options.timingMeasuresOut && captured) {
+      await writeTimingMeasures(options.timingMeasuresOut, captured);
+    }
+  } finally {
+    // Both halves of what was borrowed, and in a `finally` because a failed
+    // write must not strand them: the switch left on costs every later run in
+    // the process, and the raised ceiling left behind removes the retention
+    // bound entirely.
+    setTimingMeasuresEnabled(priorMeasures.enabled, { cap: priorMeasures.cap });
   }
-  setTimingMeasuresEnabled(priorMeasureState);
 
   // Summary
   const totalTime = allResults.reduce((sum, r) => sum + r.totalDurationMs, 0);

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -2014,7 +2014,12 @@ export async function runTests(
   const captured: CapturedMeasure[] | undefined = options.timingMeasuresOut
     ? []
     : undefined;
-  if (options.timingMeasuresOut) setTimingMeasuresEnabled(true);
+  if (options.timingMeasuresOut) {
+    // Draining per file means the buffer never holds more than one file's
+    // worth, so the default ceiling — which exists to bound a process that
+    // never drains — would only truncate the capture for no benefit.
+    setTimingMeasuresEnabled(true, { cap: Number.MAX_SAFE_INTEGER });
+  }
   const allResults: TestRunResult[] = [];
   let totalPassed = 0;
   let totalFailed = 0;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -2010,7 +2010,7 @@ export async function runTests(
   // Emission is process-global, so a run that turns it on owes the process its
   // previous state back — otherwise a later `runTests()` without the option
   // keeps emitting into a buffer nobody will read.
-  const priorMeasureState = getTimingMeasuresState().enabled;
+  const priorMeasures = getTimingMeasuresState();
   const captured: CapturedMeasure[] | undefined = options.timingMeasuresOut
     ? []
     : undefined;
@@ -2212,7 +2212,9 @@ export async function runTests(
   if (options.timingMeasuresOut && captured) {
     await writeTimingMeasures(options.timingMeasuresOut, captured);
   }
-  setTimingMeasuresEnabled(priorMeasureState);
+  // Both halves of what was borrowed: the switch and the ceiling. Restoring
+  // only the switch would leave the raised cap behind for the whole process.
+  setTimingMeasuresEnabled(priorMeasures.enabled, { cap: priorMeasures.cap });
 
   // Summary
   const totalTime = allResults.reduce((sum, r) => sum + r.totalDurationMs, 0);

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -66,6 +66,7 @@ import type {
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
   type CDFPoint,
+  clearTimingMeasures,
   getLogger,
   getLoggerCountsBreakdown,
   getTimingStatsBreakdown,
@@ -73,6 +74,7 @@ import {
   resetAllLoggerCounts,
   resetAllTimingBaselines,
   resetAllTimingStats,
+  setTimingMeasuresEnabled,
 } from "@commonfabric/utils/logger";
 import { timeout } from "@commonfabric/utils/sleep";
 
@@ -127,6 +129,27 @@ async function withPhase<T>(
     phaseLogger.timeEnd(...keys);
     performance.measure(`${label}#${phaseMarkSequence}`, startMark, endMark);
   }
+}
+
+/**
+ * Write every emitted timing measure out as JSON, then drop them.
+ *
+ * The entries are the only copy and nothing else clears them, so draining here
+ * is what keeps a long run from growing its buffer without bound.
+ */
+async function writeTimingMeasures(path: string): Promise<void> {
+  const entries = performance.getEntriesByType("measure").map((entry) => ({
+    name: entry.name,
+    startTime: entry.startTime,
+    duration: entry.duration,
+  }));
+  await Deno.writeTextFile(path, JSON.stringify(entries));
+  clearTimingMeasures();
+  console.log(
+    `\nWrote ${entries.length} timing measure(s) to ${path}. Aggregate with:` +
+      `\n  deno run --allow-read ` +
+      `skills/perf-investigation/scripts/aggregate-measures.ts ${path}`,
+  );
 }
 
 function formatError(error: unknown): string {
@@ -311,6 +334,16 @@ export interface TestRunnerOptions {
   patternCoverageDir?: string;
   /** Keep the test descriptor's `$UI` demanded for the full test run. */
   continuousUI?: boolean;
+  /**
+   * Emit a `performance.measure` per logger time span and write them here.
+   *
+   * The statistics a run prints are aggregates: they say a key was reached
+   * 4,000 times and what that cost on average, and nothing about which of
+   * them nested inside which. The measures keep each span's own interval, so
+   * a consumer can roll them up by key prefix and find the level where the
+   * count starts multiplying.
+   */
+  timingMeasuresOut?: string;
   /**
    * Run against a caller-supplied identity and storage manager, and observe
    * what the run instantiates.
@@ -1952,6 +1985,7 @@ export async function runTests(
   results: TestRunResult[];
 }> {
   const paths = Array.isArray(pathOrPaths) ? pathOrPaths : [pathOrPaths];
+  if (options.timingMeasuresOut) setTimingMeasuresEnabled(true);
   const allResults: TestRunResult[] = [];
   let totalPassed = 0;
   let totalFailed = 0;
@@ -2136,6 +2170,10 @@ export async function runTests(
     recordFile(testPath, totalFailed > failedBefore, result.totalDurationMs);
   }
   recordsFragment?.close();
+
+  if (options.timingMeasuresOut) {
+    await writeTimingMeasures(options.timingMeasuresOut);
+  }
 
   // Summary
   const totalTime = allResults.reduce((sum, r) => sum + r.totalDurationMs, 0);

--- a/packages/cli/test/test-runner-timing-measures.test.ts
+++ b/packages/cli/test/test-runner-timing-measures.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Guard for `--timing-measures-out`, whose whole value is that the file it
+ * writes describes the run rather than a fragment of it.
+ *
+ * Each test file starts by clearing the performance timeline, so a capture read
+ * once at the end of a multi-file run keeps only the last file and reports its
+ * count as though it were the run's. That is invisible in a passing run — the
+ * tests still pass, the file still exists, and only the numbers are wrong —
+ * which is why it is pinned here rather than left to a reading of the code.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+import {
+  getTimingMeasuresState,
+  TIMING_MEASURE_PREFIX,
+} from "@commonfabric/utils/logger";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/step-kinds");
+const FIXTURE = resolve(FIXTURES, "marker-step.test.tsx");
+
+interface Written {
+  name: string;
+  startTime: number;
+  duration: number;
+}
+
+async function runCapturing(paths: string | string[]): Promise<Written[]> {
+  const out = await Deno.makeTempFile({ suffix: ".json" });
+  try {
+    await runTests(paths, { root: FIXTURES, timingMeasuresOut: out });
+    return JSON.parse(await Deno.readTextFile(out)) as Written[];
+  } finally {
+    await Deno.remove(out);
+  }
+}
+
+describe(
+  "test-runner timing measures",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("writes the spans a run emitted, each carrying the logger's prefix", async () => {
+      const written = await runCapturing(FIXTURE);
+
+      expect(written.length).toBeGreaterThan(0);
+      expect(
+        written.every((entry) => entry.name.startsWith(TIMING_MEASURE_PREFIX)),
+      ).toBe(true);
+      // Intervals are the point of emitting these at all: without them the
+      // statistics already say how long and how often.
+      expect(written.every((entry) => entry.duration >= 0)).toBe(true);
+    });
+
+    it("keeps every file's spans when several are run", async () => {
+      const single = await runCapturing(FIXTURE);
+      const double = await runCapturing([FIXTURE, FIXTURE]);
+
+      // The same file twice, so the second run should hold about twice the
+      // spans. Reading the timeline once at the end instead of draining per
+      // file would leave it holding roughly the same as one.
+      expect(double.length).toBeGreaterThan(single.length * 1.5);
+    });
+
+    it("leaves emission as it found it", async () => {
+      const before = getTimingMeasuresState().enabled;
+      await runCapturing(FIXTURE);
+      // Emission is process-global; a run that borrows it owes it back, or
+      // every later run in the process pays for a capture nobody reads.
+      expect(getTimingMeasuresState().enabled).toBe(before);
+    });
+
+    it("emits nothing when the option is absent", async () => {
+      await runTests(FIXTURE, { root: FIXTURES });
+      expect(
+        performance.getEntriesByType("measure").some((entry) =>
+          entry.name.startsWith(TIMING_MEASURE_PREFIX)
+        ),
+      ).toBe(false);
+    });
+  },
+);

--- a/packages/cli/test/test-runner-timing-measures.test.ts
+++ b/packages/cli/test/test-runner-timing-measures.test.ts
@@ -72,12 +72,17 @@ describe(
       expect(compiles(await runCapturing([FIXTURE, FIXTURE]))).toBe(2);
     });
 
-    it("leaves emission as it found it", async () => {
-      const before = getTimingMeasuresState().enabled;
+    it("leaves emission and the cap as it found them", async () => {
+      const before = getTimingMeasuresState();
       await runCapturing(FIXTURE);
+      const after = getTimingMeasuresState();
       // Emission is process-global; a run that borrows it owes it back, or
       // every later run in the process pays for a capture nobody reads.
-      expect(getTimingMeasuresState().enabled).toBe(before);
+      expect(after.enabled).toBe(before.enabled);
+      // The ceiling is borrowed too — the run raises it because it drains per
+      // file. Left behind, it removes the retention bound for the whole
+      // process, which is the one thing the cap exists to provide.
+      expect(after.cap).toBe(before.cap);
     });
 
     it("emits nothing when the option is absent", async () => {

--- a/packages/cli/test/test-runner-timing-measures.test.ts
+++ b/packages/cli/test/test-runner-timing-measures.test.ts
@@ -13,7 +13,9 @@ import { expect } from "@std/expect";
 import { resolve } from "@std/path";
 import { runTests } from "../lib/test-runner.ts";
 import {
+  clearTimingMeasures,
   getTimingMeasuresState,
+  setTimingMeasuresEnabled,
   TIMING_MEASURE_PREFIX,
 } from "@commonfabric/utils/logger";
 
@@ -53,13 +55,21 @@ describe(
     });
 
     it("keeps every file's spans when several are run", async () => {
-      const single = await runCapturing(FIXTURE);
-      const double = await runCapturing([FIXTURE, FIXTURE]);
+      // Counting a phase that runs exactly once per file rather than comparing
+      // totals: a warm compile cache makes a second run of the same file much
+      // cheaper, so span counts across runs are not comparable — the phase
+      // still runs, and still reports, whether or not it hits the cache.
+      const compiles = (written: Written[]) =>
+        written.filter((entry) =>
+          entry.name.startsWith(
+            `${TIMING_MEASURE_PREFIX}runTestPattern/compile#`,
+          )
+        ).length;
 
-      // The same file twice, so the second run should hold about twice the
-      // spans. Reading the timeline once at the end instead of draining per
-      // file would leave it holding roughly the same as one.
-      expect(double.length).toBeGreaterThan(single.length * 1.5);
+      expect(compiles(await runCapturing(FIXTURE))).toBe(1);
+      // Reading the timeline once at the end instead of draining per file
+      // would report one here, because each file clears what came before it.
+      expect(compiles(await runCapturing([FIXTURE, FIXTURE]))).toBe(2);
     });
 
     it("leaves emission as it found it", async () => {
@@ -77,6 +87,29 @@ describe(
           entry.name.startsWith(TIMING_MEASURE_PREFIX)
         ),
       ).toBe(false);
+    });
+
+    it("takes its cap from the environment when none is passed", () => {
+      // This lives here rather than beside the other logger tests because
+      // `packages/utils` runs its suite with no permissions at all, and
+      // reading an environment variable needs one. The library copes — every
+      // env read there is wrapped — but a test that sets one cannot.
+      const before = getTimingMeasuresState();
+      Deno.env.set("CF_TIMING_MEASURES_CAP", "4242");
+      try {
+        setTimingMeasuresEnabled(true);
+        expect(getTimingMeasuresState().cap).toBe(4242);
+
+        // A value naming no positive integer is ignored rather than applied,
+        // which would otherwise disable the guard from outside the process.
+        Deno.env.set("CF_TIMING_MEASURES_CAP", "not-a-number");
+        setTimingMeasuresEnabled(true);
+        expect(getTimingMeasuresState().cap).toBe(4242);
+      } finally {
+        Deno.env.delete("CF_TIMING_MEASURES_CAP");
+        setTimingMeasuresEnabled(before.enabled, { cap: before.cap });
+        clearTimingMeasures();
+      }
     });
   },
 );

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -531,14 +531,27 @@ function getEnvMeasuresEnabled(): boolean {
  * sample — and a reader who does not know that will attribute a whole run from
  * its setup. Raising it has to be reachable from wherever emission is.
  */
+/**
+ * What `CF_TIMING_MEASURES_CAP` means, separated from reading it.
+ *
+ * Separate because the decision is the part with a rule in it — anything that
+ * does not name a positive integer is ignored rather than applied, since a cap
+ * of zero or `NaN` would disable the guard from outside the process. Reading an
+ * environment variable needs a permission this package's test suite
+ * deliberately does not grant, and the rule should be testable without one.
+ */
+export function parseTimingMeasureCap(
+  raw: string | undefined,
+): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 function getEnvMeasureCap(): number | undefined {
   if (isDeno()) {
     try {
-      const raw = Deno.env.get("CF_TIMING_MEASURES_CAP");
-      if (raw) {
-        const parsed = Number(raw);
-        if (Number.isInteger(parsed) && parsed > 0) return parsed;
-      }
+      return parseTimingMeasureCap(Deno.env.get("CF_TIMING_MEASURES_CAP"));
     } catch { /* ignore permission errors */ }
   }
   return undefined;

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -559,11 +559,23 @@ export function setTimingMeasuresEnabled(
   options?: { cap?: number },
 ): void {
   _emitTimingMeasures = enabled;
-  const envCap = getEnvMeasureCap();
-  if (options?.cap !== undefined) _timingMeasureCap = options.cap;
-  else if (envCap !== undefined) _timingMeasureCap = envCap;
-  _timingMeasuresEmitted = 0;
-  _timingMeasureCapReported = false;
+  if (options?.cap !== undefined) {
+    // A cap of `NaN`, `Infinity`, or zero would disable the guard rather than
+    // configure it, and the guard is the only thing bounding retention.
+    if (!Number.isInteger(options.cap) || options.cap <= 0) {
+      throw new RangeError(
+        `Timing measure cap must be a positive integer: ${options.cap}`,
+      );
+    }
+    _timingMeasureCap = options.cap;
+  } else {
+    const envCap = getEnvMeasureCap();
+    if (envCap !== undefined) _timingMeasureCap = envCap;
+  }
+  // The budget deliberately survives this. It counts entries that are still on
+  // the timeline, so returning it without draining them would let a caller
+  // toggling emission retain another whole cap's worth — the growth the cap
+  // exists to bound. `clearTimingMeasures()` is what gives it back.
 }
 
 /** Whether measure emission is currently on, and what it has spent. */

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -503,6 +503,16 @@ let _timingMeasureCapReported = false;
 /** A monotonic suffix, so two spans on one key stay distinguishable. */
 let _timingMeasureSequence = 0;
 
+/**
+ * What marks a measure as this logger's.
+ *
+ * The performance timeline is shared with whatever else the host instruments,
+ * so emitted entries carry a prefix for two reasons: clearing can then remove
+ * only what this emitted rather than destroying a page's own measures, and a
+ * human scanning a timeline can tell logger spans from application ones.
+ */
+export const TIMING_MEASURE_PREFIX = "cf:";
+
 function getEnvMeasuresEnabled(): boolean {
   if (isDeno()) {
     try {
@@ -577,8 +587,27 @@ export function getTimingMeasuresState(): {
  */
 export function clearTimingMeasures(): void {
   try {
-    performance.clearMeasures();
+    // By name rather than wholesale: the timeline belongs to the host, and a
+    // page or worker that instruments itself would otherwise lose its own
+    // measures to a call that claims only to drain this feature's.
+    for (const entry of performance.getEntriesByType("measure")) {
+      if (entry.name.startsWith(TIMING_MEASURE_PREFIX)) {
+        performance.clearMeasures(entry.name);
+      }
+    }
   } catch { /* not every host implements it */ }
+  resetTimingMeasureBudget();
+}
+
+/**
+ * Give the budget back without touching the timeline.
+ *
+ * Something other than this feature may clear the timeline — a test runner
+ * resetting between files does — and the count of what has been emitted has to
+ * follow, or emission stays stopped against a cap it no longer owes anything
+ * to.
+ */
+export function resetTimingMeasureBudget(): void {
   _timingMeasuresEmitted = 0;
   _timingMeasureCapReported = false;
 }
@@ -1193,10 +1222,13 @@ export class Logger {
       return;
     }
     try {
-      performance.measure(`${path}#${++_timingMeasureSequence}`, {
-        start: startTime,
-        end: startTime + elapsed,
-      });
+      performance.measure(
+        `${TIMING_MEASURE_PREFIX}${path}#${++_timingMeasureSequence}`,
+        {
+          start: startTime,
+          end: startTime + elapsed,
+        },
+      );
       _timingMeasuresEmitted++;
     } catch {
       // Instrumentation never fails the thing it is measuring.

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -558,15 +558,20 @@ export function setTimingMeasuresEnabled(
   enabled: boolean,
   options?: { cap?: number },
 ): void {
-  _emitTimingMeasures = enabled;
-  if (options?.cap !== undefined) {
+  // Validated before anything is assigned, so a rejected call leaves the
+  // switch exactly as it found it rather than half-applied.
+  if (
+    options?.cap !== undefined && (!Number.isInteger(options.cap) ||
+      options.cap <= 0)
+  ) {
     // A cap of `NaN`, `Infinity`, or zero would disable the guard rather than
     // configure it, and the guard is the only thing bounding retention.
-    if (!Number.isInteger(options.cap) || options.cap <= 0) {
-      throw new RangeError(
-        `Timing measure cap must be a positive integer: ${options.cap}`,
-      );
-    }
+    throw new RangeError(
+      `Timing measure cap must be a positive integer: ${options.cap}`,
+    );
+  }
+  _emitTimingMeasures = enabled;
+  if (options?.cap !== undefined) {
     _timingMeasureCap = options.cap;
   } else {
     const envCap = getEnvMeasureCap();

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -471,10 +471,15 @@ _globalLevelFloor = getEnvFloor();
 /**
  * Whether every recorded time span also emits a `performance.measure`.
  *
- * Off unless asked for, and the reason is cost rather than caution: a measure
- * costs roughly three times what recording the span into the statistics does,
- * and the spans this instruments are the hot paths a profile is trying to
- * describe. Paying that always would distort what it measures.
+ * Off unless asked for, because these are for a tool rather than for a person.
+ * A run emits hundreds of thousands of them — a topics pattern test produces
+ * over 800,000 — and a human opening the timeline wants to see the handful of
+ * phases someone named, not every span the runtime recorded. Emission is turned
+ * on for the length of an investigation and read by something that aggregates.
+ *
+ * The cost is real but secondary: a measure runs about three and a half times
+ * what recording the span into the statistics does, which is worth knowing for
+ * a hot path and is not what decides the default.
  *
  * Turned on, every span already carried by a logger becomes an entry on the
  * timeline of the process that ran it — which is the whole point, because a
@@ -508,7 +513,29 @@ function getEnvMeasuresEnabled(): boolean {
   return false;
 }
 
+/**
+ * The cap named by `CF_TIMING_MEASURES_CAP`, when it names a positive integer.
+ *
+ * Separate from the on/off variable because a run that hits the cap stops
+ * emitting partway through, which leaves an early-run prefix rather than a
+ * sample — and a reader who does not know that will attribute a whole run from
+ * its setup. Raising it has to be reachable from wherever emission is.
+ */
+function getEnvMeasureCap(): number | undefined {
+  if (isDeno()) {
+    try {
+      const raw = Deno.env.get("CF_TIMING_MEASURES_CAP");
+      if (raw) {
+        const parsed = Number(raw);
+        if (Number.isInteger(parsed) && parsed > 0) return parsed;
+      }
+    } catch { /* ignore permission errors */ }
+  }
+  return undefined;
+}
+
 _emitTimingMeasures = getEnvMeasuresEnabled();
+_timingMeasureCap = getEnvMeasureCap() ?? _timingMeasureCap;
 
 /**
  * Turn `performance.measure` emission on or off for every logger.
@@ -522,7 +549,9 @@ export function setTimingMeasuresEnabled(
   options?: { cap?: number },
 ): void {
   _emitTimingMeasures = enabled;
+  const envCap = getEnvMeasureCap();
   if (options?.cap !== undefined) _timingMeasureCap = options.cap;
+  else if (envCap !== undefined) _timingMeasureCap = envCap;
   _timingMeasuresEmitted = 0;
   _timingMeasureCapReported = false;
 }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -587,8 +587,10 @@ export function setTimingMeasuresEnabled(
   if (options?.cap !== undefined) {
     _timingMeasureCap = options.cap;
   } else {
-    const envCap = getEnvMeasureCap();
-    if (envCap !== undefined) _timingMeasureCap = envCap;
+    // Coalesced rather than branched: an environment that names no usable cap
+    // leaves the current one alone, and there is nothing here that only some
+    // runs execute.
+    _timingMeasureCap = getEnvMeasureCap() ?? _timingMeasureCap;
   }
   // The budget deliberately survives this. It counts entries that are still on
   // the timeline, so returning it without draining them would let a caller

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -469,6 +469,92 @@ function getEnvFloor(): LogLevel | undefined {
 _globalLevelFloor = getEnvFloor();
 
 /**
+ * Whether every recorded time span also emits a `performance.measure`.
+ *
+ * Off unless asked for, and the reason is cost rather than caution: a measure
+ * costs roughly three times what recording the span into the statistics does,
+ * and the spans this instruments are the hot paths a profile is trying to
+ * describe. Paying that always would distort what it measures.
+ *
+ * Turned on, every span already carried by a logger becomes an entry on the
+ * timeline of the process that ran it — which is the whole point, because a
+ * sampling profile knows nothing about phases and marks only reach the profile
+ * taken in their own process.
+ */
+let _emitTimingMeasures = false;
+
+/**
+ * How many measures may be emitted before emission stops.
+ *
+ * Entries are retained until something clears them, so an unbounded run would
+ * grow the buffer without limit and eventually distort the measurement it was
+ * turned on to take. Emission stops at the cap and says so once, rather than
+ * silently continuing to grow or silently dropping.
+ */
+let _timingMeasureCap = 200_000;
+let _timingMeasuresEmitted = 0;
+let _timingMeasureCapReported = false;
+
+/** A monotonic suffix, so two spans on one key stay distinguishable. */
+let _timingMeasureSequence = 0;
+
+function getEnvMeasuresEnabled(): boolean {
+  if (isDeno()) {
+    try {
+      const raw = Deno.env.get("CF_TIMING_MEASURES");
+      return raw !== undefined && raw !== "" && raw !== "0";
+    } catch { /* ignore permission errors */ }
+  }
+  return false;
+}
+
+_emitTimingMeasures = getEnvMeasuresEnabled();
+
+/**
+ * Turn `performance.measure` emission on or off for every logger.
+ *
+ * The environment variable `CF_TIMING_MEASURES` sets the initial value in Deno;
+ * this is how a browser or worker, which has no environment to read, asks for
+ * the same thing. Passing a `cap` resets the budget along with it.
+ */
+export function setTimingMeasuresEnabled(
+  enabled: boolean,
+  options?: { cap?: number },
+): void {
+  _emitTimingMeasures = enabled;
+  if (options?.cap !== undefined) _timingMeasureCap = options.cap;
+  _timingMeasuresEmitted = 0;
+  _timingMeasureCapReported = false;
+}
+
+/** Whether measure emission is currently on, and what it has spent. */
+export function getTimingMeasuresState(): {
+  enabled: boolean;
+  emitted: number;
+  cap: number;
+} {
+  return {
+    enabled: _emitTimingMeasures,
+    emitted: _timingMeasuresEmitted,
+    cap: _timingMeasureCap,
+  };
+}
+
+/**
+ * Drop every emitted measure and give the budget back.
+ *
+ * A consumer that has read the entries should call this: the entries are the
+ * only copy, so draining is what keeps a long run from growing without bound.
+ */
+export function clearTimingMeasures(): void {
+  try {
+    performance.clearMeasures();
+  } catch { /* not every host implements it */ }
+  _timingMeasuresEmitted = 0;
+  _timingMeasureCapReported = false;
+}
+
+/**
  * Indicates whether a message at the given level should be logged. Respects
  * the global floor when set — the effective threshold is the more restrictive
  * of (floor, per-logger level).
@@ -820,7 +906,7 @@ export class Logger {
 
     const endTime = performance.now();
     const elapsed = endTime - startTime;
-    this.#recordTime(elapsed, keys);
+    this.#recordTime(elapsed, keys, startTime);
     return elapsed;
   }
 
@@ -856,7 +942,7 @@ export class Logger {
 
     const elapsed = endTime - startTime;
     if (keys.length > 0) {
-      this.#recordTime(elapsed, keys);
+      this.#recordTime(elapsed, keys, startTime);
     }
     return elapsed;
   }
@@ -1038,7 +1124,7 @@ export class Logger {
    * Records timing against the full key path only, with no rollup to the
    * shorter paths.
    */
-  #recordTime(elapsed: number, keys: string[]): void {
+  #recordTime(elapsed: number, keys: string[], startTime?: number): void {
     const path = keys.join("/");
     let store = this.#timingsByKey.get(path);
     if (!store) {
@@ -1049,6 +1135,43 @@ export class Logger {
       this.#timingsByKey.set(path, store);
     }
     store.record(elapsed);
+    if (_emitTimingMeasures && startTime !== undefined) {
+      this.#emitMeasure(path, startTime, elapsed);
+    }
+  }
+
+  /**
+   * Put this span on the timeline as well as into the statistics.
+   *
+   * Named `<path>#<n>`, because two spans on one key are two different events
+   * and a shared name would leave a reader unable to tell them apart. The
+   * suffix is what an aggregating consumer strips to recover the key.
+   *
+   * The timestamp form is deliberate: the caller already holds the start, so
+   * there is nothing to gain from marking the boundaries and looking them up
+   * again — the mark-based spelling costs several times as much.
+   */
+  #emitMeasure(path: string, startTime: number, elapsed: number): void {
+    if (_timingMeasuresEmitted >= _timingMeasureCap) {
+      if (!_timingMeasureCapReported) {
+        _timingMeasureCapReported = true;
+        console.warn(
+          `[logger] timing measures stopped at the cap of ` +
+            `${_timingMeasureCap}; call clearTimingMeasures() after reading ` +
+            `them, or raise the cap with setTimingMeasuresEnabled().`,
+        );
+      }
+      return;
+    }
+    try {
+      performance.measure(`${path}#${++_timingMeasureSequence}`, {
+        start: startTime,
+        end: startTime + elapsed,
+      });
+      _timingMeasuresEmitted++;
+    } catch {
+      // Instrumentation never fails the thing it is measuring.
+    }
   }
 
   /** Returns the total count of all log calls, over all four levels. */

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -2138,5 +2138,42 @@ describe("logger", () => {
         expect(parseTimingMeasureCap(bad)).toBeUndefined();
       }
     });
+
+    it("keeps working when the host's performance API refuses", () => {
+      // Instrumentation must never fail the thing it is measuring, and not
+      // every host implements every part of the timeline. Both seams swallow
+      // it: the span is still recorded into the statistics, and draining still
+      // returns the budget.
+      const realMeasure = performance.measure;
+      const realClear = performance.clearMeasures;
+      const boom = () => {
+        throw new Error("no performance API here");
+      };
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-hostile-host");
+      try {
+        // A real entry first, so the drain below has something to reach for —
+        // otherwise it finds nothing to clear and never calls the seam under
+        // test.
+        logger.timeStart("phase", "ten");
+        logger.timeEnd("phase", "ten");
+        expect(getTimingMeasuresState().emitted).toBe(1);
+
+        (performance as { clearMeasures: unknown }).clearMeasures = boom;
+        expect(() => clearTimingMeasures()).not.toThrow();
+        expect(getTimingMeasuresState().emitted).toBe(0);
+
+        (performance as { measure: unknown }).measure = boom;
+        expect(() => {
+          logger.timeStart("phase", "eleven");
+          logger.timeEnd("phase", "eleven");
+        }).not.toThrow();
+        // The statistics still hold it: only the timeline entry was lost.
+        expect(logger.getTimeStats("phase", "eleven")?.count).toBe(1);
+      } finally {
+        performance.measure = realMeasure;
+        performance.clearMeasures = realClear;
+      }
+    });
   });
 });

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   clearTimingMeasures,
   getTimingMeasuresState,
+  parseTimingMeasureCap,
   resetTimingMeasureBudget,
   setTimingMeasuresEnabled,
   TIMING_MEASURE_PREFIX,
@@ -2126,6 +2127,16 @@ describe("logger", () => {
           n.startsWith(`${TIMING_MEASURE_PREFIX}phase/nine#`)
         ).length,
       ).toBe(2);
+    });
+
+    it("reads a cap out of an environment value, or refuses it", () => {
+      expect(parseTimingMeasureCap("4242")).toBe(4242);
+      // Anything that does not name a positive integer is ignored rather than
+      // applied: a zero or NaN cap would disable the guard from outside the
+      // process, which is the one thing the environment must not be able to do.
+      for (const bad of ["", undefined, "0", "-1", "1.5", "not-a-number"]) {
+        expect(parseTimingMeasureCap(bad)).toBeUndefined();
+      }
     });
   });
 });

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -2091,5 +2091,56 @@ describe("logger", () => {
         ).length,
       ).toBe(1);
     });
+
+    it("refuses a cap that would disable the guard rather than set it", () => {
+      // NaN and Infinity both make the `emitted >= cap` test never fire, and
+      // the cap is the only thing bounding retention — so these are refused
+      // rather than quietly accepted.
+      for (const bad of [Number.NaN, Infinity, 0, -1, 1.5]) {
+        expect(() => setTimingMeasuresEnabled(true, { cap: bad })).toThrow(
+          RangeError,
+        );
+      }
+      setTimingMeasuresEnabled(true, { cap: 5 });
+      expect(getTimingMeasuresState().cap).toBe(5);
+    });
+
+    it("takes the cap from the environment when none is passed", () => {
+      Deno.env.set("CF_TIMING_MEASURES_CAP", "4242");
+      try {
+        setTimingMeasuresEnabled(true);
+        expect(getTimingMeasuresState().cap).toBe(4242);
+        // A value that names no positive integer is ignored rather than
+        // applied, which would otherwise disable the guard from the outside.
+        Deno.env.set("CF_TIMING_MEASURES_CAP", "not-a-number");
+        setTimingMeasuresEnabled(true);
+        expect(getTimingMeasuresState().cap).toBe(4242);
+      } finally {
+        Deno.env.delete("CF_TIMING_MEASURES_CAP");
+      }
+    });
+
+    it("keeps the budget across a toggle, since the entries are still there", () => {
+      setTimingMeasuresEnabled(true, { cap: 2 });
+      const logger = getLogger("measure-toggle");
+      for (let i = 0; i < 2; i++) {
+        logger.timeStart("phase", "nine");
+        logger.timeEnd("phase", "nine");
+      }
+      expect(getTimingMeasuresState().emitted).toBe(2);
+
+      // Turning it off and on again must not hand back a budget the retained
+      // entries are still spending, or a toggling caller grows without bound.
+      setTimingMeasuresEnabled(false);
+      setTimingMeasuresEnabled(true);
+      expect(getTimingMeasuresState().emitted).toBe(2);
+      logger.timeStart("phase", "nine");
+      logger.timeEnd("phase", "nine");
+      expect(
+        measureNames().filter((n) =>
+          n.startsWith(`${TIMING_MEASURE_PREFIX}phase/nine#`)
+        ).length,
+      ).toBe(2);
+    });
   });
 });

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -12,6 +12,11 @@ import {
   resetAllTimingStats,
   setGlobalLogFloor,
 } from "../src/logger.ts";
+import {
+  clearTimingMeasures,
+  getTimingMeasuresState,
+  setTimingMeasuresEnabled,
+} from "../src/logger.ts";
 
 describe("logger", () => {
   beforeEach(() => {
@@ -1933,6 +1938,98 @@ describe("logger", () => {
       expect(logger.counts.info).toBe(1);
       expect(logger.counts.warn).toBe(1);
       expect(logger.counts.error).toBe(1);
+    });
+  });
+
+  describe("timing measures", () => {
+    afterEach(() => {
+      setTimingMeasuresEnabled(false);
+      clearTimingMeasures();
+    });
+
+    const measureNames = () =>
+      performance.getEntriesByType("measure").map((entry) => entry.name);
+
+    it("records a span without emitting a measure until asked", () => {
+      clearTimingMeasures();
+      const logger = getLogger("measure-off");
+      logger.timeStart("phase", "one");
+      logger.timeEnd("phase", "one");
+
+      expect(measureNames().some((n) => n.startsWith("phase/one#"))).toBe(
+        false,
+      );
+      // The statistics are recorded either way — that is the whole point of
+      // emission being separable from measurement.
+      expect(logger.getTimeStats("phase", "one")?.count).toBe(1);
+    });
+
+    it("emits one measure per span, keyed by the joined path", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-on");
+      logger.timeStart("phase", "two");
+      logger.timeEnd("phase", "two");
+
+      const mine = measureNames().filter((n) => n.startsWith("phase/two#"));
+      expect(mine.length).toBe(1);
+    });
+
+    it("gives two spans on one key distinguishable names", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-twice");
+      for (let i = 0; i < 2; i++) {
+        logger.timeStart("phase", "three");
+        logger.timeEnd("phase", "three");
+      }
+
+      const mine = measureNames().filter((n) => n.startsWith("phase/three#"));
+      expect(mine.length).toBe(2);
+      expect(new Set(mine).size).toBe(2);
+    });
+
+    it("measures the span it recorded, not the moment it was emitted", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-span");
+      const started = performance.now();
+      logger.timeStart("phase", "four");
+      logger.timeEnd("phase", "four");
+
+      const entry = performance.getEntriesByType("measure").find((e) =>
+        e.name.startsWith("phase/four#")
+      );
+      expect(entry).toBeDefined();
+      expect(entry!.startTime).toBeGreaterThanOrEqual(started);
+      const recorded = logger.getTimeStats("phase", "four")!;
+      expect(Math.abs(entry!.duration - recorded.totalTime)).toBeLessThan(1);
+    });
+
+    it("stops emitting at the cap rather than growing without bound", () => {
+      setTimingMeasuresEnabled(true, { cap: 3 });
+      const logger = getLogger("measure-cap");
+      for (let i = 0; i < 10; i++) {
+        logger.timeStart("phase", "five");
+        logger.timeEnd("phase", "five");
+      }
+
+      expect(measureNames().filter((n) => n.startsWith("phase/five#")).length)
+        .toBe(3);
+      expect(getTimingMeasuresState().emitted).toBe(3);
+      // Every span still reached the statistics; only emission stopped.
+      expect(logger.getTimeStats("phase", "five")?.count).toBe(10);
+    });
+
+    it("gives the budget back when the entries are drained", () => {
+      setTimingMeasuresEnabled(true, { cap: 2 });
+      const logger = getLogger("measure-drain");
+      logger.timeStart("phase", "six");
+      logger.timeEnd("phase", "six");
+      expect(getTimingMeasuresState().emitted).toBe(1);
+
+      clearTimingMeasures();
+      expect(getTimingMeasuresState().emitted).toBe(0);
+      expect(measureNames().some((n) => n.startsWith("phase/six#"))).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -2105,21 +2105,6 @@ describe("logger", () => {
       expect(getTimingMeasuresState().cap).toBe(5);
     });
 
-    it("takes the cap from the environment when none is passed", () => {
-      Deno.env.set("CF_TIMING_MEASURES_CAP", "4242");
-      try {
-        setTimingMeasuresEnabled(true);
-        expect(getTimingMeasuresState().cap).toBe(4242);
-        // A value that names no positive integer is ignored rather than
-        // applied, which would otherwise disable the guard from the outside.
-        Deno.env.set("CF_TIMING_MEASURES_CAP", "not-a-number");
-        setTimingMeasuresEnabled(true);
-        expect(getTimingMeasuresState().cap).toBe(4242);
-      } finally {
-        Deno.env.delete("CF_TIMING_MEASURES_CAP");
-      }
-    });
-
     it("keeps the budget across a toggle, since the entries are still there", () => {
       setTimingMeasuresEnabled(true, { cap: 2 });
       const logger = getLogger("measure-toggle");

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -15,7 +15,9 @@ import {
 import {
   clearTimingMeasures,
   getTimingMeasuresState,
+  resetTimingMeasureBudget,
   setTimingMeasuresEnabled,
+  TIMING_MEASURE_PREFIX,
 } from "../src/logger.ts";
 
 describe("logger", () => {
@@ -1956,7 +1958,11 @@ describe("logger", () => {
       logger.timeStart("phase", "one");
       logger.timeEnd("phase", "one");
 
-      expect(measureNames().some((n) => n.startsWith("phase/one#"))).toBe(
+      expect(
+        measureNames().some((n) =>
+          n.startsWith(`${TIMING_MEASURE_PREFIX}phase/one#`)
+        ),
+      ).toBe(
         false,
       );
       // The statistics are recorded either way — that is the whole point of
@@ -1970,7 +1976,9 @@ describe("logger", () => {
       logger.timeStart("phase", "two");
       logger.timeEnd("phase", "two");
 
-      const mine = measureNames().filter((n) => n.startsWith("phase/two#"));
+      const mine = measureNames().filter((n) =>
+        n.startsWith(`${TIMING_MEASURE_PREFIX}phase/two#`)
+      );
       expect(mine.length).toBe(1);
     });
 
@@ -1982,7 +1990,9 @@ describe("logger", () => {
         logger.timeEnd("phase", "three");
       }
 
-      const mine = measureNames().filter((n) => n.startsWith("phase/three#"));
+      const mine = measureNames().filter((n) =>
+        n.startsWith(`${TIMING_MEASURE_PREFIX}phase/three#`)
+      );
       expect(mine.length).toBe(2);
       expect(new Set(mine).size).toBe(2);
     });
@@ -1995,7 +2005,7 @@ describe("logger", () => {
       logger.timeEnd("phase", "four");
 
       const entry = performance.getEntriesByType("measure").find((e) =>
-        e.name.startsWith("phase/four#")
+        e.name.startsWith(`${TIMING_MEASURE_PREFIX}phase/four#`)
       );
       expect(entry).toBeDefined();
       expect(entry!.startTime).toBeGreaterThanOrEqual(started);
@@ -2011,7 +2021,11 @@ describe("logger", () => {
         logger.timeEnd("phase", "five");
       }
 
-      expect(measureNames().filter((n) => n.startsWith("phase/five#")).length)
+      expect(
+        measureNames().filter((n) =>
+          n.startsWith(`${TIMING_MEASURE_PREFIX}phase/five#`)
+        ).length,
+      )
         .toBe(3);
       expect(getTimingMeasuresState().emitted).toBe(3);
       // Every span still reached the statistics; only emission stopped.
@@ -2027,9 +2041,55 @@ describe("logger", () => {
 
       clearTimingMeasures();
       expect(getTimingMeasuresState().emitted).toBe(0);
-      expect(measureNames().some((n) => n.startsWith("phase/six#"))).toBe(
+      expect(
+        measureNames().some((n) =>
+          n.startsWith(`${TIMING_MEASURE_PREFIX}phase/six#`)
+        ),
+      ).toBe(
         false,
       );
+    });
+
+    it("leaves measures it did not emit alone", () => {
+      setTimingMeasuresEnabled(true);
+      performance.measure("someone-elses-measure", {
+        start: performance.now(),
+        end: performance.now(),
+      });
+      const logger = getLogger("measure-foreign");
+      logger.timeStart("phase", "seven");
+      logger.timeEnd("phase", "seven");
+
+      clearTimingMeasures();
+      // The host's timeline is shared; draining this feature must not take a
+      // page's own instrumentation with it.
+      expect(measureNames()).toContain("someone-elses-measure");
+      expect(
+        measureNames().some((n) => n.startsWith(TIMING_MEASURE_PREFIX)),
+      ).toBe(false);
+      performance.clearMeasures("someone-elses-measure");
+    });
+
+    it("emits again after something else clears the timeline", () => {
+      setTimingMeasuresEnabled(true, { cap: 2 });
+      const logger = getLogger("measure-external-clear");
+      for (let i = 0; i < 5; i++) {
+        logger.timeStart("phase", "eight");
+        logger.timeEnd("phase", "eight");
+      }
+      expect(getTimingMeasuresState().emitted).toBe(2);
+
+      // A test runner resetting between files does exactly this, and the
+      // budget has to follow or later files emit nothing at all.
+      performance.clearMeasures();
+      resetTimingMeasureBudget();
+      logger.timeStart("phase", "eight");
+      logger.timeEnd("phase", "eight");
+      expect(
+        measureNames().filter((n) =>
+          n.startsWith(`${TIMING_MEASURE_PREFIX}phase/eight#`)
+        ).length,
+      ).toBe(1);
     });
   });
 });

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -150,6 +150,13 @@ you begin and what you can trust:
   problem, many asking for a little is a frequency one, and they are fixed at
   opposite ends of the stack.
 
+Ask the next question rather than reporting the first table. Who calls it,
+frequency or width, is the unit cost flat, and — the one most easily skipped —
+who calls the _heavy_ instances, whose callers are routinely not the typical
+ones. `docs/development/debugging/profiling.md` carries that ladder. A chain
+that reaches uninstrumented ground has produced a result rather than a dead end:
+it names where to wrap next.
+
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a
 hypothesis. Confirm it correlates — that it moves with the real measurement

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -130,6 +130,16 @@ you begin and what you can trust:
   process with no browser; a worker CPU profile comes from a different process
   over CDP. Bracketing a phase is what gives a profile its interval, but the
   bracket has to be on the same side of that boundary as the samples.
+- **Every recorded span can put itself on the timeline.** `CF_TIMING_MEASURES=1`
+  — or `cf test --timing-measures-out <file>` — makes each logger time span emit
+  a `performance.measure` as well as recording into the statistics, across the
+  whole stack rather than only what someone wrapped by hand. It is off by
+  default because a measure costs several times what recording the span does,
+  and these are the hot paths a profile is trying to describe.
+  `skills/perf-investigation/scripts/aggregate-measures.ts` rolls the result up
+  by key prefix, which is what the statistics cannot do: a logger records
+  against its full joined path and nothing shorter, so the count at the level
+  where it starts multiplying exists in no stored row.
 
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -134,8 +134,9 @@ you begin and what you can trust:
   — or `cf test --timing-measures-out <file>` — makes each logger time span emit
   a `performance.measure` as well as recording into the statistics, across the
   whole stack rather than only what someone wrapped by hand. It is off by
-  default because a measure costs several times what recording the span does,
-  and these are the hot paths a profile is trying to describe.
+  default because the volume is for a tool, not a person: a topics pattern test
+  emits over 800,000 spans, and a human opening a timeline wants the phases
+  someone named rather than every span the runtime recorded.
   `skills/perf-investigation/scripts/aggregate-measures.ts` rolls the result up
   by key prefix, which is what the statistics cannot do: a logger records
   against its full joined path and nothing shorter, so the count at the level

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -141,6 +141,14 @@ you begin and what you can trust:
   by key prefix, which is what the statistics cannot do: a logger records
   against its full joined path and nothing shorter, so the count at the level
   where it starts multiplying exists in no stored row.
+- **Intervals recover the caller.** A key that runs everywhere is recorded
+  against itself whoever reached it, so no aggregate can say who is responsible.
+  Spans nest, so the span open when another began is the one that called it:
+  `skills/perf-investigation/scripts/attribute-measures.ts` rebuilds that tree
+  and answers who, how deep, and how many each caller asked for. Read its ratio
+  rather than its totals — few callers asking for a great deal each is a width
+  problem, many asking for a little is a frequency one, and they are fixed at
+  opposite ends of the stack.
 
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -8,12 +8,10 @@
  *
  * The roll-up is the point. A logger records a span against its full joined key
  * path and against nothing shorter, so `cell/get/user-data` never contributes
- * to `cell/get`. That is the right call for the statistics, and it is exactly
- * what hides a call explosion: the count that matters is the one at the level
- * where it starts multiplying, and no stored row holds it. This computes those
- * levels after the fact.
+ * to `cell/get` and no stored row holds a total for a prefix. This computes
+ * those totals after the fact.
  *
- * This groups by how keys are NAMED, not by who called whom, so `calls` counts
+ * It groups by how keys are NAMED, not by who called whom, so `calls` counts
  * every span at a prefix or below it and can only fall as you descend. Read
  * `ms/call` to find where time concentrates, and the two `self` columns to tell
  * a level that is itself expensive from one that merely contains expensive
@@ -25,10 +23,10 @@
  *   deno run --allow-read aggregate-measures.ts < measures.json
  *   deno run --allow-read aggregate-measures.ts measures.json --sort=calls
  *
- * One caveat about a `cf test` capture: `withPhase` emits its own measure under
- * a `cf-test/` prefix as well as recording the span through a logger, so those
- * phases appear twice — once as `cf-test/<keys>` and once as `<keys>`. Read one
- * branch or the other rather than summing across both.
+ * A `cf test` capture holds only what a logger recorded: `withPhase` emits a
+ * measure of its own too, under a `cf-test/` name without the logger's prefix,
+ * and the capture does not collect it. Reading the timeline directly rather
+ * than from a written capture is where both would appear.
  */
 
 interface MeasureEntry {

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -46,10 +46,14 @@ interface Bucket {
   children: Map<string, Bucket>;
 }
 
-/** `cell/get/user-data#4127` names the span `cell/get/user-data`. */
+/** `cf:cell/get/user-data#4127` names the span `cell/get/user-data`. */
+const MEASURE_PREFIX = "cf:";
 function keyOf(name: string): string {
-  const hash = name.lastIndexOf("#");
-  return hash === -1 ? name : name.slice(0, hash);
+  const body = name.startsWith(MEASURE_PREFIX)
+    ? name.slice(MEASURE_PREFIX.length)
+    : name;
+  const hash = body.lastIndexOf("#");
+  return hash === -1 ? body : body.slice(0, hash);
 }
 
 function emptyBucket(path: string, depth: number): Bucket {

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -13,9 +13,13 @@
  * where it starts multiplying, and no stored row holds it. This computes those
  * levels after the fact.
  *
- * Read it by scanning down a branch and watching `calls` against `ms/call`. A
- * level whose calls jump by a large factor over its parent's, while its own
- * time per call stays flat, is where the multiplication was introduced.
+ * This groups by how keys are NAMED, not by who called whom, so `calls` counts
+ * every span at a prefix or below it and can only fall as you descend. Read
+ * `ms/call` to find where time concentrates, and the two `self` columns to tell
+ * a level that is itself expensive from one that merely contains expensive
+ * children. For who called whom — and for a count that can rise — use
+ * `attribute-measures.ts`, which reconstructs the call tree from the
+ * intervals.
  *
  *   deno run --allow-read aggregate-measures.ts measures.json
  *   deno run --allow-read aggregate-measures.ts < measures.json
@@ -96,8 +100,8 @@ export function aggregate(entries: readonly MeasureEntry[]): Bucket {
 
 export function render(root: Bucket, sortBy: "time" | "calls"): string {
   const lines: string[] = [
-    "  calls      total ms     ms/call        self  key",
-    "  -----      --------     -------        ----  ---",
+    "  calls      total ms     ms/call    self n   self ms  key",
+    "  -----      --------     -------    ------   -------  ---",
   ];
   const walk = (bucket: Bucket) => {
     const kids = [...bucket.children.values()].sort((a, b) =>
@@ -107,13 +111,14 @@ export function render(root: Bucket, sortBy: "time" | "calls"): string {
       const perCall = child.calls === 0 ? 0 : child.time / child.calls;
       // Spans recorded at this exact level, where there are any, separate
       // "this level is slow" from "this level fans out into slow children".
-      const self = child.own === 0 ? "" : `${child.own}x`;
+      const selfN = child.own === 0 ? "" : String(child.own);
+      const selfMs = child.own === 0 ? "" : child.ownTime.toFixed(1);
       lines.push(
         `${String(child.calls).padStart(7)} ${
           child.time.toFixed(1).padStart(11)
-        } ${perCall.toFixed(3).padStart(11)} ${self.padStart(11)}  ${
-          "  ".repeat(child.depth - 1)
-        }${child.path.split("/").pop()}`,
+        } ${perCall.toFixed(3).padStart(11)} ${selfN.padStart(9)} ${
+          selfMs.padStart(9)
+        }  ${"  ".repeat(child.depth - 1)}${child.path.split("/").pop()}`,
       );
       walk(child);
     }

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Accumulate calls and time per key segment from emitted timing measures.
+ *
+ * Reads the measures a run produced with `CF_TIMING_MEASURES=1` — either a JSON
+ * array of `PerformanceEntry`-shaped objects on stdin, or a file named as the
+ * first argument — and rolls them up by key prefix.
+ *
+ * The roll-up is the point. A logger records a span against its full joined key
+ * path and against nothing shorter, so `cell/get/user-data` never contributes
+ * to `cell/get`. That is the right call for the statistics, and it is exactly
+ * what hides a call explosion: the count that matters is the one at the level
+ * where it starts multiplying, and no stored row holds it. This computes those
+ * levels after the fact.
+ *
+ * Read it by scanning down a branch and watching `calls` against `ms/call`. A
+ * level whose calls jump by a large factor over its parent's, while its own
+ * time per call stays flat, is where the multiplication was introduced.
+ *
+ *   deno run --allow-read aggregate-measures.ts measures.json
+ *   deno run --allow-read aggregate-measures.ts < measures.json
+ *   deno run --allow-read aggregate-measures.ts measures.json --sort=calls
+ *
+ * One caveat about a `cf test` capture: `withPhase` emits its own measure under
+ * a `cf-test/` prefix as well as recording the span through a logger, so those
+ * phases appear twice — once as `cf-test/<keys>` and once as `<keys>`. Read one
+ * branch or the other rather than summing across both.
+ */
+
+interface MeasureEntry {
+  name: string;
+  duration: number;
+  startTime?: number;
+}
+
+/** One key segment's accumulation, and the segments below it. */
+interface Bucket {
+  path: string;
+  depth: number;
+  /** Spans recorded at this exact path. */
+  own: number;
+  ownTime: number;
+  /** Spans recorded at this path or anywhere beneath it. */
+  calls: number;
+  time: number;
+  children: Map<string, Bucket>;
+}
+
+/** `cell/get/user-data#4127` names the span `cell/get/user-data`. */
+function keyOf(name: string): string {
+  const hash = name.lastIndexOf("#");
+  return hash === -1 ? name : name.slice(0, hash);
+}
+
+function emptyBucket(path: string, depth: number): Bucket {
+  return {
+    path,
+    depth,
+    own: 0,
+    ownTime: 0,
+    calls: 0,
+    time: 0,
+    children: new Map(),
+  };
+}
+
+export function aggregate(entries: readonly MeasureEntry[]): Bucket {
+  const root = emptyBucket("", 0);
+  for (const entry of entries) {
+    const segments = keyOf(entry.name).split("/").filter(Boolean);
+    if (segments.length === 0) continue;
+    let bucket = root;
+    bucket.calls++;
+    bucket.time += entry.duration;
+    let path = "";
+    for (const [index, segment] of segments.entries()) {
+      path = path ? `${path}/${segment}` : segment;
+      let child = bucket.children.get(segment);
+      if (!child) {
+        child = emptyBucket(path, index + 1);
+        bucket.children.set(segment, child);
+      }
+      child.calls++;
+      child.time += entry.duration;
+      bucket = child;
+    }
+    bucket.own++;
+    bucket.ownTime += entry.duration;
+  }
+  return root;
+}
+
+export function render(root: Bucket, sortBy: "time" | "calls"): string {
+  const lines: string[] = [
+    "  calls      total ms     ms/call        self  key",
+    "  -----      --------     -------        ----  ---",
+  ];
+  const walk = (bucket: Bucket) => {
+    const kids = [...bucket.children.values()].sort((a, b) =>
+      sortBy === "calls" ? b.calls - a.calls : b.time - a.time
+    );
+    for (const child of kids) {
+      const perCall = child.calls === 0 ? 0 : child.time / child.calls;
+      // Spans recorded at this exact level, where there are any, separate
+      // "this level is slow" from "this level fans out into slow children".
+      const self = child.own === 0 ? "" : `${child.own}x`;
+      lines.push(
+        `${String(child.calls).padStart(7)} ${
+          child.time.toFixed(1).padStart(11)
+        } ${perCall.toFixed(3).padStart(11)} ${self.padStart(11)}  ${
+          "  ".repeat(child.depth - 1)
+        }${child.path.split("/").pop()}`,
+      );
+      walk(child);
+    }
+  };
+  walk(root);
+  lines.push("");
+  lines.push(
+    `${root.calls} spans, ${root.time.toFixed(1)}ms total across ` +
+      `${root.children.size} top-level key(s).`,
+  );
+  return lines.join("\n");
+}
+
+async function readInput(path?: string): Promise<string> {
+  if (path) return await Deno.readTextFile(path);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Deno.stdin.readable) chunks.push(chunk);
+  let length = 0;
+  for (const chunk of chunks) length += chunk.length;
+  const merged = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+if (import.meta.main) {
+  const args = Deno.args.filter((arg) => !arg.startsWith("--"));
+  const sortBy = Deno.args.includes("--sort=calls") ? "calls" : "time";
+  const raw = await readInput(args[0]);
+  const parsed = JSON.parse(raw);
+  const entries: MeasureEntry[] = Array.isArray(parsed)
+    ? parsed
+    : parsed.measures ?? [];
+  if (entries.length === 0) {
+    console.error(
+      "No measures found. Run with CF_TIMING_MEASURES=1 and pass the entries " +
+        'from performance.getEntriesByType("measure").',
+    );
+    Deno.exit(1);
+  }
+  console.log(render(aggregate(entries), sortBy));
+}

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -14,6 +14,9 @@
  *   # many reads each traverse issues
  *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --via=traverse
  *
+ *   # and who calls the heavy ones specifically — usually not the same answer
+ *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --via=traverse --heavy=1000
+ *
  *   # the most common full call chains
  *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --chains
  *
@@ -38,6 +41,7 @@ function flag(name: string): string | undefined {
 const path = Deno.args.find((arg) => !arg.startsWith("--"));
 const target = flag("key");
 const via = flag("via");
+const heavy = Number(flag("heavy") ?? "0");
 const wantChains = Deno.args.includes("--chains");
 
 if (!target) {
@@ -108,6 +112,44 @@ if (wantChains) {
     if (children > row.max) row.max = children;
     byCaller.set(caller, row);
   }
+  // How lopsided the distribution is. A handful of parents holding most of the
+  // children is the single most useful thing this can say: it means the fix is
+  // aimed at those instances rather than at the call site in general.
+  const counts = [...perParent.values()].sort((a, b) => b - a);
+  const viaTotal = spans.filter((sp) => sp.key === via).length;
+  const childTotal = counts.reduce((a, b) => a + b, 0);
+  if (childTotal > 0) {
+    const buckets: [string, number, number][] = [
+      ["1000+", 1000, Infinity],
+      ["300-999", 300, 1000],
+      ["100-299", 100, 300],
+      ["10-99", 10, 100],
+      ["1-9", 1, 10],
+    ];
+    console.log(`\nhow ${target} is spread across ${via} spans:`);
+    console.log(`  ${target} each      ${via}     ${target}    share`);
+    let covered = 0;
+    for (const [label, lo, hi] of buckets) {
+      const inB = counts.filter((c) => c >= lo && c < hi);
+      if (inB.length === 0) continue;
+      const sum = inB.reduce((a, b) => a + b, 0);
+      covered += inB.length;
+      console.log(
+        `  ${label.padEnd(12)} ${String(inB.length).padStart(9)} ${
+          String(sum).padStart(9)
+        } ${((sum / childTotal * 100).toFixed(1) + "%").padStart(8)}`,
+      );
+    }
+    const idle = viaTotal - covered;
+    if (idle > 0) {
+      console.log(
+        `  ${"none".padEnd(12)} ${String(idle).padStart(9)} ${
+          "0".padStart(9)
+        } ${"0.0%".padStart(8)}`,
+      );
+    }
+  }
+
   console.log(`\nvia ${via} — one row per caller of ${via}:`);
   console.log(
     `  ${via}    ${target}   per ${via}    max      ms  caller`,
@@ -125,6 +167,35 @@ if (wantChains) {
         row.ms.toFixed(0).padStart(7)
       }  ${caller}`,
     );
+  }
+  if (heavy > 0) {
+    // The callers of the heavy instances specifically, which are usually not
+    // the callers of the call site in general.
+    const chains = new Map<string, { n: number; children: number }>();
+    for (const [parent, children] of perParent) {
+      if (children < heavy) continue;
+      const chain = collapseRepeats(ancestors(spans, parent)).slice(0, 4);
+      const sig = chain.length ? chain.join("  <  ") : ROOT;
+      const row = chains.get(sig) ?? { n: 0, children: 0 };
+      row.n++;
+      row.children += children;
+      chains.set(sig, row);
+    }
+    console.log(
+      `\ncallers of ${via} spans with ${heavy}+ ${target} ` +
+        `(${[...chains.values()].reduce((a, b) => a + b.n, 0)} of them):`,
+    );
+    for (
+      const [sig, row] of [...chains].sort((a, b) =>
+        b[1].children - a[1].children
+      )
+    ) {
+      console.log(
+        `  ${String(row.n).padStart(5)} ${via}  ${
+          String(row.children).padStart(8)
+        } ${target}   ${sig}`,
+      );
+    }
   }
 } else {
   const byCaller = new Map<string, { n: number; ms: number }>();

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -88,8 +88,12 @@ if (wantChains) {
   ) {
     // Truncate for the eye only, after the counting is done.
     const parts = chain.split("  <  ");
+    // Name the outermost link as well as the count, so two chains that were
+    // counted separately do not print as the same row.
     const shown = parts.length > 5
-      ? `${parts.slice(0, 5).join("  <  ")}  <  …(+${parts.length - 5})`
+      ? `${parts.slice(0, 5).join("  <  ")}  <  …(+${
+        parts.length - 5
+      }, outermost ${parts[parts.length - 1]})`
       : chain;
     console.log(`  ${String(n).padStart(8)}  ${shown}`);
   }

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -76,7 +76,9 @@ const ROOT = "(root — no instrumented span above)";
 if (wantChains) {
   const chains = new Map<string, number>();
   for (const i of hits) {
-    const chain = collapseRepeats(ancestors(spans, i)).slice(0, 5);
+    // Aggregate on the whole chain; truncating first would merge callers that
+    // differ only above the cut and report them as one.
+    const chain = collapseRepeats(ancestors(spans, i));
     const sig = chain.length ? chain.join("  <  ") : ROOT;
     chains.set(sig, (chains.get(sig) ?? 0) + 1);
   }
@@ -84,16 +86,26 @@ if (wantChains) {
   for (
     const [chain, n] of [...chains].sort((a, b) => b[1] - a[1]).slice(0, 15)
   ) {
-    console.log(`  ${String(n).padStart(8)}  ${chain}`);
+    // Truncate for the eye only, after the counting is done.
+    const parts = chain.split("  <  ");
+    const shown = parts.length > 5
+      ? `${parts.slice(0, 5).join("  <  ")}  <  …(+${parts.length - 5})`
+      : chain;
+    console.log(`  ${String(n).padStart(8)}  ${shown}`);
   }
 } else if (via) {
   // Every `via` span, with how many target spans it directly contains and what
   // called it. The ratio is the point; the totals only say where to look.
   const perParent = new Map<number, number>();
   for (const i of hits) {
-    const parent = spans[i].parent;
-    if (parent !== -1 && spans[parent].key === via) {
-      perParent.set(parent, (perParent.get(parent) ?? 0) + 1);
+    // The nearest enclosing `via`, not the immediate parent: an instrumented
+    // span sitting between the two is common, and counting only direct
+    // children would report zero for a call that plainly runs inside it.
+    for (let p = spans[i].parent; p !== -1; p = spans[p].parent) {
+      if (spans[p].key === via) {
+        perParent.set(p, (perParent.get(p) ?? 0) + 1);
+        break;
+      }
     }
   }
   const byCaller = new Map<

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Ask who called a key, using the containment forest in `measure-forest.ts`.
+ *
+ * `aggregate-measures.ts` answers "where did the time go" by rolling spans up
+ * along their own key paths. This answers the question that follows it: a key
+ * that runs hundreds of thousands of times is recorded against itself no matter
+ * who asked, so its own row cannot say which caller is responsible.
+ *
+ *   # who calls tx/read, innermost caller first
+ *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read
+ *
+ *   # of those, the ones that go through traverse: what is above it, and how
+ *   # many reads each traverse issues
+ *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --via=traverse
+ *
+ *   # the most common full call chains
+ *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --chains
+ *
+ * Read the `--via` table for the ratio rather than the totals. A caller with
+ * few parent spans and many children each is a width problem — one call doing
+ * too much — and is fixed differently from a caller with many parent spans
+ * doing a little each, which is a frequency problem.
+ */
+import {
+  ancestors,
+  buildForest,
+  callerOf,
+  collapseRepeats,
+  loadMeasures,
+} from "./measure-forest.ts";
+
+function flag(name: string): string | undefined {
+  const hit = Deno.args.find((arg) => arg.startsWith(`--${name}=`));
+  return hit?.slice(name.length + 3);
+}
+
+const path = Deno.args.find((arg) => !arg.startsWith("--"));
+const target = flag("key");
+const via = flag("via");
+const wantChains = Deno.args.includes("--chains");
+
+if (!target) {
+  console.error(
+    "Pass the key to attribute, e.g. --key=tx/read. " +
+      "A measures file is read from the first argument, or from stdin.",
+  );
+  Deno.exit(1);
+}
+
+const spans = buildForest(await loadMeasures(path));
+const hits: number[] = [];
+for (let i = 0; i < spans.length; i++) {
+  if (spans[i].key === target) hits.push(i);
+}
+
+if (hits.length === 0) {
+  console.error(
+    `No spans named ${target}. Keys are logger paths, e.g. cell/get.`,
+  );
+  Deno.exit(1);
+}
+
+const totalMs = hits.reduce(
+  (sum, i) => sum + (spans[i].end - spans[i].start),
+  0,
+);
+console.log(`${target}: ${hits.length} spans, ${totalMs.toFixed(0)}ms total`);
+
+const ROOT = "(root — no instrumented span above)";
+
+if (wantChains) {
+  const chains = new Map<string, number>();
+  for (const i of hits) {
+    const chain = collapseRepeats(ancestors(spans, i)).slice(0, 5);
+    const sig = chain.length ? chain.join("  <  ") : ROOT;
+    chains.set(sig, (chains.get(sig) ?? 0) + 1);
+  }
+  console.log("\nmost common chains (innermost first):");
+  for (
+    const [chain, n] of [...chains].sort((a, b) => b[1] - a[1]).slice(0, 15)
+  ) {
+    console.log(`  ${String(n).padStart(8)}  ${chain}`);
+  }
+} else if (via) {
+  // Every `via` span, with how many target spans it directly contains and what
+  // called it. The ratio is the point; the totals only say where to look.
+  const perParent = new Map<number, number>();
+  for (const i of hits) {
+    const parent = spans[i].parent;
+    if (parent !== -1 && spans[parent].key === via) {
+      perParent.set(parent, (perParent.get(parent) ?? 0) + 1);
+    }
+  }
+  const byCaller = new Map<
+    string,
+    { parents: number; children: number; ms: number; max: number }
+  >();
+  for (let i = 0; i < spans.length; i++) {
+    if (spans[i].key !== via) continue;
+    const caller = callerOf(spans, i) ?? ROOT;
+    const children = perParent.get(i) ?? 0;
+    const row = byCaller.get(caller) ??
+      { parents: 0, children: 0, ms: 0, max: 0 };
+    row.parents++;
+    row.children += children;
+    row.ms += spans[i].end - spans[i].start;
+    if (children > row.max) row.max = children;
+    byCaller.set(caller, row);
+  }
+  console.log(`\nvia ${via} — one row per caller of ${via}:`);
+  console.log(
+    `  ${via}    ${target}   per ${via}    max      ms  caller`,
+  );
+  for (
+    const [caller, row] of [...byCaller].sort((a, b) =>
+      b[1].children - a[1].children
+    ).slice(0, 15)
+  ) {
+    const per = row.parents === 0 ? 0 : row.children / row.parents;
+    console.log(
+      `${String(row.parents).padStart(9)} ${String(row.children).padStart(9)} ${
+        per.toFixed(1).padStart(11)
+      } ${String(row.max).padStart(6)} ${
+        row.ms.toFixed(0).padStart(7)
+      }  ${caller}`,
+    );
+  }
+} else {
+  const byCaller = new Map<string, { n: number; ms: number }>();
+  for (const i of hits) {
+    const caller = callerOf(spans, i) ?? ROOT;
+    const row = byCaller.get(caller) ?? { n: 0, ms: 0 };
+    row.n++;
+    row.ms += spans[i].end - spans[i].start;
+    byCaller.set(caller, row);
+  }
+  console.log("\n  spans       ms   share  innermost instrumented caller");
+  for (
+    const [caller, row] of [...byCaller].sort((a, b) => b[1].n - a[1].n).slice(
+      0,
+      20,
+    )
+  ) {
+    const share = ((row.n / hits.length) * 100).toFixed(1);
+    console.log(
+      `${String(row.n).padStart(7)} ${row.ms.toFixed(0).padStart(8)} ${
+        (share + "%").padStart(7)
+      }  ${caller}`,
+    );
+  }
+  const rootShare = byCaller.get(ROOT);
+  if (rootShare) {
+    console.log(
+      `\nA large root share is a statement about the instrumentation rather ` +
+        `than\nthe code: those spans ran outside every wrapped region.`,
+    );
+  }
+}

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -32,10 +32,16 @@ export interface Span {
   parent: number;
 }
 
-/** `cell/get/user-data#4127` names the span `cell/get/user-data`. */
+/** Emitted entries carry this, so clearing can be selective. */
+export const MEASURE_PREFIX = "cf:";
+
+/** `cf:cell/get/user-data#4127` names the span `cell/get/user-data`. */
 export function keyOf(name: string): string {
-  const hash = name.lastIndexOf("#");
-  return hash === -1 ? name : name.slice(0, hash);
+  const body = name.startsWith(MEASURE_PREFIX)
+    ? name.slice(MEASURE_PREFIX.length)
+    : name;
+  const hash = body.lastIndexOf("#");
+  return hash === -1 ? body : body.slice(0, hash);
 }
 
 /**

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -1,0 +1,149 @@
+/**
+ * Recover the caller tree from emitted timing measures.
+ *
+ * A logger records a span against its own key and nothing else, so
+ * `tx/read` is `tx/read` whoever asked for it. What the measures add over the
+ * statistics is an interval per span, and intervals nest: the span that was
+ * open when another began is the one that called it. Rebuilding that
+ * containment forest is what turns "this key ran 800,000 times" into "this key
+ * ran 800,000 times, and here is who asked".
+ *
+ * Containment is inferred, not recorded. Spans that overlap without nesting —
+ * which async work produces — are left without a parent rather than assigned a
+ * plausible-looking one, because an invented parent is an invented caller.
+ *
+ * Used by `attribute-measures.ts`; import it for an analysis that script does
+ * not cover.
+ */
+
+/** One emitted measure, as `performance.getEntriesByType("measure")` gives it. */
+export interface MeasureEntry {
+  name: string;
+  startTime: number;
+  duration: number;
+}
+
+/** A span placed in the forest. `parent` is an index, or -1 at a root. */
+export interface Span {
+  /** The logger key, with the uniquifying suffix removed. */
+  key: string;
+  start: number;
+  end: number;
+  parent: number;
+}
+
+/** `cell/get/user-data#4127` names the span `cell/get/user-data`. */
+export function keyOf(name: string): string {
+  const hash = name.lastIndexOf("#");
+  return hash === -1 ? name : name.slice(0, hash);
+}
+
+/**
+ * The test harness's own phases wrap everything a `cf test` run does, so they
+ * would win every containment test and hide the runtime span that issued the
+ * work. Treated as transparent by default when walking up.
+ */
+export const HARNESS_KEY = /^(runTestPattern|cf-test)(\/|$)/;
+
+/**
+ * Build the containment forest.
+ *
+ * Returns spans sorted by start, each carrying the index of the innermost span
+ * that fully contains it. Sorting longest-first at an equal start is what puts
+ * a parent before the child it opened alongside.
+ */
+export function buildForest(entries: readonly MeasureEntry[]): Span[] {
+  const spans: Span[] = entries
+    .map((entry) => ({
+      key: keyOf(entry.name),
+      start: entry.startTime,
+      end: entry.startTime + entry.duration,
+      parent: -1,
+    }))
+    .sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const open: number[] = [];
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i];
+    while (open.length && spans[open[open.length - 1]].end <= span.start) {
+      open.pop();
+    }
+    const top = open.length ? open[open.length - 1] : -1;
+    if (top !== -1 && spans[top].end >= span.end) span.parent = top;
+    open.push(i);
+  }
+  return spans;
+}
+
+/** Every ancestor key, innermost first. */
+export function ancestors(
+  spans: readonly Span[],
+  index: number,
+  options: { skip?: RegExp } = {},
+): string[] {
+  const skip = options.skip ?? HARNESS_KEY;
+  const out: string[] = [];
+  for (let p = spans[index].parent; p !== -1; p = spans[p].parent) {
+    const key = spans[p].key;
+    if (!skip.test(key)) out.push(key);
+  }
+  return out;
+}
+
+/**
+ * The innermost ancestor that is not skipped, or `undefined` at a root.
+ *
+ * A root is a real answer rather than a gap in the data: it means the span ran
+ * outside every instrumented region, which is a statement about where the
+ * instrumentation stops.
+ */
+export function callerOf(
+  spans: readonly Span[],
+  index: number,
+  options: { skip?: RegExp } = {},
+): string | undefined {
+  return ancestors(spans, index, options)[0];
+}
+
+/**
+ * Collapse an immediate repeat, so a recursive stretch reads as one shape:
+ * `["traverse", "traverse", "cell/get"]` becomes `["traverse x2", "cell/get"]`.
+ */
+export function collapseRepeats(chain: readonly string[]): string[] {
+  const out: string[] = [];
+  let last = "";
+  let run = 0;
+  for (const key of chain) {
+    if (key === last) {
+      run++;
+      continue;
+    }
+    if (last) out.push(run > 1 ? `${last} x${run}` : last);
+    last = key;
+    run = 1;
+  }
+  if (last) out.push(run > 1 ? `${last} x${run}` : last);
+  return out;
+}
+
+/** Read a measures file, or stdin when no path is given. */
+export async function loadMeasures(path?: string): Promise<MeasureEntry[]> {
+  let raw: string;
+  if (path) {
+    raw = await Deno.readTextFile(path);
+  } else {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of Deno.stdin.readable) chunks.push(chunk);
+    let length = 0;
+    for (const chunk of chunks) length += chunk.length;
+    const merged = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    raw = new TextDecoder().decode(merged);
+  }
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : parsed.measures ?? [];
+}

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -74,15 +74,19 @@ export function buildForest(entries: readonly MeasureEntry[]): Span[] {
     while (open.length && spans[open[open.length - 1]].end <= span.start) {
       open.pop();
     }
-    const top = open.length ? open[open.length - 1] : -1;
     // A strictly larger interval is a container. An identical one is two spans
     // that began and ended together, which says nothing about which called
-    // which — and guessing there would invent a caller.
-    if (
-      top !== -1 && spans[top].end >= span.end &&
-      !(spans[top].start === span.start && spans[top].end === span.end)
-    ) {
-      span.parent = top;
+    // which — so it is stepped over rather than claimed as a parent, and the
+    // search continues beneath it: a real container further down the stack is
+    // still the answer, and stopping at the twin would report a root instead.
+    for (let k = open.length - 1; k >= 0; k--) {
+      const candidate = spans[open[k]];
+      if (candidate.end < span.end) break;
+      if (candidate.start === span.start && candidate.end === span.end) {
+        continue;
+      }
+      span.parent = open[k];
+      break;
     }
     open.push(i);
   }

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -81,12 +81,19 @@ export function buildForest(entries: readonly MeasureEntry[]): Span[] {
     // still the answer, and stopping at the twin would report a root instead.
     for (let k = open.length - 1; k >= 0; k--) {
       const candidate = spans[open[k]];
-      if (candidate.end < span.end) break;
       if (candidate.start === span.start && candidate.end === span.end) {
-        continue;
+        // A twin says nothing about which called which, but it does share
+        // whatever contains it — so its answer is this span's answer, and
+        // taking it keeps a long run of identical intervals from rescanning
+        // the whole run for each one.
+        span.parent = candidate.parent;
+        break;
       }
-      span.parent = open[k];
-      break;
+      if (candidate.end >= span.end) {
+        span.parent = open[k];
+        break;
+      }
+      // Overlapping without containing: an outer span may still contain this.
     }
     open.push(i);
   }

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -75,7 +75,15 @@ export function buildForest(entries: readonly MeasureEntry[]): Span[] {
       open.pop();
     }
     const top = open.length ? open[open.length - 1] : -1;
-    if (top !== -1 && spans[top].end >= span.end) span.parent = top;
+    // A strictly larger interval is a container. An identical one is two spans
+    // that began and ended together, which says nothing about which called
+    // which — and guessing there would invent a caller.
+    if (
+      top !== -1 && spans[top].end >= span.end &&
+      !(spans[top].start === span.start && spans[top].end === span.end)
+    ) {
+      span.parent = top;
+    }
     open.push(i);
   }
   return spans;


### PR DESCRIPTION
A logger's statistics are aggregates: a key was reached four thousand times and cost this much on average. Two questions they structurally cannot answer are the two an investigation actually asks — *which* of those reaches nested inside which, and *who* asked for them. A key is recorded against itself no matter who called it, and a logger records against its full joined path and nothing shorter, so the count at the level where a call explosion begins exists in no stored row.

The measures keep each span's own interval. That is enough to rebuild both.

## Using it

**1. Capture.** Emission is opt-in:

```bash
deno task cf test packages/patterns/<pattern>/<name>.test.tsx \
  --timing-measures-out /tmp/measures.json
```

`CF_TIMING_MEASURES=1` does the same for anything else running in Deno, and `CF_TIMING_MEASURES_CAP` raises the ceiling — worth setting, because emission *stops* at the cap rather than sampling, so a run that hits it leaves an early-run prefix rather than a representative sample.

**2. Where did the time go.**

```bash
deno run --allow-read skills/perf-investigation/scripts/aggregate-measures.ts /tmp/measures.json
```

Rolls every span up by key prefix — the hierarchy the statistics deliberately do not keep:

```
  calls      total ms     ms/call        self  key
    143      7457.4      52.150              runTestPattern
      1      3396.2    3396.217          1x    compile
    126      2782.9      22.087                step
      8      1385.4     173.174                  action_1
      6      1384.5     230.745          1x        settle
```

Scan down a branch: the level whose calls jump by a large factor over its parent's, while its time per call stays flat, is where the multiplication was introduced.

**3. Who asked for it.**

```bash
# who calls a key
… attribute-measures.ts /tmp/measures.json --key=tx/read
# how many each caller asks for per call
… attribute-measures.ts /tmp/measures.json --key=tx/read --via=traverse
# and who calls the heavy ones — usually a different answer
… attribute-measures.ts /tmp/measures.json --key=tx/read --via=traverse --heavy=1000
# the full chains
… attribute-measures.ts /tmp/measures.json --key=tx/read --chains
```

Spans nest, so the span open when another began is the one that called it. `measure-forest.ts` rebuilds that tree and is importable for an analysis these three modes do not cover.

## Reading the output

The `--via` table is the one that decides what kind of defect you have, and it is the ratio that matters rather than the totals:

- **many callers doing a little each** is a frequency problem, fixed by calling less;
- **few callers doing a great deal each** is a width problem, fixed by making one call ask for less.

Those live at opposite ends of the stack, so getting this backwards sends the fix to the wrong layer. A worked example from `topics.test.tsx`, which is what shook out the `--heavy` mode: `tx/read` runs 873,541 times — 97% of every span the run emits — and 134,844 of those sit under `traverse`. That reads like traverse being called too often, until the ratio says 5,599 traverses at ~24 reads each with single traverses issuing 1,419, 1,594 and 2,755. Traverse is not called too often; one traverse reads too much, and the skew table makes it plain: 355 of 5,599 traverses issue 87% of the reads while 2,380 read nothing at all.

Two further things that table settles. Time per read is flat across every bucket, so the heavy traverses are voluminous rather than pathological — one defect, not two. And eight of the fourteen heaviest have no instrumented caller, which is where that particular chain ends.

**A large root share is a result, not a gap.** It says those spans ran outside every instrumented region, and names the next thing to wrap. Reporting the attributable fraction as though it were the whole is the failure the ladder in `docs/development/debugging/profiling.md` exists to prevent.

## Why it is off by default

Volume, not overhead. A topics pattern test emits over 800,000 spans; a human opening a timeline wants the handful of phases someone deliberately named, not every span the runtime recorded. Emission is turned on for the length of an investigation and read by something that aggregates. The per-span cost is real but small enough not to decide anything.

## Notes on the implementation

Emitted entries carry a `cf:` prefix. That is what lets draining remove only what this emitted — the performance timeline belongs to the host, and a page or worker that instruments itself would otherwise lose its own measures to a call that claims only to drain this feature's. Names also carry a monotonic suffix, so two spans on one key stay distinguishable, which is what makes per-instance data recoverable at all.

Containment is inferred rather than recorded. A span that overlaps without nesting — which async work produces — is left without a parent rather than given a plausible-looking one, because in a tool whose whole job is attribution an invented parent is an invented caller.

## Tests

Eight cases in `packages/utils/test/logger.test.ts`: off by default, one measure per span keyed by the joined path, two spans on one key staying distinguishable, the measure describing the span rather than the moment of emission, the cap stopping emission while the statistics still record every span, draining restoring the budget, draining leaving foreign measures alone, and emission resuming after something else clears the timeline. The first six were mutation-checked — removing the cap, dropping the suffix, and ignoring the enabled flag each fail the case that covers them.

Verified end to end rather than only in unit tests, including a two-file run, which is what the review caught: each file clears the timeline as it starts, so measures are drained per file rather than read once at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
