### PR TITLE
fix(shell): publish app after navigation setup

### DIFF
--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -57,7 +57,6 @@ setupHostToggles();
 
 const root = document.querySelector<XRootView>("x-root-view");
 if (!root) throw new Error("No root view found.");
-globalThis.app = root;
 
 // Opens the browser key store, hands it to the root element, and restores a
 // logged-in session from the stored root identity when there is one.
@@ -81,3 +80,9 @@ if (deviceLink.kind !== "absent") {
 await initializeKeys(root);
 
 const _navigation = new Navigation(root);
+
+// `globalThis.app` is the integration-driver readiness boundary. Publishing
+// it before Navigation is installed lets a driver change the view while this
+// module is awaiting the KeyStore, only for Navigation's initial URL apply to
+// overwrite that newer view when bootstrap resumes.
+globalThis.app = root;


### PR DESCRIPTION
## Summary

- publish the shell's integration-driver handle only after key restoration and navigation setup complete
- prevent the initial URL reconciliation from overwriting a piece selected during bootstrap

## Root cause

`XRootView` initializes its view from the current URL before `index.ts` finishes awaiting `KeyStore.open()`. The integration harness could therefore observe `globalThis.app` and select a piece while bootstrap was still pending. When bootstrap resumed, `Navigation` reapplied the original space-only URL and could erase that newer selection.

This makes `globalThis.app` an explicit readiness boundary: integration drivers cannot mutate the app until the final bootstrap navigation write has completed.

## Validation

- focused shell piece integration suite: 4 fresh-start passes (12 steps)
- full shell integration suite: 20 steps passed
- shell unit suite: 176 steps passed
- `deno fmt --check packages/shell/src/index.ts`
- `deno lint packages/shell/src/index.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

