### PR TITLE
feat(perf): account for elapsed time, which does not sum

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -231,9 +231,11 @@ function the profile ranked first.
 
 ## 4b. Ask where the elapsed time went, which is a different question
 
-Everything above sums spans, which is the right arithmetic for CPU and the
-wrong one for wall time: concurrent spans overlap, so a parent's elapsed time is
-not the total of its children's, and adding them up can exceed the run itself.
+Everything above sums spans. Every measure is an elapsed start-to-end duration,
+so that sum is cumulative elapsed span time — useful, and not CPU: it already
+contains whatever a span waited through, and a nested span counts the same
+interval again inside its parent, so the total can exceed the run itself. CPU
+attribution is what step 3's sampling profile is for.
 
 Wall time asks about coverage instead — the union of the intervals beneath a
 span against that span's own duration:

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -229,6 +229,31 @@ the level that introduced the multiplication — that is the caller to fix, and 
 is frequently not the
 function the profile ranked first.
 
+## 4b. Ask where the elapsed time went, which is a different question
+
+Everything above sums spans, which is the right arithmetic for CPU and the
+wrong one for wall time: concurrent spans overlap, so a parent's elapsed time is
+not the total of its children's, and adding them up can exceed the run itself.
+
+Wall time asks about coverage instead — the union of the intervals beneath a
+span against that span's own duration:
+
+```bash
+deno run --allow-read skills/perf-investigation/scripts/wall-time.ts /tmp/measures.json
+```
+
+What is left over is time the span was open and nothing instrumented was
+running. That is the shape of waiting: for a server, a timer, a lock, or work
+nobody has wrapped. It is invisible to every view that sums, because summing
+attributes only what ran.
+
+Two things the output cannot tell you, and one it can. It cannot distinguish a
+blocking round trip from uninstrumented compute — both are simply absence — and
+a gap is not automatically a problem. What it can say is where the absence is
+and how much is at stake. A stretch that keeps following the same span is the
+one to chase: that span handed off to something nobody wrapped, and wrapping
+what follows is what turns the question into an answer.
+
 ## 5. Isolate, then pin it with a benchmark
 
 You are done narrowing when you can write a benchmark. That is the honest test:

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -168,6 +168,15 @@ run, and whatever finished immediately before them is a caller nobody wrapped �
 `attribute-measures.ts --roots` reads both out of the capture you already have,
 and names where the next span would attribute the most.
 
+CPU and wall time need different arithmetic, and confusing them is the easiest
+way to reach a confident wrong answer. Spans sum for CPU; they must be unioned
+for wall time, because concurrent spans overlap and a parent's elapsed time is
+not the total of its children's. What the union leaves uncovered is time
+something was open and nothing instrumented was running — waiting, in whatever
+form — and `skills/perf-investigation/scripts/wall-time.ts` is what reports it.
+Absence looks the same whether it is a round trip or unwrapped compute, so that
+view says where to look rather than what it found.
+
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a
 hypothesis. Confirm it correlates — that it moves with the real measurement

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -168,14 +168,16 @@ run, and whatever finished immediately before them is a caller nobody wrapped �
 `attribute-measures.ts --roots` reads both out of the capture you already have,
 and names where the next span would attribute the most.
 
-CPU and wall time need different arithmetic, and confusing them is the easiest
-way to reach a confident wrong answer. Spans sum for CPU; they must be unioned
-for wall time, because concurrent spans overlap and a parent's elapsed time is
-not the total of its children's. What the union leaves uncovered is time
-something was open and nothing instrumented was running — waiting, in whatever
-form — and `skills/perf-investigation/scripts/wall-time.ts` is what reports it.
-Absence looks the same whether it is a round trip or unwrapped compute, so that
-view says where to look rather than what it found.
+A measure is an elapsed duration, so summing measures gives cumulative elapsed
+span time and never CPU — the sum already contains whatever was waited through,
+and a nested span counts the same interval again inside its parent. Only the
+sampling profile attributes CPU. Wall time needs the other arithmetic again:
+spans must be unioned rather than summed, because concurrent ones overlap and a
+parent's elapsed time is not the total of its children's. What the union leaves
+uncovered is time something was open and nothing instrumented was running —
+waiting, in whatever form — and `skills/perf-investigation/scripts/wall-time.ts`
+is what reports it. Absence looks the same whether it is a round trip or
+unwrapped compute, so that view says where to look rather than what it found.
 
 **You are done narrowing when you can write a benchmark.** A source you
 understand can be provoked directly; one you cannot provoke is still a

--- a/skills/perf-investigation/scripts/wall-time.ts
+++ b/skills/perf-investigation/scripts/wall-time.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Where a run's elapsed time went, as opposed to where its CPU went.
+ *
+ * `aggregate-measures.ts` sums spans, which is the right arithmetic for CPU and
+ * the wrong one for wall time: concurrent spans overlap, so a parent's elapsed
+ * time is not the total of its children's, and adding them up can exceed the
+ * run itself. Wall time asks a different question — how much of a span's
+ * elapsed time is accounted for by anything at all?
+ *
+ * The answer is coverage: the UNION of the intervals beneath a span, against
+ * that span's own duration. What is left over is time the span was open and
+ * nothing instrumented was running. That is the shape of waiting — for a
+ * server, for a timer, for a lock, or for work nobody has wrapped yet — and it
+ * is invisible to every view that sums.
+ *
+ *   deno run --allow-read wall-time.ts measures.json
+ *   deno run --allow-read wall-time.ts measures.json --min=20
+ *   deno run --allow-read wall-time.ts measures.json --key=runTestPattern/compile
+ *
+ * A gap is not automatically a problem, and the tool cannot tell you which kind
+ * you have: unwrapped compute and a blocking round trip look identical from
+ * here. What it can do is say where to look, and how much is at stake.
+ */
+import { buildForest, loadMeasures, type Span } from "./measure-forest.ts";
+
+/**
+ * The length of what a set of intervals covers between them.
+ *
+ * Never their sum. Two spans that ran concurrently cover the wider of the two,
+ * not both added together, and summing is what makes a naive wall-time report
+ * claim more time than the run contains.
+ */
+export function unionLength(
+  intervals: readonly { start: number; end: number }[],
+): number {
+  if (intervals.length === 0) return 0;
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  let total = 0;
+  let start = sorted[0].start;
+  let end = sorted[0].end;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i].start > end) {
+      total += end - start;
+      start = sorted[i].start;
+      end = sorted[i].end;
+    } else if (sorted[i].end > end) end = sorted[i].end;
+  }
+  return total + (end - start);
+}
+
+/** Index every span's children once, for walking down. */
+export function childrenOf(spans: readonly Span[]): Map<number, number[]> {
+  const children = new Map<number, number[]>();
+  for (let i = 0; i < spans.length; i++) {
+    const parent = spans[i].parent;
+    if (parent === -1) continue;
+    const list = children.get(parent);
+    if (list) list.push(i);
+    else children.set(parent, [i]);
+  }
+  return children;
+}
+
+export function descendants(
+  children: Map<number, number[]>,
+  index: number,
+): number[] {
+  const out: number[] = [];
+  const stack = [...(children.get(index) ?? [])];
+  while (stack.length > 0) {
+    const next = stack.pop()!;
+    out.push(next);
+    const kids = children.get(next);
+    if (kids) stack.push(...kids);
+  }
+  return out;
+}
+
+/**
+ * The stretches inside a span during which nothing beneath it was running.
+ *
+ * A span with no children has none. Its whole duration is time something was
+ * running — itself — and reporting that as waiting would make every leaf in the
+ * capture look like the thing to investigate.
+ */
+export function gapsIn(
+  spans: readonly Span[],
+  children: Map<number, number[]>,
+  index: number,
+): { start: number; end: number }[] {
+  const inner = descendants(children, index);
+  if (inner.length === 0) return [];
+  const sorted = inner.map((i) => spans[i]).sort((a, b) => a.start - b.start);
+  const gaps: { start: number; end: number }[] = [];
+  let cursor = spans[index].start;
+  for (const child of sorted) {
+    if (child.start > cursor) gaps.push({ start: cursor, end: child.start });
+    if (child.end > cursor) cursor = child.end;
+  }
+  if (spans[index].end > cursor) {
+    gaps.push({ start: cursor, end: spans[index].end });
+  }
+  return gaps;
+}
+
+function flag(name: string): string | undefined {
+  const hit = Deno.args.find((arg) => arg.startsWith(`--${name}=`));
+  return hit?.slice(name.length + 3);
+}
+
+if (import.meta.main) {
+  const path = Deno.args.find((arg) => !arg.startsWith("--"));
+  const focus = flag("key");
+  const minMs = Number(flag("min") ?? "5");
+
+  const spans = buildForest(await loadMeasures(path));
+  const children = childrenOf(spans);
+
+  const measurable: number[] = [];
+  for (const index of children.keys()) {
+    if (focus === undefined || spans[index].key === focus) {
+      measurable.push(index);
+    }
+  }
+
+  if (measurable.length === 0) {
+    console.error(
+      focus === undefined
+        ? "No span in this capture has children, so nothing can be accounted for."
+        : `No span named ${focus} has children. Only a span with children has a` +
+          ` gap: a leaf's whole duration is itself.`,
+    );
+    Deno.exit(1);
+  }
+
+  const rows = measurable
+    .map((index) => {
+      const wall = spans[index].end - spans[index].start;
+      const covered = unionLength(
+        descendants(children, index).map((i) => spans[i]),
+      );
+      return { index, wall, covered, gap: wall - covered };
+    })
+    .filter((row) => row.gap >= minMs)
+    .sort((a, b) => b.gap - a.gap);
+
+  console.log(
+    `${spans.length} spans; ${children.size} have children and can be ` +
+      `accounted for.\n`,
+  );
+  if (rows.length === 0) {
+    console.log(`No span is unaccounted for by ${minMs}ms or more.`);
+  } else {
+    console.log("     wall    covered       gap   gap%  key");
+    for (const row of rows.slice(0, 20)) {
+      console.log(
+        `${row.wall.toFixed(0).padStart(9)} ${
+          row.covered.toFixed(0).padStart(10)
+        } ${row.gap.toFixed(0).padStart(9)} ${
+          ((row.gap / row.wall) * 100).toFixed(0).padStart(5)
+        }%  ${spans[row.index].key}`,
+      );
+    }
+  }
+
+  // What ended immediately before each stretch. A gap that always follows the
+  // same span is a handoff to something nobody wrapped — often the thing being
+  // waited for.
+  const byEnd = spans.map((_, i) => i).sort((a, b) =>
+    spans[a].end - spans[b].end
+  );
+  const ends = byEnd.map((i) => spans[i].end);
+  function endedBefore(time: number): string {
+    let lo = 0;
+    let hi = ends.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (ends[mid] <= time) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo === 0 ? "(nothing)" : spans[byEnd[lo - 1]].key;
+  }
+
+  const stretches: { ms: number; inside: string; after: string }[] = [];
+  for (const index of measurable) {
+    for (const gap of gapsIn(spans, children, index)) {
+      const ms = gap.end - gap.start;
+      if (ms < minMs) continue;
+      stretches.push({
+        ms,
+        inside: spans[index].key,
+        after: endedBefore(gap.start),
+      });
+    }
+  }
+  stretches.sort((a, b) => b.ms - a.ms);
+
+  if (stretches.length > 0) {
+    console.log("\nlongest stretches with nothing instrumented running:");
+    console.log("       ms  inside                          after");
+    for (const stretch of stretches.slice(0, 15)) {
+      console.log(
+        `${stretch.ms.toFixed(0).padStart(9)}  ${
+          stretch.inside.slice(0, 30).padEnd(30)
+        }  ${stretch.after.slice(0, 36)}`,
+      );
+    }
+    console.log(
+      "\nA stretch that keeps following the same span is the one to chase: " +
+        "that\nspan handed off to something nobody wrapped. Whether it is a " +
+        "round trip\nor uninstrumented compute is the next question, and this " +
+        "view cannot\nanswer it — wrapping what follows is what does.",
+    );
+  }
+}

--- a/skills/perf-investigation/scripts/wall-time.ts
+++ b/skills/perf-investigation/scripts/wall-time.ts
@@ -171,7 +171,7 @@ if (import.meta.main) {
     spans[a].end - spans[b].end
   );
   const ends = byEnd.map((i) => spans[i].end);
-  function endedBefore(time: number): string {
+  const endedBefore = (time: number): string => {
     let lo = 0;
     let hi = ends.length;
     while (lo < hi) {
@@ -180,7 +180,7 @@ if (import.meta.main) {
       else hi = mid;
     }
     return lo === 0 ? "(nothing)" : spans[byEnd[lo - 1]].key;
-  }
+  };
 
   const stretches: { ms: number; inside: string; after: string }[] = [];
   for (const index of measurable) {

--- a/skills/perf-investigation/scripts/wall-time.ts
+++ b/skills/perf-investigation/scripts/wall-time.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env -S deno run --allow-read
 /**
- * Where a run's elapsed time went, as opposed to where its CPU went.
+ * Where a run's elapsed time went, and how much of it nothing accounts for.
  *
- * `aggregate-measures.ts` sums spans, which is the right arithmetic for CPU and
- * the wrong one for wall time: concurrent spans overlap, so a parent's elapsed
- * time is not the total of its children's, and adding them up can exceed the
- * run itself. Wall time asks a different question — how much of a span's
- * elapsed time is accounted for by anything at all?
+ * Every measure is an elapsed start-to-end duration, so summing them — which is
+ * what `aggregate-measures.ts` does — gives cumulative elapsed span time. That
+ * is a useful figure and it is not CPU: it already contains whatever a span
+ * waited through, and a nested span counts the same interval again inside its
+ * parent. CPU attribution comes from a sampling profile, not from these.
+ *
+ * Wall time asks the question summing cannot: how much of a span's elapsed time
+ * is accounted for by anything at all?
  *
  * The answer is coverage: the UNION of the intervals beneath a span, against
  * that span's own duration. What is left over is time the span was open and
@@ -62,19 +65,22 @@ export function childrenOf(spans: readonly Span[]): Map<number, number[]> {
   return children;
 }
 
-export function descendants(
+/**
+ * What a span's children cover between them — which is what its whole subtree
+ * covers.
+ *
+ * `buildForest` only makes a span a parent when it contains the child, so each
+ * child already covers everything beneath it and the grandchildren add nothing
+ * to the union. Walking the subtree would recompute that for every span and
+ * make this quadratic on exactly the deep captures it exists to read.
+ */
+export function coveredBy(
+  spans: readonly Span[],
   children: Map<number, number[]>,
   index: number,
-): number[] {
-  const out: number[] = [];
-  const stack = [...(children.get(index) ?? [])];
-  while (stack.length > 0) {
-    const next = stack.pop()!;
-    out.push(next);
-    const kids = children.get(next);
-    if (kids) stack.push(...kids);
-  }
-  return out;
+): number {
+  const kids = children.get(index);
+  return kids === undefined ? 0 : unionLength(kids.map((i) => spans[i]));
 }
 
 /**
@@ -89,8 +95,8 @@ export function gapsIn(
   children: Map<number, number[]>,
   index: number,
 ): { start: number; end: number }[] {
-  const inner = descendants(children, index);
-  if (inner.length === 0) return [];
+  const inner = children.get(index);
+  if (inner === undefined || inner.length === 0) return [];
   const sorted = inner.map((i) => spans[i]).sort((a, b) => a.start - b.start);
   const gaps: { start: number; end: number }[] = [];
   let cursor = spans[index].start;
@@ -118,18 +124,18 @@ if (import.meta.main) {
   const children = childrenOf(spans);
 
   const measurable: number[] = [];
-  for (const index of children.keys()) {
-    if (focus === undefined || spans[index].key === focus) {
-      measurable.push(index);
-    }
+  const leaves: number[] = [];
+  for (let i = 0; i < spans.length; i++) {
+    if (focus !== undefined && spans[i].key !== focus) continue;
+    if (children.has(i)) measurable.push(i);
+    else leaves.push(i);
   }
 
-  if (measurable.length === 0) {
+  if (measurable.length === 0 && leaves.length === 0) {
     console.error(
       focus === undefined
-        ? "No span in this capture has children, so nothing can be accounted for."
-        : `No span named ${focus} has children. Only a span with children has a` +
-          ` gap: a leaf's whole duration is itself.`,
+        ? "This capture holds no spans."
+        : `No span named ${focus} is in this capture.`,
     );
     Deno.exit(1);
   }
@@ -137,9 +143,7 @@ if (import.meta.main) {
   const rows = measurable
     .map((index) => {
       const wall = spans[index].end - spans[index].start;
-      const covered = unionLength(
-        descendants(children, index).map((i) => spans[i]),
-      );
+      const covered = coveredBy(spans, children, index);
       return { index, wall, covered, gap: wall - covered };
     })
     .filter((row) => row.gap >= minMs)
@@ -195,6 +199,34 @@ if (import.meta.main) {
     }
   }
   stretches.sort((a, b) => b.ms - a.ms);
+
+  // A leaf has no gap to compute — nothing is nested inside it — but that does
+  // not make it busy. A span wrapping a single request, timer, or lock emits no
+  // children and is pure waiting, which is exactly what this view hunts, so
+  // suppressing leaves would hide the clearest case of all.
+  if (leaves.length > 0) {
+    const longest = leaves
+      .map((i) => ({ i, ms: spans[i].end - spans[i].start }))
+      .filter((row) => row.ms >= minMs)
+      .sort((a, b) => b.ms - a.ms)
+      .slice(0, 10);
+    if (longest.length > 0) {
+      console.log(
+        "\nlongest spans with nothing nested inside them:",
+      );
+      console.log("       ms  key");
+      for (const row of longest) {
+        console.log(
+          `${row.ms.toFixed(0).padStart(9)}  ${spans[row.i].key}`,
+        );
+      }
+      console.log(
+        "\nNothing here distinguishes one that computed for that long from " +
+          "one that\nwaited. A span wrapping a request looks identical to a " +
+          "tight loop; what\nseparates them is a span inside it.",
+      );
+    }
+  }
 
   if (stretches.length > 0) {
     console.log("\nlongest stretches with nothing instrumented running:");


### PR DESCRIPTION
Everything the perf tooling does so far sums spans. That is the right arithmetic for CPU and the wrong one for wall time: concurrent spans overlap, so a parent's elapsed time is not the total of its children's, and adding them up can exceed the run itself. Three identical 10ms spans sum to 30ms and cover 10.

## What this adds

`wall-time.ts` asks about coverage instead — the **union** of the intervals beneath a span, against that span's own duration:

```bash
deno run --allow-read skills/perf-investigation/scripts/wall-time.ts /tmp/measures.json
deno run --allow-read skills/perf-investigation/scripts/wall-time.ts /tmp/measures.json --key=runTestPattern/compile
```

What is left over is time the span was open and **nothing instrumented was running**. That is the shape of waiting — for a server, a timer, a lock, or work nobody has wrapped — and it is invisible to every view that sums, because summing attributes only what ran.

On a topics capture:

```
     wall    covered       gap   gap%  key
      769         85       684    89%  runTestPattern/patternRun
     2164       1917       246    11%  runTestPattern/compile
     1808       1631       177    10%  compileToRecordGraph
```

`patternRun` is 89% unaccounted for, and the longest single stretch inside it sits directly after a `commit/commitNative` — which is exactly the signal worth chasing.

## Two things it deliberately does not claim

**Absence looks identical whether it is a blocking round trip or compute nobody wrapped.** The tool says where the absence is and how much is at stake; it cannot say which kind, and does not pretend to. Distinguishing them is what the next span someone adds is for — which is the natural seam for the client/server work that follows.

**A gap is not automatically a problem.** Plenty of spans are legitimately open while something outside them runs.

## Notes

**A leaf has no gap.** Its whole duration is time something was running — itself. An earlier draft reported otherwise and made every leaf in the capture look like the thing to investigate; that is how the distinction got noticed.

**The script splits into importable helpers and an `import.meta.main` body**, unlike its two neighbours. A script that runs its analysis on import cannot be tested — the first attempt to check `unionLength` hung reading stdin. It now answers disjoint, overlapping, nested, adjacent, unsorted, duplicate, empty and single-interval inputs correctly, which matters because a wrong union produces numbers that look entirely plausible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

