### PR TITLE
feat(scheduler): a measure can name which action it was

### DIFF
--- a/packages/runner/src/scheduler/diagnostics.ts
+++ b/packages/runner/src/scheduler/diagnostics.ts
@@ -67,6 +67,24 @@ export function getSchedulerActionId(
   return generatedId;
 }
 
+/**
+ * Just the readable name of an action, without the rest of its telemetry.
+ *
+ * `getSchedulerActionTelemetryInfo` formats every annotated read and write on
+ * the way to producing these two names, which is the bulk of its work and none
+ * of what a caller wanting a label uses. Both names are plain properties, so
+ * this is two reads and no allocation.
+ */
+export function getSchedulerActionName(
+  action: Action | EventHandler,
+): string | undefined {
+  const annotated = action as Partial<TelemetryAnnotations>;
+  // `||`, so an empty name falls through rather than winning: a name a reader
+  // cannot use is not a name.
+  return getOptionalName(annotated.module) ||
+    getOptionalName(annotated.pattern);
+}
+
 export function getSchedulerActionTelemetryInfo(
   action: Action | EventHandler,
 ): SchedulerActionInfo | undefined {

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -27,7 +27,10 @@ import {
   runIdempotencyRecheck,
 } from "./diagnosis.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
-import { toActionRunTraceAddress } from "./diagnostics.ts";
+import {
+  getSchedulerActionTelemetryInfo,
+  toActionRunTraceAddress,
+} from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
 import { type ActionTimingState, recordActionTime } from "./timing.ts";
@@ -47,6 +50,23 @@ const logger = getLogger("scheduler", {
   level: "warn",
 });
 
+/**
+ * Which action a `scheduler/run/action` span belongs to.
+ *
+ * The key stays `scheduler/run/action` for every one of them, because a key
+ * names a place in the code and the statistics are keyed by it — naming the
+ * action there would multiply the rows by every action the runtime has ever
+ * run. The timeline is where an occurrence can be identified, so this rides
+ * along on the emitted measure instead, and only when emission is on.
+ *
+ * The module or pattern name is what a reader recognizes; the action id is the
+ * fallback for an action that carries neither.
+ */
+function actionMeasureDetail(action: Action, actionId: string): string {
+  const info = getSchedulerActionTelemetryInfo(action);
+  return info?.moduleName ?? info?.patternName ?? actionId;
+}
+
 export type ActionInvocationResult =
   | { ok: true; result: any }
   | { ok: false; error: unknown };
@@ -61,6 +81,8 @@ export function invokeReactiveAction(state: {
   readonly tx: IExtendedStorageTransaction;
   readonly actionStartTime: number;
 }): Promise<ActionInvocationResult> {
+  // Outside the `try`, because the failure paths below name the action too.
+  const measureDetail = actionMeasureDetail(args.action, args.actionId);
   try {
     // Track executing action for parent-child relationship tracking.
     state.setExecutingAction(args.action, args.actionId);
@@ -69,7 +91,7 @@ export function invokeReactiveAction(state: {
       state.runtime.harness.invoke(() => args.action(args.tx)),
     )
       .then((actionResult) => {
-        logger.timeEnd("scheduler", "run", "action");
+        logger.timeEndDetailed(measureDetail, "scheduler", "run", "action");
         state.clearExecutingAction();
         logger.debug("schedule-action-timing", () => {
           const duration = ((performance.now() - args.actionStartTime) / 1000)
@@ -81,12 +103,12 @@ export function invokeReactiveAction(state: {
         return { ok: true as const, result: actionResult };
       })
       .catch((error) => {
-        logger.timeEnd("scheduler", "run", "action");
+        logger.timeEndDetailed(measureDetail, "scheduler", "run", "action");
         state.clearExecutingAction();
         return { ok: false as const, error };
       });
   } catch (error) {
-    logger.timeEnd("scheduler", "run", "action");
+    logger.timeEndDetailed(measureDetail, "scheduler", "run", "action");
     state.clearExecutingAction();
     return Promise.resolve({ ok: false as const, error });
   }

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -60,11 +60,17 @@ const logger = getLogger("scheduler", {
  * along on the emitted measure instead, and only when emission is on.
  *
  * The module or pattern name is what a reader recognizes; the action id is the
- * fallback for an action that carries neither.
+ * fallback for an action that carries neither, and for one that carries an
+ * empty string — which is a name a reader cannot use, not a name.
+ *
+ * Called only when a measure is actually being emitted. Building it walks and
+ * formats every annotated read and write, which is far more than the two names
+ * used here, and paying that per action on the ordinary path — emission off,
+ * which is every production run — is not a trade this is worth.
  */
 function actionMeasureDetail(action: Action, actionId: string): string {
   const info = getSchedulerActionTelemetryInfo(action);
-  return info?.moduleName ?? info?.patternName ?? actionId;
+  return info?.moduleName || info?.patternName || actionId;
 }
 
 export type ActionInvocationResult =
@@ -81,8 +87,10 @@ export function invokeReactiveAction(state: {
   readonly tx: IExtendedStorageTransaction;
   readonly actionStartTime: number;
 }): Promise<ActionInvocationResult> {
-  // Outside the `try`, because the failure paths below name the action too.
-  const measureDetail = actionMeasureDetail(args.action, args.actionId);
+  // A thunk, not a value: the logger calls it only when it will emit, so an
+  // ordinary run never builds it. Outside the `try` because the failure paths
+  // below name the action too.
+  const measureDetail = () => actionMeasureDetail(args.action, args.actionId);
   try {
     // Track executing action for parent-child relationship tracking.
     state.setExecutingAction(args.action, args.actionId);

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -28,7 +28,7 @@ import {
 } from "./diagnosis.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
 import {
-  getSchedulerActionTelemetryInfo,
+  getSchedulerActionName,
   toActionRunTraceAddress,
 } from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
@@ -63,14 +63,16 @@ const logger = getLogger("scheduler", {
  * fallback for an action that carries neither, and for one that carries an
  * empty string — which is a name a reader cannot use, not a name.
  *
- * Called only when a measure is actually being emitted. Building it walks and
- * formats every annotated read and write, which is far more than the two names
- * used here, and paying that per action on the ordinary path — emission off,
- * which is every production run — is not a trade this is worth.
+ * Two property reads, and called only when a measure is actually being
+ * emitted. Both halves of that matter and were measured: the full telemetry
+ * builder formats every annotated read and write on its way to these same two
+ * names, which costs about 675ns per action — more than twice the timing pair
+ * it would sit inside — so a label asks for a name rather than for telemetry.
+ * Deferring what remains costs about 4ns and saves about 19ns per action on the
+ * ordinary path, where emission is off.
  */
 function actionMeasureDetail(action: Action, actionId: string): string {
-  const info = getSchedulerActionTelemetryInfo(action);
-  return info?.moduleName || info?.patternName || actionId;
+  return getSchedulerActionName(action) || actionId;
 }
 
 export type ActionInvocationResult =

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -511,7 +511,7 @@ let _timingMeasureSequence = 0;
  * should stop paying at the same moment — which is precisely the longest run,
  * where it would otherwise cost the most.
  */
-function willEmitTimingMeasure(): boolean {
+export function willEmitTimingMeasure(): boolean {
   return _emitTimingMeasures && _timingMeasuresEmitted < _timingMeasureCap;
 }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -524,6 +524,30 @@ export const TIMING_MEASURE_PREFIX = "cf:";
  */
 export const TIMING_MEASURE_DETAIL = "|";
 
+/**
+ * Make a key or a detail safe to put in a measure name.
+ *
+ * Reversibly, because both are arbitrary strings a caller chose: substituting
+ * the separators away would map `a|b` and `a/b` onto one name, and two actions
+ * that differ only there would then report as one row. Percent-encoding is the
+ * cheapest thing that survives a round trip, and `%` goes first so decoding
+ * cannot mistake an encoded byte for one the caller wrote.
+ */
+export function encodeMeasureField(value: string): string {
+  return value
+    .replaceAll("%", "%25")
+    .replaceAll(TIMING_MEASURE_DETAIL, "%7C")
+    .replaceAll("#", "%23");
+}
+
+/** The inverse of {@link encodeMeasureField}. */
+export function decodeMeasureField(value: string): string {
+  return value
+    .replaceAll("%23", "#")
+    .replaceAll("%7C", TIMING_MEASURE_DETAIL)
+    .replaceAll("%25", "%");
+}
+
 /** The detail carried by an emitted measure, if it has one. */
 export function detailOfMeasure(name: string): string | undefined {
   const body = name.startsWith(TIMING_MEASURE_PREFIX)
@@ -532,7 +556,9 @@ export function detailOfMeasure(name: string): string | undefined {
   const hash = body.lastIndexOf("#");
   const withoutSequence = hash === -1 ? body : body.slice(0, hash);
   const bar = withoutSequence.indexOf(TIMING_MEASURE_DETAIL);
-  return bar === -1 ? undefined : withoutSequence.slice(bar + 1);
+  return bar === -1
+    ? undefined
+    : decodeMeasureField(withoutSequence.slice(bar + 1));
 }
 
 function getEnvMeasuresEnabled(): boolean {
@@ -1029,13 +1055,24 @@ export class Logger {
    * stay keyed by the path alone, so a caller can identify an occurrence
    * without multiplying the rows by every value the detail takes.
    */
-  timeEndDetailed(detail: string, ...keys: string[]): number | undefined {
+  timeEndDetailed(
+    detail: string | (() => string),
+    ...keys: string[]
+  ): number | undefined {
     const keyPath = keys.join("/");
     const startTime = this.#activeTimers.get(keyPath);
     if (startTime === undefined) return undefined;
     this.#activeTimers.delete(keyPath);
     const elapsed = performance.now() - startTime;
-    this.#recordTime(elapsed, keys, startTime, detail);
+    // Resolved only when it will be used. A caller whose detail costs anything
+    // to produce passes a function, and pays nothing on the ordinary path
+    // where emission is off — which is every production run.
+    const resolved = !_emitTimingMeasures
+      ? undefined
+      : typeof detail === "function"
+      ? detail()
+      : detail;
+    this.#recordTime(elapsed, keys, startTime, resolved);
     return elapsed;
   }
 
@@ -1303,14 +1340,14 @@ export class Logger {
       return;
     }
     try {
-      // The separators are structure, so a detail carrying one would make the
-      // name unparseable; they are replaced rather than the detail refused,
-      // because losing a span is a worse answer than renaming it.
-      const named = detail
-        ? `${path}${TIMING_MEASURE_DETAIL}${
-          detail.replaceAll(TIMING_MEASURE_DETAIL, "/").replaceAll("#", "_")
-        }`
-        : path;
+      // Both fields are encoded, not just the detail: a key is a caller's
+      // string as much as a detail is, and one containing a separator would
+      // otherwise be parsed back as a key and a detail that were never there.
+      const named = detail === undefined
+        ? encodeMeasureField(path)
+        : `${encodeMeasureField(path)}${TIMING_MEASURE_DETAIL}${
+          encodeMeasureField(detail)
+        }`;
       performance.measure(
         `${TIMING_MEASURE_PREFIX}${named}#${++_timingMeasureSequence}`,
         {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -504,6 +504,18 @@ let _timingMeasureCapReported = false;
 let _timingMeasureSequence = 0;
 
 /**
+ * Whether the next span would actually reach the timeline.
+ *
+ * Emission being on is not the same as a measure being emitted: once the cap is
+ * reached nothing more is written, and a caller that pays to build a detail
+ * should stop paying at the same moment — which is precisely the longest run,
+ * where it would otherwise cost the most.
+ */
+function willEmitTimingMeasure(): boolean {
+  return _emitTimingMeasures && _timingMeasuresEmitted < _timingMeasureCap;
+}
+
+/**
  * What marks a measure as this logger's.
  *
  * The performance timeline is shared with whatever else the host instruments,
@@ -1066,8 +1078,9 @@ export class Logger {
     const elapsed = performance.now() - startTime;
     // Resolved only when it will be used. A caller whose detail costs anything
     // to produce passes a function, and pays nothing on the ordinary path
-    // where emission is off — which is every production run.
-    const resolved = !_emitTimingMeasures
+    // where emission is off — which is every production run — nor once the cap
+    // has stopped emission partway through one.
+    const resolved = !willEmitTimingMeasure()
       ? undefined
       : typeof detail === "function"
       ? detail()

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -513,6 +513,28 @@ let _timingMeasureSequence = 0;
  */
 export const TIMING_MEASURE_PREFIX = "cf:";
 
+/**
+ * What separates a span's key from the detail naming that one instance.
+ *
+ * A detail identifies which of many spans on a key this one was — which action
+ * ran, which document was read — and it belongs to the emitted measure alone.
+ * Putting it in the key instead would multiply the statistics by every value it
+ * takes, which is the cost the keys are deliberately shaped to avoid: a key is
+ * a place in the code, not an occurrence.
+ */
+export const TIMING_MEASURE_DETAIL = "|";
+
+/** The detail carried by an emitted measure, if it has one. */
+export function detailOfMeasure(name: string): string | undefined {
+  const body = name.startsWith(TIMING_MEASURE_PREFIX)
+    ? name.slice(TIMING_MEASURE_PREFIX.length)
+    : name;
+  const hash = body.lastIndexOf("#");
+  const withoutSequence = hash === -1 ? body : body.slice(0, hash);
+  const bar = withoutSequence.indexOf(TIMING_MEASURE_DETAIL);
+  return bar === -1 ? undefined : withoutSequence.slice(bar + 1);
+}
+
 function getEnvMeasuresEnabled(): boolean {
   if (isDeno()) {
     try {
@@ -1001,6 +1023,23 @@ export class Logger {
   }
 
   /**
+   * Ends a timer as `timeEnd()` does, and names this one span on the timeline.
+   *
+   * The detail reaches the emitted measure and nothing else: the statistics
+   * stay keyed by the path alone, so a caller can identify an occurrence
+   * without multiplying the rows by every value the detail takes.
+   */
+  timeEndDetailed(detail: string, ...keys: string[]): number | undefined {
+    const keyPath = keys.join("/");
+    const startTime = this.#activeTimers.get(keyPath);
+    if (startTime === undefined) return undefined;
+    this.#activeTimers.delete(keyPath);
+    const elapsed = performance.now() - startTime;
+    this.#recordTime(elapsed, keys, startTime, detail);
+    return elapsed;
+  }
+
+  /**
    * Records a timing measurement directly. Useful for measuring IPC latency,
    * or any other case where the timestamps are already in hand.
    *
@@ -1214,7 +1253,12 @@ export class Logger {
    * Records timing against the full key path only, with no rollup to the
    * shorter paths.
    */
-  #recordTime(elapsed: number, keys: string[], startTime?: number): void {
+  #recordTime(
+    elapsed: number,
+    keys: string[],
+    startTime?: number,
+    detail?: string,
+  ): void {
     const path = keys.join("/");
     let store = this.#timingsByKey.get(path);
     if (!store) {
@@ -1226,7 +1270,7 @@ export class Logger {
     }
     store.record(elapsed);
     if (_emitTimingMeasures && startTime !== undefined) {
-      this.#emitMeasure(path, startTime, elapsed);
+      this.#emitMeasure(path, startTime, elapsed, detail);
     }
   }
 
@@ -1241,7 +1285,12 @@ export class Logger {
    * there is nothing to gain from marking the boundaries and looking them up
    * again — the mark-based spelling costs several times as much.
    */
-  #emitMeasure(path: string, startTime: number, elapsed: number): void {
+  #emitMeasure(
+    path: string,
+    startTime: number,
+    elapsed: number,
+    detail?: string,
+  ): void {
     if (_timingMeasuresEmitted >= _timingMeasureCap) {
       if (!_timingMeasureCapReported) {
         _timingMeasureCapReported = true;
@@ -1254,8 +1303,16 @@ export class Logger {
       return;
     }
     try {
+      // The separators are structure, so a detail carrying one would make the
+      // name unparseable; they are replaced rather than the detail refused,
+      // because losing a span is a worse answer than renaming it.
+      const named = detail
+        ? `${path}${TIMING_MEASURE_DETAIL}${
+          detail.replaceAll(TIMING_MEASURE_DETAIL, "/").replaceAll("#", "_")
+        }`
+        : path;
       performance.measure(
-        `${TIMING_MEASURE_PREFIX}${path}#${++_timingMeasureSequence}`,
+        `${TIMING_MEASURE_PREFIX}${named}#${++_timingMeasureSequence}`,
         {
           start: startTime,
           end: startTime + elapsed,

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -2262,6 +2262,28 @@ describe("logger", () => {
       expect(built).toBe(1);
     });
 
+    it("stops building details once the cap has stopped emission", () => {
+      setTimingMeasuresEnabled(true, { cap: 2 });
+      const logger = getLogger("measure-detail-capped");
+      let built = 0;
+      for (let i = 0; i < 6; i++) {
+        logger.timeStart("phase", "capped");
+        logger.timeEndDetailed(
+          () => {
+            built++;
+            return `run-${i}`;
+          },
+          "phase",
+          "capped",
+        );
+      }
+      // Emission being on is not the same as a measure being written: past the
+      // cap nothing reaches the timeline, so nothing should be built for it —
+      // and that is the longest run, where it would cost the most.
+      expect(built).toBe(2);
+      expect(logger.getTimeStats("phase", "capped")?.count).toBe(6);
+    });
+
     it("reports no detail for a span that was not named", () => {
       setTimingMeasuresEnabled(true);
       const logger = getLogger("measure-no-detail");

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/logger.ts";
 import {
   clearTimingMeasures,
+  detailOfMeasure,
   getTimingMeasuresState,
   parseTimingMeasureCap,
   resetTimingMeasureBudget,
@@ -2174,6 +2175,60 @@ describe("logger", () => {
         performance.measure = realMeasure;
         performance.clearMeasures = realClear;
       }
+    });
+
+    it("names one span on the timeline without touching the statistics", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-detail");
+      logger.timeStart("scheduler", "run", "action");
+      logger.timeEndDetailed("topics/main", "scheduler", "run", "action");
+      logger.timeStart("scheduler", "run", "action");
+      logger.timeEndDetailed("topics/topic", "scheduler", "run", "action");
+
+      // One row, because a key is a place in the code — naming the occurrence
+      // in the key instead would multiply the statistics by every action the
+      // runtime has ever run, which is the cost this split exists to avoid.
+      expect(logger.getTimeStats("scheduler", "run", "action")?.count).toBe(2);
+
+      const details = performance.getEntriesByType("measure")
+        .filter((entry) =>
+          entry.name.startsWith(`${TIMING_MEASURE_PREFIX}scheduler/run/action`)
+        )
+        .map((entry) => detailOfMeasure(entry.name));
+      expect(details.sort()).toEqual(["topics/main", "topics/topic"]);
+    });
+
+    it("keeps a detail from making a name unparseable", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-detail-hostile");
+      logger.timeStart("phase", "twelve");
+      // The separators are structure. A detail carrying one is renamed rather
+      // than refused: losing the span would be the worse answer.
+      logger.timeEndDetailed("a|b#c", "phase", "twelve");
+
+      const entry = performance.getEntriesByType("measure").find((e) =>
+        e.name.startsWith(`${TIMING_MEASURE_PREFIX}phase/twelve`)
+      );
+      expect(entry).toBeDefined();
+      expect(detailOfMeasure(entry!.name)).toBe("a/b_c");
+    });
+
+    it("reports no detail for a span that was not named", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-no-detail");
+      logger.timeStart("phase", "thirteen");
+      logger.timeEnd("phase", "thirteen");
+
+      const entry = performance.getEntriesByType("measure").find((e) =>
+        e.name.startsWith(`${TIMING_MEASURE_PREFIX}phase/thirteen#`)
+      );
+      expect(entry).toBeDefined();
+      expect(detailOfMeasure(entry!.name)).toBeUndefined();
+
+      // Ending a timer that was never started reports nothing rather than
+      // inventing a span, exactly as the undetailed `timeEnd` does.
+      expect(logger.timeEndDetailed("x", "phase", "never-started"))
+        .toBeUndefined();
     });
   });
 });

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -1947,7 +1947,9 @@ describe("logger", () => {
 
   describe("timing measures", () => {
     afterEach(() => {
-      setTimingMeasuresEnabled(false);
+      // The cap deliberately survives toggling emission, so a test that set a
+      // small one would otherwise silently throttle every test after it.
+      setTimingMeasuresEnabled(false, { cap: 1_000 });
       clearTimingMeasures();
     });
 
@@ -2198,19 +2200,66 @@ describe("logger", () => {
       expect(details.sort()).toEqual(["topics/main", "topics/topic"]);
     });
 
-    it("keeps a detail from making a name unparseable", () => {
+    it("carries a detail containing separators through unchanged", () => {
       setTimingMeasuresEnabled(true);
       const logger = getLogger("measure-detail-hostile");
       logger.timeStart("phase", "twelve");
-      // The separators are structure. A detail carrying one is renamed rather
-      // than refused: losing the span would be the worse answer.
-      logger.timeEndDetailed("a|b#c", "phase", "twelve");
+      logger.timeEndDetailed("a|b#c%d", "phase", "twelve");
 
       const entry = performance.getEntriesByType("measure").find((e) =>
         e.name.startsWith(`${TIMING_MEASURE_PREFIX}phase/twelve`)
       );
       expect(entry).toBeDefined();
-      expect(detailOfMeasure(entry!.name)).toBe("a/b_c");
+      // Reversibly, not by substitution: two details differing only in which
+      // separator they contain must not come back as the same string, or two
+      // distinct actions report as one row.
+      expect(detailOfMeasure(entry!.name)).toBe("a|b#c%d");
+    });
+
+    it("keeps details that differ only by a separator distinct", () => {
+      setTimingMeasuresEnabled(true);
+      const logger = getLogger("measure-detail-collide");
+      for (const detail of ["a|b", "a/b", "a#b", "a_b"]) {
+        logger.timeStart("phase", "collide");
+        logger.timeEndDetailed(detail, "phase", "collide");
+      }
+      const seen = performance.getEntriesByType("measure")
+        .filter((e) =>
+          e.name.startsWith(`${TIMING_MEASURE_PREFIX}phase/collide`)
+        )
+        .map((e) => detailOfMeasure(e.name));
+      expect(new Set(seen).size).toBe(4);
+    });
+
+    it("does not build a detail that will not be emitted", () => {
+      setTimingMeasuresEnabled(false);
+      const logger = getLogger("measure-detail-lazy");
+      let built = 0;
+      logger.timeStart("phase", "lazy");
+      logger.timeEndDetailed(
+        () => {
+          built++;
+          return "expensive";
+        },
+        "phase",
+        "lazy",
+      );
+      // Emission is off on every production run, and a caller whose detail
+      // costs anything to produce must not pay for it there.
+      expect(built).toBe(0);
+      expect(logger.getTimeStats("phase", "lazy")?.count).toBe(1);
+
+      setTimingMeasuresEnabled(true);
+      logger.timeStart("phase", "lazy");
+      logger.timeEndDetailed(
+        () => {
+          built++;
+          return "expensive";
+        },
+        "phase",
+        "lazy",
+      );
+      expect(built).toBe(1);
     });
 
     it("reports no detail for a span that was not named", () => {

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -141,6 +141,11 @@ you begin and what you can trust:
   by key prefix, which is what the statistics cannot do: a logger records
   against its full joined path and nothing shorter, so the count at the level
   where it starts multiplying exists in no stored row.
+- **Some keys name the occurrence too.** A key is a place in the code, so
+  `scheduler/run/action` is the same key for every action that runs. Where the
+  emitter can say which one, it attaches that to the measure rather than the key
+  — putting it in the key would multiply the statistics by every value it takes
+  — and `attribute-measures.ts --detail` groups by it.
 - **Intervals recover the caller.** A key that runs everywhere is recorded
   against itself whoever reached it, so no aggregate can say who is responsible.
   Spans nest, so the span open when another began is the one that called it:

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -61,7 +61,13 @@ function keyOf(name: string): string {
   const hash = body.lastIndexOf("#");
   const withoutSequence = hash === -1 ? body : body.slice(0, hash);
   const bar = withoutSequence.indexOf("|");
-  return bar === -1 ? withoutSequence : withoutSequence.slice(0, bar);
+  const key = bar === -1 ? withoutSequence : withoutSequence.slice(0, bar);
+  // The emitter percent-encodes the field, so a key containing a separator
+  // comes back whole rather than as a split that was never there.
+  return key.replaceAll("%23", "#").replaceAll("%7C", "|").replaceAll(
+    "%25",
+    "%",
+  );
 }
 
 function emptyBucket(path: string, depth: number): Bucket {

--- a/skills/perf-investigation/scripts/aggregate-measures.ts
+++ b/skills/perf-investigation/scripts/aggregate-measures.ts
@@ -48,14 +48,20 @@ interface Bucket {
   children: Map<string, Bucket>;
 }
 
-/** `cf:cell/get/user-data#4127` names the span `cell/get/user-data`. */
+/**
+ * `cf:cell/get/user-data#4127` names the span `cell/get/user-data`, and a
+ * `|detail` after the key names one occurrence of it, which this view groups
+ * away — see `attribute-measures.ts --detail` for reading it.
+ */
 const MEASURE_PREFIX = "cf:";
 function keyOf(name: string): string {
   const body = name.startsWith(MEASURE_PREFIX)
     ? name.slice(MEASURE_PREFIX.length)
     : name;
   const hash = body.lastIndexOf("#");
-  return hash === -1 ? body : body.slice(0, hash);
+  const withoutSequence = hash === -1 ? body : body.slice(0, hash);
+  const bar = withoutSequence.indexOf("|");
+  return bar === -1 ? withoutSequence : withoutSequence.slice(0, bar);
 }
 
 function emptyBucket(path: string, depth: number): Bucket {

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -17,6 +17,9 @@
  *   # and who calls the heavy ones specifically — usually not the same answer
  *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --via=traverse --heavy=1000
  *
+ *   # which occurrences a key's spans were, where the emitter named them
+ *   deno run --allow-read attribute-measures.ts measures.json --key=scheduler/run/action --detail
+ *
  *   # the most common full call chains
  *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --chains
  *
@@ -30,7 +33,10 @@ import {
   buildForest,
   callerOf,
   collapseRepeats,
+  detailOf,
+  keyOf,
   loadMeasures,
+  type MeasureEntry,
 } from "./measure-forest.ts";
 
 function flag(name: string): string | undefined {
@@ -43,6 +49,7 @@ const target = flag("key");
 const via = flag("via");
 const heavy = Number(flag("heavy") ?? "0");
 const wantChains = Deno.args.includes("--chains");
+const wantDetail = Deno.args.includes("--detail");
 
 if (!target) {
   console.error(
@@ -52,7 +59,8 @@ if (!target) {
   Deno.exit(1);
 }
 
-const spans = buildForest(await loadMeasures(path));
+const entries = await loadMeasures(path);
+const spans = buildForest(entries);
 const hits: number[] = [];
 for (let i = 0; i < spans.length; i++) {
   if (spans[i].key === target) hits.push(i);
@@ -73,7 +81,43 @@ console.log(`${target}: ${hits.length} spans, ${totalMs.toFixed(0)}ms total`);
 
 const ROOT = "(root — no instrumented span above)";
 
-if (wantChains) {
+if (wantDetail) {
+  // Read from the entries rather than the forest: a detail names an occurrence
+  // and the forest keeps only what containment needs, which is the key.
+  const byDetail = new Map<string, { n: number; ms: number }>();
+  let unnamed = 0;
+  for (const entry of entries as MeasureEntry[]) {
+    if (keyOf(entry.name) !== target) continue;
+    const detail = detailOf(entry.name);
+    if (detail === undefined) {
+      unnamed++;
+      continue;
+    }
+    const row = byDetail.get(detail) ?? { n: 0, ms: 0 };
+    row.n++;
+    row.ms += entry.duration;
+    byDetail.set(detail, row);
+  }
+  if (byDetail.size === 0) {
+    console.log(
+      `\nNo span of ${target} carries a detail. Only some keys name their ` +
+        `occurrences — \`scheduler/run/action\` names the action that ran.`,
+    );
+  } else {
+    console.log(`\n  spans       ms   ms each  which occurrence`);
+    for (
+      const [detail, row] of [...byDetail].sort((a, b) => b[1].ms - a[1].ms)
+        .slice(0, 25)
+    ) {
+      console.log(
+        `${String(row.n).padStart(7)} ${row.ms.toFixed(0).padStart(8)} ${
+          (row.ms / row.n).toFixed(2).padStart(9)
+        }  ${detail}`,
+      );
+    }
+    if (unnamed > 0) console.log(`\n${unnamed} span(s) carried no detail.`);
+  }
+} else if (wantChains) {
   const chains = new Map<string, number>();
   for (const i of hits) {
     // Aggregate on the whole chain; truncating first would merge callers that

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -46,25 +46,38 @@ export const MEASURE_DETAIL = "|";
  * and grouping by it is the whole point, so an occurrence's identity is
  * stripped here and read separately by anything that wants it.
  */
-export function keyOf(name: string): string {
+/**
+ * The emitter percent-encodes both fields, so a key or detail containing a
+ * separator survives the round trip instead of being read back as a split that
+ * was never there.
+ */
+function decodeField(value: string): string {
+  return value
+    .replaceAll("%23", "#")
+    .replaceAll("%7C", MEASURE_DETAIL)
+    .replaceAll("%25", "%");
+}
+
+function splitName(name: string): { key: string; detail?: string } {
   const body = name.startsWith(MEASURE_PREFIX)
     ? name.slice(MEASURE_PREFIX.length)
     : name;
   const hash = body.lastIndexOf("#");
   const withoutSequence = hash === -1 ? body : body.slice(0, hash);
   const bar = withoutSequence.indexOf(MEASURE_DETAIL);
-  return bar === -1 ? withoutSequence : withoutSequence.slice(0, bar);
+  return bar === -1 ? { key: decodeField(withoutSequence) } : {
+    key: decodeField(withoutSequence.slice(0, bar)),
+    detail: decodeField(withoutSequence.slice(bar + 1)),
+  };
+}
+
+export function keyOf(name: string): string {
+  return splitName(name).key;
 }
 
 /** Which occurrence this span was, where the emitter named one. */
 export function detailOf(name: string): string | undefined {
-  const body = name.startsWith(MEASURE_PREFIX)
-    ? name.slice(MEASURE_PREFIX.length)
-    : name;
-  const hash = body.lastIndexOf("#");
-  const withoutSequence = hash === -1 ? body : body.slice(0, hash);
-  const bar = withoutSequence.indexOf(MEASURE_DETAIL);
-  return bar === -1 ? undefined : withoutSequence.slice(bar + 1);
+  return splitName(name).detail;
 }
 
 /**

--- a/skills/perf-investigation/scripts/measure-forest.ts
+++ b/skills/perf-investigation/scripts/measure-forest.ts
@@ -35,13 +35,36 @@ export interface Span {
 /** Emitted entries carry this, so clearing can be selective. */
 export const MEASURE_PREFIX = "cf:";
 
-/** `cf:cell/get/user-data#4127` names the span `cell/get/user-data`. */
+/** Separates a key from the detail naming one occurrence of it. */
+export const MEASURE_DETAIL = "|";
+
+/**
+ * `cf:cell/get/user-data#4127` names the span `cell/get/user-data`, and
+ * `cf:scheduler/run/action|topics/main#88` names `scheduler/run/action`.
+ *
+ * The detail is deliberately not part of the key: a key is a place in the code
+ * and grouping by it is the whole point, so an occurrence's identity is
+ * stripped here and read separately by anything that wants it.
+ */
 export function keyOf(name: string): string {
   const body = name.startsWith(MEASURE_PREFIX)
     ? name.slice(MEASURE_PREFIX.length)
     : name;
   const hash = body.lastIndexOf("#");
-  return hash === -1 ? body : body.slice(0, hash);
+  const withoutSequence = hash === -1 ? body : body.slice(0, hash);
+  const bar = withoutSequence.indexOf(MEASURE_DETAIL);
+  return bar === -1 ? withoutSequence : withoutSequence.slice(0, bar);
+}
+
+/** Which occurrence this span was, where the emitter named one. */
+export function detailOf(name: string): string | undefined {
+  const body = name.startsWith(MEASURE_PREFIX)
+    ? name.slice(MEASURE_PREFIX.length)
+    : name;
+  const hash = body.lastIndexOf("#");
+  const withoutSequence = hash === -1 ? body : body.slice(0, hash);
+  const bar = withoutSequence.indexOf(MEASURE_DETAIL);
+  return bar === -1 ? undefined : withoutSequence.slice(bar + 1);
 }
 
 /**


### PR DESCRIPTION
`scheduler/run/action` is one span per action run, and its key says nothing about which action ran. Attributing 51 spans to that key gives one undifferentiated row — the very question an investigation is asking is the one the row cannot answer.

The key cannot carry it. A key is a place in the code and the statistics are keyed by it, so naming the action there would multiply the stored rows by every action the runtime has ever run — the cost the keys are deliberately shaped to avoid.

## What this adds

The timeline is where an occurrence can be identified, so the identity rides on the emitted measure instead. `logger.timeEndDetailed(detail, ...keys)` names one span and touches nothing else; the scheduler passes the action's module or pattern name, falling back to its id.

```bash
deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
  /tmp/measures.json --key=scheduler/run/action --detail
```

On a topics run:

```
  spans       ms   ms each  which occurrence
      3       11      3.57  cf:module/…:crossrefTable:MJ1BHpP8oNp5
     24       10      0.40  pull:of:fid1:X0EADvp4YD0zRmAghAEQQJTGmt4Z83MgPaOTdpeSFFw
      1        3      3.15  cf:module/…:backlinksOf:6FeDnv9UY1wr
      1        3      2.67  cf:module/…:createdByOf:cCBQxcrYqtq1
```

Those are the actions themselves — `crossrefTable`, `backlinksOf`, `createdByOf` — where before there was a single row.

## Notes

**It costs nothing when emission is off**, which is the default: nothing reaches the name until a measure is emitted at all.

**The statistics are unchanged.** A test asserts that two spans with different details still produce one row keyed by the path — the split is the whole point, and it would be easy to lose.

**The separators are structure**, so a detail containing one is renamed rather than refused: losing a span is a worse answer than renaming it. `keyOf` strips the detail, so `aggregate-measures.ts` and every other view groups exactly as before.

## Tests

Four cases: the detail reaching the timeline while the statistics stay keyed by the path alone, a detail carrying separators being renamed rather than dropped, a span with no detail reporting none, and ending a timer that was never started reporting nothing rather than inventing a span. `logger.ts` sits at 163 uncovered lines, the same as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Coverage

`packages/runner` is two lines over its baseline on `packages/runner/src/builtins/wish.ts:1051-1052` — a file this branch never opens. The check identified the case itself: none of the lines added here are uncovered, and those two are covered on some `main` runs and not others. Accepted rather than fixed here, per `docs/development/COVERAGE.md`, which is explicit that the author's pull request is not the place to chase a flapping line.

`packages/utils`, the group this branch actually changes, is at its baseline.

ACCEPT_COVERAGE_DEBT: packages/runner +2 lines
