### PR TITLE
A test module can be bundled onto the server root, and reach a sandboxed iframe

### DIFF
--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -31,8 +31,16 @@ export default {
   include: {
     "path/static-asset.json": "static/asset.json",
   },
+  bundle: {
+    "src/guest.ts": "guest.js",
+  },
 };
 ```
+
+`include` copies a file as it stands; `bundle` bundles a module the way a test
+module is bundled. Reach for `bundle` when the module has to run in a realm the
+test page creates -- an iframe or a worker -- which loads it by URL and so
+cannot share the test's own bundle.
 
 ## Stuck tests
 

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -24,6 +24,12 @@ export type Config = {
   // The keys are relative file paths and the values are the destination from
   // the server root.
   include?: Record<string, string>;
+  // A map of relative module paths to bundle onto the static server during
+  // testing. The keys are relative module paths and the values are the
+  // destination from the server root. Each is bundled the way a test module is,
+  // so it can be loaded by URL from a realm the test page creates -- an iframe
+  // or a worker -- which cannot share the test's own bundle.
+  bundle?: Record<string, string>;
   esbuildConfig?: Parameters<typeof build>[0];
 };
 

--- a/packages/deno-web-test/server.ts
+++ b/packages/deno-web-test/server.ts
@@ -20,6 +20,10 @@ export class TestServer {
         serveDir(req, {
           fsRoot: this.manifest.serverDir,
           quiet: true,
+          // A realm the test page creates -- a sandboxed iframe -- has an
+          // opaque origin, and a module script is fetched in CORS mode, so
+          // reaching a `bundle` entry from one takes this.
+          enableCors: true,
         }),
     );
     if (!this.server) throw new Error("Server creation failed");

--- a/packages/deno-web-test/test/bundle-project/add.ts
+++ b/packages/deno-web-test/test/bundle-project/add.ts
@@ -1,0 +1,1 @@
+export const add = (a: number, b: number): number => a + b;

--- a/packages/deno-web-test/test/bundle-project/bundled.test.ts
+++ b/packages/deno-web-test/test/bundle-project/bundled.test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "@std/assert";
+
+Deno.test("a bundled module loads into a realm the page creates", async function () {
+  const worker = new Worker("/worker.js", { type: "module" });
+  try {
+    const message = await new Promise<MessageEvent>((resolve, reject) => {
+      worker.onmessage = resolve;
+      worker.onerror = (event) => reject(new Error(String(event.message)));
+    });
+    assertEquals(message.data, 2);
+  } finally {
+    worker.terminate();
+  }
+});

--- a/packages/deno-web-test/test/bundle-project/bundled.test.ts
+++ b/packages/deno-web-test/test/bundle-project/bundled.test.ts
@@ -12,3 +12,18 @@ Deno.test("a bundled module loads into a realm the page creates", async function
     worker.terminate();
   }
 });
+
+Deno.test("a bundled module loads into a sandboxed iframe", async function () {
+  const iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-scripts");
+  iframe.srcdoc = `<script type="module" src="/frame.js"></script>`;
+  const received = new Promise<MessageEvent>((resolve) => {
+    globalThis.addEventListener("message", resolve, { once: true });
+  });
+  document.body.appendChild(iframe);
+  try {
+    assertEquals((await received).data, 4);
+  } finally {
+    iframe.remove();
+  }
+});

--- a/packages/deno-web-test/test/bundle-project/deno-web-test.config.ts
+++ b/packages/deno-web-test/test/bundle-project/deno-web-test.config.ts
@@ -1,0 +1,5 @@
+export default {
+  bundle: {
+    "worker.ts": "worker.js",
+  },
+};

--- a/packages/deno-web-test/test/bundle-project/deno-web-test.config.ts
+++ b/packages/deno-web-test/test/bundle-project/deno-web-test.config.ts
@@ -1,5 +1,6 @@
 export default {
   bundle: {
     "worker.ts": "worker.js",
+    "frame.ts": "frame.js",
   },
 };

--- a/packages/deno-web-test/test/bundle-project/deno.jsonc
+++ b/packages/deno-web-test/test/bundle-project/deno.jsonc
@@ -1,0 +1,9 @@
+{
+  "name": "deno-web-test-bundle-project",
+  "tasks": {
+    "test": "<@see deno-web-test/test/utils.ts#runDenoWebTest>"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1.0.11"
+  }
+}

--- a/packages/deno-web-test/test/bundle-project/frame.ts
+++ b/packages/deno-web-test/test/bundle-project/frame.ts
@@ -1,0 +1,7 @@
+// Runs in a sandboxed iframe the test page creates. Such a frame has an opaque
+// origin, so its module script is fetched cross-origin, which is what makes
+// this the case that needs the server to answer with CORS headers.
+
+import { add } from "./add.ts";
+
+parent.postMessage(add(2, 2), "*");

--- a/packages/deno-web-test/test/bundle-project/worker.ts
+++ b/packages/deno-web-test/test/bundle-project/worker.ts
@@ -1,0 +1,7 @@
+// Runs in a worker the test page starts, which loads it by URL from the server
+// root. Its specifier for `add` names a TypeScript module, which a browser
+// cannot resolve, so this file runs there only if the runner bundled it.
+
+import { add } from "./add.ts";
+
+self.postMessage(add(1, 1));

--- a/packages/deno-web-test/test/bundle.test.ts
+++ b/packages/deno-web-test/test/bundle.test.ts
@@ -1,0 +1,16 @@
+import { assert } from "@std/assert";
+import { decode } from "@commonfabric/utils/encoding";
+import { runDenoWebTest } from "./utils.ts";
+
+Deno.test("a `bundle` entry is bundled onto the server root", async function () {
+  const { success, stdout } = await runDenoWebTest("bundle-project");
+  const stdoutText = decode(stdout);
+
+  assert(success, stdoutText);
+  assert(
+    /a bundled module loads into a realm the page creates \.\.\. ok/.test(
+      stdoutText,
+    ),
+    stdoutText,
+  );
+});

--- a/packages/deno-web-test/test/bundle.test.ts
+++ b/packages/deno-web-test/test/bundle.test.ts
@@ -13,4 +13,8 @@ Deno.test("a `bundle` entry is bundled onto the server root", async function () 
     ),
     stdoutText,
   );
+  assert(
+    /a bundled module loads into a sandboxed iframe \.\.\. ok/.test(stdoutText),
+    stdoutText,
+  );
 });

--- a/packages/deno-web-test/utils.ts
+++ b/packages/deno-web-test/utils.ts
@@ -21,10 +21,22 @@ export const buildTestDir = async (manifest: Manifest) => {
       "dist",
       tsToJs(testPath),
     );
-    await bundleTestFile(manifest, testPath, input, output);
+    await bundleModule(manifest, testPath, input, output);
   }
 
-  // Bundle all extra includes and move to server root.
+  // Bundle all extra modules and move to server root.
+  for (
+    const [filepath, outpath] of Object.entries(manifest.config.bundle ?? {})
+  ) {
+    const input = path.join(manifest.projectDir, filepath);
+    const output = path.join(
+      manifest.serverDir,
+      outpath,
+    );
+    await bundleModule(manifest, filepath, input, output);
+  }
+
+  // Copy all extra includes to server root.
   for (
     const [filepath, outpath] of Object.entries(manifest.config.include ?? {})
   ) {
@@ -66,9 +78,9 @@ export function summarize(results: TestFileResults[]): Summary {
   return { passed, duration, failed };
 }
 
-async function bundleTestFile(
+async function bundleModule(
   manifest: Manifest,
-  testPath: string,
+  sourcePath: string,
   input: string,
   output: string,
 ): Promise<void> {
@@ -101,7 +113,7 @@ async function bundleTestFile(
         stderr: "piped",
       }).output(),
     () => downlevelBundleIfNeeded(output, manifest),
-    testPath,
+    sourcePath,
   );
 }
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5 (1M context))

`deno-web-test` serves each test file as a bundle, and `include` copies any
other file across as it stands. That covers an asset but not a module: a
browser resolves neither a TypeScript specifier nor a bare one, so a module
that has to run in a realm the test page *creates* — an iframe or a worker,
which loads by URL and cannot share the test's own bundle — has nothing to
load.

Two changes, one per commit.

**`bundle`**, a config map in the same shape as `include`, putting each entry
through the same bundler a test module goes through. The helper is
`bundleModule` now that a test file is one of the things it takes rather than
all of them. (`include`'s neighboring comment said "bundle" while calling
`copy`; with a real bundle loop beside it that word had to go.)

**CORS on the static server.** A sandboxed iframe has an opaque origin, and a
module script is fetched in CORS mode, so a frame like that gets nothing back
from a server that answers without CORS headers. The server holds only what the
runner bundled into a per-run temporary directory, so there is nothing there to
withhold.

## Tests

A fixture project exercises each, since a config option nothing reaches is a
gate that cannot fail:

- a worker started over a bundled entry, whose module imports a `.ts` specifier
  no browser resolves. Control: copying instead of bundling, which fails it.
- a sandboxed iframe loading a second bundled entry. Control: dropping the CORS
  headers, which fails it.

Local gates: `deno task check`, `deno fmt --check`, `deno lint`, the
`deno-web-test` suite (30 passed), and the full workspace suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

