### PR TITLE
refactor(data-model): a validator is named after the type it guards

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -179,12 +179,12 @@ elaboration of one implementation arm.
 >   conversion, hashing, and encoding boundaries (Sections 4.9, 6,
 >   and 5). Symbol-keyed *properties* on plain objects are a separate
 >   matter — see Section 1.5 (Recursive Containers / Objects).
-> - `function` — Functions are opaque closures with no portable
->   representation. They are explicitly **not** representable as fabric
->   values, eliciting a thrown error from `fabricFromNativeValue()` and a
->   `false` return value from `isFabricCompatible()`. (`FabricInstance`s
->   are not functions in this sense — they are class instances whose
->   encoding is handled by their class's `[CODEC]`.)
+> - `function` — Functions are opaque closures with no portable representation.
+>   They are explicitly **not** representable as fabric values, eliciting a
+>   thrown error from `fabricFromNativeValue()` and a `false` return value from
+>   `isValidFabricConvertibleValue()`. (`FabricInstance`s are not functions in
+>   this sense — they are class instances whose encoding is handled by their
+>   class's `[CODEC]`.)
 >
 >   A proposed, deliberately narrow exception adds a `FabricFactory` arm for
 >   builder-created factories and codec-decoded factory shells admitted to the
@@ -237,13 +237,13 @@ type FabricNativeObject =
  * A `FabricValue`, a `FabricNativeObject`, or a deep tree of either — the
  * values that convert to and from fabric form. This is the precondition of
  * `fabricFromNativeValue()`, the result of `nativeFromFabricValue()`, and
- * what `isFabricCompatible()` tests for (Section 8).
+ * what `isValidFabricConvertibleValue()` tests for (Section 8).
  */
-type FabricOrConvertibleNativeValue =
+type FabricConvertibleValue =
   | FabricValue
   | FabricNativeObject
-  | readonly FabricOrConvertibleNativeValue[]
-  | { readonly [key: string]: FabricOrConvertibleNativeValue };
+  | readonly FabricConvertibleValue[]
+  | { readonly [key: string]: FabricConvertibleValue };
 ```
 
 `Map` and `Set` are named with unconstrained type arguments: their contents are
@@ -252,7 +252,7 @@ bind in any case while `FabricMap` and `FabricSet` remain stubbed
 (Sections 1.4.3 and 1.4.4).
 
 Neither type is ever a member of `FabricValue`; both exist solely at the
-conversion boundary (Section 8). Of the two, **`FabricOrConvertibleNativeValue`
+conversion boundary (Section 8). Of the two, **`FabricConvertibleValue`
 is the one the boundary actually speaks**, and it exists because
 `FabricValue | FabricNativeObject` cannot say "or a tree of these." A container
 arm of `FabricValue` holds `FabricValue`s, so it cannot hold an `Error`; and a
@@ -261,7 +261,7 @@ Converting a `FabricError` yields an `Error`, so an array of `FabricError`s
 converts to an array of `Error`s — a value that is neither a `FabricValue` nor a
 `FabricNativeObject`, and which only the recursive type names. It is what
 `fabricFromNativeValue()` succeeds on, what `nativeFromFabricValue()` returns,
-and what `isFabricCompatible()` tests (Sections 8.3 and 8.4). It is a
+and what `isValidFabricConvertibleValue()` tests (Sections 8.3 and 8.4). It is a
 precondition rather than a parameter type: the conversion functions that accept
 arbitrary input declare `unknown` and reject what they cannot convert
 (Section 8.2).
@@ -1399,9 +1399,9 @@ so.
 build one containing a cycle; it preserves shared references, so the converted
 form for a given original is reused and structural sharing survives. That is a
 third answer under the same rule, not an exception to it: membership admits a
-cycle -- `isFabricValue()` handles one and returns `true` -- while this entry
-point declines to construct one. A value holding a cycle therefore reaches the
-model by being built directly rather than converted.
+cycle -- `isValidFabricValue()` handles one and returns `true` -- while this
+entry point declines to construct one. A value holding a cycle therefore reaches
+the model by being built directly rather than converted.
 
 Note that preserving shared references means preserving _structure_: the same
 encoded subtree appears at each position it appeared at. Whether the decoded
@@ -3033,7 +3033,7 @@ the left layer (JS wild west) and the middle layer (`FabricValue`) at the
 
 The module also provides a shallow conversion function
 (`shallowFabricFromNativeValue()`) and a type-check function
-(`isFabricCompatible()`). The public surface is re-exported from
+(`isValidFabricConvertibleValue()`). The public surface is re-exported from
 `fabric-value.ts`, which also defines the comparison function `valueEqual()`.
 
 ```typescript
@@ -3077,7 +3077,7 @@ The implementation is split across several files for separation of concerns:
 | File | Purpose |
 |------|---------|
 | `fabric-value.ts` | Public surface: re-exports the conversion functions (from `native-conversion.ts`), the type declarations (from `interface.ts`), and the clone helpers (from `value-clone.ts`); defines `valueEqual()` |
-| `native-conversion.ts` | Conversion: `fabricFromNativeValue`, `shallowFabricFromNativeValue`, `nativeFromFabricValue`, `isFabricCompatible` |
+| `native-conversion.ts` | Conversion: `fabricFromNativeValue`, `shallowFabricFromNativeValue`, `nativeFromFabricValue`, `isValidFabricConvertibleValue` |
 | `fabric-bases/` | The abstract bases a concrete fabric value extends, one per branch of the type hierarchy: `BaseFabricInstance.ts`, `BaseFabricPrimitive.ts` (plus an `index.ts` barrel). These are the implementer's half of the hierarchy; `interface.ts` is the client's, and reaching it does not reach these. |
 | `fabric-instances/` | Concrete `FabricInstance` subclasses, each in its own file: `FabricNativeWrapper.ts`, `FabricError.ts`, `FabricLink.ts`, `FabricMap.ts`, `FabricSet.ts` (plus an `index.ts` barrel). `UnknownValue` and `ProblematicValue` are `FabricInstance`s too, but live in `codec-common/`, existing only as products of a decode fault. |
 | `fabric-primitives/` | Concrete `FabricPrimitive` subclasses, each in its own file: `FabricBytes.ts`, `FabricHash.ts`, `FabricEpochNsec.ts`, `FabricEpochDay.ts`, `FabricRegExp.ts` (plus an `index.ts` barrel). |
@@ -3747,7 +3747,7 @@ tree incrementally (e.g., merging data from multiple sources) can use
 complete. The `freeze` parameter does not affect validation or wrapping — the
 returned value is always a valid `FabricValue` regardless of its frozen state.
 
-### 8.3 `isFabricCompatible()`
+### 8.3 `isValidFabricConvertibleValue()`
 
 ```typescript
 // Shown for illustration only.
@@ -3757,8 +3757,8 @@ returned value is always a valid `FabricValue` regardless of its frozen state.
  * Type predicate: returns `true` if `fabricFromNativeValue()` would succeed
  * on the given value — i.e., the value is a `FabricValue`, a
  * `FabricNativeObject`, or a tree of these types. That is exactly what
- * `FabricOrConvertibleNativeValue` names (Section 1.2), so callers can use
- * `isFabricCompatible(x)` as a type guard in conditionals.
+ * `FabricConvertibleValue` names (Section 1.2), so callers can use
+ * `isValidFabricConvertibleValue(x)` as a type guard in conditionals.
  *
  * This is a check-without-conversion function for system boundaries where
  * code receives `unknown` and needs to determine convertibility without
@@ -3766,18 +3766,19 @@ returned value is always a valid `FabricValue` regardless of its frozen state.
  * and allocation).
  *
  * Relationship to other functions and checks:
- * - `isFabricValue(x)` (in `type-check.ts`): the narrower check — "is `x`
+ * - `isValidFabricValue(x)` (in `type-check.ts`): the narrower check — "is `x`
  *   already a `FabricValue`?" — which does NOT accept raw native types like
  *   `Error` or `Map`.
- * - `isFabricCompatible(x)`: "Could `x` be converted to a `FabricValue` via
- *   `fabricFromNativeValue()`?" Returns `true` for both `FabricValue`
- *   values AND `FabricNativeObject` values (and deep trees thereof).
+ * - `isValidFabricConvertibleValue(x)`: "Could `x` be converted to a
+ *   `FabricValue` via `fabricFromNativeValue()`?" Returns `true` for both
+ *   `FabricValue` values AND `FabricNativeObject` values (and deep trees
+ *   thereof).
  * - `fabricFromNativeValue(x)`: Actually performs the conversion,
  *   throwing on unsupported types.
  */
-export function isFabricCompatible(
+export function isValidFabricConvertibleValue(
   value: unknown,
-): value is FabricOrConvertibleNativeValue;
+): value is FabricConvertibleValue;
 ```
 
 The function recursively checks the value tree. It returns `true` if and only
@@ -3791,21 +3792,21 @@ if the value is:
 - A `FabricInstance` (including the native object wrapper classes)
 - A `FabricNativeObject` (`Error`, `Map`, `Set`, `Date`, `RegExp`,
   `Uint8Array`)
-- An array where every present element satisfies `isFabricCompatible()`, and
+- An array where every present element satisfies
+  `isValidFabricConvertibleValue()`, and
   which the array rule of Section 1.5 accepts
-- A plain object where every value satisfies `isFabricCompatible()`
+- A plain object where every value satisfies `isValidFabricConvertibleValue()`
 
 It returns `false` for unsupported types (`WeakMap`, `Promise`, DOM nodes,
 class instances that don't implement `FabricInstance`, etc.) and for unique
 symbols.
 
-> **Performance note.** `isFabricCompatible()` walks the value tree without
-> allocating wrappers or frozen copies. For large trees, this is cheaper than
-> calling `fabricFromNativeValue()` inside a try/catch, since it avoids the
-> wrapping and freezing work that would be discarded on failure. However, if
-> the caller intends to convert on success, calling
-> `fabricFromNativeValue()` directly (and catching the error) avoids walking
-> the tree twice.
+> **Performance note.** `isValidFabricConvertibleValue()` walks the value tree
+> without allocating wrappers or frozen copies. For large trees, this is cheaper
+> than calling `fabricFromNativeValue()` inside a try/catch, since it avoids the
+> wrapping and freezing work that would be discarded on failure. However, if the
+> caller intends to convert on success, calling `fabricFromNativeValue()`
+> directly (and catching the error) avoids walking the tree twice.
 
 ### 8.4 `nativeFromFabricValue()`
 
@@ -3841,7 +3842,7 @@ symbols.
 export function nativeFromFabricValue(
   value: FabricValue,
   frozen?: boolean, // default: true
-): FabricOrConvertibleNativeValue;
+): FabricConvertibleValue;
 ```
 
 #### Unwrapping Rules
@@ -3861,7 +3862,7 @@ export function nativeFromFabricValue(
 | Arrays | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 | Plain objects | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 
-The output type is `FabricOrConvertibleNativeValue` (Section 1.2), reflecting
+The output type is `FabricConvertibleValue` (Section 1.2), reflecting
 that the result may contain native JS types at any depth — a container of them
 is neither a `FabricValue` nor a `FabricNativeObject`, so the recursive type is
 what names it.
@@ -4031,9 +4032,9 @@ into participating `FabricInstance`s' `[DEEP_FREEZE]` impls via the
 to a value the outer call is already deep-freezing short-circuits rather
 than recursing.
 
-#### `isDeepFrozenFabricValue()` and the 4-arm type guard
+#### `isValidDeepFrozenFabricValue()` and the 4-arm type guard
 
-The type guard (`isDeepFrozenFabricValue`) is the side-effect-free sibling
+The type guard (`isValidDeepFrozenFabricValue`) is the side-effect-free sibling
 of `deepFreeze()`. It mirrors the same arm shape:
 
 1. Primitives are accepted directly.

--- a/docs/specs/sparse-array-preservation.md
+++ b/docs/specs/sparse-array-preservation.md
@@ -116,9 +116,10 @@ because their sparse support was part of the original design:
 
 ### Value validation (`packages/data-model/src/type-check.ts`)
 
-`isFabricValueLayer()` and `isFabricValue()` accept sparse arrays — holes are
-valid fabric structure. `isFabricValue()` uses `for` + `i in` because it needs
-early return, skipping holes rather than validating them as values.
+`isValidFabricValueLayer()` and `isValidFabricValue()` accept sparse arrays —
+holes are valid fabric structure. `isValidFabricValue()` uses `for` + `i in`
+because it needs early return, skipping holes rather than validating them as
+values.
 
 ### v2-transaction write path (`packages/runner/src/storage/v2-transaction.ts`)
 
@@ -239,8 +240,8 @@ the preferred entry point in runner code.
 
 Test coverage verifies sparse preservation at each layer:
 
-- **`packages/data-model/test/type-check.test.ts`** — `isFabricValueLayer()`
-  accepts sparse arrays.
+- **`packages/data-model/test/type-check.test.ts`** —
+  `isValidFabricValueLayer()` accepts sparse arrays.
 - **`packages/data-model/test/native-conversion.test.ts`** — 
   `fabricFromNativeValue()` preserves holes.
 - **`packages/runner/test/cell-core.test.ts`** — sparse-array writes through

--- a/packages/data-model/src/codec-common/toReportableState.ts
+++ b/packages/data-model/src/codec-common/toReportableState.ts
@@ -1,5 +1,5 @@
 import type { FabricValue } from "@/interface.ts";
-import { isFabricValue } from "@/type-check.ts";
+import { isValidFabricValue } from "@/type-check.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 
 /** How much of a rendered state to keep. */
@@ -26,7 +26,7 @@ const MAX_RENDERED_LENGTH = 200;
  *
  * The membership check runs guarded, so that a defect in it cannot take this
  * function down with it. That is prophylaxis against an unanticipated bug in
- * `isFabricValue()` rather than a guard against any particular input: this
+ * `isValidFabricValue()` rather than a guard against any particular input: this
  * runs on the failure path, where throwing does not surface a second problem
  * so much as replace the first one, the original error being lost in favor of
  * whatever the predicate did. `toCompactDebugString()` needs no such wrapping,
@@ -38,7 +38,7 @@ const MAX_RENDERED_LENGTH = 200;
  */
 export function toReportableState(state: any): FabricValue {
   try {
-    if (isFabricValue(state)) {
+    if (isValidFabricValue(state)) {
       return state;
     }
   } catch {

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -19,14 +19,14 @@ import {
   IS_DEEP_FROZEN,
 } from "./fabric-bases/BaseFabricInstance.ts";
 import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
-import { isFabricValue } from "./type-check.ts";
+import { isValidFabricValue } from "./type-check.ts";
 
 /** Cache of confirmed deep-frozen objects. */
 const deepFrozenCache = new WeakSet<object>();
 
 /**
  * Object graphs proven to be deep-frozen `FabricValue`s, memoized by root
- * identity for `isDeepFrozenFabricValue()`. Sound to cache because the
+ * identity for `isValidDeepFrozenFabricValue()`. Sound to cache because the
  * deep-frozen-honesty mandate makes such a proof permanent (see
  * `[IS_DEEP_FROZEN]` on `BaseFabricInstance` and the `FabricValue` doc).
  */
@@ -264,12 +264,14 @@ export function deepFreeze<T>(value: T): T {
 
 /**
  * Indicates whether the value is a deep-frozen `FabricValue`: both a
- * `FabricValue` (`isFabricValue()`) and deeply frozen (`isDeepFrozen()`), with
- * an identity-cached fast path. The cache is sound per the deep-frozen-honesty
- * mandate (see `[IS_DEEP_FROZEN]` and the `FabricValue` doc), which makes a
- * deep-frozen proof permanent.
+ * `FabricValue` (`isValidFabricValue()`) and deeply frozen (`isDeepFrozen()`),
+ * with an identity-cached fast path. The cache is sound per the
+ * deep-frozen-honesty mandate (see `[IS_DEEP_FROZEN]` and the `FabricValue`
+ * doc), which makes a deep-frozen proof permanent.
  */
-export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
+export function isValidDeepFrozenFabricValue(
+  value: unknown,
+): value is FabricValue {
   if (
     typeof value === "object" && value !== null &&
     deepFrozenFabricValueCache.has(value)
@@ -280,12 +282,12 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // The frozen-ness question goes first because it is the cheap one, and a
   // `false` from it settles the conjunction. `isDeepFrozen()` returns in
   // constant time for anything not frozen at its root, and memoizes every
-  // subtree it does walk; `isFabricValue()` walks the whole tree afresh on
+  // subtree it does walk; `isValidFabricValue()` walks the whole tree afresh on
   // every call. With the walk second, a mutable tree -- what the write path
   // hands this function at every level of its own recursion -- costs one
   // `Object.isFrozen()` call rather than a full membership walk of its
   // subtree.
-  const result = isDeepFrozen(value) && isFabricValue(value);
+  const result = isDeepFrozen(value) && isValidFabricValue(value);
 
   if (result && typeof value === "object" && value !== null) {
     deepFrozenFabricValueCache.add(value);

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -10,9 +10,9 @@
 // base class.
 export {
   type FabricArray,
+  type FabricConvertibleValue,
   FabricInstance,
   type FabricNativeObject,
-  type FabricOrConvertibleNativeValue,
   type FabricPlainObject,
   FabricPrimitive,
   FabricSpecialObject,
@@ -40,13 +40,14 @@ export {
 export {
   isFabricObjectOrArray,
   isFabricPlainObject,
-  isFabricValue,
-  isFabricValueLayer,
+  isValidFabricPlainObject,
+  isValidFabricValue,
+  isValidFabricValueLayer,
 } from "./type-check.ts";
 
 export {
   fabricFromNativeValue,
-  isFabricCompatible,
+  isValidFabricConvertibleValue,
   nativeFromFabricValue,
   shallowCleanArray,
   shallowCleanPlainObject,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -250,14 +250,15 @@ export type FabricNativeObject =
  * A `FabricValue`, a `FabricNativeObject`, or a deep tree thereof -- the values
  * that convert to and from fabric form. This is the precondition of
  * `fabricFromNativeValue()` (which fails on anything else), the result of
- * `nativeFromFabricValue()`, and what `isFabricCompatible()` tests for.
+ * `nativeFromFabricValue()`, and what `isValidFabricConvertibleValue()` tests
+ * for.
  *
  * Distinct from `FabricValue`: containers here may hold `FabricNativeObject`s.
  * Converting a `FabricError` yields an `Error`, so an array of them is an array
  * of natives, which has no `FabricValue` name.
  */
-export type FabricOrConvertibleNativeValue =
+export type FabricConvertibleValue =
   | FabricValue
   | FabricNativeObject
-  | readonly FabricOrConvertibleNativeValue[]
-  | { readonly [key: string]: FabricOrConvertibleNativeValue };
+  | readonly FabricConvertibleValue[]
+  | { readonly [key: string]: FabricConvertibleValue };

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -30,7 +30,8 @@ import {
 } from "@commonfabric/utils/arrays";
 
 import {
-  type FabricOrConvertibleNativeValue,
+  type FabricConvertibleValue,
+  type FabricNativeObject,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -42,7 +43,7 @@ import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { cloneHelper } from "./value-clone.ts";
-import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
+import { isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 
 /**
  * Helper for `shallowFabricFromNativeValue()`, which rejects native objects
@@ -163,16 +164,19 @@ export function shallowCleanPlainObject(
 }
 
 /**
- * Returns `true` if the value is a native JS object type that the fabric
- * system knows how to wrap. These are the "wild-west" instances that get
- * converted into `FabricNativeWrapper` subclasses, `FabricPrimitive` types,
- * or `FabricInstance` types by the conversion layer.
+ * Returns `true` if the value is a `FabricNativeObject`: one of the
+ * "wild-west" native JS instances that the conversion layer wraps into a
+ * `FabricNativeWrapper` subclass, a `FabricPrimitive`, or a `FabricInstance`.
  *
  * Arrays, plain objects, and system-defined special primitives are recognized
- * by `tagFromNativeValue()` but are _not_ convertible native instances -- they
- * have their own handling paths in the conversion layer.
+ * by `tagFromNativeValue()` but are _not_ `FabricNativeObject`s -- they have
+ * their own handling paths in the conversion layer.
+ *
+ * This function is a TypeScript type guard for `FabricNativeObject`.
  */
-export function isConvertibleNativeInstance(value: object): boolean {
+export function isValidFabricNativeObject(
+  value: unknown,
+): value is FabricNativeObject {
   switch (tagFromNativeValue(value)) {
     case NATIVE_TAGS.Error:
     case NATIVE_TAGS.Map:
@@ -401,7 +405,7 @@ const PROCESSING = Symbol("PROCESSING");
  *
  * @param value - The value to convert. Declared `unknown` for caller
  *   convenience, but the call _throws_ unless it is in fact a
- *   `FabricOrConvertibleNativeValue`; `isFabricCompatible()` reports in
+ *   `FabricConvertibleValue`; `isValidFabricConvertibleValue()` reports in
  *   advance whether it is.
  * @param freeze - When `true` (default), deep-freezes the result tree.
  *   When `false`, wrapping and validation still occur but the result is
@@ -413,7 +417,7 @@ export function fabricFromNativeValue(
 ): FabricValue {
   // Identity optimization: if the value is already a deep-frozen
   // `FabricValue`, return it without copying.
-  if (freeze && isDeepFrozenFabricValue(value)) {
+  if (freeze && isValidDeepFrozenFabricValue(value)) {
     return value;
   }
   return fabricFromNativeValueInternal(
@@ -584,27 +588,27 @@ function rebuildFabricErrorDeep(
  * is, if the value is a `FabricValue`, a `FabricNativeObject`, or a deep tree
  * thereof.
  *
- * The distinction from `isFabricValueLayer()`:
- * - `isFabricValueLayer(x)`: "is x already a `FabricValue`?" but only a shallow
- *   check.
- * - `isFabricCompatible(x)`: "could x be converted to a `FabricValue` via
- *   `fabricFromNativeValue()`?"
+ * The distinction from `isValidFabricValueLayer()`:
+ * - `isValidFabricValueLayer(x)`: "is x already a `FabricValue`?" but only a
+ *   shallow check.
+ * - `isValidFabricConvertibleValue(x)`: "could x be converted to a
+ *   `FabricValue` via `fabricFromNativeValue()`?"
  *
- * `isFabricCompatible()` additionally accepts `FabricNativeObject` types. It
- * checks recursively, so all nested values in arrays and objects must also be
- * fabric-compatible or convertible.
+ * `isValidFabricConvertibleValue()` additionally accepts `FabricNativeObject`
+ * types. It checks recursively, so all nested values in arrays and objects must
+ * also be fabric-convertible.
  *
  * This function is a TypeScript type guard for
- * `FabricOrConvertibleNativeValue`, which names the recursive shape described
+ * `FabricConvertibleValue`, which names the recursive shape described
  * above.
  */
-export function isFabricCompatible(
+export function isValidFabricConvertibleValue(
   value: unknown,
-): value is FabricOrConvertibleNativeValue {
-  return isFabricCompatibleInternal(value, new Set());
+): value is FabricConvertibleValue {
+  return isValidFabricConvertibleValueInternal(value, new Set());
 }
 
-function isFabricCompatibleInternal(
+function isValidFabricConvertibleValueInternal(
   value: unknown,
   seen: Set<object>,
 ): boolean {
@@ -621,7 +625,7 @@ function isFabricCompatibleInternal(
     }
 
     case "symbol": {
-      // Registry-interned symbols are fabric-compatible; unique ones are not.
+      // Registry-interned symbols are fabric-convertible; unique ones are not.
       return Symbol.keyFor(value) !== undefined;
     }
 
@@ -636,7 +640,7 @@ function isFabricCompatibleInternal(
 
       // `FabricNativeObject` types would be wrapped by
       // `fabricFromNativeValue()`.
-      if (isConvertibleNativeInstance(value)) {
+      if (isValidFabricNativeObject(value)) {
         return true;
       }
 
@@ -653,7 +657,9 @@ function isFabricCompatibleInternal(
         }
         // Check all elements recursively.
         for (let i = 0; i < value.length; i++) {
-          if (i in value && !isFabricCompatibleInternal(value[i], seen)) {
+          if (
+            i in value && !isValidFabricConvertibleValueInternal(value[i], seen)
+          ) {
             seen.delete(value);
             return false;
           }
@@ -662,7 +668,7 @@ function isFabricCompatibleInternal(
         return true;
       }
 
-      // Class instances are not fabric-compatible.
+      // Class instances are not fabric-convertible.
       if (isInstance(value)) {
         seen.delete(value);
         return false;
@@ -679,7 +685,7 @@ function isFabricCompatibleInternal(
         return false;
       }
       for (const val of Object.values(value)) {
-        if (!isFabricCompatibleInternal(val, seen)) {
+        if (!isValidFabricConvertibleValueInternal(val, seen)) {
           seen.delete(value);
           return false;
         }
@@ -706,7 +712,7 @@ function isFabricCompatibleInternal(
 export function nativeFromFabricValue(
   value: FabricValue,
   frozen = true,
-): FabricOrConvertibleNativeValue {
+): FabricConvertibleValue {
   if (value instanceof FabricError) {
     return deepUnwrapFabricError(value, frozen);
   }
@@ -724,7 +730,7 @@ export function nativeFromFabricValue(
   }
 
   if (Array.isArray(value)) {
-    const result: FabricOrConvertibleNativeValue[] = [];
+    const result: FabricConvertibleValue[] = [];
     for (let i = 0; i < value.length; i++) {
       if (!(i in value)) {
         result.length = i + 1;
@@ -739,7 +745,7 @@ export function nativeFromFabricValue(
     return result;
   }
 
-  const result: Record<string, FabricOrConvertibleNativeValue> = {};
+  const result: Record<string, FabricConvertibleValue> = {};
   for (const [key, val] of Object.entries(value)) {
     if (!isUnsafeObjectKey(key)) {
       result[key] = nativeFromFabricValue(val, frozen);

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -37,7 +37,7 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
  *
  * This function is a TypeScript type guard for `FabricValueLayer`.
  */
-export function isFabricValueLayer(
+export function isValidFabricValueLayer(
   value: unknown,
 ): value is FabricValueLayer {
   switch (typeof value) {
@@ -106,17 +106,17 @@ export function isFabricValueLayer(
  *
  * This is a *membership* check, not a frozen-ness check: a structurally-valid
  * but unfrozen object or array is still a `FabricValue`. For the deep-frozen
- * question, see `isDeepFrozenFabricValue()`. A fabric instance is a member by
- * type (it is a `FabricSpecialObject`); this does not recurse into its private
- * interior, whose contents are `FabricValue`s by the instance's construction
- * contract and are reachable only via frozen-semantic protocols that a
- * membership check must not invoke.
+ * question, see `isValidDeepFrozenFabricValue()`. A fabric instance is a member
+ * by type (it is a `FabricSpecialObject`); this does not recurse into its
+ * private interior, whose contents are `FabricValue`s by the instance's
+ * construction contract and are reachable only via frozen-semantic protocols
+ * that a membership check must not invoke.
  *
- * Contrast the shallow, single-level sibling `isFabricValueLayer()` and
- * `isFabricCompatible()` (which additionally accepts native values
+ * Contrast the shallow, single-level sibling `isValidFabricValueLayer()` and
+ * `isValidFabricConvertibleValue()` (which additionally accepts native values
  * *convertible* to fabric form).
  */
-export function isFabricValue(value: unknown): value is FabricValue {
+export function isValidFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive returns without
   // allocating the cycle-tracking set or the recursion closure below.
   if (typeof value === "function") {
@@ -124,7 +124,7 @@ export function isFabricValue(value: unknown): value is FabricValue {
   } else if (typeof value === "symbol") {
     // Only registry-interned symbols are `FabricValue`s; unique (uninterned)
     // symbols are not portable across realms and are rejected, matching
-    // `isFabricValueLayer()`.
+    // `isValidFabricValueLayer()`.
     return Symbol.keyFor(value) !== undefined;
   } else if (value === null || typeof value !== "object") {
     // A non-function, non-symbol primitive -- a direct `FabricValue` member.
@@ -192,6 +192,22 @@ export function isFabricValue(value: unknown): value is FabricValue {
 }
 
 /**
+ * Indicates whether the value is a `FabricPlainObject`: both a `FabricValue`
+ * (`isValidFabricValue()`) and a plain object, meaning its prototype is
+ * `Object.prototype` and its every property value is a `FabricValue` in turn.
+ *
+ * This is a *membership* check asked of an `unknown`, which makes it strictly
+ * narrower at runtime than the narrowing `isFabricPlainObject()`: that one is
+ * asked of a value already typed as a `FabricValue`, and accepts a
+ * null-prototype object, which membership refuses.
+ */
+export function isValidFabricPlainObject(
+  value: unknown,
+): value is FabricPlainObject {
+  return isValidFabricValue(value) && isFabricPlainObject(value);
+}
+
+/**
  * Indicates whether a fabric value is a plain object, an array, or a
  * `FabricSpecialObject` -- everything a `typeof value === "object"` test
  * accepts, minus `null`. The name states the array case because "object"
@@ -226,9 +242,11 @@ export function isFabricObjectOrArray(
  * value the type already says is a `FabricValue`, and a null-prototype object
  * answers yes as readily as any other record. That makes it deliberately looser
  * than membership: a `FabricPlainObject` is `Object.prototype`-rooted, so
- * `isFabricValue()` refuses the null-prototype object this accepts. The
+ * `isValidFabricValue()` refuses the null-prototype object this accepts. The
  * looseness costs nothing, the input being out of contract either way, and it
  * keeps callers holding un-validated values from losing a reader they can use.
+ * For the membership question asked of an `unknown`, see
+ * `isValidFabricPlainObject()`.
  */
 export function isFabricPlainObject(
   value: FabricValue,

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -21,7 +21,7 @@ import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
 import { FabricInstance, FabricValue } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
-import { deepFreeze, isDeepFrozenFabricValue } from "./deep-freeze.ts";
+import { deepFreeze, isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 import { toDebugKindString } from "./value-debug.ts";
 
 /** Options for `cloneIfNecessary()`. */
@@ -166,7 +166,7 @@ export function shallowMutableClone<T extends FabricValue>(
  * matches the requested state. When `force` is true, always copies (unless
  * the value is a primitive or special primitive).
  *
- * Deep mode uses `isDeepFrozenFabricValue()` for identity optimization;
+ * Deep mode uses `isValidDeepFrozenFabricValue()` for identity optimization;
  * shallow mode uses `Object.isFrozen(value) === frozen`.
  */
 export function cloneHelper(
@@ -178,12 +178,12 @@ export function cloneHelper(
 ): FabricValue {
   // Identity optimization: when `force` is off, check if the value's frozenness
   // already matches the requested state. Deep mode uses
-  // `isDeepFrozenFabricValue()`; shallow mode uses `Object.isFrozen(v) ===
+  // `isValidDeepFrozenFabricValue()`; shallow mode uses `Object.isFrozen(v) ===
   // frozen`.
   function canReturnAsIs(v: FabricValue): boolean {
     if (force) return false;
     if (deep) {
-      if (frozen && isDeepFrozenFabricValue(v)) return true;
+      if (frozen && isValidDeepFrozenFabricValue(v)) return true;
       if (!frozen && !Object.isFrozen(v)) return true;
       return false;
     }

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -24,10 +24,10 @@ import { expect } from "@std/expect";
 import {
   cloneIfNecessary,
   type CloneOptions,
-  isFabricValue,
+  isValidFabricValue,
 } from "@/fabric-value.ts";
 import type { FabricValue } from "@/fabric-value.ts";
-import { isDeepFrozen, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
+import { isDeepFrozen, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochDay } from "@/fabric-primitives/FabricEpochDay.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -375,12 +375,14 @@ describe("cloneIfNecessary()", () => {
       expect(result.child.v).toBe(42);
     });
 
-    it("produces a value `isFabricValue()` accepts", () => {
+    it("produces a value `isValidFabricValue()` accepts", () => {
       // The point of canonicalizing: what comes out is a member of the type,
       // where the input was not.
       const value = nullProto({ a: 1 });
-      expect(isFabricValue(value)).toBe(false);
-      expect(isFabricValue(cloneIfNecessary(value as FabricValue))).toBe(true);
+      expect(isValidFabricValue(value)).toBe(false);
+      expect(isValidFabricValue(cloneIfNecessary(value as FabricValue))).toBe(
+        true,
+      );
     });
   });
 
@@ -434,7 +436,7 @@ describe("cloneIfNecessary()", () => {
 
     it("does not report a frozen subclass instance as deep-frozen", () => {
       // This is what turns off the identity optimization below.
-      expect(isDeepFrozenFabricValue(frozenSmuggler()))
+      expect(isValidDeepFrozenFabricValue(frozenSmuggler()))
         .toBe(false);
     });
 
@@ -530,8 +532,8 @@ describe("cloneIfNecessary()", () => {
    * Other distinctions (whether the subclass is a `FabricPrimitive`, whether
    * the deep-freeze protocol is implemented as a real impl vs. a stub) are
    * detected at test time -- the former via `instanceof FabricPrimitive` on the
-   * factory output, the latter via `try/catch` around `isDeepFrozenFabricValue`
-   * in the predicate.
+   * factory output, the latter via `try/catch` around
+   * `isValidDeepFrozenFabricValue` in the predicate.
    */
   type SubclassCase = {
     readonly name: string;
@@ -616,7 +618,7 @@ describe("cloneIfNecessary()", () => {
    *   2. For `FabricInstance`, `canReturnAsIs` short-circuits the call when
    *      the requested frozenness matches the input's frozenness AND
    *      `force: false`. In `deep: true` mode that check uses
-   *      `isDeepFrozenFabricValue`, which invokes `[IS_DEEP_FROZEN]` on
+   *      `isValidDeepFrozenFabricValue`, which invokes `[IS_DEEP_FROZEN]` on
    *      `FabricInstance` arms -- a subclass with a throwing stub for that
    *      member throws if the probe descends that far.
    *   3. Otherwise `cloneIfNecessary` falls through to `shallowClone(frozen)`
@@ -638,14 +640,15 @@ describe("cloneIfNecessary()", () => {
     if (!force) {
       let canReturnAsIs: boolean;
       if (deep) {
-        // The check is `frozen && isDeepFrozenFabricValue(v)`. The latter may
-        // call `[IS_DEEP_FROZEN]` on a `FabricInstance` arm -- if a subclass's
-        // implementation is a throwing stub, the probe throws and propagates.
+        // The check is `frozen && isValidDeepFrozenFabricValue(v)`. The latter
+        // may call `[IS_DEEP_FROZEN]` on a `FabricInstance` arm -- if a
+        // subclass's implementation is a throwing stub, the probe throws and
+        // propagates.
         if (!frozen) {
           canReturnAsIs = false;
         } else {
           try {
-            canReturnAsIs = isDeepFrozenFabricValue(value);
+            canReturnAsIs = isValidDeepFrozenFabricValue(value);
           } catch {
             return { kind: "throws" };
           }
@@ -745,7 +748,7 @@ describe("cloneIfNecessary()", () => {
                   identityExpected = false;
                 } else if (vec.opts.deep) {
                   identityExpected = vec.opts.frozen &&
-                    isDeepFrozenFabricValue(
+                    isValidDeepFrozenFabricValue(
                       value,
                     );
                 } else {

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -21,7 +21,7 @@ import {
 import { CODEC } from "@/codec-interface/interface.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
-import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
+import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "../fabric-instances/fixtures.ts";
 
 describe("ProblematicValue", () => {
@@ -66,8 +66,8 @@ describe("ProblematicValue", () => {
     });
 
     it("survives a state whose own membership check throws", () => {
-      // Prophylaxis rather than a proxy guard: this path must not fail even
-      // if `isFabricValue()` itself has a defect, since throwing here would
+      // Prophylaxis rather than a proxy guard: this path must not fail even if
+      // `isValidFabricValue()` itself has a defect, since throwing here would
       // replace the failure being reported rather than add to it. A hostile
       // proxy is the only way to provoke that from outside.
       const hostile = new Proxy({}, {
@@ -109,7 +109,7 @@ describe("ProblematicValue", () => {
         expect(result).toBe(pv);
         expect(Object.isFrozen(pv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
-        expect(isDeepFrozenFabricValue(pv)).toBe(true);
+        expect(isValidDeepFrozenFabricValue(pv)).toBe(true);
       });
 
       it("via direct member invocation: recurses state, freezes in place", () => {

--- a/packages/data-model/test/codec-common/UnknownValue.test.ts
+++ b/packages/data-model/test/codec-common/UnknownValue.test.ts
@@ -19,7 +19,7 @@ import {
 import { CODEC } from "@/codec-interface/interface.ts";
 import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
-import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
+import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "../fabric-instances/fixtures.ts";
 
 describe("UnknownValue", () => {
@@ -85,7 +85,7 @@ describe("UnknownValue", () => {
         expect(result).toBe(uv);
         expect(Object.isFrozen(uv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
-        expect(isDeepFrozenFabricValue(uv)).toBe(true);
+        expect(isValidDeepFrozenFabricValue(uv)).toBe(true);
       });
 
       it("via direct member invocation: recurses state, freezes in place", () => {

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -22,7 +22,7 @@ import { expect } from "@std/expect";
 import {
   deepFreeze,
   isDeepFrozen,
-  isDeepFrozenFabricValue,
+  isValidDeepFrozenFabricValue,
 } from "@/deep-freeze.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
@@ -255,7 +255,7 @@ describe("deep-freeze", () => {
     // inspecting its logical contents, not its enumerable own-props -- so
     // values held in non-enumerable slots (such as
     // `FabricError`'s private extras `Map`) are checked too.
-    // (`isDeepFrozenFabricValue` uses the same protocol dispatch but
+    // (`isValidDeepFrozenFabricValue` uses the same protocol dispatch but
     // additionally type-guards the value as a `FabricValue`; it has its own
     // coverage in the sibling describe below.)
     describe("`FabricInstance` and `FabricPrimitive`", () => {
@@ -365,25 +365,25 @@ describe("deep-freeze", () => {
     });
   });
 
-  describe("`isDeepFrozenFabricValue()` with `FabricInstance` (R6)", () => {
+  describe("`isValidDeepFrozenFabricValue()` with `FabricInstance` (R6)", () => {
     it("returns `false` without throwing for an unfrozen `FabricInstance`", () => {
       const fe = FabricError.fromNativeError(new Error("test"));
       // Two separate guarantees, hence two assertions: an unfrozen instance is
       // classified rather than refused, and the classification is `false`.
-      expect(() => isDeepFrozenFabricValue(fe)).not.toThrow();
-      expect(isDeepFrozenFabricValue(fe)).toBe(false);
+      expect(() => isValidDeepFrozenFabricValue(fe)).not.toThrow();
+      expect(isValidDeepFrozenFabricValue(fe)).toBe(false);
     });
 
     it("returns `true` for a deep-frozen `FabricInstance`", () => {
       const fe = FabricError.fromNativeError(new Error("test"));
       deepFreeze(fe);
-      expect(isDeepFrozenFabricValue(fe)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(fe)).toBe(true);
     });
 
     it("returns `true` for a deep-frozen `FabricInstance` nested in a tree", () => {
       const fe = FabricError.fromNativeError(new Error("nested"));
       const tree = deepFreeze({ a: 1, e: fe });
-      expect(isDeepFrozenFabricValue(tree)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(true);
     });
 
     it("returns `false` (no throw) for a non-canonical-form instance", () => {
@@ -391,26 +391,26 @@ describe("deep-freeze", () => {
       const err = new Error("partial", { cause: { mutable: true } });
       const fe = FabricError.fromNativeError(err);
       Object.freeze(fe);
-      expect(() => isDeepFrozenFabricValue(fe)).not.toThrow();
-      expect(isDeepFrozenFabricValue(fe)).toBe(false);
+      expect(() => isValidDeepFrozenFabricValue(fe)).not.toThrow();
+      expect(isValidDeepFrozenFabricValue(fe)).toBe(false);
     });
   });
 
-  describe("`isDeepFrozenFabricValue()` array structure validity", () => {
+  describe("`isValidDeepFrozenFabricValue()` array structure validity", () => {
     it("returns `false` for a frozen array with enumerable named properties", () => {
       // An array carrying a named property has no fabric representation, so it
       // is not a valid `FabricValue` even when fully frozen.
       const arr = [1, 2, 3] as unknown[] & { foo?: string };
       arr.foo = "bar";
       Object.freeze(arr);
-      expect(isDeepFrozenFabricValue(arr)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(arr)).toBe(false);
     });
 
     it("returns `false` for a frozen array with named properties nested in a tree", () => {
       const arr = [1, 2] as unknown[] & { extra?: number };
       arr.extra = 42;
       const tree = Object.freeze({ data: Object.freeze(arr) });
-      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(false);
     });
 
     it("returns `true` for a frozen sparse array (holes are not named properties)", () => {
@@ -418,11 +418,11 @@ describe("deep-freeze", () => {
       sparse[0] = 1;
       sparse[2] = 3; // hole at index 1
       Object.freeze(sparse);
-      expect(isDeepFrozenFabricValue(sparse)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(sparse)).toBe(true);
     });
   });
 
-  describe("`isDeepFrozenFabricValue()` accessor properties", () => {
+  describe("`isValidDeepFrozenFabricValue()` accessor properties", () => {
     it("returns `false` for a frozen object with a getter", () => {
       // Freezing an object does not make an accessor inert: a read still
       // executes it and can return a different value every time. Such an
@@ -430,7 +430,7 @@ describe("deep-freeze", () => {
       const obj = { a: 1 };
       Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
       Object.freeze(obj);
-      expect(isDeepFrozenFabricValue(obj)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(obj)).toBe(false);
     });
 
     it("returns `false` for a frozen tree with a getter-bearing record inside", () => {
@@ -438,7 +438,7 @@ describe("deep-freeze", () => {
       Object.defineProperty(inner, "g", { get: () => 4, enumerable: true });
       Object.freeze(inner);
       const tree = Object.freeze({ data: inner });
-      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(false);
     });
 
     it("returns `false` for a frozen array with a getter-backed index", () => {
@@ -451,7 +451,7 @@ describe("deep-freeze", () => {
         configurable: false,
       });
       Object.freeze(arr);
-      expect(isDeepFrozenFabricValue(arr)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(arr)).toBe(false);
     });
 
     it("returns `false` for a frozen tree with a getter-index array inside", () => {
@@ -463,34 +463,34 @@ describe("deep-freeze", () => {
       });
       Object.freeze(inner);
       const tree = Object.freeze({ data: inner });
-      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(false);
     });
   });
 
-  describe("`isDeepFrozenFabricValue()` symbols", () => {
+  describe("`isValidDeepFrozenFabricValue()` symbols", () => {
     // Only registry-interned symbols are `FabricValue`s; unique (uninterned)
     // symbols are not portable across realms and are rejected, consistent with
-    // `isFabricValue()` / `isFabricValueLayer()`.
+    // `isValidFabricValue()` / `isValidFabricValueLayer()`.
     it("returns `true` for an interned symbol", () => {
-      expect(isDeepFrozenFabricValue(Symbol.for("k"))).toBe(true);
+      expect(isValidDeepFrozenFabricValue(Symbol.for("k"))).toBe(true);
     });
 
     it("returns `false` for a unique (uninterned) symbol", () => {
-      expect(isDeepFrozenFabricValue(Symbol("k"))).toBe(false);
+      expect(isValidDeepFrozenFabricValue(Symbol("k"))).toBe(false);
     });
 
     it("returns `false` for a frozen tree reaching a unique symbol", () => {
       const tree = Object.freeze({ a: 1, s: Symbol("nope") });
-      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(false);
     });
 
     it("returns `true` for a frozen tree reaching only interned symbols", () => {
       const tree = Object.freeze({ a: 1, s: Symbol.for("ok") });
-      expect(isDeepFrozenFabricValue(tree)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(tree)).toBe(true);
     });
   });
 
-  describe("`isDeepFrozenFabricValue()` identity cache", () => {
+  describe("`isValidDeepFrozenFabricValue()` identity cache", () => {
     it("does not revalidate an already-proven frozen Fabric value", () => {
       let childReads = 0;
       const child = Object.freeze({ value: 1 });
@@ -502,18 +502,18 @@ describe("deep-freeze", () => {
       });
       Object.freeze(value);
 
-      expect(isDeepFrozenFabricValue(value)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(value)).toBe(true);
       const readsAfterProof = childReads;
       expect(readsAfterProof).toBeGreaterThan(0);
 
-      expect(isDeepFrozenFabricValue(value)).toBe(true);
+      expect(isValidDeepFrozenFabricValue(value)).toBe(true);
       expect(childReads).toBe(readsAfterProof);
     });
   });
 
   // Cycle coverage for `deepFreeze()`'s arms (per the function's doc-comment
-  // 4-arm dispatch) and for `isDeepFrozenFabricValue()`, which composes
-  // `isFabricValue()` and `isDeepFrozen()` -- each threading its own
+  // 4-arm dispatch) and for `isValidDeepFrozenFabricValue()`, which composes
+  // `isValidFabricValue()` and `isDeepFrozen()` -- each threading its own
   // cycle-tracking set (`seen` / `inProgress`) through its recursion.
   //
   // Termination assertion: a cycle without such threading would manifest as
@@ -556,8 +556,8 @@ describe("deep-freeze", () => {
       });
     });
 
-    describe("`isDeepFrozenFabricValue()` (regression pin)", () => {
-      // `isDeepFrozenFabricValue()` composes `isFabricValue()` and
+    describe("`isValidDeepFrozenFabricValue()` (regression pin)", () => {
+      // `isValidDeepFrozenFabricValue()` composes `isValidFabricValue()` and
       // `isDeepFrozen()`, each of which threads its own cycle-tracking set
       // through its recursion, so the composition is cycle-safe. These tests
       // pin that property so a future change does not regress it.
@@ -565,9 +565,9 @@ describe("deep-freeze", () => {
         const a: Record<string, unknown> = { x: 1 };
         a.self = a;
         Object.freeze(a);
-        expect(() => isDeepFrozenFabricValue(a)).not.toThrow();
+        expect(() => isValidDeepFrozenFabricValue(a)).not.toThrow();
         // The graph is deep-frozen-shaped (every reachable object frozen).
-        expect(isDeepFrozenFabricValue(a)).toBe(true);
+        expect(isValidDeepFrozenFabricValue(a)).toBe(true);
       });
 
       it("terminates on a deep-frozen two-node cycle", () => {
@@ -577,8 +577,8 @@ describe("deep-freeze", () => {
         b.next = a;
         Object.freeze(a);
         Object.freeze(b);
-        expect(() => isDeepFrozenFabricValue(a)).not.toThrow();
-        expect(isDeepFrozenFabricValue(a)).toBe(true);
+        expect(() => isValidDeepFrozenFabricValue(a)).not.toThrow();
+        expect(isValidDeepFrozenFabricValue(a)).toBe(true);
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -35,7 +35,7 @@ import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import {
   deepFreeze,
   isDeepFrozen,
-  isDeepFrozenFabricValue,
+  isValidDeepFrozenFabricValue,
 } from "@/deep-freeze.ts";
 import { dummyEnv, subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 
@@ -443,12 +443,12 @@ describe("FabricError", () => {
 
       it("via dispatch: `[IS_DEEP_FROZEN]` is `true` only when wrapper + cause are frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
-        expect(isDeepFrozenFabricValue(fe)).toBe(false);
+        expect(isValidDeepFrozenFabricValue(fe)).toBe(false);
         Object.freeze(fe); // wrapper only; some descendants still mutable
         // (May be true since this particular FabricError has no nested
         // FabricValue descendants beyond primitive strings.)
         deepFreeze(fe);
-        expect(isDeepFrozenFabricValue(fe)).toBe(true);
+        expect(isValidDeepFrozenFabricValue(fe)).toBe(true);
       });
 
       it("via direct member invocation: `[DEEP_FREEZE]` freezes wrapper + recurses cause", () => {

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -24,7 +24,7 @@ import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts"
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import { FrozenMap } from "@/frozen-builtins.ts";
-import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
+import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 
 describe("FabricMap", () => {
@@ -94,7 +94,7 @@ describe("FabricMap", () => {
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );
         Object.freeze(fm);
-        expect(() => isDeepFrozenFabricValue(fm)).toThrow(
+        expect(() => isValidDeepFrozenFabricValue(fm)).toThrow(
           "`FabricMap`: not yet implemented",
         );
       });

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -23,7 +23,7 @@ import { CODEC_TYPE_TAGS } from "@/codec-interface/codec-type-tags.ts";
 import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { FabricSet } from "@/fabric-instances/FabricSet.ts";
 import { FrozenSet } from "@/frozen-builtins.ts";
-import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
+import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
 import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 
 describe("FabricSet", () => {
@@ -82,7 +82,7 @@ describe("FabricSet", () => {
       it("via dispatch: `[IS_DEEP_FROZEN]` throws not-yet-implemented (via type guard)", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         Object.freeze(fs);
-        expect(() => isDeepFrozenFabricValue(fs)).toThrow(
+        expect(() => isValidDeepFrozenFabricValue(fs)).toThrow(
           "`FabricSet`: not yet implemented",
         );
       });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -25,11 +25,11 @@ import { JSON_CODEC } from "@/codec-interface/interface.ts";
 import { fabricFromJsonValue, jsonFromFabricValue } from "@/codecs.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import {
-  isFabricCompatible,
+  isValidFabricConvertibleValue,
   shallowFabricFromNativeValue,
 } from "@/fabric-value.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import { isConvertibleNativeInstance } from "@/native-conversion.ts";
+import { isValidFabricNativeObject } from "@/native-conversion.ts";
 import {
   NATIVE_TAGS,
   tagFromNativeClass,
@@ -350,19 +350,19 @@ describe("FabricRegExp", () => {
       expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("`isConvertibleNativeInstance()` returns `true` for `RegExp`", () => {
-      expect(isConvertibleNativeInstance(/abc/)).toBe(true);
-      expect(isConvertibleNativeInstance(new RegExp("test", "gi"))).toBe(true);
+    it("`isValidFabricNativeObject()` returns `true` for `RegExp`", () => {
+      expect(isValidFabricNativeObject(/abc/)).toBe(true);
+      expect(isValidFabricNativeObject(new RegExp("test", "gi"))).toBe(true);
     });
   });
 
-  describe("isFabricCompatible()", () => {
+  describe("isValidFabricConvertibleValue()", () => {
     it("returns `true` for a plain `RegExp`", () => {
-      expect(isFabricCompatible(/abc/gi)).toBe(true);
+      expect(isValidFabricConvertibleValue(/abc/gi)).toBe(true);
     });
 
     it("returns `true` for a `RegExp` nested in objects", () => {
-      expect(isFabricCompatible({ pattern: /abc/gi })).toBe(true);
+      expect(isValidFabricConvertibleValue({ pattern: /abc/gi })).toBe(true);
     });
   });
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -48,14 +48,14 @@ import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FrozenMap, FrozenSet } from "@/frozen-builtins.ts";
 import {
+  type FabricConvertibleValue,
   FabricInstance,
-  type FabricOrConvertibleNativeValue,
   type FabricValue,
 } from "@/interface.ts";
 import {
   fabricFromNativeValue,
-  isConvertibleNativeInstance,
-  isFabricCompatible,
+  isValidFabricConvertibleValue,
+  isValidFabricNativeObject,
   nativeFromFabricValue,
   shallowCleanArray,
   shallowCleanPlainObject,
@@ -67,7 +67,7 @@ import {
  * `fabricFromNativeValue()` and decodes it back to native form via
  * `nativeFromFabricValue()`.
  */
-function roundTrip(value: FabricValue): FabricOrConvertibleNativeValue {
+function roundTrip(value: FabricValue): FabricConvertibleValue {
   return nativeFromFabricValue(fabricFromNativeValue(value));
 }
 
@@ -338,33 +338,41 @@ describe("native-conversion", () => {
     });
   });
 
-  describe("isConvertibleNativeInstance()", () => {
+  describe("isValidFabricNativeObject()", () => {
     it("returns `true` for all convertible types", () => {
-      expect(isConvertibleNativeInstance(new Error("e"))).toBe(true);
-      expect(isConvertibleNativeInstance(new TypeError("e"))).toBe(true);
-      expect(isConvertibleNativeInstance(new Map())).toBe(true);
-      expect(isConvertibleNativeInstance(new Set())).toBe(true);
-      expect(isConvertibleNativeInstance(new Date())).toBe(true);
-      expect(isConvertibleNativeInstance(new Uint8Array())).toBe(true);
+      expect(isValidFabricNativeObject(new Error("e"))).toBe(true);
+      expect(isValidFabricNativeObject(new TypeError("e"))).toBe(true);
+      expect(isValidFabricNativeObject(new Map())).toBe(true);
+      expect(isValidFabricNativeObject(new Set())).toBe(true);
+      expect(isValidFabricNativeObject(new Date())).toBe(true);
+      expect(isValidFabricNativeObject(new Uint8Array())).toBe(true);
     });
 
     it("returns `true` for exotic `Error` subclass", () => {
       class WeirdError extends RangeError {}
-      expect(isConvertibleNativeInstance(new WeirdError("weird"))).toBe(true);
+      expect(isValidFabricNativeObject(new WeirdError("weird"))).toBe(true);
     });
 
     it("returns `true` for `RegExp`", () => {
-      expect(isConvertibleNativeInstance(/abc/)).toBe(true);
+      expect(isValidFabricNativeObject(/abc/)).toBe(true);
     });
 
     it("returns `false` for non-convertible types", () => {
-      expect(isConvertibleNativeInstance({})).toBe(false);
-      expect(isConvertibleNativeInstance([])).toBe(false);
-      expect(isConvertibleNativeInstance(new WeakMap())).toBe(false);
+      expect(isValidFabricNativeObject({})).toBe(false);
+      expect(isValidFabricNativeObject([])).toBe(false);
+      expect(isValidFabricNativeObject(new WeakMap())).toBe(false);
     });
 
     it("returns `false` for objects with `toJSON()`", () => {
-      expect(isConvertibleNativeInstance({ toJSON: () => "x" })).toBe(false);
+      expect(isValidFabricNativeObject({ toJSON: () => "x" })).toBe(false);
+    });
+
+    it("returns `false` for a non-object", () => {
+      expect(isValidFabricNativeObject(null)).toBe(false);
+      expect(isValidFabricNativeObject(undefined)).toBe(false);
+      expect(isValidFabricNativeObject(1)).toBe(false);
+      expect(isValidFabricNativeObject("a")).toBe(false);
+      expect(isValidFabricNativeObject(() => {})).toBe(false);
     });
   });
 
@@ -1786,8 +1794,8 @@ describe("native-conversion", () => {
       it("throws on a top-level unique symbol (freeze default)", () => {
         // A unique symbol is not a `FabricValue`; conversion rejects it
         // regardless of the `freeze` flag -- the deep-frozen fast-path
-        // (`isDeepFrozenFabricValue`) must not admit it and short-circuit the
-        // validation that `freeze=false` performs (see below).
+        // (`isValidDeepFrozenFabricValue`) must not admit it and short-circuit
+        // the validation that `freeze=false` performs (see below).
         expect(() => fabricFromNativeValue(Symbol("bad"))).toThrow(
           "Not representable as a `FabricValue`: unique (uninterned) symbol",
         );
@@ -1893,146 +1901,166 @@ describe("native-conversion", () => {
     });
   });
 
-  describe("isFabricCompatible()", () => {
+  describe("isValidFabricConvertibleValue()", () => {
     describe("primitives", () => {
       it("returns `true` for `null`", () => {
-        expect(isFabricCompatible(null)).toBe(true);
+        expect(isValidFabricConvertibleValue(null)).toBe(true);
       });
 
       it("returns `true` for booleans", () => {
-        expect(isFabricCompatible(true)).toBe(true);
-        expect(isFabricCompatible(false)).toBe(true);
+        expect(isValidFabricConvertibleValue(true)).toBe(true);
+        expect(isValidFabricConvertibleValue(false)).toBe(true);
       });
 
       it("returns `true` for numbers (including `-0`, `NaN`, and infinities)", () => {
-        expect(isFabricCompatible(42)).toBe(true);
-        expect(isFabricCompatible(0)).toBe(true);
-        expect(isFabricCompatible(-0)).toBe(true);
-        expect(isFabricCompatible(-3.14)).toBe(true);
-        expect(isFabricCompatible(NaN)).toBe(true);
-        expect(isFabricCompatible(Infinity)).toBe(true);
-        expect(isFabricCompatible(-Infinity)).toBe(true);
+        expect(isValidFabricConvertibleValue(42)).toBe(true);
+        expect(isValidFabricConvertibleValue(0)).toBe(true);
+        expect(isValidFabricConvertibleValue(-0)).toBe(true);
+        expect(isValidFabricConvertibleValue(-3.14)).toBe(true);
+        expect(isValidFabricConvertibleValue(NaN)).toBe(true);
+        expect(isValidFabricConvertibleValue(Infinity)).toBe(true);
+        expect(isValidFabricConvertibleValue(-Infinity)).toBe(true);
       });
 
       it("returns `true` for strings", () => {
-        expect(isFabricCompatible("hello")).toBe(true);
-        expect(isFabricCompatible("")).toBe(true);
+        expect(isValidFabricConvertibleValue("hello")).toBe(true);
+        expect(isValidFabricConvertibleValue("")).toBe(true);
       });
 
       it("returns `true` for `undefined`", () => {
-        expect(isFabricCompatible(undefined)).toBe(true);
+        expect(isValidFabricConvertibleValue(undefined)).toBe(true);
       });
 
       it("returns `true` for `bigint`", () => {
-        expect(isFabricCompatible(42n)).toBe(true);
-        expect(isFabricCompatible(0n)).toBe(true);
+        expect(isValidFabricConvertibleValue(42n)).toBe(true);
+        expect(isValidFabricConvertibleValue(0n)).toBe(true);
       });
 
       it("returns `true` for interned symbols", () => {
-        expect(isFabricCompatible(Symbol.for("k"))).toBe(true);
-        expect(isFabricCompatible(Symbol.for(""))).toBe(true);
+        expect(isValidFabricConvertibleValue(Symbol.for("k"))).toBe(true);
+        expect(isValidFabricConvertibleValue(Symbol.for(""))).toBe(true);
       });
 
       it("returns `false` for unique (uninterned) symbols", () => {
-        expect(isFabricCompatible(Symbol("test"))).toBe(false);
+        expect(isValidFabricConvertibleValue(Symbol("test"))).toBe(false);
       });
     });
 
     describe("functions", () => {
       it("returns `false` for a bare function", () => {
-        expect(isFabricCompatible(() => 42)).toBe(false);
+        expect(isValidFabricConvertibleValue(() => 42)).toBe(false);
       });
 
       it("returns `false` for a function carrying members", () => {
-        expect(isFabricCompatible(Object.assign(() => 1, { x: 1 }))).toBe(
-          false,
-        );
+        expect(isValidFabricConvertibleValue(Object.assign(() => 1, { x: 1 })))
+          .toBe(
+            false,
+          );
       });
 
       it("returns `false` for a function nested in a container", () => {
-        expect(isFabricCompatible({ fn: () => 1 })).toBe(false);
-        expect(isFabricCompatible([() => 1])).toBe(false);
+        expect(isValidFabricConvertibleValue({ fn: () => 1 })).toBe(false);
+        expect(isValidFabricConvertibleValue([() => 1])).toBe(false);
       });
     });
 
     describe("native object types", () => {
       it("returns `true` for `Error` instances", () => {
-        expect(isFabricCompatible(new Error("test"))).toBe(true);
-        expect(isFabricCompatible(new TypeError("test"))).toBe(true);
+        expect(isValidFabricConvertibleValue(new Error("test"))).toBe(true);
+        expect(isValidFabricConvertibleValue(new TypeError("test"))).toBe(true);
       });
 
       it("returns `true` for `Map` instances", () => {
-        expect(isFabricCompatible(new Map())).toBe(true);
+        expect(isValidFabricConvertibleValue(new Map())).toBe(true);
       });
 
       it("returns `true` for `Set` instances", () => {
-        expect(isFabricCompatible(new Set())).toBe(true);
+        expect(isValidFabricConvertibleValue(new Set())).toBe(true);
       });
 
       it("returns `true` for `Date` instances", () => {
-        expect(isFabricCompatible(new Date())).toBe(true);
+        expect(isValidFabricConvertibleValue(new Date())).toBe(true);
       });
 
       it("returns `true` for `Uint8Array` instances", () => {
-        expect(isFabricCompatible(new Uint8Array([1, 2, 3]))).toBe(true);
+        expect(isValidFabricConvertibleValue(new Uint8Array([1, 2, 3]))).toBe(
+          true,
+        );
       });
 
       it("returns `false` for a class instance", () => {
         class Foo {
           x = 1;
         }
-        expect(isFabricCompatible(new Foo())).toBe(false);
+        expect(isValidFabricConvertibleValue(new Foo())).toBe(false);
       });
     });
 
     describe("fabric values", () => {
       it("returns `true` for `FabricInstance` (e.g. `FabricError`) values", () => {
         expect(
-          isFabricCompatible(FabricError.fromNativeError(new Error("test"))),
+          isValidFabricConvertibleValue(
+            FabricError.fromNativeError(new Error("test")),
+          ),
         ).toBe(true);
       });
 
       it("returns `true` for `FabricPrimitive` (e.g. `FabricBytes`) values", () => {
-        expect(isFabricCompatible(new FabricBytes(new Uint8Array([1, 2, 3]))))
+        expect(
+          isValidFabricConvertibleValue(
+            new FabricBytes(new Uint8Array([1, 2, 3])),
+          ),
+        )
           .toBe(true);
       });
     });
 
     describe("containers", () => {
       it("returns `true` for plain objects with fabric values", () => {
-        expect(isFabricCompatible({ a: 1, b: "hello", c: null })).toBe(true);
+        expect(isValidFabricConvertibleValue({ a: 1, b: "hello", c: null }))
+          .toBe(true);
       });
 
       it("returns `true` for arrays with fabric values", () => {
-        expect(isFabricCompatible([1, "hello", null, true])).toBe(true);
+        expect(isValidFabricConvertibleValue([1, "hello", null, true])).toBe(
+          true,
+        );
       });
 
       it("returns `true` for nested structures", () => {
-        expect(isFabricCompatible({
+        expect(isValidFabricConvertibleValue({
           users: [{ name: "Alice", age: 30 }],
           meta: { version: 1 },
         })).toBe(true);
       });
 
       it("returns `true` for objects containing `Error` values", () => {
-        expect(isFabricCompatible({ error: new Error("test"), code: 500 }))
+        expect(
+          isValidFabricConvertibleValue({
+            error: new Error("test"),
+            code: 500,
+          }),
+        )
           .toBe(true);
       });
 
       it("returns `true` for arrays containing `Error` values", () => {
-        expect(isFabricCompatible([1, new Error("test"), "hello"])).toBe(true);
+        expect(isValidFabricConvertibleValue([1, new Error("test"), "hello"]))
+          .toBe(true);
       });
 
       it("returns `false` for objects with non-fabric nested values", () => {
-        expect(isFabricCompatible({ a: 1, b: Symbol("bad") })).toBe(false);
+        expect(isValidFabricConvertibleValue({ a: 1, b: Symbol("bad") })).toBe(
+          false,
+        );
       });
 
       it("returns `false` for arrays with non-fabric elements", () => {
-        expect(isFabricCompatible([1, Symbol("bad")])).toBe(false);
+        expect(isValidFabricConvertibleValue([1, Symbol("bad")])).toBe(false);
       });
 
       it("returns `false` for deeply nested non-fabric values", () => {
-        expect(isFabricCompatible({
+        expect(isValidFabricConvertibleValue({
           a: { b: { c: [1, 2, { d: Symbol("bad") }] } },
         })).toBe(false);
       });
@@ -2040,39 +2068,42 @@ describe("native-conversion", () => {
       it("returns `false` for circular references", () => {
         const obj: Record<string, unknown> = { a: 1 };
         obj.self = obj;
-        expect(isFabricCompatible(obj)).toBe(false);
+        expect(isValidFabricConvertibleValue(obj)).toBe(false);
       });
 
       it("returns `false` for an array with extra named properties", () => {
         const arr = [1, 2, 3] as number[] & { extra?: string };
         arr.extra = "nope";
-        expect(isFabricCompatible(arr)).toBe(false);
+        expect(isValidFabricConvertibleValue(arr)).toBe(false);
       });
 
       it("returns `false` for an object with a symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
-        expect(isFabricCompatible(obj)).toBe(false);
+        expect(isValidFabricConvertibleValue(obj)).toBe(false);
       });
 
       it("returns `false` for an object with a non-enumerable string-keyed property", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
-        expect(isFabricCompatible(obj)).toBe(false);
+        expect(isValidFabricConvertibleValue(obj)).toBe(false);
       });
 
       it("returns `false` for an array with named properties nested inside an object", () => {
         const arr = [1] as number[] & { extra?: string };
         arr.extra = "nope";
-        expect(isFabricCompatible({ list: arr })).toBe(false);
+        expect(isValidFabricConvertibleValue({ list: arr })).toBe(false);
       });
 
       it("returns `false` for a property name this runtime reserves", () => {
-        expect(isFabricCompatible({ ["__proto__"]: 1 })).toBe(false);
-        expect(isFabricCompatible({ ["constructor"]: 1 })).toBe(false);
-        expect(isFabricCompatible({ nested: { ["__proto__"]: 1 } })).toBe(
+        expect(isValidFabricConvertibleValue({ ["__proto__"]: 1 })).toBe(false);
+        expect(isValidFabricConvertibleValue({ ["constructor"]: 1 })).toBe(
           false,
         );
+        expect(isValidFabricConvertibleValue({ nested: { ["__proto__"]: 1 } }))
+          .toBe(
+            false,
+          );
       });
     });
 
@@ -2081,25 +2112,26 @@ describe("native-conversion", () => {
         class Sub extends Array {}
         const sub = new Sub();
         sub.push(1, 2);
-        expect(isFabricCompatible(sub)).toBe(false);
-        expect(isFabricCompatible({ data: sub })).toBe(false);
+        expect(isValidFabricConvertibleValue(sub)).toBe(false);
+        expect(isValidFabricConvertibleValue({ data: sub })).toBe(false);
       });
 
       it("returns `false` for an array whose prototype was severed", () => {
         const severed: unknown[] = [1, 2];
         Object.setPrototypeOf(severed, null);
-        expect(isFabricCompatible(severed)).toBe(false);
+        expect(isValidFabricConvertibleValue(severed)).toBe(false);
       });
     });
 
     describe("`toJSON()` is intentionally not supported", () => {
       it("returns `false` for an object whose only member is `toJSON`", () => {
-        expect(isFabricCompatible({ toJSON: () => ({ x: 1 }) })).toBe(false);
+        expect(isValidFabricConvertibleValue({ toJSON: () => ({ x: 1 }) }))
+          .toBe(false);
       });
 
       it("returns `false` for a function carrying `toJSON()`", () => {
         const fn = Object.assign(() => 1, { toJSON: () => ({ x: 1 }) });
-        expect(isFabricCompatible(fn)).toBe(false);
+        expect(isValidFabricConvertibleValue(fn)).toBe(false);
       });
 
       it("returns `false` for a class instance carrying `toJSON()`", () => {
@@ -2108,7 +2140,7 @@ describe("native-conversion", () => {
             return { x: 1 };
           }
         }
-        expect(isFabricCompatible(new WithToJSON())).toBe(false);
+        expect(isValidFabricConvertibleValue(new WithToJSON())).toBe(false);
       });
     });
   });

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -1,6 +1,7 @@
 /**
  * Membership in the `FabricValue` type, asked one level deep and asked all the
- * way down, plus the narrowing to its plain-record arm.
+ * way down, plus the plain-record question asked as membership and as a
+ * narrowing.
  *
  * The two depths ask the same question at different scopes, and the cases are
  * arranged around where that difference tells.
@@ -15,8 +16,9 @@ import { expect } from "@std/expect";
 
 import {
   isFabricPlainObject,
-  isFabricValue,
-  isFabricValueLayer,
+  isValidFabricPlainObject,
+  isValidFabricValue,
+  isValidFabricValueLayer,
 } from "@/type-check.ts";
 import type { FabricValue } from "@/interface.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -24,95 +26,98 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 
 describe("type-check", () => {
-  describe("isFabricValueLayer()", () => {
+  describe("isValidFabricValueLayer()", () => {
     describe("given a scalar `FabricValue`", () => {
       it("returns `true` for a boolean", () => {
-        expect(isFabricValueLayer(true)).toBe(true);
-        expect(isFabricValueLayer(false)).toBe(true);
+        expect(isValidFabricValueLayer(true)).toBe(true);
+        expect(isValidFabricValueLayer(false)).toBe(true);
       });
 
       it("returns `true` for a string", () => {
-        expect(isFabricValueLayer("")).toBe(true);
-        expect(isFabricValueLayer("hello")).toBe(true);
-        expect(isFabricValueLayer("with\nnewlines")).toBe(true);
+        expect(isValidFabricValueLayer("")).toBe(true);
+        expect(isValidFabricValueLayer("hello")).toBe(true);
+        expect(isValidFabricValueLayer("with\nnewlines")).toBe(true);
       });
 
       it("returns `true` for a finite number (including `-0`)", () => {
-        expect(isFabricValueLayer(0)).toBe(true);
-        expect(isFabricValueLayer(-0)).toBe(true);
-        expect(isFabricValueLayer(1)).toBe(true);
-        expect(isFabricValueLayer(-1)).toBe(true);
-        expect(isFabricValueLayer(3.14159)).toBe(true);
-        expect(isFabricValueLayer(Number.MAX_VALUE)).toBe(true);
-        expect(isFabricValueLayer(Number.MIN_VALUE)).toBe(true);
+        expect(isValidFabricValueLayer(0)).toBe(true);
+        expect(isValidFabricValueLayer(-0)).toBe(true);
+        expect(isValidFabricValueLayer(1)).toBe(true);
+        expect(isValidFabricValueLayer(-1)).toBe(true);
+        expect(isValidFabricValueLayer(3.14159)).toBe(true);
+        expect(isValidFabricValueLayer(Number.MAX_VALUE)).toBe(true);
+        expect(isValidFabricValueLayer(Number.MIN_VALUE)).toBe(true);
       });
 
       it("returns `true` for a non-finite number", () => {
-        expect(isFabricValueLayer(NaN)).toBe(true);
-        expect(isFabricValueLayer(Infinity)).toBe(true);
-        expect(isFabricValueLayer(-Infinity)).toBe(true);
+        expect(isValidFabricValueLayer(NaN)).toBe(true);
+        expect(isValidFabricValueLayer(Infinity)).toBe(true);
+        expect(isValidFabricValueLayer(-Infinity)).toBe(true);
       });
 
       it("returns `true` for a `bigint`", () => {
-        expect(isFabricValueLayer(0n)).toBe(true);
-        expect(isFabricValueLayer(123n)).toBe(true);
+        expect(isValidFabricValueLayer(0n)).toBe(true);
+        expect(isValidFabricValueLayer(123n)).toBe(true);
       });
 
       it("returns `true` for an interned symbol", () => {
-        expect(isFabricValueLayer(Symbol.for("k"))).toBe(true);
+        expect(isValidFabricValueLayer(Symbol.for("k"))).toBe(true);
       });
 
       it("returns `true` for `null`", () => {
-        expect(isFabricValueLayer(null)).toBe(true);
+        expect(isValidFabricValueLayer(null)).toBe(true);
       });
 
       it("returns `true` for `undefined`", () => {
-        expect(isFabricValueLayer(undefined)).toBe(true);
+        expect(isValidFabricValueLayer(undefined)).toBe(true);
       });
     });
 
     describe("given a container or fabric object", () => {
       it("returns `true` for a plain object", () => {
-        expect(isFabricValueLayer({})).toBe(true);
-        expect(isFabricValueLayer({ a: 1 })).toBe(true);
-        expect(isFabricValueLayer({ nested: { object: true } })).toBe(true);
+        expect(isValidFabricValueLayer({})).toBe(true);
+        expect(isValidFabricValueLayer({ a: 1 })).toBe(true);
+        expect(isValidFabricValueLayer({ nested: { object: true } })).toBe(
+          true,
+        );
       });
 
       it("returns `true` for a dense array", () => {
-        expect(isFabricValueLayer([])).toBe(true);
-        expect(isFabricValueLayer([1, 2, 3])).toBe(true);
-        expect(isFabricValueLayer([{ a: 1 }, { b: 2 }])).toBe(true);
-        expect(isFabricValueLayer([null, "test", null])).toBe(true);
+        expect(isValidFabricValueLayer([])).toBe(true);
+        expect(isValidFabricValueLayer([1, 2, 3])).toBe(true);
+        expect(isValidFabricValueLayer([{ a: 1 }, { b: 2 }])).toBe(true);
+        expect(isValidFabricValueLayer([null, "test", null])).toBe(true);
       });
 
       it("returns `true` for an array with `undefined` elements", () => {
-        expect(isFabricValueLayer([1, undefined, 3])).toBe(true);
-        expect(isFabricValueLayer([undefined])).toBe(true);
+        expect(isValidFabricValueLayer([1, undefined, 3])).toBe(true);
+        expect(isValidFabricValueLayer([undefined])).toBe(true);
       });
 
       it("returns `true` for a sparse array (with holes)", () => {
         const sparse: unknown[] = [];
         sparse[0] = 1;
         sparse[2] = 3; // hole at index 1
-        expect(isFabricValueLayer(sparse)).toBe(true);
+        expect(isValidFabricValueLayer(sparse)).toBe(true);
       });
 
       it("returns `true` for a `FabricInstance`", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
-        expect(isFabricValueLayer(fe)).toBe(true);
+        expect(isValidFabricValueLayer(fe)).toBe(true);
       });
 
       it("returns `true` for a `FabricPrimitive`", () => {
         const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
-        expect(isFabricValueLayer(bytes)).toBe(true);
+        expect(isValidFabricValueLayer(bytes)).toBe(true);
       });
 
       it("returns `true` without recursively validating contents", () => {
-        // `isFabricValueLayer()` is a shallow, per-se check; deep validation is
-        // `isFabricCompatible()`'s job. A non-fabric nested value does not
-        // make the container itself fail the per-se check.
-        expect(isFabricValueLayer({ a: Symbol("x") })).toBe(true);
-        expect(isFabricValueLayer([Symbol("x")])).toBe(true);
+        // `isValidFabricValueLayer()` is a shallow, per-se check; deep
+        // validation is `isValidFabricConvertibleValue()`'s job. A non-fabric
+        // nested value does not make the container itself fail the per-se
+        // check.
+        expect(isValidFabricValueLayer({ a: Symbol("x") })).toBe(true);
+        expect(isValidFabricValueLayer([Symbol("x")])).toBe(true);
       });
     });
 
@@ -124,19 +129,19 @@ describe("type-check", () => {
       it("returns `false` for a symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
-        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
       });
 
       it("returns `false` for a registered symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol.for("s")] = 2;
-        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
       });
 
       it("returns `false` for a non-enumerable string-keyed property", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
-        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
       });
 
       it("returns `false` for an accessor-backed property", () => {
@@ -144,19 +149,19 @@ describe("type-check", () => {
         // return a different value every time. Freezing does not change that.
         const obj = { a: 1 };
         Object.defineProperty(obj, "g", { get: () => 2, enumerable: true });
-        expect(isFabricValueLayer(obj)).toBe(false);
-        expect(isFabricValueLayer(Object.freeze(obj))).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(Object.freeze(obj))).toBe(false);
       });
 
       it("returns `false` for a setter-only property", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "s", { set: () => {}, enumerable: true });
-        expect(isFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
       });
 
       it("returns `true` for an object whose keys are all enumerable strings", () => {
-        expect(isFabricValueLayer({ a: 1, b: 2 })).toBe(true);
-        expect(isFabricValueLayer({})).toBe(true);
+        expect(isValidFabricValueLayer({ a: 1, b: 2 })).toBe(true);
+        expect(isValidFabricValueLayer({})).toBe(true);
       });
 
       it("returns `false` for a property name this runtime reserves", () => {
@@ -164,8 +169,10 @@ describe("type-check", () => {
         // inert, and a runtime that does not route assignment through a
         // prototype chain would carry it fine. It is refused because in this
         // host the name cannot survive the copy that every boundary performs.
-        expect(isFabricValueLayer({ ["__proto__"]: 1, other: 2 })).toBe(false);
-        expect(isFabricValueLayer({ ["constructor"]: 1 })).toBe(false);
+        expect(isValidFabricValueLayer({ ["__proto__"]: 1, other: 2 })).toBe(
+          false,
+        );
+        expect(isValidFabricValueLayer({ ["constructor"]: 1 })).toBe(false);
       });
 
       it("returns `false` for a null-prototype object", () => {
@@ -175,8 +182,8 @@ describe("type-check", () => {
         // accepted and quietly changed.
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
-        expect(isFabricValueLayer(obj)).toBe(false);
-        expect(isFabricValueLayer(Object.create(null))).toBe(false);
+        expect(isValidFabricValueLayer(obj)).toBe(false);
+        expect(isValidFabricValueLayer(Object.create(null))).toBe(false);
       });
     });
 
@@ -184,13 +191,13 @@ describe("type-check", () => {
       it("returns `false` for an array with extra non-numeric properties", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
-        expect(isFabricValueLayer(arr)).toBe(false);
+        expect(isValidFabricValueLayer(arr)).toBe(false);
       });
 
       it("returns `false` for an array with a symbol-keyed property", () => {
         const arr = [1, 2, 3];
         (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
-        expect(isFabricValueLayer(arr)).toBe(false);
+        expect(isValidFabricValueLayer(arr)).toBe(false);
       });
 
       it("returns `false` for an array with an accessor-backed index", () => {
@@ -202,14 +209,14 @@ describe("type-check", () => {
           enumerable: true,
           configurable: false,
         });
-        expect(isFabricValueLayer(arr)).toBe(false);
-        expect(isFabricValueLayer(Object.freeze(arr))).toBe(false);
+        expect(isValidFabricValueLayer(arr)).toBe(false);
+        expect(isValidFabricValueLayer(Object.freeze(arr))).toBe(false);
       });
 
       it("returns `false` for an array with a setter-only index", () => {
         const arr = [1, 2, 3];
         Object.defineProperty(arr, 2, { set: () => {}, enumerable: true });
-        expect(isFabricValueLayer(arr)).toBe(false);
+        expect(isValidFabricValueLayer(arr)).toBe(false);
       });
 
       it("returns `false` for an `Array` subclass instance", () => {
@@ -218,14 +225,14 @@ describe("type-check", () => {
         class Sub extends Array {}
         const sub = new Sub();
         sub.push(1, 2);
-        expect(isFabricValueLayer(sub)).toBe(false);
-        expect(isFabricValueLayer(Object.freeze(sub))).toBe(false);
+        expect(isValidFabricValueLayer(sub)).toBe(false);
+        expect(isValidFabricValueLayer(Object.freeze(sub))).toBe(false);
       });
 
       it("returns `false` for an array whose prototype was severed", () => {
         const severed: unknown[] = [1, 2];
         Object.setPrototypeOf(severed, null);
-        expect(isFabricValueLayer(severed)).toBe(false);
+        expect(isValidFabricValueLayer(severed)).toBe(false);
       });
 
       it("returns `false` for a sparse array with extra named properties", () => {
@@ -235,29 +242,29 @@ describe("type-check", () => {
         sparse[0] = 1;
         sparse[2] = 3;
         sparse.foo = "bar";
-        expect(isFabricValueLayer(sparse)).toBe(false);
+        expect(isValidFabricValueLayer(sparse)).toBe(false);
       });
 
       it("returns `false` for a function", () => {
-        expect(isFabricValueLayer(() => {})).toBe(false);
-        expect(isFabricValueLayer(function () {})).toBe(false);
-        expect(isFabricValueLayer(async () => {})).toBe(false);
+        expect(isValidFabricValueLayer(() => {})).toBe(false);
+        expect(isValidFabricValueLayer(function () {})).toBe(false);
+        expect(isValidFabricValueLayer(async () => {})).toBe(false);
       });
 
       it("returns `false` for a class instance", () => {
-        expect(isFabricValueLayer(new Date())).toBe(false);
-        expect(isFabricValueLayer(new Map())).toBe(false);
-        expect(isFabricValueLayer(new Set())).toBe(false);
-        expect(isFabricValueLayer(/regex/)).toBe(false);
+        expect(isValidFabricValueLayer(new Date())).toBe(false);
+        expect(isValidFabricValueLayer(new Map())).toBe(false);
+        expect(isValidFabricValueLayer(new Set())).toBe(false);
+        expect(isValidFabricValueLayer(/regex/)).toBe(false);
       });
 
       it("returns `false` for a unique (uninterned) symbol", () => {
-        expect(isFabricValueLayer(Symbol("k"))).toBe(false);
+        expect(isValidFabricValueLayer(Symbol("k"))).toBe(false);
       });
     });
   });
 
-  describe("isFabricValue()", () => {
+  describe("isValidFabricValue()", () => {
     it("returns `true` for a schema using the `if` / `then` / `else` keywords", () => {
       // This system's schemas are themselves fabric values, and JSON Schema
       // spells conditional subschemas with those three keywords. So `then` is
@@ -266,7 +273,7 @@ describe("type-check", () => {
       // stop an ordinary schema being a fabric value at all. That hazard is
       // handled where a property can become callable, in the value proxies,
       // rather than by refusing the name here.
-      expect(isFabricValue({
+      expect(isValidFabricValue({
         type: "object",
         if: { properties: { kind: { const: "a" } } },
         then: { required: ["aField"] },
@@ -276,128 +283,130 @@ describe("type-check", () => {
 
     describe("given a scalar `FabricValue`", () => {
       it("returns `true` for a boolean", () => {
-        expect(isFabricValue(true)).toBe(true);
-        expect(isFabricValue(false)).toBe(true);
+        expect(isValidFabricValue(true)).toBe(true);
+        expect(isValidFabricValue(false)).toBe(true);
       });
 
       it("returns `true` for a string", () => {
-        expect(isFabricValue("")).toBe(true);
-        expect(isFabricValue("hello")).toBe(true);
+        expect(isValidFabricValue("")).toBe(true);
+        expect(isValidFabricValue("hello")).toBe(true);
       });
 
       it("returns `true` for a finite number (including `-0`)", () => {
-        expect(isFabricValue(0)).toBe(true);
-        expect(isFabricValue(-0)).toBe(true);
-        expect(isFabricValue(3.14159)).toBe(true);
-        expect(isFabricValue(Number.MAX_VALUE)).toBe(true);
+        expect(isValidFabricValue(0)).toBe(true);
+        expect(isValidFabricValue(-0)).toBe(true);
+        expect(isValidFabricValue(3.14159)).toBe(true);
+        expect(isValidFabricValue(Number.MAX_VALUE)).toBe(true);
       });
 
       it("returns `true` for a non-finite number (`NaN`, `±Infinity`)", () => {
-        expect(isFabricValue(NaN)).toBe(true);
-        expect(isFabricValue(Infinity)).toBe(true);
-        expect(isFabricValue(-Infinity)).toBe(true);
+        expect(isValidFabricValue(NaN)).toBe(true);
+        expect(isValidFabricValue(Infinity)).toBe(true);
+        expect(isValidFabricValue(-Infinity)).toBe(true);
       });
 
       it("returns `true` for a `bigint`", () => {
-        expect(isFabricValue(0n)).toBe(true);
-        expect(isFabricValue(123n)).toBe(true);
+        expect(isValidFabricValue(0n)).toBe(true);
+        expect(isValidFabricValue(123n)).toBe(true);
       });
 
       it("returns `true` for an interned symbol", () => {
         // Registry-interned symbols are portable and are members, matching
-        // `isFabricValueLayer()`.
-        expect(isFabricValue(Symbol.for("k"))).toBe(true);
+        // `isValidFabricValueLayer()`.
+        expect(isValidFabricValue(Symbol.for("k"))).toBe(true);
       });
 
       it("returns `true` for `null`", () => {
-        expect(isFabricValue(null)).toBe(true);
+        expect(isValidFabricValue(null)).toBe(true);
       });
 
       it("returns `true` for `undefined`", () => {
-        expect(isFabricValue(undefined)).toBe(true);
+        expect(isValidFabricValue(undefined)).toBe(true);
       });
     });
 
     describe("given a nested container", () => {
       it("returns `true` for a plain object of `FabricValue`s", () => {
-        expect(isFabricValue({})).toBe(true);
-        expect(isFabricValue({ a: 1, b: "two", c: null })).toBe(true);
-        expect(isFabricValue({ nested: { deeply: { value: 1 } } })).toBe(true);
+        expect(isValidFabricValue({})).toBe(true);
+        expect(isValidFabricValue({ a: 1, b: "two", c: null })).toBe(true);
+        expect(isValidFabricValue({ nested: { deeply: { value: 1 } } })).toBe(
+          true,
+        );
       });
 
       it("returns `false` for a reserved property name, at any depth", () => {
         const unsafe = { ["__proto__"]: 1 };
-        expect(isFabricValue(unsafe)).toBe(false);
-        expect(isFabricValue({ nested: unsafe })).toBe(false);
-        expect(isFabricValue([unsafe])).toBe(false);
-        expect(isFabricValue({ ["constructor"]: 1 })).toBe(false);
+        expect(isValidFabricValue(unsafe)).toBe(false);
+        expect(isValidFabricValue({ nested: unsafe })).toBe(false);
+        expect(isValidFabricValue([unsafe])).toBe(false);
+        expect(isValidFabricValue({ ["constructor"]: 1 })).toBe(false);
       });
 
       it("returns `false` for a null-prototype object, at any depth", () => {
         const obj = Object.create(null) as Record<string, unknown>;
         obj.a = 1;
-        expect(isFabricValue(obj)).toBe(false);
-        expect(isFabricValue({ nested: obj })).toBe(false);
-        expect(isFabricValue([obj])).toBe(false);
+        expect(isValidFabricValue(obj)).toBe(false);
+        expect(isValidFabricValue({ nested: obj })).toBe(false);
+        expect(isValidFabricValue([obj])).toBe(false);
       });
 
       it("returns `false` for an object with a symbol-keyed property", () => {
         const obj = { a: 1 } as Record<string | symbol, unknown>;
         obj[Symbol("s")] = 2;
-        expect(isFabricValue(obj)).toBe(false);
+        expect(isValidFabricValue(obj)).toBe(false);
       });
 
       it("returns `false` for an object with a non-enumerable string key", () => {
         const obj = { a: 1 };
         Object.defineProperty(obj, "hidden", { value: 2, enumerable: false });
-        expect(isFabricValue(obj)).toBe(false);
+        expect(isValidFabricValue(obj)).toBe(false);
       });
 
       it("returns `false` for a symbol-keyed object nested in the graph", () => {
         const inner = { a: 1 } as Record<string | symbol, unknown>;
         inner[Symbol("s")] = 2;
-        expect(isFabricValue({ outer: [inner] })).toBe(false);
+        expect(isValidFabricValue({ outer: [inner] })).toBe(false);
       });
 
       it("returns `true` for an array of `FabricValue`s", () => {
-        expect(isFabricValue([])).toBe(true);
-        expect(isFabricValue([1, 2, 3])).toBe(true);
-        expect(isFabricValue([{ a: 1 }, [2, 3], "x"])).toBe(true);
+        expect(isValidFabricValue([])).toBe(true);
+        expect(isValidFabricValue([1, 2, 3])).toBe(true);
+        expect(isValidFabricValue([{ a: 1 }, [2, 3], "x"])).toBe(true);
       });
 
       it("returns `true` for an array with `undefined` elements and sparse holes", () => {
-        expect(isFabricValue([1, undefined, 3])).toBe(true);
+        expect(isValidFabricValue([1, undefined, 3])).toBe(true);
         const sparse: unknown[] = [];
         sparse[0] = 1;
         sparse[2] = 3; // hole at index 1
-        expect(isFabricValue(sparse)).toBe(true);
+        expect(isValidFabricValue(sparse)).toBe(true);
       });
 
       it("returns `true` for a `FabricPrimitive` (`FabricBytes`, `FabricEpochNsec`)", () => {
-        expect(isFabricValue(new FabricBytes(new Uint8Array([1, 2, 3]))))
+        expect(isValidFabricValue(new FabricBytes(new Uint8Array([1, 2, 3]))))
           .toBe(true);
-        expect(isFabricValue(new FabricEpochNsec(0n))).toBe(true);
+        expect(isValidFabricValue(new FabricEpochNsec(0n))).toBe(true);
       });
 
       it("returns `true` for a `FabricInstance` (`FabricError`)", () => {
-        expect(isFabricValue(FabricError.fromNativeError(new Error("x"))))
+        expect(isValidFabricValue(FabricError.fromNativeError(new Error("x"))))
           .toBe(true);
       });
 
       it("returns `true` for a `FabricInstance` nested in a tree", () => {
         const fe = FabricError.fromNativeError(new Error("nested"));
-        expect(isFabricValue({ a: 1, e: fe, list: [fe] })).toBe(true);
+        expect(isValidFabricValue({ a: 1, e: fe, list: [fe] })).toBe(true);
       });
     });
 
     describe("given an unfrozen value (membership ignores frozen-ness)", () => {
       it("returns `true` for an unfrozen plain object and array", () => {
         // Structurally valid but not frozen: still a `FabricValue`. This is the
-        // deliberate difference from `isDeepFrozenFabricValue()`.
+        // deliberate difference from `isValidDeepFrozenFabricValue()`.
         const obj = { a: 1, nested: { b: 2 } };
         expect(Object.isFrozen(obj)).toBe(false);
-        expect(isFabricValue(obj)).toBe(true);
-        expect(isFabricValue([1, [2, 3]])).toBe(true);
+        expect(isValidFabricValue(obj)).toBe(true);
+        expect(isValidFabricValue([1, [2, 3]])).toBe(true);
       });
 
       it("returns `true` for an unfrozen `FabricInstance` (member by type)", () => {
@@ -406,34 +415,34 @@ describe("type-check", () => {
         // interior.
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(Object.isFrozen(fe)).toBe(false);
-        expect(isFabricValue(fe)).toBe(true);
+        expect(isValidFabricValue(fe)).toBe(true);
       });
     });
 
     describe("given a non-`FabricValue`", () => {
       it("returns `false` for a function at the top level", () => {
-        expect(isFabricValue(() => {})).toBe(false);
-        expect(isFabricValue(function () {})).toBe(false);
-        expect(isFabricValue(async () => {})).toBe(false);
+        expect(isValidFabricValue(() => {})).toBe(false);
+        expect(isValidFabricValue(function () {})).toBe(false);
+        expect(isValidFabricValue(async () => {})).toBe(false);
       });
 
       it("returns `false` for a function reached anywhere within the graph", () => {
-        expect(isFabricValue({ a: 1, fn: () => {} })).toBe(false);
-        expect(isFabricValue([1, [2, () => {}]])).toBe(false);
-        expect(isFabricValue({ deep: { nested: { fn: () => {} } } }))
+        expect(isValidFabricValue({ a: 1, fn: () => {} })).toBe(false);
+        expect(isValidFabricValue([1, [2, () => {}]])).toBe(false);
+        expect(isValidFabricValue({ deep: { nested: { fn: () => {} } } }))
           .toBe(false);
       });
 
       it("returns `false` for a non-fabric class instance (`Date`, `Map`, `Set`, `RegExp`)", () => {
-        expect(isFabricValue(new Date())).toBe(false);
-        expect(isFabricValue(new Map())).toBe(false);
-        expect(isFabricValue(new Set())).toBe(false);
-        expect(isFabricValue(/regex/)).toBe(false);
+        expect(isValidFabricValue(new Date())).toBe(false);
+        expect(isValidFabricValue(new Map())).toBe(false);
+        expect(isValidFabricValue(new Set())).toBe(false);
+        expect(isValidFabricValue(/regex/)).toBe(false);
       });
 
       it("returns `false` for a non-fabric class instance nested in the graph", () => {
-        expect(isFabricValue({ a: 1, d: new Date() })).toBe(false);
-        expect(isFabricValue([1, [2, new Map()]])).toBe(false);
+        expect(isValidFabricValue({ a: 1, d: new Date() })).toBe(false);
+        expect(isValidFabricValue([1, [2, new Map()]])).toBe(false);
       });
 
       it("returns `false` for an accessor-backed property, at any depth", () => {
@@ -441,37 +450,37 @@ describe("type-check", () => {
         // return a different value every time. Freezing does not change that.
         const top = { a: 1 };
         Object.defineProperty(top, "g", { get: () => 2, enumerable: true });
-        expect(isFabricValue(top)).toBe(false);
-        expect(isFabricValue(Object.freeze(top))).toBe(false);
+        expect(isValidFabricValue(top)).toBe(false);
+        expect(isValidFabricValue(Object.freeze(top))).toBe(false);
 
         const inner = { b: 3 };
         Object.defineProperty(inner, "g", { get: () => 4, enumerable: true });
-        expect(isFabricValue({ outer: inner })).toBe(false);
-        expect(isFabricValue([1, [inner]])).toBe(false);
+        expect(isValidFabricValue({ outer: inner })).toBe(false);
+        expect(isValidFabricValue([1, [inner]])).toBe(false);
       });
 
       it("returns `false` for an array with enumerable named (non-index) properties", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
-        expect(isFabricValue(arr)).toBe(false);
+        expect(isValidFabricValue(arr)).toBe(false);
       });
 
       it("returns `false` for a named-property array nested in the graph", () => {
         const arr = [1, 2] as unknown[] & { extra?: number };
         arr.extra = 42;
-        expect(isFabricValue({ data: arr })).toBe(false);
+        expect(isValidFabricValue({ data: arr })).toBe(false);
       });
 
       it("returns `false` for an array with a symbol-keyed property", () => {
         const arr = [1, 2, 3];
         (arr as unknown as Record<symbol, unknown>)[Symbol("foo")] = "bar";
-        expect(isFabricValue(arr)).toBe(false);
+        expect(isValidFabricValue(arr)).toBe(false);
       });
 
       it("returns `false` for an array with a non-enumerable named property", () => {
         const arr = [1, 2, 3];
         Object.defineProperty(arr, "foo", { value: "bar", enumerable: false });
-        expect(isFabricValue(arr)).toBe(false);
+        expect(isValidFabricValue(arr)).toBe(false);
       });
 
       it("returns `false` for an accessor-backed array index, at any depth", () => {
@@ -483,19 +492,19 @@ describe("type-check", () => {
           enumerable: true,
           configurable: false,
         });
-        expect(isFabricValue(top)).toBe(false);
-        expect(isFabricValue(Object.freeze(top))).toBe(false);
+        expect(isValidFabricValue(top)).toBe(false);
+        expect(isValidFabricValue(Object.freeze(top))).toBe(false);
 
         const inner = [4, 5];
         Object.defineProperty(inner, 0, { set: () => {}, enumerable: true });
-        expect(isFabricValue({ data: inner })).toBe(false);
-        expect(isFabricValue([1, [inner]])).toBe(false);
+        expect(isValidFabricValue({ data: inner })).toBe(false);
+        expect(isValidFabricValue([1, [inner]])).toBe(false);
       });
 
       it("returns `false` for a symbol-keyed-property array nested in the graph", () => {
         const arr = [1, 2];
         (arr as unknown as Record<symbol, unknown>)[Symbol.for("extra")] = 42;
-        expect(isFabricValue({ data: arr })).toBe(false);
+        expect(isValidFabricValue({ data: arr })).toBe(false);
       });
 
       it("returns `false` for an indirect `Array` instance, at any depth", () => {
@@ -505,24 +514,24 @@ describe("type-check", () => {
         class Sub extends Array {}
         const top = new Sub();
         top.push(1, 2);
-        expect(isFabricValue(top)).toBe(false);
-        expect(isFabricValue(Object.freeze(top))).toBe(false);
-        expect(isFabricValue({ data: top })).toBe(false);
-        expect(isFabricValue([1, [top]])).toBe(false);
+        expect(isValidFabricValue(top)).toBe(false);
+        expect(isValidFabricValue(Object.freeze(top))).toBe(false);
+        expect(isValidFabricValue({ data: top })).toBe(false);
+        expect(isValidFabricValue([1, [top]])).toBe(false);
 
         const severed: unknown[] = [3, 4];
         Object.setPrototypeOf(severed, null);
-        expect(isFabricValue(severed)).toBe(false);
-        expect(isFabricValue({ data: severed })).toBe(false);
+        expect(isValidFabricValue(severed)).toBe(false);
+        expect(isValidFabricValue({ data: severed })).toBe(false);
       });
 
       it("returns `false` for a unique (uninterned) symbol", () => {
-        expect(isFabricValue(Symbol("k"))).toBe(false);
+        expect(isValidFabricValue(Symbol("k"))).toBe(false);
       });
 
       it("returns `false` for a unique (uninterned) symbol reached within the graph", () => {
-        expect(isFabricValue({ a: 1, s: Symbol("nope") })).toBe(false);
-        expect(isFabricValue([Symbol("nope")])).toBe(false);
+        expect(isValidFabricValue({ a: 1, s: Symbol("nope") })).toBe(false);
+        expect(isValidFabricValue([Symbol("nope")])).toBe(false);
       });
     });
 
@@ -530,8 +539,8 @@ describe("type-check", () => {
       it("returns `true` (terminates) for a self-referential plain object", () => {
         const a: Record<string, unknown> = { x: 1 };
         a.self = a;
-        expect(() => isFabricValue(a)).not.toThrow();
-        expect(isFabricValue(a)).toBe(true);
+        expect(() => isValidFabricValue(a)).not.toThrow();
+        expect(isValidFabricValue(a)).toBe(true);
       });
 
       it("returns `true` (terminates) for a two-node cycle (a -> b -> a)", () => {
@@ -539,22 +548,84 @@ describe("type-check", () => {
         const b: Record<string, unknown> = { tag: "b" };
         a.next = b;
         b.next = a;
-        expect(() => isFabricValue(a)).not.toThrow();
-        expect(isFabricValue(a)).toBe(true);
+        expect(() => isValidFabricValue(a)).not.toThrow();
+        expect(isValidFabricValue(a)).toBe(true);
       });
 
       it("returns `true` (terminates) for a self-referential array", () => {
         const arr: unknown[] = [1, 2];
         arr.push(arr);
-        expect(() => isFabricValue(arr)).not.toThrow();
-        expect(isFabricValue(arr)).toBe(true);
+        expect(() => isValidFabricValue(arr)).not.toThrow();
+        expect(isValidFabricValue(arr)).toBe(true);
       });
 
       it("returns `false` for a non-member reached past a cycle", () => {
         const a: Record<string, unknown> = { tag: "a" };
         a.self = a;
         a.bad = () => {};
-        expect(isFabricValue(a)).toBe(false);
+        expect(isValidFabricValue(a)).toBe(false);
+      });
+    });
+  });
+
+  describe("isValidFabricPlainObject()", () => {
+    describe("given a plain object of `FabricValue`s", () => {
+      it("returns `true` for an empty object", () => {
+        expect(isValidFabricPlainObject({})).toBe(true);
+      });
+
+      it("returns `true` for a nested record", () => {
+        expect(isValidFabricPlainObject({ a: 1, b: { c: ["x", 2n] } }))
+          .toBe(true);
+      });
+
+      it("returns `true` for an unfrozen object", () => {
+        const obj = { a: 1 };
+
+        expect(Object.isFrozen(obj)).toBe(false);
+        expect(isValidFabricPlainObject(obj)).toBe(true);
+      });
+    });
+
+    describe("given a record membership refuses", () => {
+      it("returns `false` for a null-prototype object", () => {
+        // The narrowing `isFabricPlainObject()` accepts this one; membership
+        // requires an `Object.prototype`-rooted record.
+        const obj = Object.create(null) as Record<string, never>;
+
+        expect(isFabricPlainObject(obj as FabricValue)).toBe(true);
+        expect(isValidFabricPlainObject(obj)).toBe(false);
+      });
+
+      it("returns `false` for a record holding a nested function", () => {
+        expect(isValidFabricPlainObject({ a: { b: () => {} } })).toBe(false);
+      });
+
+      it("returns `false` for a record holding a nested class instance", () => {
+        expect(isValidFabricPlainObject({ a: [new Date()] })).toBe(false);
+      });
+    });
+
+    describe("given a non-record value", () => {
+      it("returns `false` for an array", () => {
+        expect(isValidFabricPlainObject([])).toBe(false);
+        expect(isValidFabricPlainObject([1, 2, 3])).toBe(false);
+      });
+
+      it("returns `false` for `null` and `undefined`", () => {
+        expect(isValidFabricPlainObject(null)).toBe(false);
+        expect(isValidFabricPlainObject(undefined)).toBe(false);
+      });
+
+      it("returns `false` for a scalar", () => {
+        expect(isValidFabricPlainObject(1)).toBe(false);
+        expect(isValidFabricPlainObject("a")).toBe(false);
+        expect(isValidFabricPlainObject(42n)).toBe(false);
+      });
+
+      it("returns `false` for a `FabricSpecialObject`", () => {
+        expect(isValidFabricPlainObject(new FabricBytes(new Uint8Array([1]))))
+          .toBe(false);
       });
     });
   });

--- a/packages/runner/src/builder/to-encodable-form.ts
+++ b/packages/runner/src/builder/to-encodable-form.ts
@@ -133,9 +133,9 @@ export function withAliasBindings(
   // for the same reason a non-inert plain object is refused there: `.map()`
   // rebuilds by index, so it drops a named or symbol-keyed property and
   // EVALUATES an accessor-backed index into a data property, and -- since
-  // `.map()` honors `Symbol.species` -- hands back an `Array` subclass
-  // instance still carrying its live prototype. The first two produce an array
-  // that satisfies `isFabricValue()` while meaning something else; the last
+  // `.map()` honors `Symbol.species` -- hands back an `Array` subclass instance
+  // still carrying its live prototype. The first two produce an array that
+  // satisfies `isValidFabricValue()` while meaning something else; the last
   // produces one that does not satisfy it at all.
   if (isInertArray(value)) {
     return (value as FactoryInput<any>).map((v: FactoryInput<any>, i: number) =>
@@ -176,7 +176,7 @@ export function withAliasBindings(
   // `for...in` rebuild silently drops a symbol key and a non-enumerable
   // property, EVALUATES an accessor into a data property, and reparents a
   // null-prototype object -- each producing a plain object that satisfies
-  // `isFabricValue()` while meaning something else. Nothing downstream can
+  // `isValidFabricValue()` while meaning something else. Nothing downstream can
   // catch it, because what it produces is genuinely valid.
   if (
     isObjectOrArray(value) && !isPattern(value) && !isInertPlainObject(value)

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -7,9 +7,9 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import {
   cloneIfNecessary,
+  type FabricConvertibleValue,
   fabricFromNativeValue,
   FabricInstance,
-  type FabricOrConvertibleNativeValue,
   FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
@@ -3430,14 +3430,14 @@ export function frameAnchorIds(
  * the conversion exists to replace. None of it is durable until it has been
  * through there.
  *
- * `FabricOrConvertibleNativeValue` is an arm rather than something restated, so
+ * `FabricConvertibleValue` is an arm rather than something restated, so
  * this stays true of whatever that comes to admit. The container arms are here
  * as well, and they are not redundant with it: theirs hold only what is already
  * fabric or convertible, where a cell may sit at any depth in what a pattern
  * produced. Replacing a nested one is the whole of what this conversion is for.
  */
 export type CellLinkInput =
-  | FabricOrConvertibleNativeValue
+  | FabricConvertibleValue
   | readonly CellLinkInput[]
   | { readonly [key: string]: CellLinkInput }
   | Cell<any>;

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -601,14 +601,15 @@ function createViewProxy<T>(
         if (Array.isArray(proxyTarget)) {
           if (!keys.includes("length")) {
             // Insert `length` where a real array carries it -- after the index
-            // keys, ahead of any other name -- rather than appending it. Own-key
-            // order is load-bearing: a consumer can tell an index-only array from
-            // one carrying named properties by asking whether `length` comes
-            // last, and appending would make a named property look like an
-            // index-only one. `isInertArray()` reads exactly that, and fabric
-            // membership (`isFabricValue()`) is decided by it for every array,
-            // so the order here is what makes a proxied array carrying a named
-            // property fail membership instead of passing as index-only.
+            // keys, ahead of any other name -- rather than appending it.
+            // Own-key order is load-bearing: a consumer can tell an index-only
+            // array from one carrying named properties by asking whether
+            // `length` comes last, and appending would make a named property
+            // look like an index-only one. `isInertArray()` reads exactly that,
+            // and fabric membership (`isValidFabricValue()`) is decided by it
+            // for every array, so the order here is what makes a proxied array
+            // carrying a named property fail membership instead of passing as
+            // index-only.
             const firstNonIndex = keys.findIndex((key) =>
               !((typeof key === "string") && isArrayIndexPropertyName(key))
             );

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -1,7 +1,7 @@
 import {
   type FabricValue,
   isFabricPlainObject,
-  isFabricValue,
+  isValidFabricPlainObject,
   shallowMutableClone,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
@@ -685,8 +685,7 @@ function mergeSchemaDefaultsInternal(
     if (defaults === undefined && !traversesPresentObject) return value;
     if (
       defaults !== undefined &&
-      (!(isFabricValue(defaults) && isFabricPlainObject(defaults)) ||
-        isCellLink(defaults))
+      (!isValidFabricPlainObject(defaults) || isCellLink(defaults))
     ) {
       return valuePresent ? value : defaults;
     }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -306,12 +306,12 @@ const freezeReadValue = <T extends FabricValue | undefined>(value: T): T => {
   // `cloneIfNecessary()`.
   //
   // `cloneIfNecessary()` decides its own identity fast path with
-  // `isDeepFrozenFabricValue()`, which conjoins the frozen-ness question with
-  // a membership walk of every node in the value. That walk is uncached, so
-  // the first read of a stored document runs it in full, and for a list it
+  // `isValidDeepFrozenFabricValue()`, which conjoins the frozen-ness question
+  // with a membership walk of every node in the value. That walk is uncached,
+  // so the first read of a stored document runs it in full, and for a list it
   // costs several times what the rest of the read does. Membership is settled
-  // before a value reaches the replica: the write paths below hand every
-  // value to `cloneIfNecessary()`, which either accepts it as a deep-frozen
+  // before a value reaches the replica: the write paths below hand every value
+  // to `cloneIfNecessary()`, which either accepts it as a deep-frozen
   // `FabricValue` or rebuilds it as one.
   return (isDeepFrozen(value) ? value : cloneIfNecessary(value)) as T;
 };

--- a/packages/runner/test/convert-cells-to-links-sharing.test.ts
+++ b/packages/runner/test/convert-cells-to-links-sharing.test.ts
@@ -9,7 +9,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricEpochNsec } from "@commonfabric/data-model/fabric-primitives";
-import { type FabricOrConvertibleNativeValue } from "@commonfabric/data-model/fabric-value";
+import { type FabricConvertibleValue } from "@commonfabric/data-model/fabric-value";
 
 import { convertCellsToLinks } from "../src/cell.ts";
 
@@ -62,7 +62,7 @@ describe("convert-cells-to-links-sharing", () => {
   });
 
   it("returns a back-link for an ancestor, so a cycle stays representable", () => {
-    const cyclic: Record<string, FabricOrConvertibleNativeValue> = { n: 1 };
+    const cyclic: Record<string, FabricConvertibleValue> = { n: 1 };
     cyclic.self = cyclic;
     const result = convertCellsToLinks(cyclic) as Record<string, unknown>;
 

--- a/packages/runner/test/to-encodable-form.test.ts
+++ b/packages/runner/test/to-encodable-form.test.ts
@@ -178,9 +178,9 @@ describe("to-encodable-form", () => {
     it("converts a native to its canonical fabric form", () => {
       // A `Uint8Array` is NOT a `FabricValue`. Left to the `for...in` copy it
       // is rebuilt by property name into `{"0":7,"1":9}` -- which IS an inert
-      // plain object and so passes `isFabricValue()`. That is the hazard: not
-      // a lost value, but a legal one meaning something else, stored with no
-      // trace of what it was. A `Date` goes the same way, to `{}`.
+      // plain object and so passes `isValidFabricValue()`. That is the hazard:
+      // not a lost value, but a legal one meaning something else, stored with
+      // no trace of what it was. A `Date` goes the same way, to `{}`.
       const fromBytes = withAliasBindings(new Uint8Array([7, 9]) as any) as any;
       expect(fromBytes).toBeInstanceOf(FabricBytes);
       expect([...fromBytes.slice()]).toEqual([7, 9]);
@@ -242,7 +242,7 @@ describe("to-encodable-form", () => {
       // the conversion, the `for...in` rebuild would silently drop the symbol
       // key, EVALUATE the accessor into a data property, and reparent the
       // null-prototype object -- each producing a plain object that satisfies
-      // `isFabricValue()` while meaning something else, with nothing
+      // `isValidFabricValue()` while meaning something else, with nothing
       // downstream able to notice. They must be refused here.
       const sym = Symbol("s");
       expect(() => withAliasBindings({ a: 1, [sym]: "x" } as any)).toThrow(
@@ -270,7 +270,7 @@ describe("to-encodable-form", () => {
       // The array analog of the plain-object case above, and it matters for
       // the same reason: `.map()` rebuilds by index, so a named property is
       // dropped and an accessor-backed index is EVALUATED into a data
-      // property, each yielding an array that satisfies `isFabricValue()`
+      // property, each yielding an array that satisfies `isValidFabricValue()`
       // while meaning something else. An `Array` subclass is worse than
       // laundered -- `.map()` honors `Symbol.species`, so the result is still
       // a subclass instance, carrying a live prototype that `isInertArray()`


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`isFabricValue()` reads as a type check but deeply validates: it walks the whole
value tree. The rest of the family shared the defect in one form or another.

The names now split on what a predicate takes, which is also what it costs:

- **`isValid*`** takes an `unknown` and establishes membership in the type it
  names.
- **`isFabric*`** takes a `FabricValue` and asks a cheap shape question of it.

| before | after |
|---|---|
| `isFabricValue` | `isValidFabricValue` |
| `isDeepFrozenFabricValue` | `isValidDeepFrozenFabricValue` |
| `isFabricValueLayer` | `isValidFabricValueLayer` |
| `isFabricCompatible` | `isValidFabricConvertibleValue` |
| `FabricOrConvertibleNativeValue` (type) | `FabricConvertibleValue` |
| `isConvertibleNativeInstance` | `isValidFabricNativeObject` |
| `isFabricObjectOrArray`, `isFabricPlainObject` | unchanged |

"Valid" is not a coinage here: the formal spec already says "already a valid
`FabricValue`" and "all nested values are already valid `FabricValue`" in prose,
and `isValidSlug` / `isValidSpaceDid` / `isValidSegment` are the same shape
elsewhere in the tree.

On the convertible half: `ConvertibleFabricValue` would read as a *restriction*
of `FabricValue` — a fabric value that happens to be convertible — where the
type is a *widening*, adding the six native objects and trees mixing them.
`FabricConvertibleValue` puts the modifier in compound position, which widens
correctly, and stays neutral about direction, which the type needs: it is both
what `fabricFromNativeValue()` accepts and what `nativeFromFabricValue()`
returns.

## Two substantive changes beyond the rename

`isValidFabricNativeObject()` now takes `unknown` and narrows to
`FabricNativeObject`, rather than taking `object` and returning a bare boolean.
It already tested exactly that type's six arms; `tagFromNativeValue()` was
already `unknown`-accepting, so the widening needed no new code.

`isValidFabricPlainObject()` is new: the membership form of the plain-record
question, `isValidFabricValue(value) && isFabricPlainObject(value)`. That
conjunction was written long-hand in `runner-utils.ts`, which now calls it. It
is strictly narrower at runtime than the narrowing `isFabricPlainObject()`,
which accepts a null-prototype object that membership refuses — the new tests
assert both halves of that difference.

## Verification

The rename half was checked to be purely mechanical: applying the inverse
mapping to every touched file reproduces the parent commit byte-for-byte across
all 26 files (control: an intentionally partial inverse is detected as
differing). Comment and prose paragraphs the longer names pushed past 80 columns
were rewrapped; a whitespace-and-decoration-insensitive comparison confirms the
only content changes are the ones described above.

Ablating `isValidFabricPlainObject()` to the bare narrowing fails exactly the
three differential tests (null-prototype, nested function, nested class
instance) and no others.

Green locally: `deno task check`, `deno lint`, `deno fmt --check`,
`deno task check-docs` (561 blocks), `deno task check-skill-facts`,
`data-model` (56 passed), `runner` (1242 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AREpTHp2jx5WPKJ1say8sG


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

