### PR TITLE
fix(patterns): mint the integrity a floored list requires

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -110,11 +110,14 @@ export type SharedProfilesCell = Writable<SharedProfilesValue>;
 export type TrustedChatRoom = ChatRoom<SharedChatMessage>;
 
 export type ChatAdminList = RequiresIntegrity<
-  TrustedActionWrite<
-    ChatAdminRole[],
-    typeof commitTrustedAdminToggle,
-    typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
-    typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+  AddIntegrity<
+    TrustedActionWrite<
+      ChatAdminRole[],
+      typeof commitTrustedAdminToggle,
+      typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+      typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
   >,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
@@ -156,11 +159,14 @@ export type ChatAdminRegistryValue =
 export type ChatAdminRegistryCell = Writable<ChatAdminRegistryValue>;
 
 export type SharedRoomList = RequiresIntegrity<
-  TrustedActionWrite<
-    TrustedChatRoom[],
-    typeof commitTrustedRoomAdd,
-    typeof TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION,
-    typeof TRUSTED_GROUP_CHAT_ROOM_SURFACE
+  AddIntegrity<
+    TrustedActionWrite<
+      TrustedChatRoom[],
+      typeof commitTrustedRoomAdd,
+      typeof TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION,
+      typeof TRUSTED_GROUP_CHAT_ROOM_SURFACE
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
   >,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;

--- a/packages/patterns/cfc/README.md
+++ b/packages/patterns/cfc/README.md
@@ -73,7 +73,10 @@ type ProjectAdminRole = AddIntegrity<
 >;
 
 type ProjectAdminList = RequiresIntegrity<
-  ProjectAdminRole[],
+  AddIntegrity<
+    ProjectAdminRole[],
+    readonly [typeof PROJECT_ADMIN_MANAGER_INTEGRITY]
+  >,
   readonly [typeof PROJECT_ADMIN_MANAGER_INTEGRITY]
 >;
 
@@ -85,6 +88,21 @@ const admins = adminRegistryEntries<ProjectAdminRole>(adminRegistry);
 const everyoneIsAdmin = adminRegistryEveryoneIsAdmin(adminRegistry);
 const canEditAdmins = adminManagerCredentialIsActive(managerCredential.get());
 ```
+
+`ProjectAdminList` names `PROJECT_ADMIN_MANAGER_INTEGRITY` twice, once as the
+floor it requires and once as the atom it mints. The floor is checked against
+the value being written at the path that declares it, and a mint on the entries
+below that path does not reach it, so a list that floors an atom nothing mints
+is a list no write can satisfy once `cfcWriteFloor` reaches `enforce`.
+
+Mint the floored atom when the pattern's own gated write is the endorsement, as
+it is here: the manager credential and the trusted handler decide who may write
+the list, and the mint records that they did. Leave the floor unminted when the
+endorsement has to come from outside the pattern. A record of an externally
+verified fact is the case to watch: the value reaches the pattern as a link to a
+document that already carries the atom, the floor is met by the label that link
+carries, and minting the atom locally would let the pattern endorse whatever it
+writes.
 
 Keep subject lookup and local role toggling in the pattern when the domain model
 is local, such as people, profiles, rooms, or projects.

--- a/packages/patterns/factory-outputs/lot-watch/DESIGN.md
+++ b/packages/patterns/factory-outputs/lot-watch/DESIGN.md
@@ -201,8 +201,9 @@ does. The integrity-tagged role model:
 
 - `adminManagerCredentialIsActive(credential)` — gates who may _assign_ admins.
 - `adminRegistryEntries<Role>(registry)` — read the admin list.
-- `AddIntegrity<...>` / `RequiresIntegrity<...>` — brand the role/list types so
-  they can only be produced through the credentialed path.
+- `AddIntegrity<...>` / `RequiresIntegrity<...>` — label the role and list
+  types. The list requires the manager atom and mints it, which is what the
+  write floor checks; the credential check above decides who may write it.
 
 ```ts
 export const LOT_WATCH_ADMIN_INTEGRITY = "lot-watch-admin" as const;

--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -147,7 +147,10 @@ export type LotWatchAdminManagerCredential = AdminManagerCredential<
 >;
 
 export type LotWatchAdminList = RequiresIntegrity<
-  LotWatchAdminRole[],
+  AddIntegrity<
+    LotWatchAdminRole[],
+    readonly [typeof LOT_WATCH_ADMIN_MANAGER_INTEGRITY]
+  >,
   readonly [typeof LOT_WATCH_ADMIN_MANAGER_INTEGRITY]
 >;
 

--- a/packages/patterns/lobby/main.tsx
+++ b/packages/patterns/lobby/main.tsx
@@ -91,11 +91,14 @@ export type LobbyRosterValue =
 export type LobbyRosterCell = Writable<LobbyRosterValue>;
 
 export type LobbyAdminList = RequiresIntegrity<
-  TrustedActionWrite<
-    LobbyAdminRole[],
-    typeof commitTrustedLobbyAction,
-    typeof TRUSTED_LOBBY_ACTION,
-    typeof TRUSTED_LOBBY_SURFACE
+  AddIntegrity<
+    TrustedActionWrite<
+      LobbyAdminRole[],
+      typeof commitTrustedLobbyAction,
+      typeof TRUSTED_LOBBY_ACTION,
+      typeof TRUSTED_LOBBY_SURFACE
+    >,
+    readonly [typeof LOBBY_ADMIN_INTEGRITY]
   >,
   readonly [typeof LOBBY_ADMIN_INTEGRITY]
 >;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3327,7 +3327,7 @@ const isNonEndorsementProvenanceAtom = (atom: unknown): boolean =>
 // provenance reads that could have fed the write. Provenance-only reads still
 // count as "the write had labeled input" for the #14 empty-prefix arm — the
 // group-chat admin-grant shape (provenance lookup + protected write, no
-// endorsed read, no mint) must keep committing.
+// endorsed read) must keep committing.
 const isProvenanceOnlyConsumedLabel = (label: IFCLabel): boolean => {
   if ((label.confidentiality?.length ?? 0) > 0) return false;
   const integrity = label.integrity ?? [];

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -214,6 +214,66 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
+  it("a mint on an array's items does not satisfy a floor on the array path", async () => {
+    // The shape a pattern reaches for when a list of endorsed entries is
+    // stored behind a floor: each entry mints the atom, the list path
+    // declares it. The floor is checked at the path it is declared on, and
+    // the items' mints sit below that path, so the list write is unendorsed
+    // until the list path mints too. Both halves run here — the item-only
+    // shape rejects, the same shape with a path mint commits.
+    const items = {
+      type: "object",
+      properties: {
+        subject: { type: "string" },
+        displayName: { type: "string" },
+      },
+      required: ["subject", "displayName"],
+      ifc: { addIntegrity: [ADMIN_ATOM] },
+    } as const;
+    const itemMintOnly = {
+      type: "object",
+      properties: {
+        admins: {
+          type: "array",
+          items,
+          ifc: { requiredIntegrity: [ADMIN_ATOM] },
+        },
+      },
+      required: ["admins"],
+    } as const satisfies JSONSchema;
+    const alsoPathMint = {
+      type: "object",
+      properties: {
+        admins: {
+          type: "array",
+          items,
+          ifc: { requiredIntegrity: [ADMIN_ATOM], addIntegrity: [ADMIN_ATOM] },
+        },
+      },
+      required: ["admins"],
+    } as const satisfies JSONSchema;
+
+    const writeAdmins = async (schema: JSONSchema, id: string) => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+      try {
+        const tx = runtime.edit();
+        const sink = runtime.getCell(signer.did(), id, schema, tx);
+        sink.set({ admins: [{ subject: "alice", displayName: "Alice" }] });
+        tx.prepareCfc();
+        return String((await tx.commit()).error?.message ?? "");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    expect(await writeAdmins(itemMintOnly, "wf-item-mint-sink")).toContain(
+      "write floor failed",
+    );
+    expect(await writeAdmins(alsoPathMint, "wf-path-mint-sink")).toBe("");
+  });
+
   it("the floor is a minimum: extra minted integrity is fine", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });


### PR DESCRIPTION
Four list types across three patterns declare a required-integrity floor on the path they are stored at, while nothing mints that atom on the value written there. They are `SharedRoomList` and `ChatAdminList` in the group-chat demo, `LobbyAdminList` in the lobby, and `LotWatchAdminList` in lot-watch.

The write-side floor tests the integrity of the value being written. Three things can supply that integrity: an `addIntegrity` mint in the schema, the label a link carries from the document it points at, and the hereditary meet of the flow where flow labels are persisted. An atom that is a plain string is bound to the value it labels and is never hereditary, so the admin registry a commit handler reads on its way to the write contributes nothing to the integrity of the list it then writes. A mint on the entries below the path does not reach it either, because the floor is checked at the path that declares it. A path that declares a floor and mints nothing therefore fails its own floor on every write once `cfcWriteFloor` is set to `enforce`, so every trusted room add and every admin change in these patterns fails.

Wrap each list in `AddIntegrity` of the atom its own floor names, which is the shape the write-floor suite documents for a floor-protected path: the schema that declares the floor also mints it. The admin-helper guide taught the mintless shape, so it now carries the corrected example and the rule on either side of it. Mint the floored atom where the pattern's own gated write is the endorsement. Leave the floor unminted where the endorsement comes from outside, as `VerifiedExternalIdentity` does in the profile pattern: there the value arrives as a link to a document that already carries the atom, and minting locally would let the pattern endorse whatever it writes.

The mint grants no authority these writes did not already have. The group-chat and lobby lists name their writer with `writeAuthorizedBy`, so the pattern's own commit handler is the only writer the path accepts, and the gesture that drives it carries the trusted-surface contract. The lot-watch list declares no writer binding. There the same atom is already minted by the admin-manager credential, which that pattern lets a user set for themselves, so minting it on the list the credential guards grants nothing a user could not already mint. These atoms are plain strings, which no mint gate restricts, so any schema could always declare them.

A test pins the mechanism: under an enforcing floor, a list whose entries each mint the atom is still rejected when the list path itself mints nothing, and the same write commits once the path mints. That is the failure these four types had, and it is the reason the mint has to sit where the floor is declared rather than on the entries below it.

Two consequences are worth recording, both inert at today's dials. A store written before this change that already carries a declared entry at one of these paths would see the new atom as an addition, which the declared-monotonicity check counts as a weakening once that dial leaves `off`; the group-chat and lobby paths are in that position, because their writer and contract claims already persist an entry there. And a declared entry covers the paths beneath it that declare nothing of their own, so a room's fields now read as carrying the admin atom, which is the authority the trusted add handler wrote them under.

The parking coordinator has the same mintless shape in `ParkingAdminList` and `ParkingSpotList` and is deliberately left alone. Minting there makes reads of those paths labeled, which pulls them into the gating set that the read-side `requiredIntegrity` check quantifies over, and that check needs one shared witness atom across every gated read. A registry floored on the manager atom and a spot list floored on the admin atom have no shared witness, so the mints reject sixteen of that pattern's writes. It needs its own change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

