### PR TITLE
fix(cli): a verb's fields are read through a top-level $ref

### DIFF
--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -768,15 +768,14 @@ run_piece_call_retry() {
   # --- 6. An absent payload the verb cannot run without is refused, id intact.
   # The mirror of scenario 5 for the second-most-likely agent mistake:
   # forgetting the payload rather than misspelling a field. `recordNote`'s
-  # event schema sits behind a top-level local $ref, so the CLI derives no
-  # flags from it and an explicit `invoke` with no payload parses to an
-  # absent (undefined) event. Before the absent-payload gate (verb contract
-  # D5) this dispatched: the handler ran with no event, recorded
-  # "(no event)", and the receipt spent the invocation id — the corrected
-  # same-id retry then reported deduplicated with the correction never
-  # applied. Now the gate normalizes absence to {} against the resolved
-  # object schema and refuses because `required` survives relaxation, so
-  # nothing dispatches and the same id still buys the corrected call.
+  # event schema sits behind a top-level local $ref, and the CLI reads the
+  # definition's fields through it, so an explicit `invoke` carrying none is
+  # refused by name — `note` is required and nothing supplies it.
+  # What this scenario pins is not which door refuses but what the refusal
+  # costs: nothing dispatches, so the invocation id is never spent and the
+  # corrected same-id retry below still applies. A dispatch here would run
+  # the handler with no event and burn the id, leaving the retry
+  # deduplicated against an outcome the caller never wanted.
   RETRY_PIECE_6=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS "$SCRIPT_DIR/pattern/fuse-exec.tsx")
   INVOCATION_6=$(new_invocation_id)
   set +e
@@ -788,8 +787,8 @@ run_piece_call_retry() {
     error "An absent payload against a required-fields verb should fail, got: $ABSENT_OUT"
   fi
   case "$ABSENT_OUT" in
-    *'Invalid input for "recordNote"'*'no payload was supplied'*) ;;
-    *) error "An absent-payload refusal should say no payload was supplied, got: $ABSENT_OUT" ;;
+    *'Missing required flag --note'*) ;;
+    *) error "An absent-payload refusal should name the missing field, got: $ABSENT_OUT" ;;
   esac
   assert_message_count "$RETRY_PIECE_6" 0 \
     "A refused absent-payload call must not record a message"

--- a/packages/cli/integration/pattern/fuse-exec.tsx
+++ b/packages/cli/integration/pattern/fuse-exec.tsx
@@ -71,12 +71,13 @@ const recordMessage = handler(
   },
 );
 
-// The event schema sits behind a top-level local $ref, deliberately: the
-// deployed stream schema then has no top-level `properties`, so a bare
-// `cf piece call <piece> recordNote` parses to an absent (`undefined`)
-// payload instead of schema-derived flags — the deployed shape the
-// absent-payload gate (verb contract D5) exists for. `recordMessage` keeps
-// the inline form so the fixture carries one verb of each shape.
+// The event schema sits behind a top-level local $ref, deliberately: it is
+// the shape a pattern routinely deploys, and the deployed stream schema then
+// carries no top-level `properties` of its own. What a caller sees through
+// that indirection — the flags, the required-ness, the refusal when a
+// payload is missing — is what the integration scenario exercises.
+// `recordMessage` keeps the inline form so the fixture carries one verb of
+// each shape and the two can be compared.
 const recordNote = handler(
   {
     $ref: "#/$defs/RecordNoteEvent",

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -759,12 +759,18 @@ export function declaredEventFields(
   // caller a `--value` whose string could not satisfy the object it named.
   //
   // `resolveCfcSchemaRefs` rather than `localRefTarget`, because a `$ref` may
-  // carry SIBLINGS and 2020-12 says they apply: `{$ref, properties: {...}}`
-  // declares the target's fields and its own. Jumping to the target returns
-  // the definition alone and drops them, which would put this door back in
-  // disagreement with the validator — reading fewer fields than a payload is
-  // judged against, rather than none. Merging is also what carries the two
-  // `$defs` scopes, which a ref site and its target do not share.
+  // carry SIBLINGS and the runtime applies them. It flattens the ref site OVER
+  // its target keyword by keyword, so a `properties` written beside the ref
+  // replaces the target's rather than joining it — which is the resolution the
+  // validator performs, and therefore the field list a payload is judged
+  // against. Jumping to the target instead returns the definition alone: for
+  // `{$ref → {query}, properties: {limit}}` that names `--query`, which the
+  // validator refuses as an undeclared field, and hides `--limit`, which it
+  // accepts. Which fields exist is the validator's answer to give; this door
+  // reports it rather than deriving a second one.
+  //
+  // Merging is also what reconciles the two `$defs` scopes, which a ref site
+  // and its target do not share.
   //
   // It answers `undefined` where a ref dangles or cycles, which fails toward
   // "not a fields position" — the scalar vocabulary, exactly where an

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -742,21 +742,35 @@ export function declaredEventFields(
   schema: JSONSchema | undefined,
 ): DeclaredEventFields | null {
   if (!isSchemaObject(schema)) return null;
+  // A top-level local `$ref` is resolved before the position is read, because
+  // a stream's event schema is routinely written through one:
+  // `{$ref: "#/$defs/AddEvent", asCell: ["stream"], $defs: {...}}` puts every
+  // field in the definition and none at the root. The indirection is only
+  // NEEDED for a recursive event type, but a pattern gets it either way, and
+  // a verb should not lose its flags over how its schema happens to be spelled.
+  //
+  // Both payload doors already resolve it — `normalizeAbsentVerbPayload` and
+  // `eventSchemaJudgesRootFields` — so reading the root unresolved here was
+  // the two doors disagreeing about the same schema: the verb's fields were
+  // judged on arrival while every flag surface reported none, leaving the
+  // caller a `--value` whose string could not satisfy the object it named.
+  const scopeRoot = cfcSchemaChildRoot(schema, schema);
+  const target = localRefTarget(schema, scopeRoot);
+  if (!isSchemaObject(target)) return null;
+  const targetRoot = cfcSchemaChildRoot(target, scopeRoot);
   // The gate the flag surfaces have always applied, widened by exactly one
   // term. A position stating `type: "object"` or carrying `properties` is a
   // fields position, and now so is one carrying `allOf` — because that is
-  // where its fields live. A root `$ref` is deliberately NOT resolved here:
-  // doing so would give flags to verbs that have never had them, which is a
-  // wider change than reading a conjunction and belongs to whoever wants it.
-  const statesItsOwnFields = schema.type === "object" || !!schema.properties;
-  if (!statesItsOwnFields && !Array.isArray(schema.allOf)) return null;
+  // where its fields live.
+  const statesItsOwnFields = target.type === "object" || !!target.properties;
+  if (!statesItsOwnFields && !Array.isArray(target.allOf)) return null;
   // A disjunction BESIDE properties is not a reason to report none. It adds
   // constraints the flag surfaces cannot express, but the properties it sits
   // next to are still declared and still typed, and refusing to name them
   // would take away flags that already worked. `declaredFieldsAt` reads the
   // conjunction and steps over the disjunction, which is the whole of what is
   // wanted here — a root check would only discard the fields beside it.
-  const declared = declaredFieldsAt(schema, cfcSchemaChildRoot(schema, schema));
+  const declared = declaredFieldsAt(target, targetRoot);
   // A conjunction earns the object path only by CONTRIBUTING fields. `allOf:
   // [{type: "string"}]` constrains a scalar, and admitting it here would route
   // a single-value verb through flag parsing and offer it a vocabulary of
@@ -771,6 +785,52 @@ export function declaredEventFields(
     }
   }
   return { properties, required: declared.required };
+}
+
+/**
+ * Whether a verb can be invoked carrying no payload at all.
+ *
+ * A field marked `required` that carries a `default` does not make a payload
+ * mandatory: `normalizeAbsentVerbPayload` turns absence into `{}` and the
+ * runtime fills the default in. Reading `required` raw would refuse at the
+ * flag door a call the payload door accepts and dispatches — the same
+ * disagreement between the two doors that `declaredEventFields` settles for
+ * WHICH fields exist, asked here about whether any of them is owed.
+ *
+ * `relaxDefaultedRequired` is the runtime's own answer to "what does a
+ * default satisfy", which is why it is borrowed rather than restated.
+ */
+export function verbRunsWithoutPayload(
+  schema: JSONSchema | undefined,
+): boolean {
+  return declaredEventFields(schema) !== null &&
+    requiredEventFieldsOwed(schema).size === 0;
+}
+
+/**
+ * The fields a caller must actually supply, which is `required` minus every
+ * field a default already answers for.
+ *
+ * The distinction matters at two doors that used to read `required` raw: the
+ * one deciding whether a bare invoke is allowed, and the one enforcing
+ * per-flag presence. Both would refuse a call the runtime accepts and fills
+ * in, and a caller told "Missing required flag --mode" about a field with a
+ * default has been sent to supply what the pattern already supplies.
+ *
+ * Returns the declared `required` unchanged when there is nothing to relax or
+ * the schema cannot be relaxed — failing toward the stricter answer, since a
+ * wrongly-relaxed field would be refused by the runtime instead, and further
+ * from the caller.
+ */
+export function requiredEventFieldsOwed(
+  schema: JSONSchema | undefined,
+): Set<string> {
+  const declared = declaredEventFields(schema);
+  if (declared === null) return new Set();
+  if (declared.required.size === 0) return declared.required;
+  if (!isSchemaObject(schema)) return declared.required;
+  const relaxed = relaxDefaultedRequired(schema, schema, new Map());
+  return declaredEventFields(relaxed)?.required ?? declared.required;
 }
 
 /**

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -846,10 +846,15 @@ export function verbRunsWithoutPayload(
 export function requiredEventFieldsOwed(
   schema: JSONSchema | undefined,
 ): Set<string> {
+  // Asked first because it settles two things at once: `declaredEventFields`
+  // answers non-null only for an object schema, and `relaxDefaultedRequired`
+  // takes one. Asking again further down would be re-deciding a question this
+  // answer has already closed.
+  if (!isSchemaObject(schema)) return new Set();
   const declared = declaredEventFields(schema);
-  if (declared === null) return new Set();
-  if (declared.required.size === 0) return declared.required;
-  if (!isSchemaObject(schema)) return declared.required;
+  if (declared === null || declared.required.size === 0) {
+    return declared?.required ?? new Set();
+  }
   const relaxed = relaxDefaultedRequired(schema, schema, new Map());
   return declaredEventFields(relaxed)?.required ?? declared.required;
 }

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -8,7 +8,10 @@ import {
   type MemorySpace,
   type NormalizedFullLink,
 } from "@commonfabric/runner";
-import { cfcSchemaChildRoot } from "@commonfabric/runner/cfc/schema-refs";
+import {
+  cfcSchemaChildRoot,
+  resolveCfcSchemaRefs,
+} from "@commonfabric/runner/cfc/schema-refs";
 import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import {
   type NormalizedLLMFriendlyRef,
@@ -754,8 +757,20 @@ export function declaredEventFields(
   // the two doors disagreeing about the same schema: the verb's fields were
   // judged on arrival while every flag surface reported none, leaving the
   // caller a `--value` whose string could not satisfy the object it named.
+  //
+  // `resolveCfcSchemaRefs` rather than `localRefTarget`, because a `$ref` may
+  // carry SIBLINGS and 2020-12 says they apply: `{$ref, properties: {...}}`
+  // declares the target's fields and its own. Jumping to the target returns
+  // the definition alone and drops them, which would put this door back in
+  // disagreement with the validator — reading fewer fields than a payload is
+  // judged against, rather than none. Merging is also what carries the two
+  // `$defs` scopes, which a ref site and its target do not share.
+  //
+  // It answers `undefined` where a ref dangles or cycles, which fails toward
+  // "not a fields position" — the scalar vocabulary, exactly where an
+  // unresolvable event schema sat before.
   const scopeRoot = cfcSchemaChildRoot(schema, schema);
-  const target = localRefTarget(schema, scopeRoot);
+  const target = resolveCfcSchemaRefs(schema, scopeRoot);
   if (!isSchemaObject(target)) return null;
   const targetRoot = cfcSchemaChildRoot(target, scopeRoot);
   // The gate the flag surfaces have always applied, widened by exactly one
@@ -853,8 +868,13 @@ export function eventSchemaJudgesRootFields(
   schema: JSONSchema | undefined,
 ): boolean {
   if (!isSchemaObject(schema)) return false;
+  // Resolved the same way `declaredEventFields` resolves it, and for the same
+  // reason: these two answer about one position — which fields it has, and
+  // whether it judges them — and the flag door asks both. Reading a `$ref`
+  // one way here and another way there would let an `additionalProperties`
+  // written beside the ref go unseen while the fields it governs are named.
   const scopeRoot = cfcSchemaChildRoot(schema, schema);
-  const target = localRefTarget(schema, scopeRoot);
+  const target = resolveCfcSchemaRefs(schema, scopeRoot);
   if (!isSchemaObject(target)) return false;
   if (target.anyOf !== undefined || target.oneOf !== undefined) return false;
   const targetRoot = cfcSchemaChildRoot(target, scopeRoot);

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -107,10 +107,6 @@ function objectProperties(
   return declaredEventFields(schema)?.properties ?? null;
 }
 
-function requiredFlags(schema: JSONSchema): Set<string> {
-  return declaredEventFields(schema)?.required ?? new Set();
-}
-
 function schemaType(schema: JSONSchema): string | undefined {
   return isSchemaObject(schema) ? schema.type as string | undefined : undefined;
 }
@@ -636,8 +632,15 @@ function isSchemaLessHandlerInput(schema: JSONSchema): boolean {
   // root looks bare either way, so reading it alone called such a verb
   // schema-less and rendered its page as `void`: no input type, no flags, and
   // no sign that the fields the parser accepts exist at all.
+  //
+  // What settles it is where the ref LANDS, not that one is written. A ref
+  // reaching a fields position describes an event and the verb is not
+  // schema-less; a ref to a scalar, to a position naming nothing, or one that
+  // does not resolve describes no fields to derive, and the classification
+  // stays where it was — a verb that invoked bare goes on doing so rather
+  // than being refused for an event nothing could name.
   if (typeof schema.$ref === "string") {
-    return false;
+    return objectProperties(schema) === null;
   }
   return Array.isArray(schema.asCell) && schema.asCell.at(0) === "stream";
 }
@@ -861,7 +864,7 @@ function specificFlagLines(schema: JSONSchema): string[] {
     ];
   }
 
-  const required = requiredFlags(schema);
+  const required = requiredEventFieldsOwed(schema);
   const descriptors = Object.entries(properties).map(
     ([key, propertySchema]) => {
       const flagName = flagNameForKey(key);
@@ -1055,7 +1058,7 @@ function usageLine(
     return `${prefix} ${verb} --value ${valuePlaceholder(spec.inputSchema)}`;
   }
 
-  const required = requiredFlags(spec.inputSchema);
+  const required = requiredEventFieldsOwed(spec.inputSchema);
   const requiredUsages = Object.entries(properties)
     .filter(([key]) => required.has(key))
     .map(([key, propertySchema]) =>

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -119,37 +119,6 @@ function flagNameForKey(key: string): string {
   return key.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
-/**
- * The flag name a verb's single argument property answers to besides its own.
- *
- * A verb declaring exactly one field has nothing to disambiguate, so naming
- * the field and naming "the value" are the same act — `--title Milk` and
- * `--value Milk` carry one payload, and this is what makes the second spell
- * the first. The value is parsed against the FIELD's schema either way, so
- * the two spellings cannot diverge on type.
- *
- * `null` for every other shape. Two fields or more and there is a choice to
- * make, so `--value` names nothing and is refused; none at all and the
- * position is not a fields position, which is the separate scalar vocabulary
- * in {@link SCALAR_INPUT_FLAGS}. A verb whose one field is already spelled
- * `--value` needs no alias and gets none — the name it would add is the name
- * it already has.
- *
- * On a schema that welcomes undeclared fields the alias still wins, which is
- * the one case where it takes a name a payload could otherwise have used for
- * a field of its own. `--json` carries such a payload whole and is the door
- * for it.
- */
-function soleFieldAlias(schema: JSONSchema): FlagDescriptor | null {
-  const properties = objectProperties(schema);
-  if (!properties) return null;
-  const entries = Object.entries(properties);
-  if (entries.length !== 1) return null;
-  const [key, propertySchema] = entries[0];
-  if (flagNameForKey(key) === "value") return null;
-  return { key, flagName: "value", schema: propertySchema };
-}
-
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -317,25 +286,10 @@ const HELP_TAKES_NO_ARGUMENTS =
 function undeclaredFlagError(
   rawFlag: string,
   descriptors: Map<string, FlagDescriptor>,
-  alias: FlagDescriptor | null,
 ): string {
   const declared = [...descriptors.keys()];
   const opening = `"--${rawFlag}" at ${EVENT_ROOT_POSITION} is not a field ` +
     "this verb declares. ";
-
-  // `--value` against a verb that declares more than one field is a caller
-  // carrying over the spelling a single-field verb accepts, not a misspelling
-  // of any name here. The near miss cannot say that — it would offer whichever
-  // declared name is closest to "value", which is a coincidence of letters
-  // rather than the answer. Only the field count explains the refusal, so it
-  // is what the message leads with.
-  if (rawFlag === "value" && alias === null && declared.length > 1) {
-    return opening +
-      `"--value" spells the sole field of a verb that declares one, and ` +
-      `this verb declares ${declared.length}: ${
-        declared.map((name) => `"--${name}"`).join(", ")
-      }`;
-  }
 
   // A caller who wrote `--no-something` is asking to negate, and only a
   // boolean can be negated. Both halves of the answer narrow accordingly:
@@ -361,25 +315,14 @@ function undeclaredFlagError(
         }`);
   }
 
-  // The alias is a name that works, so a slip toward it deserves the same
-  // near miss a field name does — `--valu` on a single-field verb is the same
-  // slip as `--titel`. It stays out of the vocabulary sentence's list, which
-  // answers what the verb DECLARES; the clause after it says the field
-  // answers to a second spelling, which is a different claim.
-  const nearest = nearestName(
-    rawFlag,
-    alias === null ? declared : [...declared, alias.flagName],
-  );
-  const alsoSpells = alias === null
-    ? ""
-    : `, which this verb's sole field also spells "--${alias.flagName}"`;
+  const nearest = nearestName(rawFlag, declared);
   return opening +
     (nearest === undefined ? "" : `Did you mean "--${nearest}"? `) +
     (declared.length === 0
       ? `${EVENT_ROOT_POSITION} declares no fields at all`
       : `${EVENT_ROOT_POSITION} takes ${
         declared.map((name) => `"--${name}"`).join(", ")
-      }${alsoSpells}`);
+      }`);
 }
 
 function parseObjectInput(
@@ -392,15 +335,6 @@ function parseObjectInput(
     const flagName = flagNameForKey(key);
     descriptors.set(flagName, { key, flagName, schema: propertySchema });
   }
-  // Held beside the declared names rather than inside them. Everything that
-  // reads `descriptors` is answering "what does this verb declare" — the
-  // refusal vocabulary, the help page — and the alias is not a declaration.
-  // Resolution is the one place the two are the same, which is what
-  // `resolveFlag` is.
-  const alias = soleFieldAlias(schema);
-  const resolveFlag = (name: string): FlagDescriptor | undefined =>
-    descriptors.get(name) ??
-      (alias !== null && name === alias.flagName ? alias : undefined);
 
   const input: Record<string, unknown> = {};
   let directJsonInput: unknown;
@@ -470,9 +404,9 @@ function parseObjectInput(
     const inlineValue = inlineSplit.length === 2 ? inlineSplit[1] : undefined;
 
     let negated = false;
-    let descriptor = resolveFlag(rawFlag);
+    let descriptor = descriptors.get(rawFlag);
     if (!descriptor && rawFlag.startsWith("no-")) {
-      descriptor = resolveFlag(rawFlag.slice(3));
+      descriptor = descriptors.get(rawFlag.slice(3));
       negated = descriptor !== undefined;
     }
     if (!descriptor) {
@@ -483,7 +417,7 @@ function parseObjectInput(
       // accepted as a silent alias, when what the caller needs is the near
       // miss naming the spelling that works.
       if (eventSchemaJudgesRootFields(schema)) {
-        throw new Error(undeclaredFlagError(rawFlag, descriptors, alias));
+        throw new Error(undeclaredFlagError(rawFlag, descriptors));
       }
       // A schema judging nothing says nothing about the value either, so the
       // flag is taken as the string the caller typed: there is no declared
@@ -964,19 +898,6 @@ function specificFlagLines(schema: JSONSchema): string[] {
     },
   );
 
-  // The alias earns a line of its own rather than a mention on the field's,
-  // because the page is read to find out what may be typed and a spelling
-  // buried in another line's prose is not found that way. Its detail names
-  // the field it fills, which is the whole of what distinguishes it.
-  const alias = soleFieldAlias(schema);
-  if (alias) {
-    descriptors.push({
-      usage: fullFlagUsage(alias.flagName, alias.schema),
-      detail: `The same field as --${flagNameForKey(alias.key)}, ` +
-        "spelled for a verb that declares only the one.",
-    });
-  }
-
   const maxUsage = descriptors.reduce(
     (width, descriptor) => Math.max(width, descriptor.usage.length),
     0,
@@ -1166,19 +1087,8 @@ function helpUsageLines(
   );
   const verb = optionalVerbUsage(spec);
   const properties = objectProperties(spec.inputSchema);
-  const alias = soleFieldAlias(spec.inputSchema);
-  // The usage block names what a call must carry, so the alias belongs in it
-  // on exactly the terms its field does: beneath the line naming the field
-  // when that field is required, and nowhere when it is not. Listing it for
-  // an optional field would put "--value" in a block that never mentions
-  // "--title", which reads as the alias being the primary spelling.
-  const aliasUsage = alias !== null &&
-      requiredFlags(spec.inputSchema).has(alias.key)
-    ? [`  ${prefix} ${verb} ${primaryFlagUsage(alias.flagName, alias.schema)}`]
-    : [];
   return [
     `  ${usageLine(mountedFilePath, spec, invocationStyle, commandPrefix)}`,
-    ...aliasUsage,
     ...(!properties ? [`  ${prefix} ${verb} --value-file <path>`] : []),
     `  ${prefix} ${verb} --json`,
     `  ${prefix} ${verb} --json-file <path>`,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -11,6 +11,8 @@ import { cliCommand } from "./cli-name.ts";
 import {
   declaredEventFields,
   eventSchemaJudgesRootFields,
+  requiredEventFieldsOwed,
+  verbRunsWithoutPayload,
 } from "./callable.ts";
 import { EVENT_ROOT_POSITION, nearestName } from "./refusal.ts";
 
@@ -552,8 +554,13 @@ function parseObjectInput(
 
   // Only enforce required fields for schema-derived flags.
   // JSON input validation is deferred to the runner.
+  //
+  // What is enforced is what the caller is OWED to supply, not what the
+  // schema marks required: a field carrying a default is answered by the
+  // pattern, and demanding it here refuses a call the runtime would have
+  // filled in and dispatched.
   if (!usedJson) {
-    for (const key of requiredFlags(schema)) {
+    for (const key of requiredEventFieldsOwed(schema)) {
       if (!(key in input)) {
         throw new Error(`Missing required flag --${flagNameForKey(key)}`);
       }
@@ -688,6 +695,14 @@ function isSchemaLessHandlerInput(schema: JSONSchema): boolean {
     return false;
   }
   if (schema.type !== undefined || schema.properties !== undefined) {
+    return false;
+  }
+  // A `$ref` beside the stream marker describes the event — in the definition
+  // rather than at the root, which is where a pattern routinely puts it. The
+  // root looks bare either way, so reading it alone called such a verb
+  // schema-less and rendered its page as `void`: no input type, no flags, and
+  // no sign that the fields the parser accepts exist at all.
+  if (typeof schema.$ref === "string") {
     return false;
   }
   return Array.isArray(schema.asCell) && schema.asCell.at(0) === "stream";
@@ -1176,8 +1191,7 @@ function handlerAllowsInvokeWithoutInputs(schema: JSONSchema): boolean {
   if (isSchemaLessHandlerInput(schema)) {
     return true;
   }
-  const properties = objectProperties(schema);
-  return properties !== null && requiredFlags(schema).size === 0;
+  return verbRunsWithoutPayload(schema);
 }
 
 export function parseExecArgs(

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -117,6 +117,37 @@ function flagNameForKey(key: string): string {
   return key.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
+/**
+ * The flag name a verb's single argument property answers to besides its own.
+ *
+ * A verb declaring exactly one field has nothing to disambiguate, so naming
+ * the field and naming "the value" are the same act — `--title Milk` and
+ * `--value Milk` carry one payload, and this is what makes the second spell
+ * the first. The value is parsed against the FIELD's schema either way, so
+ * the two spellings cannot diverge on type.
+ *
+ * `null` for every other shape. Two fields or more and there is a choice to
+ * make, so `--value` names nothing and is refused; none at all and the
+ * position is not a fields position, which is the separate scalar vocabulary
+ * in {@link SCALAR_INPUT_FLAGS}. A verb whose one field is already spelled
+ * `--value` needs no alias and gets none — the name it would add is the name
+ * it already has.
+ *
+ * On a schema that welcomes undeclared fields the alias still wins, which is
+ * the one case where it takes a name a payload could otherwise have used for
+ * a field of its own. `--json` carries such a payload whole and is the door
+ * for it.
+ */
+function soleFieldAlias(schema: JSONSchema): FlagDescriptor | null {
+  const properties = objectProperties(schema);
+  if (!properties) return null;
+  const entries = Object.entries(properties);
+  if (entries.length !== 1) return null;
+  const [key, propertySchema] = entries[0];
+  if (flagNameForKey(key) === "value") return null;
+  return { key, flagName: "value", schema: propertySchema };
+}
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -284,10 +315,25 @@ const HELP_TAKES_NO_ARGUMENTS =
 function undeclaredFlagError(
   rawFlag: string,
   descriptors: Map<string, FlagDescriptor>,
+  alias: FlagDescriptor | null,
 ): string {
   const declared = [...descriptors.keys()];
   const opening = `"--${rawFlag}" at ${EVENT_ROOT_POSITION} is not a field ` +
     "this verb declares. ";
+
+  // `--value` against a verb that declares more than one field is a caller
+  // carrying over the spelling a single-field verb accepts, not a misspelling
+  // of any name here. The near miss cannot say that — it would offer whichever
+  // declared name is closest to "value", which is a coincidence of letters
+  // rather than the answer. Only the field count explains the refusal, so it
+  // is what the message leads with.
+  if (rawFlag === "value" && alias === null && declared.length > 1) {
+    return opening +
+      `"--value" spells the sole field of a verb that declares one, and ` +
+      `this verb declares ${declared.length}: ${
+        declared.map((name) => `"--${name}"`).join(", ")
+      }`;
+  }
 
   // A caller who wrote `--no-something` is asking to negate, and only a
   // boolean can be negated. Both halves of the answer narrow accordingly:
@@ -313,14 +359,25 @@ function undeclaredFlagError(
         }`);
   }
 
-  const nearest = nearestName(rawFlag, declared);
+  // The alias is a name that works, so a slip toward it deserves the same
+  // near miss a field name does — `--valu` on a single-field verb is the same
+  // slip as `--titel`. It stays out of the vocabulary sentence's list, which
+  // answers what the verb DECLARES; the clause after it says the field
+  // answers to a second spelling, which is a different claim.
+  const nearest = nearestName(
+    rawFlag,
+    alias === null ? declared : [...declared, alias.flagName],
+  );
+  const alsoSpells = alias === null
+    ? ""
+    : `, which this verb's sole field also spells "--${alias.flagName}"`;
   return opening +
     (nearest === undefined ? "" : `Did you mean "--${nearest}"? `) +
     (declared.length === 0
       ? `${EVENT_ROOT_POSITION} declares no fields at all`
       : `${EVENT_ROOT_POSITION} takes ${
         declared.map((name) => `"--${name}"`).join(", ")
-      }`);
+      }${alsoSpells}`);
 }
 
 function parseObjectInput(
@@ -333,6 +390,15 @@ function parseObjectInput(
     const flagName = flagNameForKey(key);
     descriptors.set(flagName, { key, flagName, schema: propertySchema });
   }
+  // Held beside the declared names rather than inside them. Everything that
+  // reads `descriptors` is answering "what does this verb declare" — the
+  // refusal vocabulary, the help page — and the alias is not a declaration.
+  // Resolution is the one place the two are the same, which is what
+  // `resolveFlag` is.
+  const alias = soleFieldAlias(schema);
+  const resolveFlag = (name: string): FlagDescriptor | undefined =>
+    descriptors.get(name) ??
+      (alias !== null && name === alias.flagName ? alias : undefined);
 
   const input: Record<string, unknown> = {};
   let directJsonInput: unknown;
@@ -402,9 +468,9 @@ function parseObjectInput(
     const inlineValue = inlineSplit.length === 2 ? inlineSplit[1] : undefined;
 
     let negated = false;
-    let descriptor = descriptors.get(rawFlag);
+    let descriptor = resolveFlag(rawFlag);
     if (!descriptor && rawFlag.startsWith("no-")) {
-      descriptor = descriptors.get(rawFlag.slice(3));
+      descriptor = resolveFlag(rawFlag.slice(3));
       negated = descriptor !== undefined;
     }
     if (!descriptor) {
@@ -415,7 +481,7 @@ function parseObjectInput(
       // accepted as a silent alias, when what the caller needs is the near
       // miss naming the spelling that works.
       if (eventSchemaJudgesRootFields(schema)) {
-        throw new Error(undeclaredFlagError(rawFlag, descriptors));
+        throw new Error(undeclaredFlagError(rawFlag, descriptors, alias));
       }
       // A schema judging nothing says nothing about the value either, so the
       // flag is taken as the string the caller typed: there is no declared
@@ -883,6 +949,19 @@ function specificFlagLines(schema: JSONSchema): string[] {
     },
   );
 
+  // The alias earns a line of its own rather than a mention on the field's,
+  // because the page is read to find out what may be typed and a spelling
+  // buried in another line's prose is not found that way. Its detail names
+  // the field it fills, which is the whole of what distinguishes it.
+  const alias = soleFieldAlias(schema);
+  if (alias) {
+    descriptors.push({
+      usage: fullFlagUsage(alias.flagName, alias.schema),
+      detail: `The same field as --${flagNameForKey(alias.key)}, ` +
+        "spelled for a verb that declares only the one.",
+    });
+  }
+
   const maxUsage = descriptors.reduce(
     (width, descriptor) => Math.max(width, descriptor.usage.length),
     0,
@@ -1072,8 +1151,19 @@ function helpUsageLines(
   );
   const verb = optionalVerbUsage(spec);
   const properties = objectProperties(spec.inputSchema);
+  const alias = soleFieldAlias(spec.inputSchema);
+  // The usage block names what a call must carry, so the alias belongs in it
+  // on exactly the terms its field does: beneath the line naming the field
+  // when that field is required, and nowhere when it is not. Listing it for
+  // an optional field would put "--value" in a block that never mentions
+  // "--title", which reads as the alias being the primary spelling.
+  const aliasUsage = alias !== null &&
+      requiredFlags(spec.inputSchema).has(alias.key)
+    ? [`  ${prefix} ${verb} ${primaryFlagUsage(alias.flagName, alias.schema)}`]
+    : [];
   return [
     `  ${usageLine(mountedFilePath, spec, invocationStyle, commandPrefix)}`,
+    ...aliasUsage,
     ...(!properties ? [`  ${prefix} ${verb} --value-file <path>`] : []),
     `  ${prefix} ${verb} --json`,
     `  ${prefix} ${verb} --json-file <path>`,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -634,13 +634,16 @@ function isSchemaLessHandlerInput(schema: JSONSchema): boolean {
   // no sign that the fields the parser accepts exist at all.
   //
   // What settles it is where the ref LANDS, not that one is written. A ref
-  // reaching a fields position describes an event and the verb is not
-  // schema-less; a ref to a scalar, to a position naming nothing, or one that
-  // does not resolve describes no fields to derive, and the classification
-  // stays where it was — a verb that invoked bare goes on doing so rather
-  // than being refused for an event nothing could name.
-  if (typeof schema.$ref === "string") {
-    return objectProperties(schema) === null;
+  // reaching a fields position describes an event, and only that answers
+  // here. Every other ref — to a scalar, to a position naming nothing, or one
+  // that does not resolve — carries no fields to derive and is left to the
+  // marker check below, which is the classification it had before any ref was
+  // followed. Answering for those directly would take the marker out of the
+  // question: a `$ref` to a scalar with no stream marker is a single-value
+  // verb, and calling it schema-less costs it both `--value` and its input
+  // type on the page.
+  if (typeof schema.$ref === "string" && objectProperties(schema) !== null) {
+    return false;
   }
   return Array.isArray(schema.asCell) && schema.asCell.at(0) === "stream";
 }

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -777,6 +777,75 @@ describe("parseExecArgs edge cases", () => {
       .toEqual({ fooBar: 5 });
   });
 
+  it("derives flags from fields behind a top-level $ref", () => {
+    // The shape a stream's event is routinely written in. Its fields sit in
+    // the definition, and a caller should not have to know that to name them.
+    const refSchema = (
+      properties: Record<string, JSONSchema>,
+      required: string[],
+    ): JSONSchema => ({
+      $ref: "#/$defs/AddEvent",
+      asCell: ["stream"],
+      $defs: { AddEvent: { type: "object", properties, required } },
+    } as JSONSchema);
+
+    const one = makeSpec(
+      "handler",
+      refSchema({ query: { type: "string" } }, ["query"]),
+    );
+    expect(parseExecArgs(one, ["--query", "Milk"]).input)
+      .toEqual({ query: "Milk" });
+    // One field, so it answers to --value as well — the same rule any
+    // single-field verb follows, reached through the indirection.
+    expect(parseExecArgs(one, ["--value", "Milk"]).input)
+      .toEqual({ query: "Milk" });
+
+    const two = makeSpec(
+      "handler",
+      refSchema(
+        { query: { type: "string" }, limit: { type: "number" } },
+        ["query"],
+      ),
+    );
+    expect(parseExecArgs(two, ["--query", "Milk", "--limit", "5"]).input)
+      .toEqual({ query: "Milk", limit: 5 });
+    expect(() => parseExecArgs(two, ["--value", "Milk"]))
+      .toThrow(/this verb declares 2: "--query", "--limit"/);
+    expect(() => parseExecArgs(two, ["--quer", "Milk"]))
+      .toThrow(/Did you mean "--query"\?/);
+
+    // The page reports the resolved event rather than calling it void, and
+    // names the flags the parser accepts.
+    const help = renderExecHelp("/tmp/x.handler", one);
+    expect(help).toContain("query: string");
+    expect(help).toContain("--query <string>");
+    expect(help).not.toContain("Input type:\n  void");
+  });
+
+  it("counts a defaulted field as supplied rather than owed", () => {
+    // The payload gate relaxes `required` for a field carrying a default, so
+    // demanding it at the flag door would refuse a call the runtime fills in.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: {
+        mode: { type: "string", default: "fast" },
+        note: { type: "string" },
+      },
+      required: ["mode"],
+    });
+    expect(parseExecArgs(spec, []).input).toEqual({});
+    expect(parseExecArgs(spec, ["--note", "hi"]).input).toEqual({ note: "hi" });
+
+    // A required field with no default is still owed.
+    const owed = makeSpec("handler", {
+      type: "object",
+      properties: { mode: { type: "string" } },
+      required: ["mode"],
+    });
+    expect(() => parseExecArgs(owed, ["invoke"]))
+      .toThrow(/Missing required flag --mode/);
+  });
+
   it("lets a verb's single field be named by --value as well as its own name", () => {
     const spec = makeSpec("handler", {
       type: "object",
@@ -3108,13 +3177,10 @@ describe("mounted callable resolution and execution", () => {
     expect(harness.tracker.handlerWrites).toEqual([]);
   });
 
-  // Characterized first (pre-D5, observed passing on unmodified code with
-  // the dispatch assertion): a mounted handler invoked with nothing at all
-  // dispatched `undefined` when its event schema sat behind a top-level
-  // local $ref the arg parser derives no flags from. The gate now normalizes
-  // absence to `{}` against the resolved object schema and refuses when
-  // `required` survives relaxation — nothing dispatches, so an invocation id
-  // would never have been spent.
+  // A mounted handler whose event schema sits behind a top-level local $ref
+  // is refused at the flag door, which reads the definition's fields and can
+  // name the type the caller must supply. Nothing dispatches, so an
+  // invocation id is never spent.
   it("refuses an absent payload for a mounted handler that cannot run without one", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
@@ -3153,7 +3219,7 @@ describe("mounted callable resolution and execution", () => {
         },
       ),
     ).rejects.toThrow(
-      /Invalid input for "add": no payload was supplied.*query.*send a payload/,
+      /Handler requires input\. Expected type: \{\s*query: string\s*\}/,
     );
 
     expect(harness.tracker.handlerWrites).toEqual([]);

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -777,6 +777,144 @@ describe("parseExecArgs edge cases", () => {
       .toEqual({ fooBar: 5 });
   });
 
+  it("lets a verb's single field be named by --value as well as its own name", () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    });
+
+    // The two spellings are one payload, not two shapes: --value fills the
+    // declared field rather than becoming the whole event.
+    expect(parseExecArgs(spec, ["--title", "Milk"]).input)
+      .toEqual({ title: "Milk" });
+    expect(parseExecArgs(spec, ["--value", "Milk"]).input)
+      .toEqual({ title: "Milk" });
+    expect(parseExecArgs(spec, ["--value=Milk"]).input)
+      .toEqual({ title: "Milk" });
+
+    // The value is read against the FIELD's schema, so the alias cannot
+    // deliver a string where its field is typed a number.
+    const numeric = makeSpec("handler", {
+      type: "object",
+      properties: { qty: { type: "number" } },
+      required: ["qty"],
+    });
+    expect(parseExecArgs(numeric, ["--value", "7"]).input).toEqual({ qty: 7 });
+
+    // A boolean field keeps both halves of its own vocabulary under the alias.
+    const flag = makeSpec("handler", {
+      type: "object",
+      properties: { done: { type: "boolean" } },
+      required: ["done"],
+    });
+    expect(parseExecArgs(flag, ["--value"]).input).toEqual({ done: true });
+    expect(parseExecArgs(flag, ["--no-value"]).input).toEqual({ done: false });
+
+    // Naming the field satisfies its own requirement, however it was spelled.
+    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
+      .not.toThrow(/Missing required flag/);
+
+    // The alias carries a field, so it is a generated flag and shares their
+    // one rule: --json carries the whole event or nothing does.
+    expect(() => parseExecArgs(spec, ["--value", "Milk", "--json", "{}"]))
+      .toThrow(/--json cannot be combined with generated flags/);
+  });
+
+  it("refuses --value where a verb declares more than one field", () => {
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" }, qty: { type: "number" } },
+    });
+
+    // The field count is the reason, so the field count is what the refusal
+    // leads with — a near miss would offer whichever declared name happens to
+    // sit closest to "value", which explains nothing.
+    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
+      .toThrow(/"--value" spells the sole field of a verb that declares one/);
+    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
+      .toThrow(/this verb declares 2: "--title", "--qty"/);
+    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
+      .not.toThrow(/Did you mean/);
+
+    // A verb declaring nothing has no field for the alias to spell either.
+    const empty = makeSpec("handler", { type: "object", properties: {} });
+    expect(() => parseExecArgs(empty, ["--value", "Milk"]))
+      .toThrow(/declares no fields at all/);
+  });
+
+  it("keeps one spelling for a single field already named value", () => {
+    // The alias would be the name the field already answers to, so there is
+    // none to add and nothing to collide with.
+    const spec = makeSpec("handler", {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    });
+    expect(parseExecArgs(spec, ["--value", "Milk"]).input)
+      .toEqual({ value: "Milk" });
+    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
+      .not.toThrow();
+
+    // And the help page names it once, as the field it is.
+    const help = renderExecHelp("/tmp/x.handler", spec);
+    expect(help).toContain("--value <string>  Required.");
+    expect(help).not.toContain("The same field as");
+  });
+
+  it("offers --value as a near miss only where the verb has a single field", () => {
+    const single = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" } },
+    });
+    // A slip toward a spelling that works is owed the same near miss a slip
+    // toward a field name is.
+    expect(() => parseExecArgs(single, ["--valu", "x"]))
+      .toThrow(/Did you mean "--value"\?/);
+    // The vocabulary sentence still answers what the verb DECLARES; the
+    // alias rides a separate clause because it is not a declaration.
+    expect(() => parseExecArgs(single, ["--valu", "x"]))
+      .toThrow(
+        /takes "--title", which this verb's sole field also spells "--value"/,
+      );
+
+    const many = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" }, qty: { type: "number" } },
+    });
+    expect(() => parseExecArgs(many, ["--valu", "x"]))
+      .not.toThrow(/--value/);
+  });
+
+  it("names both spellings on the help page of a single-field verb", () => {
+    const required = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    });
+    const help = renderExecHelp("/tmp/x.handler", required);
+    expect(help).toContain("--value <string>  The same field as --title");
+    // The usage block names what a call must carry, so the alias appears
+    // there beneath the field's own line — never above it.
+    expect(help).toContain("[invoke] --title <string>\n");
+    expect(help).toContain("[invoke] --value <string>\n");
+    expect(help.indexOf("[invoke] --title")).toBeLessThan(
+      help.indexOf("[invoke] --value"),
+    );
+
+    // An optional field is named in neither usage line, and the alias follows
+    // it rather than standing alone in a block that never mentions --title.
+    const optional = makeSpec("handler", {
+      type: "object",
+      properties: { title: { type: "string" } },
+    });
+    const optionalHelp = renderExecHelp("/tmp/x.handler", optional);
+    expect(optionalHelp).toContain(
+      "--value <string>  The same field as --title",
+    );
+    expect(optionalHelp).not.toContain("[invoke] --value <string>");
+  });
+
   it("handles each non-object input mode and its errors", () => {
     const booleanSpec = makeSpec("tool", { type: "boolean" });
     const stringSpec = makeSpec("tool", { type: "string" });

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -863,6 +863,52 @@ describe("parseExecArgs edge cases", () => {
     expect(help).not.toContain("Input type:\n  void");
   });
 
+  it("keeps a defaulted field optional on the help page too", () => {
+    // The page and the parser must answer required-ness the same way. Labelling
+    // `--mode` required while the last line says a bare invoke works, and while
+    // the parser accepts one, is the page contradicting itself and the caller.
+    const spec = makeSpec("handler", {
+      $ref: "#/$defs/RefreshEvent",
+      asCell: ["stream"],
+      $defs: {
+        RefreshEvent: {
+          type: "object",
+          properties: { mode: { type: "string", default: "fast" } },
+          required: ["mode"],
+        },
+      },
+    } as unknown as JSONSchema);
+
+    const help = renderExecHelp("/tmp/x.handler", spec);
+    expect(help).toContain('--mode <string>  Optional. Default: "fast".');
+    // Usage names what a call must carry, and this one need carry nothing.
+    expect(help).not.toContain("[invoke] --mode");
+    expect(help).toContain("Invoke alone will call the handler");
+    expect(parseExecArgs(spec, []).input).toEqual({});
+  });
+
+  it("leaves a verb schema-less when its $ref lands on no fields", () => {
+    // Only where the ref reaches a fields position is there anything to derive.
+    // A ref to a scalar, to a position naming nothing, or one that does not
+    // resolve leaves the verb invoking bare, as it did before it was followed.
+    const streamOf = (defs: Record<string, unknown>) => ({
+      $ref: "#/$defs/Target",
+      asCell: ["stream"],
+      $defs: defs,
+    } as unknown as JSONSchema);
+
+    for (
+      const inputSchema of [
+        streamOf({ Target: {} }),
+        streamOf({ Target: { type: "string" } }),
+        streamOf({}),
+      ]
+    ) {
+      expect(parseExecArgs(makeSpec("handler", inputSchema), []).input)
+        .toBeUndefined();
+    }
+  });
+
   it("counts a defaulted field as supplied rather than owed", () => {
     // The payload gate relaxes `required` for a field carrying a default, so
     // demanding it at the flag door would refuse a call the runtime fills in.

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -863,6 +863,26 @@ describe("parseExecArgs edge cases", () => {
     expect(help).not.toContain("Input type:\n  void");
   });
 
+  it("spells a boolean without a placeholder, and a boolean value with one", () => {
+    // A boolean FIELD is named bare in Usage, because writing the flag is
+    // already the whole of saying true — a placeholder there would invite a
+    // value the parser does not take in that position.
+    const field = makeSpec("handler", {
+      type: "object",
+      properties: { done: { type: "boolean" } },
+      required: ["done"],
+    });
+    const fieldHelp = renderExecHelp("/tmp/x.handler", field);
+    expect(fieldHelp).toContain("[invoke] --done\n");
+    expect(fieldHelp).not.toContain("--done <boolean>");
+
+    // A verb whose whole event IS a boolean has no field to name, so the
+    // value rides `--value` and the placeholder says which value it takes.
+    const whole = makeSpec("tool", { type: "boolean" });
+    const wholeHelp = renderExecHelp("/tmp/x.tool", whole);
+    expect(wholeHelp).toContain("--value <boolean>");
+  });
+
   it("keeps a defaulted field optional on the help page too", () => {
     // The page and the parser must answer required-ness the same way. Labelling
     // `--mode` required while the last line says a bare invoke works, and while

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -907,6 +907,20 @@ describe("parseExecArgs edge cases", () => {
       expect(parseExecArgs(makeSpec("handler", inputSchema), []).input)
         .toBeUndefined();
     }
+
+    // The stream marker is still what makes a bare position schema-less, and
+    // following the ref must not take it out of the question. A $ref to a
+    // scalar with no marker is a single-value verb, and owes its caller the
+    // flags and the input type that go with one.
+    const scalarTool = makeSpec("tool", {
+      $ref: "#/$defs/Target",
+      $defs: { Target: { type: "string" } },
+    } as unknown as JSONSchema);
+    expect(parseExecArgs(scalarTool, ["--value", "Milk"]).input).toBe("Milk");
+    const help = renderExecHelp("/tmp/x.tool", scalarTool);
+    expect(help).toContain("--value");
+    expect(help).toContain("Input type:\n  string");
+    expect(help).not.toContain("Input type:\n  void");
   });
 
   it("counts a defaulted field as supplied rather than owed", () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -795,10 +795,10 @@ describe("parseExecArgs edge cases", () => {
     );
     expect(parseExecArgs(one, ["--query", "Milk"]).input)
       .toEqual({ query: "Milk" });
-    // One field, so it answers to --value as well — the same rule any
-    // single-field verb follows, reached through the indirection.
-    expect(parseExecArgs(one, ["--value", "Milk"]).input)
-      .toEqual({ query: "Milk" });
+    // The field has a name, so that name is the flag. `--value` belongs to a
+    // verb whose event IS a single value, and this one's is an object.
+    expect(() => parseExecArgs(one, ["--value", "Milk"]))
+      .toThrow(/"--value" at <event> is not a field this verb declares/);
 
     const two = makeSpec(
       "handler",
@@ -810,7 +810,7 @@ describe("parseExecArgs edge cases", () => {
     expect(parseExecArgs(two, ["--query", "Milk", "--limit", "5"]).input)
       .toEqual({ query: "Milk", limit: 5 });
     expect(() => parseExecArgs(two, ["--value", "Milk"]))
-      .toThrow(/this verb declares 2: "--query", "--limit"/);
+      .toThrow(/<event> takes "--query", "--limit"/);
     expect(() => parseExecArgs(two, ["--quer", "Milk"]))
       .toThrow(/Did you mean "--query"\?/);
 
@@ -844,144 +844,6 @@ describe("parseExecArgs edge cases", () => {
     });
     expect(() => parseExecArgs(owed, ["invoke"]))
       .toThrow(/Missing required flag --mode/);
-  });
-
-  it("lets a verb's single field be named by --value as well as its own name", () => {
-    const spec = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" } },
-      required: ["title"],
-    });
-
-    // The two spellings are one payload, not two shapes: --value fills the
-    // declared field rather than becoming the whole event.
-    expect(parseExecArgs(spec, ["--title", "Milk"]).input)
-      .toEqual({ title: "Milk" });
-    expect(parseExecArgs(spec, ["--value", "Milk"]).input)
-      .toEqual({ title: "Milk" });
-    expect(parseExecArgs(spec, ["--value=Milk"]).input)
-      .toEqual({ title: "Milk" });
-
-    // The value is read against the FIELD's schema, so the alias cannot
-    // deliver a string where its field is typed a number.
-    const numeric = makeSpec("handler", {
-      type: "object",
-      properties: { qty: { type: "number" } },
-      required: ["qty"],
-    });
-    expect(parseExecArgs(numeric, ["--value", "7"]).input).toEqual({ qty: 7 });
-
-    // A boolean field keeps both halves of its own vocabulary under the alias.
-    const flag = makeSpec("handler", {
-      type: "object",
-      properties: { done: { type: "boolean" } },
-      required: ["done"],
-    });
-    expect(parseExecArgs(flag, ["--value"]).input).toEqual({ done: true });
-    expect(parseExecArgs(flag, ["--no-value"]).input).toEqual({ done: false });
-
-    // Naming the field satisfies its own requirement, however it was spelled.
-    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
-      .not.toThrow(/Missing required flag/);
-
-    // The alias carries a field, so it is a generated flag and shares their
-    // one rule: --json carries the whole event or nothing does.
-    expect(() => parseExecArgs(spec, ["--value", "Milk", "--json", "{}"]))
-      .toThrow(/--json cannot be combined with generated flags/);
-  });
-
-  it("refuses --value where a verb declares more than one field", () => {
-    const spec = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" }, qty: { type: "number" } },
-    });
-
-    // The field count is the reason, so the field count is what the refusal
-    // leads with — a near miss would offer whichever declared name happens to
-    // sit closest to "value", which explains nothing.
-    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
-      .toThrow(/"--value" spells the sole field of a verb that declares one/);
-    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
-      .toThrow(/this verb declares 2: "--title", "--qty"/);
-    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
-      .not.toThrow(/Did you mean/);
-
-    // A verb declaring nothing has no field for the alias to spell either.
-    const empty = makeSpec("handler", { type: "object", properties: {} });
-    expect(() => parseExecArgs(empty, ["--value", "Milk"]))
-      .toThrow(/declares no fields at all/);
-  });
-
-  it("keeps one spelling for a single field already named value", () => {
-    // The alias would be the name the field already answers to, so there is
-    // none to add and nothing to collide with.
-    const spec = makeSpec("handler", {
-      type: "object",
-      properties: { value: { type: "string" } },
-      required: ["value"],
-    });
-    expect(parseExecArgs(spec, ["--value", "Milk"]).input)
-      .toEqual({ value: "Milk" });
-    expect(() => parseExecArgs(spec, ["--value", "Milk"]))
-      .not.toThrow();
-
-    // And the help page names it once, as the field it is.
-    const help = renderExecHelp("/tmp/x.handler", spec);
-    expect(help).toContain("--value <string>  Required.");
-    expect(help).not.toContain("The same field as");
-  });
-
-  it("offers --value as a near miss only where the verb has a single field", () => {
-    const single = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" } },
-    });
-    // A slip toward a spelling that works is owed the same near miss a slip
-    // toward a field name is.
-    expect(() => parseExecArgs(single, ["--valu", "x"]))
-      .toThrow(/Did you mean "--value"\?/);
-    // The vocabulary sentence still answers what the verb DECLARES; the
-    // alias rides a separate clause because it is not a declaration.
-    expect(() => parseExecArgs(single, ["--valu", "x"]))
-      .toThrow(
-        /takes "--title", which this verb's sole field also spells "--value"/,
-      );
-
-    const many = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" }, qty: { type: "number" } },
-    });
-    expect(() => parseExecArgs(many, ["--valu", "x"]))
-      .not.toThrow(/--value/);
-  });
-
-  it("names both spellings on the help page of a single-field verb", () => {
-    const required = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" } },
-      required: ["title"],
-    });
-    const help = renderExecHelp("/tmp/x.handler", required);
-    expect(help).toContain("--value <string>  The same field as --title");
-    // The usage block names what a call must carry, so the alias appears
-    // there beneath the field's own line — never above it.
-    expect(help).toContain("[invoke] --title <string>\n");
-    expect(help).toContain("[invoke] --value <string>\n");
-    expect(help.indexOf("[invoke] --title")).toBeLessThan(
-      help.indexOf("[invoke] --value"),
-    );
-
-    // An optional field is named in neither usage line, and the alias follows
-    // it rather than standing alone in a block that never mentions --title.
-    const optional = makeSpec("handler", {
-      type: "object",
-      properties: { title: { type: "string" } },
-    });
-    const optionalHelp = renderExecHelp("/tmp/x.handler", optional);
-    expect(optionalHelp).toContain(
-      "--value <string>  The same field as --title",
-    );
-    expect(optionalHelp).not.toContain("[invoke] --value <string>");
   });
 
   it("handles each non-object input mode and its errors", () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -777,6 +777,47 @@ describe("parseExecArgs edge cases", () => {
       .toEqual({ fooBar: 5 });
   });
 
+  it("reads a $ref's siblings the way the payload door resolves them", () => {
+    // 2020-12 lets a `$ref` carry siblings, and the runtime's own
+    // `resolveCfcSchemaRefs` merges the ref site over its target. Jumping
+    // straight to the target instead would name `query` here — a flag the
+    // validator refuses as an additional property — while hiding `limit`,
+    // the one it accepts. Which fields exist is the validator's answer to
+    // give; this door's job is to report the same one.
+    const spec = makeSpec("handler", {
+      $ref: "#/$defs/AddEvent",
+      asCell: ["stream"],
+      properties: { limit: { type: "number" } },
+      additionalProperties: false,
+      $defs: {
+        AddEvent: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          additionalProperties: false,
+        },
+      },
+    } as unknown as JSONSchema);
+
+    expect(parseExecArgs(spec, ["--limit", "5"]).input).toEqual({ limit: 5 });
+    expect(() => parseExecArgs(spec, ["--query", "Milk"]))
+      .toThrow(/<event> takes "--limit"/);
+  });
+
+  it("falls back to the single-value vocabulary for an unresolvable $ref", () => {
+    // A dangling ref describes nothing, so there is no fields position to
+    // read and the scalar flags are all that remain — where such a schema
+    // sat before any of this resolved.
+    const spec = makeSpec("handler", {
+      $ref: "#/$defs/Missing",
+      asCell: ["stream"],
+      $defs: {},
+    } as unknown as JSONSchema);
+
+    expect(parseExecArgs(spec, ["--value", "Milk"]).input).toBe("Milk");
+    expect(() => parseExecArgs(spec, ["--query", "Milk"]))
+      .toThrow(/This verb takes a single value/);
+  });
+
   it("derives flags from fields behind a top-level $ref", () => {
     // The shape a stream's event is routinely written in. Its fields sit in
     // the definition, and a caller should not have to know that to name them.

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -299,12 +299,13 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.sendOptions).toEqual([]);
   });
 
-  // Characterized first (pre-D5, observed passing on unmodified code): this
-  // exact call dispatched — the handler ran with `$event === undefined` and
-  // its receipt spent the invocation id. The schema below is the deployed
-  // shape absence reaches dispatch through: a top-level local $ref with the
-  // stream marker, which the arg parser cannot derive flags from, so a bare
-  // call parses to `input === undefined`.
+  // The schema below is the deployed shape a stream's event is routinely
+  // written in: a top-level local $ref with the stream marker. The arg
+  // parser reads the definition's fields, so absence is refused where the
+  // caller can act on it — naming the type to supply — rather than deeper in
+  // at the payload gate. Either way nothing dispatches; what this pins is
+  // that the id survives a refusal, so the retry that does send a payload
+  // can still use it.
   it("refuses an absent payload against a verb that provably cannot run without one", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
@@ -342,7 +343,7 @@ describe("executePieceCallable", () => {
         },
       ),
     ).rejects.toThrow(
-      /Invalid input for "recordMessage": no payload was supplied.*message.*send a payload/,
+      /Handler requires input\. Expected type: \{\s*message: string\s*\}/,
     );
 
     // Nothing reached the stream, so the invocation id was never spent — the
@@ -351,12 +352,13 @@ describe("executePieceCallable", () => {
     expect(harness.tracker.sendOptions).toEqual([]);
   });
 
-  // The $ref-carrying stream shape is schema-less to the arg parser, so a
-  // bare call skips the implicit-pipe read and the absence gate above
-  // decides — with stdin untouched. A rejecting reader pins the "untouched"
-  // half: piped bytes cannot reach a verb through this shape, they can only
-  // be spelled explicitly (`--json`, `--json-file -`).
-  it("refuses a bare $ref-stream verb call without reading piped stdin", async () => {
+  // A $ref-carrying stream shape declares its fields in the definition, and
+  // the arg parser reads them there — so a bare call takes the same
+  // implicit-pipe path as the identical verb written without the
+  // indirection ("infers piped stdin for object handlers", below). Piped
+  // bytes reach a verb through this shape; how the schema spells its event
+  // is not something a caller should have to know to pipe into it.
+  it("infers piped stdin for a bare $ref-stream verb call", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
       cellKey: "recordMessage",
@@ -375,28 +377,30 @@ describe("executePieceCallable", () => {
       } as JSONSchema,
     });
 
-    await expect(
-      executePieceCallable(
-        {
-          apiUrl: "http://localhost:8000",
-          identity: "/tmp/test-identity.pem",
-          piece: "fid1:piece-123",
-          space: "home",
-        },
-        "recordMessage",
-        [],
-        {
-          loadPieces: () => Promise.resolve(harness.pieces),
-          loadPiece: () => Promise.resolve(harness.piece),
-          isStdinTerminal: () => false,
-          readTextInput: () => Promise.reject(new Error("stdin was read")),
-        },
-      ),
-    ).rejects.toThrow(
-      /Invalid input for "recordMessage": no payload was supplied/,
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "recordMessage",
+      [],
+      {
+        loadPieces: () => Promise.resolve(harness.pieces),
+        loadPiece: () => Promise.resolve(harness.piece),
+        isStdinTerminal: () => false,
+        readTextInput: () => Promise.resolve('{"message":"Milk"}'),
+      },
     );
 
-    expect(harness.tracker.handlerWrites).toEqual([]);
+    expect(harness.tracker.handlerWrites).toEqual([
+      {
+        cellProp: "result",
+        path: ["recordMessage"],
+        value: { message: "Milk" },
+      },
+    ]);
   });
 
   it("normalizes an absent payload to {} so an all-defaulted verb receives its defaults", async () => {

--- a/packages/cli/test/verb-required-fields-owed.test.ts
+++ b/packages/cli/test/verb-required-fields-owed.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Pins `requiredEventFieldsOwed` and `verbRunsWithoutPayload` directly.
+ *
+ * Both answer one question the flag door asks at three separate places — the
+ * bare-invoke gate, the per-flag presence check, and the required-ness a help
+ * page prints. Driving them through any one of those would pin the caller
+ * rather than the answer, and the three would be free to drift apart again.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  requiredEventFieldsOwed,
+  verbRunsWithoutPayload,
+} from "../lib/callable.ts";
+
+describe("verb-required-fields-owed", () => {
+  it("owes nothing for a schema that is not a fields position", () => {
+    // Nothing to owe where nothing is named: an absent schema, an open one,
+    // and a verb whose event is a single value.
+    expect(requiredEventFieldsOwed(undefined)).toEqual(new Set());
+    expect(requiredEventFieldsOwed(true)).toEqual(new Set());
+    expect(requiredEventFieldsOwed({ type: "string" })).toEqual(new Set());
+  });
+
+  it("owes the fields a schema requires and no others", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: { note: { type: "string" }, tag: { type: "string" } },
+      required: ["note"],
+    };
+    expect(requiredEventFieldsOwed(schema)).toEqual(new Set(["note"]));
+
+    // A fields position requiring none owes none.
+    expect(
+      requiredEventFieldsOwed({
+        type: "object",
+        properties: { note: { type: "string" } },
+      }),
+    ).toEqual(new Set());
+  });
+
+  it("stops owing a required field once a default answers for it", () => {
+    // The runtime fills the default in, so demanding it from the caller would
+    // refuse a call that was always going to succeed.
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        mode: { type: "string", default: "fast" },
+        note: { type: "string" },
+      },
+      required: ["mode", "note"],
+    };
+    expect(requiredEventFieldsOwed(schema)).toEqual(new Set(["note"]));
+  });
+
+  it("reads what is owed through a top-level $ref", () => {
+    const schema = {
+      $ref: "#/$defs/RefreshEvent",
+      asCell: ["stream"],
+      $defs: {
+        RefreshEvent: {
+          type: "object",
+          properties: {
+            mode: { type: "string", default: "fast" },
+            note: { type: "string" },
+          },
+          required: ["mode", "note"],
+        },
+      },
+    } as unknown as JSONSchema;
+    expect(requiredEventFieldsOwed(schema)).toEqual(new Set(["note"]));
+  });
+
+  it("runs without a payload exactly when nothing is owed", () => {
+    const allDefaulted: JSONSchema = {
+      type: "object",
+      properties: { mode: { type: "string", default: "fast" } },
+      required: ["mode"],
+    };
+    expect(verbRunsWithoutPayload(allDefaulted)).toBe(true);
+
+    const owesOne: JSONSchema = {
+      type: "object",
+      properties: { note: { type: "string" } },
+      required: ["note"],
+    };
+    expect(verbRunsWithoutPayload(owesOne)).toBe(false);
+
+    // Not a fields position at all, which is a different answer from
+    // "a fields position owing nothing" — there is no payload to normalize.
+    expect(verbRunsWithoutPayload({ type: "string" })).toBe(false);
+    expect(verbRunsWithoutPayload(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
A stream's event schema is routinely written through an indirection:

```json
{ "$ref": "#/$defs/AddEvent", "asCell": ["stream"],
  "$defs": { "AddEvent": { "type": "object",
    "properties": { "query": { "type": "string" } }, "required": ["query"] } } }
```

Every field sits in the definition and none at the root. The `$ref` is only
*needed* for a recursive event type, but a pattern gets it either way — and a
verb should not lose its flags over how its schema happens to be spelled.

## ⚠️ Breaking: how arguments reach a `$ref`-shaped verb

Reading these verbs correctly changes how a caller passes their arguments. If
you have scripts, agent prompts, or docs that call verbs whose event schema goes
through a `$ref`, they need updating:

```bash
# before — the CLI derived no flags, so --value was the only spelling offered
cf call --piece $ID add -- --value 'Milk'

# now — the fields are visible, so they are named
cf call --piece $ID add -- --query 'Milk'
```

`--value` is now **refused** on these verbs, naming the fields that replace it.
Worth knowing: the old spelling never actually delivered a usable payload — it
handed the raw string through against an object schema, which failed validation
downstream — so what changes is where the call fails, not whether it worked.
`--json` was the only spelling that carried a payload through this shape before,
and it is unaffected.

Three further caller-visible shifts, all from the same cause:

- **A missing payload is refused earlier**, at the flag door rather than the
  payload gate, and the message changes from
  `Invalid input for "add": no payload was supplied…` to
  `Handler requires input. Expected type: { query: string }` — or, when a verb
  is named explicitly, `Missing required flag --query`. Nothing dispatches
  either way and the invocation id still survives a refusal.
- **A bare `$ref`-stream call now reads piped stdin**, taking the same
  implicit-pipe path as the identical verb written without the indirection.
  A script that pipes on stdin while calling such a verb bare will have that
  input consumed where it previously was not.
- **A required field carrying a `default` is no longer demanded.** The runtime
  fills it in, so `Missing required flag --mode` no longer fires for a field the
  pattern already answers for. This one is a relaxation, not a break.

## The disagreement being fixed

The payload doors have always resolved that `$ref` — both
`normalizeAbsentVerbPayload` and `eventSchemaJudgesRootFields` do. The flag
surfaces read the root unresolved. So the verb's fields were judged on arrival
while every caller-facing surface reported none:

- no `--query` flag; only `--value`, whose string cannot satisfy the object it
  names
- the help page rendered the event as `void`, with an empty Flags block
- `required` was not enforced, and a near miss had no vocabulary to search

`declaredEventFields` now resolves a top-level local `$ref` before reading the
position, and `isSchemaLessHandlerInput` stops calling a verb schema-less on the
strength of a root that only *looks* bare. Flags, required-ness, the input type,
and the refusal vocabulary all follow.

`--value` keeps its one meaning throughout: the whole payload of a verb whose
event is a single value, which is the only position where no field name exists
to use instead. That includes a `$ref` landing on a scalar — following the ref
must not take the stream marker out of the question.

## Resolution details

`resolveCfcSchemaRefs`, not `localRefTarget`. A `$ref` may carry siblings, and
the runtime flattens the ref site **over** its target keyword by keyword — so a
`properties` beside the ref replaces the target's rather than joining it. That is
the resolution the validator performs, and therefore the field list a payload is
judged against. Jumping to the target instead would name `--query` for
`{$ref → {query}, properties: {limit}}` — a flag the validator refuses — while
hiding `--limit`, which it accepts.

Where a ref dangles or cycles, resolution answers `undefined`, which fails toward
"not a fields position": the single-value vocabulary, exactly where such a schema
sat before.

Required-ness is read through `requiredEventFieldsOwed` at all three doors that
ask — the bare-invoke gate, per-flag presence, and the help page's labels — so
the page cannot advertise `--mode` as required while the parser accepts its
absence.

## Checks

`deno task check`, `cfcheck` (420 patterns), `deno fmt --check`, `deno lint`,
`check-no-waitfor`, `check-skill-facts`, `check-verb-session-sync`,
`check-docs-history-index` all pass. CLI package suite: 175 passed / 0 failed.
Merged with `main` at `ea2f97e63`; gates re-run after the merge.

The runner suite shows 146 failures both with and without this change (verified
against the base commit) — pre-existing and unrelated.

## Known residual, not fixed here

The single-value path still reads the root unresolved, so a `$ref` to a scalar
renders `--value <json>` rather than `<string>`, and `--value 7` against a
`$ref` → `number` yields the string `"7"`. Same family as the bug fixed on the
object path; left out to keep this change to the boundary it states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
