### PR TITLE
ci(coverage): keep the file attribution when a debt is accepted

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -566,6 +566,13 @@ that starts with `ACCEPT_COVERAGE_DEBT:` and that the check cannot read fails th
 job and says what form to write instead, rather than being passed over as though
 it were not there.
 
+An accepted group keeps its attribution. The gate keeps one comment on the pull
+request and rewrites it in place as the answer changes, and the comment an
+acceptance leaves behind names the files holding the lines it accepted, under
+"Files with new uncovered lines" — the same heading and the same counts the
+failing run wrote. So the pull request goes on saying which file the debt is in
+after the acceptance stops anything from failing over it.
+
 The left margin is what tells an acceptance from a mention of one. A description
 can name the marker in a sentence, and can indent an example of it into a code
 block, without either being read as accepting anything — or as a malformed

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -783,6 +783,39 @@ Deno.test("buildCoverageResolvedComment says the debt was overridden, not improv
     resolved,
     "| `packages/runner` | 12 | 15 | 3 lines more |",
   );
+  // Nothing was named, so the section that names files is left out entirely.
+  assertFalse(resolved.includes("### Files with new uncovered lines"));
+});
+
+Deno.test("buildCoverageResolvedComment names the files an accepted debt stands in for", () => {
+  const resolved = buildCoverageResolvedComment(
+    0,
+    [{ group: "tasks", baseline: 1846, current: 1857 }],
+    true,
+    [
+      { relativePath: "tasks/one.ts", group: "tasks", uncoveredCount: 11 },
+      { relativePath: "tasks/two.ts", group: "tasks", uncoveredCount: 1 },
+    ],
+  );
+
+  assertStringIncludes(resolved, "### Files with new uncovered lines");
+  assertStringIncludes(resolved, "- `tasks/one.ts` — 11 lines");
+  // A single line reads as a line, the same as it does in the regression body.
+  assertStringIncludes(resolved, "- `tasks/two.ts` — 1 line");
+});
+
+Deno.test("buildCoverageResolvedComment names no files when the debt was covered", () => {
+  // Coverage that improved has no acceptance to account for, so a file list
+  // would be describing debt that is not there.
+  const resolved = buildCoverageResolvedComment(
+    5,
+    [{ group: "tasks", baseline: 1857, current: 1852 }],
+    false,
+    [{ relativePath: "tasks/one.ts", group: "tasks", uncoveredCount: 11 }],
+  );
+
+  assertFalse(resolved.includes("### Files with new uncovered lines"));
+  assertFalse(resolved.includes("tasks/one.ts"));
 });
 
 Deno.test("buildCoverageResolvedComment falls back to a sentence with no groups", () => {

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -63,9 +63,10 @@ export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
  * - `state: "resolved"` carries `improvedLines`, the net reduction in uncovered
  *   lines versus baseline across the changed, gated coverage groups, and
  *   `groups`, the per-group baseline-versus-this-PR breakdown. When the gate
- *   passed only because the debt was accepted, `overridden` is set. The poster
- *   rebuilds an existing comment into a collapsed summary of where the PR left
- *   coverage; it does nothing when there is no existing comment to update.
+ *   passed only because the debt was accepted, `overridden` is set and `files`
+ *   names what the acceptance is standing in for. The poster rebuilds an
+ *   existing comment into a collapsed summary of where the PR left coverage; it
+ *   does nothing when there is no existing comment to update.
  */
 export interface CoverageCommentPayload {
   prNumber: number;
@@ -85,6 +86,9 @@ export interface CoverageCommentPayload {
    * changed group's debt was accepted with a per-group acceptance or the reset
    * marker, not because the new code is covered. */
   overridden?: boolean;
+  /** Present when `overridden` is set: the files holding the uncovered lines
+   * the acceptance covers for. */
+  files?: CoverageSuggestionFileLines[];
 }
 
 /**
@@ -920,6 +924,22 @@ function uncoveredLineCount(count: number): string {
 }
 
 /**
+ * The Markdown bullet list naming each file and how many of the lines it adds
+ * no test executes. Both coverage comments render it, in the same words, so a
+ * reader who has seen one recognizes the other.
+ */
+function uncoveredFileList(
+  files: CoverageSuggestionFileLines[],
+  omitted: number,
+): string[] {
+  const lines = files.map((file) =>
+    `- \`${file.relativePath}\` — ${uncoveredLineCount(file.uncoveredCount)}`
+  );
+  if (omitted > 0) lines.push(`- _…and ${omitted} more file(s)._`);
+  return lines;
+}
+
+/**
  * Render the disclosure `<summary>`, leading with the detective emoji. The
  * regression comment wraps the line in an `<h3>` so it stands out while the
  * details are open; the resolved comment uses `<strong>`, a quieter weight that
@@ -1044,16 +1064,7 @@ export function buildCoverageDebtSuggestionComment(
   out.push("### Files with new uncovered lines");
   out.push("");
   if (files.length > 0) {
-    for (const file of files) {
-      out.push(
-        `- \`${file.relativePath}\` — ${
-          uncoveredLineCount(file.uncoveredCount)
-        }`,
-      );
-    }
-    if (omitted > 0) {
-      out.push(`- _…and ${omitted} more file(s)._`);
-    }
+    out.push(...uncoveredFileList(files, omitted));
   } else {
     out.push(
       "Could not tie the regression to specific files from the diff (the " +
@@ -1375,11 +1386,19 @@ function coverageChangeText(baseline: number, current: number): string {
  * `overridden` is set the gate passed only because the debt was accepted with an
  * override or the reset marker, so the summary says the metric was overridden
  * rather than implying the new code is covered.
+ *
+ * `files` names where those uncovered lines are, and is rendered only under an
+ * override. This comment replaces an earlier regression body in place, and that
+ * body is the only place the attribution was ever written down: without it here,
+ * accepting the debt erases the answer to "which file" from the pull request.
+ * The other two resolutions have no such answer to keep — the debt was covered
+ * rather than accepted.
  */
 export function buildCoverageResolvedComment(
   improvedLines: number,
   groups: CoverageResolvedGroup[],
   overridden = false,
+  files: CoverageSuggestionFileLines[] = [],
 ): string {
   const summary = overridden
     ? "Code coverage debt accepted with an override."
@@ -1421,6 +1440,15 @@ export function buildCoverageResolvedComment(
         "uncovered lines.",
     );
   }
+
+  const limited = limitSuggestionFiles(files);
+  if (overridden && limited.files.length > 0) {
+    out.push("");
+    out.push("### Files with new uncovered lines");
+    out.push("");
+    out.push(...uncoveredFileList(limited.files, limited.omitted));
+  }
+
   out.push("");
   out.push("</details>");
 

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -878,7 +878,11 @@ export interface CoverageSuggestionGroup {
   current: number;
 }
 
-/** Count of lines a PR added that no test executes, for one file. */
+/**
+ * Count of newly uncovered lines attributed to one file. Usually these are
+ * lines the PR added; an accepted unattributed regression can instead name
+ * lines in an unchanged file that the baseline run covered.
+ */
 export interface CoverageSuggestionFileLines {
   relativePath: string;
   group: string;

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -508,7 +508,7 @@ Deno.test("writeCoverageResolved omits groups the PR did not change", async () =
   ];
   // No changed files map to a coverage group, so there is no per-group summary.
   const payload = await payloadFrom(() =>
-    writeCoverageResolved(4211, rows, [{ filename: "README.md" }])
+    writeCoverageResolved(4211, rows, [{ filename: "README.md" }], "")
   );
 
   assertEquals(payload?.state, "resolved");
@@ -524,7 +524,7 @@ Deno.test("writeCoverageResolved flags a changed group whose debt was overridden
     coverageRow("coverage-debt: tasks uncovered lines", 15, 12, "ovrd"),
   ];
   const payload = await payloadFrom(() =>
-    writeCoverageResolved(4211, rows, [{ filename: "tasks/foo.ts" }])
+    writeCoverageResolved(4211, rows, [{ filename: "tasks/foo.ts" }], "")
   );
 
   assertEquals(payload?.state, "resolved");
@@ -534,6 +534,57 @@ Deno.test("writeCoverageResolved flags a changed group whose debt was overridden
   assertEquals(payload?.groups, [
     { group: "tasks", baseline: 12, current: 15 },
   ]);
+  // The changed file carries no patch, so no line can be attributed to it.
+  assertEquals(payload?.files, []);
+});
+
+Deno.test("writeCoverageResolved names the files an accepted debt stands in for", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
+    coverageRow("coverage-debt: tasks uncovered lines", 15, 12, "ovrd"),
+  ];
+  // Lines 10 and 11 are uncovered and added; 12 is added but covered, and 20 is
+  // uncovered but not added. Only the overlap is the PR's new uncovered debt.
+  const lcov = [
+    `SF:${path.join(Deno.cwd(), "tasks/foo.ts")}`,
+    "DA:10,0",
+    "DA:11,0",
+    "DA:12,4",
+    "DA:20,0",
+    "end_of_record",
+  ].join("\n");
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [{
+      filename: "tasks/foo.ts",
+      patch: ["@@ -9,0 +10,3 @@", "+one", "+two", "+three"].join("\n"),
+    }], lcov)
+  );
+
+  assertEquals(payload?.overridden, true);
+  assertEquals(payload?.files, [
+    { relativePath: "tasks/foo.ts", group: "tasks", uncoveredCount: 2 },
+  ]);
+});
+
+Deno.test("writeCoverageResolved leaves the file list empty when nothing was overridden", async () => {
+  const rows = [
+    coverageRow("coverage-debt: tasks uncovered lines", 4, 9),
+  ];
+  const lcov = [
+    `SF:${path.join(Deno.cwd(), "tasks/foo.ts")}`,
+    "DA:10,0",
+    "end_of_record",
+  ].join("\n");
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [{
+      filename: "tasks/foo.ts",
+      patch: ["@@ -9,0 +10,1 @@", "+one"].join("\n"),
+    }], lcov)
+  );
+
+  // The group passed on its own, so there is no acceptance to account for.
+  assertEquals(payload?.overridden, false);
+  assertEquals(payload?.files, []);
 });
 
 Deno.test("writeCoverageResolved sums gated groups and ignores workspace and overrides", async () => {
@@ -545,7 +596,7 @@ Deno.test("writeCoverageResolved sums gated groups and ignores workspace and ove
     coverageRow("coverage-debt: identity uncovered lines", 50, 60, "ovrd"),
   ];
   const payload = await payloadFrom(() =>
-    writeCoverageResolved(4211, rows, [])
+    writeCoverageResolved(4211, rows, [], "")
   );
 
   assertEquals(payload?.state, "resolved");
@@ -561,7 +612,7 @@ Deno.test("writeCoverageResolved reports zero improvement when gated groups sit 
     coverageRow("coverage-debt: tasks uncovered lines", 4, 4),
   ];
   const payload = await payloadFrom(() =>
-    writeCoverageResolved(4211, rows, [])
+    writeCoverageResolved(4211, rows, [], "")
   );
 
   assertEquals(payload?.state, "resolved");
@@ -572,7 +623,7 @@ Deno.test("writeCoverageResolved reports zero improvement when gated groups sit 
 Deno.test("writeCoverageResolved reports zero improvement without a workspace baseline", async () => {
   const rows = [coverageRow("coverage-debt: workspace uncovered lines", 100)];
   const payload = await payloadFrom(() =>
-    writeCoverageResolved(4211, rows, [])
+    writeCoverageResolved(4211, rows, [], "")
   );
 
   assertEquals(payload?.state, "resolved");

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -566,6 +566,38 @@ Deno.test("writeCoverageResolved names the files an accepted debt stands in for"
   ]);
 });
 
+Deno.test("writeCoverageResolved preserves an accepted unchanged-file attribution", async () => {
+  await withFlakyLineCheckout(async ({ rootDir, lcov, baselineLcov }) => {
+    const rows: Row[] = [{ ...unattributedFailure(), status: "ovrd" }];
+    const payload = await payloadFrom(() =>
+      writeCoverageResolved(
+        4211,
+        rows,
+        // The PR changed this coverage group, but not the file whose coverage
+        // moved between otherwise comparable runs.
+        [{ filename: "packages/example/src/changed.ts" }],
+        lcov,
+        {
+          rootDir,
+          readBaselineLcov: (runId) => {
+            assertEquals(runId, 900);
+            return Promise.resolve(baselineLcov);
+          },
+        },
+      )
+    );
+
+    assertEquals(payload?.overridden, true);
+    // The resolved payload replaces the detailed failing comment, so it must
+    // carry the unchanged-file diagnosis forward rather than erase it.
+    assertEquals(payload?.files, [{
+      relativePath: "packages/example/src/racy.ts",
+      group: "packages/example",
+      uncoveredCount: 1,
+    }]);
+  });
+});
+
 Deno.test("writeCoverageResolved leaves the file list empty when nothing was overridden", async () => {
   const rows = [
     coverageRow("coverage-debt: tasks uncovered lines", 4, 9),

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1483,7 +1483,7 @@ export async function writeCoverageComment(
       lcov,
     );
   } else {
-    await writeCoverageResolved(prNumber, coverageRows, prFiles);
+    await writeCoverageResolved(prNumber, coverageRows, prFiles, lcov);
   }
 }
 
@@ -1583,6 +1583,50 @@ export async function buildUnattributedRegressionBody(
 }
 
 /**
+ * Per changed file in one of `groups`, how many of the lines the pull request
+ * added no test executes. Files that added no uncovered line are left out.
+ *
+ * This is the attribution both coverage comments carry: a regression names the
+ * files to write tests for, and an accepted debt names the files the acceptance
+ * stands in for. Uncovered line numbers are resolved only for changed files in
+ * those groups, so per-line data is never materialized for the whole workspace.
+ */
+async function uncoveredAddedLinesByFile(
+  prFiles: PRFile[],
+  lcov: string,
+  groups: Set<string>,
+): Promise<CoverageSuggestionFileLines[]> {
+  const changedInGroups = prFiles
+    .map((prFile) => prFile.filename.replaceAll("\\", "/"))
+    .filter((relativePath) => {
+      const group = coverageGroupForChangedFile(relativePath);
+      return group !== null && groups.has(group);
+    });
+  const uncoveredByPath = await collectUncoveredLinesForFiles({
+    rootDir: Deno.cwd(),
+    lcov,
+    files: changedInGroups,
+  });
+
+  const files: CoverageSuggestionFileLines[] = [];
+  for (const prFile of prFiles) {
+    const relativePath = prFile.filename.replaceAll("\\", "/");
+    const group = coverageGroupForChangedFile(relativePath);
+    if (!group || !groups.has(group)) continue;
+
+    const uncoveredLines = uncoveredByPath.get(relativePath);
+    if (!uncoveredLines || !prFile.patch) continue;
+
+    const addedLines = parseAddedLinesFromPatch(prFile.patch);
+    const uncoveredCount = uncoveredLines.filter((line) =>
+      addedLines.has(line)
+    ).length;
+    if (uncoveredCount > 0) files.push({ relativePath, group, uncoveredCount });
+  }
+  return files;
+}
+
+/**
  * Write the coverage-debt regression comment to a file for a later workflow to
  * post. The gate runs on `pull_request`, where fork PRs get a read-only token
  * and cannot comment, so the `coverage-comment` workflow_run job posts this from
@@ -1607,39 +1651,11 @@ export async function writeCoverageDebtSuggestion(
 
   if (groups.length === 0) return;
 
-  const failingGroups = new Set(groups.map((group) => group.group));
-
-  // Resolve uncovered line numbers only for changed files in the regressed
-  // groups, so we never materialize per-line data for the whole workspace.
-  const changedInFailingGroups = prFiles
-    .map((prFile) => prFile.filename.replaceAll("\\", "/"))
-    .filter((relativePath) => {
-      const group = coverageGroupForChangedFile(relativePath);
-      return group !== null && failingGroups.has(group);
-    });
-  const uncoveredByPath = await collectUncoveredLinesForFiles({
-    rootDir: Deno.cwd(),
+  const files = await uncoveredAddedLinesByFile(
+    prFiles,
     lcov,
-    files: changedInFailingGroups,
-  });
-
-  // Count, per changed file, the lines this PR added that coverage marks
-  // uncovered.
-  const files: CoverageSuggestionFileLines[] = [];
-  for (const prFile of prFiles) {
-    const relativePath = prFile.filename.replaceAll("\\", "/");
-    const group = coverageGroupForChangedFile(relativePath);
-    if (!group || !failingGroups.has(group)) continue;
-
-    const uncoveredLines = uncoveredByPath.get(relativePath);
-    if (!uncoveredLines || !prFile.patch) continue;
-
-    const addedLines = parseAddedLinesFromPatch(prFile.patch);
-    const uncoveredCount = uncoveredLines.filter((line) =>
-      addedLines.has(line)
-    ).length;
-    if (uncoveredCount > 0) files.push({ relativePath, group, uncoveredCount });
-  }
+    new Set(groups.map((group) => group.group)),
+  );
 
   try {
     // Nothing the pull request added accounts for the regression, so the lines
@@ -1692,11 +1708,18 @@ export async function writeCoverageDebtSuggestion(
  * changed, the same groups the gate ratchets, so the collapsed comment can show
  * where the PR left coverage. Never throws —
  * best-effort, like the regression path.
+ *
+ * An accepted debt also carries the files holding the uncovered lines, because
+ * this payload rewrites the regression comment that named them and would
+ * otherwise leave the pull request with no record of which file the acceptance
+ * is for. They are read only for an accepted debt: every other resolution
+ * covered its debt rather than accepting it, so there is nothing to name.
  */
 export async function writeCoverageResolved(
   prNumber: number,
   coverageRows: Row[],
   prFiles: PRFile[],
+  lcov: string,
 ): Promise<void> {
   const improvedLines = coverageRows.reduce((sum, row) => {
     if (row.status !== "OK" || row.baseline === undefined) return sum;
@@ -1721,14 +1744,18 @@ export async function writeCoverageResolved(
       changedGroups.has(group.group)
     );
 
-  // The gate passed because a changed group's debt was accepted with a
-  // per-group acceptance or the reset marker (status "ovrd"), not because the
-  // new code is covered.
-  const overridden = coverageRows.some((row) => {
-    if (row.status !== "ovrd") return false;
-    const group = coverageMetricGroupName(row.metric);
-    return group !== null && group !== "workspace" && changedGroups.has(group);
-  });
+  // The groups whose debt the gate accepted with a per-group acceptance or the
+  // reset marker (status "ovrd"), rather than passing because the new code is
+  // covered.
+  const overriddenGroups = new Set(
+    coverageRows
+      .filter((row) => row.status === "ovrd")
+      .map((row) => coverageMetricGroupName(row.metric))
+      .filter((group): group is string =>
+        group !== null && group !== "workspace" && changedGroups.has(group)
+      ),
+  );
+  const overridden = overriddenGroups.size > 0;
 
   try {
     const payload: CoverageCommentPayload = {
@@ -1737,6 +1764,9 @@ export async function writeCoverageResolved(
       improvedLines,
       groups,
       overridden,
+      files: overridden
+        ? await uncoveredAddedLinesByFile(prFiles, lcov, overriddenGroups)
+        : [],
     };
     const outputFile = coverageCommentOutputPath();
     await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -1511,6 +1511,7 @@ function measurementFromFailures(failures: Row[]): CoverageMeasurement {
  * pull request changed — and the caller falls back to the ordinary comment.
  */
 export interface UnattributedRegressionOptions {
+  /** Repository checkout whose source files the LCOV reports describe. */
   rootDir: string;
   groups: CoverageSuggestionGroup[];
   coverageFailures: Row[];
@@ -1521,9 +1522,24 @@ export interface UnattributedRegressionOptions {
   readBaselineLcov: (runId: number) => Promise<string | null>;
 }
 
-export async function buildUnattributedRegressionBody(
-  options: UnattributedRegressionOptions,
-): Promise<string | null> {
+interface UnattributedRegressionFile extends CoverageUnattributedFile {
+  group: string;
+}
+
+interface UnattributedRegressionAttribution {
+  files: UnattributedRegressionFile[];
+  baselineByGroup: Map<string, CoverageRunIdentity>;
+}
+
+/**
+ * Resolve an unattributed regression to unchanged files by comparing each
+ * affected group's current LCOV with the particular baseline run that supplied
+ * its ratchet. The result stays as data so both the failing and accepted-debt
+ * comment paths can describe the same attribution.
+ */
+async function collectUnattributedRegressionAttribution(
+  options: Omit<UnattributedRegressionOptions, "groups">,
+): Promise<UnattributedRegressionAttribution> {
   // Each metric resolves its own ratchet baseline, so two regressed groups can
   // be held against two different `main` runs. A group is compared against the
   // run its own baseline came from and no other: another run measured a
@@ -1543,13 +1559,12 @@ export async function buildUnattributedRegressionBody(
       sha: failure.baselineSha,
     });
   }
-  if (groupsByBaselineRun.size === 0) return null;
 
   const changedFiles = new Set(
     options.prFiles.map((prFile) => prFile.filename.replaceAll("\\", "/")),
   );
 
-  const files: CoverageUnattributedFile[] = [];
+  const files: UnattributedRegressionFile[] = [];
   for (const [runId, groups] of groupsByBaselineRun) {
     const baselineLcov = await options.readBaselineLcov(runId);
     if (baselineLcov === null) continue;
@@ -1561,9 +1576,22 @@ export async function buildUnattributedRegressionBody(
       changedFiles,
     });
     for (const file of regressed) {
-      files.push({ relativePath: file.relativePath, lines: file.lines });
+      files.push({
+        relativePath: file.relativePath,
+        group: file.metricGroup,
+        lines: file.lines,
+      });
     }
   }
+
+  return { files, baselineByGroup };
+}
+
+export async function buildUnattributedRegressionBody(
+  options: UnattributedRegressionOptions,
+): Promise<string | null> {
+  const { files, baselineByGroup } =
+    await collectUnattributedRegressionAttribution(options);
 
   if (files.length === 0) return null;
 
@@ -1712,14 +1740,20 @@ export async function writeCoverageDebtSuggestion(
  * An accepted debt also carries the files holding the uncovered lines, because
  * this payload rewrites the regression comment that named them and would
  * otherwise leave the pull request with no record of which file the acceptance
- * is for. They are read only for an accepted debt: every other resolution
- * covered its debt rather than accepting it, so there is nothing to name.
+ * is for. When no added line explains the regression, the same baseline LCOV
+ * comparison as the failing path recovers its attribution to unchanged files.
+ * Files are read only for an accepted debt: every other resolution covered its
+ * debt rather than accepting it, so there is nothing to name.
  */
 export async function writeCoverageResolved(
   prNumber: number,
   coverageRows: Row[],
   prFiles: PRFile[],
   lcov: string,
+  options: {
+    rootDir?: string;
+    readBaselineLcov?: (runId: number) => Promise<string | null>;
+  } = {},
 ): Promise<void> {
   const improvedLines = coverageRows.reduce((sum, row) => {
     if (row.status !== "OK" || row.baseline === undefined) return sum;
@@ -1747,26 +1781,54 @@ export async function writeCoverageResolved(
   // The groups whose debt the gate accepted with a per-group acceptance or the
   // reset marker (status "ovrd"), rather than passing because the new code is
   // covered.
+  const overriddenRows = coverageRows.filter((row) => {
+    if (row.status !== "ovrd") return false;
+    const group = coverageMetricGroupName(row.metric);
+    return group !== null && group !== "workspace" && changedGroups.has(group);
+  });
   const overriddenGroups = new Set(
-    coverageRows
-      .filter((row) => row.status === "ovrd")
+    overriddenRows
       .map((row) => coverageMetricGroupName(row.metric))
-      .filter((group): group is string =>
-        group !== null && group !== "workspace" && changedGroups.has(group)
-      ),
+      .filter((group): group is string => group !== null),
   );
   const overridden = overriddenGroups.size > 0;
 
   try {
+    let files: CoverageSuggestionFileLines[] = [];
+    if (overridden) {
+      files = await uncoveredAddedLinesByFile(
+        prFiles,
+        lcov,
+        overriddenGroups,
+      );
+
+      // The failing comment takes this same fallback when no added line in the
+      // diff accounts for the regression. Recompute it here after an override,
+      // because this payload replaces that comment and must not erase its only
+      // record of which unchanged file started flapping.
+      if (files.length === 0) {
+        const unattributed = await collectUnattributedRegressionAttribution({
+          rootDir: options.rootDir ?? Deno.cwd(),
+          coverageFailures: overriddenRows,
+          prFiles,
+          lcov,
+          readBaselineLcov: options.readBaselineLcov ?? baselineLcovForRun,
+        });
+        files = unattributed.files.map((file) => ({
+          relativePath: file.relativePath,
+          group: file.group,
+          uncoveredCount: file.lines.length,
+        }));
+      }
+    }
+
     const payload: CoverageCommentPayload = {
       prNumber,
       state: "resolved",
       improvedLines,
       groups,
       overridden,
-      files: overridden
-        ? await uncoveredAddedLinesByFile(prFiles, lcov, overriddenGroups)
-        : [],
+      files,
     };
     const outputFile = coverageCommentOutputPath();
     await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -185,6 +185,31 @@ Deno.test("postCoverageComment reports an overridden metric rather than improved
   );
 });
 
+Deno.test("postCoverageComment keeps the file attribution when it overwrites a regression", async () => {
+  // The regression body it replaces is the only place the files were named, so
+  // the payload carries them through rather than letting the rewrite lose them.
+  const existing =
+    `${COVERAGE_SUGGESTION_MARKER}\n<details open>\nregression\n</details>`;
+
+  const requests = await runWithPayload(
+    {
+      prNumber: 4211,
+      state: "resolved",
+      improvedLines: 0,
+      groups: [{ group: "tasks", baseline: 1846, current: 1857 }],
+      overridden: true,
+      files: [
+        { relativePath: "tasks/one.ts", group: "tasks", uncoveredCount: 11 },
+      ],
+    },
+    [existing],
+  );
+
+  assertEquals(requests.length, 1);
+  assertStringIncludes(requests[0].body, "### Files with new uncovered lines");
+  assertStringIncludes(requests[0].body, "- `tasks/one.ts` — 11 lines");
+});
+
 Deno.test("postCoverageComment does nothing to resolve when no comment exists", async () => {
   const requests = await runWithPayload(
     { prNumber: 4211, state: "resolved", improvedLines: 5 },

--- a/tasks/post-coverage-comment.ts
+++ b/tasks/post-coverage-comment.ts
@@ -82,6 +82,7 @@ export async function postCoverageComment(): Promise<void> {
         payload.improvedLines ?? 0,
         payload.groups ?? [],
         payload.overridden ?? false,
+        payload.files ?? [],
       );
       if (updated === marked.body) {
         console.log(


### PR DESCRIPTION
The coverage gate keeps one comment on the pull request and rewrites it in place as the answer changes. A regression names the files holding the lines no test executes; accepting that debt with `ACCEPT_COVERAGE_DEBT` replaced the whole body with a group-total summary, so the pull request stopped saying which file the debt was in at exactly the moment nothing else was failing over it.

That cost real time on #6013. The failing runs both said `tasks/pattern-vintage.ts — 11 lines`; the acceptance overwrote it, and the later investigation had only `tasks 1846 -> 1857` to work from.

The resolved payload now carries those files under an override, and the comment renders them under the heading the failing run used, with the same counts. The two comments share one renderer for the list so they cannot drift into describing the same thing differently.

Only an override carries them. Every other resolution covered its debt rather than accepting it, so it has no accepted lines to name, and the per-file work is skipped on that path rather than computed and dropped.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-docs`, `deno task check-skill-facts`, and the full `tasks` suite (599 passed) are green. New cases cover the payload the gate writes, the comment the poster renders, and that a covered — not accepted — resolution names nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

