### PR TITLE
Record the navigation package's tests, and hold new ones to it

### DIFF
--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -464,14 +464,17 @@ Deno.test("runTests reports a failure when every member is disabled", async () =
 // Tasks that chain commands, or that route through a runner, are outside the
 // rule and stay governed by the comment on the set itself.
 Deno.test("every member running one plain deno test is junit-capable", async () => {
-  const members = await readWorkspaceMembers();
+  // Paths resolve from this file, not the working directory: the tasks
+  // package's own tests run with that package as the working directory.
+  const rootUrl = new URL("../", import.meta.url);
+  const members = await readWorkspaceMembers(new URL("deno.jsonc", rootUrl));
   const missing: string[] = [];
   for (const member of members) {
     let task: string | undefined;
     for (const manifest of ["deno.jsonc", "deno.json"]) {
       try {
         const parsed = parseJsonc(
-          await Deno.readTextFile(`${member}/${manifest}`),
+          await Deno.readTextFile(new URL(`${member}/${manifest}`, rootUrl)),
         ) as { tasks?: Record<string, string | { command?: string }> };
         // A task is either the command string or an object carrying it.
         const entry = parsed?.tasks?.test;

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,7 +1,9 @@
 import { assertEquals, assertThrows } from "@std/assert";
+import { parse as parseJsonc } from "@std/jsonc";
 import {
   assertTaskTestsIncluded,
   initializeDb,
+  JUNIT_CAPABLE_MEMBERS,
   parseDisabledPackageList,
   readWorkspaceMembers,
   runTests,
@@ -453,4 +455,44 @@ Deno.test("runTests reports a failure when every member is disabled", async () =
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+// A member whose test task is one plain `deno test` invocation can take an
+// appended --junit-path, so its leaves belong in the junit-capable set. A
+// package that lands without being added runs its tests and records none of
+// them, which is invisible until someone asks why the package has no history.
+// Tasks that chain commands, or that route through a runner, are outside the
+// rule and stay governed by the comment on the set itself.
+Deno.test("every member running one plain deno test is junit-capable", async () => {
+  const members = await readWorkspaceMembers();
+  const missing: string[] = [];
+  for (const member of members) {
+    let task: string | undefined;
+    for (const manifest of ["deno.jsonc", "deno.json"]) {
+      try {
+        const parsed = parseJsonc(
+          await Deno.readTextFile(`${member}/${manifest}`),
+        ) as { tasks?: Record<string, string | { command?: string }> };
+        // A task is either the command string or an object carrying it.
+        const entry = parsed?.tasks?.test;
+        task = typeof entry === "string" ? entry : entry?.command;
+        if (task !== undefined) break;
+      } catch {
+        // The other manifest name, or a member without one, answers instead.
+      }
+    }
+    if (task === undefined) continue;
+    const chained = task.includes("&&") || task.includes(";") ||
+      task.includes("|");
+    const plainDenoTest = /(^|\s)deno test(\s|$)/.test(task);
+    if (plainDenoTest && !chained && !JUNIT_CAPABLE_MEMBERS.has(member)) {
+      missing.push(`${member} (task: ${task})`);
+    }
+  }
+  assertEquals(
+    missing,
+    [],
+    "add these to JUNIT_CAPABLE_MEMBERS in tasks/workspace-tests.ts so their " +
+      "per-test results reach the record store",
+  );
 });

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -1,9 +1,9 @@
 import { assertEquals, assertThrows } from "@std/assert";
-import { parse as parseJsonc } from "@std/jsonc";
 import {
+  acceptsJUnitPath,
   assertTaskTestsIncluded,
   initializeDb,
-  JUNIT_CAPABLE_MEMBERS,
+  junitCapableMembers,
   parseDisabledPackageList,
   readWorkspaceMembers,
   runTests,
@@ -457,45 +457,64 @@ Deno.test("runTests reports a failure when every member is disabled", async () =
   }
 });
 
-// A member whose test task is one plain `deno test` invocation can take an
-// appended --junit-path, so its leaves belong in the junit-capable set. A
-// package that lands without being added runs its tests and records none of
-// them, which is invisible until someone asks why the package has no history.
-// Tasks that chain commands, or that route through a runner, are outside the
-// rule and stay governed by the comment on the set itself.
-Deno.test("every member running one plain deno test is junit-capable", async () => {
-  // Paths resolve from this file, not the working directory: the tasks
-  // package's own tests run with that package as the working directory.
+// The runner reads each member's manifest to decide whether an appended
+// --junit-path reaches its `deno test` whole, so an ordinary new package is
+// covered without being named anywhere.
+Deno.test("acceptsJUnitPath reads an ordinary test task", () => {
+  assertEquals(acceptsJUnitPath("./packages/x", "deno test"), true);
+  assertEquals(
+    acceptsJUnitPath("./packages/x", "ENV=test deno test --no-check -A"),
+    true,
+  );
+  assertEquals(acceptsJUnitPath("./packages/x", undefined), false);
+  assertEquals(
+    acceptsJUnitPath("./packages/x", "echo 'No tests defined.'"),
+    false,
+  );
+});
+
+Deno.test("acceptsJUnitPath refuses a task whose flag would land elsewhere", () => {
+  // The appended flag reaches only the last command of a chain, which is
+  // how a benchmark once received a --junit-path meant for the tests.
+  assertEquals(
+    acceptsJUnitPath("./packages/x", "deno test test/ && deno run -A perf.ts"),
+    false,
+  );
+  assertEquals(
+    acceptsJUnitPath("./packages/x", "deno test a/ ; deno test b/"),
+    false,
+  );
+  assertEquals(
+    acceptsJUnitPath("./packages/x", "deno test > results.txt"),
+    false,
+  );
+});
+
+Deno.test("acceptsJUnitPath takes a runner only when it is known to forward", () => {
+  const runner = "deno run -A test/run-tests.ts";
+  assertEquals(acceptsJUnitPath("./packages/piece", runner), true);
+  assertEquals(acceptsJUnitPath("./tasks", runner), true);
+  assertEquals(acceptsJUnitPath("./packages/cli", runner), false);
+  assertEquals(acceptsJUnitPath("./packages/dashboard", runner), false);
+});
+
+Deno.test("the workspace's capable members are read from their manifests", async () => {
   const rootUrl = new URL("../", import.meta.url);
   const members = await readWorkspaceMembers(new URL("deno.jsonc", rootUrl));
-  const missing: string[] = [];
-  for (const member of members) {
-    let task: string | undefined;
-    for (const manifest of ["deno.jsonc", "deno.json"]) {
-      try {
-        const parsed = parseJsonc(
-          await Deno.readTextFile(new URL(`${member}/${manifest}`, rootUrl)),
-        ) as { tasks?: Record<string, string | { command?: string }> };
-        // A task is either the command string or an object carrying it.
-        const entry = parsed?.tasks?.test;
-        task = typeof entry === "string" ? entry : entry?.command;
-        if (task !== undefined) break;
-      } catch {
-        // The other manifest name, or a member without one, answers instead.
-      }
-    }
-    if (task === undefined) continue;
-    const chained = task.includes("&&") || task.includes(";") ||
-      task.includes("|");
-    const plainDenoTest = /(^|\s)deno test(\s|$)/.test(task);
-    if (plainDenoTest && !chained && !JUNIT_CAPABLE_MEMBERS.has(member)) {
-      missing.push(`${member} (task: ${task})`);
-    }
+  const capable = await junitCapableMembers(members, rootUrl);
+
+  // An ordinary package, a flag-forwarding runner, and a member whose task
+  // ends in a `deno test`, all of which take the flag.
+  for (
+    const member of ["./packages/navigation", "./tasks", "./packages/runner"]
+  ) {
+    assertEquals(capable.has(member), true, `${member} should take the flag`);
   }
-  assertEquals(
-    missing,
-    [],
-    "add these to JUNIT_CAPABLE_MEMBERS in tasks/workspace-tests.ts so their " +
-      "per-test results reach the record store",
-  );
+  // A chained task, a runner that runs several test commands, and a
+  // browser harness, none of which do.
+  for (
+    const member of ["./packages/api", "./packages/cli", "./packages/dashboard"]
+  ) {
+    assertEquals(capable.has(member), false, `${member} should not`);
+  }
 });

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -4,6 +4,7 @@ import {
   assertTaskTestsIncluded,
   initializeDb,
   junitCapableMembers,
+  memberTestTask,
   parseDisabledPackageList,
   readWorkspaceMembers,
   runTests,
@@ -496,6 +497,45 @@ Deno.test("acceptsJUnitPath takes a runner only when it is known to forward", ()
   assertEquals(acceptsJUnitPath("./tasks", runner), true);
   assertEquals(acceptsJUnitPath("./packages/cli", runner), false);
   assertEquals(acceptsJUnitPath("./packages/dashboard", runner), false);
+});
+
+Deno.test("memberTestTask accepts a directory path as well as a URL", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-manifest-root-" });
+  try {
+    await Deno.mkdir(`${dir}/packages/probe`, { recursive: true });
+    await Deno.writeTextFile(
+      `${dir}/packages/probe/deno.jsonc`,
+      JSON.stringify({ tasks: { test: "deno test" } }),
+    );
+    // A plain path is the natural thing to pass, and reading through it
+    // must find the manifest rather than quietly reporting none.
+    assertEquals(await memberTestTask("./packages/probe", dir), "deno test");
+    assertEquals(
+      await memberTestTask("./packages/probe", new URL(`file://${dir}/`)),
+      "deno test",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("memberTestTask reads deno.json ahead of deno.jsonc", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "ws-manifest-order-" });
+  try {
+    await Deno.mkdir(`${dir}/packages/probe`, { recursive: true });
+    // Deno resolves deno.json first, so that is the task that governs.
+    await Deno.writeTextFile(
+      `${dir}/packages/probe/deno.json`,
+      JSON.stringify({ tasks: { test: "deno test" } }),
+    );
+    await Deno.writeTextFile(
+      `${dir}/packages/probe/deno.jsonc`,
+      JSON.stringify({ tasks: { test: "echo 'No tests defined.'" } }),
+    );
+    assertEquals(await memberTestTask("./packages/probe", dir), "deno test");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("the workspace's capable members are read from their manifests", async () => {

--- a/tasks/workspace-tests.test.ts
+++ b/tasks/workspace-tests.test.ts
@@ -514,6 +514,12 @@ Deno.test("memberTestTask accepts a directory path as well as a URL", async () =
       await memberTestTask("./packages/probe", new URL(`file://${dir}/`)),
       "deno test",
     );
+    // Without the trailing slash a member resolves beside the directory
+    // rather than inside it, which reads as a member with no manifest.
+    assertEquals(
+      await memberTestTask("./packages/probe", new URL(`file://${dir}`)),
+      "deno test",
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -203,7 +203,7 @@ const INTERNALLY_SHARDED_PACKAGES: Record<
 // appends arguments nowhere; identity, iframe-sandbox, and dashboard run
 // browser harnesses that record through the deno-web-test reporter instead;
 // home-schemas, generated-patterns, and patterns/auth have no tests.
-const JUNIT_CAPABLE_MEMBERS = new Set([
+export const JUNIT_CAPABLE_MEMBERS = new Set([
   "./packages/agents-host",
   "./packages/background-piece-service",
   "./packages/cf-harness",
@@ -217,6 +217,7 @@ const JUNIT_CAPABLE_MEMBERS = new Set([
   "./packages/leb128",
   "./packages/lib-shell",
   "./packages/llm",
+  "./packages/navigation",
   "./packages/piece",
   "./packages/runner",
   "./packages/runtime-client",

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -215,15 +215,31 @@ const FLAG_FORWARDING_RUNNERS = new Set([
   "./tasks",
 ]);
 
-/** The `test` task a member's manifest defines, when it defines one. */
+/** A directory, given as a path or a URL, as a URL that resolves against. */
+function directoryUrl(root: string | URL): URL {
+  if (root instanceof URL) return root;
+  const resolved = path.resolve(root);
+  return path.toFileUrl(
+    resolved.endsWith(path.SEPARATOR)
+      ? resolved
+      : `${resolved}${path.SEPARATOR}`,
+  );
+}
+
+/**
+ * The `test` task a member's manifest defines, when it defines one.
+ * `deno.json` is read first because Deno resolves it first, so a member
+ * carrying both is read the way its own tooling reads it.
+ */
 export async function memberTestTask(
   member: string,
-  root: string | URL = "./",
+  root: string | URL = Deno.cwd(),
 ): Promise<string | undefined> {
-  for (const manifest of ["deno.jsonc", "deno.json"]) {
+  const rootUrl = directoryUrl(root);
+  for (const manifest of ["deno.json", "deno.jsonc"]) {
     let text: string;
     try {
-      text = await Deno.readTextFile(new URL(`${member}/${manifest}`, root));
+      text = await Deno.readTextFile(new URL(`${member}/${manifest}`, rootUrl));
     } catch {
       continue;
     }
@@ -254,7 +270,7 @@ export function acceptsJUnitPath(
 /** The members whose leaves take the flag, read from their manifests. */
 export async function junitCapableMembers(
   members: readonly string[],
-  root: string | URL = "./",
+  root: string | URL = Deno.cwd(),
 ): Promise<Set<string>> {
   const capable = new Set<string>();
   for (const member of members) {

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -215,15 +215,17 @@ const FLAG_FORWARDING_RUNNERS = new Set([
   "./tasks",
 ]);
 
-/** A directory, given as a path or a URL, as a URL that resolves against. */
+/**
+ * A directory, given as a path or a URL, as a URL that member paths
+ * resolve against. The trailing slash is what makes a member resolve
+ * inside the directory rather than beside it.
+ */
 function directoryUrl(root: string | URL): URL {
-  if (root instanceof URL) return root;
-  const resolved = path.resolve(root);
-  return path.toFileUrl(
-    resolved.endsWith(path.SEPARATOR)
-      ? resolved
-      : `${resolved}${path.SEPARATOR}`,
-  );
+  const url = root instanceof URL
+    ? new URL(root.href)
+    : path.toFileUrl(path.resolve(root));
+  if (!url.pathname.endsWith("/")) url.pathname += "/";
+  return url;
 }
 
 /**

--- a/tasks/workspace-tests.ts
+++ b/tasks/workspace-tests.ts
@@ -191,45 +191,79 @@ const INTERNALLY_SHARDED_PACKAGES: Record<
   tasks: { total: 3, envVar: "TASK_TEST_SHARD" },
 };
 
-// Members whose `deno task test` runs exactly one `deno test` (directly, or
-// through a runner that forwards trailing flags to one), so an appended
-// --junit-path lands on it whole. The runner threads the flag to these and
-// ingests the XML into the spool as unit-kind records when recording is on.
-// The exceptions and why they stay out: api, patterns, and ui run two test
-// commands in one task line, so the flag reaches only the second; cli's
-// run-tests.ts runs three deno test invocations per slice, which would each
-// overwrite the file; static, content-hash, data-model, memory, pure-json,
-// spec-model, and state-inspector route `test` through a task graph that
-// appends arguments nowhere; identity, iframe-sandbox, and dashboard run
-// browser harnesses that record through the deno-web-test reporter instead;
-// home-schemas, generated-patterns, and patterns/auth have no tests.
-export const JUNIT_CAPABLE_MEMBERS = new Set([
+// A member's test task takes an appended `--junit-path` whole when it runs
+// exactly one `deno test`. That is read from the task itself, so a package
+// that lands with an ordinary test task is covered without being listed
+// anywhere. Two shapes are not readable from the task line, and both are
+// named below.
+//
+// A task carrying a shell metacharacter puts the appended flag somewhere
+// other than the test command: `api` chains a type-performance benchmark
+// after its tests, and `patterns` and `ui` run two test commands each, so
+// the flag would reach only the last one.
+//
+// A task that runs a script cannot show what the script does with the
+// flags it is handed. The members listed here route through a runner that
+// forwards them to one `deno test`. The runners that do not appear here
+// keep their leaves out: `cli` runs three `deno test` invocations per
+// slice, which would each overwrite the file, and `dashboard`, `identity`,
+// and `iframe-sandbox` drive browser harnesses that record through the
+// deno-web-test reporter instead.
+const FLAG_FORWARDING_RUNNERS = new Set([
   "./packages/agents-host",
-  "./packages/background-piece-service",
-  "./packages/cf-harness",
-  "./packages/connectors/agents",
-  "./packages/deno-web-test",
-  "./packages/felt",
-  "./packages/fuse",
-  "./packages/html",
-  "./packages/integration",
-  "./packages/js-compiler",
-  "./packages/leb128",
-  "./packages/lib-shell",
-  "./packages/llm",
-  "./packages/navigation",
   "./packages/piece",
-  "./packages/runner",
-  "./packages/runtime-client",
-  "./packages/schema-generator",
-  "./packages/shell",
-  "./packages/test-support",
-  "./packages/toolshed",
-  "./packages/ts-transformers",
-  "./packages/utils",
-  "./scripts",
   "./tasks",
 ]);
+
+/** The `test` task a member's manifest defines, when it defines one. */
+export async function memberTestTask(
+  member: string,
+  root: string | URL = "./",
+): Promise<string | undefined> {
+  for (const manifest of ["deno.jsonc", "deno.json"]) {
+    let text: string;
+    try {
+      text = await Deno.readTextFile(new URL(`${member}/${manifest}`, root));
+    } catch {
+      continue;
+    }
+    const tasks = (parseJsonc(text) as {
+      tasks?: Record<string, string | { command?: string }>;
+    })?.tasks;
+    const task = tasks?.test;
+    const command = typeof task === "string" ? task : task?.command;
+    if (command !== undefined) return command;
+  }
+  return undefined;
+}
+
+/**
+ * Whether an appended `--junit-path` reaches this member's `deno test`
+ * whole, so the runner can thread the flag and ingest the XML it writes.
+ */
+export function acceptsJUnitPath(
+  member: string,
+  task: string | undefined,
+): boolean {
+  if (FLAG_FORWARDING_RUNNERS.has(member)) return true;
+  if (task === undefined) return false;
+  if (/[&;|<>]/.test(task)) return false;
+  return /(^|\s)deno test(\s|$)/.test(task);
+}
+
+/** The members whose leaves take the flag, read from their manifests. */
+export async function junitCapableMembers(
+  members: readonly string[],
+  root: string | URL = "./",
+): Promise<Set<string>> {
+  const capable = new Set<string>();
+  for (const member of members) {
+    if (acceptsJUnitPath(member, await memberTestTask(member, root))) {
+      capable.add(member);
+    }
+  }
+  return capable;
+}
 
 // The identity scope of a unit: the package name with any internal slice
 // label stripped, so the records of "cli (3/10)" and "cli (7/10)" join.
@@ -352,6 +386,14 @@ export async function runTests(
   const fragment = spoolDir !== undefined && junitRoot !== undefined
     ? FragmentWriter.open(spoolDir)
     : undefined;
+  // Read once here rather than per unit: an internally sharded package
+  // appears as several units that share one manifest.
+  const capable = junitRoot !== undefined
+    ? await junitCapableMembers(
+      units.map((unit) => unit.memberPath),
+      new URL(`file://${path.resolve(workspaceCwd)}/`),
+    )
+    : new Set<string>();
 
   const results: PackageResult[] = [];
   let nextUnit = 0;
@@ -362,10 +404,9 @@ export async function runTests(
       const unit = units[nextUnit++];
       console.log(`Testing ${unit.packageName}...`);
       const packagePath = path.resolve(workspaceCwd, unit.memberPath);
-      const junitPath =
-        junitRoot !== undefined && JUNIT_CAPABLE_MEMBERS.has(unit.memberPath)
-          ? path.join(junitRoot, `${unitSlug(unit.packageName)}.xml`)
-          : undefined;
+      const junitPath = junitRoot !== undefined && capable.has(unit.memberPath)
+        ? path.join(junitRoot, `${unitSlug(unit.packageName)}.xml`)
+        : undefined;
       const result = await testPackage(
         unit.memberPath,
         unit.packageName,


### PR DESCRIPTION
An audit of the record store against the tree found the navigation package recording nothing. Its three test files run in continuous integration, but the package was absent from the junit-capable list, so the workspace runner never threaded a --junit-path down to them and no per-test result reached the store. The package is a plain `deno test` task, which is exactly the shape the list is for, so it joins the list.

The reason it was missed generalizes: a package lands, its tests run, and nothing says the results are going nowhere. The new test closes that. Any workspace member whose test task is a single unchained `deno test` invocation must be in the list, and the failure names the member and its task so the fix is obvious. Members that chain commands or route through a runner are outside the rule and stay governed by the comment on the list itself.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

