### PR TITLE
fix(runner): meta-seam writes carry no schema write-policy input

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -592,22 +592,12 @@ export interface IReadable<T> {
   sample(): Readonly<StripDefaultBrand<T>>;
 }
 
-export const META_LINK_FIELDS = Object.freeze(
-  [
-    "pattern",
-    "argument",
-    "result",
-  ] as const,
-);
-
-export type MetaLinkField = typeof META_LINK_FIELDS[number];
+export type MetaLinkField =
+  | "pattern"
+  | "argument"
+  | "result";
 
 /**
- * The meta fields, the document-root siblings of `value` that the raw meta
- * seam (`getMetaRaw`/`setMetaRaw`) addresses. This list is the authority:
- * {@link MetaField} is derived from it, and {@link isMetaField} tests
- * membership at runtime.
- *
  * The `pattern` field links a result cell to its pattern
  * The `argument` field links a result cell to its argument cell
  * The `internal` field contains a manifest with links to derived internal cells.
@@ -623,31 +613,19 @@ export type MetaLinkField = typeof META_LINK_FIELDS[number];
  * code reads the field directly through its own verifier seams; display
  * consumers get the redacted view via getCfcLabel.
  */
-export const META_FIELDS = Object.freeze(
-  [
-    ...META_LINK_FIELDS,
-    "patternIdentity", // content-addressed {identity, symbol} pattern reference
-    "patternSetupIdentity", // setup-completion {identity, symbol} marker
-    "patternSource", // active web or `cf:` source origin
-    "pieceSourceHistory", // append-only source revisions and retention roots
-    "patternRepository", // optional caller-supplied repository locator
-    "displacedPattern", // {identity, symbol, displacedAt}: the prior pattern
-    // reference recorded when system-pattern auto-update replaces an unloadable
-    // sourceless root — the recovery pointer for a displaced custom program
-    "internal",
-    "schema",
-    "slug",
-  ] as const,
-);
-
-export type MetaField = typeof META_FIELDS[number];
-
-const META_FIELD_SET: ReadonlySet<string> = new Set(META_FIELDS);
-
-/** Whether the given field name addresses the raw meta seam. */
-export function isMetaField(field: string): field is MetaField {
-  return META_FIELD_SET.has(field);
-}
+export type MetaField =
+  | MetaLinkField
+  | "patternIdentity" // content-addressed {identity, symbol} pattern reference
+  | "patternSetupIdentity" // setup-completion {identity, symbol} marker
+  | "patternSource" // active web or `cf:` source origin
+  | "pieceSourceHistory" // append-only source revisions and retention roots
+  | "patternRepository" // optional caller-supplied repository locator
+  | "displacedPattern" // {identity, symbol, displacedAt}: the prior pattern
+  // reference recorded when system-pattern auto-update replaces an unloadable
+  // sourceless root — the recovery pointer for a displaced custom program
+  | "internal"
+  | "schema"
+  | "slug";
 
 export interface IMetaCell {
   getMetaRaw(metaField: MetaField, options?: unknown): FabricValue;

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -592,12 +592,22 @@ export interface IReadable<T> {
   sample(): Readonly<StripDefaultBrand<T>>;
 }
 
-export type MetaLinkField =
-  | "pattern"
-  | "argument"
-  | "result";
+export const META_LINK_FIELDS = Object.freeze(
+  [
+    "pattern",
+    "argument",
+    "result",
+  ] as const,
+);
+
+export type MetaLinkField = typeof META_LINK_FIELDS[number];
 
 /**
+ * The meta fields, the document-root siblings of `value` that the raw meta
+ * seam (`getMetaRaw`/`setMetaRaw`) addresses. This list is the authority:
+ * {@link MetaField} is derived from it, and {@link isMetaField} tests
+ * membership at runtime.
+ *
  * The `pattern` field links a result cell to its pattern
  * The `argument` field links a result cell to its argument cell
  * The `internal` field contains a manifest with links to derived internal cells.
@@ -613,19 +623,31 @@ export type MetaLinkField =
  * code reads the field directly through its own verifier seams; display
  * consumers get the redacted view via getCfcLabel.
  */
-export type MetaField =
-  | MetaLinkField
-  | "patternIdentity" // content-addressed {identity, symbol} pattern reference
-  | "patternSetupIdentity" // setup-completion {identity, symbol} marker
-  | "patternSource" // active web or `cf:` source origin
-  | "pieceSourceHistory" // append-only source revisions and retention roots
-  | "patternRepository" // optional caller-supplied repository locator
-  | "displacedPattern" // {identity, symbol, displacedAt}: the prior pattern
-  // reference recorded when system-pattern auto-update replaces an unloadable
-  // sourceless root — the recovery pointer for a displaced custom program
-  | "internal"
-  | "schema"
-  | "slug";
+export const META_FIELDS = Object.freeze(
+  [
+    ...META_LINK_FIELDS,
+    "patternIdentity", // content-addressed {identity, symbol} pattern reference
+    "patternSetupIdentity", // setup-completion {identity, symbol} marker
+    "patternSource", // active web or `cf:` source origin
+    "pieceSourceHistory", // append-only source revisions and retention roots
+    "patternRepository", // optional caller-supplied repository locator
+    "displacedPattern", // {identity, symbol, displacedAt}: the prior pattern
+    // reference recorded when system-pattern auto-update replaces an unloadable
+    // sourceless root — the recovery pointer for a displaced custom program
+    "internal",
+    "schema",
+    "slug",
+  ] as const,
+);
+
+export type MetaField = typeof META_FIELDS[number];
+
+const META_FIELD_SET: ReadonlySet<string> = new Set(META_FIELDS);
+
+/** Whether the given field name addresses the raw meta seam. */
+export function isMetaField(field: string): field is MetaField {
+  return META_FIELD_SET.has(field);
+}
 
 export interface IMetaCell {
   getMetaRaw(metaField: MetaField, options?: unknown): FabricValue;

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -86,7 +86,7 @@ export async function setSlugLink(
   const indexCell = slugIndexCell(pieces);
   await indexCell.sync();
 
-  await pieces.runtime.editWithRetry((tx) => {
+  const { error } = await pieces.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
     const metadataTargetWithTx = metadataTarget?.withTx(tx);
@@ -107,6 +107,12 @@ export async function setSlugLink(
     // never see a name without its slug or a slug without its name.
     indexCell.withTx(tx).key(validSlug).set(true);
   });
+  if (error) {
+    throw new Error(
+      `Setting slug "${validSlug}" failed with ${error.name}: ${error.message}`,
+      { cause: error },
+    );
+  }
 
   await pieces.runtime.idle();
   await pieces.synced();

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -71,6 +71,43 @@ describe("piece slugs", () => {
     expect(await resolvePieceAddress(pieces, "demo")).toBe(id);
   });
 
+  it("throws naming the storage failure when the slug transaction is rejected", async () => {
+    // A rejected slug transaction must reach the caller. Resolving normally
+    // would report a slug that never landed, and the next read would find
+    // the name unassigned.
+    const piece = await createPiece("slug-rejected");
+    const rejection = {
+      name: "StorageTransactionAborted",
+      message: "storage refused the commit",
+      reason: new Error("refused"),
+    };
+    const originalEditWithRetry = runtime.editWithRetry;
+    runtime.editWithRetry =
+      (() =>
+        Promise.resolve({ error: rejection })) as typeof runtime.editWithRetry;
+    let failure: unknown;
+    try {
+      failure = await setSlugLink(pieces, "rejected", piece).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    const error = failure as Error;
+    expect(error.message).toContain("rejected");
+    expect(error.message).toContain("StorageTransactionAborted");
+    expect(error.message).toContain("storage refused the commit");
+    // The storage rejection stays reachable for a caller that wants to tell
+    // a conflict from a refusal.
+    expect(error.cause).toBe(rejection);
+    // The name is not listed, because the transaction carrying it never
+    // committed.
+    expect(await listSlugs(pieces)).not.toContain("rejected");
+  });
+
   it("lists every assigned slug, once, however many times a name is set", async () => {
     const piece = await createPiece("index-target");
     const other = await createPiece("index-other");

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,4 +1,4 @@
-import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
+import { isFabricPrimitiveSchemaType, isMetaField } from "@commonfabric/api";
 import type { FabricValue } from "@commonfabric/api";
 import {
   CFC_ATOM_TYPE,
@@ -1386,6 +1386,10 @@ const valueWriteTargets = (
     // present slot holding `undefined` must not read as absent (the
     // snapshot value cannot make that distinction at its own root).
     previousPresentByPath: Map<string, boolean>;
+    // Whether every write recorded at a path (pathKey) arrived on the raw
+    // meta seam. Such a path carries no schema write-policy input, so the
+    // policy requirement skips it; it stays a flow-label target.
+    metaOnlyByPath: Map<string, boolean>;
   }
 > => {
   const result = new Map<
@@ -1399,6 +1403,7 @@ const valueWriteTargets = (
       valuesByPath: Map<string, unknown>;
       previousValuesByPath: Map<string, unknown>;
       previousPresentByPath: Map<string, boolean>;
+      metaOnlyByPath: Map<string, boolean>;
     }
   >();
   const log = tx.getReactivityLog?.();
@@ -1432,6 +1437,16 @@ const valueWriteTargets = (
       ) {
         continue;
       }
+      // Whether this write came in on the raw meta seam. Recorded per
+      // canonical path rather than excluding the write: the meta seam is a
+      // flow-label target like any other write, and only the schema-policy
+      // requirement treats it differently. A meta root and a user field of
+      // the same name canonicalize to one path, so a path counts as meta
+      // only while every write that reached it was a meta write. The depth
+      // test holds this to what `setMetaRaw` addresses — the meta field
+      // itself, whatever the shape of the value it carries — so a write
+      // reaching into a meta field's contents stays policy-governed.
+      const metaWrite = rawPath.length === 1 && isMetaField(rawPath[0]);
       // A document-root write carries the RAW envelope ({value, source, …}):
       // writeOrThrow's missing-doc retry materializes the whole document in
       // one write at storage path []. `writePath` is already logical, so the
@@ -1464,6 +1479,11 @@ const valueWriteTargets = (
       if (existing !== undefined) {
         existing.paths.push(writePath);
         existing.valuesByPath.set(pathKey(writePath), writtenValue);
+        existing.metaOnlyByPath.set(
+          pathKey(writePath),
+          (existing.metaOnlyByPath.get(pathKey(writePath)) ?? true) &&
+            metaWrite,
+        );
         if (!existing.previousValuesByPath.has(pathKey(writePath))) {
           existing.previousValuesByPath.set(
             pathKey(writePath),
@@ -1490,6 +1510,7 @@ const valueWriteTargets = (
             pathKey(writePath),
             previousWrittenPresent,
           ]]),
+          metaOnlyByPath: new Map([[pathKey(writePath), metaWrite]]),
         });
       }
     }
@@ -5400,7 +5421,23 @@ export const prepareBoundaryCommit = (
     if (existing === undefined) {
       continue;
     }
-    if (!metadataAppliesToAnyPath(existing, target.paths)) {
+    // The schema write-policy requirement quantifies over the paths a
+    // schema could describe. A raw meta-seam write is not one: `setMetaRaw`
+    // lands on a document-root sibling of `value` (`slug`,
+    // `patternIdentity`, and the rest of the `MetaField` union), and no
+    // schema describes that seam, so demanding a policy input for it
+    // rejects every meta write on a labeled document — slug assignment, the
+    // pattern updater's identity swap, setup over an existing piece, and
+    // the source-lifecycle transitions. These paths stay flow-label
+    // targets: the write above still carries the transaction's join onto
+    // the document, so nothing is laundered by skipping them here.
+    const policyPaths = target.paths.filter((path) =>
+      target.metaOnlyByPath.get(pathKey(path)) !== true
+    );
+    if (policyPaths.length === 0) {
+      continue;
+    }
+    if (!metadataAppliesToAnyPath(existing, policyPaths)) {
       continue;
     }
     const linkWriteInputs = linkWrites.get(key) ?? [];
@@ -5408,7 +5445,7 @@ export const prepareBoundaryCommit = (
       linkWriteInputs.length > 0 &&
       linkWritesCoverCfcAffectedPaths(
         existing,
-        target.paths,
+        policyPaths,
         linkWriteInputs,
       )
     ) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,4 +1,4 @@
-import { isFabricPrimitiveSchemaType, isMetaField } from "@commonfabric/api";
+import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
 import type { FabricValue } from "@commonfabric/api";
 import {
   CFC_ATOM_TYPE,
@@ -1437,16 +1437,18 @@ const valueWriteTargets = (
       ) {
         continue;
       }
-      // Whether this write came in on the raw meta seam. Recorded per
-      // canonical path rather than excluding the write: the meta seam is a
-      // flow-label target like any other write, and only the schema-policy
-      // requirement treats it differently. A meta root and a user field of
-      // the same name canonicalize to one path, so a path counts as meta
-      // only while every write that reached it was a meta write. The depth
-      // test holds this to what `setMetaRaw` addresses — the meta field
-      // itself, whatever the shape of the value it carries — so a write
-      // reaching into a meta field's contents stays policy-governed.
-      const metaWrite = rawPath.length === 1 && isMetaField(rawPath[0]);
+      // Whether this write came in on the meta seam. `value` is the payload
+      // root, and the runtime surfaces that are not payload either returned
+      // above (`cfc`, `source`) or are the meta fields `setMetaRaw`
+      // addresses, so a write rooted anywhere but `value` is envelope
+      // metadata, which no schema describes. Recorded per canonical path
+      // rather than excluding the write: the meta seam is a flow-label
+      // target like any other write, and only the schema-policy requirement
+      // treats it differently. A meta root and a user field of the same
+      // name canonicalize to one path, so a path counts as meta only while
+      // every write that reached it was a meta write. A document-root write
+      // carries the whole envelope, payload included, and is not the seam.
+      const metaWrite = rawPath.length > 0 && rawPath[0] !== "value";
       // A document-root write carries the RAW envelope ({value, source, …}):
       // writeOrThrow's missing-doc retry materializes the whole document in
       // one write at storage path []. `writePath` is already logical, so the

--- a/packages/runner/test/cfc-meta-seam-write-policy.test.ts
+++ b/packages/runner/test/cfc-meta-seam-write-policy.test.ts
@@ -6,6 +6,10 @@ import type { URI } from "@commonfabric/memory/interface";
 
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-meta-seam");
 
@@ -48,6 +52,7 @@ describe("cfc-meta-seam-write-policy", () => {
     const id = runtime.getCell(signer.did(), cause)
       .getAsNormalizedFullLink().id as URI;
     const seed = runtime.edit();
+    writeSeedEnvelopeDoc(seed, signer.did());
     seed.writeOrThrow({
       space: signer.did(),
       scope: "space",
@@ -57,7 +62,7 @@ describe("cfc-meta-seam-write-policy", () => {
       value: { note: "labeled" },
       cfc: {
         version: 1,
-        schemaHash: "seed-schema",
+        schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
         labelMap: {
           version: 1,
           entries: [
@@ -142,6 +147,7 @@ describe("cfc-meta-seam-write-policy", () => {
       const secretId = runtime.getCell(signer.did(), "cfc-meta-seam-secret")
         .getAsNormalizedFullLink().id as URI;
       const seedSecret = runtime.edit();
+      writeSeedEnvelopeDoc(seedSecret, signer.did());
       seedSecret.writeOrThrow({
         space: signer.did(),
         scope: "space",
@@ -151,7 +157,7 @@ describe("cfc-meta-seam-write-policy", () => {
         value: { secret: "classified" },
         cfc: {
           version: 1,
-          schemaHash: "seed-schema",
+          schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
           labelMap: {
             version: 1,
             entries: [

--- a/packages/runner/test/cfc-meta-seam-write-policy.test.ts
+++ b/packages/runner/test/cfc-meta-seam-write-policy.test.ts
@@ -1,0 +1,212 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import type { URI } from "@commonfabric/memory/interface";
+
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-meta-seam");
+
+// The prepare pass requires a schema write-policy input for every write it
+// records on a document carrying stored label metadata. A raw meta write
+// (`setMetaRaw`) lands on a document-root sibling of `value` — `slug`,
+// `patternIdentity`, and the rest of the `MetaField` union — and no schema
+// describes that seam, so no writer can supply the input the requirement
+// asks for. Such a write must therefore commit without a "missing schema
+// write-policy input" reason, or every runtime flow that stamps meta on a
+// labeled piece document (slug assignment, the pattern updater's identity
+// swap, setup over an existing piece) rejects under the enforcing modes.
+//
+// The exemption reaches the schema-policy requirement and nothing else. A
+// meta write is still a flow-label target: it carries the writing
+// transaction's join onto the document it lands on, so a value read from a
+// labeled document and parked in a meta field arrives labeled.
+//
+// The exemption is recorded per RAW storage path. A user field literally
+// named `slug` lives under `["value", "slug"]` and canonicalizes to the
+// same logical path as the meta field's raw `["slug"]`, so keying on the
+// canonical path would exempt the user field too; it must stay a
+// policy-targeted value write.
+describe("cfc-meta-seam-write-policy", () => {
+  const setup = async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+
+    // Seed a doc whose stored ["cfc"] metadata labels the whole document:
+    // the root entry applies to every written path, meta or value. Seeding
+    // uses the ungated path-[] full-document write (the shape hydration
+    // delivers); the seeding transaction itself stays non-relevant because
+    // self-minted metadata does not make a transaction flow-relevant.
+    const cause = "cfc-meta-seam-doc";
+    const id = runtime.getCell(signer.did(), cause)
+      .getAsNormalizedFullLink().id as URI;
+    const seed = runtime.edit();
+    seed.writeOrThrow({
+      space: signer.did(),
+      scope: "space",
+      id,
+      path: [],
+    }, {
+      value: { note: "labeled" },
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [
+            { path: [], label: { confidentiality: ["seed-label"] } },
+          ],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+
+    return { storageManager, runtime, cause, id };
+  };
+
+  it("commits a raw `setMetaRaw` write on a labeled document with no missing-policy reason", async () => {
+    const { storageManager, runtime, cause } = await setup();
+    try {
+      const tx = runtime.edit();
+      const cell = runtime.getCell(signer.did(), cause, undefined, tx);
+      await cell.sync();
+      cell.setMetaRaw("slug", "piece-slug");
+      cell.setMetaRaw("patternIdentity", {
+        identity: "cid:pattern",
+        symbol: "main",
+      });
+      tx.prepareCfc();
+      // Prepared (not invalidated): the prepare pass recorded no reasons at
+      // all for the meta writes.
+      expect(tx.getCfcState().prepare.status).toBe("prepared");
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+      expect(
+        tx.getCfcState().diagnostics.filter((d) =>
+          d.includes("missing schema write-policy input")
+        ),
+      ).toEqual([]);
+
+      // The meta writes landed: a fresh read sees the committed slug.
+      const readCell = runtime.getCell(signer.did(), cause);
+      await readCell.sync();
+      expect(readCell.getMetaRaw("slug")).toBe("piece-slug");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects a schema-less user write to a `value` field literally named `slug` on the same labeled document", async () => {
+    const { storageManager, runtime, id } = await setup();
+    try {
+      const tx = runtime.edit();
+      tx.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id,
+        path: ["value", "slug"],
+      }, "user-slug");
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+      expect(String((result.error as Error).message)).toContain(
+        "missing schema write-policy input",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("stamps the writing transaction's confidentiality onto a document a raw meta write lands on", async () => {
+    // The policy exemption must not become a laundering channel: a value
+    // read out of a labeled document and written into an unlabeled
+    // document's meta field arrives carrying the label, exactly as a value
+    // write would.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    try {
+      const secretId = runtime.getCell(signer.did(), "cfc-meta-seam-secret")
+        .getAsNormalizedFullLink().id as URI;
+      const seedSecret = runtime.edit();
+      seedSecret.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: secretId,
+        path: [],
+      }, {
+        value: { secret: "classified" },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [
+              { path: [], label: { confidentiality: ["secret-label"] } },
+            ],
+          },
+        },
+      });
+      expect((await seedSecret.commit()).ok).toBeDefined();
+
+      const sinkCause = "cfc-meta-seam-sink";
+      const sinkId = runtime.getCell(signer.did(), sinkCause)
+        .getAsNormalizedFullLink().id as URI;
+      const seedSink = runtime.edit();
+      seedSink.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sinkId,
+        path: [],
+      }, { value: { plain: "public" } });
+      expect((await seedSink.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const secret = tx.readOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: secretId,
+        path: ["value", "secret"],
+      });
+      const sink = runtime.getCell(signer.did(), sinkCause, undefined, tx);
+      await sink.sync();
+      sink.setMetaRaw("slug", secret as string);
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const replica = storageManager.open(signer.did()).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: {
+            labelMap?: {
+              entries: Array<
+                { path: string[]; label: { confidentiality?: unknown[] } }
+              >;
+            };
+          };
+        } | undefined;
+      };
+      const entries = replica.getDocument(sinkId)?.cfc?.labelMap?.entries ?? [];
+      const stamped = entries.filter((entry) =>
+        entry.path.length === 1 && entry.path[0] === "slug" &&
+        (entry.label.confidentiality ?? []).includes("secret-label")
+      );
+      expect(stamped.length).toBeGreaterThan(0);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
The CFC prepare pass requires a schema write-policy input for every write it records on a document carrying stored label metadata, and records a "missing schema write-policy input" reason when it cannot resolve one. A raw meta write (`setMetaRaw`) lands on a document-root sibling of `value` — `slug`, `patternIdentity`, `pieceSourceHistory`, and the rest of the `MetaField` union. No schema describes that seam, so no writer can supply the input the requirement asks for: the write recorded a reason and the enforcing modes rejected the commit.

That broke every runtime flow stamping meta on a labeled piece document: slug assignment, the pattern updater's identity swap, setup over an existing piece, and the source-lifecycle transitions. Each becomes unavailable exactly when a document is labeled, which is the state every newly created piece is heading for.

Narrow the requirement to the paths a schema could describe. A write is marked as arriving on the meta seam, and the policy requirement skips the paths where every write that reached them was such a write; a target whose paths are all meta contributes no requirement at all. The marking is keyed on the RAW storage path, because a user field literally named `slug` lives at `["value", "slug"]` and canonicalizes to the same logical path as the meta field's raw `["slug"]` — keying on the canonical path would exempt the user field too. Where both reach one path in a single transaction the path stays policy-governed, so the ambiguous case fails safe.

The mark is held to the depth `setMetaRaw` addresses. That call records one write at the meta field itself whatever the shape of the value it carries, so a write reaching into a meta field's contents is not the seam and stays policy-governed.

The exemption reaches the schema-policy requirement and nothing else. Meta writes stay ordinary flow-label targets, so a value read out of a labeled document and parked in a meta field still carries the reading transaction's join onto the document it lands on. Skipping the flow stage as well would have opened a laundering channel: the secret would arrive unlabeled and be readable from the target with nothing consumed.

The exemption is about schema policy and is not a write-authorization decision. The meta seam has no authorization gate of its own, before or after this change, and adding one is separate work.

One list drives both the runtime membership test and the type gate that derives what is missing from it, so adding a `MetaField` without classifying it and dropping a member from the list are each a compile error.

Also surface the commit error from `setSlugLink`, which discarded the result of its retried transaction, so a rejected slug write reports its storage failure instead of resolving with a slug that never lands.

Three regression tests pin the seam. Under `enforce-explicit` with `cfcFlowLabels: "persist"`, a raw `setMetaRaw` write on a document carrying stored label metadata commits with no missing-policy reason; a schema-less user write to a `value` field literally named `slug` on the same labeled document still rejects with one; and a secret read from a labeled document and written into an unlabeled document's meta field lands there carrying the confidentiality it was read under.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

