### PR TITLE
feat(perf): the capture says where the next span belongs

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -204,7 +204,26 @@ Reaching uninstrumented ground is a result, not a dead end. A large root share
 says those spans ran outside every wrapped region, and the next move is to wrap
 one level above the thing you were chasing and run again — which is step 2 of
 this list with a better vantage point. Say so explicitly rather than reporting
-the attributable fraction as though it were the whole. The level where a count stops being
+the attributable fraction as though it were the whole.
+
+The same capture usually says where to put that span:
+
+```bash
+deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
+  /tmp/measures.json --key=traverse --roots --ignore=tx/read
+```
+
+Two views, from data already in hand. The first drops the transparency that
+attribution applies to the harness phases — for a span nothing else encloses,
+they are the only thing that locates it, and they say *when* in the run it
+happened. The second names what finished most recently before each one, which
+is a caller nobody wrapped: it ran, returned, and the work followed it.
+
+A name concentrated in both is where a span would attribute the most. The two
+disagreeing is worth more than either alone, because they answer different
+questions. And `--ignore` matters more than it looks: a key emitted constantly
+is always the nearest thing to have ended, so it crowds the second view without
+handing off to anything — dropping it is what lets the real predecessor show. The level where a count stops being
 proportional to the work and starts being proportional to the work squared is
 the level that introduced the multiplication — that is the caller to fix, and it
 is frequently not the

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -162,6 +162,12 @@ ones. `docs/development/debugging/profiling.md` carries that ladder. A chain
 that reaches uninstrumented ground has produced a result rather than a dead end:
 it names where to wrap next.
 
+A chain that reaches uninstrumented ground has not run out of data. The harness
+phases that attribution treats as transparent still locate those spans in the
+run, and whatever finished immediately before them is a caller nobody wrapped —
+`attribute-measures.ts --roots` reads both out of the capture you already have,
+and names where the next span would attribute the most.
+
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a
 hypothesis. Confirm it correlates — that it moves with the real measurement

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -23,6 +23,11 @@
  *   # the most common full call chains
  *   deno run --allow-read attribute-measures.ts measures.json --key=tx/read --chains
  *
+ *   # where to add the next span, for the ones nothing encloses
+ *   deno run --allow-read attribute-measures.ts measures.json --key=traverse --roots
+ *   #   ...ignoring a key so frequent it is always the nearest thing to end
+ *   deno run --allow-read attribute-measures.ts measures.json --key=traverse --roots --ignore=tx/read
+ *
  * Read the `--via` table for the ratio rather than the totals. A caller with
  * few parent spans and many children each is a width problem — one call doing
  * too much — and is fixed differently from a caller with many parent spans
@@ -50,6 +55,8 @@ const via = flag("via");
 const heavy = Number(flag("heavy") ?? "0");
 const wantChains = Deno.args.includes("--chains");
 const wantDetail = Deno.args.includes("--detail");
+const wantRoots = Deno.args.includes("--roots");
+const ignored = new Set((flag("ignore") ?? "").split(",").filter(Boolean));
 
 if (!target) {
   console.error(
@@ -116,6 +123,86 @@ if (wantDetail) {
       );
     }
     if (unnamed > 0) console.log(`\n${unnamed} span(s) carried no detail.`);
+  }
+} else if (wantRoots) {
+  // A root is an honest answer — the span ran outside every instrumented
+  // region — but it is not a useful one on its own. These two views turn it
+  // into a place to put the next span, from data already in hand.
+  const roots = hits.filter((i) => callerOf(spans, i) === undefined);
+  console.log(
+    `\n${roots.length} of ${hits.length} ${target} spans have no ` +
+      `instrumented caller.`,
+  );
+  if (roots.length === 0) {
+    console.log("Nothing to locate: every span already sits inside a span.");
+  } else {
+    // The harness phases are transparent to attribution on purpose, but for a
+    // span nothing else encloses they are the only thing that locates it.
+    const byAny = new Map<string, number>();
+    for (const i of roots) {
+      const parent = spans[i].parent;
+      byAny.set(
+        parent === -1 ? "(nothing at all)" : spans[parent].key,
+        (byAny.get(parent === -1 ? "(nothing at all)" : spans[parent].key) ??
+          0) + 1,
+      );
+    }
+    console.log("\nwhat encloses them once nothing is treated as transparent:");
+    for (
+      const [key, n] of [...byAny].sort((a, b) => b[1] - a[1]).slice(0, 12)
+    ) {
+      console.log(`  ${String(n).padStart(7)}  ${key}`);
+    }
+
+    // What finished immediately before. A shared predecessor across many roots
+    // is a caller nobody wrapped: it ran, returned, and the work followed it.
+    const ends = spans.map((_, i) => i).sort((a, b) =>
+      spans[a].end - spans[b].end
+    );
+    const endTimes = ends.map((i) => spans[i].end);
+    const before = new Map<string, number>();
+    for (const i of roots) {
+      const t = spans[i].start;
+      let lo = 0, hi = endTimes.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (endTimes[mid] <= t) lo = mid + 1;
+        else hi = mid;
+      }
+      let label = "(nothing before)";
+      for (let j = lo - 1; j >= 0; j--) {
+        const candidate = spans[ends[j]];
+        // Only spans nothing encloses, and never the target itself. A child of
+        // whatever ran previously is almost always the nearest thing to have
+        // ended, and it says nothing: it belongs to that work rather than
+        // handing off to this. The previous top-level span is the handoff.
+        if (candidate.parent !== -1 || candidate.key === target) continue;
+        if (ignored.has(candidate.key)) continue;
+        label = candidate.key;
+        break;
+      }
+      before.set(label, (before.get(label) ?? 0) + 1);
+    }
+    console.log("\nwhat finished most recently before each began:");
+    for (
+      const [key, n] of [...before].sort((a, b) => b[1] - a[1]).slice(0, 12)
+    ) {
+      console.log(`  ${String(n).padStart(7)}  ${key}`);
+    }
+    // No attempt to flag which name is noise: a key that dominates because it
+    // is emitted constantly and one that dominates because it really is the
+    // handoff look identical from here, and guessing wrong would point an
+    // investigation at the wrong place with a confident-sounding label.
+    console.log(
+      "\nA name concentrated in both views is where a span would attribute " +
+        "the\nmost, and the two disagreeing is worth more than either alone: " +
+        "one says\nwhen in the run, the other says what handed off to it.",
+    );
+    console.log(
+      "\nA key emitted constantly is always the nearest thing to have ended, " +
+        "so it\ncrowds this column without handing off to anything. Pass " +
+        "--ignore=a,b to\ndrop such a key and see what is behind it.",
+    );
   }
 } else if (wantChains) {
   const chains = new Map<string, number>();

--- a/skills/perf-investigation/scripts/attribute-measures.ts
+++ b/skills/perf-investigation/scripts/attribute-measures.ts
@@ -172,18 +172,26 @@ if (wantDetail) {
       let label = "(nothing before)";
       for (let j = lo - 1; j >= 0; j--) {
         const candidate = spans[ends[j]];
-        // Only spans nothing encloses, and never the target itself. A child of
-        // whatever ran previously is almost always the nearest thing to have
-        // ended, and it says nothing: it belongs to that work rather than
-        // handing off to this. The previous top-level span is the handoff.
-        if (candidate.parent !== -1 || candidate.key === target) continue;
-        if (ignored.has(candidate.key)) continue;
+        // Top level in the same sense the root count uses — no *instrumented*
+        // caller — rather than no parent at all. A span whose only parent is a
+        // transparent harness phase is top level for this purpose, and reading
+        // the raw parent here would have discarded exactly the handoffs worth
+        // finding, since a rootless target usually sits inside such a phase.
+        if (candidate.key === target || ignored.has(candidate.key)) continue;
+        if (callerOf(spans, ends[j]) !== undefined) continue;
         label = candidate.key;
         break;
       }
       before.set(label, (before.get(label) ?? 0) + 1);
     }
-    console.log("\nwhat finished most recently before each began:");
+    console.log(
+      `\nwhat finished most recently before each began` +
+        `${
+          ignored.size === 0
+            ? " (ignoring nothing)"
+            : ` (ignoring ${[...ignored].join(", ")})`
+        }:`,
+    );
     for (
       const [key, n] of [...before].sort((a, b) => b[1] - a[1]).slice(0, 12)
     ) {


### PR DESCRIPTION
A chain that reaches uninstrumented ground stops being answerable. On one topics run, 62% of `tx/read` spans had no instrumented caller — the honest report is that they ran outside every wrapped region, which names the next step without saying where to take it.

The same capture usually can.

## `--roots`

```bash
deno run --allow-read skills/perf-investigation/scripts/attribute-measures.ts \
  /tmp/measures.json --key=traverse --roots --ignore=tx/read
```

Two views, from data already in hand:

**What encloses them once nothing is transparent.** Attribution deliberately treats the harness phases as see-through, because otherwise they win every containment test. But for a span nothing *else* encloses, they are the only thing that locates it — they say *when* in the run it happened.

**What finished most recently before each one.** A shared predecessor across many roots is a caller nobody wrapped: it ran, returned, and the work followed it.

On the topics capture, the second view puts **1,906 rootless traverses immediately after `scheduler/execute`** — a specific place to put a span, rather than a direction to look in. The first independently puts 438 of them inside `runTestPattern/patternRun`, which is a different statement: pattern instantiation rather than a handoff.

The two disagreeing is worth more than either alone, because they answer different questions.

## `--ignore` earns its place

A key emitted constantly is always the nearest thing to have ended, so it crowds the predecessor column without handing off to anything. `tx/read` took 1,909 of those rows until it was dropped — `scheduler/execute` was underneath it the whole time.

**No attempt to detect that automatically.** A key that dominates because it is emitted constantly and one that dominates because it really *is* the handoff look identical from here. I built the heuristic, found it fired on `scheduler/execute` — the true answer — as readily as on `tx/read`, and removed it: a wrong guess would point an investigation somewhere confidently and wrongly, which is worse than asking the reader to name the noisy key themselves. The flag is named in the output instead.

## Verified

Reproduces the finding I had previously reached with a throwaway script, on the same capture. The empty case reports plainly — a key whose spans all sit inside something says "nothing to locate" rather than printing two empty tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

