### PR TITLE
fix(runner): writer-fit admits a document's own space principal

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -195,9 +195,21 @@ The strict-only delta is:
   join landing as a target's `derived` value component is measured against the
   target's DECLARED store-policy component (declared + legacy entries, resolved
   by the same per-component longest-prefix rule reads use; absent declarations
-  are the empty "public" ceiling, fail-closed) at each path where the component
-  lands, with the shared clause-subsumption predicate of the egress gates
-  (`atomsOutsideCeiling`). Under `enforce-strict` a misfit records a prepare
+  are the empty "public" ceiling, fail-closed) joined with the target's
+  RESIDENCY clause at each path where the component lands, with the shared
+  clause-subsumption predicate of the egress gates (`atomsOutsideCeiling`).
+  The residency clause is `Space(<the space the document lives in>)`. That
+  atom's audience is the space's reader set — §4.9.3 resolves it by
+  dereferencing its id against the space's ACL, the same document that decides
+  who receives a replica — so every principal holding the bytes is inside the
+  audience it names, and a flow clause listing the target's own space among
+  its alternatives fits a document there whatever that document declares. The
+  measurement admits the write; it does not drop the clause. The stamp
+  persists the full join, so the egress and display ceilings gate reads on the
+  unchanged label, and the space principal there reaches a concrete reader
+  only through the verified `HasRole` exchange rule. Residency inherits the
+  bound the render membership lookup carries: it is exactly as strong as the
+  deployment's ACL posture. Under `enforce-strict` a misfit records a prepare
   reason and the commit rejects; every mode below persists the measurement and
   flags a `writer-fit(persist-and-flag)` diagnostic carrying the same reason
   string — so `enforce-explicit` keeps the shipped persist-and-flag posture
@@ -207,7 +219,13 @@ The strict-only delta is:
   <clauses>`. Scope note (v1): link-covered writes carry per-slot link labels
   instead of the join and are outside the check, as is the pure-link-structure
   shape channel; grown existence atoms (SC-4) are historical and deliberately
-  never measured — only the current join is. Implementation in
+  never measured — only the current join is; `Space` is the only principal
+  form residency admits, because `PersonalSpace`, `User`, and the bare
+  DID-string spelling all gate by equality against one acting reader, making
+  their audience a person rather than the container and so narrower than the
+  set of principals a space grants reader roles to; and the ungrantable
+  read-failed marker sits outside every ceiling, the residency clause
+  included, so a poisoned measurement never proves fit. Implementation in
   [prepare.ts](../../packages/runner/src/cfc/prepare.ts) (`prepareBoundaryCommit`
   flow-persist stamping), asserted both ways in
   [cfc-writer-fit.test.ts](../../packages/runner/test/cfc-writer-fit.test.ts).
@@ -232,6 +250,14 @@ four-dial matrix, the "no consuming enforcement ahead of its producing dial"
 ordering constraint, and the `enforce-strict` reject set. File it once H4's code
 step lands and the strict rejects have concrete reason contracts to cite.
 Tracked in [`cfc-spec-changes.md`](./cfc-spec-changes.md) SC-13.
+
+The residency half of the writer-fit ceiling is owed to the spec as well:
+§8.12.4 states the fit against the declared policy and says nothing about the
+space a document lives in widening it. The same PR should make residency part
+of the write ceiling, state that only the container-naming `Space` form
+counts, and record that residency admits the write without altering the
+persisted label. Tracked in
+[`cfc-spec-changes.md`](./cfc-spec-changes.md) SC-18(d).
 
 ## Provenance
 

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -317,13 +317,29 @@ names, and the write reaches no reader the data had not already reached. The
 guarantee is therefore exactly as strong as the deployment's ACL posture, the
 same bound the §4.9.3 membership lookup carries.
 
-The rule is confined to `Space` deliberately. `PersonalSpace`, `User`, and the
-bare DID-string spelling gate by equality against a single acting reader —
-§4.6.4.2 field classification groups `PersonalSpace.owner` with `User.subject`
-for that reason, while only `Space.id` stays public so it can be dereferenced
-— so their audience is a person rather than the container. A space grants
-reader roles its owner does not hold in person, so admitting those forms would
-place data readable by one principal into a store its co-readers sync. Reading
+The rule is confined to `Space` deliberately. §3.6.4 gives a personal space
+fixed membership — its owner alone — and says sharing happens by moving the
+data to a shared space or by converting the personal space into one, so
+`PersonalSpace(<owner>)` names a single principal rather than a container with
+a reader set. The runtime agrees: no exchange rule maps a space reader onto a
+`PersonalSpace` clause, the display ceiling admits it only by exact match
+against the acting user, and the deployment's §4.6.4.2 field classification
+commits `PersonalSpace.owner` alongside `User.subject` while keeping
+`Space.id` public precisely so §4.9.3's point query can dereference it. A
+space grants reader roles its owner does not hold in person, so admitting
+those forms would place data readable by one principal into a store its
+co-readers sync.
+
+One spec question this exposes and should settle: §4.9.4 describes
+`HasRole(user, PersonalSpace(User), reader)` as minted by a §4.9.3 point query
+against that space's own ACL record, and calls it one of "the two `Space(...)`
+atoms", which reads `PersonalSpace` as an ACL-dereferenced container atom. That
+sits in tension with §3.6.4's fixed membership, and with a deployment
+classification that commits the very field such a point query would have to
+read. If `PersonalSpace` is genuinely ACL-dereferenced, its audience is the
+space's reader set and residency admits it on the same footing as `Space`;
+if membership is fixed, it names one principal and residency must not. The
+implementation takes the second reading, which is the fail-closed one. Reading
 back is unaffected in every case: the derived stamp persists the full join, so
 the egress and display ceilings fit the unchanged label, and the space
 principal there resolves to a reader only through the §4.3.3

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -300,8 +300,45 @@ string) under every lower mode, with the stable SC-18c reason
 <offending clauses>`. Contract text in
 `docs/specs/cfc-enforcement-matrix.md` §4; implementation in
 `prepareBoundaryCommit` (runner `cfc/prepare.ts`) sharing the egress gates'
-clause-subsumption predicate; tests `cfc-writer-fit.test.ts`. Only (a) — the
-standard-profile default — stays open on the confidentiality side.
+clause-subsumption predicate; tests `cfc-writer-fit.test.ts`. Two items stay
+open on the confidentiality side: (a) the standard-profile default, and (d)
+the residency half of the write ceiling, recorded next.
+
+(d) **[normative] Residency fit — the ceiling a document carries by living
+where it lives.** The fit measurement joins the target's declared policy with
+one RESIDENCY clause, `Space(<the space the document resides in>)`. A flow
+clause listing that space among its alternatives therefore fits the document
+whatever it declares. The soundness argument is that writing into the space
+the clause already names discloses nothing: the `Space` atom's audience is
+that space's reader set — §4.9.3 resolves it by dereferencing its id against
+the space's ACL, the same document that decides who receives a replica — so
+every principal holding the target is inside the audience the alternative
+names, and the write reaches no reader the data had not already reached. The
+guarantee is therefore exactly as strong as the deployment's ACL posture, the
+same bound the §4.9.3 membership lookup carries.
+
+The rule is confined to `Space` deliberately. `PersonalSpace`, `User`, and the
+bare DID-string spelling gate by equality against a single acting reader —
+§4.6.4.2 field classification groups `PersonalSpace.owner` with `User.subject`
+for that reason, while only `Space.id` stays public so it can be dereferenced
+— so their audience is a person rather than the container. A space grants
+reader roles its owner does not hold in person, so admitting those forms would
+place data readable by one principal into a store its co-readers sync. Reading
+back is unaffected in every case: the derived stamp persists the full join, so
+the egress and display ceilings fit the unchanged label, and the space
+principal there resolves to a reader only through the §4.3.3
+`SpaceReaderAccess` exchange rule on verified `HasRole` membership. The
+ungrantable read-failed marker stays outside the residency clause as it stays
+outside every ceiling.
+
+Spec home: §8.12.4's `canWrite`, alongside the declared-policy measurement.
+Two points the spec should settle explicitly. Residency is a property of the
+store rather than a carve-out for an atom family: a store satisfies a clause
+whose audience already contains everyone the store's bytes reach. And
+residency holds over a declared policy rather than only in its absence — a
+declaration narrower than the physical audience of the space cannot be
+enforced by the store anyway, and making residency a fallback would mean that
+adding a narrow declaration newly breaks space-internal flows.
 
 The **integrity direction** is genuinely unstated (§8.12.4's `canWrite`
 checks confidentiality only; §8.10.3's `requiredIntegrity` is consume-side)

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -6107,7 +6107,8 @@ export const prepareBoundaryCommit = (
       // H4 writer-fit (SC-18b, §8.12.4 `canWrite`): the per-tx join landing
       // below as this target's `derived` value component is the measurement
       // of the written value's actual taint, and canWrite demands it fit the
-      // store's DECLARED policy component at each path where it lands. The
+      // target's write ceiling at each path where it lands — the store's
+      // DECLARED policy component joined with the residency clause below. The
       // policy component is the declared + legacy entries only — link/
       // derived/structure entries are per-value data components (§8.12.8),
       // not store policy — and of those, only the entries a VALUE read
@@ -6121,10 +6122,28 @@ export const prepareBoundaryCommit = (
       // (SC-4 freeze-at-creation) and measuring them would permanently
       // misfit clean overwrites of a store created under taint.
       // A schema declaring a covering policy in this same tx passes by
-      // construction — §8.12.5's monotone-safe upgrade route; the other two
-      // outs are writing to a fitting store or not writing. Link-covered
-      // writes carry per-slot link labels instead of the join and are
-      // outside this v1 check, as is the pure-link-structure shape channel.
+      // construction — §8.12.5's monotone-safe upgrade route; the other outs
+      // are writing to a fitting store, writing to a store whose space the
+      // clause already names, and not writing. Link-covered writes carry
+      // per-slot link labels instead of the join and are outside this v1
+      // check, as is the pure-link-structure shape channel.
+      // §8.12.4 residency: `Space(<this space>)` joins each path's declared
+      // ceiling, so a flow clause listing the target's own space among its
+      // alternatives fits a document stored there, and a clause without such
+      // an alternative measures against the declared policy alone. The atom's
+      // audience is the space's reader set — §4.9.3 resolves it against the
+      // space's ACL, the same document that decides who receives a replica —
+      // so it already contains every principal the stored bytes reach, and
+      // the guarantee is as strong as the deployment's ACL posture. The flow
+      // stamp below persists the full join, leaving the egress and display
+      // gates the unchanged label.
+      //
+      // `Space` is the only form admitted here. `PersonalSpace` and the bare
+      // DID-string spelling gate by equality against one acting reader
+      // (`label-field-classification.ts` classes their subject fields with
+      // `User.subject`), so they name a person rather than the container and
+      // reach a narrower audience than the space's readers.
+      const residencyCeiling: readonly CfcConfClause[] = [cfcAtom.space(space)];
       const declaredPolicyEntries = flowConfidentiality.length > 0
         ? persistedLabelEntries.filter((entry) =>
           (entry.origin === undefined || entry.origin === "declared") &&
@@ -6233,17 +6252,22 @@ export const prepareBoundaryCommit = (
           // Absent declared entries resolve to the EMPTY ceiling ("public
           // store"), never the undefined "no ceiling" — a tainted write to
           // an undeclared store is the canonical misfit, and fitting it
-          // by default would hollow the rule out. Clause membership is the
-          // shared subsumption predicate of the egress/observation gates,
-          // so writer-fit cannot drift from what a ceiling admits — and the
-          // ungrantable read-failed marker stays outside every declared
-          // policy (a poisoned measurement never proves fit).
+          // by default would hollow the rule out. The residency clause is
+          // then the whole ceiling, so only the target's own space audience
+          // fits. Clause membership is the shared subsumption predicate of
+          // the egress/observation gates, so writer-fit cannot drift from
+          // what a ceiling admits — and the ungrantable read-failed marker
+          // stays outside every ceiling, the residency clause included (a
+          // poisoned measurement never proves fit).
           const declaredCeiling =
             labelForEntriesAtPath(declaredPolicyEntries, path)
               ?.confidentiality ?? [];
           const offending = atomsOutsideCeiling(
             flowConfidentiality,
-            declaredCeiling as readonly CfcConfClause[],
+            [
+              ...declaredCeiling as readonly CfcConfClause[],
+              ...residencyCeiling,
+            ],
           );
           if (offending.length > 0) {
             // SC-18c error contract: a stable reason naming the rule id and

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -1,9 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { FabricValue } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
+import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-writer-fit");
 
@@ -47,9 +50,20 @@ const newRuntime = (
     cfcFlowLabels: "persist",
   });
 
-// Seed a source doc whose `secret` field carries a confidentiality label, and
-// return a transaction that read it (tainting the per-tx flow join).
-const seedSecretSource = async (runtime: Runtime, name: string) => {
+// The space principal of the space every doc in this file lives in — the
+// clause residency admits (§8.12.4).
+const ownSpacePrincipal = {
+  type: "https://commonfabric.org/cfc/atom/Space",
+  id: signer.did(),
+};
+
+// Seed a source doc whose `secret` field carries `confidentiality`, so a
+// transaction reading it takes those clauses into the per-tx flow join.
+const seedSecretSource = async (
+  runtime: Runtime,
+  name: string,
+  confidentiality: readonly FabricValue[] = ["secret"],
+) => {
   const seed = runtime.edit();
   const sourceCell = runtime.getCell(
     signer.did(),
@@ -74,7 +88,7 @@ const seedSecretSource = async (runtime: Runtime, name: string) => {
         version: 1,
         entries: [{
           path: ["secret"],
-          label: { confidentiality: ["secret"] },
+          label: { confidentiality: [...confidentiality] },
         }],
       },
     },
@@ -82,13 +96,47 @@ const seedSecretSource = async (runtime: Runtime, name: string) => {
   expect((await seed.commit()).ok).toBeDefined();
 };
 
+// Read the seeded source in a fresh transaction at `mode`, derive a value
+// into `targetName`, and commit. `targetSchema` declares the target's store
+// policy; omitted, the target declares nothing.
+const deriveIntoTarget = async (
+  runtime: Runtime,
+  sourceName: string,
+  targetName: string,
+  mode: "enforce-strict" | "enforce-explicit" = "enforce-strict",
+  targetSchema?: JSONSchema,
+) => {
+  const tx = runtime.edit();
+  tx.setCfcEnforcementMode(mode);
+  const source = runtime.getCell(signer.did(), sourceName, undefined, tx);
+  const raw = source.getRaw() as { secret?: string };
+  const target = runtime.getCell<{ copied?: string }>(
+    signer.did(),
+    targetName,
+    targetSchema,
+    tx,
+  );
+  target.set({ copied: `${raw.secret}!` });
+  const targetId = target.getAsNormalizedFullLink().id;
+  tx.prepareCfc();
+  return { tx, targetId, result: await tx.commit() };
+};
+
+// The writer-fit reasons this transaction recorded, whether they rejected the
+// commit or landed as persist-and-flag diagnostics.
+const writerFitDiagnostics = (
+  tx: { getCfcState(): { diagnostics: string[] } },
+) => tx.getCfcState().diagnostics.filter((d) => d.includes("writer-fit"));
+
 // H4 writer-fit (SC-18b, spec §8.12.4): a write whose derived flow label does
-// not fit the target's DECLARED store policy. Under `enforce-explicit` the
-// derived component is a measurement, not a write ceiling — the write
+// not fit the target's write ceiling — its DECLARED store policy joined with
+// the residency clause its own space contributes. Under `enforce-explicit`
+// the derived component is a measurement, not a write ceiling — the write
 // persists and the misfit is flagged as a diagnostic (SC-18a/c). Under
 // `enforce-strict` the same misfit is a fail-closed reject (the strict-only
 // delta of docs/specs/cfc-enforcement-matrix.md §4), leaving the §8.12.5
-// outs: upgrade the store label in the same tx, or write to a fitting store.
+// outs: upgrade the store label in the same tx, write to a fitting store, or
+// write to a store whose space the clause already names.
 describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
   it("rejects a confidentiality misfit under enforce-strict with the SC-18c reason", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
@@ -107,8 +155,8 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       const raw = source.getRaw() as { secret?: string };
       expect(raw.secret).toBe("s3cr3t");
 
-      // Target doc declares NO store policy: its declared label is public,
-      // so a secret-tainted derived component cannot fit.
+      // Target doc declares NO store policy, so residency is its whole
+      // ceiling: a `secret`-tainted component, naming no space, cannot fit.
       const derived = runtime.getCell(
         signer.did(),
         "writer-fit-strict-derived",
@@ -305,9 +353,200 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
       expect(result.error?.message).toContain(
         "writer-fit confidentiality misfit",
       );
-      // The reason names the clause(s) outside the declared policy so the
+      // The reason names the clause(s) outside the write ceiling so the
       // flag identifies exactly what the store would need to declare.
       expect(result.error?.message).toContain('"secret"');
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("admits a same-space principal clause into an undeclared store under enforce-strict", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      // The source's confidentiality names this space's own principal, so
+      // residency fits the tainted write below even though the target
+      // declares nothing.
+      await seedSecretSource(runtime, "wf-samespace-source", [
+        ownSpacePrincipal,
+      ]);
+      const { tx, targetId, result } = await deriveIntoTarget(
+        runtime,
+        "wf-samespace-source",
+        "wf-samespace-derived",
+      );
+      expect(result.error?.message).toBeUndefined();
+
+      // The fit is a write admission, not a label drop: the derived stamp
+      // still carries the space principal for the egress gates.
+      const flowEntry = replicaEntries(storageManager, targetId)
+        .find((e) => e.origin === "derived");
+      expect(flowEntry).toBeDefined();
+      expect(flowEntry!.label.confidentiality).toContainEqual(
+        ownSpacePrincipal,
+      );
+      expect(writerFitDiagnostics(tx)).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("admits a clause carrying the space principal as one alternative", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      // Residency reaches into an OR-clause: the ceiling clause subsumes a
+      // label clause listing the space among its alternatives.
+      await seedSecretSource(runtime, "wf-alternative-source", [{
+        anyOf: [
+          {
+            type: "https://commonfabric.org/cfc/atom/User",
+            subject: "did:key:zReader",
+          },
+          ownSpacePrincipal,
+        ],
+      }]);
+      const { tx, result } = await deriveIntoTarget(
+        runtime,
+        "wf-alternative-source",
+        "wf-alternative-derived",
+      );
+      expect(result.error?.message).toBeUndefined();
+      expect(writerFitDiagnostics(tx)).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("raises no persist-and-flag diagnostic for a same-space clause under enforce-explicit", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      // The measurement is one computation feeding both the strict reject and
+      // the lower-mode diagnostic, so a residency fit is silent at every rung.
+      await seedSecretSource(runtime, "wf-explicit-source", [
+        ownSpacePrincipal,
+      ]);
+      const { tx, result } = await deriveIntoTarget(
+        runtime,
+        "wf-explicit-source",
+        "wf-explicit-derived",
+        "enforce-explicit",
+      );
+      expect(result.error?.message).toBeUndefined();
+      expect(writerFitDiagnostics(tx)).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects a principal naming a space other than the target's", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSecretSource(runtime, "wf-foreignspace-source", [{
+        type: "https://commonfabric.org/cfc/atom/Space",
+        id: "did:key:zForeignSpace",
+      }]);
+      const { result } = await deriveIntoTarget(
+        runtime,
+        "wf-foreignspace-source",
+        "wf-foreignspace-derived",
+      );
+      expect(result.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(result.error?.message).toContain("zForeignSpace");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects the personal-space principal form under enforce-strict", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSecretSource(runtime, "wf-personalspace-source", [{
+        type: "https://commonfabric.org/cfc/atom/PersonalSpace",
+        owner: signer.did(),
+      }]);
+      const { result } = await deriveIntoTarget(
+        runtime,
+        "wf-personalspace-source",
+        "wf-personalspace-derived",
+      );
+      // `PersonalSpace` gates by equality against one acting reader, so its
+      // audience is a person rather than the space's reader set. Residency
+      // does not admit it, even though the owner DID matches this space's.
+      expect(result.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(result.error?.message).toContain("PersonalSpace");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects the bare DID-string principal that the declared policy omits", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      // Two clauses: one the target's declared policy lists, one it does not
+      // — the bare DID-string spelling, which names a reader by identity
+      // rather than naming the container.
+      await seedSecretSource(runtime, "wf-baredid-source", [
+        "internal",
+        signer.did(),
+      ]);
+      const { result } = await deriveIntoTarget(
+        runtime,
+        "wf-baredid-source",
+        "wf-baredid-derived",
+        "enforce-strict",
+        {
+          type: "object",
+          properties: { copied: { type: "string" } },
+          ifc: { confidentiality: ["internal"] },
+        },
+      );
+      expect(result.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(result.error?.message).toContain(signer.did());
+      expect(result.error?.message).not.toContain('"internal"');
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects a read-failed marker clause that lists a same-space alternative", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      // The ungrantable marker stays outside every ceiling, the residency
+      // clause included. This is also the fence against reimplementing the
+      // rule as a filter over the measured label, which would drop the
+      // clause before the marker check ever ran.
+      await seedSecretSource(runtime, "wf-poisoned-source", [{
+        anyOf: [CFC_LABEL_READ_FAILED_ATOM, ownSpacePrincipal],
+      }]);
+      const { result } = await deriveIntoTarget(
+        runtime,
+        "wf-poisoned-source",
+        "wf-poisoned-derived",
+      );
+      expect(result.error?.message).toContain(
+        "writer-fit confidentiality misfit",
+      );
+      expect(result.error?.message).toContain(CFC_LABEL_READ_FAILED_ATOM);
     } finally {
       await runtime.dispose();
       await storageManager.close();


### PR DESCRIPTION
The §8.12.4 writer-fit check measures a transaction's confidentiality flow join against the target document's declared store policy, and an absent declaration resolves to the empty "public" ceiling. A clause naming the space the target document lives in therefore misfits on every undeclared store. Under `enforce-strict` that rejects ordinary space-internal flows. A handler that reads a space-labeled piece document and appends to the space's own piece registry has no way to commit: the registry declares nothing, so the space principal the handler picked up has nowhere to fit.

The fix gives every document the ceiling it carries by living where it lives. The fit measurement now joins one residency clause — `Space(<the space the document resides in>)` — onto each path's declared ceiling, and the existing clause-subsumption predicate decides the rest. A flow clause listing the target's own space among its alternatives fits; a clause without one measures against the declared policy exactly as before, so foreign-space principals, user principals, caveats, and resource atoms still misfit on an undeclared store.

Storing data in the space it is already labeled for discloses nothing. The audience a `Space` atom names is that space's reader set, because §4.9.3 resolves the atom by dereferencing its id against the space's ACL — the same document that decides who receives a replica. Every principal holding the bytes is therefore already inside the audience, and the write reaches no reader the data had not already reached. The guarantee is as strong as the deployment's ACL posture, the same bound the render membership lookup carries.

`Space` is the only principal form admitted, and the restriction is load-bearing. `PersonalSpace` and the bare DID-string spelling gate by equality against a single acting reader, which is why label field classification groups their subject fields with `User.subject` while leaving `Space.id` public so it can be dereferenced. Their audience is a person rather than the container, and a space grants reader roles its owner does not hold in person, so admitting them would place data readable by one principal into a store its co-readers sync.

The check remains a write admission and not a relabeling: the derived stamp still persists the full join, so the egress and display ceilings fit the unchanged label, and the space principal there reaches a concrete reader only through the SpaceReaderAccess exchange rule over verified HasRole membership. Expressing the rule as a clause added to the ceiling rather than as a filter over the measured label keeps one fit predicate in play, so the ungrantable read-failed marker stays outside the residency clause as it stays outside every ceiling, and the rejection message still names only the clauses a store would need to declare.

The enforcement matrix records the ceiling the check measures against, and the spec change list gains SC-18(d) for the normative rule and the two points its spec text owes: that residency is a property of the store rather than a carve-out for an atom family, and that it holds over a declared policy rather than only in its absence.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

