### PR TITLE
refactor(ts-transformers): read one transparent-wrapper set everywhere

### DIFF
--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -9,6 +9,7 @@ import {
 import { isFunctionLikeExpression } from "./function-predicates.ts";
 import { symbolDeclaresCommonFabricDefault } from "../core/common-fabric-symbols.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 import { isSafeIdentifierText } from "../utils/identifiers.ts";
 import {
   detectCallKind,
@@ -97,27 +98,10 @@ const mergeAnalyses = (...analyses: InternalAnalysis[]): InternalAnalysis => {
   };
 };
 
-function unwrapStructuralDataFlowExpression(
-  expression: ts.Expression,
-): ts.Expression {
-  let current = expression;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isTypeAssertionExpression(current) ||
-    ts.isSatisfiesExpression(current) ||
-    ts.isNonNullExpression(current) ||
-    ts.isPartiallyEmittedExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
-}
-
 function isStructuralOpaqueKeyDataFlow(
   expression: ts.Expression,
 ): boolean {
-  const target = unwrapStructuralDataFlowExpression(expression);
+  const target = unwrapExpression(expression);
   return ts.isCallExpression(target) &&
     classifyOpaquePathTerminalCall(target) === "key";
 }
@@ -162,9 +146,9 @@ export function createDataFlowAnalyzer(
   const leftmostIdentifierIsArrayMethodElementBinding = (
     expression: ts.Expression,
   ): boolean => {
-    let current: ts.Expression = unwrapStructuralDataFlowExpression(expression);
+    let current: ts.Expression = unwrapExpression(expression);
     while (ts.isPropertyAccessExpression(current)) {
-      current = unwrapStructuralDataFlowExpression(current.expression);
+      current = unwrapExpression(current.expression);
     }
     return ts.isIdentifier(current) &&
       isArrayMethodElementBindingReference(current);
@@ -307,7 +291,7 @@ export function createDataFlowAnalyzer(
     root: ts.Expression,
     path: readonly StaticBindingAccessSegment[],
   ): ts.Expression => {
-    let current = unwrapStructuralDataFlowExpression(root);
+    let current = unwrapExpression(root);
 
     for (const segment of path) {
       if (segment.kind === "index") {
@@ -391,7 +375,7 @@ export function createDataFlowAnalyzer(
       return undefined;
     }
 
-    const target = unwrapStructuralDataFlowExpression(initializer);
+    const target = unwrapExpression(initializer);
     if (
       ts.isObjectLiteralExpression(target) ||
       ts.isArrayLiteralExpression(target)
@@ -456,7 +440,7 @@ export function createDataFlowAnalyzer(
   const shouldPreserveConstAliasIdentity = (
     initializer: ts.Expression,
   ): boolean => {
-    const target = unwrapStructuralDataFlowExpression(initializer);
+    const target = unwrapExpression(initializer);
 
     return !(
       ts.isObjectLiteralExpression(target) ||
@@ -594,7 +578,7 @@ export function createDataFlowAnalyzer(
     expression: ts.Expression,
     seenSymbols = new Set<ts.Symbol>(),
   ): boolean => {
-    const target = unwrapStructuralDataFlowExpression(expression);
+    const target = unwrapExpression(expression);
 
     if (ts.isCallExpression(target)) {
       return classifyOpaquePathTerminalCall(target) === "key";

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
@@ -1,7 +1,10 @@
 import ts from "typescript";
 
 import type { Emitter, EmitterContext } from "../types.ts";
-import { createReactiveWrapperForExpression } from "../rewrite-helpers.ts";
+import {
+  createReactiveWrapperForExpression,
+  isArrayMethodReceiverExpression,
+} from "../rewrite-helpers.ts";
 import { shouldDeferFallbackMapReceiverRewrite } from "../fallback-array-method-rewrite.ts";
 import {
   findPendingComputeWrapCandidate,
@@ -9,56 +12,12 @@ import {
 } from "./compute-wrap-invariants.ts";
 import { createUnlessCall, createWhenCall } from "../../builtins/ifelse.ts";
 import {
-  classifyArrayMethodCall,
   isReactiveValueExpression,
   isSimpleReactiveAccessExpression,
   registerSyntheticCallType,
   selectDataFlowsReferencedIn,
 } from "../../../ast/mod.ts";
 import { shouldLowerLogicalExpression } from "../../../policy/mod.ts";
-
-function getTransparentReceiverWrappedExpression(
-  node: ts.Node,
-): ts.Expression | undefined {
-  if (
-    ts.isParenthesizedExpression(node) ||
-    ts.isAsExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isNonNullExpression(node) ||
-    ts.isPartiallyEmittedExpression(node)
-  ) {
-    return node.expression;
-  }
-  return undefined;
-}
-
-function isArrayMethodReceiverExpression(node: ts.Node): boolean {
-  let current: ts.Node = node;
-  let parent = current.parent;
-  while (parent) {
-    const wrapped = getTransparentReceiverWrappedExpression(parent);
-    if (!wrapped) break;
-    if (wrapped !== current) return false;
-    current = parent;
-    parent = parent.parent;
-  }
-
-  if (
-    !parent ||
-    (
-      !ts.isPropertyAccessExpression(parent) &&
-      !ts.isElementAccessExpression(parent)
-    ) ||
-    parent.expression !== current
-  ) {
-    return false;
-  }
-
-  const call = parent.parent;
-  return !!call && ts.isCallExpression(call) && call.expression === parent &&
-    !!classifyArrayMethodCall(call);
-}
 
 function isAllowedSyntheticArrayReceiverWrap(
   node: ts.Expression,

--- a/packages/ts-transformers/src/transformers/expression-rewrite/fallback-array-method-rewrite.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/fallback-array-method-rewrite.ts
@@ -5,6 +5,17 @@ import { unwrapExpression } from "../../utils/expression.ts";
 import { isFallbackOperator } from "../../utils/reactive-keys.ts";
 import { isSimpleReactiveAccess } from "../cell-type.ts";
 
+/**
+ * True when `expression` is the receiver of an unlowered `map`, so a fallback
+ * such as `(xs ?? []).map(...)` can be left for the array-method rewrite to
+ * own rather than wrapped on its own.
+ *
+ * The receiver walk steps through parentheses and partially emitted nodes, and
+ * deliberately not the rest of the transparent wrapper set: the shapes this
+ * gate accepts are binary fallback expressions, and an `as`, `<T>`,
+ * `satisfies`, or `!` between the fallback and the `.map` changes what the
+ * array-method rewrite reads there.
+ */
 export function isFallbackMapReceiverExpression(
   expression: ts.BinaryExpression,
 ): boolean {

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
@@ -12,6 +12,7 @@ import type {
   EmitterContext,
   RewriteParams,
 } from "./types.ts";
+import { isArrayMethodReceiverExpression } from "./rewrite-helpers.ts";
 import {
   emitBinaryExpression,
   emitCallExpression,
@@ -60,58 +61,6 @@ function hasSyntheticComputeCallbackAncestor(
     current = current.parent;
   }
   return false;
-}
-
-function isTransparentReceiverWrapper(node: ts.Node): boolean {
-  return ts.isParenthesizedExpression(node) ||
-    ts.isAsExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isNonNullExpression(node) ||
-    ts.isPartiallyEmittedExpression(node);
-}
-
-function getTransparentReceiverWrappedExpression(
-  node: ts.Node,
-): ts.Expression | undefined {
-  if (
-    ts.isParenthesizedExpression(node) ||
-    ts.isAsExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isNonNullExpression(node) ||
-    ts.isPartiallyEmittedExpression(node)
-  ) {
-    return node.expression;
-  }
-  return undefined;
-}
-
-function isArrayMethodReceiverExpression(node: ts.Node): boolean {
-  let current: ts.Node = node;
-  let parent = current.parent;
-  while (parent && isTransparentReceiverWrapper(parent)) {
-    if (getTransparentReceiverWrappedExpression(parent) !== current) {
-      return false;
-    }
-    current = parent;
-    parent = parent.parent;
-  }
-
-  if (
-    !parent ||
-    (
-      !ts.isPropertyAccessExpression(parent) &&
-      !ts.isElementAccessExpression(parent)
-    ) ||
-    parent.expression !== current
-  ) {
-    return false;
-  }
-
-  const call = parent.parent;
-  return !!call && ts.isCallExpression(call) && call.expression === parent &&
-    !!classifyArrayMethodCall(call);
 }
 
 function isInsideKnownSafeCallbackWrapper(

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 
 import {
+  classifyArrayMethodCall,
   detectCallKind,
   isSyntheticNode,
   type NormalizedDataFlow,
@@ -9,8 +10,45 @@ import {
   typeToTypeNodeWithRegistry,
 } from "../../ast/mod.ts";
 import { isModuleScopedDeclaration } from "../../ast/scope-analysis.ts";
+import { unwrapTransparentWrapperOnce } from "../../utils/expression.ts";
 import { TransformationContext } from "../../core/mod.ts";
 import { createLiftAppliedCall } from "../builtins/lift-applied.ts";
+
+/**
+ * True when `node` is the receiver an array-method call is made on, looking
+ * through any transparent wrappers between the two: `xs`, `(xs)`, and
+ * `(xs as T[])!` are all the receiver of `.map(...)`.
+ *
+ * The walk runs outward through parents and checks at each step that it is on
+ * the wrapper's `expression` spine, so a node sitting in a wrapper's *type*
+ * position is not mistaken for the value being wrapped.
+ */
+export function isArrayMethodReceiverExpression(node: ts.Node): boolean {
+  let current: ts.Node = node;
+  let parent = current.parent;
+  while (parent) {
+    const wrapped = unwrapTransparentWrapperOnce(parent);
+    if (!wrapped) break;
+    if (wrapped !== current) return false;
+    current = parent;
+    parent = parent.parent;
+  }
+
+  if (
+    !parent ||
+    (
+      !ts.isPropertyAccessExpression(parent) &&
+      !ts.isElementAccessExpression(parent)
+    ) ||
+    parent.expression !== current
+  ) {
+    return false;
+  }
+
+  const call = parent.parent;
+  return !!call && ts.isCallExpression(call) && call.expression === parent &&
+    !!classifyArrayMethodCall(call);
+}
 
 function getCaptureRootExpression(expression: ts.Expression): ts.Expression {
   let current = expression;

--- a/packages/ts-transformers/src/transformers/opaque-roots.ts
+++ b/packages/ts-transformers/src/transformers/opaque-roots.ts
@@ -2,7 +2,10 @@ import ts from "typescript";
 
 import { detectCallKind, isReactiveOriginExpression } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../utils/expression.ts";
 import { getKnownComputedKeyExpression } from "../utils/reactive-keys.ts";
 import type { PathSegment } from "./destructuring-lowering.ts";
 import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
@@ -60,28 +63,9 @@ export function getOpaqueAccessInfo(
   let dynamic = false;
 
   while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isSatisfiesExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isPartiallyEmittedExpression(current)) {
-      current = current.expression;
+    const unwrapped = unwrapTransparentWrapperOnce(current);
+    if (unwrapped) {
+      current = unwrapped;
       continue;
     }
 

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -14,7 +14,7 @@ import {
   isReactiveValueExpression,
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import { isTransparentWrapper, unwrapExpression } from "../utils/expression.ts";
 import { isBrandedCellType } from "./cell-type.ts";
 import {
   isPatternFactoryCalleeExpression,
@@ -285,7 +285,7 @@ function visitExpressionWithCausePath(
       context.tsContext,
     ) as ts.Expression;
   }
-  if (addRootFor && isTransparentExpressionWrapper(expression)) {
+  if (addRootFor && isTransparentWrapper(expression)) {
     return createForCall(expression, causePath, context);
   }
 
@@ -306,15 +306,6 @@ function visitExpressionWithCausePath(
   }
 
   return createForCall(visited, causePath, context);
-}
-
-function isTransparentExpressionWrapper(expression: ts.Expression): boolean {
-  return ts.isParenthesizedExpression(expression) ||
-    ts.isAsExpression(expression) ||
-    ts.isTypeAssertionExpression(expression) ||
-    ts.isSatisfiesExpression(expression) ||
-    ts.isNonNullExpression(expression) ||
-    ts.isPartiallyEmittedExpression(expression);
 }
 
 function visitExpressionChildrenWithCausePath(

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -2,46 +2,68 @@ import ts from "typescript";
 
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 
-interface UnwrapExpressionOptions {
-  readonly includePartiallyEmitted?: boolean;
+/**
+ * The expression forms that wrap an inner expression without changing the
+ * value it denotes: `(x)`, `x as T`, `<T>x`, `x satisfies T`, `x!`, and the
+ * partially emitted node that carries an already-rewritten subtree.
+ *
+ * This is the one set the pipeline looks through, and it is read in three
+ * forms so that every shape of consumer has a definition to reach for:
+ * {@link isTransparentWrapper} tests a node, {@link unwrapTransparentWrapperOnce}
+ * steps through a single wrapper, and {@link unwrapExpression} reaches the
+ * innermost expression. A spelling added here reaches all three at once, so a
+ * wrapper cannot be handled by one resolver and missed by another.
+ *
+ * A stripper that reads a narrower set does so deliberately, and says why at
+ * its own definition.
+ */
+export type TransparentWrapper =
+  | ts.ParenthesizedExpression
+  | ts.AsExpression
+  | ts.TypeAssertion
+  | ts.SatisfiesExpression
+  | ts.NonNullExpression
+  | ts.PartiallyEmittedExpression;
+
+/**
+ * True for a node that wraps an inner expression without changing the value it
+ * denotes.
+ */
+export function isTransparentWrapper(
+  node: ts.Node,
+): node is TransparentWrapper {
+  return ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isPartiallyEmittedExpression(node);
 }
 
 /**
- * Removes non-semantic wrappers around expressions.
+ * The expression a single transparent wrapper wraps, or `undefined` when the
+ * node is not one.
+ *
+ * This is the form for a caller that walks a wrapper chain a node at a time:
+ * one following parent links outward, or one that must know which side of a
+ * wrapper it arrived from. A caller that only wants the innermost expression
+ * uses {@link unwrapExpression}.
  */
-export function unwrapExpression(
-  expr: ts.Expression,
-  options: UnwrapExpressionOptions = {},
-): ts.Expression {
-  const includePartiallyEmitted = options.includePartiallyEmitted ?? true;
+export function unwrapTransparentWrapperOnce(
+  node: ts.Node,
+): ts.Expression | undefined {
+  return isTransparentWrapper(node) ? node.expression : undefined;
+}
+
+/**
+ * The innermost expression, reached by removing every transparent wrapper.
+ */
+export function unwrapExpression(expr: ts.Expression): ts.Expression {
   let current = expr;
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isAsExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isTypeAssertionExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isSatisfiesExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (ts.isNonNullExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    if (includePartiallyEmitted && ts.isPartiallyEmittedExpression(current)) {
-      current = current.expression;
-      continue;
-    }
-    return current;
+  while (isTransparentWrapper(current)) {
+    current = current.expression;
   }
+  return current;
 }
 
 /**

--- a/packages/ts-transformers/test/utils/expression.test.ts
+++ b/packages/ts-transformers/test/utils/expression.test.ts
@@ -1,25 +1,84 @@
-import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
 
 import ts from "typescript";
 
-import { unwrapExpression } from "../../src/utils/expression.ts";
+import {
+  isTransparentWrapper,
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../../src/utils/expression.ts";
 
-Deno.test("unwrapExpression unwraps a partially emitted expression", () => {
-  const literal = ts.factory.createNumericLiteral("1");
-  const wrapped = ts.factory.createPartiallyEmittedExpression(literal);
+const numberType = () =>
+  ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
 
-  assertEquals(unwrapExpression(wrapped), literal);
-});
+/** One constructor per transparent wrapper spelling, keyed by its syntax. */
+const WRAPPERS: Readonly<
+  Record<string, (inner: ts.Expression) => ts.Expression>
+> = {
+  "(x)": (inner) => ts.factory.createParenthesizedExpression(inner),
+  "x as T": (inner) => ts.factory.createAsExpression(inner, numberType()),
+  "<T>x": (inner) => ts.factory.createTypeAssertion(numberType(), inner),
+  "x satisfies T": (inner) =>
+    ts.factory.createSatisfiesExpression(inner, numberType()),
+  "x!": (inner) => ts.factory.createNonNullExpression(inner),
+  "partially emitted": (inner) =>
+    ts.factory.createPartiallyEmittedExpression(inner),
+};
 
-Deno.test(
-  "unwrapExpression keeps a partially emitted wrapper when excluded",
-  () => {
-    const literal = ts.factory.createNumericLiteral("1");
-    const wrapped = ts.factory.createPartiallyEmittedExpression(literal);
+describe("expression", () => {
+  describe("isTransparentWrapper()", () => {
+    for (const [syntax, wrap] of Object.entries(WRAPPERS)) {
+      it(`returns \`true\` for \`${syntax}\``, () => {
+        expect(isTransparentWrapper(wrap(ts.factory.createNumericLiteral("1"))))
+          .toBe(true);
+      });
+    }
 
-    const result = unwrapExpression(wrapped, {
-      includePartiallyEmitted: false,
+    it("returns `false` for an expression that is not a wrapper", () => {
+      expect(isTransparentWrapper(ts.factory.createNumericLiteral("1")))
+        .toBe(false);
     });
-    assert(ts.isPartiallyEmittedExpression(result));
-  },
-);
+  });
+
+  describe("unwrapTransparentWrapperOnce()", () => {
+    for (const [syntax, wrap] of Object.entries(WRAPPERS)) {
+      it(`returns the expression wrapped by \`${syntax}\``, () => {
+        const literal = ts.factory.createNumericLiteral("1");
+
+        expect(unwrapTransparentWrapperOnce(wrap(literal))).toBe(literal);
+      });
+    }
+
+    it("removes a single wrapper, leaving the rest of the chain in place", () => {
+      const literal = ts.factory.createNumericLiteral("1");
+      const inner = ts.factory.createParenthesizedExpression(literal);
+      const outer = ts.factory.createNonNullExpression(inner);
+
+      expect(unwrapTransparentWrapperOnce(outer)).toBe(inner);
+    });
+
+    it("returns `undefined` for an expression that is not a wrapper", () => {
+      expect(unwrapTransparentWrapperOnce(ts.factory.createNumericLiteral("1")))
+        .toBe(undefined);
+    });
+  });
+
+  describe("unwrapExpression()", () => {
+    it("removes every wrapper spelling from a nested chain", () => {
+      const literal = ts.factory.createNumericLiteral("1");
+      const wrapped = Object.values(WRAPPERS).reduce<ts.Expression>(
+        (inner, wrap) => wrap(inner),
+        literal,
+      );
+
+      expect(unwrapExpression(wrapped)).toBe(literal);
+    });
+
+    it("returns the expression itself when it carries no wrapper", () => {
+      const literal = ts.factory.createNumericLiteral("1");
+
+      expect(unwrapExpression(literal)).toBe(literal);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #6057, which made this argument for call classification alone. The drift it removes is what produced the `satisfies` bug fixed in #6050: `stripWrappers` had silently diverged from `unwrapExpression` by one node kind.

## The vocabulary

`packages/ts-transformers/src/utils/expression.ts` now exports the set in three forms, so every shape of consumer has a canonical version rather than a reason to spell the list out again:

| Form | Use |
| --- | --- |
| `isTransparentWrapper(node)` | test a node; a type guard onto the new `TransparentWrapper` union |
| `unwrapTransparentWrapperOnce(node)` | step through one wrapper — for parent walks, and for callers that must know which side of a wrapper they arrived from |
| `unwrapExpression(expr)` | reach the innermost expression |

All three read one list, so adding a spelling reaches every consumer at once.

## Sites reconciled

- `src/ast/dataflow.ts` — `unwrapStructuralDataFlowExpression` deleted; its 7 call sites use `unwrapExpression`.
- `src/transformers/opaque-roots.ts` — the six inline wrapper branches in `getOpaqueAccessInfo` collapse to one `unwrapTransparentWrapperOnce` step, leaving the property/element path extraction it interleaves with untouched.
- `src/transformers/reactive-variable-for.ts` — local `isTransparentExpressionWrapper` deleted.
- `src/transformers/expression-rewrite/rewrite-expression.ts` — local `isTransparentReceiverWrapper` and `getTransparentReceiverWrappedExpression` deleted.
- `src/transformers/expression-rewrite/emitters/binary-expression.ts` — local `getTransparentReceiverWrappedExpression` deleted.
- `src/ast/call-kind.ts` — untouched; `stripWrappers` already delegates as of #6057, and three open PRs touch this file.

### Adjacent dedupe, separable if you'd rather not

`isArrayMethodReceiverExpression` was duplicated **verbatim** between `rewrite-expression.ts` and `binary-expression.ts` — identical apart from how the loop is spelled — and was the actual consumer of the two duplicated wrapper helpers. Deduping only the wrapper helpers would have left two copies of the walk, each importing the shared predicate, so it moves to `rewrite-helpers.ts`. No cycle: that module already imports from `ast/mod.ts`, and nothing under `expression-rewrite/` imports `rewrite-expression.ts` except `mod.ts`.

## Dead option removed

`unwrapExpression` loses `includePartiallyEmitted`. #6057 removed the last caller that passed it; nothing in `packages/` referenced it but its own definition and the test of the option itself. The pipeline transforms authored source through `ts.transform`, not TypeScript's emit — `createPartiallyEmittedExpression` appears nowhere outside tests — so a partially emitted node has no route into these helpers, and there is no narrower set for a caller to want.

## Deliberately narrower sets, left alone

Two strippers read fewer kinds on purpose. Neither joins the vocabulary, and both now say why at their own definition so the next reader doesn't file them as drift:

- `pattern-body-reactive-root-lowering.ts` `stripSyntacticWrappers` — keeps casts and `satisfies`, whose types downstream stages read. Already documented; unchanged.
- `fallback-array-method-rewrite.ts` `isFallbackMapReceiverExpression` — a parent walk through parentheses and partially emitted nodes, and a different operation from a child unwrap. Comment added; **set unchanged**, since probing five spellings of a fallback-map receiver surfaced no behavioral divergence.

## Proof of no behavior change

- `deno task test` in `packages/ts-transformers`: **1155 passed, 0 failed**.
- `UPDATE_GOLDENS=1 deno task test`: **zero golden diffs** — `git status` after the run shows only the source files edited here, no `.expected.*`.
- Repo-wide `deno fmt --check`, `deno lint`, `deno task check` all clean, plus `check-package-cycles`, `check-single-copy-deps`, `check-unused-deps`, `check-deno-pins`, `check-no-waitfor`, `check-conflict-markers`, `check-skill-facts`, `check-docs-history-index`.
- `test/spec-sync.test.ts` passes unchanged. No documented shape list moved, so no behavior-spec edit.

The unification is load-bearing rather than cosmetic: deleting the `satisfies` branch from `expression.ts` alone — the exact #6050 mutation — now fails 7 tests across `call-kind`, `opaque-roots`, `schema-generator`, `closures`, and `schema-first-imported-callback`, plus the three direct tests of the vocabulary. Before this change that deletion would have been caught in one resolver at a time.

`test/utils/expression.test.ts` is rewritten in the `describe`/`it` + `expect` style of `docs/development/unit-test-coding-style.md`, parameterized over all six spellings, and each assertion was confirmed to fail against a broken wrapper set.

## Found but not done here

Nine more sites read a **five**-kind set — the canonical set minus `PartiallyEmittedExpression` — in `policy/capability-analysis.ts` (5), `transformers/pattern-context-validation.ts`, `transformers/write-authorized-by-validation.ts`, `transformers/expression-site-lowering.ts`, and the parent walk in `ast/call-kind.ts:1572`. Most are parent walks with a `parent.expression === current` spine check rather than child unwraps.

They are left out because folding them in is not the same kind of edit. Every change here is a no-op by construction; adopting the canonical set at those sites adds `PartiallyEmittedExpression` and is a no-op only because that node is unreachable in this pipeline — true, but an argument rather than an identity. It also raises a question this PR doesn't answer: whether a canonical parent-walk helper should be the vocabulary's fourth member. Worth its own PR.

**3. A latent divergence in the receiver walk, surfaced in review.** `isArrayMethodReceiverExpression` compares `call.expression === parent` by identity, so a transparently-wrapped callee — `((items ?? []).map)(fn)` — fails the check even though `classifyArrayMethodCall` accepts the call. Confirmed by probe:

```
plain callee           (items ?? []).map(fn)          classify=map  isReceiver=true
parenthesized callee   ((items ?? []).map)(fn)        classify=map  isReceiver=false
as-wrapped callee      ((items ?? []).map as any)(fn) classify=map  isReceiver=false
```

Pre-existing rather than introduced here — the moved body is byte-identical to both originals apart from the helper's name — and fixing it would change behavior, which this PR's golden proof exists to rule out. An AST scan of 1526 files (fixtures, `packages/patterns`, `src`) found zero occurrences of the shape, so it is latent rather than live.

Refs #6057, #6050.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


