### PR TITLE
fix(runner): report a settled transaction's commit as a result

### DIFF
--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -115,7 +115,10 @@ import {
   takeSchemaRefusalTx,
   unmarkLazyMaterializationTx,
 } from "./reactivity-log.ts";
-import { TransactionAborted } from "./transaction-errors.ts";
+import {
+  TransactionAborted,
+  TransactionCompleteError,
+} from "./transaction-errors.ts";
 import {
   getDirectTransactionReactivityLog,
   getTransactionReadActivities,
@@ -2098,6 +2101,20 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   ): Promise<Result<Unit, CommitError>> {
     if (this.statusOverride?.status === "error") {
       return { error: this.statusOverride.error };
+    }
+    // A transaction that is no longer open takes none of the commit-path
+    // work below. The CFC relevance probes read stored metadata through this
+    // transaction, and one whose commit is in flight, settled, or aborted
+    // admits no reads. The terminal state is reported here as the result. The
+    // underlying transaction holds a single commit verdict, and that verdict
+    // belongs to the commit that is running.
+    const openState = this.tx.status();
+    if (openState.status !== "ready") {
+      return {
+        error: openState.status === "error"
+          ? openState.error
+          : TransactionCompleteError(),
+      };
     }
     const readOnly = this.isReadOnly();
     if (readOnly) {

--- a/packages/runner/test/cell-callbacks.test.ts
+++ b/packages/runner/test/cell-callbacks.test.ts
@@ -268,6 +268,7 @@ describe("Cell commit callbacks", () => {
     const inner = {
       journal: {},
       clearReadOnly() {},
+      status: () => ({ status: "ready", journal: {} }),
       commit: () => Promise.reject(rejection),
     } as unknown as IStorageTransaction;
     const extended = new ExtendedStorageTransaction(inner);

--- a/packages/runner/test/extended-storage-transaction.test.ts
+++ b/packages/runner/test/extended-storage-transaction.test.ts
@@ -75,6 +75,106 @@ describe("extended-storage-transaction", () => {
     });
   });
 
+  describe("commit on a transaction that is no longer open", () => {
+    // A second commit reports the transaction's terminal state as its result.
+    // It runs none of the commit-path work: the CFC relevance probes read
+    // stored metadata through the transaction, which admits no reads once its
+    // commit is in flight, settled, or aborted. The underlying transaction
+    // holds a single commit verdict, which stays with the commit that is
+    // running.
+    it("returns the completion error while the first commit is in flight", async () => {
+      const tx = runtime.edit();
+      runtime.getCell(space, "double-commit", undefined, tx).set({
+        title: "once",
+      });
+      const flushed: string[] = [];
+      const verdicts: string[] = [];
+      const settlements: string[] = [];
+      tx.enqueuePostCommitEffect({
+        id: "double-commit-effect",
+        kind: "test",
+        flush: () => {
+          flushed.push("flushed");
+        },
+      });
+      tx.addVerdictCallback((_tx, result) => {
+        verdicts.push(result.error ? result.error.name : "ok");
+      });
+      tx.addCommitCallback((_tx, result) => {
+        settlements.push(result.error ? result.error.name : "ok");
+      });
+
+      const first = tx.commit();
+      expect(tx.status().status).toBe("pending");
+      const second = await tx.commit();
+      expect(second.error?.name).toBe("StorageTransactionCompleteError");
+
+      expect((await first).error).toBeUndefined();
+      await tx.postCommitEffectsSettled();
+      expect(verdicts).toEqual(["ok"]);
+      expect(settlements).toEqual(["ok"]);
+      expect(flushed).toEqual(["flushed"]);
+    });
+
+    it("returns the completion error after the first commit settled", async () => {
+      const tx = runtime.edit();
+      runtime.getCell(space, "double-commit-settled", undefined, tx).set({
+        title: "once",
+      });
+      expect((await tx.commit()).error).toBeUndefined();
+      const second = await tx.commit();
+      expect(second.error?.name).toBe("StorageTransactionCompleteError");
+    });
+
+    it("returns the abort reason after the transaction was aborted", async () => {
+      const tx = runtime.edit();
+      runtime.getCell(space, "commit-after-abort", undefined, tx).set({
+        title: "once",
+      });
+      tx.abort("done with this one");
+      const result = await tx.commit();
+      expect(result.error?.name).toBe("StorageTransactionAborted");
+    });
+
+    describe("with flow labels persisted", () => {
+      // The flow-labels probe is what reads stored metadata, and it runs only
+      // with the dial on, which the shared runtime leaves off. An aborted
+      // transaction keeps its read and write activity so the scheduler can
+      // rebuild the action's dependencies, so the probe has work to walk
+      // there; a settled one does not.
+      beforeEach(async () => {
+        await runtime.dispose();
+        await storageManager.close();
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+          cfcFlowLabels: "persist",
+        });
+      });
+
+      it("returns the completion error while the first commit is in flight", async () => {
+        const tx = runtime.edit();
+        runtime.getCell(space, "labeled-double-commit", undefined, tx).set({
+          title: "once",
+        });
+        const first = tx.commit();
+        const second = await tx.commit();
+        expect(second.error?.name).toBe("StorageTransactionCompleteError");
+        expect((await first).error).toBeUndefined();
+      });
+
+      it("returns the abort reason after the transaction was aborted", async () => {
+        const tx = runtime.edit();
+        runtime.getCell(space, "labeled-commit-after-abort", undefined, tx)
+          .set({ title: "once" });
+        tx.abort("done with this one");
+        const result = await tx.commit();
+        expect(result.error?.name).toBe("StorageTransactionAborted");
+      });
+    });
+  });
+
   describe("a wrapped transaction", () => {
     it("answers for the instant as the transaction it wraps does", async () => {
       const { tx, cell } = await seeded("wrapped-instant");


### PR DESCRIPTION
A second commit() on a transaction whose first commit is still in flight, or already settled or aborted, is meant to resolve with the underlying StorageTransactionCompleteError result, as the interface documents. Two things break that.

The commit path runs CFC relevance probes before delegating, and the flow-labels probe reads stored metadata through the transaction itself. A transaction that is no longer open refuses those reads, so the probe threw StorageTransactionCompleteError out of commit() instead of returning it as the commit result. That fires whenever the runtime's flow-labels dial is at "observe" or "persist", which is the shipped shell posture, and after an abort it needs no race at all: an aborted transaction keeps its read and write activity so the scheduler can rebuild the action's dependencies, so the probe still has work to walk.

The second break needs no dial. The underlying transaction holds a single commit verdict, and every commit() call resolves it from its own promise. A second commit issued while the first is in flight resolves that verdict first, with its own error, so the running commit's verdict callbacks report a failure it did not suffer and its post-commit outbox is discarded instead of flushed. Commit callbacks dispatch once, so the doomed commit takes that dispatch too.

Report the terminal state directly when the transaction's status is no longer "ready", rather than delegating to the underlying commit: the result is the same one the underlying commit would produce, the probe and prepare work that assumes an open transaction is skipped, and the verdict stays with the commit that is running.

The regression tests cover the in-flight, settled, and aborted cases. The in-flight test also pins the running commit's verdict, its commit callback, and its outbox flush, which is what the shared verdict corrupted. The cases that reach the probe run on a runtime built with cfcFlowLabels: "persist", because the probe only runs with the dial on and the Runtime default is "off".

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

