### PR TITLE
feat(piece): declare space-scoped labels on piece creation

### DIFF
--- a/packages/agents-host/test/debug_view_deployment_test.ts
+++ b/packages/agents-host/test/debug_view_deployment_test.ts
@@ -14,6 +14,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import {
+  createDefaultPatternPiece,
   identity,
   installDefaultPattern,
   newSharedServer,
@@ -632,14 +633,12 @@ Deno.test("debug deployment rejects a replaced default pattern", async () => {
       runtime,
       spaceDid: session.space,
     });
-    const replacementRoot = runtime.getCell(
-      session.space,
+    // A second root piece, created the way every root is and left unlinked
+    // until the deployment is under way.
+    const replacementRoot = await createDefaultPatternPiece(
+      manager,
       `replacement-default-pattern-${crypto.randomUUID()}`,
     );
-    const replacementResult = await runtime.editWithRetry((tx) => {
-      replacementRoot.withTx(tx).setRawUntyped({ replacement: true });
-    });
-    if (replacementResult.error) throw replacementResult.error;
 
     const originalGetDefaultPattern = manager.getDefaultPattern;
     let replaced = false;

--- a/packages/agents-host/test/debug_view_support.ts
+++ b/packages/agents-host/test/debug_view_support.ts
@@ -330,8 +330,14 @@ export async function readRawDataProvenance(
   };
 }
 
-export async function installDefaultPattern(
+/**
+ * A root piece shaped like the space's default pattern, created but not yet
+ * linked. Created through the controller, as every root in production is, so
+ * it carries the creation label a root document is expected to have.
+ */
+export async function createDefaultPatternPiece(
   manager: PiecesController,
+  cause = "agents-host-debug-test-default-pattern",
 ): Promise<Cell<unknown>> {
   const { handler, pattern } = createBuilder().commonfabric;
   const addPiece = handler<
@@ -369,11 +375,18 @@ export async function installDefaultPattern(
       addPiece: addPiece({ allPieces }),
     }),
   );
-  const piece = await manager.runPersistent(
+  return await manager.runPersistent(
     defaultPattern,
     { allPieces: [], recentPieces: [] },
-    "agents-host-debug-test-default-pattern",
+    cause,
   );
+}
+
+/** {@link createDefaultPatternPiece}, linked as the space's default pattern. */
+export async function installDefaultPattern(
+  manager: PiecesController,
+): Promise<Cell<unknown>> {
+  const piece = await createDefaultPatternPiece(manager);
   await manager.linkDefaultPattern(piece);
   await manager.runtime.idle();
   await manager.synced();

--- a/packages/piece/src/ops/clone-data-guards.ts
+++ b/packages/piece/src/ops/clone-data-guards.ts
@@ -4,16 +4,21 @@
  * remains the piece controller's responsibility.
  */
 
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import {
   type Cell,
   type IExtendedStorageTransaction,
 } from "@commonfabric/runner";
-import { cfcLabelViewForCellFailClosed } from "@commonfabric/runner/cfc";
+import {
+  cfcLabelViewForCellFailClosed,
+  clauseAlternatives,
+} from "@commonfabric/runner/cfc";
 import {
   FabricInstance,
   FabricPrimitive,
 } from "@commonfabric/data-model/fabric-value";
 import { commitPreconditionValueHash } from "@commonfabric/memory/v2";
+import { isObjectOrArray } from "@commonfabric/utils/types";
 
 export function cloneCellKey(cell: Cell<unknown>): string {
   const link = cell.getAsNormalizedFullLink();
@@ -49,11 +54,51 @@ export function assertNoCloneFabricInstance(
   }
 }
 
-/** Reject a value copy that would discard Common Fabric Control labels. */
-export function assertCloneDataUnlabeled(carrier: unknown): void {
+/**
+ * Whether a confidentiality clause is exactly `space`'s own principal —
+ * `Space(<space>)`, `PersonalSpace(<space>)`, or the legacy DID-string form,
+ * and nothing else. Such a clause is the source space's residency scoping,
+ * which a clone drops by design: the destination copy is re-declared under
+ * the destination space's own principal at creation.
+ *
+ * A clause offering that principal alongside other alternatives says more
+ * than where the data lives, so it is not residency scoping and still
+ * refuses the copy.
+ */
+const sameSpacePrincipalClause = (
+  space: string,
+  clause: unknown,
+): boolean => {
+  const alternatives = clauseAlternatives(
+    clause as Parameters<typeof clauseAlternatives>[0],
+  );
+  if (alternatives.length !== 1) return false;
+  const [alternative] = alternatives;
+  return alternative === space ||
+    (isObjectOrArray(alternative) &&
+      (((alternative as { type?: unknown }).type === CFC_ATOM_TYPE.Space &&
+        (alternative as { id?: unknown }).id === space) ||
+        ((alternative as { type?: unknown }).type ===
+            CFC_ATOM_TYPE.PersonalSpace &&
+          (alternative as { owner?: unknown }).owner === space)));
+};
+
+/**
+ * Reject a value copy that would discard Common Fabric Control labels.
+ * Confidentiality clauses naming `sourceSpace`'s own principal are not
+ * labels a copy discards — see {@link sameSpacePrincipalClause} — so they
+ * do not refuse the clone; every other clause and any integrity entry does.
+ */
+export function assertCloneDataUnlabeled(
+  carrier: unknown,
+  sourceSpace?: string,
+): void {
   const view = cfcLabelViewForCellFailClosed(carrier);
   const labeled = view?.entries.some((entry) =>
-    (entry.label.confidentiality?.length ?? 0) > 0 ||
+    (entry.label.confidentiality ?? []).some((clause) =>
+      sourceSpace === undefined ||
+      !sameSpacePrincipalClause(sourceSpace, clause)
+    ) ||
     (entry.label.integrity?.length ?? 0) > 0
   );
   if (labeled) {

--- a/packages/piece/src/ops/clone-data-snapshot.ts
+++ b/packages/piece/src/ops/clone-data-snapshot.ts
@@ -21,13 +21,19 @@ import {
   cloneEntityKey,
 } from "./clone-data-guards.ts";
 
-/** Copy materialized piece data into detached arrays and plain objects. */
+/**
+ * Copy materialized piece data into detached arrays and plain objects.
+ * `sourceSpace` is the space the piece is being copied FROM, threaded through
+ * the whole walk: it names the one principal whose residency scoping a copy
+ * drops. Omitting it refuses every labeled value.
+ */
 export function snapshotCloneValue(
   value: unknown,
   sourceCell?: Cell<unknown>,
   seen = new WeakMap<object, unknown>(),
   cells = new Map<string, Cell<unknown>>(),
   preloadedCells?: { has(key: string): boolean },
+  sourceSpace?: string,
 ): unknown {
   let cell = sourceCell;
   if (isCell(value)) {
@@ -49,8 +55,8 @@ export function snapshotCloneValue(
     }
     cells.set(key, cell);
   }
-  assertCloneDataUnlabeled(cell);
-  assertCloneDataUnlabeled(value);
+  assertCloneDataUnlabeled(cell, sourceSpace);
+  assertCloneDataUnlabeled(value, sourceSpace);
   const raw = cell?.getRawUntyped();
   if (value instanceof FabricInstance || raw instanceof FabricInstance) {
     throw new Error(
@@ -76,6 +82,7 @@ export function snapshotCloneValue(
         seen,
         cells,
         preloadedCells,
+        sourceSpace,
       );
     }
     return snapshot;
@@ -100,19 +107,24 @@ export function snapshotCloneValue(
         seen,
         cells,
         preloadedCells,
+        sourceSpace,
       ),
     });
   }
   return snapshot;
 }
 
-/** Load every linked cell that a later synchronous transaction read can reach. */
+/**
+ * Load every linked cell that a later synchronous transaction read can reach.
+ * `sourceSpace` carries the same meaning as in {@link snapshotCloneValue}.
+ */
 export async function preloadCloneValue(
   value: unknown,
   sourceCell: Cell<unknown> | undefined,
   cells: Map<string, Cell<unknown>>,
   loadedEntities = new Set<string>(),
   seen = new WeakSet<object>(),
+  sourceSpace?: string,
 ): Promise<void> {
   let cell = sourceCell;
   if (isCell(value)) {
@@ -141,8 +153,8 @@ export async function preloadCloneValue(
   }
 
   assertNoCloneFabricInstance(value);
-  assertCloneDataUnlabeled(cell);
-  assertCloneDataUnlabeled(value);
+  assertCloneDataUnlabeled(cell, sourceSpace);
+  assertCloneDataUnlabeled(value, sourceSpace);
   if (
     value === null || typeof value !== "object" ||
     value instanceof FabricPrimitive || value instanceof FabricInstance ||
@@ -159,6 +171,7 @@ export async function preloadCloneValue(
         cells,
         loadedEntities,
         seen,
+        sourceSpace,
       );
     }
     return;
@@ -170,6 +183,7 @@ export async function preloadCloneValue(
       cells,
       loadedEntities,
       seen,
+      sourceSpace,
     );
   }
 }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -37,6 +37,7 @@ import {
   type RuntimeProgram,
   sanitizeSchemaForLinks,
   schemaAcceptsOpaqueCellValue,
+  schemaHasIfc,
 } from "@commonfabric/runner";
 import {
   cfcSchemaChildRoot,
@@ -88,8 +89,19 @@ async function snapshotCloneData(
   inputCell: Cell<unknown>,
   expectedSource: PieceSourceSnapshot,
 ): Promise<{ input: unknown; internals: CloneInternalSnapshot[] }> {
+  // The space the copy is taken FROM, so the clone guards can tell this
+  // space's own residency scoping — which the destination re-declares — from
+  // every other label, wherever in the walk they appear.
+  const sourceSpace = piece.getAsNormalizedFullLink().space;
   const preloadedCells = new Map<string, Cell<unknown>>();
-  await preloadCloneValue(inputCell, undefined, preloadedCells);
+  await preloadCloneValue(
+    inputCell,
+    undefined,
+    preloadedCells,
+    undefined,
+    undefined,
+    sourceSpace,
+  );
   const initialManifest = cloneInternalManifest(piece);
   for (const entry of initialManifest) {
     if (entry.kind === "computed") continue;
@@ -97,7 +109,14 @@ async function snapshotCloneData(
       parseLinkOrThrow(entry.link, piece),
     );
     if (!isStream(internal)) {
-      await preloadCloneValue(internal, undefined, preloadedCells);
+      await preloadCloneValue(
+        internal,
+        undefined,
+        preloadedCells,
+        undefined,
+        undefined,
+        sourceSpace,
+      );
     }
   }
 
@@ -121,6 +140,7 @@ async function snapshotCloneData(
       new WeakMap(),
       snapshotCells,
       preloadedCells,
+      sourceSpace,
     );
     const internals: CloneInternalSnapshot[] = [];
     const manifest = cloneInternalManifest(txPiece);
@@ -141,6 +161,7 @@ async function snapshotCloneData(
           new WeakMap(),
           snapshotCells,
           preloadedCells,
+          sourceSpace,
         ),
       });
     }
@@ -4272,6 +4293,17 @@ function pieceSourceCfcEnvelopeIssue(
     return `the CFC schema envelope stored for this piece's argument ` +
       `document could not be read (${stored.reason}); applying a source ` +
       `would be rejected over the same failure`;
+  }
+  // The commit never merges a schema the pattern declared unless that schema
+  // carries `ifc` claims. For an ifc-less write on a document that already
+  // stores metadata, `recordRelevantSchemaWritePolicyInput` records the
+  // document's OWN stored schema as the candidate, so the persist pass merges
+  // the stored envelope with itself and leaves it as it was. Either way the
+  // candidate's argument schema never meets the stored envelope — an envelope
+  // minted by a link write, claiming nothing, is the common carrier — so
+  // there is nothing here to reject.
+  if (!schemaHasIfc(candidate.argumentSchema)) {
+    return undefined;
   }
   // The commit takes the stored envelope unchanged when it already covers the
   // candidate's, so a preflight that skipped this fast path would manufacture

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -23,6 +23,7 @@ import {
   getMetaLink,
   getPatternIdentityRef,
   getPieceSourceSnapshot,
+  type IExtendedStorageTransaction,
   isCell,
   isLink,
   isStoredArgumentSchemaRefusal,
@@ -47,9 +48,10 @@ import {
   setPatternSource,
   type SpaceCellContents,
 } from "@commonfabric/runner";
-import type {
-  CfcEnforcementMode,
-  CfcFlowLabelsMode,
+import {
+  type CfcEnforcementMode,
+  type CfcFlowLabelsMode,
+  cfcLabelViewForCellFailClosed,
 } from "@commonfabric/runner/cfc";
 import { CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON } from "@commonfabric/runner/cfc/migration-reason";
 import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
@@ -354,10 +356,16 @@ export class PiecesController<T = unknown> {
   async linkDefaultPattern(
     defaultPatternCell: Cell<any>,
   ): Promise<void> {
-    await this.runtime.editWithRetry((tx) => {
+    const { error } = await this.runtime.editWithRetry((tx) => {
       const spaceCellWithTx = this.spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(defaultPatternCell.withTx(tx));
     });
+    if (error) {
+      throw new Error(
+        `Linking the default pattern failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
     await this.runtime.idle();
   }
 
@@ -366,10 +374,16 @@ export class PiecesController<T = unknown> {
    * Used when the default pattern is being deleted.
    */
   async unlinkDefaultPattern(): Promise<void> {
-    await this.runtime.editWithRetry((tx) => {
+    const { error } = await this.runtime.editWithRetry((tx) => {
       const spaceCellWithTx = this.spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(undefined);
     });
+    if (error) {
+      throw new Error(
+        `Clearing the default pattern failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
     await this.runtime.idle();
   }
 
@@ -1240,7 +1254,70 @@ export class PiecesController<T = unknown> {
           : this.syncPattern(piece),
     );
 
+    await timePiecePhase(
+      "setupPersistent.declareSpaceScopedLabel",
+      async () => {
+        const { error } = await this.runtime.editWithRetry((tx) => {
+          this.declareSpaceScopedPieceLabel(piece, tx);
+        });
+        if (error) {
+          throw new Error(
+            `Declaring the new piece's space-scoped CFC label failed: ${error.message}`,
+            { cause: error },
+          );
+        }
+      },
+    );
+
     return piece;
+  }
+
+  /**
+   * Declare the space-scoped confidentiality on a piece root within `tx`:
+   * `PersonalSpace(<space>)` when this space is its owner's identity space,
+   * `Space(<space did>)` otherwise. Recorded as the piece doc's declared
+   * store-policy component (§8.12.4), so labeled space-internal flows fit
+   * the doc's write ceiling and the display boundary resolves the label
+   * through the acting user's space membership. The piece's value must
+   * already be written when this runs — creation paths call it after the
+   * pattern setup write, inside the same transaction or a follow-up one.
+   *
+   * A piece that already carries confidentiality at any path — a pattern
+   * declaring it on one of its own fields, a restored or copied source
+   * snapshot bringing its own labels — keeps that labeling: declared
+   * confidentiality evolves monotonically (§8.12.1), so the space-scoped
+   * declaration only ever seeds a piece born without one. The skip reaches
+   * every path rather than the root alone because the declaration re-mints
+   * the document's store policy from the root down, which over a document
+   * declaring a clause deeper is the weakening §8.12.1 refuses. A label read
+   * that errors reads as labeled, since a document whose labels cannot be
+   * read must not have a policy stamped over them.
+   */
+  private declareSpaceScopedPieceLabel(
+    piece: Cell<unknown>,
+    tx: IExtendedStorageTransaction,
+  ): void {
+    const withTx = piece.withTx(tx);
+    if (withTx.getRaw() === undefined) {
+      // A piece whose value is not written yet (a snapshot restore still
+      // materializing, a refused setup) has nothing to label; the declared
+      // component applies to a stored value.
+      return;
+    }
+    const view = cfcLabelViewForCellFailClosed(withTx);
+    if (
+      view?.entries.some((entry) =>
+        (entry.label.confidentiality?.length ?? 0) > 0
+      )
+    ) {
+      return;
+    }
+    const space = this.getSpace();
+    const atom = space === this.runtime.userIdentityDID
+      ? cfcAtom.personalSpace(space)
+      : cfcAtom.space(space);
+    withTx.asSchema({ ifc: { confidentiality: [atom] } })
+      .applyCfcSchemaToExistingValue();
   }
 
   /** Start scheduling and running a prepared piece. */
@@ -1562,6 +1639,8 @@ export class PiecesController<T = unknown> {
         setPatternRepository(pieceCell, tx, options.repository);
       }
 
+      this.declareSpaceScopedPieceLabel(pieceCell, tx);
+
       // Link as default pattern within same transaction
       const spaceCellWithTx = spaceCellContents.withTx(tx);
       const defaultPatternCell = spaceCellWithTx.key("defaultPattern");
@@ -1701,6 +1780,8 @@ export class PiecesController<T = unknown> {
           // Stamp the provenance the piece tracks for updates (the source it
           // was born from) — the same transaction, one extra meta write.
           setPatternSource(pieceCell, tx, patternConfig.source);
+
+          this.declareSpaceScopedPieceLabel(pieceCell, tx);
 
           // Link as default pattern within same transaction
           defaultPatternCell.set(pieceCell.withTx(tx));

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -86,7 +86,7 @@ export async function setSlugLink(
   const indexCell = slugIndexCell(pieces);
   await indexCell.sync();
 
-  await pieces.runtime.editWithRetry((tx) => {
+  const { error } = await pieces.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
     const metadataTargetWithTx = metadataTarget?.withTx(tx);
@@ -107,6 +107,12 @@ export async function setSlugLink(
     // never see a name without its slug or a slug without its name.
     indexCell.withTx(tx).key(validSlug).set(true);
   });
+  if (error) {
+    throw new Error(
+      `Setting slug "${validSlug}" failed because storage returned ${error.name}: ${error.message}`,
+      { cause: error },
+    );
+  }
 
   await pieces.runtime.idle();
   await pieces.synced();

--- a/packages/piece/test/pattern-compatibility-check.test.ts
+++ b/packages/piece/test/pattern-compatibility-check.test.ts
@@ -12,7 +12,10 @@ import {
 } from "@commonfabric/runner/storage/cache.deno";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import type * as MemoryV2Server from "@commonfabric/memory/v2/server";
-import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
+import {
+  loadStoredCfcEnvelope,
+  readStoredCfcMetadata,
+} from "@commonfabric/runner/cfc";
 import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 // `cf piece setsrc <main>` replaces the source of a LIVE piece. Until now the
@@ -223,6 +226,58 @@ function strengthenedProgram(): RuntimeProgram {
     }],
   };
 }
+
+/**
+ * A source piece publishing a writable another piece can link to. Its own
+ * document carries the space's creation label, which is what makes a link into
+ * it a labeled write.
+ */
+function writableSourceProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern, Writable } from 'commonfabric';",
+        "export default pattern<Record<string, never>, {",
+        "  value: Writable<string>;",
+        "}>(() => ({",
+        "  [NAME]: 'Link source',",
+        "  value: new Writable('shared').for('value'),",
+        "}));",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/**
+ * A piece taking one linked input alongside a REQUIRED plain field that
+ * declares no default — the shape the additive-required merge rule rejects —
+ * and no `ifc` claims anywhere.
+ */
+function linkedProgram(label: string): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern, Writable } from 'commonfabric';",
+        "interface Args { seed: string; linked: Writable<string>; }",
+        "export default pattern<Args, { label: string }>(",
+        "  ({ seed, linked }) => ({",
+        "    [NAME]: 'Compatibility check',",
+        `    label: ${label},`,
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+const linkedBase = () => linkedProgram("seed");
+const linkedNext = () => linkedProgram("`seen:${seed}`");
 
 describe("setsrc compatibility preflight", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -532,6 +587,64 @@ describe("setsrc compatibility preflight", () => {
       await freshRuntime.dispose();
       await freshStorage.close();
     }
+  });
+
+  /**
+   * A piece whose argument document carries an envelope no pattern declared.
+   * Writing a link into the argument makes the write CFC-relevant — the linked
+   * piece carries its space's creation label — and a link write supplies no
+   * schema candidate, so what lands is an envelope whose schema claims
+   * nothing. This is the ordinary shape for a piece reading another piece's
+   * data.
+   */
+  const pieceLinkingLabeledData = async () => {
+    const source = await pieces.create(writableSourceProgram());
+    await runtime.idle();
+    const piece = await pieces.create(linkedBase(), {
+      input: { seed: "hello", linked: source.getCell().key("value") },
+    });
+    await runtime.idle();
+
+    const link = pieces.getArgument(piece.getCell()).getAsNormalizedFullLink();
+    const stored = loadStoredCfcEnvelope(runtime.readTx(), {
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+    });
+    expect(
+      stored.status,
+      "the linked fixture stored no CFC envelope, so the cases below would " +
+        "pass for want of one rather than because the check works",
+    ).toBe("loaded");
+    expect(
+      JSON.stringify(stored.status === "loaded" ? stored.schema : undefined),
+      "the fixture's envelope carries ifc claims, so it is the labeled case " +
+        "above rather than the claim-less one these cases are about",
+    ).not.toContain("ifc");
+    return piece;
+  };
+
+  it("clears a candidate whose argument schema claims nothing", async () => {
+    // The candidate declares no `ifc`, so the commit records no schema
+    // candidate for the argument document and keeps the stored envelope as it
+    // is — there is no merge for the preflight to disagree with. Running the
+    // merge anyway rejects every candidate carrying a required field, because
+    // an envelope that claims nothing declares no default to migrate from.
+    const piece = await pieceLinkingLabeledData();
+    const report = await piece.checkPattern(linkedNext());
+
+    expect(report.issues.cfc).toBe(undefined);
+    expect(report.compatible).toBe(true);
+  });
+
+  it("agrees with the apply path on a candidate that claims nothing", async () => {
+    // The verdict above is worth acting on only if the deploy really lands.
+    const piece = await pieceLinkingLabeledData();
+    await piece.setPattern(linkedNext());
+    await runtime.idle();
+
+    expect((piece.getCell().getAsQueryResult() as { label?: string }).label)
+      .toBe("seen:hello");
   });
 
   it("still lets the dangerous override through", async () => {

--- a/packages/piece/test/piece-creation-labels.test.ts
+++ b/packages/piece/test/piece-creation-labels.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Creation-time space labeling: every piece the controller creates records a
+ * declared confidentiality on the piece document — `PersonalSpace(<space>)`
+ * when the space is its owner's identity space, `Space(<space did>)`
+ * otherwise — and a piece whose document already carries confidentiality
+ * keeps its own labeling.
+ */
+
+import { expect } from "@std/expect";
+import { afterEach, describe, it } from "@std/testing/bdd";
+
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { createSession, Identity, type Session } from "@commonfabric/identity";
+import {
+  type Cell,
+  resolveEntryIdentity,
+  resolveSystemPatternSource,
+  Runtime,
+} from "@commonfabric/runner";
+import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  DEFAULT_APP_PATTERN_SOURCE,
+  PiecesController,
+} from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece creation labels");
+
+const COUNTER_SOURCE = [
+  "import { pattern, Writable } from 'commonfabric';",
+  "export default pattern<{ label: string }>(({ label }) => {",
+  "  const count = new Writable(0).for('count');",
+  "  return { label, count };",
+  "});",
+  "",
+].join("\n");
+
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: COUNTER_SOURCE }],
+};
+
+/** The route the space root's pattern ref resolves to. */
+const DEFAULT_APP_PATTERN_PATH = resolveSystemPatternSource(
+  DEFAULT_APP_PATTERN_SOURCE,
+)!;
+
+const ROOT_SOURCE = [
+  "import { pattern } from 'commonfabric';",
+  "export default pattern<{ items?: string[] }>(({ items }) => ({ items }));",
+  "",
+].join("\n");
+
+/** Serve the space root's pattern, which `ensureDefaultPattern` fetches. */
+function serveRootPattern(): { restore(): void } {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const href = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
+    const url = new URL(href);
+    if (url.pathname !== DEFAULT_APP_PATTERN_PATH) {
+      return new Response("not found", { status: 404 });
+    }
+    if (url.searchParams.has("identity")) {
+      const identity = await resolveEntryIdentity(
+        DEFAULT_APP_PATTERN_PATH,
+        (name) =>
+          name === DEFAULT_APP_PATTERN_PATH
+            ? Promise.resolve(ROOT_SOURCE)
+            : Promise.reject(new Error(`not found: ${name}`)),
+      );
+      return new Response(identity, {
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response(ROOT_SOURCE, {
+      headers: { "content-type": "text/typescript-jsx" },
+    });
+  }) as typeof globalThis.fetch;
+  return { restore: () => (globalThis.fetch = original) };
+}
+
+/**
+ * The confidentiality a document DECLARES at its root: the store-policy
+ * component (§8.12.4) as it sits in storage. Read from the stored label map
+ * rather than from a display label view, because the view also carries what a
+ * document merely inherits — link-carried and flow-derived components, and the
+ * labels of whatever it links to — and none of those is the document's own
+ * policy.
+ */
+function declaredRootConfidentiality(
+  runtime: Runtime,
+  cell: Cell<unknown>,
+): readonly unknown[] {
+  const link = cell.getAsNormalizedFullLink();
+  const metadata = readStoredCfcMetadata(runtime.readTx(), {
+    space: link.space,
+    id: link.id,
+    scope: link.scope,
+  });
+  return (metadata?.labelMap.entries ?? [])
+    .filter((entry) =>
+      entry.path.length === 0 &&
+      (entry.origin === undefined || entry.origin === "declared")
+    )
+    .flatMap((entry) => entry.label.confidentiality ?? []);
+}
+
+describe("piece creation labels", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  async function controllerFor(session: Session): Promise<PiecesController> {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    const pieces = new PiecesController(session, runtime);
+    await pieces.synced();
+    return pieces;
+  }
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  it("declares the space principal on a piece created in a named space", async () => {
+    const pieces = await controllerFor(
+      await createSession({
+        identity: signer,
+        spaceName: `creation-label-${crypto.randomUUID()}`,
+      }),
+    );
+    const piece = await pieces.create(PROGRAM, {
+      input: { label: "labeled" },
+    });
+
+    expect(declaredRootConfidentiality(runtime!, piece.getCell())).toEqual([
+      { type: CFC_ATOM_TYPE.Space, id: pieces.getSpace() },
+    ]);
+  });
+
+  it("declares the personal-space principal in the owner's identity space", async () => {
+    const pieces = await controllerFor(
+      await createSession({
+        identity: signer,
+        spaceDid: signer.did(),
+      }),
+    );
+    const piece = await pieces.create(PROGRAM, {
+      input: { label: "home" },
+    });
+
+    expect(declaredRootConfidentiality(runtime!, piece.getCell())).toEqual([
+      { type: CFC_ATOM_TYPE.PersonalSpace, owner: signer.did() },
+    ]);
+  });
+
+  it("keeps a document's own confidentiality instead of adding the space's", async () => {
+    const pieces = await controllerFor(
+      await createSession({
+        identity: signer,
+        spaceName: `creation-label-kept-${crypto.randomUUID()}`,
+      }),
+    );
+    const carried = {
+      type: CFC_ATOM_TYPE.Resource,
+      class: "CreationLabelTest",
+      subject: "did:example:carried",
+    } as const;
+    const cause = `prelabeled-${crypto.randomUUID()}`;
+    const seeded = runtime!.getCell<Record<string, never>>(
+      pieces.getSpace(),
+      cause,
+    );
+    const { error } = await runtime!.editWithRetry((tx) => {
+      const withTx = seeded.withTx(tx);
+      withTx.set({});
+      withTx.asSchema({ ifc: { confidentiality: [carried] } })
+        .applyCfcSchemaToExistingValue();
+    });
+    expect(error).toBeUndefined();
+
+    const piece = await pieces.create(PROGRAM, {
+      input: { label: "kept" },
+    }, cause);
+
+    const clauses = declaredRootConfidentiality(runtime!, piece.getCell());
+    expect(clauses).toContainEqual(carried);
+    expect(clauses).not.toContainEqual(
+      { type: CFC_ATOM_TYPE.Space, id: pieces.getSpace() },
+    );
+  });
+
+  it("re-declares the destination's principal on a piece copied across spaces", async () => {
+    // Both halves of the clone story in one case: the source space's own
+    // principal is residency scoping, so the guards let the copy through
+    // rather than refusing every labeled piece, and the copy comes out of
+    // creation carrying the destination space's principal instead.
+    const pieces = await controllerFor(
+      await createSession({
+        identity: signer,
+        spaceName: `creation-label-clone-source-${crypto.randomUUID()}`,
+      }),
+    );
+    const source = await pieces.create(PROGRAM, {
+      input: { label: "copied" },
+    });
+    const destination = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `creation-label-clone-destination-${crypto.randomUUID()}`,
+      }),
+      runtime!,
+    );
+    await destination.synced();
+
+    const clone = await source.cloneTo(destination, { copyData: true });
+
+    expect(declaredRootConfidentiality(runtime!, clone.getCell())).toEqual([
+      { type: CFC_ATOM_TYPE.Space, id: destination.getSpace() },
+    ]);
+    expect(await clone.input.get()).toEqual({ label: "copied" });
+  });
+
+  it("declares the space principal on the root piece", async () => {
+    const server = serveRootPattern();
+    try {
+      const pieces = await controllerFor(
+        await createSession({
+          identity: signer,
+          spaceName: `creation-label-root-${crypto.randomUUID()}`,
+        }),
+      );
+      const root = await pieces.ensureDefaultPattern();
+
+      expect(declaredRootConfidentiality(runtime!, root.getCell())).toEqual([
+        { type: CFC_ATOM_TYPE.Space, id: pieces.getSpace() },
+      ]);
+    } finally {
+      server.restore();
+    }
+  });
+
+  it("declares the space principal on a recreated root piece", async () => {
+    const pieces = await controllerFor(
+      await createSession({
+        identity: signer,
+        spaceName: `creation-label-recreate-${crypto.randomUUID()}`,
+      }),
+    );
+    const recreated = await pieces.recreateDefaultPattern({
+      customProgram: {
+        main: "/root.tsx",
+        files: [{ name: "/root.tsx", contents: ROOT_SOURCE }],
+      },
+    });
+
+    expect(declaredRootConfidentiality(runtime!, recreated.getCell())).toEqual([
+      { type: CFC_ATOM_TYPE.Space, id: pieces.getSpace() },
+    ]);
+  });
+});

--- a/packages/piece/test/piece-origin.test.ts
+++ b/packages/piece/test/piece-origin.test.ts
@@ -1548,9 +1548,13 @@ describe("reading a piece's source state", () => {
     );
     await destination.synced();
 
+    // The linked piece carries its own space's creation label, so the label
+    // guard refuses the cross-space copy before the snapshot-consistency
+    // check sees the second space.
     await expect(source.cloneTo(destination, { copyData: true })).rejects
       .toThrow(
-        "piece data linked from another space cannot be copied consistently",
+        "piece data with confidentiality or integrity labels cannot be " +
+          "copied into another space",
       );
   });
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,5 +1,5 @@
 import { isFabricPrimitiveSchemaType } from "@commonfabric/api";
-import type { FabricValue } from "@commonfabric/api";
+import type { FabricValue, MetaField } from "@commonfabric/api";
 import {
   CFC_ATOM_TYPE,
   CFC_COMPILED_BY_ATOM_PREFIX,
@@ -1323,6 +1323,29 @@ const schemaEnvelopeForTargetPath = (
   return envelope;
 };
 
+// Document-root storage paths the raw meta seam writes (`setMetaRaw`). Typed
+// as a total map over `MetaField`, so adding a meta field without deciding its
+// treatment here is a compile error.
+const RAW_META_WRITE_PATH_ROOTS: Readonly<Record<MetaField, true>> = {
+  pattern: true,
+  argument: true,
+  result: true,
+  patternIdentity: true,
+  patternSetupIdentity: true,
+  patternSource: true,
+  pieceSourceHistory: true,
+  patternRepository: true,
+  displacedPattern: true,
+  internal: true,
+  schema: true,
+  slug: true,
+};
+
+/** Whether a raw storage path addresses the meta seam rather than a value. */
+const isRawMetaWritePath = (rawPath: readonly string[]): boolean =>
+  rawPath.length > 0 &&
+  Object.hasOwn(RAW_META_WRITE_PATH_ROOTS, rawPath[0]);
+
 const valueWriteTargets = (
   tx: IExtendedStorageTransaction,
 ): Map<
@@ -1333,6 +1356,9 @@ const valueWriteTargets = (
     id: URI;
     type: MediaType;
     paths: (readonly string[])[];
+    // The subset of `paths` a schema write-policy input can describe: every
+    // written path except the raw meta seam, which no schema covers.
+    schemaPolicyPaths: (readonly string[])[];
     // Last written value per path (pathKey), for flow-label value-shape
     // classification (pure link structure is not stamped).
     valuesByPath: Map<string, unknown>;
@@ -1362,6 +1388,7 @@ const valueWriteTargets = (
       id: URI;
       type: MediaType;
       paths: (readonly string[])[];
+      schemaPolicyPaths: (readonly string[])[];
       valuesByPath: Map<string, unknown>;
       previousValuesByPath: Map<string, unknown>;
       previousPresentByPath: Map<string, boolean>;
@@ -1377,16 +1404,17 @@ const valueWriteTargets = (
     for (const write of tx.getWriteDetails?.(space) ?? []) {
       const rawPath = write.address.path;
       const writePath = canonicalizeLogicalPath(rawPath);
-      // The `cfc`/`source` surface exclusions key on the RAW storage path:
-      // the runtime-internal surfaces are document-root siblings of `value`
-      // (raw `["cfc", ...]`/`["source", ...]`), while user fields of the
-      // same names live under `["value", ...]` and canonicalize to identical
-      // logical paths. Keying on the canonical path would let a user write
-      // to `value.source` dodge schema write policy and flow-label
-      // attachment (#4011 review). The link-valued `internal` exclusion
-      // stays canonical on purpose: it covers the runtime's link plumbing
-      // both at the root surface and inside process-doc values; link writes
-      // carry their labels via the link-write machinery, not here.
+      // The runtime-surface exclusions key on the RAW storage path: the
+      // runtime-internal surfaces are document-root siblings of `value`
+      // (raw `["cfc", ...]`/`["source", ...]` and the `MetaField` roots the
+      // raw meta seam writes), while user fields of the same names live
+      // under `["value", ...]` and canonicalize to identical logical paths.
+      // Keying on the canonical path would let a user write to
+      // `value.source` dodge schema write policy and flow-label attachment
+      // (#4011 review). The link-valued `internal` exclusion stays canonical
+      // on purpose: it covers the runtime's link plumbing both at the root
+      // surface and inside process-doc values; link writes carry their labels
+      // via the link-write machinery, not here.
       if (
         write.address.id.startsWith("cid:") ||
         rawPath[0] === "cfc" ||
@@ -1398,6 +1426,14 @@ const valueWriteTargets = (
       ) {
         continue;
       }
+      // A raw meta write (`setMetaRaw`) lands on a document-root sibling of
+      // `value`, and no schema describes that seam, so it can carry no schema
+      // write-policy input. It stays a flow-label target — reads of the seam
+      // still feed the taint join, so its writes must still be stamped — and
+      // is recorded here only to be left out of the schema-policy
+      // requirement. Keyed on the RAW path, so a user field of the same name
+      // under `value` keeps its policy requirement.
+      const metaWrite = isRawMetaWritePath(rawPath);
       // A document-root write carries the RAW envelope ({value, source, …}):
       // writeOrThrow's missing-doc retry materializes the whole document in
       // one write at storage path []. `writePath` is already logical, so the
@@ -1429,6 +1465,7 @@ const valueWriteTargets = (
       const existing = result.get(key);
       if (existing !== undefined) {
         existing.paths.push(writePath);
+        if (!metaWrite) existing.schemaPolicyPaths.push(writePath);
         existing.valuesByPath.set(pathKey(writePath), writtenValue);
         if (!existing.previousValuesByPath.has(pathKey(writePath))) {
           existing.previousValuesByPath.set(
@@ -1447,6 +1484,7 @@ const valueWriteTargets = (
           id: write.address.id as URI,
           type: (write.address.type ?? "application/json") as MediaType,
           paths: [writePath],
+          schemaPolicyPaths: metaWrite ? [] : [writePath],
           valuesByPath: new Map([[pathKey(writePath), writtenValue]]),
           previousValuesByPath: new Map([[
             pathKey(writePath),
@@ -5241,7 +5279,7 @@ export const prepareBoundaryCommit = (
     if (existing === undefined) {
       continue;
     }
-    if (!metadataAppliesToAnyPath(existing, target.paths)) {
+    if (!metadataAppliesToAnyPath(existing, target.schemaPolicyPaths)) {
       continue;
     }
     const linkWriteInputs = linkWrites.get(key) ?? [];

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -264,6 +264,7 @@ export type {
 } from "./telemetry-otel-bridge.ts";
 
 // Utility functions (split from utils.ts)
+export { schemaHasIfc } from "./schema.ts";
 export { createJsonSchema } from "./builder/create-json-schema.ts";
 export { deepEqual } from "@commonfabric/utils/deep-equal";
 export { getValueAtPath, setValueAtPath } from "./path-utils.ts";


### PR DESCRIPTION
Every piece the controller creates — `cf piece new` and `run_pattern` deployments through `setupPersistent`, and the space's root piece through `ensureDefaultPattern` and `recreateDefaultPattern` — now records a declared confidentiality on the piece document at creation: `PersonalSpace(<space>)` when the space is its owner's identity space, `Space(<space did>)` otherwise.

The declared component is the document's store policy (§8.12.4), so a labeled space-internal flow fits the piece's write ceiling, and the display boundary resolves the label through the acting user's space membership (the §8.10.6 profile plus the HasRole exchange rules). A piece born from a restored or copied snapshot that already carries confidentiality keeps its own labeling — declared confidentiality evolves monotonically (§8.12.1), so the space scoping only ever seeds a piece born without one — and a piece whose value is not written yet is left unlabeled until it materializes.

Labeling a piece document exposed two rules that only ever ran against unlabeled ones, so both are fixed here rather than left for the caller to trip over.

First, the raw meta seam. The CFC prepare pass requires a schema write-policy input for every recorded write to a document that carries stored label metadata. A raw meta write (`setMetaRaw`) lands on a document-root sibling of `value` — `slug`, `patternIdentity`, `pieceSourceHistory`, and the rest of the `MetaField` union — where no schema describes the seam and so none can be recorded. On a labeled document such a write therefore recorded a "missing schema write-policy input" reason and the enforcing modes rejected the commit, which reaches every flow that stamps meta on a piece: slug assignment, the pattern updater's identity swap, setup over an existing piece, and the source-lifecycle transitions. The requirement now skips the meta seam, keyed on the RAW storage path, so a user field of the same name — which lives under `value` and canonicalizes to an identical logical path — keeps its policy requirement. The skip is deliberately confined to that one requirement: meta writes stay flow-label targets, because reads of the seam still feed the taint join and a write the join reaches must still be stamped. A total map over `MetaField` makes adding a meta field without deciding its treatment here a compile error. `setSlugLink` also reports its commit error now instead of discarding the result of its retried transaction and resolving with a slug that never landed.

Second, the source-change preflight. It dry-runs the CFC schema- envelope merge so its verdict cannot disagree with the deploy, but the commit never merges a schema a pattern declared unless that schema carries `ifc` claims. For an ifc-less write on a document that already stores metadata, `recordRelevantSchemaWritePolicyInput` records the document's own stored schema as the candidate, so the persist pass merges the stored envelope with itself and leaves it as it was. A cross-piece link write against a labeled source mints an envelope whose schema claims nothing, since a plain link write supplies no schema candidate, and creation labels make that the ordinary shape for a piece reading another piece's data. The preflight ran the merge anyway, so it produced a "cannot migrate: required field needs a default" issue for every candidate carrying a required field, over a merge no commit performs. Every source change on such a piece then warned "incompatible", and the retained-input-changed rejection became unreachable, because a recomputed review always carried the bogus issue and confirmation returned a fresh warning instead of throwing. The preflight now mirrors the commit's candidate-selection rule: no `ifc` claims on the candidate's argument schema means no commit-side merge to disagree with, so no envelope issue. The covers fast path, the merge for ifc-bearing candidates, and the unreadable-envelope blocker are unchanged.

`schemaHasIfc`, which the preflight needs to ask that question, is exported from the runner package rather than reached for through a relative path into its source tree.

The clone guards learn the residency form. A confidentiality clause that is exactly the source space's own principal is that space's residency scoping, which a copy into another space drops by design, because the destination re-declares its own principal at creation — a clone creates its copy through the same `create` path every other piece is born on. So `assertCloneDataUnlabeled` no longer refuses every freshly created piece. Everything else still refuses the copy: other spaces, users, caveats, every integrity entry, and a clause that merely offers the space principal among other alternatives, since such a clause says more about its audience than where the data lives. The space that counts is the one the copy is taken from, threaded through the whole walk rather than read off each node, so a label naming some other space's own principal cannot pass as residency at the node that happens to live there. The cross-space clone test follows: the label guard now refuses a piece linking foreign-space data before the snapshot-consistency check sees the second space.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

