### PR TITLE
feat(runner): make str a builtin so its module carries an identity

### DIFF
--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -28,7 +28,7 @@ import { LLMDialogResultSchema } from "../builtins/llm-schemas.ts";
 import { sqliteQueryNodeFactory } from "../builtins/sqlite/query-node.ts";
 import { isCell } from "../cell.ts";
 import { h } from "./h.ts";
-import { createNodeFactory, lift } from "./module.ts";
+import { createNodeFactory } from "./module.ts";
 import type {
   Cell as CellType,
   FactoryInput,
@@ -481,27 +481,26 @@ export function wish<T = unknown>(
   })(param);
 }
 
+let strFactory:
+  | NodeFactory<{ strings: string[]; values: unknown[] }, string>
+  | undefined;
+
 // Example:
 // str`Hello, ${name}!`
 //
-// TODO(seefeld): This should be a built-in module
 export function str(
   strings: TemplateStringsArray,
   ...values: unknown[]
 ): Reactive<string> {
-  const interpolatedString = ({
-    strings,
-    values,
-  }: {
-    strings: TemplateStringsArray;
-    values: unknown[];
-  }) =>
-    strings.reduce(
-      (result, str, i) => result + str + (i < values.length ? values[i] : ""),
-      "",
-    );
+  strFactory ||= createNodeFactory({
+    type: "ref",
+    implementation: "str",
+  });
 
-  return lift(interpolatedString)({ strings, values });
+  // Spread the template strings into a plain array: a `TemplateStringsArray`
+  // carries a `raw` property that the binding walk does not preserve, and the
+  // interpolation reads only the indexed chunks.
+  return strFactory({ strings: [...strings], values }) as Reactive<string>;
 }
 
 /**

--- a/packages/runner/src/builder/builtin-replayability.ts
+++ b/packages/runner/src/builder/builtin-replayability.ts
@@ -45,6 +45,7 @@ export const REPLAYABLE_BUILTIN_REFS: ReadonlySet<string> = new Set([
   "when",
   "unless",
   "sqliteDatabase",
+  "str",
 ]);
 
 /**

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -18,6 +18,7 @@ import {
 import { filter } from "./filter.ts";
 import { flatMap } from "./flatmap.ts";
 import { IF_ELSE_ARGUMENT_SCHEMA, ifElse } from "./if-else.ts";
+import { str, STR_ARGUMENT_SCHEMA } from "./str.ts";
 import { inspectConfLabel } from "./inspect-conf-label.ts";
 import { llmDialog } from "./llm-dialog.ts";
 import { generateObject, generateText, llm } from "./llm.ts";
@@ -65,6 +66,10 @@ export function registerBuiltins(runtime: Runtime) {
   moduleRegistry.addModuleByRef(
     "ifElse",
     raw(ifElse, { argumentSchema: IF_ELSE_ARGUMENT_SCHEMA }),
+  );
+  moduleRegistry.addModuleByRef(
+    "str",
+    raw(str, { argumentSchema: STR_ARGUMENT_SCHEMA }),
   );
   moduleRegistry.addModuleByRef("when", raw(when));
   moduleRegistry.addModuleByRef("unless", raw(unless));

--- a/packages/runner/src/builtins/str.ts
+++ b/packages/runner/src/builtins/str.ts
@@ -1,0 +1,45 @@
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+
+import { type Cell } from "../cell.ts";
+import { type Action } from "../scheduler.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+
+/**
+ * Argument schema for `str`. Both inputs are value-read: a substitution that
+ * resolves to a cell is read through this schema, so the node re-runs when
+ * that cell changes, and the interpolation sees the value rather than a link.
+ */
+export const STR_ARGUMENT_SCHEMA = internSchema({
+  type: "object",
+  properties: {
+    strings: { type: "array", items: { type: "string" } },
+    values: { type: "array" },
+  },
+});
+
+/**
+ * `str` — interpolate a template literal whose substitutions may be reactive.
+ *
+ * Concatenation matches a native template literal exactly, including how it
+ * renders `undefined`, `null`, and objects: authors reach for this in place of
+ * a template literal precisely because the cells inside it are reactive, so
+ * the rendering rules should not shift underneath them.
+ */
+export function str(
+  inputsCell: Cell<{ strings: string[]; values: unknown[] }>,
+  sendResult: (tx: IExtendedStorageTransaction, result: string) => void,
+): Action {
+  return (tx: IExtendedStorageTransaction) => {
+    const inputs = inputsCell.asSchema(STR_ARGUMENT_SCHEMA).withTx(tx).get();
+    const strings = inputs?.strings ?? [];
+    const values = inputs?.values ?? [];
+    sendResult(
+      tx,
+      strings.reduce(
+        (result, chunk, i) =>
+          result + chunk + (i < values.length ? values[i] : ""),
+        "",
+      ),
+    );
+  };
+}

--- a/packages/runner/test/str-builtin.test.ts
+++ b/packages/runner/test/str-builtin.test.ts
@@ -3,7 +3,8 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
-import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 const signer = await Identity.fromPassphrase("str builtin");
@@ -22,24 +23,30 @@ export default pattern<{ who?: Writable<string | Default<"world">> }>(({ who }) 
   }],
 });
 
+const GREETING = "return { who, greeting: str`Hello, ${who}!` };";
+
 describe("str builtin", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
-  let runtime: Runtime;
 
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({ as: signer });
-    runtime = new Runtime({
+  const newRuntime = () =>
+    new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
     });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
   });
 
   afterEach(async () => {
-    await runtime?.dispose();
     await storageManager?.close();
   });
 
-  const runProgram = async (body: string, label: string) => {
+  const runProgram = async (
+    runtime: Runtime,
+    body: string,
+    label: string,
+  ) => {
     const compiled = await runtime.patternManager.compilePattern(
       programFor(body),
     );
@@ -54,75 +61,150 @@ describe("str builtin", () => {
     const result = runtime.run(tx, compiled, {}, resultCell) as any;
     await tx.commit();
     await result.pull();
-    return result;
+    return { compiled, result };
   };
 
   it("interpolates a reactive substitution", async () => {
-    const result = await runProgram(
-      "return { who, greeting: str`Hello, ${who}!` };",
-      "interpolates",
-    );
-    expect(result.key("greeting").get()).toBe("Hello, world!");
+    const runtime = newRuntime();
+    try {
+      const { result } = await runProgram(runtime, GREETING, "interpolates");
+      expect(result.key("greeting").get()).toBe("Hello, world!");
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("recomputes when a substituted cell changes", async () => {
-    const result = await runProgram(
-      "return { who, greeting: str`Hello, ${who}!` };",
-      "recomputes",
-    );
-    expect(result.key("greeting").get()).toBe("Hello, world!");
+    const runtime = newRuntime();
+    try {
+      const { result } = await runProgram(runtime, GREETING, "recomputes");
+      expect(result.key("greeting").get()).toBe("Hello, world!");
 
-    const writeTx = runtime.edit();
-    result.withTx(writeTx).key("who").set("fabric");
-    await writeTx.commit();
-    await runtime.idle();
-    await result.pull();
-    expect(result.key("greeting").get()).toBe("Hello, fabric!");
+      const writeTx = runtime.edit();
+      result.withTx(writeTx).key("who").set("fabric");
+      await writeTx.commit();
+      await runtime.idle();
+      await result.pull();
+      expect(result.key("greeting").get()).toBe("Hello, fabric!");
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("interpolates several substitutions in order", async () => {
-    const result = await runProgram(
-      "return { who, greeting: str`a${who}b${who}c` };",
-      "several",
-    );
-    expect(result.key("greeting").get()).toBe("aworldbworldc");
+    const runtime = newRuntime();
+    try {
+      const { result } = await runProgram(
+        runtime,
+        "return { who, greeting: str`a${who}b${who}c` };",
+        "several",
+      );
+      expect(result.key("greeting").get()).toBe("aworldbworldc");
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("returns the template unchanged when it has no substitutions", async () => {
-    const result = await runProgram(
-      "return { who, greeting: str`no substitutions` };",
-      "no-subs",
-    );
-    expect(result.key("greeting").get()).toBe("no substitutions");
+    const runtime = newRuntime();
+    try {
+      const { result } = await runProgram(
+        runtime,
+        "return { who, greeting: str`no substitutions` };",
+        "no-subs",
+      );
+      expect(result.key("greeting").get()).toBe("no substitutions");
+    } finally {
+      await runtime.dispose();
+    }
   });
 
   it("renders a substitution exactly as a native template literal does", async () => {
-    const result = await runProgram(
-      "return { who, greeting: str`v=${undefined} ${null} ${{ a: 1 }}` };",
-      "native-parity",
-    );
-    // Matches `v=${undefined} ${null} ${{ a: 1 }}` evaluated natively: authors
-    // reach for `str` in place of a template literal, so the rendering rules
-    // must not shift underneath them.
-    expect(result.key("greeting").get()).toBe(
-      `v=${undefined} ${null} ${{ a: 1 }}`,
-    );
+    const runtime = newRuntime();
+    try {
+      const { result } = await runProgram(
+        runtime,
+        "return { who, greeting: str`v=${undefined} ${null} ${{ a: 1 }}` };",
+        "native-parity",
+      );
+      // Authors reach for `str` in place of a template literal, so the
+      // rendering rules must not shift underneath them.
+      expect(result.key("greeting").get()).toBe(
+        `v=${undefined} ${null} ${{ a: 1 }}`,
+      );
+    } finally {
+      await runtime.dispose();
+    }
   });
 
-  it("resolves without falling back to unverified source", async () => {
-    const fallbackCount = () =>
-      ((getLoggerCountsBreakdown() as Record<
-        string,
-        Record<string, { total?: number }>
-      >)["runner"]?.["unverified-source-fallback"]?.total) ?? 0;
+  it("compiles to a ref node naming the builtin, leaving no unverified module", async () => {
+    const runtime = newRuntime();
+    try {
+      const { compiled } = await runProgram(runtime, GREETING, "node-shape");
+      const nodes = (compiled as Pattern).nodes;
 
-    const before = fallbackCount();
-    await runProgram(
-      "return { who, greeting: str`Hello, ${who}!` };",
-      "verified",
-    );
-    // `str` resolves through the builtin registry, so nothing in this program
-    // re-evaluates stringified source in a bare SES compartment.
-    expect(fallbackCount()).toBe(before);
+      const strNode = nodes.find((node) => {
+        const module = node.module as Module;
+        return module.type === "ref" && module.implementation === "str";
+      });
+      expect(strNode).toBeDefined();
+
+      // Every javascript module the program does carry is registered, so none
+      // of them serializes body-only for a reader to re-evaluate as source.
+      for (const node of nodes) {
+        const module = node.module as Module;
+        if (module.type !== "javascript") continue;
+        expect(getVerifiedProvenance(module.implementation)).toBeDefined();
+      }
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("interpolates after resuming the piece in a cold runtime", async () => {
+    const cause = "cold-resume";
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      const tx1 = rt1.edit();
+      const compiled = await rt1.patternManager.compilePattern(
+        programFor(GREETING),
+        { space, tx: tx1 },
+      );
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        cause,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, compiled, {}, resultCell1) as any;
+      await tx1.commit();
+      await r1.pull();
+      expect(r1.key("greeting").get()).toBe("Hello, world!");
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // A fresh runtime resumes the piece from the PERSISTED graph, where the
+      // node carries the builtin's name rather than a live function.
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        cause,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+      await resultCell2.sync();
+      expect(await rt2.start(resultCell2)).toBe(true);
+      await resultCell2.pull();
+      expect(
+        (resultCell2.getAsQueryResult() as { greeting: string }).greeting,
+      ).toBe("Hello, world!");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
   });
 });

--- a/packages/runner/test/str-builtin.test.ts
+++ b/packages/runner/test/str-builtin.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("str builtin");
+const space = signer.did();
+
+const programFor = (body: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: `/// <cts-enable />
+import { NAME, pattern, str, Writable, Default } from "commonfabric";
+export default pattern<{ who?: Writable<string | Default<"world">> }>(({ who }) => {
+  ${body}
+});
+`,
+  }],
+});
+
+describe("str builtin", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const runProgram = async (body: string, label: string) => {
+    const compiled = await runtime.patternManager.compilePattern(
+      programFor(body),
+    );
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<Record<string, unknown>>(
+      space,
+      label,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(tx, compiled, {}, resultCell) as any;
+    await tx.commit();
+    await result.pull();
+    return result;
+  };
+
+  it("interpolates a reactive substitution", async () => {
+    const result = await runProgram(
+      "return { who, greeting: str`Hello, ${who}!` };",
+      "interpolates",
+    );
+    expect(result.key("greeting").get()).toBe("Hello, world!");
+  });
+
+  it("recomputes when a substituted cell changes", async () => {
+    const result = await runProgram(
+      "return { who, greeting: str`Hello, ${who}!` };",
+      "recomputes",
+    );
+    expect(result.key("greeting").get()).toBe("Hello, world!");
+
+    const writeTx = runtime.edit();
+    result.withTx(writeTx).key("who").set("fabric");
+    await writeTx.commit();
+    await runtime.idle();
+    await result.pull();
+    expect(result.key("greeting").get()).toBe("Hello, fabric!");
+  });
+
+  it("interpolates several substitutions in order", async () => {
+    const result = await runProgram(
+      "return { who, greeting: str`a${who}b${who}c` };",
+      "several",
+    );
+    expect(result.key("greeting").get()).toBe("aworldbworldc");
+  });
+
+  it("returns the template unchanged when it has no substitutions", async () => {
+    const result = await runProgram(
+      "return { who, greeting: str`no substitutions` };",
+      "no-subs",
+    );
+    expect(result.key("greeting").get()).toBe("no substitutions");
+  });
+
+  it("renders a substitution exactly as a native template literal does", async () => {
+    const result = await runProgram(
+      "return { who, greeting: str`v=${undefined} ${null} ${{ a: 1 }}` };",
+      "native-parity",
+    );
+    // Matches `v=${undefined} ${null} ${{ a: 1 }}` evaluated natively: authors
+    // reach for `str` in place of a template literal, so the rendering rules
+    // must not shift underneath them.
+    expect(result.key("greeting").get()).toBe(
+      `v=${undefined} ${null} ${{ a: 1 }}`,
+    );
+  });
+
+  it("resolves without falling back to unverified source", async () => {
+    const fallbackCount = () =>
+      ((getLoggerCountsBreakdown() as Record<
+        string,
+        Record<string, { total?: number }>
+      >)["runner"]?.["unverified-source-fallback"]?.total) ?? 0;
+
+    const before = fallbackCount();
+    await runProgram(
+      "return { who, greeting: str`Hello, ${who}!` };",
+      "verified",
+    );
+    // `str` resolves through the builtin registry, so nothing in this program
+    // re-evaluates stringified source in a bare SES compartment.
+    expect(fallbackCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
## Why

`str` built its interpolation lambda **inside its own function body**, so every call minted a fresh closure that no verified evaluation ever registered. A module like that carries neither provenance nor a verified entry ref, so it serializes body-only with no `$implRef`, and the only way to resolve it is to re-evaluate its source in a bare SES compartment — the one resolution path where module-scope references do not exist. The source itself carried `TODO(seefeld): This should be a built-in module`; this does that.

It is also the blocker for a companion change (#4749) that surfaces ref-less module resolution as a warning. `str` is used across shipped patterns, so today that warning fires on ordinary correct pattern code — and the pattern-test harness fails any test that emits logger warnings. **Measured:** `record-module-fields.test.tsx` (one of four that the warning elevation turned red) passes 13/0 with this change and the warning still enabled, and a probe pattern's `unverified-source-fallback` count goes 1 → 0 while its output is unchanged.

## What changed

- New `builtins/str.ts` — a `type: "ref"` builtin alongside map/filter/ifElse. Substitutions are read through `STR_ARGUMENT_SCHEMA`, so a substituted cell is still tracked and still triggers a re-run.
- One registration line in `builtins/index.ts`; `str()` in `built-in.ts` switches from `lift(...)` to a memoized ref factory (which left `lift` unused there).
- Template strings are spread into a plain array: `TemplateStringsArray` carries a `raw` property the binding walk does not preserve, and the interpolation reads only the indexed chunks.
- **Declared replayable.** `builtin-replayability.ts` classifies by name and fails strict, so an unlisted builtin would silently disqualify the cells it writes and the cell roots bound into its inputs. The interpolation is a pure derivation of its inputs — the classification it already had as a lift — so this preserves semantics rather than changing them.

## Two things to rule on

1. **`undefined` rendering — deliberately unchanged.** `str` renders `undefined` as `"undefined"`, `null` as `"null"`, objects as `"[object Object]"` — verified byte-identical to a native template literal. In a reactive context there is a real argument for diverging (a cell reads `undefined` transiently before it loads, and that leaks into piece names), but that changes rendered output for existing patterns, so it does not belong inside a refactor. Happy to take it as a follow-up if you want the divergence.
2. **Baseline churn.** A javascript node becomes a ref node, so node shape and any derived ids move for patterns using `str`. Nothing in the suites flagged it, but it is the risk worth a second opinion.

## Alternatives rejected

- **Hoisting the lambda to module scope**: runner-internal code is not verified-evaluated, so it still gets no provenance.
- **Host-trusting the implementation**: an execution grant with no provenance — CFC still resolves `unsupported` — and `host:<n>` identities are session-scoped, so a stored graph referencing one would not resolve on reload.
- **Transformer-lowering `str` into a hoisted lift in the authoring module**: arguably the most semantically correct, since the interpolation belongs to the pattern, but a much wider blast radius in `ts-transformers`.

## Test plan

- New `test/str-builtin.test.ts`: reactive interpolation, recompute-on-cell-change, several substitutions in order, no-substitution templates, native-parity rendering, and an assertion that the program no longer reaches the unverified-source fallback.
- `packages/runner` full suite: **1237 passed / 0 failed**
- `deno task integration pattern-tests 1/8`: **all 22 pattern tests pass**
- repo `deno task check`, `deno fmt --check`, `deno lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

