### PR TITLE
fix(state-inspector): a link's schema renders as what the link stores

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -1257,8 +1257,7 @@ export const inspect = new Command()
   .option("--doc", "Show the whole document, not just value.")
   .option(
     "--full-depth",
-    "Do not truncate nested values, or summarize any link's schema, while " +
-      "producing annotated output.",
+    "Do not truncate nested values or link schemas in annotated output.",
   )
   .action(async (options, space, entity) => {
     const path = parsePathOptions(options);

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -1257,7 +1257,8 @@ export const inspect = new Command()
   .option("--doc", "Show the whole document, not just value.")
   .option(
     "--full-depth",
-    "Do not truncate nested values while producing annotated output.",
+    "Do not truncate nested values, or summarize any link's schema, while " +
+      "producing annotated output.",
   )
   .action(async (options, space, entity) => {
     const path = parsePathOptions(options);

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -74,7 +74,10 @@ failure mode it guards against:
   to read inline is replaced by a `$elidedSchema` summary — top-level keys, byte
   count, and a digest that separates two schemas of the same shape — which is
   not a schema and is not mistakable for one. `--full-depth` writes every schema
-  out in full. No `schema` key at all means the link stores none.
+  out in full — annotated like any other value, so a sigil-shaped literal under
+  `const` / `default` / `enum` reads back as `$link` / `$ref`; the digest hashes
+  the stored schema, so that is what to compare two links by. No `schema` key at
+  all means the link stores none.
 
 ## Fidelity — reconstruction is the engine's, not a fork
 

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -68,16 +68,19 @@ failure mode it guards against:
   (content-addressed ids). The scan labels `cross-space-linked` (real replica →
   drift bug) vs `no-cross-space-link` (likely instance).
 - **A `schema` under `$link` is the schema the link stores**, never a stand-in
-  for one. A stored schema is a JSON Schema, so `true` (constrains nothing) and
-  `false` (admits nothing) are values a link can really hold, and the difference
-  decides how the runtime resolves a hop through that link. A schema too large
-  to read inline is replaced by a `$elidedSchema` summary — top-level keys, byte
-  count, and a digest that separates two schemas of the same shape — which is
-  not a schema and is not mistakable for one. `--full-depth` writes every schema
-  out in full — annotated like any other value, so a sigil-shaped literal under
-  `const` / `default` / `enum` reads back as `$link` / `$ref`; the digest hashes
-  the stored schema, so that is what to compare two links by. No `schema` key at
-  all means the link stores none.
+  for one. A stored schema is a JSON Schema, so `true` (selects every value) and
+  `false` (selects none) are values a link can really hold, and they say
+  different things about what that link constrains. A schema too large to read
+  inline is described by a `$schemaSummary` **beside** `schema` rather than
+  under it — top-level keys, byte count as stored, and a truncated digest. The
+  slot is what carries the distinction: a link can store a schema of any shape,
+  so a summary placed under `schema` could be a schema some link really holds,
+  while nothing stored reaches a `$`-prefixed sibling. The two never both
+  appear, and neither appearing means the link stores no schema. Different
+  digests prove two schemas differ; equal ones make agreement overwhelmingly
+  likely without proving it. `--full-depth` writes every schema out in full —
+  annotated like any other value, so a sigil-shaped literal under `const` /
+  `default` / `enum` reads back as `$link` / `$ref`.
 
 ## Fidelity — reconstruction is the engine's, not a fork
 

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -67,6 +67,14 @@ failure mode it guards against:
 - **Same id across spaces is usually independent instances**, not replica drift
   (content-addressed ids). The scan labels `cross-space-linked` (real replica →
   drift bug) vs `no-cross-space-link` (likely instance).
+- **A `schema` under `$link` is the schema the link stores**, never a stand-in
+  for one. A stored schema is a JSON Schema, so `true` (constrains nothing) and
+  `false` (admits nothing) are values a link can really hold, and the difference
+  decides how the runtime resolves a hop through that link. A schema too large
+  to read inline is replaced by a `$elidedSchema` summary — top-level keys, byte
+  count, and a digest that separates two schemas of the same shape — which is
+  not a schema and is not mistakable for one. `--full-depth` writes every schema
+  out in full. No `schema` key at all means the link stores none.
 
 ## Fidelity — reconstruction is the engine's, not a fork
 
@@ -119,7 +127,7 @@ deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
 deno task cf inspect history  z6Mkqa41 of:fid1:…
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count [--seq N]
-deno task cf inspect value-at z6Mkqa41 of:fid1:… --full-depth # preserve every nested value
+deno task cf inspect value-at z6Mkqa41 of:fid1:… --full-depth # every nested value, every link schema
 
 # the entity graph (relationships between pieces/cells/modules)
 deno task cf inspect graph    z6Mkqa41 [--root of:fid1:… --depth 2] [--dot]

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -219,9 +219,10 @@ const utf8 = new TextEncoder();
 
 /**
  * Byte length of `value` as JSON. Falls back to measuring the annotated form
- * for the values `JSON.stringify()` refuses — a `bigint` anywhere in the
- * value, or a cycle — so that a schema holding one is still measurable rather
- * than fatal.
+ * for what `JSON.stringify()` refuses — a `bigint` anywhere in the value, or a
+ * cycle — so that a schema holding one is still measurable rather than fatal.
+ * `annotate()` lowers both, and neither it nor `JSON.stringify()` recurses, so
+ * the fallback has nothing left to fail on however deeply the value nests.
  *
  * The measurement is of the value as stored, which a `FabricSpecialObject`
  * under-reports: it stringifies to `{}` whatever it holds. Such a schema can
@@ -232,62 +233,83 @@ function jsonByteLength(value: Json): number {
   try {
     return utf8.encode(JSON.stringify(value)).length;
   } catch {
-    const rendered = JSON.stringify(annotate(value, Number.POSITIVE_INFINITY));
-    return utf8.encode(rendered).length;
+    const json = JSON.stringify(annotate(value, Number.POSITIVE_INFINITY));
+    return utf8.encode(json).length;
   }
 }
 
 /**
- * Stand-in for a schema too large to write out as itself: its top-level keys,
- * its size in bytes as stored, and a truncated hash of it. Equal digests mean
- * the two links almost certainly agree, which is
- * what makes a summary enough to answer whether one link's schema is stale
- * against another's; a truncated hash bounds that at "almost".
- *
- * The `$elidedSchema` wrapper is what keeps the summary from being read as the
- * schema: `true`, `false`, and every object shape are values a link can really
- * store, so a summary wearing one of those would be indistinguishable from the
- * thing it stands for. The wrapper is not proof against a consumer that treats
- * whatever it finds here as JSON Schema and ignores keywords it does not know
- * — nothing rendered in this position could be — but it cannot be mistaken for
- * a stored schema by a reader who looks at it.
+ * Truncated hash of `schema`, or `undefined` when it cannot be computed —
+ * hashing descends recursively, so a schema nested past the call stack has no
+ * digest to report. An absent digest means it was not computed, and two
+ * summaries that both lack one say nothing about whether their schemas agree.
  */
-function elideSchema(schema: Json, bytes: number): Json {
+function schemaDigest(schema: Json): string | undefined {
+  try {
+    return hashStringOf(schema).slice(0, 12);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Summary of a schema too large to write out as itself: its top-level keys,
+ * its size in bytes as stored, and a truncated hash of it. Different digests
+ * prove the two schemas differ; equal ones make them overwhelmingly likely to
+ * agree without proving it, since the hash is truncated. Either way that is
+ * usually enough to settle whether one link's schema is stale against
+ * another's, and `--full-depth` settles it outright.
+ *
+ * `digest` is absent when it could not be computed; see `schemaDigest()`.
+ */
+function schemaSummary(schema: Json, bytes: number): Json {
+  const digest = schemaDigest(schema);
   return {
-    $elidedSchema: {
-      ...(isNameWalkable(schema) ? { keys: Object.keys(schema) } : {}),
-      bytes,
-      digest: hashStringOf(schema).slice(0, 12),
-    },
+    ...(isNameWalkable(schema) ? { keys: Object.keys(schema) } : {}),
+    bytes,
+    ...(digest === undefined ? {} : { digest }),
   };
 }
 
 /**
- * Render the schema stored on a link: as itself when it is small enough to
- * read or when `maxDepth` is infinite, and as an `elideSchema()` summary
- * otherwise. Never synthesizes a schema — a rendered `true` means `true` was
- * what the link stored.
+ * The `$link` fields describing the schema stored on a link: `schema` holding
+ * it as itself when it is small enough to read or when `maxDepth` is infinite,
+ * and `$schemaSummary` holding a `schemaSummary()` of it otherwise. Never
+ * synthesizes a schema — a rendered `true` means `true` was what the link
+ * stored.
+ *
+ * The summary is a SIBLING of `schema` rather than a value under it, and the
+ * two are never both present. A link can store a schema of any shape, so a
+ * summary written into the `schema` slot could be a schema some link really
+ * holds, and a reader would have no way to tell the summary from the thing it
+ * summarizes. Nothing stored reaches a `$`-prefixed sibling — `payloadToLink()`
+ * bounds what a link contributes to `id`, `space`, `path`, `scope`, and
+ * `schema` — so the distinction holds for every possible stored value rather
+ * than for the ones that happen not to collide.
  *
  * "As itself" is the annotated form, not the stored bytes. A schema is walked
  * like any other value, so a sigil-shaped literal inside one — under `const`,
  * `default`, or `enum` — reads back as `{ $link }` or `{ $ref }` the way it
  * would anywhere else in the output. That keeps the rendering JSON-safe, which
  * the stored form is not: a `bigint` in a schema breaks `JSON.stringify()`
- * outright, and a `FabricLink` in one flattens to `{}` and disappears. The
- * digest in an `elideSchema()` summary hashes the stored schema rather than
- * this rendering, so it stays the thing to compare two schemas by.
+ * outright, and a `FabricLink` in one flattens to `{}` and disappears. A
+ * summary's digest hashes the stored schema rather than this rendering, so it
+ * stays the thing to compare two schemas by.
  */
-function renderLinkSchema(schema: Json, maxDepth: number): Json {
+function linkSchemaFields(
+  schema: Json,
+  maxDepth: number,
+): Record<string, Json> {
   if (!Number.isFinite(maxDepth)) {
-    return annotate(schema, Number.POSITIVE_INFINITY);
+    return { schema: annotate(schema, Number.POSITIVE_INFINITY) };
   }
   // Measured before rendering, so that a schema headed for a summary is never
   // walked into a copy that only gets discarded. A space's worth of links each
   // carrying kilobytes of `$defs` is the case that makes the difference.
   const bytes = jsonByteLength(schema);
   return bytes <= MAX_INLINE_SCHEMA_BYTES
-    ? annotate(schema, Number.POSITIVE_INFINITY)
-    : elideSchema(schema, bytes);
+    ? { schema: annotate(schema, Number.POSITIVE_INFINITY) }
+    : { $schemaSummary: schemaSummary(schema, bytes) };
 }
 
 /**
@@ -295,7 +317,7 @@ function renderLinkSchema(schema: Json, maxDepth: number): Json {
  * become `{ $link: … }`, entity refs become `{ $ref: … }`, and streams become
  * `"$stream"`. `maxDepth` limits how many nested containers are retained, and
  * an infinite one additionally writes out every link's schema in full; see
- * `renderLinkSchema()` for what a finite one does with a large schema.
+ * `linkSchemaFields()` for what a finite one does with a large schema.
  */
 export function annotate(v: Json, maxDepth = 8): Json {
   const root: Record<string, Json> = {};
@@ -333,7 +355,7 @@ export function annotate(v: Json, maxDepth = 8): Json {
           // `maxDepth` rather than `frame.depth`: full schema fidelity is a
           // property of the whole rendering, not of where a link sits in it.
           ...(link.schema !== undefined
-            ? { schema: renderLinkSchema(link.schema, maxDepth) }
+            ? linkSchemaFields(link.schema, maxDepth)
             : {}),
         },
       });

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -260,7 +260,9 @@ function schemaDigest(schema: Json): string | undefined {
  * usually enough to settle whether one link's schema is stale against
  * another's, and `--full-depth` settles it outright.
  *
- * `digest` is absent when it could not be computed; see `schemaDigest()`.
+ * `bytes` is always present. `digest` is absent when it could not be computed,
+ * for which see `schemaDigest()`, and `keys` when the stored schema is not an
+ * object and so has none.
  */
 function schemaSummary(schema: Json, bytes: number): Json {
   const digest = schemaDigest(schema);

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -247,6 +247,15 @@ function elideSchema(schema: Json, bytes: number): Json {
  * read or when `maxDepth` is infinite, and as an `elideSchema()` summary
  * otherwise. Never synthesizes a schema — a rendered `true` means `true` was
  * what the link stored.
+ *
+ * "As itself" is the annotated form, not the stored bytes. A schema is walked
+ * like any other value, so a sigil-shaped literal inside one — under `const`,
+ * `default`, or `enum` — reads back as `{ $link }` or `{ $ref }` the way it
+ * would anywhere else in the output. That keeps the rendering JSON-safe, which
+ * the stored form is not: a `bigint` in a schema breaks `JSON.stringify()`
+ * outright, and a `FabricLink` in one flattens to `{}` and disappears. The
+ * digest in an `elideSchema()` summary hashes the stored schema rather than
+ * this rendering, so it stays the thing to compare two schemas by.
  */
 function renderLinkSchema(schema: Json, maxDepth: number): Json {
   const rendered = annotate(schema, Number.POSITIVE_INFINITY);

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -205,10 +205,10 @@ interface AnnotationLeave {
 type AnnotationFrame = AnnotationVisit | AnnotationLeave;
 
 /**
- * Largest schema, in bytes of JSON, written into annotated output as itself. A
- * link's schema is unbounded and routinely dwarfs the value carrying it —
- * kilobytes of `$defs` hanging off one array element — so a larger one is
- * summarized by `elideSchema()` instead. The bound is on rendered size rather
+ * Largest schema, in bytes of stored JSON, written into annotated output as
+ * itself. A link's schema is unbounded and routinely dwarfs the value carrying
+ * it — kilobytes of `$defs` hanging off one array element — so a larger one is
+ * summarized by `elideSchema()` instead. The bound is on stored size rather
  * than on depth, because a schema is metadata about the link rather than part
  * of the value's own shape, and so is not what a caller's `maxDepth` is
  * budgeting.
@@ -218,9 +218,29 @@ const MAX_INLINE_SCHEMA_BYTES = 200;
 const utf8 = new TextEncoder();
 
 /**
+ * Byte length of `value` as JSON. Falls back to measuring the annotated form
+ * for the values `JSON.stringify()` refuses — a `bigint` anywhere in the
+ * value, or a cycle — so that a schema holding one is still measurable rather
+ * than fatal.
+ *
+ * The measurement is of the value as stored, which a `FabricSpecialObject`
+ * under-reports: it stringifies to `{}` whatever it holds. Such a schema can
+ * therefore be written out inline while rendering a little longer than the
+ * bound. Nothing downstream reads the count as an allocation size.
+ */
+function jsonByteLength(value: Json): number {
+  try {
+    return utf8.encode(JSON.stringify(value)).length;
+  } catch {
+    const rendered = JSON.stringify(annotate(value, Number.POSITIVE_INFINITY));
+    return utf8.encode(rendered).length;
+  }
+}
+
+/**
  * Stand-in for a schema too large to write out as itself: its top-level keys,
- * the size in bytes of its rendered JSON, and a truncated hash of the stored
- * schema. Equal digests mean the two links almost certainly agree, which is
+ * its size in bytes as stored, and a truncated hash of it. Equal digests mean
+ * the two links almost certainly agree, which is
  * what makes a summary enough to answer whether one link's schema is stale
  * against another's; a truncated hash bounds that at "almost".
  *
@@ -258,11 +278,15 @@ function elideSchema(schema: Json, bytes: number): Json {
  * this rendering, so it stays the thing to compare two schemas by.
  */
 function renderLinkSchema(schema: Json, maxDepth: number): Json {
-  const rendered = annotate(schema, Number.POSITIVE_INFINITY);
-  if (!Number.isFinite(maxDepth)) return rendered;
-  const bytes = utf8.encode(JSON.stringify(rendered)).length;
+  if (!Number.isFinite(maxDepth)) {
+    return annotate(schema, Number.POSITIVE_INFINITY);
+  }
+  // Measured before rendering, so that a schema headed for a summary is never
+  // walked into a copy that only gets discarded. A space's worth of links each
+  // carrying kilobytes of `$defs` is the case that makes the difference.
+  const bytes = jsonByteLength(schema);
   return bytes <= MAX_INLINE_SCHEMA_BYTES
-    ? rendered
+    ? annotate(schema, Number.POSITIVE_INFINITY)
     : elideSchema(schema, bytes);
 }
 

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -18,6 +18,7 @@ import { JsonCodecEngine } from "@commonfabric/data-model/codec-json";
 import { fabricFromJsonValue } from "@commonfabric/data-model/codecs";
 import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { isPlainObject } from "@commonfabric/utils/types";
 
@@ -33,7 +34,13 @@ export interface DecodedLink {
   space?: string;
   path?: readonly string[];
   scope?: string;
-  hasSchema: boolean;
+  /**
+   * The schema stored on the link, or `undefined` when it stores none. A
+   * stored schema is a JSON Schema, so `true` and `false` are among the values
+   * it can hold — `true` constrains nothing, `false` admits nothing — and
+   * neither may be synthesized to stand for a schema that is merely present.
+   */
+  schema?: Json;
 }
 
 type Json = unknown;
@@ -67,7 +74,7 @@ function payloadToLink(payload: Record<string, Json>): DecodedLink {
       ? (payload.path as readonly string[])
       : undefined,
     scope: typeof payload.scope === "string" ? payload.scope : undefined,
-    hasSchema: payload.schema !== undefined,
+    schema: payload.schema,
   };
 }
 
@@ -178,7 +185,7 @@ export function summarizeLink(link: DecodedLink): string {
   const space = link.space
     ? ` @${escapeTerminalText(shortDid(link.space) ?? "")}`
     : "";
-  const schema = link.hasSchema ? " +schema" : "";
+  const schema = link.schema !== undefined ? " +schema" : "";
   return `🔗 ${id}${path}${space}${schema}`;
 }
 
@@ -198,9 +205,64 @@ interface AnnotationLeave {
 type AnnotationFrame = AnnotationVisit | AnnotationLeave;
 
 /**
+ * Largest schema, in bytes of JSON, written into annotated output as itself. A
+ * link's schema is unbounded and routinely dwarfs the value carrying it —
+ * kilobytes of `$defs` hanging off one array element — so a larger one is
+ * summarized by `elideSchema()` instead. The bound is on rendered size rather
+ * than on depth, because a schema is metadata about the link rather than part
+ * of the value's own shape, and so is not what a caller's `maxDepth` is
+ * budgeting.
+ */
+const MAX_INLINE_SCHEMA_BYTES = 200;
+
+const utf8 = new TextEncoder();
+
+/**
+ * Stand-in for a schema too large to write out as itself: its top-level keys,
+ * the size in bytes of its rendered JSON, and a truncated hash of the stored
+ * schema. Equal digests mean the two links almost certainly agree, which is
+ * what makes a summary enough to answer whether one link's schema is stale
+ * against another's; a truncated hash bounds that at "almost".
+ *
+ * The `$elidedSchema` wrapper is what keeps the summary from being read as the
+ * schema: `true`, `false`, and every object shape are values a link can really
+ * store, so a summary wearing one of those would be indistinguishable from the
+ * thing it stands for. The wrapper is not proof against a consumer that treats
+ * whatever it finds here as JSON Schema and ignores keywords it does not know
+ * — nothing rendered in this position could be — but it cannot be mistaken for
+ * a stored schema by a reader who looks at it.
+ */
+function elideSchema(schema: Json, bytes: number): Json {
+  return {
+    $elidedSchema: {
+      ...(isNameWalkable(schema) ? { keys: Object.keys(schema) } : {}),
+      bytes,
+      digest: hashStringOf(schema).slice(0, 12),
+    },
+  };
+}
+
+/**
+ * Render the schema stored on a link: as itself when it is small enough to
+ * read or when `maxDepth` is infinite, and as an `elideSchema()` summary
+ * otherwise. Never synthesizes a schema — a rendered `true` means `true` was
+ * what the link stored.
+ */
+function renderLinkSchema(schema: Json, maxDepth: number): Json {
+  const rendered = annotate(schema, Number.POSITIVE_INFINITY);
+  if (!Number.isFinite(maxDepth)) return rendered;
+  const bytes = utf8.encode(JSON.stringify(rendered)).length;
+  return bytes <= MAX_INLINE_SCHEMA_BYTES
+    ? rendered
+    : elideSchema(schema, bytes);
+}
+
+/**
  * Transform a stored value into an annotated, JSON-printable form. Links
  * become `{ $link: … }`, entity refs become `{ $ref: … }`, and streams become
- * `"$stream"`. `maxDepth` limits how many nested containers are retained.
+ * `"$stream"`. `maxDepth` limits how many nested containers are retained, and
+ * an infinite one additionally writes out every link's schema in full; see
+ * `renderLinkSchema()` for what a finite one does with a large schema.
  */
 export function annotate(v: Json, maxDepth = 8): Json {
   const root: Record<string, Json> = {};
@@ -235,7 +297,11 @@ export function annotate(v: Json, maxDepth = 8): Json {
           ...(link.path && link.path.length ? { path: link.path } : {}),
           ...(link.space ? { space: link.space } : {}),
           ...(link.scope ? { scope: link.scope } : {}),
-          ...(link.hasSchema ? { schema: true } : {}),
+          // `maxDepth` rather than `frame.depth`: full schema fidelity is a
+          // property of the whole rendering, not of where a link sits in it.
+          ...(link.schema !== undefined
+            ? { schema: renderLinkSchema(link.schema, maxDepth) }
+            : {}),
         },
       });
       continue;

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -210,10 +210,13 @@ function declaredSchemaFor(
     ? (ownerDoc!.value as Record<string, unknown>)[key]
     : undefined;
   const linkSchema = decodedLinkOf(naming)?.schema;
-  if (isObjectNotArray(linkSchema)) {
+  if (linkSchema !== undefined) {
     return {
       schema: annotate(linkSchema),
-      keys: Object.keys(linkSchema),
+      // A boolean schema has no keys to list, and `true` in particular is the
+      // one that constrains nothing — reporting it is the point, since the
+      // owner's declaration would otherwise stand in for it.
+      keys: isObjectNotArray(linkSchema) ? Object.keys(linkSchema) : undefined,
       via: "link",
     };
   }
@@ -245,7 +248,7 @@ function declaredSchemaFor(
   return undefined;
 }
 
-/** Collect every sigil link in a value, with its JSON path. */
+/** Collect every link in a value, in either at-rest form, with its JSON path. */
 function linksWithPaths(
   v: unknown,
   base: string[] = [],
@@ -253,7 +256,7 @@ function linksWithPaths(
   depth = 10,
 ): { link: DecodedLink; at: string }[] {
   if (depth < 0) return out;
-  const link = parseSigilLink(v);
+  const link = decodedLinkOf(v);
   if (link) {
     out.push({ link, at: base.join("/") });
     return out;
@@ -504,7 +507,7 @@ export function buildAllDetails(
       c.kind === "piece" && c.regime === "modern" && isObjectNotArray(doc.value)
     ) {
       for (const [key, val] of Object.entries(doc.value)) {
-        const tid = parseSigilLink(val)?.id;
+        const tid = decodedLinkOf(val)?.id;
         if (tid && !nameOf.has(tid)) nameOf.set(tid, { owner: id, key });
       }
     }

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -21,6 +21,7 @@ import type { SpaceDb } from "./db.ts";
 import {
   annotate,
   type DecodedLink,
+  decodedLinkOf,
   parseSigilLink,
   summarize,
 } from "./decode.ts";
@@ -196,29 +197,25 @@ function parseCfc(cfc: unknown): CfcSummary | undefined {
  * A stream / owned cell carries no schema of its own — its DECLARED schema (a
  * stream's event payload, a cell's value type) is attached where it is NAMED in
  * its owner piece, under the key `<key>`. Two sources, link-first:
- *   1. the inline `schema` on the LINK itself (`value[key]."/"."link@N".schema`)
- *      — present even when the result schema omits the handler (e.g. addFavorite),
+ *   1. the inline `schema` on the LINK itself, in either at-rest form — present
+ *      even when the result schema omits the handler (e.g. addFavorite),
  *   2. else the owner's `schema.properties[<key>]`, following a `$ref` into `$defs`.
  */
 function declaredSchemaFor(
   ownerDoc: EntityDocument | undefined,
   key: string,
 ): { schema: unknown; keys?: string[]; via: string } | undefined {
-  // 1. inline schema carried on the naming link.
-  const linkRaw = isObjectNotArray(ownerDoc?.value)
+  // 1. inline schema carried on the naming link, in either at-rest form.
+  const naming = isObjectNotArray(ownerDoc?.value)
     ? (ownerDoc!.value as Record<string, unknown>)[key]
     : undefined;
-  if (isObjectNotArray(linkRaw) && isObjectNotArray(linkRaw["/"])) {
-    const slash = linkRaw["/"] as Record<string, unknown>;
-    const linkKey = Object.keys(slash).find((k) => k.startsWith("link@"));
-    const inner = linkKey ? slash[linkKey] : undefined;
-    if (isObjectNotArray(inner) && isObjectNotArray(inner.schema)) {
-      return {
-        schema: annotate(inner.schema),
-        keys: Object.keys(inner.schema),
-        via: "link",
-      };
-    }
+  const linkSchema = decodedLinkOf(naming)?.schema;
+  if (isObjectNotArray(linkSchema)) {
+    return {
+      schema: annotate(linkSchema),
+      keys: Object.keys(linkSchema),
+      via: "link",
+    };
   }
   // 2. fallback: owner's result-schema property ($ref into $defs).
   // NOTE: this is a deliberately NARROW resolver — a single top-level

--- a/packages/state-inspector/test/declared-schema.test.ts
+++ b/packages/state-inspector/test/declared-schema.test.ts
@@ -1,0 +1,200 @@
+/**
+ * The DECLARED schema of a named owned cell or stream, which the entity itself
+ * does not carry: it is resolved from where the owner piece names it, link
+ * first and the owner's result schema second. What the link stores decides,
+ * including when what it stores is a boolean, and the naming link is found in
+ * either at-rest form.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+
+import {
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
+import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+
+import { openSpace } from "../db.ts";
+import { buildAllDetails, type EntityDetail } from "../detail.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 9, 'active');
+`;
+
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+/** A link in the legacy at-rest sigil form. */
+function link(id: string, schema?: unknown): unknown {
+  return {
+    "/": {
+      "link@1": { id, path: [], ...(schema === undefined ? {} : { schema }) },
+    },
+  };
+}
+
+/** The owner's result schema, which stands in when a link declares nothing. */
+const OWNER_SCHEMA = {
+  type: "object",
+  properties: {
+    fromOwner: { $ref: "#/$defs/OwnerDeclared" },
+    permissive: { $ref: "#/$defs/OwnerDeclared" },
+  },
+  $defs: {
+    OwnerDeclared: {
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+  },
+};
+
+/**
+ * A piece naming three owned cells: one whose link carries a schema, one whose
+ * link carries the schema `true`, and one whose link carries none at all. The
+ * owner's result schema declares the last two, so it can be told apart from
+ * what a link says.
+ */
+function seed(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, 'session:did:key:zX:u', ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+
+  // A modern link instance survives at rest only through the codec envelope.
+  setModernCellRepConfig(true);
+  let modernPieceValue: string;
+  try {
+    modernPieceValue = jsonFromFabricValue({
+      value: {
+        modernNamed: new FabricLink({ id: "of:modern-cell", path: [] }),
+      },
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: OWNER_SCHEMA,
+    });
+  } finally {
+    resetModernCellRepConfig();
+  }
+
+  commit.run(1, 1);
+  rev.run(
+    "of:piece",
+    1,
+    JSON.stringify({
+      value: {
+        fromLink: link("of:link-schema-cell", {
+          type: "object",
+          properties: { declaredOnTheLink: { type: "string" } },
+        }),
+        permissive: link("of:permissive-cell", true),
+        fromOwner: link("of:owner-schema-cell"),
+      },
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: OWNER_SCHEMA,
+    }),
+    1,
+  );
+  for (
+    const [seq, id] of [
+      [2, "of:link-schema-cell"],
+      [3, "of:permissive-cell"],
+      [4, "of:owner-schema-cell"],
+    ] as const
+  ) {
+    commit.run(seq, seq);
+    rev.run(
+      id,
+      seq,
+      JSON.stringify({ value: "v", result: link("of:piece") }),
+      seq,
+    );
+  }
+
+  commit.run(5, 5);
+  rev.run("of:modern-piece", 5, modernPieceValue, 5);
+  commit.run(6, 6);
+  rev.run(
+    "of:modern-cell",
+    6,
+    JSON.stringify({ value: "v", result: link("of:modern-piece") }),
+    6,
+  );
+  db.close();
+}
+
+/** Every entity's detail, keyed by id. */
+async function details(): Promise<Map<string, EntityDetail>> {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-declared-" });
+  const dbPath = `${dir}/space.sqlite`;
+  seed(dbPath);
+  const space = openSpace(dbPath);
+  try {
+    return new Map(buildAllDetails(space).map((d) => [d.id, d]));
+  } finally {
+    space.close();
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+describe("declared-schema", () => {
+  describe("buildAllDetails()", () => {
+    it("resolves a named cell's schema from the link that names it", async () => {
+      const detail = (await details()).get("of:link-schema-cell");
+      expect(detail?.schema).toEqual({
+        type: "object",
+        properties: { declaredOnTheLink: { type: "string" } },
+      });
+      expect(detail?.schemaSource).toContain("link");
+    });
+
+    it("resolves `true` from a link that stores it, not the owner's declaration", async () => {
+      // `true` constrains nothing, which is a fact about the link and not an
+      // absence: the owner's declaration standing in here would report a
+      // constraint the stored link does not carry.
+      const detail = (await details()).get("of:permissive-cell");
+      expect(detail?.schema).toBe(true);
+      expect(detail?.schemaKeys).toBe(undefined);
+      expect(detail?.schemaSource).toContain("link");
+    });
+
+    it("falls back to the owner's result schema for a link storing no schema", async () => {
+      const detail = (await details()).get("of:owner-schema-cell");
+      expect(detail?.schema).toEqual(OWNER_SCHEMA.$defs.OwnerDeclared);
+      expect(detail?.schemaSource).toContain("owner schema");
+    });
+
+    it("names a cell whose owner points at it with a modern `FabricLink`", async () => {
+      // The naming pass indexes children by link, so a modern link has to be
+      // read as one — otherwise the cell is never named and never reaches the
+      // declared-schema lookup at all.
+      const detail = (await details()).get("of:modern-cell");
+      expect(detail?.label).toBe("modernNamed");
+    });
+  });
+});

--- a/packages/state-inspector/test/decode.test.ts
+++ b/packages/state-inspector/test/decode.test.ts
@@ -59,7 +59,7 @@ Deno.test("decode: a modern encoded link round-trips to a recognized link", () =
 });
 
 Deno.test("decode: summarizeLink keeps the computed: scheme visible", () => {
-  const summary = (id: string) => summarizeLink({ id, hasSchema: false });
+  const summary = (id: string) => summarizeLink({ id });
   // The hash preimage is kind-free, so of:fid1:H and computed:fid1:H can be
   // two distinct docs for one cause — the display must NOT conflate them.
   assert(

--- a/packages/state-inspector/test/link-schema.test.ts
+++ b/packages/state-inspector/test/link-schema.test.ts
@@ -91,47 +91,91 @@ describe("link-schema", () => {
       expect(annotatedLink(sigilLink(schema)).schema).toEqual(schema);
     });
 
-    it("returns a summary naming the top-level keys of a large schema", () => {
+    it("describes a large schema under `$schemaSummary`, naming its top-level keys", () => {
       const schema = largeSchema("a description long enough to matter");
-      const rendered = annotatedLink(sigilLink(schema)).schema as {
-        $elidedSchema: { keys: string[]; bytes: number; digest: string };
+      const link = annotatedLink(sigilLink(schema));
+      const summary = link.$schemaSummary as {
+        keys: string[];
+        bytes: number;
+        digest: string;
       };
-      expect(rendered.$elidedSchema.keys).toEqual([
+      expect(summary.keys).toEqual([
         "type",
         "description",
         "properties",
         "required",
       ]);
-      expect(rendered.$elidedSchema.bytes).toBe(
+      expect(summary.bytes).toBe(
         new TextEncoder().encode(JSON.stringify(schema)).length,
       );
-      expect(typeof rendered.$elidedSchema.digest).toBe("string");
+      expect(typeof summary.digest).toBe("string");
     });
 
-    it("returns a summary sized by the stored schema rather than by its rendering", () => {
+    it("omits `schema` for a link whose schema it summarizes", () => {
+      const link = annotatedLink(sigilLink(largeSchema("wide")));
+      // The two never both appear, so a `schema` key always means the value
+      // beside it is what the link stores.
+      expect(Object.hasOwn(link, "schema")).toBe(false);
+      expect(Object.hasOwn(link, "$schemaSummary")).toBe(true);
+    });
+
+    it("describes a summary-shaped stored schema under `schema`, not `$schemaSummary`", () => {
+      // The summary of a large schema, stored verbatim as some other link's
+      // schema. Placing a summary in the `schema` slot would render these two
+      // identically; the sibling slot is what keeps them apart.
+      const summarized = annotatedLink(sigilLink(largeSchema("wide")));
+      const forged = annotatedLink(
+        sigilLink({ $schemaSummary: summarized.$schemaSummary }),
+      );
+      expect(forged.schema).toEqual({
+        $schemaSummary: summarized.$schemaSummary,
+      });
+      expect(Object.hasOwn(forged, "$schemaSummary")).toBe(false);
+      expect(Object.hasOwn(summarized, "schema")).toBe(false);
+    });
+
+    it("describes a schema sized as stored rather than as rendered", () => {
       // A sigil renders longer than it is stored, so a summary measuring the
       // rendering reports a size the store does not hold.
       const schema = {
         const: { "/": "of:target" },
         description: "x".repeat(300),
       };
-      const rendered = annotatedLink(sigilLink(schema)).schema as {
-        $elidedSchema: { bytes: number };
+      const summary = annotatedLink(sigilLink(schema)).$schemaSummary as {
+        bytes: number;
       };
-      expect(rendered.$elidedSchema.bytes).toBe(
+      expect(summary.bytes).toBe(
         new TextEncoder().encode(JSON.stringify(schema)).length,
       );
     });
 
-    it("returns a summary of a schema `JSON.stringify()` refuses", () => {
+    it("describes a schema `JSON.stringify()` refuses", () => {
       // A `bigint` in a schema is not serializable, so the size that decides
       // the summary comes from the annotated form instead of the stored one.
       const schema = { const: 1n, description: "x".repeat(300) };
-      const rendered = annotatedLink(sigilLink(schema)).schema as {
-        $elidedSchema: { keys: string[]; bytes: number };
+      const summary = annotatedLink(sigilLink(schema)).$schemaSummary as {
+        keys: string[];
+        bytes: number;
       };
-      expect(rendered.$elidedSchema.keys).toEqual(["const", "description"]);
-      expect(rendered.$elidedSchema.bytes).toBeGreaterThan(300);
+      expect(summary.keys).toEqual(["const", "description"]);
+      expect(summary.bytes).toBeGreaterThan(300);
+    });
+
+    it("describes a schema nested past the call stack, without a digest", () => {
+      // Hashing descends recursively, so a schema this deep has no digest to
+      // report. Reporting none beats failing the whole rendering.
+      let deep: Record<string, unknown> = { type: "string" };
+      for (let level = 0; level < 20_000; level++) {
+        deep = { properties: { a: deep } };
+      }
+      const summary = annotatedLink(sigilLink(deep)).$schemaSummary as {
+        keys: string[];
+        bytes: number;
+        digest?: string;
+      };
+      expect(summary.keys).toEqual(["properties"]);
+      expect(summary.bytes).toBeGreaterThan(20_000);
+      expect(summary.digest).toBe(undefined);
     });
 
     it("returns a large schema in full at infinite `maxDepth`", () => {
@@ -143,22 +187,10 @@ describe("link-schema", () => {
       expect(annotated.$link.schema).toEqual(schema);
     });
 
-    it("returns a schema summary distinct from every schema a link can store", () => {
-      const summarized = annotatedLink(sigilLink(largeSchema("wide")))
-        .schema as Record<string, unknown>;
-      // A reader who cannot tell an elision from the thing elided is back to
-      // reading a fabricated schema, so the summary carries a key no schema
-      // of its own does.
-      expect(Object.keys(summarized)).toEqual(["$elidedSchema"]);
-      expect(summarized).not.toEqual(true);
-      expect(summarized).not.toEqual({});
-    });
-
     it("returns different digests for two schemas of the same shape", () => {
       const digestOf = (description: string) =>
-        (annotatedLink(sigilLink(largeSchema(description))).schema as {
-          $elidedSchema: { digest: string };
-        }).$elidedSchema.digest;
+        (annotatedLink(sigilLink(largeSchema(description)))
+          .$schemaSummary as { digest: string }).digest;
       // A stale schema and its replacement agree on every top-level key, so
       // the digest is what a diff of two revisions has to separate them by.
       expect(digestOf("one description")).not.toBe(digestOf("another one"));

--- a/packages/state-inspector/test/link-schema.test.ts
+++ b/packages/state-inspector/test/link-schema.test.ts
@@ -178,6 +178,15 @@ describe("link-schema", () => {
       expect(summary.digest).toBe(undefined);
     });
 
+    it("describes a large non-object schema without naming keys", () => {
+      // Stored data decides the shape, and a value that is not an object has
+      // no top-level keys to report.
+      const summary = annotatedLink(sigilLink("x".repeat(300)))
+        .$schemaSummary as { keys?: string[]; bytes: number };
+      expect(Object.hasOwn(summary, "keys")).toBe(false);
+      expect(summary.bytes).toBe(302);
+    });
+
     it("returns a large schema in full at infinite `maxDepth`", () => {
       const schema = largeSchema("a description long enough to matter");
       const annotated = annotate(

--- a/packages/state-inspector/test/link-schema.test.ts
+++ b/packages/state-inspector/test/link-schema.test.ts
@@ -1,0 +1,160 @@
+/**
+ * How a link's stored schema reaches annotated inspector output. The tool's
+ * contract is that its output is what the store holds, so the distinctions
+ * pinned here are between an absent schema, a stored `true`, and a schema too
+ * large to write out — three states a reader has to be able to tell apart,
+ * because a JSON Schema of `true` constrains nothing while a large one freezes
+ * a shape.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+
+import { annotate, decodedLinkOf, summarizeLink } from "../decode.ts";
+
+/** A link in the legacy at-rest sigil form, carrying `schema` when given one. */
+function sigilLink(schema?: unknown): unknown {
+  return {
+    "/": {
+      "link@1": {
+        id: "of:fid1:target",
+        path: [],
+        ...(schema === undefined ? {} : { schema }),
+      },
+    },
+  };
+}
+
+/**
+ * A schema with enough in it to exceed the inline budget, shaped like the ones
+ * a pattern's argument cell really carries.
+ */
+function largeSchema(description: string): Record<string, unknown> {
+  return {
+    type: "object",
+    description,
+    properties: Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => [
+        `field${index}`,
+        { type: "string", default: "" },
+      ]),
+    ),
+    required: Array.from({ length: 12 }, (_, index) => `field${index}`),
+  };
+}
+
+/** The `$link` body of an annotated single link. */
+function annotatedLink(value: unknown): Record<string, unknown> {
+  const annotated = annotate(value) as { $link: Record<string, unknown> };
+  return annotated.$link;
+}
+
+describe("link-schema", () => {
+  describe("decodedLinkOf()", () => {
+    it("returns the stored schema itself rather than a flag", () => {
+      const schema = { type: "string" };
+      expect(decodedLinkOf(sigilLink(schema))?.schema).toEqual(schema);
+    });
+
+    it("returns `undefined` for a link storing no schema", () => {
+      expect(decodedLinkOf(sigilLink())?.schema).toBe(undefined);
+    });
+
+    it("returns the stored schema of a modern `FabricLink`", () => {
+      const schema = { type: "string" };
+      const link = new FabricLink({ id: "of:x", path: [], schema });
+      expect(decodedLinkOf(link)?.schema).toEqual(schema);
+    });
+  });
+
+  describe("annotate()", () => {
+    it("omits `schema` for a link storing no schema", () => {
+      expect(Object.hasOwn(annotatedLink(sigilLink()), "schema")).toBe(false);
+    });
+
+    it("returns `true` for a link storing the schema `true`", () => {
+      expect(annotatedLink(sigilLink(true)).schema).toBe(true);
+    });
+
+    it("returns `false` for a link storing the schema `false`", () => {
+      expect(annotatedLink(sigilLink(false)).schema).toBe(false);
+    });
+
+    it("returns the empty schema for a link storing `{}`", () => {
+      expect(annotatedLink(sigilLink({})).schema).toEqual({});
+    });
+
+    it("returns a small schema as itself", () => {
+      const schema = { type: "object", properties: { a: { type: "string" } } };
+      expect(annotatedLink(sigilLink(schema)).schema).toEqual(schema);
+    });
+
+    it("returns a summary naming the top-level keys of a large schema", () => {
+      const schema = largeSchema("a description long enough to matter");
+      const rendered = annotatedLink(sigilLink(schema)).schema as {
+        $elidedSchema: { keys: string[]; bytes: number; digest: string };
+      };
+      expect(rendered.$elidedSchema.keys).toEqual([
+        "type",
+        "description",
+        "properties",
+        "required",
+      ]);
+      expect(rendered.$elidedSchema.bytes).toBeGreaterThan(200);
+      expect(typeof rendered.$elidedSchema.digest).toBe("string");
+    });
+
+    it("returns a large schema in full at infinite `maxDepth`", () => {
+      const schema = largeSchema("a description long enough to matter");
+      const annotated = annotate(
+        sigilLink(schema),
+        Number.POSITIVE_INFINITY,
+      ) as { $link: { schema: unknown } };
+      expect(annotated.$link.schema).toEqual(schema);
+    });
+
+    it("returns a schema summary distinct from every schema a link can store", () => {
+      const summarized = annotatedLink(sigilLink(largeSchema("wide")))
+        .schema as Record<string, unknown>;
+      // A reader who cannot tell an elision from the thing elided is back to
+      // reading a fabricated schema, so the summary carries a key no schema
+      // of its own does.
+      expect(Object.keys(summarized)).toEqual(["$elidedSchema"]);
+      expect(summarized).not.toEqual(true);
+      expect(summarized).not.toEqual({});
+    });
+
+    it("returns different digests for two schemas of the same shape", () => {
+      const digestOf = (description: string) =>
+        (annotatedLink(sigilLink(largeSchema(description))).schema as {
+          $elidedSchema: { digest: string };
+        }).$elidedSchema.digest;
+      // A stale schema and its replacement agree on every top-level key, so
+      // the digest is what a diff of two revisions has to separate them by.
+      expect(digestOf("one description")).not.toBe(digestOf("another one"));
+    });
+
+    it("returns the stored schema of a modern `FabricLink`", () => {
+      const schema = { type: "string" };
+      const link = new FabricLink({ id: "of:x", path: [], schema });
+      expect(annotatedLink(link).schema).toEqual(schema);
+    });
+  });
+
+  describe("summarizeLink()", () => {
+    it("marks a link that stores a schema", () => {
+      expect(summarizeLink({ id: "of:x", schema: { type: "string" } }))
+        .toContain("+schema");
+    });
+
+    it("marks a link that stores the schema `false`", () => {
+      expect(summarizeLink({ id: "of:x", schema: false })).toContain("+schema");
+    });
+
+    it("does not mark a link that stores no schema", () => {
+      expect(summarizeLink({ id: "of:x" })).not.toContain("+schema");
+    });
+  });
+});

--- a/packages/state-inspector/test/link-schema.test.ts
+++ b/packages/state-inspector/test/link-schema.test.ts
@@ -141,6 +141,26 @@ describe("link-schema", () => {
       const link = new FabricLink({ id: "of:x", path: [], schema });
       expect(annotatedLink(link).schema).toEqual(schema);
     });
+
+    it("returns a schema's own `$ref` untouched", () => {
+      const schema = { $ref: "#/$defs/TopicLinkKind" };
+      expect(annotatedLink(sigilLink(schema)).schema).toEqual(schema);
+    });
+
+    it("returns a sigil-shaped literal inside a schema in annotated form", () => {
+      // A schema is walked like any other value, which is what keeps the
+      // rendering JSON-safe where the stored form is not.
+      const schema = { const: { "/": "of:target" } };
+      expect(annotatedLink(sigilLink(schema)).schema).toEqual({
+        const: { $ref: "of:target" },
+      });
+    });
+
+    it("returns a schema holding a `bigint`, which the stored form cannot be serialized from", () => {
+      const rendered = annotatedLink(sigilLink({ const: 1n })).schema;
+      expect(rendered).toEqual({ const: { $bigint: "1" } });
+      expect(() => JSON.stringify(rendered)).not.toThrow();
+    });
   });
 
   describe("summarizeLink()", () => {

--- a/packages/state-inspector/test/link-schema.test.ts
+++ b/packages/state-inspector/test/link-schema.test.ts
@@ -102,8 +102,36 @@ describe("link-schema", () => {
         "properties",
         "required",
       ]);
-      expect(rendered.$elidedSchema.bytes).toBeGreaterThan(200);
+      expect(rendered.$elidedSchema.bytes).toBe(
+        new TextEncoder().encode(JSON.stringify(schema)).length,
+      );
       expect(typeof rendered.$elidedSchema.digest).toBe("string");
+    });
+
+    it("returns a summary sized by the stored schema rather than by its rendering", () => {
+      // A sigil renders longer than it is stored, so a summary measuring the
+      // rendering reports a size the store does not hold.
+      const schema = {
+        const: { "/": "of:target" },
+        description: "x".repeat(300),
+      };
+      const rendered = annotatedLink(sigilLink(schema)).schema as {
+        $elidedSchema: { bytes: number };
+      };
+      expect(rendered.$elidedSchema.bytes).toBe(
+        new TextEncoder().encode(JSON.stringify(schema)).length,
+      );
+    });
+
+    it("returns a summary of a schema `JSON.stringify()` refuses", () => {
+      // A `bigint` in a schema is not serializable, so the size that decides
+      // the summary comes from the annotated form instead of the stored one.
+      const schema = { const: 1n, description: "x".repeat(300) };
+      const rendered = annotatedLink(sigilLink(schema)).schema as {
+        $elidedSchema: { keys: string[]; bytes: number };
+      };
+      expect(rendered.$elidedSchema.keys).toEqual(["const", "description"]);
+      expect(rendered.$elidedSchema.bytes).toBeGreaterThan(300);
     });
 
     it("returns a large schema in full at infinite `maxDepth`", () => {

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -115,17 +115,21 @@ Confusing an approximation for truth is the failure mode that matters here:
   legitimately differ. The scan labels `cross-space-linked` (real replica →
   drift bug) vs `no-cross-space-link` (likely independent instance). Don't cry
   wolf on the latter.
-- **A `schema` under `$link` is what the link stores, and a `$elidedSchema` is a
-  summary of it.** A link's schema is a JSON Schema, so `true` and `false` are
-  values it can really hold — `true` constrains nothing and lets the reader's
-  own schema travel through the hop, while a schema with properties in it
-  freezes a shape at that link. Never read one as the other. A schema too large
-  to print inline is replaced by `{ $elidedSchema: { keys, bytes,
-  digest } }`,
-  which is a marker rather than a schema: equal digests mean equal schemas, so
-  it answers "do these links agree?" on its own, and `--full-depth` prints every
-  schema in full when you need the text. A link with no `schema` key stores no
-  schema at all.
+- **A `schema` under `$link` is what the link stores; a `$schemaSummary` beside
+  it describes a schema too large to print.** A link's schema is a JSON Schema,
+  so `true` and `false` are values it can really hold — `true` selects every
+  value, declaring no constraint at all, where a schema with properties in it
+  pins a shape at that link. Never read one as the other. The summary is
+  `{ keys, bytes, digest }` and is a SIBLING of `schema`, never a value under
+  it, because a link can store a schema of any shape and a summary in the
+  `schema` slot could be a schema some link really holds. The two never both
+  appear: a `schema` key means that is the stored schema, a `$schemaSummary` key
+  means it was too large to print, and neither means the link stores no schema.
+  Different digests prove two schemas differ; equal ones make agreement
+  overwhelmingly likely without proving it, since the hash is truncated — reach
+  for `--full-depth` when you need certainty or the text itself. A `bytes` or
+  `digest` that is absent could not be computed, and two summaries that both
+  lack a digest say nothing about whether they agree.
 
 ## Which question → which command
 

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -127,9 +127,10 @@ Confusing an approximation for truth is the failure mode that matters here:
   means it was too large to print, and neither means the link stores no schema.
   Different digests prove two schemas differ; equal ones make agreement
   overwhelmingly likely without proving it, since the hash is truncated — reach
-  for `--full-depth` when you need certainty or the text itself. A `bytes` or
-  `digest` that is absent could not be computed, and two summaries that both
-  lack a digest say nothing about whether they agree.
+  for `--full-depth` when you need certainty or the text itself. An absent
+  `digest` could not be computed, so two summaries that both lack one say
+  nothing about whether they agree; an absent `keys` means the stored schema was
+  not an object and so had none.
 
 ## Which question → which command
 

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -115,6 +115,17 @@ Confusing an approximation for truth is the failure mode that matters here:
   legitimately differ. The scan labels `cross-space-linked` (real replica →
   drift bug) vs `no-cross-space-link` (likely independent instance). Don't cry
   wolf on the latter.
+- **A `schema` under `$link` is what the link stores, and a `$elidedSchema` is a
+  summary of it.** A link's schema is a JSON Schema, so `true` and `false` are
+  values it can really hold — `true` constrains nothing and lets the reader's
+  own schema travel through the hop, while a schema with properties in it
+  freezes a shape at that link. Never read one as the other. A schema too large
+  to print inline is replaced by `{ $elidedSchema: { keys, bytes,
+  digest } }`,
+  which is a marker rather than a schema: equal digests mean equal schemas, so
+  it answers "do these links agree?" on its own, and `--full-depth` prints every
+  schema in full when you need the text. A link with no `schema` key stores no
+  schema at all.
 
 ## Which question → which command
 


### PR DESCRIPTION
## The defect

`cf inspect value-at` reported a stored link's schema as `true`:

```json
{"$link": {"id": "of:fid1:1D7eZcK…", "scope": "space", "schema": true}}
```

What the store actually holds on that link is a ~2.2KB object: `$defs`,
`properties`, a `required` list of 13, `asCell` stream declarations, and an
external `$ref`. Across all 141 revisions of that document the literal
`"schema":true` appears zero times — the `true` was manufactured on the read
path.

This is worse than lossy. A stored schema is a JSON Schema, so `true` is a
value a link can genuinely hold, and it is the one that selects every value —
a link storing it declares no constraint at all. So a schema that pins a
13-field shape rendered as the value meaning the opposite, indistinguishably
from a link that really stores `true`.

## Where it was

One place, at decode time rather than at display time. `DecodedLink` kept only
`hasSchema: boolean`, so the schema was gone before anything could render it,
and `annotate()` then wrote `schema: true` from that boolean.

Every command that renders a value through `annotate()` shared it: `value-at`,
`piece`, `html`, `overlay`, `diff`, `timeline`, `converge`. `entities` and
`graph` go through `summarizeLink()` instead, which prints `+schema` — terse,
but it never fabricated a value.

`diff` and `timeline` had a second symptom from the same cause: both sides of a
comparison rendered `true`, so a revision that *changed* a link's schema showed
no change at all.

## The fix

`DecodedLink` carries the stored schema. `annotate()` renders it:

- **absent** → no `schema` key, as before
- **small** (≤200 bytes of JSON) → the schema itself, so `true`, `false`, and
  `{}` each read back as themselves
- **larger** → no `schema` key, and a sibling `$schemaSummary: { keys, bytes,
  digest }` on `$link`

The summary is deliberate — these schemas are genuinely huge and would drown
the value carrying them — but it sits **beside** `schema` rather than in it.
That placement is the whole point: a link can store a schema of any shape, so
a summary written into the `schema` slot could be a schema some link really
holds, and the rendering would be forgeable in exactly the way the `true` bug
was. `payloadToLink()` bounds what a stored link contributes to `id`, `space`,
`path`, `scope`, and `schema`, so nothing stored can reach a `$`-prefixed
sibling.

The digest makes the summary self-sufficient for the question that actually
gets asked: on the repro document all seven schema-bearing links share digest
`dP-TGNZVNhod`. Different digests prove two schemas differ; equal ones make
agreement overwhelmingly likely without proving it, since the hash is
truncated. It also restores `diff`/`timeline`'s ability to see a schema change
at all.

`--full-depth` writes every schema out in full. It is the annotated form, not
the stored bytes: a schema is walked like any other value, so a sigil-shaped
literal under `const` / `default` / `enum` reads back as `$link` / `$ref`. That
is deliberate — the stored form is not JSON-safe. A `bigint` in a schema breaks
`JSON.stringify()` outright and throws from `stringifyInspectorJson()`; a
`FabricLink` in one flattens to `{}` and disappears, the exact vanishing act
`decodedLinkOf()` exists to prevent. The digest hashes the *stored* schema, so
that is what to compare two links by. (For the repro link, which holds no such
literal, full-depth output is byte-identical to what SQLite holds.)

### `detail.ts` — the same defect, twice more

`buildAllDetails()` indexed a piece's children with `parseSigilLink()`, so a
child named through a modern `FabricLink` was never named, never labeled, and
never reached the declared-schema lookup. `linksWithPaths()` had the same gap
in the outgoing-link list. Both read the link in either at-rest form now.

`declaredSchemaFor()` accepted only an object schema off the naming link, so a
link storing `true` or `false` fell through to the owner's declaration —
reporting a constraint the link does not carry, in place of the one value that
says it carries none. Any stored schema answers now; only an object one has
keys to list.

### `--json` compatibility

The in-repo consumers of `cf inspect --json` are `scripts/topics-export.ts`
(reads `$link.id`) and `scripts/topics-rehearsal-lib.ts` (tests for the
presence of `$link`). Neither reads `$link.schema`; the `scripts` suite passes.

## Verification

Reproduced against the real snapshot before and after, including that entries
7..105 of the same array still render with no `schema` key.

The tests were validated by sabotage: restoring `schema: true` fails 8 of the
10 `annotate()` cases. The two that stay green are the absent case and the
stored-`true` case — precisely the two the old code got right, which is why the
bug was invisible.

The `detail.ts` fixes are pinned the same way: reverting either fails its test
and leaves the two unchanged-behavior cases green.

Gates: `deno fmt --check`, `deno lint`, `deno task check`,
`deno task check-skill-facts`, and the `state-inspector` (105), `cli` (175),
and `scripts` (5) suites all green.

Coverage: the ratchet caught a real `+1` in `packages/cli` — the continuation
line of a concatenated help string, which V8 attributes no range to. Measured
locally to confirm (3194 → 3193 with the string back on one line), so the group
returns to baseline. `packages/state-inspector` goes 465 → 454 on the same
harness, the new `detail.ts` tests covering lines that had none.

Docs updated: `skills/state-inspector/SKILL.md` (honesty contract) and
`packages/state-inspector/README.md` (ground truth vs. hint).

## Not duplicated here

- #6049 — silent truncation in `cf inspect entities`
- `fable/array-read-schema-link` — link resolution for schemas that constrain
  nothing (the runtime behavior this rendering was misreporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



