### PR TITLE
feat(tasks): refuse a literal control character in tracked source

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -120,6 +120,12 @@ jobs:
           deno task run-recorded gate repo check-conflict-markers --
           deno task check-conflict-markers
 
+      - name: 🩹 Check for literal control characters in source
+        timeout-minutes: *work-timeout
+        run: >-
+          deno task run-recorded gate repo check-control-characters --
+          deno task check-control-characters
+
       - name: 🚧 Guard the verb-session walkthrough against its demo
         timeout-minutes: *work-timeout
         run: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,10 @@ Each of these gates fails CI on its own, and none of them run as part of
   that no entry covers
 - `deno task check-conflict-markers` — an unresolved merge-conflict marker left
   in a file, which `docs/` has no other mechanical gate against
+- `deno task check-control-characters` — a literal control codepoint below 0x20,
+  other than newline, in tracked source. Written as an escape (`\x00`, `\t`) the
+  string is identical; written as the byte, a single NUL makes the whole file
+  read as binary, so `grep` skips it silently
 - `deno task check-skill-facts` — a path or import cited by a skill, an
   `AGENTS.md`, or a rule that stopped resolving
 - `deno task check-verb-session-sync` — a `cf` command or act reference in

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -48,6 +48,7 @@
     "check-docs": "deno run --allow-read --allow-write --allow-run --allow-env ./docs/check.ts",
     "check-no-waitfor": "deno run --allow-read ./tasks/check-no-waitfor.ts",
     "check-conflict-markers": "deno run --allow-read --allow-run=git ./tasks/check-conflict-markers.ts",
+    "check-control-characters": "deno run --allow-read --allow-run=git ./tasks/check-control-characters.ts",
     "check-local-program": "deno run --allow-read --allow-env --allow-run=git ./tasks/check-local-program.ts",
     "check-docs-history-index": "deno run --allow-read ./tasks/check-docs-history-index.ts",
     "check-unused-deps": "deno run --allow-read --allow-run=git ./tasks/check-unused-deps.ts",

--- a/packages/iframe-sandbox/src/outer-frame.ts
+++ b/packages/iframe-sandbox/src/outer-frame.ts
@@ -94,7 +94,7 @@ function toHost(data) {
   HOST_WINDOW.postMessage(data, HOST_ORIGIN);
 }
 
-	<\/script>
+\t<\/script>
 <\/body>
 <\/html>
 <\/html>

--- a/packages/memory/test/v2-verdict-catchup.test.ts
+++ b/packages/memory/test/v2-verdict-catchup.test.ts
@@ -879,7 +879,7 @@ Deno.test("memory v2 server: requeue after failure does not resurrect echo suppr
   }).refreshDirty = (...args) => {
     if (!failed) {
       failed = true;
-      server.markSpaceDirty(space, ["space of:doc:b"], {
+      server.markSpaceDirty(space, ["space\x00of:doc:b"], {
         sessionId: committerSessionId,
         // doc:b's ACTUAL seq: echo suppression fires only when the origin's
         // seq matches the delivered upsert's seq, so a fabricated seq would
@@ -888,7 +888,7 @@ Deno.test("memory v2 server: requeue after failure does not resurrect echo suppr
         // ("set"): a "patch" origin is delivered under CT-1965 regardless,
         // which would also let the pin pass vacuously.
         seq: 1,
-        ops: new Map([["space of:doc:b", "set" as const]]),
+        ops: new Map([["space\x00of:doc:b", "set" as const]]),
       });
       return Promise.reject(new Error("synthetic fan-out failure"));
     }

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -287,7 +287,7 @@ export function diffFingerprints(
   before: FingerprintReport,
   after: FingerprintReport,
 ): FingerprintDiff {
-  const key = (e: EntityFingerprint) => `${e.id} ${e.scope}`;
+  const key = (e: EntityFingerprint) => `${e.id}\x00${e.scope}`;
   const a = new Map(before.perEntity.map((e) => [key(e), e]));
   const b = new Map(after.perEntity.map((e) => [key(e), e]));
 

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -2005,7 +2005,7 @@ export function validateShrinkCoverage(
  * element access observed at one index matches the element position. */
 function contractPathKey(segments: readonly string[]): string {
   return segments.map((segment) => /^\d+$/.test(segment) ? "*" : segment)
-    .join(" ");
+    .join("\x00");
 }
 
 function addPrefixKeys(

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -46,10 +46,12 @@ async function fixtureRepo(
   await git(root, "add", name);
   if (options.autocrlf) {
     // Set AFTER staging, so the blob holds LF and only the checkout converts.
+    // Materialized straight from the index rather than through a commit: the
+    // conversion this reproduces happens on checkout either way, and a commit
+    // would need an author identity that a CI runner has no reason to carry.
     await git(root, "config", "core.autocrlf", "true");
-    await git(root, "commit", "-qm", "fixture");
     await Deno.remove(join(root, name));
-    await git(root, "checkout", "-q", "--", name);
+    await git(root, "checkout-index", "-f", "-a");
   }
   return root;
 }

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -103,8 +103,8 @@ describe("check-control-characters", () => {
 
   describe("isGovernedPath()", () => {
     it("governs every authored format, including ones no list named", () => {
-      // The inversion's point: an allow-list has to be complete to be true,
-      // and each of these was tracked while a list of extensions missed it.
+      // These disparate formats pin that new source types remain governed
+      // without updating a source-format registry.
       for (
         const path of [
           "tasks/a.ts",
@@ -254,11 +254,9 @@ describe("check-control-characters", () => {
     });
 
     it("catches a control byte in a blob that is not valid UTF-8", async () => {
-      // Decoding first and skipping what would not decode was fail-OPEN: this
-      // blob holds the very NUL the gate exists to catch. Raw bytes are exact
-      // here rather than a shortcut — a UTF-8 multibyte sequence is built from
-      // bytes at or above 0x80, so nothing above U+007F can contribute one
-      // below 0x20.
+      // An invalid byte elsewhere in the blob cannot hide the NUL. Raw-byte
+      // scanning is exact because UTF-8 multibyte sequences use only bytes at
+      // or above 0x80.
       const root = await fixtureRepo("subject.ts", "placeholder\n");
       await Deno.writeFile(
         join(root, "subject.ts"),

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -10,9 +10,12 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+import { fromFileUrl } from "@std/path/from-file-url";
 
 const bytes = (text: string) => new TextEncoder().encode(text);
 import {
+  blobContents,
   controlViolations,
   isGovernedPath,
   main,
@@ -298,11 +301,48 @@ describe("check-control-characters", () => {
       await expect(scan(root)).rejects.toThrow("was not fully read");
     });
 
+    it("throws when git cannot read the objects it was given", async () => {
+      // Not reachable through `scan` once `ls-files` has succeeded, and the
+      // gate's trustworthiness rests on it: a read git declined must not come
+      // back as an empty tree.
+      const root = await Deno.makeTempDir({ prefix: "check-control-no-git-" });
+      await expect(
+        blobContents(root, ["0000000000000000000000000000000000000000"]),
+      ).rejects.toThrow("git cat-file failed");
+    });
+
     it("throws when git cannot list the tree", async () => {
       // A directory that is not a repository. Reporting nothing here would be
       // a gate that silently passes over everything it was meant to read.
       const root = await Deno.makeTempDir({ prefix: "check-control-not-git-" });
       await expect(scan(root)).rejects.toThrow("git ls-files failed");
+    });
+  });
+
+  describe("as a command", () => {
+    const REPO_ROOT = fromFileUrl(new URL("..", import.meta.url));
+
+    it("exits 0 over this repository and says what it read", async () => {
+      // The only end-to-end exercise of the entry point: the permissions the
+      // shebang and the task grant, and no more.
+      const output = await runDenoCommandWithTemporaryLock({
+        root: REPO_ROOT,
+        args: (lockPath) => [
+          "run",
+          "--config",
+          join(REPO_ROOT, "deno.jsonc"),
+          "--lock",
+          lockPath,
+          "--allow-read",
+          "--allow-run=git",
+          join(REPO_ROOT, "tasks/check-control-characters.ts"),
+        ],
+      });
+      const stderr = new TextDecoder().decode(output.stderr);
+      expect(output.code, `exited non-zero:\n${stderr}`).toBe(0);
+      expect(new TextDecoder().decode(output.stdout)).toContain(
+        "No control codepoints",
+      );
     });
   });
 });

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -10,6 +10,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+
+const bytes = (text: string) => new TextEncoder().encode(text);
 import {
   controlViolations,
   isGovernedPath,
@@ -42,7 +44,9 @@ async function fixtureRepo(
 ): Promise<string> {
   const root = await Deno.makeTempDir({ prefix: "check-control-characters-" });
   await git(root, "init", "-q");
-  await Deno.writeTextFile(join(root, name), contents);
+  const at = join(root, name);
+  await Deno.mkdir(join(at, ".."), { recursive: true });
+  await Deno.writeTextFile(at, contents);
   await git(root, "add", name);
   if (options.autocrlf) {
     // Set AFTER staging, so the blob holds LF and only the checkout converts.
@@ -59,17 +63,20 @@ async function fixtureRepo(
 describe("check-control-characters", () => {
   describe("controlViolations()", () => {
     it("returns nothing for source that is only text and newlines", () => {
-      expect(controlViolations("const a = 1;\nconst b = 2;\n")).toEqual([]);
+      expect(controlViolations(bytes("const a = 1;\nconst b = 2;\n"))).toEqual(
+        [],
+      );
     });
 
     it("returns nothing for an escape written as source characters", () => {
       // The whole point of the rule: this is the spelling it asks for, so it
       // has to read as clean. These are five ordinary characters.
-      expect(controlViolations("const sep = `${a}\\x00${b}`;\n")).toEqual([]);
+      expect(controlViolations(bytes("const sep = `${a}\\x00${b}`;\n")))
+        .toEqual([]);
     });
 
     it("reports a literal NUL with the line it first appears on", () => {
-      expect(controlViolations("a\nb\nconst s = \u0000;\n")).toEqual([
+      expect(controlViolations(bytes("a\nb\nconst s = \u0000;\n"))).toEqual([
         { line: 3, code: 0x00, count: 1 },
       ]);
     });
@@ -77,59 +84,73 @@ describe("check-control-characters", () => {
     it("counts a codepoint once per file rather than once per occurrence", () => {
       // A CRLF file would otherwise report a finding per line and bury every
       // other file in the run.
-      expect(controlViolations("a\r\nb\r\nc\r\n")).toEqual([
+      expect(controlViolations(bytes("a\r\nb\r\nc\r\n"))).toEqual([
         { line: 1, code: 0x0d, count: 3 },
       ]);
     });
 
     it("reports a literal tab", () => {
-      expect(controlViolations("const a = 1;\n\tconst b = 2;\n")).toEqual([
-        { line: 2, code: 0x09, count: 1 },
-      ]);
+      expect(controlViolations(bytes("const a = 1;\n\tconst b = 2;\n")))
+        .toEqual([
+          { line: 2, code: 0x09, count: 1 },
+        ]);
     });
 
     it("allows characters at or above 0x20, including non-ASCII", () => {
-      expect(controlViolations('const s = "— ✓ é";\n')).toEqual([]);
+      expect(controlViolations(bytes('const s = "— ✓ é";\n'))).toEqual([]);
     });
   });
 
   describe("isGovernedPath()", () => {
-    it("governs the authored source extensions", () => {
+    it("governs every authored format, including ones no list named", () => {
+      // The inversion's point: an allow-list has to be complete to be true,
+      // and each of these was tracked while a list of extensions missed it.
       for (
         const path of [
           "tasks/a.ts",
           "packages/ui/b.tsx",
           "x.js",
-          "y.jsx",
-          "z.mjs",
-          "deno.json",
           "deno.jsonc",
+          "scripts/run.sh",
+          ".github/workflows/ci.yml",
+          "packages/fuse/verify-structs.c",
+          "docs/specs/memory-v2/tla/PendingStacks.tla",
+          "packages/shell/public/manifest.webmanifest",
+          "tasks/test-identity-aliases.jsonl",
+          "packages/shell/public/assets/cf.svg",
+          "Dockerfile.toolshed",
+          "docs/README.md",
         ]
       ) {
         expect(isGovernedPath(path)).toBe(true);
       }
     });
 
-    it("leaves fixtures and prose alone", () => {
-      // Text by accident rather than by authorship: a control byte there may
-      // be the data itself.
+    it("exempts formats whose contents are not text", () => {
+      for (
+        const path of ["a.png", "b.sqlite", "c.gz", "d.ttf", "e.db-wal"]
+      ) {
+        expect(isGovernedPath(path)).toBe(false);
+      }
+    });
+
+    it("exempts the named data fixtures and the trees it may not reach", () => {
       for (
         const path of [
-          "docs/README.md",
-          "packages/piece/test/vintages/x.sqlite",
-          "a.txt",
-          "b.lcov",
+          "packages/content-hash/test/fixture-frank.txt",
+          "packages/memory/memory.tldr",
+          "docs/history/specs/pattern-id-retirement.md",
+          "packages/static/assets/types/es2023.d.ts",
         ]
       ) {
         expect(isGovernedPath(path)).toBe(false);
       }
     });
 
-    it("leaves the vendored type declarations alone", () => {
-      // Upstream ships them with CRLF; rewriting a vendored artifact for the
-      // sake of a rule about our own source would be undone on re-vendoring.
-      expect(isGovernedPath("packages/static/assets/types/es2023.d.ts"))
-        .toBe(false);
+    it("governs a text file that shares a name with an exempt one", () => {
+      // The fixture is exempt by PATH, not by name: another `fixture-frank.txt`
+      // elsewhere is ordinary tracked text.
+      expect(isGovernedPath("packages/other/fixture-frank.txt")).toBe(true);
     });
   });
 
@@ -190,8 +211,21 @@ describe("check-control-characters", () => {
     });
 
     it("ignores the same byte in a file it does not govern", async () => {
-      const root = await fixtureRepo("subject.md", "prose \u0000 here\n");
+      // A binary extension. Live prose is governed now — a NUL in a Markdown
+      // document breaks grep there exactly as it does in source.
+      const root = await fixtureRepo("chart.png", "binary \u0000 here\n");
       expect(await scan(root)).toEqual([]);
+    });
+
+    it("governs live prose, and exempts only the frozen record", async () => {
+      const root = await fixtureRepo("docs/guide.md", "prose \u0000 here\n");
+      expect((await scan(root)).map((v) => v.file)).toEqual(["docs/guide.md"]);
+
+      const frozen = await fixtureRepo(
+        "docs/history/old.md",
+        "prose \u0000 here\n",
+      );
+      expect(await scan(frozen)).toEqual([]);
     });
 
     it("exits 1 and names the file when a violation stands", async () => {
@@ -219,16 +253,51 @@ describe("check-control-characters", () => {
       expect(await scan(root)).toEqual([]);
     });
 
-    it("skips a governed file whose stored bytes are not UTF-8", async () => {
-      // The extension governs, but the contents may still not decode. A file
-      // this check cannot read is one it cannot judge, not a violation.
+    it("catches a control byte in a blob that is not valid UTF-8", async () => {
+      // Decoding first and skipping what would not decode was fail-OPEN: this
+      // blob holds the very NUL the gate exists to catch. Raw bytes are exact
+      // here rather than a shortcut — a UTF-8 multibyte sequence is built from
+      // bytes at or above 0x80, so nothing above U+007F can contribute one
+      // below 0x20.
       const root = await fixtureRepo("subject.ts", "placeholder\n");
       await Deno.writeFile(
         join(root, "subject.ts"),
-        new Uint8Array([0xff, 0xfe, 0x41, 0x0a]),
+        new Uint8Array([0xff, 0x00, 0x0a]),
       );
       await gitAdd(root, "subject.ts");
+      expect(await scan(root)).toEqual([
+        { file: "subject.ts", line: 1, code: 0x00, count: 1 },
+      ]);
+    });
+
+    it("does not read a symlink's target as source", async () => {
+      // A symlink's blob is its target path and a gitlink's object is a
+      // commit; batching either lints index metadata as though it were source.
+      const root = await fixtureRepo("subject.ts", "const a = 1;\n");
+      await Deno.symlink("subject.ts", join(root, "link.ts"));
+      await gitAdd(root, "link.ts");
       expect(await scan(root)).toEqual([]);
+      expect(
+        parseIndexRecords(
+          "120000 abc123 0\tlink.ts\x00100644 def456 0\ta.ts\x00",
+        ),
+      ).toEqual([["def456", "a.ts"]]);
+    });
+
+    it("throws rather than skip a file whose blob is unavailable", async () => {
+      // A short batch would otherwise skip that file AND every file after it,
+      // and the gate would report success over source nothing read.
+      const root = await fixtureRepo("subject.ts", "const a = 1;\n");
+      const id = (await new Deno.Command("git", {
+        args: ["rev-parse", ":subject.ts"],
+        cwd: root,
+        stdout: "piped",
+      }).output()).stdout;
+      const sha = new TextDecoder().decode(id).trim();
+      await Deno.remove(
+        join(root, ".git", "objects", sha.slice(0, 2), sha.slice(2)),
+      );
+      await expect(scan(root)).rejects.toThrow("was not fully read");
     });
 
     it("throws when git cannot list the tree", async () => {

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -14,27 +14,43 @@ import {
   controlViolations,
   isGovernedPath,
   main,
+  parseBatchBlobs,
+  parseIndexRecords,
   scan,
 } from "./check-control-characters.ts";
 
 /** Helper for the tests below, which makes a git repo holding one tracked file. */
-async function fixtureRepo(name: string, contents: string): Promise<string> {
+async function git(root: string, ...args: string[]): Promise<void> {
+  const { success, stderr } = await new Deno.Command("git", {
+    args,
+    cwd: root,
+    stdout: "null",
+    stderr: "piped",
+  }).output();
+  assert(success, `git ${args.join(" ")}: ${new TextDecoder().decode(stderr)}`);
+}
+
+/** Stages a file whose contents changed after the repo was made. */
+async function gitAdd(root: string, name: string): Promise<void> {
+  await git(root, "add", name);
+}
+
+async function fixtureRepo(
+  name: string,
+  contents: string,
+  options: { autocrlf?: boolean } = {},
+): Promise<string> {
   const root = await Deno.makeTempDir({ prefix: "check-control-characters-" });
-  const run = async (...args: string[]) => {
-    const { success, stderr } = await new Deno.Command("git", {
-      args,
-      cwd: root,
-      stdout: "null",
-      stderr: "piped",
-    }).output();
-    assert(
-      success,
-      `git ${args.join(" ")}: ${new TextDecoder().decode(stderr)}`,
-    );
-  };
-  await run("init", "-q");
+  await git(root, "init", "-q");
   await Deno.writeTextFile(join(root, name), contents);
-  await run("add", name);
+  await git(root, "add", name);
+  if (options.autocrlf) {
+    // Set AFTER staging, so the blob holds LF and only the checkout converts.
+    await git(root, "config", "core.autocrlf", "true");
+    await git(root, "commit", "-qm", "fixture");
+    await Deno.remove(join(root, name));
+    await git(root, "checkout", "-q", "--", name);
+  }
   return root;
 }
 
@@ -115,6 +131,54 @@ describe("check-control-characters", () => {
     });
   });
 
+  describe("parseIndexRecords()", () => {
+    it("returns the blob id and path of each record", () => {
+      expect(
+        parseIndexRecords(
+          "100644 abc123 0\ttasks/a.ts\x00100644 def456 0\tb.md\x00",
+        ),
+      ).toEqual([["abc123", "tasks/a.ts"], ["def456", "b.md"]]);
+    });
+
+    it("keeps a path containing a space", () => {
+      expect(parseIndexRecords("100644 abc123 0\tdocs/a b.ts\x00"))
+        .toEqual([["abc123", "docs/a b.ts"]]);
+    });
+
+    it("declines a record with no path separator", () => {
+      // Guessing at a malformed record would attribute a violation to the
+      // wrong file, which is worse than reading one file fewer.
+      expect(parseIndexRecords("100644 abc123 0 no-tab-here\x00")).toEqual([]);
+    });
+  });
+
+  describe("parseBatchBlobs()", () => {
+    const encode = (text: string) => new TextEncoder().encode(text);
+    const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+    it("slices each blob by the size its header declares", () => {
+      const blobs = parseBatchBlobs(
+        encode("abc blob 2\nhi\ndef blob 3\nbye\n"),
+        2,
+      );
+      expect(blobs.map(decode)).toEqual(["hi", "bye"]);
+    });
+
+    it("keeps content that contains its own record separator", () => {
+      // The reason the size is read rather than scanned for: a blob may hold
+      // the very newline that ends its record.
+      expect(parseBatchBlobs(encode("abc blob 3\na\nb\n"), 1).map(decode))
+        .toEqual(["a\nb"]);
+    });
+
+    it("stops at a header carrying no size", () => {
+      // Continuing past one would slice every following blob at the wrong
+      // offset and report violations against the wrong files.
+      expect(parseBatchBlobs(encode("abc missing\ndef blob 2\nhi\n"), 2))
+        .toEqual([]);
+    });
+  });
+
   describe("scan()", () => {
     it("finds a literal NUL in a tracked source file", async () => {
       const root = await fixtureRepo("subject.ts", "const s = \u0000;\n");
@@ -136,6 +200,40 @@ describe("check-control-characters", () => {
     it("exits 0 for a clean tree", async () => {
       const root = await fixtureRepo("subject.ts", 'const s = "\\x00";\n');
       expect(await main(root)).toBe(0);
+    });
+
+    it("judges the stored blob, not what the checkout materialized", async () => {
+      // With `core.autocrlf=true` git writes a stored LF blob into the working
+      // tree as CRLF. Scanning the working tree would report a carriage return
+      // in source nobody wrote one in — a verdict that depends on the reader's
+      // git config rather than on the repository.
+      const root = await fixtureRepo(
+        "subject.ts",
+        "const a = 1;\nconst b = 2;\n",
+        { autocrlf: true },
+      );
+      const materialized = await Deno.readFile(join(root, "subject.ts"));
+      expect(materialized.includes(0x0d)).toBe(true);
+      expect(await scan(root)).toEqual([]);
+    });
+
+    it("skips a governed file whose stored bytes are not UTF-8", async () => {
+      // The extension governs, but the contents may still not decode. A file
+      // this check cannot read is one it cannot judge, not a violation.
+      const root = await fixtureRepo("subject.ts", "placeholder\n");
+      await Deno.writeFile(
+        join(root, "subject.ts"),
+        new Uint8Array([0xff, 0xfe, 0x41, 0x0a]),
+      );
+      await gitAdd(root, "subject.ts");
+      expect(await scan(root)).toEqual([]);
+    });
+
+    it("throws when git cannot list the tree", async () => {
+      // A directory that is not a repository. Reporting nothing here would be
+      // a gate that silently passes over everything it was meant to read.
+      const root = await Deno.makeTempDir({ prefix: "check-control-not-git-" });
+      await expect(scan(root)).rejects.toThrow("git ls-files failed");
     });
   });
 });

--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -1,0 +1,141 @@
+/**
+ * These pin a gate that fails CI, so it has to be exact in both directions.
+ *
+ * The cases that must NOT match carry most of the weight: a false positive
+ * blocks a pull request over ordinary source, and the characters here are
+ * invisible, so a reader cannot check the verdict by eye.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { assert } from "@std/assert";
+import { join } from "@std/path";
+import {
+  controlViolations,
+  isGovernedPath,
+  main,
+  scan,
+} from "./check-control-characters.ts";
+
+/** Helper for the tests below, which makes a git repo holding one tracked file. */
+async function fixtureRepo(name: string, contents: string): Promise<string> {
+  const root = await Deno.makeTempDir({ prefix: "check-control-characters-" });
+  const run = async (...args: string[]) => {
+    const { success, stderr } = await new Deno.Command("git", {
+      args,
+      cwd: root,
+      stdout: "null",
+      stderr: "piped",
+    }).output();
+    assert(
+      success,
+      `git ${args.join(" ")}: ${new TextDecoder().decode(stderr)}`,
+    );
+  };
+  await run("init", "-q");
+  await Deno.writeTextFile(join(root, name), contents);
+  await run("add", name);
+  return root;
+}
+
+describe("check-control-characters", () => {
+  describe("controlViolations()", () => {
+    it("returns nothing for source that is only text and newlines", () => {
+      expect(controlViolations("const a = 1;\nconst b = 2;\n")).toEqual([]);
+    });
+
+    it("returns nothing for an escape written as source characters", () => {
+      // The whole point of the rule: this is the spelling it asks for, so it
+      // has to read as clean. These are five ordinary characters.
+      expect(controlViolations("const sep = `${a}\\x00${b}`;\n")).toEqual([]);
+    });
+
+    it("reports a literal NUL with the line it first appears on", () => {
+      expect(controlViolations("a\nb\nconst s = \u0000;\n")).toEqual([
+        { line: 3, code: 0x00, count: 1 },
+      ]);
+    });
+
+    it("counts a codepoint once per file rather than once per occurrence", () => {
+      // A CRLF file would otherwise report a finding per line and bury every
+      // other file in the run.
+      expect(controlViolations("a\r\nb\r\nc\r\n")).toEqual([
+        { line: 1, code: 0x0d, count: 3 },
+      ]);
+    });
+
+    it("reports a literal tab", () => {
+      expect(controlViolations("const a = 1;\n\tconst b = 2;\n")).toEqual([
+        { line: 2, code: 0x09, count: 1 },
+      ]);
+    });
+
+    it("allows characters at or above 0x20, including non-ASCII", () => {
+      expect(controlViolations('const s = "— ✓ é";\n')).toEqual([]);
+    });
+  });
+
+  describe("isGovernedPath()", () => {
+    it("governs the authored source extensions", () => {
+      for (
+        const path of [
+          "tasks/a.ts",
+          "packages/ui/b.tsx",
+          "x.js",
+          "y.jsx",
+          "z.mjs",
+          "deno.json",
+          "deno.jsonc",
+        ]
+      ) {
+        expect(isGovernedPath(path)).toBe(true);
+      }
+    });
+
+    it("leaves fixtures and prose alone", () => {
+      // Text by accident rather than by authorship: a control byte there may
+      // be the data itself.
+      for (
+        const path of [
+          "docs/README.md",
+          "packages/piece/test/vintages/x.sqlite",
+          "a.txt",
+          "b.lcov",
+        ]
+      ) {
+        expect(isGovernedPath(path)).toBe(false);
+      }
+    });
+
+    it("leaves the vendored type declarations alone", () => {
+      // Upstream ships them with CRLF; rewriting a vendored artifact for the
+      // sake of a rule about our own source would be undone on re-vendoring.
+      expect(isGovernedPath("packages/static/assets/types/es2023.d.ts"))
+        .toBe(false);
+    });
+  });
+
+  describe("scan()", () => {
+    it("finds a literal NUL in a tracked source file", async () => {
+      const root = await fixtureRepo("subject.ts", "const s = \u0000;\n");
+      expect(await scan(root)).toEqual([
+        { file: "subject.ts", line: 1, code: 0x00, count: 1 },
+      ]);
+    });
+
+    it("ignores the same byte in a file it does not govern", async () => {
+      const root = await fixtureRepo("subject.md", "prose \u0000 here\n");
+      expect(await scan(root)).toEqual([]);
+    });
+
+    it("exits 1 and names the file when a violation stands", async () => {
+      const root = await fixtureRepo("subject.ts", "const s = \u0000;\n");
+      expect(await main(root)).toBe(1);
+    });
+
+    it("exits 0 for a clean tree", async () => {
+      const root = await fixtureRepo("subject.ts", 'const s = "\\x00";\n');
+      expect(await main(root)).toBe(0);
+    });
+  });
+});

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -31,14 +31,9 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 /**
  * Extensions whose contents are not text at all.
  *
- * The rule governs every tracked file by default, so what is written down is
- * the exemption rather than the coverage. That direction is deliberate: an
- * allow-list of authored formats has to be complete to be true, and each time
- * this one was written it missed something the repository already tracked —
- * C, TLA, JSONL, SVG, a web manifest, a Dockerfile with no extension at all.
- * A new binary format that is not listed here produces a false positive,
- * which someone fixes by adding a line; a new SOURCE format under an
- * allow-list produces silence, which nobody sees.
+ * Every tracked file is governed unless explicitly identified as binary.
+ * This keeps newly introduced authored formats covered automatically; an
+ * unlisted binary fails visibly and earns a reviewed exemption here.
  */
 const BINARY_EXTENSIONS: readonly string[] = [
   ".db",
@@ -113,15 +108,11 @@ export interface ControlViolation {
  * Every governed control byte in `contents`, one entry per byte value rather
  * than per occurrence.
  *
- * Scans RAW BYTES rather than decoded text, which is exact rather than a
- * shortcut: a UTF-8 multibyte sequence is built from bytes at or above 0x80,
- * so no character above U+007F can contribute a byte below 0x20. Every byte
- * under 0x20 in the stream is therefore that control character itself, and
- * counting LF bytes gives the same line numbers a decode would.
- *
- * It also fails CLOSED on a file that is not valid UTF-8. Decoding first and
- * skipping what would not decode meant a blob of `[0xff, 0x00, 0x0a]` — which
- * holds the very NUL this exists to catch — was reported clean.
+ * Raw-byte scanning is exact for UTF-8: a multibyte sequence uses only bytes
+ * at or above 0x80, so no character above U+007F can contribute a byte below
+ * 0x20. It also covers invalid UTF-8, where an unrelated invalid byte cannot
+ * hide a control byte. Counting LF bytes gives the same line numbers as
+ * decoding valid UTF-8.
  *
  * Reported per byte value because the finding a reader acts on is "this file
  * contains NULs"; a CRLF file would otherwise print a line per line of the

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -227,11 +227,16 @@ export function parseBatchBlobs(
 /**
  * The stored bytes of each blob, in the order asked for.
  *
+ * Exported for the same reason the parses are: the failure path — git
+ * declining to read the tree at all — is part of what makes this gate
+ * trustworthy, and is not reachable through `scan` once `ls-files` has
+ * already succeeded.
+ *
  * One `cat-file --batch` for the whole tree rather than a process per file:
  * the repository tracks thousands of governed files, and the difference is
  * between a gate that runs in a second and one nobody wants in CI.
  */
-async function blobContents(
+export async function blobContents(
   root: string,
   ids: readonly string[],
 ): Promise<Uint8Array[]> {

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -29,41 +29,62 @@ import { dirname, fromFileUrl } from "@std/path";
 const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 
 /**
- * Extensions this governs: the languages the repository AUTHORS.
+ * Extensions whose contents are not text at all.
  *
- * Scoped by extension rather than applied to every tracked file because the
- * tree also carries text that is not authored code, where a control byte
- * may be the data itself rather than a mistake: a `.txt` hashing fixture
- * whose CRLF endings are its whole point, a `.tldr` drawing, and the prose
- * under `docs/history/`, which is a frozen record that may not be edited to
- * satisfy a rule about today's source.
+ * The rule governs every tracked file by default, so what is written down is
+ * the exemption rather than the coverage. That direction is deliberate: an
+ * allow-list of authored formats has to be complete to be true, and each time
+ * this one was written it missed something the repository already tracked —
+ * C, TLA, JSONL, SVG, a web manifest, a Dockerfile with no extension at all.
+ * A new binary format that is not listed here produces a false positive,
+ * which someone fixes by adding a line; a new SOURCE format under an
+ * allow-list produces silence, which nobody sees.
  */
-const SOURCE_EXTENSIONS: readonly string[] = [
-  ".ts",
-  ".tsx",
-  ".js",
-  ".jsx",
-  ".mjs",
-  ".json",
-  ".jsonc",
-  ".sh",
-  ".yml",
-  ".yaml",
-  ".html",
-  ".css",
-  ".py",
-  ".toml",
-  ".cfg",
+const BINARY_EXTENSIONS: readonly string[] = [
+  ".db",
+  ".db-shm",
+  ".db-wal",
+  ".gz",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".pdf",
+  ".png",
+  ".sqlite",
+  ".ttf",
+  ".wasm",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".zip",
 ];
 
 /**
- * Paths whose contents this repository does not author.
+ * Tracked text this repository does not author as code, where a control byte
+ * is the content rather than a mistake.
  *
- * The bundled TypeScript library declarations arrive from upstream with CRLF
- * endings. Rewriting them would be a change to a vendored artifact for the
- * sake of a rule about our own source, and re-vendoring would undo it.
+ * Each is named individually rather than bucketed, because the reasons are
+ * different and a reader deciding whether to add a line needs to know which
+ * kind of case theirs is.
  */
-const VENDORED_PREFIXES: readonly string[] = [
+const EXEMPT_PATHS: readonly string[] = [
+  // A hashing fixture whose CRLF endings are the whole point of the fixture.
+  "packages/content-hash/test/fixture-frank.txt",
+  // A drawing, stored as tab-separated data.
+  "packages/memory/memory.tldr",
+];
+
+/**
+ * Trees this rule may not reach.
+ *
+ * `docs/history/` is a frozen record: `docs/README.md` permits only
+ * mechanical edits there, so a gate about today's source may not require a
+ * content change to it. The bundled TypeScript declarations arrive from
+ * upstream with CRLF, and rewriting a vendored artifact would be undone on
+ * the next re-vendoring.
+ */
+const EXEMPT_PREFIXES: readonly string[] = [
+  "docs/history/",
   "packages/static/assets/types/",
 ];
 
@@ -71,8 +92,12 @@ const VENDORED_PREFIXES: readonly string[] = [
 const NEWLINE = 0x0a;
 
 export function isGovernedPath(path: string): boolean {
-  if (VENDORED_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
-  return SOURCE_EXTENSIONS.some((extension) => path.endsWith(extension));
+  if (EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
+  if (EXEMPT_PATHS.includes(path)) return false;
+  const dot = path.lastIndexOf(".");
+  const slash = path.lastIndexOf("/");
+  const extension = dot > slash ? path.slice(dot).toLowerCase() : "";
+  return !BINARY_EXTENSIONS.includes(extension);
 }
 
 export interface ControlViolation {
@@ -85,22 +110,31 @@ export interface ControlViolation {
 }
 
 /**
- * Every governed control codepoint in `contents`, one entry per codepoint
- * rather than per occurrence.
+ * Every governed control byte in `contents`, one entry per byte value rather
+ * than per occurrence.
  *
- * Reported that way because the failure a reader needs to act on is "this
- * file contains NULs", and a file with CRLF endings would otherwise print a
- * line per line of the file and bury every other finding in the run.
+ * Scans RAW BYTES rather than decoded text, which is exact rather than a
+ * shortcut: a UTF-8 multibyte sequence is built from bytes at or above 0x80,
+ * so no character above U+007F can contribute a byte below 0x20. Every byte
+ * under 0x20 in the stream is therefore that control character itself, and
+ * counting LF bytes gives the same line numbers a decode would.
+ *
+ * It also fails CLOSED on a file that is not valid UTF-8. Decoding first and
+ * skipping what would not decode meant a blob of `[0xff, 0x00, 0x0a]` — which
+ * holds the very NUL this exists to catch — was reported clean.
+ *
+ * Reported per byte value because the finding a reader acts on is "this file
+ * contains NULs"; a CRLF file would otherwise print a line per line of the
+ * file and bury every other finding in the run.
  */
-export function controlViolations(contents: string): Omit<
+export function controlViolations(contents: Uint8Array): Omit<
   ControlViolation,
   "file"
 >[] {
   const first = new Map<number, number>();
   const counts = new Map<number, number>();
   let line = 1;
-  for (const character of contents) {
-    const code = character.codePointAt(0)!;
+  for (const code of contents) {
     if (code === NEWLINE) {
       line += 1;
       continue;
@@ -122,6 +156,10 @@ export function controlViolations(contents: string): Omit<
  * Each record is `<mode> <object> <stage>\t<path>`, NUL-separated. Split out
  * from the command so the parse is provable without a repository, including
  * the shapes it must decline rather than guess at.
+ *
+ * Only regular-file entries come back. The mode is read rather than dropped
+ * because a symlink and a submodule are both tracked entries whose object is
+ * not source.
  */
 export function parseIndexRecords(output: string): [string, string][] {
   const blobs: [string, string][] = [];
@@ -129,7 +167,11 @@ export function parseIndexRecords(output: string): [string, string][] {
     if (record === "") continue;
     const tab = record.indexOf("\t");
     if (tab === -1) continue;
-    const id = record.slice(0, tab).split(" ")[1];
+    const [mode, id] = record.slice(0, tab).split(" ");
+    // Regular files only. A symlink's blob is its target path and a gitlink's
+    // object is a commit, so batching either would lint index metadata as
+    // though it were source — and this tree tracks 49 symlinks.
+    if (mode !== "100644" && mode !== "100755") continue;
     blobs.push([id, record.slice(tab + 1)]);
   }
   return blobs;
@@ -233,20 +275,20 @@ export async function scan(root: string): Promise<ControlViolation[]> {
     .filter(([, path]) => isGovernedPath(path));
   const contents = await blobContents(root, governed.map(([id]) => id));
 
+  // Fail CLOSED on a short batch. An unavailable blob would otherwise skip
+  // that file AND every file after it, and the gate would report success over
+  // source nothing read.
+  if (contents.length !== governed.length) {
+    throw new Error(
+      `git cat-file returned ${contents.length} of ${governed.length} ` +
+        `blob(s); the tree was not fully read`,
+    );
+  }
+
   const violations: ControlViolation[] = [];
-  const decoder = new TextDecoder("utf-8", { fatal: true });
-  for (let i = 0; i < governed.length && i < contents.length; i++) {
-    const file = governed[i][1];
-    let text: string;
-    try {
-      text = decoder.decode(contents[i]);
-    } catch {
-      // A governed extension can still hold bytes that are not UTF-8. A file
-      // this cannot read is one it cannot judge, not a violation.
-      continue;
-    }
-    for (const found of controlViolations(text)) {
-      violations.push({ file, ...found });
+  for (let i = 0; i < governed.length; i++) {
+    for (const found of controlViolations(contents[i])) {
+      violations.push({ file: governed[i][1], ...found });
     }
   }
 

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env -S deno run --allow-read --allow-run=git
+/**
+ * Fails when a tracked source file contains a control codepoint below 0x20
+ * other than newline.
+ *
+ * A literal control character in source is almost always meant as a value —
+ * `"\x00"` written as the byte rather than the escape — and it reads
+ * identically to the escape at runtime while behaving differently everywhere
+ * a person or a tool looks at the FILE.
+ *
+ * A single NUL is the sharp case, because it flips the binary heuristic for
+ * the whole file: `file` reports `data` rather than source, `grep` skips the
+ * file silently rather than erroring, and the GitHub diff view renders the
+ * line wrong. A reader who greps for a symbol in such a file is told there
+ * are no matches, which is worse than being told nothing — the answer looks
+ * like an answer. The escape sequence produces the same string with none of
+ * that, so nothing is given up by requiring it.
+ *
+ * Newline is the one exception, since it is what separates the lines. A
+ * carriage return is not: a CRLF file is a line-ending accident here, and a
+ * lone CR moves the cursor rather than the line. Tab is not either — the
+ * formatter indents with spaces, so a literal tab in source is a stray.
+ *
+ * Usage: deno run --allow-read --allow-run=git ./tasks/check-control-characters.ts
+ */
+
+import { dirname, fromFileUrl } from "@std/path";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/**
+ * Extensions this governs: the languages the repository AUTHORS.
+ *
+ * Scoped by extension rather than applied to every tracked file because the
+ * tree also carries fixtures and recordings that are text by accident, where
+ * a control byte may be the data itself rather than a mistake.
+ */
+const SOURCE_EXTENSIONS: readonly string[] = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".json",
+  ".jsonc",
+];
+
+/**
+ * Paths whose contents this repository does not author.
+ *
+ * The bundled TypeScript library declarations arrive from upstream with CRLF
+ * endings. Rewriting them would be a change to a vendored artifact for the
+ * sake of a rule about our own source, and re-vendoring would undo it.
+ */
+const VENDORED_PREFIXES: readonly string[] = [
+  "packages/static/assets/types/",
+];
+
+/** The one control codepoint a source file may contain. */
+const NEWLINE = 0x0a;
+
+export function isGovernedPath(path: string): boolean {
+  if (VENDORED_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
+  return SOURCE_EXTENSIONS.some((extension) => path.endsWith(extension));
+}
+
+export interface ControlViolation {
+  file: string;
+  line: number;
+  /** The offending codepoint, e.g. `0x00`. */
+  code: number;
+  /** How many times it occurs in the file, so a CRLF file reports once. */
+  count: number;
+}
+
+/**
+ * Every governed control codepoint in `contents`, one entry per codepoint
+ * rather than per occurrence.
+ *
+ * Reported that way because the failure a reader needs to act on is "this
+ * file contains NULs", and a file with CRLF endings would otherwise print a
+ * line per line of the file and bury every other finding in the run.
+ */
+export function controlViolations(contents: string): Omit<
+  ControlViolation,
+  "file"
+>[] {
+  const first = new Map<number, number>();
+  const counts = new Map<number, number>();
+  let line = 1;
+  for (const character of contents) {
+    const code = character.codePointAt(0)!;
+    if (code === NEWLINE) {
+      line += 1;
+      continue;
+    }
+    if (code >= 0x20) continue;
+    if (!first.has(code)) first.set(code, line);
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+  return [...first].map(([code, at]) => ({
+    line: at,
+    code,
+    count: counts.get(code)!,
+  })).sort((a, b) => a.line - b.line);
+}
+
+/** Lists the repo-relative paths of every tracked file. */
+async function trackedFiles(root: string): Promise<string[]> {
+  const { success, stdout, stderr } = await new Deno.Command("git", {
+    args: ["ls-files", "-z"],
+    cwd: root,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  if (!success) {
+    throw new Error(
+      `git ls-files failed: ${new TextDecoder().decode(stderr).trim()}`,
+    );
+  }
+
+  return new TextDecoder().decode(stdout).split("\0").filter((p) => p !== "");
+}
+
+/** Scans every governed tracked file. */
+export async function scan(root: string): Promise<ControlViolation[]> {
+  const violations: ControlViolation[] = [];
+
+  for (const file of await trackedFiles(root)) {
+    if (!isGovernedPath(file)) continue;
+    let contents: string;
+    try {
+      contents = await Deno.readTextFile(`${root}/${file}`);
+    } catch (error) {
+      // A tracked path can be absent from the working tree (a sparse
+      // checkout, a submodule), and a governed extension can still hold bytes
+      // that are not UTF-8. Neither is this check's business; anything else
+      // is.
+      if (
+        error instanceof TypeError || error instanceof Deno.errors.NotFound ||
+        error instanceof Deno.errors.IsADirectory
+      ) {
+        continue;
+      }
+      throw error;
+    }
+    for (const found of controlViolations(contents)) {
+      violations.push({ file, ...found });
+    }
+  }
+
+  return violations;
+}
+
+const hex = (code: number): string =>
+  `0x${code.toString(16).padStart(2, "0").toUpperCase()}`;
+
+function reportViolations(violations: readonly ControlViolation[]): void {
+  const lines = [
+    "",
+    "Control codepoint(s) below 0x20 in tracked source:",
+    "",
+    ...violations.map((violation) =>
+      `  ${violation.file}:${violation.line}: ${hex(violation.code)}` +
+      (violation.count > 1 ? ` (${violation.count} occurrences)` : "")
+    ),
+    "",
+    "Write the value as an escape — `\\x00`, `\\t` — rather than the literal",
+    "byte. The string is the same either way, and the file stays plain text:",
+    "a single NUL makes `file` report `data`, makes `grep` skip the file",
+    "silently, and makes a diff view render the line wrong.",
+    "",
+  ];
+  console.error(lines.join("\n"));
+}
+
+/** Runs the check over `root`, reports, and returns a process code. */
+export async function main(root: string = REPO_ROOT): Promise<number> {
+  const violations = await scan(root);
+  if (violations.length > 0) {
+    reportViolations(violations);
+    return 1;
+  }
+  console.log("No control codepoints below 0x20 in tracked source.");
+  return 0;
+}
+
+if (import.meta.main) Deno.exit(await main());

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -32,8 +32,11 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
  * Extensions this governs: the languages the repository AUTHORS.
  *
  * Scoped by extension rather than applied to every tracked file because the
- * tree also carries fixtures and recordings that are text by accident, where
- * a control byte may be the data itself rather than a mistake.
+ * tree also carries text that is not authored code, where a control byte
+ * may be the data itself rather than a mistake: a `.txt` hashing fixture
+ * whose CRLF endings are its whole point, a `.tldr` drawing, and the prose
+ * under `docs/history/`, which is a frozen record that may not be edited to
+ * satisfy a rule about today's source.
  */
 const SOURCE_EXTENSIONS: readonly string[] = [
   ".ts",
@@ -43,6 +46,14 @@ const SOURCE_EXTENSIONS: readonly string[] = [
   ".mjs",
   ".json",
   ".jsonc",
+  ".sh",
+  ".yml",
+  ".yaml",
+  ".html",
+  ".css",
+  ".py",
+  ".toml",
+  ".cfg",
 ];
 
 /**
@@ -105,10 +116,38 @@ export function controlViolations(contents: string): Omit<
   })).sort((a, b) => a.line - b.line);
 }
 
-/** Lists the repo-relative paths of every tracked file. */
-async function trackedFiles(root: string): Promise<string[]> {
+/**
+ * `git ls-files -sz` output as `[blob id, path]` pairs.
+ *
+ * Each record is `<mode> <object> <stage>\t<path>`, NUL-separated. Split out
+ * from the command so the parse is provable without a repository, including
+ * the shapes it must decline rather than guess at.
+ */
+export function parseIndexRecords(output: string): [string, string][] {
+  const blobs: [string, string][] = [];
+  for (const record of output.split("\0")) {
+    if (record === "") continue;
+    const tab = record.indexOf("\t");
+    if (tab === -1) continue;
+    const id = record.slice(0, tab).split(" ")[1];
+    blobs.push([id, record.slice(tab + 1)]);
+  }
+  return blobs;
+}
+
+/**
+ * The blob id and path of every tracked file, read from the INDEX.
+ *
+ * Ids rather than paths because the content this judges is the content git
+ * stores, not the bytes a checkout materialized. Those differ: with
+ * `core.autocrlf=true` git writes a stored LF blob into the working tree as
+ * CRLF, so scanning the working tree would report a carriage return in source
+ * nobody wrote one in — a verdict that depends on the reader's git config
+ * rather than on the repository.
+ */
+async function trackedBlobs(root: string): Promise<[string, string][]> {
   const { success, stdout, stderr } = await new Deno.Command("git", {
-    args: ["ls-files", "-z"],
+    args: ["ls-files", "-sz"],
     cwd: root,
     stdout: "piped",
     stderr: "piped",
@@ -120,32 +159,93 @@ async function trackedFiles(root: string): Promise<string[]> {
     );
   }
 
-  return new TextDecoder().decode(stdout).split("\0").filter((p) => p !== "");
+  return parseIndexRecords(new TextDecoder().decode(stdout));
 }
 
-/** Scans every governed tracked file. */
-export async function scan(root: string): Promise<ControlViolation[]> {
-  const violations: ControlViolation[] = [];
+/**
+ * `git cat-file --batch` output as one byte range per blob.
+ *
+ * Each record is `<id> blob <size>\n`, then exactly `<size>` bytes, then a
+ * newline. The size comes from the header rather than from scanning for a
+ * delimiter, because the content may hold any byte — including the newline
+ * that ends its own record. A header that does not carry a size stops the
+ * parse rather than being guessed at: continuing would slice the following
+ * blobs at the wrong offsets and report violations against the wrong files.
+ */
+export function parseBatchBlobs(
+  output: Uint8Array,
+  count: number,
+): Uint8Array[] {
+  const contents: Uint8Array[] = [];
+  let at = 0;
+  while (at < output.length && contents.length < count) {
+    let lineEnd = at;
+    while (lineEnd < output.length && output[lineEnd] !== 0x0a) lineEnd++;
+    const header = new TextDecoder().decode(output.subarray(at, lineEnd));
+    const size = Number(header.split(" ")[2]);
+    if (!Number.isInteger(size)) break;
+    const start = lineEnd + 1;
+    contents.push(output.subarray(start, start + size));
+    at = start + size + 1;
+  }
+  return contents;
+}
 
-  for (const file of await trackedFiles(root)) {
-    if (!isGovernedPath(file)) continue;
-    let contents: string;
+/**
+ * The stored bytes of each blob, in the order asked for.
+ *
+ * One `cat-file --batch` for the whole tree rather than a process per file:
+ * the repository tracks thousands of governed files, and the difference is
+ * between a gate that runs in a second and one nobody wants in CI.
+ */
+async function blobContents(
+  root: string,
+  ids: readonly string[],
+): Promise<Uint8Array[]> {
+  if (ids.length === 0) return [];
+  const command = new Deno.Command("git", {
+    args: ["cat-file", "--batch"],
+    cwd: root,
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "null",
+  }).spawn();
+
+  // Start draining stdout BEFORE writing the ids. git writes as it reads, and
+  // the whole tree's contents far exceed a pipe buffer, so a writer that held
+  // the output unread until it finished would deadlock against a git that
+  // cannot accept more input until someone consumes what it has already
+  // produced.
+  const output = command.output();
+  const writer = command.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(ids.join("\n") + "\n"));
+  await writer.close();
+
+  const { success, stdout } = await output;
+  if (!success) throw new Error("git cat-file failed");
+
+  return parseBatchBlobs(stdout, ids.length);
+}
+
+/** Scans every governed tracked file, as git stores it. */
+export async function scan(root: string): Promise<ControlViolation[]> {
+  const governed = (await trackedBlobs(root))
+    .filter(([, path]) => isGovernedPath(path));
+  const contents = await blobContents(root, governed.map(([id]) => id));
+
+  const violations: ControlViolation[] = [];
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let i = 0; i < governed.length && i < contents.length; i++) {
+    const file = governed[i][1];
+    let text: string;
     try {
-      contents = await Deno.readTextFile(`${root}/${file}`);
-    } catch (error) {
-      // A tracked path can be absent from the working tree (a sparse
-      // checkout, a submodule), and a governed extension can still hold bytes
-      // that are not UTF-8. Neither is this check's business; anything else
-      // is.
-      if (
-        error instanceof TypeError || error instanceof Deno.errors.NotFound ||
-        error instanceof Deno.errors.IsADirectory
-      ) {
-        continue;
-      }
-      throw error;
+      text = decoder.decode(contents[i]);
+    } catch {
+      // A governed extension can still hold bytes that are not UTF-8. A file
+      // this cannot read is one it cannot judge, not a violation.
+      continue;
     }
-    for (const found of controlViolations(contents)) {
+    for (const found of controlViolations(text)) {
       violations.push({ file, ...found });
     }
   }

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -394,9 +394,16 @@ export function shouldRecord(findings: readonly Finding[]): boolean {
   return findings.length === 1 && findings[0].kind === "missing-baseline";
 }
 
-/** One `(pattern, baseline)` pair an accepted break forgives. */
+/**
+ * One `(pattern, baseline)` pair an accepted break forgives.
+ *
+ * NUL is the separator because it is the one byte neither half can contain,
+ * so no two pairs can produce the same key. It is written as an ESCAPE: the
+ * literal byte in the source would make the whole file read as binary, which
+ * `deno task check-control-characters` refuses for exactly that reason.
+ */
 export const acceptedBreakKey = (pattern: string, baseline: string): string =>
-  `${pattern} ${baseline}`;
+  `${pattern}\x00${baseline}`;
 
 /**
  * The schema paths an incompatibility finding blames.


### PR DESCRIPTION
Per the thread on the first revision: the complaint is about a **literal NUL in the source file**, and the straightforward fix is the escape — so this is now the lint rule @hixie and @danfuzz asked for, plus the escape at the site that prompted it.

## The rule

No tracked source file may contain a control codepoint below `0x20` other than newline. Written as an escape (`\x00`, `\t`) the runtime string is identical; written as the byte it changes how every tool sees the FILE.

NUL is the sharp case, because a single one flips the binary heuristic for the whole file:

| separator | `file` | `grep` finds text either side |
| --- | --- | --- |
| `\x00` NUL | `data` | **no — skipped, silently** |
| `\x1f` unit separator | `data` | yes |
| `\x01` SOH | `data` | yes |
| escape `\x00` (5 chars) | `ASCII text` | yes |

So `file` is not the discriminator — plenty of control bytes make it say `data` — and the problem is specifically the byte that trips grep's binary check. A reader who greps a symbol in such a file is told there are no matches, which is worse than being told nothing: the answer looks like an answer. It cost me two detours in one session, once believing a file was corrupt and once believing it had already been fixed, because `sed` and the GitHub diff view both render the byte as though it were a space. @danfuzz called that one before seeing it.

Newline is the one exception. Carriage return is not — a CRLF file here is a line-ending accident, and a lone CR moves the cursor rather than the line. Tab is not either, since the formatter indents with spaces.

## What it found

Four violations, every one of them the same class @hixie described:

- `packages/memory/test/v2-verdict-catchup.test.ts` — 2 NULs in a fixture key
- `packages/state-inspector/fingerprint.ts` — NUL joining a fingerprint key
- `packages/ts-transformers/src/transformers/type-shrinking.ts` — NUL joining a path key
- `packages/iframe-sandbox/src/outer-frame.ts` — a tab inside a template literal

All four are the escape now, so **every runtime string is byte-identical**. `acceptedBreakKey` still separates its halves with codepoint 0 — verified by printing the codepoints — and `pattern-compat` still forgives the same accepted breaks across the same patterns.

## Scope

Every tracked regular-file blob is governed by default. The gate reads paths and object IDs from the Git index with `git ls-files -sz`, then reads the stored contents through one `git cat-file --batch` process. Its verdict therefore does not depend on `core.autocrlf` or another checkout transformation. Symlinks and gitlinks are skipped because their objects are repository metadata rather than source-file contents.

The scan operates on raw bytes. That is exact for UTF-8 because every multibyte-sequence byte is at least `0x80`, and it means an unrelated invalid UTF-8 byte cannot hide a control byte. An incomplete or malformed Git batch fails the check instead of silently skipping a blob.

The exemptions are deliberately narrow:

- binary formats identified by extension
- `packages/content-hash/test/fixture-frank.txt`, whose CRLF is fixture data
- `packages/memory/memory.tldr`, a tab-separated drawing
- `docs/history/`, the repository's frozen record
- `packages/static/assets/types/`, vendored declarations that arrive with CRLF

A new authored format is covered automatically. A new binary format produces a visible false positive and earns a reviewed exemption.

Wired as `deno task check-control-characters`, a CI step beside the other repo gates, and listed in `AGENTS.md`. A codepoint is reported once per file with an occurrence count, so a CRLF file names itself once instead of burying the run.

## Checks

`deno task check`, `deno fmt --check`, `deno lint`, the checker suite (31 steps), and a clean repository-wide `check-control-characters` scan. Package suites for the runtime-preserving escape changes: ts-transformers 1160, memory 527, state-inspector + pattern-compat-lib 113.

After rebasing onto current `main`, reran the 31-step checker suite, the repository-wide scan, and focused format, lint, and type checks for the checker plus the conflict-resolved iframe source.

<sub>Authored by Claude (Fable 5, then Opus 5) on @gideonwald's behalf.</sub>
