### PR TITLE
Archive the test-run telemetry plan

### DIFF
--- a/docs/development/test-records-adoption.md
+++ b/docs/development/test-records-adoption.md
@@ -1,8 +1,9 @@
 # Adopting test-run records in another repository
 
-This guide is written for an agent implementing the test-run record system
-of [the plan](../plans/test-run-telemetry.md) in another repository of the
-organization. The storage, schema, library, and personal keys already
+This guide is written for an agent implementing the test-run record
+system — designed in [an archived
+plan](../history/plans/test-run-telemetry.md) — in another repository of
+the organization. The storage, schema, library, and personal keys already
 exist; an adopting repository adds its own identities, producers, and relay
 and leans on everything shared.
 

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -3,9 +3,9 @@
 Every execution of every test in this repository produces one record — its
 identity, outcome, and duration — shipped with the run's context to a public
 store. [The spec](../specs/test-records.md) is the contract (identity
-rules, line formats, store guarantees, trust boundaries); the design
-reasoning and execution state are in
-[the plan](../plans/test-run-telemetry.md). This document is how the
+rules, line formats, store guarantees, trust boundaries), and the
+reasoning that produced it is in [the archived
+plan](../history/plans/test-run-telemetry.md). This document is how the
 running system is operated: what gets recorded, the environment surface,
 how to opt a workstation in, and how to read the data.
 

--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -64,6 +64,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 - [PLANNED_FIXES.md](packages/cli/PLANNED_FIXES.md) — cli fix batches.
 - [AUTOSAVE-PLAN.md](packages/ui/src/v2/components/cf-file-download/AUTOSAVE-PLAN.md) — cf-file-download auto-save.
 - [2026-07-23-pathless-piece-read.md](plans/2026-07-23-pathless-piece-read.md) — why a path-less `cf piece get` returned `undefined` while every child path read fine, and the partial-object projection at the piece read boundary that fixed it, July 2026.
+- [test-run-telemetry.md](plans/test-run-telemetry.md) — the design of the test-run record system: the refactor-stable identity triple, the record and context line formats, the spool-then-one-upload path, the publicly readable append-only store with per-person and relay writers, and the eight stages that built it, August 2026.
 
 ## Shipped or superseded designs and decision records
 

--- a/docs/history/plans/test-run-telemetry.md
+++ b/docs/history/plans/test-run-telemetry.md
@@ -2,7 +2,8 @@
 status: historical
 created: 2026-08-17
 archived: 2026-08-19
-reason: "Executed plan; every test run is recorded, the store is applied, and the contract lives in specs/test-records.md."
+reason: "Executed plan; every test run is recorded and the store is applied."
+superseded-by: docs/specs/test-records.md
 ---
 
 # Tracking every test run

--- a/docs/history/plans/test-run-telemetry.md
+++ b/docs/history/plans/test-run-telemetry.md
@@ -1,3 +1,10 @@
+---
+status: historical
+created: 2026-08-17
+archived: 2026-08-19
+reason: "Executed plan; every test run is recorded, the store is applied, and the contract lives in specs/test-records.md."
+---
+
 # Tracking every test run
 
 This document designs a system that records, for every test of every kind in
@@ -845,10 +852,10 @@ activation and the follow-through that needs live data.
    durations, as designed), per-fixture `pattern-vintage` records, and
    named steps in the CLI integration sections.
 7. **Adoption** —
-   [the guide](../development/test-records-adoption.md) is written;
-   [`test-records.md`](../development/test-records.md) documents operating
+   [the guide](../../development/test-records-adoption.md) is written;
+   [`test-records.md`](../../development/test-records.md) documents operating
    the system in this repository, and the normative contract lives in
-   [the spec](../specs/test-records.md), which is what remains live when
+   [the spec](../../specs/test-records.md), which is what remains live when
    this plan is eventually archived.
 8. **Analysis** — the alias file and its gate, the collision, high-churn,
    and over-60-seconds reports (`tasks/test-records-report.ts`, whose
@@ -951,7 +958,7 @@ source moved into the managed-folder path.
   The intended eventual use — running only the fraction of tests that
   fail most often — fits the write path as built, but the selector's own
   rules are not designed here beyond the constraints
-  [the spec](../specs/test-records.md) states: an identity with no fresh
+  [the spec](../../specs/test-records.md) states: an identity with no fresh
   records must run (records exist only for tests that ran, so a selector
   that never revisits the unselected starves its own data), a renamed
   test is unknown until its alias line lands, and baselines come from

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -103,10 +103,3 @@ a record: archive it to `docs/history/plans/` following the procedure in
   do one job under two names. Separate from the read-layer plan because it
   renames rather than adds, so its risk is what breaks for a caller who already
   learned the current spelling.
-- [Tracking every test run](test-run-telemetry.md) designs a record of every
-  execution of every test — outcome, duration, commit, and run context — with
-  a refactor-stable identity scheme, a spool-then-one-upload reporting path,
-  a publicly readable storage bucket appendable only with keys that cannot
-  alter what was already recorded, a GitHub-anchored self-service path for
-  contributors' keys, and an adoption path for the organization's other
-  repositories.

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -4,10 +4,11 @@ The contract of the test-run record system: what a test's identity is, what
 a record and a run context contain, how records move from a producer to the
 store, and what the store guarantees. This is the normative description of
 the shipped system; [the operating
-guide](../development/test-records.md) says how to use it,
+guide](../development/test-records.md) says how to use it, and
 [the adoption guide](../development/test-records-adoption.md) how another
-repository joins it, and [the plan](../plans/test-run-telemetry.md) carries
-the reasoning and the execution state. The shared implementation is
+repository joins it. [The plan this system came
+from](../history/plans/test-run-telemetry.md) is archived, and carries the
+reasoning that shaped what follows. The shared implementation is
 `packages/test-support/src/records/`.
 
 ## Identity

--- a/packages/test-support/src/records/schema.ts
+++ b/packages/test-support/src/records/schema.ts
@@ -2,7 +2,7 @@
  * The test-run record schema: the identity of a test, the record of one
  * execution, and the context line that heads every uploaded object. The
  * design, including the field discipline that keeps every value public
- * material, is docs/plans/test-run-telemetry.md.
+ * material, is docs/history/plans/test-run-telemetry.md.
  */
 
 /** Schema version carried by every context line and object path. */

--- a/tasks/check-test-aliases.ts
+++ b/tasks/check-test-aliases.ts
@@ -2,12 +2,12 @@
 /**
  * Guards tasks/test-identity-aliases.jsonl, the append-only file that
  * bridges test-identity renames for readers of the test-run record store
- * (docs/plans/test-run-telemetry.md). Each line maps an old identity — or
- * a whole scope, for package renames — to its replacement, with the date
- * of the rename; readers resolve aliases transitively and apply one only
- * to records older than its date. The parsing and resolution live in
- * @commonfabric/test-support/records; this gate holds the file itself to
- * history's rules.
+ * (docs/history/plans/test-run-telemetry.md). Each line maps an old
+ * identity — or a whole scope, for package renames — to its replacement,
+ * with the date of the rename; readers resolve aliases transitively and
+ * apply one only to records older than its date. The parsing and
+ * resolution live in @commonfabric/test-support/records; this gate holds
+ * the file itself to history's rules.
  *
  * The file is history, so existing lines are never edited or removed (the
  * committed content must be a prefix of the new content), every line must


### PR DESCRIPTION
Every stage the plan describes has shipped: the record library and its producers, the relay and the personal-key path, the per-package splits, and the reader tooling. The store it specifies is applied in the infra repository and the relay has been shipping records since. What remains in the plan's own execution notes is follow-through that waits on accumulated data — flipping the duration ratchet, drawing the dashboard trends, retiring the hand-maintained weight tables — rather than plan work.

The document moves to docs/history/plans/ with the metadata header and an index entry. Its body is frozen as written, including the status line and the note that the store was not yet applied, which is what an archived document is for; the header's reason line carries the current state. Links into it are repointed: the spec, the operating guide, and the adoption guide now cite it as the archived plan the system came from, and the two source files that named its path follow the move. The live plans index no longer lists it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

