### PR TITLE
fix(integration): wait for shell app before login

### DIFF
--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -28,7 +28,7 @@ import {
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
 import { getPresentationSession } from "./presentation/session.ts";
-import { waitFor } from "./utils.ts";
+import { waitFor, waitForCondition } from "./utils.ts";
 
 import "../shell/src/globals.ts";
 
@@ -48,6 +48,8 @@ export async function login(page: Page, identity: Identity): Promise<void> {
       "Could not serialize identity. Requires 'noble' implementation.",
     );
   }
+
+  await waitForCondition(page, () => globalThis.app !== undefined);
 
   await page!.evaluate<
     Promise<void>,


### PR DESCRIPTION
## Summary

- wait for the shell's `globalThis.app` readiness boundary before the shared integration login helper reads application state
- preserve the production fix from #6066, which prevents navigation bootstrap from overwriting an integration driver's newer view

## Root cause

#6066 intentionally moved `globalThis.app` publication behind key restoration and initial navigation. The shared `login()` helper still assumed that the page `load` event meant `globalThis.app` existed. The pattern reload test calls `login()` immediately after `page.reload({ waitUntil: "load" })`, so it raced shell bootstrap and could throw while reading `globalThis.app.state()`.

The PR CI run happened to finish bootstrap first and passed. The first two main runs after merge lost the race in the Pattern Reload Integration Tests job.

## Validation

- `HEADLESS=1 EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1 deno task integration patterns-reload`
- `deno task check`
- `deno task check-no-waitfor`
- `deno fmt --check`
- `deno lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

