### PR TITLE
test(tasks): make the held-back reports claims a test can check

### DIFF
--- a/tasks/pattern-vintage-lib.test.ts
+++ b/tasks/pattern-vintage-lib.test.ts
@@ -36,6 +36,8 @@ import {
   relativeToRepo,
   removeVintages,
   reportCaptureRefusedOnRed,
+  reportCapturesSuperseded,
+  reportDropsApplied,
   reportEveryGenerationCurrent,
   reportFailures,
   reportNothingReplayed,
@@ -410,6 +412,45 @@ describe("reporting", () => {
     })).toContain(
       "2 target(s) were served routes and not identity-compared.",
     );
+  });
+
+  it("names each derived target held back once, with the rule that held it", () => {
+    // A target can be raised by several vintages, and the count is of targets
+    // rather than of times one came up — otherwise "held 6 back" describes two
+    // targets and reads as four more than are there.
+    const report = reportCapturesSuperseded([
+      "topics/topics.tsx#rows",
+      "system/home.tsx#nav",
+      "topics/topics.tsx#rows",
+    ]);
+
+    expect(report).toContain("Held 2 derived sub-pattern target(s) back");
+    // Sorted, so a run's output does not reorder with the replay order.
+    expect(report.split("\n").slice(1)).toEqual([
+      "  system/home.tsx#nav",
+      "  topics/topics.tsx#rows",
+    ]);
+    // The grounds travel with the count. A held-back target read without them
+    // looks like state the gate lost rather than state it re-supplies.
+    expect(report).toContain(
+      "a hoist is derivation the updated source re-runs",
+    );
+    expect(report).toContain("root contracts still gate");
+  });
+
+  it("names the exemption list beside the paths it forgave", () => {
+    // The reader's next move is to retire the entry once the removal it was
+    // granted for is done, so the report says where that entry lives.
+    const report = reportDropsApplied(
+      new Set(["topics/topics.tsx journal", "system/home.tsx nav"]),
+    );
+
+    expect(report).toContain("Held 2 path(s) back from their vintage");
+    expect(report).toContain("tasks/pattern-vintage-accepted-drops.ts");
+    expect(report.split("\n").slice(1)).toEqual([
+      "  system/home.tsx nav",
+      "  topics/topics.tsx journal",
+    ]);
   });
 
   it("refuses --update with no test named, and says what to name", () => {

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -1015,6 +1015,47 @@ export function reportFailures(failures: readonly ReplayFailure[]): string {
 }
 
 /**
+ * What the gate prints for the derived sub-pattern targets it held back.
+ *
+ * Each line is a target whose captured state the replay did not hold today's
+ * source to, because the state is a hoist: derivation the updated source re-runs
+ * and re-supplies for itself. Naming the rule beside the count is the point — a
+ * run that held something back and said only how many is a run whose reader has
+ * to go and find out on what grounds.
+ *
+ * One target is named once however many vintages raised it, so the count is
+ * targets held back rather than times one was.
+ */
+export function reportCapturesSuperseded(
+  targets: readonly string[],
+): string {
+  const held = [...new Set(targets)].sort();
+  return [
+    `Held ${held.length} derived sub-pattern target(s) back, each with the ` +
+    `rule that held it: a hoist is derivation the updated source re-runs and ` +
+    `re-supplies (root contracts still gate):`,
+    ...held.map((target) => `  ${target}`),
+  ].join("\n");
+}
+
+/**
+ * What the gate prints for the paths an accepted removal forgave.
+ *
+ * Each line is a `pattern` and `path` pair whose vintage held a value today's
+ * source no longer reads. The exemption list is named in the text rather than
+ * left to the reader, because the list is where the entry is retired once the
+ * removal it was granted for is done with.
+ */
+export function reportDropsApplied(pairs: Iterable<string>): string {
+  const forgiven = [...pairs].sort();
+  return [
+    `Held ${forgiven.length} path(s) back from their vintage, by accepted ` +
+    `removal (tasks/pattern-vintage-accepted-drops.ts):`,
+    ...forgiven.map((pair) => `  ${pair}`),
+  ].join("\n");
+}
+
+/**
  * What the gate prints when it PASSES — built here and tested, for the same
  * reason the failure reports are: it is the whole of what a green run tells
  * whoever reads the log, and a claim assembled inline is one nothing checks.

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -130,6 +130,8 @@ import {
   describePinOutcome,
   isClean,
   relativeToRepo,
+  reportCapturesSuperseded,
+  reportDropsApplied,
   reportFailures,
   reportNothingReplayed,
   reportReplaySummary,
@@ -298,25 +300,11 @@ async function main() {
   }
 
   if (replay.capturesSuperseded.length > 0) {
-    const targets = [...new Set(replay.capturesSuperseded)].sort();
-    console.log(
-      `\nHeld ${targets.length} derived sub-pattern target(s) back, each ` +
-        `with the rule that held it: a hoist is derivation the updated ` +
-        `source re-runs and re-supplies (root contracts still gate):`,
-    );
-    for (const target of targets) {
-      console.log(`  ${target}`);
-    }
+    console.log(`\n${reportCapturesSuperseded(replay.capturesSuperseded)}`);
   }
 
   if (replay.dropsApplied.size > 0) {
-    console.log(
-      `\nHeld ${replay.dropsApplied.size} path(s) back from their vintage, ` +
-        `by accepted removal (tasks/pattern-vintage-accepted-drops.ts):`,
-    );
-    for (const pair of [...replay.dropsApplied].sort()) {
-      console.log(`  ${pair}`);
-    }
+    console.log(`\n${reportDropsApplied(replay.dropsApplied)}`);
   }
 
   // Which patterns this run is in a position to judge: a fixture's manifest


### PR DESCRIPTION
`tasks/pattern-vintage-lib.ts` states why its reports are built there: *a claim assembled inline is one nothing checks*. Two of them were still assembled in `main()` — the derived sub-pattern targets a hoist held back, and the paths an accepted removal forgave — so nothing held either to naming the grounds beside the count, and the dedup that makes the first count *targets* rather than *occurrences* was a step no test could see.

Both move beside the reports they belong with, and each gains a case: that a target raised by several vintages is named once, that both lists sort so output does not reorder with the replay, and that each carries what its reader needs next — the rule for a hoist, the exemption list for a removal. The printed text is unchanged.

## Coverage

This also repays what #6013 accepted with `ACCEPT_COVERAGE_DEBT: tasks +11 lines`.

The `pattern-vintage` job runs `tasks/pattern-vintage.ts` on every build but sets no `DENO_COVERAGE_DIR`, so the file has no LCOV record and the debt metric charges every one of its tracked lines. #6013 added 11 of them; twelve are now in a file the tests reach.

Measured with the `tasks` suite under `--coverage` on both sides:

| | `coverage-debt: tasks` |
| --- | ---: |
| `main` (c594ce8a5) | 2213 |
| this branch | **2201** |

All 19 lines added to `pattern-vintage-lib.ts` are covered, so the −12 is the entry point shrinking.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `deno task check-skill-facts`, and the full `tasks` suite (594 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



