### PR TITLE
test(cli): gate the claim the agent's entry is built on

### DIFF
--- a/docs/common/verbs/README.md
+++ b/docs/common/verbs/README.md
@@ -19,5 +19,8 @@ The tour and the walkthrough describe one session, driven by one script.
 `deno task check-verb-session-sync` holds both documents to the demo: a `cf`
 command either quotes a line the demo runs or carries a `# not in the demo`
 comment saying why it cannot, and an act number must name an act the demo has.
-The agent's entry is not yet held to a script, so its commands are checked by
-review rather than by CI.
+The agent's entry is held to that script for the claim it is built on — step 12
+asserts that the registry does not list a piece a handler created, and that the
+piece reads on its own address regardless. Its remaining commands are not
+quoted from the demo, so `check-verb-session-sync` does not cover them and they
+are checked by review.

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -46,6 +46,12 @@ the board and follow its links, or read the index the pattern publishes for
 exactly this purpose. Substituting `cf piece ls` for a pattern's own listing is
 the single most common way to conclude a space is empty when it is not.
 
+`packages/cli/integration/verb-session-gaps.sh` asserts both halves of this
+against a live host, under the step named "the registry does not list what a
+handler created", so the paragraph above fails in CI rather than going stale: a
+board deployed at the top level is listed, the item its handler created is not,
+and that unlisted item reads on its own address regardless.
+
 `cf wish` reaches collections a pattern publishes by convention rather than the
 registry: `#pieceRegistry` resolves the registry itself, `#mentionable`,
 `#favorites`, and `#recent` resolve the collections of those names, and the

--- a/packages/cli/integration/verb-session-gaps.sh
+++ b/packages/cli/integration/verb-session-gaps.sh
@@ -443,6 +443,27 @@ AFTER=$($CF get --quiet --piece "$EPIC" children $ARGS --step 2>/dev/null |
   jq -r 'length')
 check "$((BEFORE + 1))" "$AFTER" "the write the result describes landed"
 
+step "12. the registry does not list what a handler created"
+# The claim the agent's entry is built on: `cf piece ls` reads the piece
+# registry, and nothing registers a piece on the author's behalf. The board was
+# registered when it was deployed; the item its `addItem` handler created was
+# not, because the handler never sent it to `addPiece`. Both facts have to hold
+# at once for the document to be right — an unlisted piece that also could not
+# be read would mean something else entirely.
+LS=$($CF piece ls $ARGS --json 2>/dev/null)
+check "Work tracker" \
+  "$(echo "$LS" | jq -r '[.[]? | select(.name == "Work tracker") | .name] | join(",")')" \
+  "the deployed board is registered, so the listing does find it"
+check "" \
+  "$(echo "$LS" | jq -r '[.[]? | select(.name == "Login rewrite") | .name] | join(",")')" \
+  "the item the board's handler created is absent from the registry"
+# Absence from the listing is not absence of the piece: the same item answers
+# on its own address. That is what makes an empty `ls` uninformative rather
+# than conclusive, and it is the inference the document exists to block.
+check "Login rewrite" \
+  "$($CF get --quiet --piece "$EPIC" title $ARGS 2>/dev/null | jq -r '. // empty')" \
+  "the unlisted item still reads through the address the create returned"
+
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \
   "$PASS" "$FAIL" "$GAPS" "$ELAPSED"


### PR DESCRIPTION
## Why

Follow-up to #6024, which landed `docs/common/verbs/agents-over-the-cli.md` with
its `cf` commands ungated — the only document in `verbs/` where that was true.

The document's central claim is the one a reader is most likely to act on and
most likely to be burned by: `cf piece ls` reads the piece registry, nothing
registers a piece on the author's behalf, so a listing that comes back empty is
consistent with a space full of pieces. Get that wrong and an agent reports "the
space is empty" about a space that is not.

Nothing asserted it. Cubic's review of #6024 caught me overstating the same
claim in the other direction — writing that a handler-created piece *is*
unregistered, when a handler can register one deliberately through `addPiece` —
which is evidence the claim is easy to get wrong twice, not once.

## What Changed

One step in `verb-session-gaps.sh`. No new fixture and no new scaffolding: the
harness already deploys `tracker.tsx`, whose `addItem` creates an `Item` and
never sends it to `addPiece`, so the space it builds already holds a registered
board beside an unregistered item. The step reads the registry once and checks
three facts against it:

- the deployed board **is** listed — the anchor
- the item its handler created is **not**
- that unlisted item **still reads** through the address its create returned

The third is what makes the finding mean "not registered" rather than "not
there".

Docs updated in the same change: `verbs/README.md` said the agent's entry was
held by review rather than CI, which is now half false, and the claim's own
paragraph in `agents-over-the-cli.md` now names the step that backs it.

## Test plan

Run against a local toolshed:

```
API_URL=http://localhost:8000 packages/cli/integration/verb-session-gaps.sh
# 48 passed, 0 failed, 0 gaps open — 28s wall clock
```

CI runs this script in the `piece-call` shard already, so the step needs no
wiring.

**Mutation-tested, because the absence check could have passed vacuously.**
`check ""` also succeeds when no row carries a name at all — a green that would
mean nothing. Pointing that assertion at the registered board while still
expecting absence turns it red with the board's name in hand:

```
FAIL MUTANT: a registered piece must be detected here (expected [], got [Work tracker])
== 47 passed, 1 failed
```

So `.name` is populated, the jq path resolves, a present piece is detected, and
the real assertion's empty result is genuine absence. Reverted, re-run, 48/0.

Still not covered, unchanged from #6024: the document's three bash-block
commands are not quoted from the demo, so `check-verb-session-sync` does not
reach them. That gate exists to hold a document to a demo transcript, and two of
the three commands are placeholder-only — pointing it at a document with no demo
behind it would cost more than the drift it would catch. `verbs/README.md` now
says exactly this rather than claiming the document is unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

