### PR TITLE
feat: a pattern's source declares the data files it reads

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -103,11 +103,16 @@ A pattern calling `dataFile()` needs its data files attached to the program the
 test compiles, or it fails at the read. It compiles and type-checks either way,
 so nothing earlier reports the omission.
 
-Attach them where the test builds its program: `--datafile` on `cf test`, the
-`dataFiles` field of a `generated-patterns` scenario, or `dataFilePaths` on the
-`resolveLocalProgram` call a browser integration test makes. A browser test
-needs nothing beyond that — the data reaches the browser through the space,
-inside the compiled pattern, not from the filesystem. Forgetting shows up as
+A file the pattern names in a `dataFile()` call is attached by whichever
+command builds the program, so a test that stores the file under the program
+root at the path the call names needs to say nothing further. A file the source
+cannot name — one read by a computed path — is added where the test builds its
+program: `--datafile` on `cf test`, the `dataFiles` field of a
+`generated-patterns` scenario, or `dataFilePaths` on the `resolveLocalProgram`
+call a browser integration test makes. A browser test needs nothing beyond that
+— the data reaches the browser through the space, inside the compiled pattern,
+not from the filesystem. A name with no file behind it fails the build, saying
+which module read it; an unattached file the source could not name shows up as
 `No attached data file "<path>"` when the pattern runs, and the message lists
 what is attached. That one function is the only sanctioned way to build a
 program from local files, and

--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -31,13 +31,20 @@ deno task cf piece link ... editor-id/items viewer-id/items
 - Write automated pattern tests for new or changed behavior, run every test
   entry with `cf test`, and repeat `--test` for every entry during deployment.
   Deployment packages and type-checks attached tests but does not run them.
-- Attach a file that is not code with repeatable `--datafile`. Its bytes are
-  stored verbatim — never parsed, compiled, or importable — and recovered by
-  `cf piece getsrc` with the rest of the package. The pattern reads one with
-  `dataFile(path)` from `commonfabric`, naming the path it is stored under.
-  `cf check` and `cf test` take `--datafile` as well, so the read works locally.
-  Repeat every flag on each `setsrc`; an update defines the complete source
-  revision.
+- A file that is not code travels with the source when the pattern reads it.
+  `dataFile(path)` from `commonfabric` names the path it is stored under, and
+  that call is the declaration: every command that builds the program from
+  local files — `setsrc`, `check`, `test`, `dev` — attaches what the source
+  names, the way it already follows what the source imports. The bytes are
+  stored verbatim, never parsed, compiled, or importable, and come back from
+  `cf piece getsrc` with the rest of the package. A file named this way must
+  be on disk under the program root, or the build refuses and says which
+  module asked for it.
+- `--datafile` attaches a file the source cannot name: one read by a computed
+  path, or one that ships with a program that does not read it. It is
+  repeatable, and it adds to what the source declares rather than replacing
+  it. Repeat every flag on each `setsrc`; an update defines the complete
+  source revision.
 - Deploy once, then use `setsrc` for updates
 - Repeat the complete set of `--test` flags on every `setsrc`. Each update
   defines a complete source revision, so omitted test roots are not retained.

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -229,10 +229,13 @@ run directory.
 ## Patterns that read data files
 
 A pattern calling `dataFile()` reads a file attached to the program under test.
-Every kind of test attaches them where it builds that program: `cf test` takes
-repeatable `--datafile` paths, a `generated-patterns` scenario names them in
-`dataFiles` grounded by `dataRoot`, and a browser integration test passes
-`dataFilePaths` to `resolveLocalProgram`.
+The call names the file, and that is the declaration every test path reads:
+`resolveLocalProgram` attaches what the source asks for, so a pattern under
+test behaves the way it does deployed without the test restating anything. A
+file the source cannot name — one read by a computed path — is added where the
+test builds the program: `cf test` takes repeatable `--datafile` paths, a
+`generated-patterns` scenario names them in `dataFiles` grounded by `dataRoot`,
+and a browser integration test passes `dataFilePaths` to `resolveLocalProgram`.
 
 A browser integration test needs nothing further: the data travels to the
 browser inside the compiled pattern the space holds, so there is no file to

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2369,6 +2369,11 @@ export interface BuiltInGenerateTextState {
 export interface BuiltInCompileAndRunParams<T> {
   files: Array<{ name: string; contents: string }>;
   main: string;
+  /**
+   * Names of entries in `files` that carry data rather than code. A pattern
+   * reads one with `dataFile()`; nothing compiles, imports, or transforms it.
+   */
+  dataFiles?: string[];
   input?: T;
 }
 

--- a/packages/cli/fixtures/reads-absent-data-file.tsx
+++ b/packages/cli/fixtures/reads-absent-data-file.tsx
@@ -1,0 +1,7 @@
+import { __cf_data, dataFile } from "commonfabric";
+
+/**
+ * Names a data file that is not stored under the program root, so building the
+ * program refuses rather than compiling something that fails at the read.
+ */
+export default __cf_data(dataFile("/data/absent.json"));

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1266,6 +1266,32 @@ run_piece_data_files() {
   assert_json_eq "$UPDATED" '["Oslo", "Lima", "Accra"]' \
     "Pattern should read the updated data file, got: $UPDATED"
 
+  # A data file the source does not read by name cannot be worked out from a
+  # recovered checkout: it is written to disk like any other file, with nothing
+  # recording that it was data. `getsrc` has to say so, or the next `setsrc`
+  # drops it from the revision without a word.
+  local extra_dir="$WORK_DIR/datafiles-extra"
+  mkdir -p "$extra_dir"
+  printf 'not read by the pattern\n' > "$SCRIPT_DIR/pattern/data/notes.txt"
+  EXTRA_PIECE_ID=$(cf piece new $SPACE_ARGS \
+    --root "$SCRIPT_DIR/pattern" \
+    --datafile "$SCRIPT_DIR/pattern/data/notes.txt" \
+    "$data_pattern")
+  cf piece getsrc $SPACE_ARGS --piece $EXTRA_PIECE_ID "$extra_dir" \
+    >"$WORK_DIR/getsrc-extra.out"
+  rm -f "$SCRIPT_DIR/pattern/data/notes.txt"
+  if [ ! -f "$extra_dir/data/notes.txt" ]; then
+    error "An unread data file should still come back with the source."
+  fi
+  # The pattern reads cities.json by name, so that one is re-derived and must
+  # not be listed; notes.txt is the one a later setsrc cannot recover.
+  if ! grep -q -- "--datafile ./data/notes.txt" "$WORK_DIR/getsrc-extra.out"; then
+    error "getsrc did not name the data file its source cannot re-derive."
+  fi
+  if grep -q -- "--datafile ./data/cities.json" "$WORK_DIR/getsrc-extra.out"; then
+    error "getsrc named a data file the recovered source reads by name."
+  fi
+
   echo "Successfully ran CLI data-file integration tests for ${API_URL}."
 }
 

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -157,7 +157,7 @@ export async function process(
     id,
     graph,
     mainSpecifier,
-    program.files,
+    program,
   );
   const patternJson = options.patternJson && main
     ? serializeMainExport(main, options.mainExport)

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1565,15 +1565,8 @@ export async function savePiecePattern(
     await Deno.mkdir(dirname(outFilePath), { recursive: true });
     await Deno.writeTextFile(outFilePath, contents);
   }
-  const undeclared = undeclaredDataFiles(program);
-  if (undeclared.length > 0) {
-    console.log(
-      `\nThis pattern carries ${undeclared.length} data file(s) its source ` +
-        `does not name.\nPass them on the next setsrc, or they are dropped ` +
-        `from that revision:\n` +
-        undeclared.map((name) => `  --datafile .${name}`).join("\n"),
-    );
-  }
+  const warning = undeclaredDataFileWarning(program);
+  if (warning !== undefined) console.log(warning);
 }
 
 /**
@@ -1591,6 +1584,23 @@ export function undeclaredDataFiles(program: RuntimeProgram): string[] {
     program.files.flatMap((file) => collectDataFileNames(file, TARGET)),
   );
   return (program.dataFiles ?? []).filter((name) => !declared.has(name));
+}
+
+/**
+ * What `getsrc` says about the data files it just wrote, or undefined when it
+ * has nothing to say. The flags are spelled out so that reproducing the
+ * revision is a matter of copying the line rather than working out which of
+ * the written files were data.
+ */
+export function undeclaredDataFileWarning(
+  program: RuntimeProgram,
+): string | undefined {
+  const undeclared = undeclaredDataFiles(program);
+  if (undeclared.length === 0) return undefined;
+  return `\nThis pattern carries ${undeclared.length} data file(s) its ` +
+    `source does not name.\nPass them on the next setsrc, or they are ` +
+    `dropped from that revision:\n` +
+    undeclared.map((name) => `  --datafile .${name}`).join("\n");
 }
 
 export async function applyPieceInput(config: PieceConfig, input: object) {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1540,15 +1540,10 @@ export async function checkPiecePattern(
 export async function savePiecePattern(
   config: PieceConfig,
   outPath: string,
-  deps: PieceOperationDependencies = {},
 ): Promise<void> {
   await ensureDir(outPath);
-  const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(
-    config,
-    pieces,
-    deps.resolvePieceAddress,
-  );
+  const pieces = await loadPieces(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,
@@ -1556,12 +1551,30 @@ export async function savePiecePattern(
     resolvedConfig.pieceScope,
   );
   const program = await piece.getPatternSourceProgram();
-
   if (!program) {
     throw new Error(
       `Piece "${resolvedConfig.piece}" does not contain a pattern source.`,
     );
   }
+  await writeSourcePackage(program, outPath);
+  const warning = undeclaredDataFileWarning(program);
+  if (warning !== undefined) console.log(warning);
+}
+
+/**
+ * Write a recovered source package under `outPath`, laid out by the names the
+ * package stores its files under.
+ *
+ * Those names are grounded — rooted at the program root rather than at any
+ * directory on this machine — so the layout a piece was built from is the
+ * layout it comes back to, and a `setsrc` from here resolves the same imports
+ * and the same data files. A name that is not grounded belongs to no layout
+ * and is refused rather than written somewhere arbitrary.
+ */
+export async function writeSourcePackage(
+  program: RuntimeProgram,
+  outPath: string,
+): Promise<void> {
   for (const { name, contents } of program.files) {
     if (name[0] !== "/") {
       throw new Error("Ungrounded file in pattern.");
@@ -1570,8 +1583,6 @@ export async function savePiecePattern(
     await Deno.mkdir(dirname(outFilePath), { recursive: true });
     await Deno.writeTextFile(outFilePath, contents);
   }
-  const warning = undeclaredDataFileWarning(program);
-  if (warning !== undefined) console.log(warning);
 }
 
 /**

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1540,10 +1540,15 @@ export async function checkPiecePattern(
 export async function savePiecePattern(
   config: PieceConfig,
   outPath: string,
+  deps: PieceOperationDependencies = {},
 ): Promise<void> {
   await ensureDir(outPath);
-  const pieces = await loadPieces(config);
-  const resolvedConfig = await resolvePieceConfigWithPieces(config, pieces);
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolvedConfig = await resolvePieceConfigWithPieces(
+    config,
+    pieces,
+    deps.resolvePieceAddress,
+  );
   const piece = await pieces.get(
     resolvedConfig.piece,
     false,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1565,33 +1565,32 @@ export async function savePiecePattern(
     await Deno.mkdir(dirname(outFilePath), { recursive: true });
     await Deno.writeTextFile(outFilePath, contents);
   }
-  reportUndeclaredDataFiles(program);
+  const undeclared = undeclaredDataFiles(program);
+  if (undeclared.length > 0) {
+    console.log(
+      `\nThis pattern carries ${undeclared.length} data file(s) its source ` +
+        `does not name.\nPass them on the next setsrc, or they are dropped ` +
+        `from that revision:\n` +
+        undeclared.map((name) => `  --datafile .${name}`).join("\n"),
+    );
+  }
 }
 
 /**
- * Report the data files a later `setsrc` would have to be told about.
+ * The data files a later `setsrc` would have to be told about.
  *
  * A file the recovered source reads by name is declared, so rebuilding the
  * package from this directory attaches it again on its own. A file the source
  * cannot name — one read by a computed path, or one that ships with a pattern
  * that does not read it — is on disk with nothing recording that it was data,
- * and would come back as an ordinary file nobody stores. Naming the flags here
- * is what keeps the round trip whole.
+ * and would come back as an ordinary file nobody stores. Naming those is what
+ * keeps the round trip whole.
  */
-function reportUndeclaredDataFiles(program: RuntimeProgram): void {
+export function undeclaredDataFiles(program: RuntimeProgram): string[] {
   const declared = new Set(
     program.files.flatMap((file) => collectDataFileNames(file, TARGET)),
   );
-  const undeclared = (program.dataFiles ?? []).filter((name) =>
-    !declared.has(name)
-  );
-  if (undeclared.length === 0) return;
-  console.log(
-    `\nThis pattern carries ${undeclared.length} data file(s) its source ` +
-      `does not name.\nPass them on the next setsrc, or they are dropped ` +
-      `from that revision:\n` +
-      undeclared.map((name) => `  --datafile .${name}`).join("\n"),
-  );
+  return (program.dataFiles ?? []).filter((name) => !declared.has(name));
 }
 
 export async function applyPieceInput(config: PieceConfig, input: object) {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -9,6 +9,8 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { createSession, isDID, Session } from "@commonfabric/identity";
+import { collectDataFileNames } from "@commonfabric/js-compiler";
+import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import { setLLMUrl } from "@commonfabric/llm";
 import {
@@ -1548,22 +1550,48 @@ export async function savePiecePattern(
     undefined,
     resolvedConfig.pieceScope,
   );
-  const files = await piece.getPatternSourceFiles();
+  const program = await piece.getPatternSourceProgram();
 
-  if (files) {
-    for (const { name, contents } of files) {
-      if (name[0] !== "/") {
-        throw new Error("Ungrounded file in pattern.");
-      }
-      const outFilePath = join(outPath, name.substring(1));
-      await Deno.mkdir(dirname(outFilePath), { recursive: true });
-      await Deno.writeTextFile(outFilePath, contents);
-    }
-  } else {
+  if (!program) {
     throw new Error(
       `Piece "${resolvedConfig.piece}" does not contain a pattern source.`,
     );
   }
+  for (const { name, contents } of program.files) {
+    if (name[0] !== "/") {
+      throw new Error("Ungrounded file in pattern.");
+    }
+    const outFilePath = join(outPath, name.substring(1));
+    await Deno.mkdir(dirname(outFilePath), { recursive: true });
+    await Deno.writeTextFile(outFilePath, contents);
+  }
+  reportUndeclaredDataFiles(program);
+}
+
+/**
+ * Report the data files a later `setsrc` would have to be told about.
+ *
+ * A file the recovered source reads by name is declared, so rebuilding the
+ * package from this directory attaches it again on its own. A file the source
+ * cannot name — one read by a computed path, or one that ships with a pattern
+ * that does not read it — is on disk with nothing recording that it was data,
+ * and would come back as an ordinary file nobody stores. Naming the flags here
+ * is what keeps the round trip whole.
+ */
+function reportUndeclaredDataFiles(program: RuntimeProgram): void {
+  const declared = new Set(
+    program.files.flatMap((file) => collectDataFileNames(file, TARGET)),
+  );
+  const undeclared = (program.dataFiles ?? []).filter((name) =>
+    !declared.has(name)
+  );
+  if (undeclared.length === 0) return;
+  console.log(
+    `\nThis pattern carries ${undeclared.length} data file(s) its source ` +
+      `does not name.\nPass them on the next setsrc, or they are dropped ` +
+      `from that revision:\n` +
+      undeclared.map((name) => `  --datafile .${name}`).join("\n"),
+  );
 }
 
 export async function applyPieceInput(config: PieceConfig, input: object) {

--- a/packages/cli/test/dev.test.ts
+++ b/packages/cli/test/dev.test.ts
@@ -138,16 +138,26 @@ describe("cli check", () => {
     expect(code).toBe(0);
   });
 
-  it("names --datafile when a pattern reads a file that is not attached", async () => {
+  it("evaluates a pattern that reads a data file it names itself", async () => {
+    const { code, stdout, stderr } = await cf(
+      "check --root fixtures fixtures/reads-data-file.tsx --pattern-json",
+    );
+    checkStderr(stderr);
+    // No `--datafile`: the `dataFile()` call is the declaration, so the same
+    // bytes reach the pattern as when the flag names them.
+    expect(JSON.parse(stdout.join("\n"))).toEqual(["Oslo", "Lima"]);
+    expect(code).toBe(0);
+  });
+
+  it("refuses a data file the pattern names with nothing behind it", async () => {
     const { code, stderr } = await cf(
-      "check --root fixtures fixtures/reads-data-file.tsx",
+      "check --root fixtures fixtures/reads-absent-data-file.tsx",
     );
-    // The refusal has to name the flag that fixes it, since the pattern
-    // compiles and type-checks either way.
-    expect(stripAnsi(stderr.join("\n"))).toContain(
-      'No attached data file "/data/cities.json"',
-    );
-    expect(stripAnsi(stderr.join("\n"))).toContain("--datafile");
+    // The program cannot be assembled as its source describes it, so this
+    // fails at the build, naming the module that asked and the path it wanted.
+    const text = stripAnsi(stderr.join("\n"));
+    expect(text).toContain("/reads-absent-data-file.tsx");
+    expect(text).toContain('"/data/absent.json"');
     expect(code).not.toBe(0);
   });
 

--- a/packages/cli/test/fixtures/data-files-missing/missing.test.tsx
+++ b/packages/cli/test/fixtures/data-files-missing/missing.test.tsx
@@ -1,0 +1,10 @@
+/// <cts-enable />
+// FIXTURE: names a data file that is not stored beside it, so building the
+// program refuses rather than leaving the read to fail.
+import { assert, dataFile, pattern, TESTS } from "commonfabric";
+
+export default pattern(() => {
+  const contents = dataFile("/data/absent.json");
+  const assert_never_runs = assert(() => contents.length > 0);
+  return { [TESTS]: [{ assertion: assert_never_runs }] };
+});

--- a/packages/cli/test/test-runner-data-files.test.ts
+++ b/packages/cli/test/test-runner-data-files.test.ts
@@ -1,10 +1,11 @@
 /**
- * Contract tests for `cf test --datafile`.
+ * Contract tests for the data files `cf test` attaches.
  *
  * A pattern that reads a data file compiles and type-checks whether or not one
- * is attached — `dataFile` is declared either way — so the absence only shows
- * when the pattern runs. These pin that the attachment reaches the runtime that
- * runs the pattern, in both shapes `cf test` supports.
+ * is attached — `dataFile` is declared either way — so a missing attachment
+ * would otherwise only show when the pattern runs. These pin that the file
+ * reaches the runtime that runs the pattern, in both shapes `cf test`
+ * supports, whether the run names it or the source does.
  */
 
 import { describe, it } from "@std/testing/bdd";
@@ -19,7 +20,7 @@ function fixture(name: string): string {
   return join(FIXTURES, name);
 }
 
-describe("cf test --datafile", () => {
+describe("cf test data files", () => {
   it("runs a pattern that reads an attached data file", async () => {
     const result = await runTests(fixture("single.test.tsx"), {
       root: FIXTURES,
@@ -41,10 +42,19 @@ describe("cf test --datafile", () => {
     expect(result.passed).toBe(2);
   });
 
-  it("fails naming the flag when the file is not attached", async () => {
+  it("attaches what the pattern reads without being given the path", async () => {
+    // The source names `/data/cities.json`, which is the same declaration an
+    // import makes: the run does not repeat it.
     const result = await runTests(fixture("single.test.tsx"), {
       root: FIXTURES,
     });
+    expect(result.failed).toBe(0);
+    expect(result.passed).toBeGreaterThan(0);
+  });
+
+  it("refuses a name the pattern reads with no file behind it", async () => {
+    const root = resolve(import.meta.dirname!, "fixtures/data-files-missing");
+    const result = await runTests(join(root, "missing.test.tsx"), { root });
     expect(result.failed).toBeGreaterThan(0);
   });
 });

--- a/packages/cli/test/undeclared-data-files.test.ts
+++ b/packages/cli/test/undeclared-data-files.test.ts
@@ -8,7 +8,10 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { RuntimeProgram } from "@commonfabric/runner";
-import { undeclaredDataFiles } from "../lib/piece.ts";
+import {
+  undeclaredDataFiles,
+  undeclaredDataFileWarning,
+} from "../lib/piece.ts";
 
 const READS_CITIES = 'import { dataFile } from "commonfabric";\n' +
   'export default () => dataFile("/data/cities.json");\n';
@@ -75,5 +78,41 @@ describe("undeclaredDataFiles", () => {
         }, ["/data/cities.json"]),
       ),
     ).toEqual([]);
+  });
+});
+
+describe("undeclaredDataFileWarning", () => {
+  it("says nothing when the source accounts for every data file", () => {
+    expect(
+      undeclaredDataFileWarning(
+        program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
+          "/data/cities.json",
+        ]),
+      ),
+    ).toBe(undefined);
+  });
+
+  it("spells out the flag that puts a file back on the next revision", () => {
+    const warning = undeclaredDataFileWarning(
+      program({ "/main.tsx": "export default 1;\n", "/extra.txt": "hi" }, [
+        "/extra.txt",
+      ]),
+    );
+    expect(warning).toContain("1 data file(s)");
+    expect(warning).toContain("--datafile ./extra.txt");
+    expect(warning).toContain("setsrc");
+  });
+
+  it("names every file it cannot account for", () => {
+    const warning = undeclaredDataFileWarning(
+      program({
+        "/main.tsx": "export default 1;\n",
+        "/a.txt": "a",
+        "/b.txt": "b",
+      }, ["/a.txt", "/b.txt"]),
+    );
+    expect(warning).toContain("2 data file(s)");
+    expect(warning).toContain("--datafile ./a.txt");
+    expect(warning).toContain("--datafile ./b.txt");
   });
 });

--- a/packages/cli/test/undeclared-data-files.test.ts
+++ b/packages/cli/test/undeclared-data-files.test.ts
@@ -10,9 +10,9 @@ import { expect } from "@std/expect";
 import type { RuntimeProgram } from "@commonfabric/runner";
 import { join } from "@std/path";
 import {
-  savePiecePattern,
   undeclaredDataFiles,
   undeclaredDataFileWarning,
+  writeSourcePackage,
 } from "../lib/piece.ts";
 
 const READS_CITIES = 'import { dataFile } from "commonfabric";\n' +
@@ -119,105 +119,71 @@ describe("undeclaredDataFileWarning", () => {
   });
 });
 
-describe("savePiecePattern", () => {
-  const CONFIG = {
-    apiUrl: "https://cf.dev",
-    space: "common-knowledge",
-    identity: "~/.my.key",
-    piece: "p",
-  };
-
-  // The command reads one thing from the piece — its source program — and
-  // writes what it finds. Everything else about a piece is beside the point.
-  const piecesOver = (program: RuntimeProgram | undefined) => () =>
-    Promise.resolve({
-      get: () =>
-        Promise.resolve({
-          getPatternSourceProgram: () => Promise.resolve(program),
-        }),
-      // deno-lint-ignore no-explicit-any
-    } as any);
-
-  // Runs `body` with console.log captured, returning what it received.
-  async function captureLog(body: () => Promise<void>): Promise<string> {
-    const lines: string[] = [];
-    const original = console.log;
-    console.log = (...args: unknown[]) =>
-      lines.push(args.map(String).join(" "));
+describe("writeSourcePackage", () => {
+  // Writes `program` into a fresh temp tree, runs `body` against that tree,
+  // and removes it.
+  async function written(
+    program: RuntimeProgram,
+    body: (out: string) => Promise<void>,
+  ): Promise<void> {
+    const out = await Deno.makeTempDir({ prefix: "source-package-" });
     try {
-      await body();
+      await writeSourcePackage(program, out);
+      await body(out);
     } finally {
-      console.log = original;
+      await Deno.remove(out, { recursive: true });
     }
-    return lines.join("\n");
   }
 
-  it("writes every file the package holds, data included", async () => {
-    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
-    try {
-      await savePiecePattern(CONFIG, out, {
-        loadPieces: piecesOver(
-          program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
-            "/data/cities.json",
-          ]),
-        ),
-        resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-      });
-      expect(await Deno.readTextFile(join(out, "main.tsx"))).toBe(READS_CITIES);
-      expect(await Deno.readTextFile(join(out, "data/cities.json"))).toBe("[]");
-    } finally {
-      await Deno.remove(out, { recursive: true });
-    }
+  it("lays a file out under the name the package stores it by", async () => {
+    await written(
+      program({ "/main.tsx": READS_CITIES }),
+      async (out) => {
+        expect(await Deno.readTextFile(join(out, "main.tsx"))).toBe(
+          READS_CITIES,
+        );
+      },
+    );
   });
 
-  it("stays quiet when the source accounts for every data file", async () => {
-    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
-    try {
-      const logged = await captureLog(async () => {
-        await savePiecePattern(CONFIG, out, {
-          loadPieces: piecesOver(
-            program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
-              "/data/cities.json",
-            ]),
-          ),
-          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-        });
-      });
-      expect(logged).toBe("");
-    } finally {
-      await Deno.remove(out, { recursive: true });
-    }
+  it("writes a data file beside the code, in its own directory", async () => {
+    await written(
+      program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
+        "/data/cities.json",
+      ]),
+      async (out) => {
+        // The nested directory is what makes a `setsrc` from here resolve the
+        // same `/data/cities.json` the piece was built with.
+        expect(await Deno.readTextFile(join(out, "data/cities.json"))).toBe(
+          "[]",
+        );
+      },
+    );
   });
 
-  it("names a data file the written source cannot re-derive", async () => {
-    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
-    try {
-      const logged = await captureLog(async () => {
-        await savePiecePattern(CONFIG, out, {
-          loadPieces: piecesOver(
-            program({
-              "/main.tsx": "export default 1;\n",
-              "/extra.txt": "hi",
-            }, ["/extra.txt"]),
-          ),
-          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-        });
-      });
-      expect(logged).toContain("--datafile ./extra.txt");
-    } finally {
-      await Deno.remove(out, { recursive: true });
-    }
+  it("writes a file's bytes unchanged", async () => {
+    const authored = '{ "cities":  ["Oslo"] }\n';
+    await written(
+      program({ "/main.tsx": READS_CITIES, "/data/cities.json": authored }),
+      async (out) => {
+        // Spacing a formatter would not produce, so a re-serialization
+        // anywhere on the way out shows up here.
+        expect(await Deno.readTextFile(join(out, "data/cities.json"))).toBe(
+          authored,
+        );
+      },
+    );
   });
 
-  it("refuses a piece that holds no pattern source", async () => {
-    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
+  it("refuses a name that belongs to no layout", async () => {
+    const out = await Deno.makeTempDir({ prefix: "source-package-" });
     try {
       await expect(
-        savePiecePattern(CONFIG, out, {
-          loadPieces: piecesOver(undefined),
-          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
-        }),
-      ).rejects.toThrow("does not contain a pattern source");
+        writeSourcePackage(
+          program({ "main.tsx": "export default 1;\n" }),
+          out,
+        ),
+      ).rejects.toThrow("Ungrounded file in pattern");
     } finally {
       await Deno.remove(out, { recursive: true });
     }

--- a/packages/cli/test/undeclared-data-files.test.ts
+++ b/packages/cli/test/undeclared-data-files.test.ts
@@ -8,7 +8,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { RuntimeProgram } from "@commonfabric/runner";
+import { join } from "@std/path";
 import {
+  savePiecePattern,
   undeclaredDataFiles,
   undeclaredDataFileWarning,
 } from "../lib/piece.ts";
@@ -114,5 +116,110 @@ describe("undeclaredDataFileWarning", () => {
     expect(warning).toContain("2 data file(s)");
     expect(warning).toContain("--datafile ./a.txt");
     expect(warning).toContain("--datafile ./b.txt");
+  });
+});
+
+describe("savePiecePattern", () => {
+  const CONFIG = {
+    apiUrl: "https://cf.dev",
+    space: "common-knowledge",
+    identity: "~/.my.key",
+    piece: "p",
+  };
+
+  // The command reads one thing from the piece — its source program — and
+  // writes what it finds. Everything else about a piece is beside the point.
+  const piecesOver = (program: RuntimeProgram | undefined) => () =>
+    Promise.resolve({
+      get: () =>
+        Promise.resolve({
+          getPatternSourceProgram: () => Promise.resolve(program),
+        }),
+      // deno-lint-ignore no-explicit-any
+    } as any);
+
+  // Runs `body` with console.log captured, returning what it received.
+  async function captureLog(body: () => Promise<void>): Promise<string> {
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) =>
+      lines.push(args.map(String).join(" "));
+    try {
+      await body();
+    } finally {
+      console.log = original;
+    }
+    return lines.join("\n");
+  }
+
+  it("writes every file the package holds, data included", async () => {
+    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
+    try {
+      await savePiecePattern(CONFIG, out, {
+        loadPieces: piecesOver(
+          program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
+            "/data/cities.json",
+          ]),
+        ),
+        resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+      });
+      expect(await Deno.readTextFile(join(out, "main.tsx"))).toBe(READS_CITIES);
+      expect(await Deno.readTextFile(join(out, "data/cities.json"))).toBe("[]");
+    } finally {
+      await Deno.remove(out, { recursive: true });
+    }
+  });
+
+  it("stays quiet when the source accounts for every data file", async () => {
+    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
+    try {
+      const logged = await captureLog(async () => {
+        await savePiecePattern(CONFIG, out, {
+          loadPieces: piecesOver(
+            program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
+              "/data/cities.json",
+            ]),
+          ),
+          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+        });
+      });
+      expect(logged).toBe("");
+    } finally {
+      await Deno.remove(out, { recursive: true });
+    }
+  });
+
+  it("names a data file the written source cannot re-derive", async () => {
+    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
+    try {
+      const logged = await captureLog(async () => {
+        await savePiecePattern(CONFIG, out, {
+          loadPieces: piecesOver(
+            program({
+              "/main.tsx": "export default 1;\n",
+              "/extra.txt": "hi",
+            }, ["/extra.txt"]),
+          ),
+          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+        });
+      });
+      expect(logged).toContain("--datafile ./extra.txt");
+    } finally {
+      await Deno.remove(out, { recursive: true });
+    }
+  });
+
+  it("refuses a piece that holds no pattern source", async () => {
+    const out = await Deno.makeTempDir({ prefix: "getsrc-" });
+    try {
+      await expect(
+        savePiecePattern(CONFIG, out, {
+          loadPieces: piecesOver(undefined),
+          resolvePieceAddress: (_pieces, id) => Promise.resolve(id),
+        }),
+      ).rejects.toThrow("does not contain a pattern source");
+    } finally {
+      await Deno.remove(out, { recursive: true });
+    }
   });
 });

--- a/packages/cli/test/undeclared-data-files.test.ts
+++ b/packages/cli/test/undeclared-data-files.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `cf piece getsrc` writes a recovered source package to disk, and the files
+ * it writes carry no record of which were data. A later `setsrc` re-derives
+ * that from the source, so what it cannot re-derive is what getsrc has to say
+ * out loud.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { RuntimeProgram } from "@commonfabric/runner";
+import { undeclaredDataFiles } from "../lib/piece.ts";
+
+const READS_CITIES = 'import { dataFile } from "commonfabric";\n' +
+  'export default () => dataFile("/data/cities.json");\n';
+
+function program(
+  files: Record<string, string>,
+  dataFiles?: string[],
+): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: Object.entries(files).map(([name, contents]) => ({
+      name,
+      contents,
+    })),
+    ...(dataFiles === undefined ? {} : { dataFiles }),
+  };
+}
+
+describe("undeclaredDataFiles", () => {
+  it("says nothing about a file the source reads by name", () => {
+    expect(
+      undeclaredDataFiles(
+        program({ "/main.tsx": READS_CITIES, "/data/cities.json": "[]" }, [
+          "/data/cities.json",
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("names a file the source never reads", () => {
+    expect(
+      undeclaredDataFiles(
+        program({ "/main.tsx": "export default 1;\n", "/extra.txt": "hi" }, [
+          "/extra.txt",
+        ]),
+      ),
+    ).toEqual(["/extra.txt"]);
+  });
+
+  it("names only the file the source cannot account for", () => {
+    expect(
+      undeclaredDataFiles(
+        program({
+          "/main.tsx": READS_CITIES,
+          "/data/cities.json": "[]",
+          "/extra.txt": "hi",
+        }, ["/data/cities.json", "/extra.txt"]),
+      ),
+    ).toEqual(["/extra.txt"]);
+  });
+
+  it("says nothing about a program carrying no data at all", () => {
+    expect(undeclaredDataFiles(program({ "/main.tsx": "export default 1;\n" })))
+      .toEqual([]);
+  });
+
+  it("reads a declaration from any module of the program", () => {
+    expect(
+      undeclaredDataFiles(
+        program({
+          "/main.tsx": 'export { default } from "./reader.ts";\n',
+          "/reader.ts": READS_CITIES,
+          "/data/cities.json": "[]",
+        }, ["/data/cities.json"]),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -3931,7 +3931,8 @@ Deno.test("CellBridge reports pattern metadata subscription failures", async () 
     getCell: () => immediateRootCell,
     getPatternRef: () => Promise.resolve(undefined),
     getPatternMeta: () => Promise.resolve({}),
-    getPatternSourceFiles: () => Promise.resolve([]),
+    getPatternSourceProgram: () =>
+      Promise.resolve({ main: "/main.tsx", files: [] }),
     input: {
       getCell: () => Promise.resolve(makeCell({}, undefined)),
       get: () => Promise.resolve({}),
@@ -3972,7 +3973,8 @@ Deno.test("CellBridge reports pattern metadata setup failures", async () => {
     },
     getPatternRef: () => Promise.resolve(undefined),
     getPatternMeta: () => Promise.resolve({}),
-    getPatternSourceFiles: () => Promise.resolve([]),
+    getPatternSourceProgram: () =>
+      Promise.resolve({ main: "/main.tsx", files: [] }),
     input: {
       getCell: () => Promise.resolve(makeCell({}, undefined)),
       get: () => Promise.resolve({}),
@@ -4122,10 +4124,13 @@ Deno.test("CellBridge.buildSourceTree encodes source path segments and decodes w
   const pieceIno = tree.addDir(state.piecesIno, "notes");
   const piece = {
     id: "of:source-piece",
-    getPatternSourceFiles: () =>
-      Promise.resolve([
-        { name: "/src/has:colon.tsx", contents: "export default 1;" },
-      ]),
+    getPatternSourceProgram: () =>
+      Promise.resolve({
+        main: "/src/has:colon.tsx",
+        files: [
+          { name: "/src/has:colon.tsx", contents: "export default 1;" },
+        ],
+      }),
   };
   state.pieceControllers.set("notes", piece as never);
   state.srcInos.set("notes", pieceIno);
@@ -4206,10 +4211,13 @@ Deno.test("CellBridge decodes encoded space directory names for source write pat
         source: { ref: `cf:pattern:${"C".repeat(43)}` },
       });
     },
-    getPatternSourceFiles: () =>
-      Promise.resolve([
-        { name: "/src/main.ts", contents: "export default 1;" },
-      ]),
+    getPatternSourceProgram: () =>
+      Promise.resolve({
+        main: "/src/main.ts",
+        files: [
+          { name: "/src/main.ts", contents: "export default 1;" },
+        ],
+      }),
   };
   state.pieceControllers.set("notes", piece as never);
   state.pieceInos.set("notes", pieceIno);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -4262,7 +4262,7 @@ export class CellBridge {
   ): Promise<void> {
     let sourceFiles: { name: string; contents: string }[] | undefined;
     try {
-      sourceFiles = await piece.getPatternSourceFiles();
+      sourceFiles = (await piece.getPatternSourceProgram())?.files;
     } catch {
       // Pattern source not always available
     }

--- a/packages/js-compiler/interface.ts
+++ b/packages/js-compiler/interface.ts
@@ -10,12 +10,30 @@ export type Source = {
 export type ProgramResolver = {
   main(): Promise<Source>;
   resolveSource(identifier: string): Promise<Source | undefined>;
+  /**
+   * Reads a data file the program's source declares, by the root-relative name
+   * a `dataFile()` call gives it. Undefined when this resolver holds no such
+   * file.
+   *
+   * A resolver that does not implement it has its data files read through
+   * `resolveSource`, which is right wherever source and data come from the
+   * same place. A resolver reads them itself when the transport calls for it:
+   * the file system reads a data file strictly as UTF-8 and keeps a byte order
+   * mark that module reading would consume.
+   */
+  resolveDataFile?(name: string): Promise<Source | undefined>;
 };
 
 // An entry point and its sources for a program.
 export type Program = {
   main: string;
   files: Source[];
+  /**
+   * Names of entries in `files` that carry data rather than code. A data file
+   * travels with the source package and is never transformed, compiled, or
+   * executed; a pattern reads one by name with `dataFile()`.
+   */
+  dataFiles?: string[];
 };
 
 // A ready-to-execute string of JavaScript,

--- a/packages/js-compiler/mod.ts
+++ b/packages/js-compiler/mod.ts
@@ -19,6 +19,7 @@ export {
   type TypeScriptCompilerOptions,
 } from "./typescript/mod.ts";
 export {
+  collectDataFileNames,
   collectImportSpecifiers,
   resolveImportSpecifier,
 } from "./typescript/resolver.ts";

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -146,49 +146,45 @@ export class FileSystemProgramResolver implements ProgramResolver {
   }
 
   resolveSource(specifier: string): Promise<Source | undefined> {
-    if (!specifier || specifier[0] !== "/") {
-      return Promise.resolve(undefined);
-    }
-    const absPath = normalize(
-      join(
-        this.fsRoot,
-        specifier.substring(1, specifier.length).replaceAll("/", SEPARATOR),
-      ),
-    );
-    if (isOutsideRoot(relative(this.fsRoot, absPath))) {
-      throw new Error(
-        `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
-      );
-    }
-    const realPath = this.#realPath(absPath);
-    if (isOutsideRoot(relative(this.realFsRoot, realPath))) {
-      throw new Error(
-        `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
-      );
-    }
+    const realPath = this.#groundedRealPath(specifier, "Import");
+    if (realPath === undefined) return Promise.resolve(undefined);
     return Promise.resolve({
       name: specifier,
       contents: this.#readFile(realPath),
     });
   }
 
-  resolveDataFile(name: string): Promise<Source | undefined> {
+  // Async so that a refusal — an escaping name, bytes that are not text —
+  // arrives as a rejection. A method that returns a promise and also throws
+  // where it is called cannot be handled one way.
+  async resolveDataFile(name: string): Promise<Source | undefined> {
     requireDeno("FileSystemProgramResolver");
-    const path = this.#groundedPath(name);
-    if (path === undefined) return Promise.resolve(undefined);
-    let bytes: Uint8Array;
+    let realPath: string | undefined;
     try {
-      bytes = Deno.readFileSync(path);
+      realPath = this.#groundedRealPath(name, "Data file");
     } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        return Promise.resolve(undefined);
-      }
+      // A name with nothing behind it is the caller's to report, against the
+      // module that read it. An escape is refused here, as it is for a module.
+      if (error instanceof Deno.errors.NotFound) return undefined;
       throw error;
     }
-    return Promise.resolve({ name, contents: decodeDataFile(bytes, name) });
+    if (realPath === undefined) return undefined;
+    return {
+      name,
+      contents: decodeDataFile(await Deno.readFile(realPath), name),
+    };
   }
 
-  #groundedPath(specifier: string): string | undefined {
+  /**
+   * The real path a grounded specifier names, or undefined when the specifier
+   * is not grounded against the root at all.
+   *
+   * A path that leaves the root is refused twice over: once as written, and
+   * again after symbolic links are followed, so a link inside the root cannot
+   * name a file outside it. `kind` names the thing being resolved in that
+   * refusal, since a module and a data file both arrive here.
+   */
+  #groundedRealPath(specifier: string, kind: string): string | undefined {
     if (!specifier || specifier[0] !== "/") return undefined;
     const absPath = normalize(
       join(
@@ -198,10 +194,16 @@ export class FileSystemProgramResolver implements ProgramResolver {
     );
     if (isOutsideRoot(relative(this.fsRoot, absPath))) {
       throw new Error(
-        `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+        `${kind} "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
       );
     }
-    return absPath;
+    const realPath = this.#realPath(absPath);
+    if (isOutsideRoot(relative(this.realFsRoot, realPath))) {
+      throw new Error(
+        `${kind} "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+      );
+    }
+    return realPath;
   }
 
   #realPath(path: string): string {

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -88,20 +88,29 @@ export function readDataFileSource(
       `Data file "${dataPath}" must be within root directory "${fsRoot}".`,
     );
   }
-  const bytes = Deno.readFileSync(realDataPath);
-  let contents: string;
+  return {
+    name: groundedSourceName(relativeDataPath),
+    contents: decodeDataFile(Deno.readFileSync(realDataPath), dataPath),
+  };
+}
+
+/**
+ * Decode a data file's bytes as the text a source package stores.
+ *
+ * A source package holds text, so the bytes are decoded as UTF-8 strictly: a
+ * file that is not valid UTF-8 is reported by `name` rather than stored with
+ * replacement characters in place of the bytes that were read. `ignoreBOM`
+ * keeps a leading byte order mark in the result instead of consuming it, since
+ * a data file is stored byte for byte and dropping the mark would deploy
+ * something other than the authored file.
+ */
+export function decodeDataFile(bytes: Uint8Array, name: string): string {
   try {
-    // `ignoreBOM` keeps a leading byte order mark in `contents` instead of
-    // consuming it. A data file is stored byte-for-byte, so dropping the mark
-    // would deploy something other than the authored file.
-    contents = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
       .decode(bytes);
   } catch {
-    throw new Error(
-      `Data file "${dataPath}" is not valid UTF-8 text.`,
-    );
+    throw new Error(`Data file "${name}" is not valid UTF-8 text.`);
   }
-  return { name: groundedSourceName(relativeDataPath), contents };
 }
 
 // Resolve a program using the file system.
@@ -163,6 +172,38 @@ export class FileSystemProgramResolver implements ProgramResolver {
     });
   }
 
+  resolveDataFile(name: string): Promise<Source | undefined> {
+    requireDeno("FileSystemProgramResolver");
+    const path = this.#groundedPath(name);
+    if (path === undefined) return Promise.resolve(undefined);
+    let bytes: Uint8Array;
+    try {
+      bytes = Deno.readFileSync(path);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        return Promise.resolve(undefined);
+      }
+      throw error;
+    }
+    return Promise.resolve({ name, contents: decodeDataFile(bytes, name) });
+  }
+
+  #groundedPath(specifier: string): string | undefined {
+    if (!specifier || specifier[0] !== "/") return undefined;
+    const absPath = normalize(
+      join(
+        this.fsRoot,
+        specifier.substring(1, specifier.length).replaceAll("/", SEPARATOR),
+      ),
+    );
+    if (isOutsideRoot(relative(this.fsRoot, absPath))) {
+      throw new Error(
+        `Import "${specifier}" resolves outside of root directory "${this.fsRoot}".`,
+      );
+    }
+    return absPath;
+  }
+
   #realPath(path: string): string {
     requireDeno("FileSystemProgramResolver");
     return Deno.realPathSync(path);
@@ -206,6 +247,18 @@ export class HttpProgramResolver implements ProgramResolver {
     const url = new URL(this.#mainUrl);
     url.pathname = normalize(specifier);
     return this.#fetch(url);
+  }
+
+  async resolveDataFile(name: string): Promise<Source | undefined> {
+    if (!name || name[0] !== "/") return undefined;
+    const url = new URL(this.#mainUrl);
+    url.pathname = normalize(name);
+    const res = await this.#fetchImpl(url);
+    if (!res.ok) return undefined;
+    return {
+      name,
+      contents: decodeDataFile(new Uint8Array(await res.arrayBuffer()), name),
+    };
   }
 
   async #fetch(url: URL): Promise<Source> {

--- a/packages/js-compiler/program.ts
+++ b/packages/js-compiler/program.ts
@@ -256,7 +256,16 @@ export class HttpProgramResolver implements ProgramResolver {
     const url = new URL(this.#mainUrl);
     url.pathname = normalize(name);
     const res = await this.#fetchImpl(url);
-    if (!res.ok) return undefined;
+    // Absent is the caller's to report, against the module that read the name.
+    // Anything else — unauthorized, forbidden, a server fault — is not absence,
+    // and saying the file is missing would send the reader after the wrong
+    // thing.
+    if (res.status === 404) return undefined;
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch data file ${url}: ${res.status} ${res.statusText}`,
+      );
+    }
     return {
       name,
       contents: decodeDataFile(new Uint8Array(await res.arrayBuffer()), name),

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -271,3 +271,167 @@ describe("HttpProgramResolver", () => {
     });
   });
 });
+
+describe("FileSystemProgramResolver.resolveDataFile", () => {
+  // Writes the named files into a fresh temp tree and returns its root. The
+  // caller removes the tree.
+  async function tree(files: Record<string, string>): Promise<string> {
+    const root = await Deno.makeTempDir({ prefix: "resolve-data-file-" });
+    for (const [name, contents] of Object.entries(files)) {
+      const full = path.join(root, name);
+      await Deno.mkdir(path.join(full, ".."), { recursive: true });
+      await Deno.writeTextFile(full, contents);
+    }
+    return root;
+  }
+
+  it("reads the file the name grounds to", async () => {
+    const root = await tree({
+      "main.tsx": "export default 1;\n",
+      "data/cities.json": '["Oslo"]\n',
+    });
+    try {
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "main.tsx"),
+        root,
+      );
+      const source = await resolver.resolveDataFile("/data/cities.json");
+      expect(source).toEqual({
+        name: "/data/cities.json",
+        contents: '["Oslo"]\n',
+      });
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("keeps a byte order mark that reading a module would consume", async () => {
+    const root = await tree({ "main.tsx": "export default 1;\n" });
+    try {
+      await Deno.writeFile(
+        path.join(root, "marked.txt"),
+        new Uint8Array([0xef, 0xbb, 0xbf, 0x68, 0x69]),
+      );
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "main.tsx"),
+        root,
+      );
+      const source = await resolver.resolveDataFile("/marked.txt");
+      expect(source?.contents).toBe("\uFEFFhi");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses bytes that are not UTF-8 rather than storing replacements", async () => {
+    const root = await tree({ "main.tsx": "export default 1;\n" });
+    try {
+      await Deno.writeFile(
+        path.join(root, "bad.bin"),
+        new Uint8Array([0xff, 0xfe, 0x00]),
+      );
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "main.tsx"),
+        root,
+      );
+      await expect(resolver.resolveDataFile("/bad.bin")).rejects.toThrow(
+        "is not valid UTF-8 text",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("returns undefined for a name with no file behind it", async () => {
+    const root = await tree({ "main.tsx": "export default 1;\n" });
+    try {
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "main.tsx"),
+        root,
+      );
+      expect(await resolver.resolveDataFile("/data/absent.json")).toBe(
+        undefined,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("returns undefined for a name that is not grounded", async () => {
+    const root = await tree({ "main.tsx": "export default 1;\n" });
+    try {
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "main.tsx"),
+        root,
+      );
+      expect(await resolver.resolveDataFile("data/cities.json")).toBe(
+        undefined,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses a name that climbs out of the root", async () => {
+    const root = await tree({ "inner/main.tsx": "export default 1;\n" });
+    try {
+      await Deno.writeTextFile(path.join(root, "outside.json"), "[]\n");
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "inner", "main.tsx"),
+        path.join(root, "inner"),
+      );
+      await expect(resolver.resolveDataFile("/../outside.json")).rejects
+        .toThrow("outside of root directory");
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("refuses a link inside the root that names a file outside it", async () => {
+    const root = await tree({ "inner/main.tsx": "export default 1;\n" });
+    try {
+      await Deno.writeTextFile(path.join(root, "outside.json"), "[]\n");
+      await Deno.symlink(
+        path.join(root, "outside.json"),
+        path.join(root, "inner", "linked.json"),
+      );
+      const resolver = new FileSystemProgramResolver(
+        path.join(root, "inner", "main.tsx"),
+        path.join(root, "inner"),
+      );
+      // The written path stays inside the root; only following the link shows
+      // that it does not.
+      await expect(resolver.resolveDataFile("/linked.json")).rejects.toThrow(
+        "outside of root directory",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});
+
+describe("HttpProgramResolver.resolveDataFile", () => {
+  const at = (url: string | URL, body: string, status = 200) =>
+    new HttpProgramResolver(
+      url,
+      () => Promise.resolve(new Response(body, { status })),
+    );
+
+  it("fetches the file the name grounds to", async () => {
+    const resolver = at("https://example.com/main.tsx", '["Oslo"]');
+    expect(await resolver.resolveDataFile("/data/cities.json")).toEqual({
+      name: "/data/cities.json",
+      contents: '["Oslo"]',
+    });
+  });
+
+  it("returns undefined when the fetch does not find it", async () => {
+    const resolver = at("https://example.com/main.tsx", "nope", 404);
+    expect(await resolver.resolveDataFile("/data/absent.json")).toBe(undefined);
+  });
+
+  it("returns undefined for a name that is not grounded", async () => {
+    const resolver = at("https://example.com/main.tsx", "[]");
+    expect(await resolver.resolveDataFile("data/cities.json")).toBe(undefined);
+  });
+});

--- a/packages/js-compiler/test/program.test.ts
+++ b/packages/js-compiler/test/program.test.ts
@@ -434,4 +434,12 @@ describe("HttpProgramResolver.resolveDataFile", () => {
     const resolver = at("https://example.com/main.tsx", "[]");
     expect(await resolver.resolveDataFile("data/cities.json")).toBe(undefined);
   });
+
+  it("reports a refusal as a refusal, not as a missing file", async () => {
+    for (const status of [401, 403, 500]) {
+      const resolver = at("https://example.com/main.tsx", "no", status);
+      await expect(resolver.resolveDataFile("/data/cities.json")).rejects
+        .toThrow(`${status}`);
+    }
+  });
 });

--- a/packages/js-compiler/test/typescript.resolver.test.ts
+++ b/packages/js-compiler/test/typescript.resolver.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { resolveProgram } from "../typescript/resolver.ts";
+import {
+  collectDataFileNames,
+  resolveProgram,
+} from "../typescript/resolver.ts";
 import { TARGET } from "../typescript/options.ts";
 import { InMemoryProgram } from "../program.ts";
 
@@ -82,6 +85,77 @@ describe("typescript/resolver.ts", () => {
         },
       );
       expect(program.files.length).toBe(2);
+    });
+  });
+
+  describe("collectDataFileNames", () => {
+    const names = (contents: string) =>
+      collectDataFileNames({ name: "/main.tsx", contents }, TARGET);
+
+    it("reads the path a dataFile call names", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("/data/cities.json");\n',
+      )).toEqual(["/data/cities.json"]);
+    });
+
+    it("reads every path a module names", () => {
+      expect(names(
+        'import { dataFile, pattern } from "commonfabric";\n' +
+          "export default pattern(() => ({\n" +
+          '  a: dataFile("/a.json"),\n' +
+          '  b: dataFile("/b.txt"),\n' +
+          "}));\n",
+      )).toEqual(["/a.json", "/b.txt"]);
+    });
+
+    it("follows the binding through a renaming import", () => {
+      expect(names(
+        'import { dataFile as read } from "commonfabric";\n' +
+          'export default () => read("/data/cities.json");\n',
+      )).toEqual(["/data/cities.json"]);
+    });
+
+    it("follows the binding through a namespace import", () => {
+      expect(names(
+        'import * as cf from "commonfabric";\n' +
+          'export default () => cf.dataFile("/data/cities.json");\n',
+      )).toEqual(["/data/cities.json"]);
+    });
+
+    it("ignores a dataFile that is not the runtime's", () => {
+      expect(names(
+        'import { dataFile } from "./local-helpers.ts";\n' +
+          'export default () => dataFile("/data/cities.json");\n',
+      )).toEqual([]);
+    });
+
+    it("ignores a type-only import, which binds no value", () => {
+      expect(names(
+        'import type { dataFile } from "commonfabric";\n' +
+          "export default () => 1;\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a path the source does not state", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default (name: string) => dataFile(name);\n",
+      )).toEqual([]);
+    });
+
+    it("reads a call nested inside other code", () => {
+      expect(names(
+        'import { dataFile, pattern } from "commonfabric";\n' +
+          "export default pattern(() => {\n" +
+          '  const parsed = JSON.parse(dataFile("/data/cities.json"));\n' +
+          "  return { count: parsed.length };\n" +
+          "});\n",
+      )).toEqual(["/data/cities.json"]);
+    });
+
+    it("finds nothing in a module that never imports it", () => {
+      expect(names("export const x = 1;\n")).toEqual([]);
     });
   });
 });

--- a/packages/js-compiler/test/typescript.resolver.test.ts
+++ b/packages/js-compiler/test/typescript.resolver.test.ts
@@ -168,6 +168,56 @@ describe("typescript/resolver.ts", () => {
       )).toEqual([]);
     });
 
+    it("ignores a call through a parameter of the same name", () => {
+      // The inner `dataFile` is the parameter, not the import, so the file it
+      // names is not one this module reads.
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "function helper(dataFile: (s: string) => string) {\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "}\n" +
+          'export default () => [helper((s) => s), dataFile("/real.json")];\n',
+      )).toEqual(["/real.json"]);
+    });
+
+    it("ignores a call through a local of the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  const dataFile = (s: string) => s;\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call through a destructured binding of the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default (input: { dataFile: (s: string) => string }) => {\n" +
+          "  const { dataFile } = input;\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call through a shadowed namespace alias", () => {
+      expect(names(
+        'import * as cf from "commonfabric";\n' +
+          "export default (cf: { dataFile: (s: string) => string }) =>\n" +
+          '  cf.dataFile("/shadowed.json");\n',
+      )).toEqual([]);
+    });
+
+    it("reads a call whose scope shadows some other name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  const other = 1;\n" +
+          '  return [other, dataFile("/data/cities.json")];\n' +
+          "};\n",
+      )).toEqual(["/data/cities.json"]);
+    });
+
     it("finds nothing in a module that never imports it", () => {
       expect(names("export const x = 1;\n")).toEqual([]);
     });

--- a/packages/js-compiler/test/typescript.resolver.test.ts
+++ b/packages/js-compiler/test/typescript.resolver.test.ts
@@ -154,6 +154,20 @@ describe("typescript/resolver.ts", () => {
       )).toEqual(["/data/cities.json"]);
     });
 
+    it("ignores an inline type-only specifier, which binds no value", () => {
+      expect(names(
+        'import { pattern, type dataFile } from "commonfabric";\n' +
+          "export default pattern(() => ({}));\n",
+      )).toEqual([]);
+    });
+
+    it("ignores an import that binds no names at all", () => {
+      expect(names(
+        'import "commonfabric";\n' +
+          'export default () => dataFile("/data/cities.json");\n',
+      )).toEqual([]);
+    });
+
     it("finds nothing in a module that never imports it", () => {
       expect(names("export const x = 1;\n")).toEqual([]);
     });

--- a/packages/js-compiler/test/typescript.resolver.test.ts
+++ b/packages/js-compiler/test/typescript.resolver.test.ts
@@ -218,6 +218,78 @@ describe("typescript/resolver.ts", () => {
       )).toEqual(["/data/cities.json"]);
     });
 
+    it("ignores a call under a catch binding of the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  try {\n" +
+          "    return 1;\n" +
+          "  } catch (dataFile) {\n" +
+          '    return dataFile("/shadowed.json");\n' +
+          "  }\n" +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call under a loop variable of the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  for (let dataFile = 0; dataFile < 1; dataFile++) {\n" +
+          '    console.log(dataFile("/shadowed.json"));\n' +
+          "  }\n" +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call under a function declared with the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  function dataFile(s: string) {\n" +
+          "    return s;\n" +
+          "  }\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call under a class declared with the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default () => {\n" +
+          "  class dataFile {}\n" +
+          '  return [dataFile, dataFile("/shadowed.json")];\n' +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call inside a function expression of the same name", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default function dataFile(s: string) {\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "}\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a call through an array-destructured binding", () => {
+      expect(names(
+        'import { dataFile } from "commonfabric";\n' +
+          "export default (input: ((s: string) => string)[]) => {\n" +
+          "  const [dataFile] = input;\n" +
+          '  return dataFile("/shadowed.json");\n' +
+          "};\n",
+      )).toEqual([]);
+    });
+
+    it("ignores a default import, which does not bind the reader", () => {
+      expect(names(
+        'import cf from "commonfabric";\n' +
+          'export default () => cf.dataFile("/data/cities.json");\n',
+      )).toEqual([]);
+    });
+
     it("finds nothing in a module that never imports it", () => {
       expect(names("export const x = 1;\n")).toEqual([]);
     });

--- a/packages/js-compiler/typescript/resolver.ts
+++ b/packages/js-compiler/typescript/resolver.ts
@@ -208,9 +208,10 @@ export function collectDataFileNames(
  */
 function isShadowed(use: ts.Identifier): boolean {
   const name = use.text;
-  for (let node = use.parent; node !== undefined; node = node.parent) {
-    if (ts.isSourceFile(node)) return false;
+  let node: ts.Node = use.parent;
+  while (!ts.isSourceFile(node)) {
     if (bindsName(node, name)) return true;
+    node = node.parent;
   }
   return false;
 }

--- a/packages/js-compiler/typescript/resolver.ts
+++ b/packages/js-compiler/typescript/resolver.ts
@@ -175,14 +175,19 @@ export function collectDataFileNames(
   function visit(node: ts.Node) {
     if (ts.isCallExpression(node)) {
       const callee = node.expression;
-      const reads = ts.isIdentifier(callee)
-        ? direct.has(callee.text)
+      const read = ts.isIdentifier(callee) && direct.has(callee.text)
+        ? callee
         : ts.isPropertyAccessExpression(callee) &&
-          ts.isIdentifier(callee.expression) &&
-          namespaces.has(callee.expression.text) &&
-          callee.name.text === DATA_FILE_READER;
+            ts.isIdentifier(callee.expression) &&
+            namespaces.has(callee.expression.text) &&
+            callee.name.text === DATA_FILE_READER
+        ? callee.expression
+        : undefined;
       const argument = node.arguments[0];
-      if (reads && argument !== undefined && ts.isStringLiteral(argument)) {
+      if (
+        read !== undefined && argument !== undefined &&
+        ts.isStringLiteral(argument) && !isShadowed(read)
+      ) {
         names.push(argument.text);
       }
     }
@@ -190,6 +195,80 @@ export function collectDataFileNames(
   }
   visit(sourceFile);
   return names;
+}
+
+/**
+ * Whether `use` names something other than the module's own import: a binding
+ * of the same name declared in a scope between the two.
+ *
+ * The walk goes outward from the use until it reaches a scope that binds the
+ * name, so an inner declaration wins over the import exactly as it does when
+ * the code runs. Reaching the file without finding one means the import is
+ * what the name refers to.
+ */
+function isShadowed(use: ts.Identifier): boolean {
+  const name = use.text;
+  for (let node = use.parent; node !== undefined; node = node.parent) {
+    if (ts.isSourceFile(node)) return false;
+    if (bindsName(node, name)) return true;
+  }
+  return false;
+}
+
+/** Whether `scope` declares `name` directly, not counting nested scopes. */
+function bindsName(scope: ts.Node, name: string): boolean {
+  if (ts.isFunctionLike(scope)) {
+    if (scope.parameters.some((p) => patternBinds(p.name, name))) return true;
+  }
+  if (
+    (ts.isFunctionExpression(scope) || ts.isClassExpression(scope) ||
+      ts.isClassDeclaration(scope) || ts.isFunctionDeclaration(scope)) &&
+    scope.name?.text === name
+  ) {
+    return true;
+  }
+  if (ts.isCatchClause(scope)) {
+    const declared = scope.variableDeclaration?.name;
+    if (declared !== undefined && patternBinds(declared, name)) return true;
+  }
+  if (
+    ts.isForStatement(scope) || ts.isForOfStatement(scope) ||
+    ts.isForInStatement(scope)
+  ) {
+    const initializer = scope.initializer;
+    if (
+      initializer !== undefined &&
+      ts.isVariableDeclarationList(initializer) &&
+      initializer.declarations.some((d) => patternBinds(d.name, name))
+    ) {
+      return true;
+    }
+  }
+  const statements = ts.isBlock(scope) || ts.isModuleBlock(scope)
+    ? scope.statements
+    : undefined;
+  if (statements === undefined) return false;
+  return statements.some((statement) => {
+    if (ts.isVariableStatement(statement)) {
+      return statement.declarationList.declarations.some((d) =>
+        patternBinds(d.name, name)
+      );
+    }
+    if (
+      ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)
+    ) {
+      return statement.name?.text === name;
+    }
+    return false;
+  });
+}
+
+/** Whether a binding name — plain, or destructured — binds `name`. */
+function patternBinds(binding: ts.BindingName, name: string): boolean {
+  if (ts.isIdentifier(binding)) return binding.text === name;
+  return binding.elements.some((element) =>
+    ts.isBindingElement(element) && patternBinds(element.name, name)
+  );
 }
 
 function getImports(

--- a/packages/js-compiler/typescript/resolver.ts
+++ b/packages/js-compiler/typescript/resolver.ts
@@ -115,6 +115,83 @@ export function collectImportSpecifiers(
   return getImports(source, target, { includeImportTypeNodes: true });
 }
 
+/** The module an authored pattern takes the runtime's own names from. */
+const FABRIC_MODULE = "commonfabric";
+
+/** The runtime function that reads a data file stored with the program. */
+const DATA_FILE_READER = "dataFile";
+
+/**
+ * Returns the data-file names `source` declares, as the paths its `dataFile()`
+ * calls name.
+ *
+ * A pattern declares the code it depends on by importing it and the data it
+ * depends on by reading it, so this is the data-side counterpart of the import
+ * scan: both read a declaration out of the source rather than take one from a
+ * caller.
+ *
+ * Only a call to the runtime's own `dataFile` counts, and only where the
+ * argument is a string literal. The binding is followed through a renaming
+ * import and through a namespace import, so `df("/x.json")` and
+ * `cf.dataFile("/x.json")` are the same declaration as the plain call. A
+ * type-only import binds no value and so declares nothing. A computed path
+ * cannot be read from the source at all, and stays the caller's to name.
+ */
+export function collectDataFileNames(
+  source: Source,
+  target: ts.ScriptTarget,
+): string[] {
+  const sourceFile = ts.createSourceFile(
+    source.name,
+    source.contents,
+    target,
+    true,
+  );
+  const direct = new Set<string>();
+  const namespaces = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = statement.moduleSpecifier;
+    if (!ts.isStringLiteral(specifier) || specifier.text !== FABRIC_MODULE) {
+      continue;
+    }
+    const clause = statement.importClause;
+    if (clause === undefined || clause.isTypeOnly) continue;
+    const bindings = clause.namedBindings;
+    if (bindings === undefined) continue;
+    if (ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text);
+      continue;
+    }
+    for (const element of bindings.elements) {
+      if (element.isTypeOnly) continue;
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === DATA_FILE_READER) direct.add(element.name.text);
+    }
+  }
+  if (direct.size === 0 && namespaces.size === 0) return [];
+
+  const names: string[] = [];
+  function visit(node: ts.Node) {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const reads = ts.isIdentifier(callee)
+        ? direct.has(callee.text)
+        : ts.isPropertyAccessExpression(callee) &&
+          ts.isIdentifier(callee.expression) &&
+          namespaces.has(callee.expression.text) &&
+          callee.name.text === DATA_FILE_READER;
+      const argument = node.arguments[0];
+      if (reads && argument !== undefined && ts.isStringLiteral(argument)) {
+        names.push(argument.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return names;
+}
+
 function getImports(
   source: Source,
   target: ts.ScriptTarget,

--- a/packages/patterns/integration/data-file-multi-runtime.test.ts
+++ b/packages/patterns/integration/data-file-multi-runtime.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Multi-runtime regression test: a data file attached to a pattern reaches
+ * every runtime that runs it, not just the one that compiled it.
+ *
+ * The harness compiles the pattern in a bootstrap worker process, so the
+ * attachment cannot be made where the harness runs — the paths travel with the
+ * `createPiece` request and the worker attaches them on the other side. Every
+ * other session then opens the piece by id, which loads the pattern from
+ * storage rather than from disk, in yet another process.
+ *
+ * That is two boundaries, and a data file lost at either one is invisible
+ * until the read: the program compiles, type-checks, and runs, and the pattern
+ * is told the file is not there. Alice reads through the runtime that created
+ * the piece; bob reads through a runtime that only ever saw the stored source.
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const FIXTURE_DIR = join(
+  import.meta.dirname!,
+  "fixtures",
+  "data-file-multi-runtime",
+);
+const PROGRAM_PATH = join(FIXTURE_DIR, "main.tsx");
+const DATA_FILE_PATH = join(FIXTURE_DIR, "data", "cities.json");
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+describe("attached data files across runtimes", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let bob: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    // Session order matters: the harness bootstraps the piece with alice's
+    // identity (sessions[0]) and opens it in every session in order, so bob's
+    // runtime reaches the pattern only through what was stored.
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      dataFilePaths: [DATA_FILE_PATH],
+      sessions: ["alice", "bob"],
+    });
+    alice = harness.session("alice");
+    bob = harness.session("bob");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("reads the file in the runtime that compiled the pattern", async () => {
+    await harness.settle();
+    assertEquals(await alice.read(["cities"]), ["Oslo", "Lima"]);
+    assertEquals(await alice.read(["count"]), 2);
+  });
+
+  it("reads the file in a runtime that only loaded the stored source", async () => {
+    await harness.settle();
+    assertEquals(await bob.read(["cities"]), ["Oslo", "Lima"]);
+    assertEquals(await bob.read(["count"]), 2);
+  });
+});

--- a/packages/patterns/integration/fixtures/data-file-multi-runtime/data/cities.json
+++ b/packages/patterns/integration/fixtures/data-file-multi-runtime/data/cities.json
@@ -1,0 +1,1 @@
+{ "cities": ["Oslo", "Lima"] }

--- a/packages/patterns/integration/fixtures/data-file-multi-runtime/main.tsx
+++ b/packages/patterns/integration/fixtures/data-file-multi-runtime/main.tsx
@@ -1,0 +1,21 @@
+/// <cts-enable />
+// FIXTURE (multi-runtime integration): reads a data file attached to the
+// program, so the test has something that can only succeed if the file
+// travelled with the source. The pattern compiles and type-checks whether or
+// not the file is attached; it fails at the read.
+import { dataFile, NAME, pattern } from "commonfabric";
+
+interface Cities {
+  cities: string[];
+}
+
+export default pattern(() => {
+  const parsed = JSON.parse(
+    dataFile("/integration/fixtures/data-file-multi-runtime/data/cities.json"),
+  ) as Cities;
+  return {
+    [NAME]: "Data file reader (multi-runtime fixture)",
+    cities: parsed.cities,
+    count: parsed.cities.length,
+  };
+});

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -3506,16 +3506,6 @@ export class PieceController<T = unknown> {
   }
 
   /**
-   * The pattern's authored source files (see {@link getPatternSourceProgram}).
-   * Returns undefined when no verified source closure exists.
-   */
-  async getPatternSourceFiles(): Promise<
-    { name: string; contents: string }[] | undefined
-  > {
-    return (await this.getPatternSourceProgram())?.files;
-  }
-
-  /**
    * Detach from the current origin, restore an exact retained source revision,
    * or follow an origin recorded by an earlier revision.
    */

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -69,6 +69,8 @@ export interface PieceSourceState {
   entry?: string;
   /** The authored source files of the current pattern, when readable. */
   files: { name: string; contents: string }[];
+  /** Names among `files` that carry data rather than code. */
+  dataFiles?: string[];
   /** Ordered, append-only source and origin states accepted by the piece. */
   history: PieceSourceRevisionState[];
   currentRevisionId?: string;
@@ -415,6 +417,7 @@ export async function readPieceSourceState(
     if (program !== undefined) {
       state.entry = program.main;
       state.files = sortSourceFiles(program.files, program.main);
+      if (program.dataFiles !== undefined) state.dataFiles = program.dataFiles;
     }
   }
   return state;
@@ -423,6 +426,8 @@ export async function readPieceSourceState(
 export interface PieceSourceRevisionSource {
   pattern: { identity: string; symbol: string };
   files: { name: string; contents: string }[];
+  /** Names among `files` that carry data rather than code. */
+  dataFiles?: string[];
 }
 
 /** Read the retained authored files for one recorded source revision. */
@@ -448,6 +453,9 @@ export async function readPieceSourceRevision(
     files: program === undefined
       ? []
       : sortSourceFiles(program.files, program.main),
+    ...(program?.dataFiles === undefined
+      ? {}
+      : { dataFiles: program.dataFiles }),
   };
 }
 

--- a/packages/piece/test/piece-source-lifecycle.test.ts
+++ b/packages/piece/test/piece-source-lifecycle.test.ts
@@ -37,6 +37,30 @@ function versionProgram(version: string): RuntimeProgram {
   };
 }
 
+// A pattern that reads a data file, with the file attached and classified as
+// data. What the source state and a revision say about it is what a writer
+// built on either would need to put the package back the way it came.
+function dataFileProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { dataFile, NAME, pattern } from 'commonfabric';",
+          "export default pattern(() => ({",
+          "  [NAME]: 'Reads a data file',",
+          "  cities: JSON.parse(dataFile('/data/cities.json')).cities,",
+          "}));",
+          "",
+        ].join("\n"),
+      },
+      { name: "/data/cities.json", contents: '{ "cities": ["Oslo"] }\n' },
+    ],
+    dataFiles: ["/data/cities.json"],
+  };
+}
+
 function incompatibleProgram(): RuntimeProgram {
   return {
     main: "/main.tsx",
@@ -269,6 +293,25 @@ describe("piece source lifecycle", () => {
       readPieceSourceRevision(runtime, piece.getCell(), "missing-revision"),
     ).rejects.toThrow("source revision missing-revision was not found");
     expect(await piece.result.get(["version"])).toBe("local");
+  });
+
+  it("says which of a piece's source files carry data", async () => {
+    const program = dataFileProgram();
+    const piece = await pieces.create(program, { input: {} });
+    const sourceState = await readPieceSourceState(runtime, piece.getCell());
+    expect(sourceState.files.map((file) => file.name).sort()).toEqual([
+      "/data/cities.json",
+      "/main.tsx",
+    ]);
+    // Without this the two entries are indistinguishable, and rebuilding the
+    // package from them compiles the JSON as TypeScript.
+    expect(sourceState.dataFiles).toEqual(["/data/cities.json"]);
+    const revisionSource = await readPieceSourceRevision(
+      runtime,
+      piece.getCell(),
+      sourceState.history[0].revisionId,
+    );
+    expect(revisionSource.dataFiles).toEqual(["/data/cities.json"]);
   });
 
   it("rejects malformed actions and actions that do not apply", async () => {

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1730,10 +1730,10 @@ describe("piece pull materialization", () => {
     const sourceController = new PieceController(pieces, source);
     const targetController = new PieceController(pieces, target);
 
-    expect(await sourceController.getPatternSourceFiles()).toEqual(
+    expect((await sourceController.getPatternSourceProgram())?.files).toEqual(
       sourceProgram.files,
     );
-    expect(await targetController.getPatternSourceFiles()).toBeUndefined();
+    expect(await targetController.getPatternSourceProgram()).toBeUndefined();
 
     await pieces.link(
       sourceController.id,

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -1,5 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import type { Program } from "@commonfabric/js-compiler";
+import type { RuntimeProgram } from "../harness/types.ts";
 import { CompilerError } from "@commonfabric/js-compiler/errors";
 import { type BuiltInCompileAndRunParams } from "commonfabric";
 
@@ -68,7 +68,7 @@ export function compileAndRun(
     tx.resetNarrowestReadScope();
     // TODO(seefeld): Ideally, this cell already has this schema, because we set
     // it on the node itself.
-    const program: Program = inputsCell.asSchema({
+    const program: RuntimeProgram = inputsCell.asSchema({
       type: "object",
       properties: {
         files: {
@@ -84,6 +84,10 @@ export function compileAndRun(
           default: [],
         },
         main: { type: "string", default: "" },
+        // Named here or dropped: the traverser omits every key the properties
+        // map leaves out, so a field missing from this schema never reaches
+        // the compile however well the parameter type declares it.
+        dataFiles: { type: "array", items: { type: "string" } },
       },
       required: ["files", "main"],
     }).withTx(tx).get();

--- a/packages/runner/src/harness/compiler-stack.ts
+++ b/packages/runner/src/harness/compiler-stack.ts
@@ -27,8 +27,9 @@ export {
   transformCfDirective,
 } from "@commonfabric/ts-transformers";
 export {
+  collectDataFileNames,
   collectImportSpecifiers,
   getTypeScriptEnvironmentTypes,
   TypeScriptCompiler,
 } from "@commonfabric/js-compiler";
-export { resolveProgram } from "@commonfabric/js-compiler/typescript";
+export { resolveProgram, TARGET } from "@commonfabric/js-compiler/typescript";

--- a/packages/runner/src/harness/declared-data-files.ts
+++ b/packages/runner/src/harness/declared-data-files.ts
@@ -30,8 +30,13 @@ export async function attachDeclaredDataFiles(
   resolver: ProgramResolver,
 ): Promise<RuntimeProgram> {
   const { collectDataFileNames, TARGET } = compilerStack();
+  // A data file is not code and is never parsed as code. One already attached
+  // is in `files` like any other entry, and its bytes may happen to read as a
+  // `dataFile()` call.
+  const alreadyAttached = new Set(program.dataFiles ?? []);
   const declaredBy = new Map<string, string>();
   for (const file of program.files) {
+    if (alreadyAttached.has(file.name)) continue;
     for (const name of collectDataFileNames(file, TARGET)) {
       if (!declaredBy.has(name)) declaredBy.set(name, file.name);
     }

--- a/packages/runner/src/harness/declared-data-files.ts
+++ b/packages/runner/src/harness/declared-data-files.ts
@@ -1,0 +1,65 @@
+import {
+  collectDataFileNames,
+  type ProgramResolver,
+  type Source,
+} from "@commonfabric/js-compiler";
+import { TARGET } from "@commonfabric/js-compiler/typescript";
+import type { RuntimeProgram } from "./types.ts";
+
+/**
+ * Attach the data files a program's own source declares.
+ *
+ * A pattern declares the code it depends on by importing it, and the resolver
+ * follows that declaration. A pattern declares the data it depends on by
+ * reading it, with `dataFile("/data/cities.json")`, and this follows that one.
+ * Both are read out of the source, so a program carries the same files however
+ * it was built and whoever built it, and no caller has to state a second time
+ * what the source already says.
+ *
+ * The names come from the resolved closure, and each is read back through the
+ * resolver that produced it, so a program assembled from the file system, from
+ * a web address, or from anywhere else reaches its data the way it reaches its
+ * source.
+ *
+ * A declared name the resolver cannot produce is an error. The program cannot
+ * be assembled as its source describes it, and saying so here names both the
+ * module that asked and the name it asked for, while the pattern that would
+ * otherwise fail at the read is still being built.
+ */
+export async function attachDeclaredDataFiles(
+  program: RuntimeProgram,
+  resolver: ProgramResolver,
+): Promise<RuntimeProgram> {
+  const declaredBy = new Map<string, string>();
+  for (const file of program.files) {
+    for (const name of collectDataFileNames(file, TARGET)) {
+      if (!declaredBy.has(name)) declaredBy.set(name, file.name);
+    }
+  }
+  if (declaredBy.size === 0) return program;
+
+  const attached: Source[] = [];
+  const names: string[] = [];
+  for (const [name, source] of declaredBy) {
+    // A name the closure already holds is a module the program compiles, and
+    // reading it as data as well would store it twice under one name.
+    if (program.files.some((file) => file.name === name)) continue;
+    const file = resolver.resolveDataFile
+      ? await resolver.resolveDataFile(name)
+      : await resolver.resolveSource(name);
+    if (file === undefined) {
+      throw new Error(
+        `"${source}" reads the data file "${name}", which this program does ` +
+          `not contain. Store it under the program root at that path.`,
+      );
+    }
+    attached.push({ ...file, name });
+    names.push(name);
+  }
+  if (names.length === 0) return program;
+  return {
+    ...program,
+    files: [...program.files, ...attached],
+    dataFiles: [...new Set([...(program.dataFiles ?? []), ...names])],
+  };
+}

--- a/packages/runner/src/harness/declared-data-files.ts
+++ b/packages/runner/src/harness/declared-data-files.ts
@@ -1,10 +1,6 @@
-import {
-  collectDataFileNames,
-  type ProgramResolver,
-  type Source,
-} from "@commonfabric/js-compiler";
-import { TARGET } from "@commonfabric/js-compiler/typescript";
+import type { ProgramResolver, Source } from "@commonfabric/js-compiler";
 import type { RuntimeProgram } from "./types.ts";
+import { compilerStack } from "./deferred-compiler-stack.ts";
 
 /**
  * Attach the data files a program's own source declares.
@@ -21,6 +17,9 @@ import type { RuntimeProgram } from "./types.ts";
  * a web address, or from anywhere else reaches its data the way it reaches its
  * source.
  *
+ * Parsing is the compiler stack's work, so the caller must have awaited
+ * `ensureCompilerStack()` — `Engine.resolve` has, by the time it gets here.
+ *
  * A declared name the resolver cannot produce is an error. The program cannot
  * be assembled as its source describes it, and saying so here names both the
  * module that asked and the name it asked for, while the pattern that would
@@ -30,6 +29,7 @@ export async function attachDeclaredDataFiles(
   program: RuntimeProgram,
   resolver: ProgramResolver,
 ): Promise<RuntimeProgram> {
+  const { collectDataFileNames, TARGET } = compilerStack();
   const declaredBy = new Map<string, string>();
   for (const file of program.files) {
     for (const name of collectDataFileNames(file, TARGET)) {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -96,6 +96,7 @@ import {
   type RuntimeProgram,
   type TypeScriptHarnessProcessOptions,
 } from "./types.ts";
+import { attachDeclaredDataFiles } from "./declared-data-files.ts";
 import {
   getDefiningModule,
   readBindingIdentity,
@@ -184,6 +185,12 @@ class RootedProgramResolver implements ProgramResolver {
       throw new Error(`Source root "${this.root}" could not be resolved.`);
     }
     return source;
+  }
+
+  resolveDataFile(name: string): Promise<Source | undefined> {
+    return this.inner.resolveDataFile
+      ? this.inner.resolveDataFile(name)
+      : this.inner.resolveSource(name);
   }
 
   resolveSource(identifier: string): Promise<Source | undefined> {
@@ -354,8 +361,26 @@ export class Engine extends EventTarget {
     return { ...runtimeInternals, ...compilerInternals };
   }
 
-  // Resolve a `ProgramResolver` into a `Program`.
+  /**
+   * Resolve a `ProgramResolver` into a program: the entry, the closure its
+   * imports reach, and the data files its source declares by reading them.
+   *
+   * This is how a program is assembled from a source of truth — a directory, a
+   * web address, the fabric — so it is where a declaration in the source is
+   * acted on. Re-resolving a program the engine already holds goes through
+   * {@link resolveModules}, which follows imports and nothing else.
+   */
   async resolve(program: ProgramResolver): Promise<RuntimeProgram> {
+    return await attachDeclaredDataFiles(
+      await this.resolveModules(program),
+      program,
+    );
+  }
+
+  /** Resolve the module closure an entry's imports reach. */
+  private async resolveModules(
+    program: ProgramResolver,
+  ): Promise<RuntimeProgram> {
     const { compiler } = await this.getCompilerInternals();
     logger.timeStart("resolve");
     try {
@@ -371,11 +396,11 @@ export class Engine extends EventTarget {
     resolver: ProgramResolver,
     sourceRoots: readonly string[],
   ): Promise<RuntimeProgram> {
-    const programs = [await this.resolve(resolver)];
+    const programs = [await this.resolveModules(resolver)];
     for (const root of new Set(sourceRoots)) {
       if (root === programs[0].main) continue;
       programs.push(
-        await this.resolve(new RootedProgramResolver(resolver, root)),
+        await this.resolveModules(new RootedProgramResolver(resolver, root)),
       );
     }
 
@@ -1224,13 +1249,7 @@ export class Engine extends EventTarget {
       program,
       options,
     );
-    return this.evaluateRecordGraph(
-      id,
-      graph,
-      mainSpecifier,
-      program.files,
-      program.dataFiles,
-    );
+    return this.evaluateRecordGraph(id, graph, mainSpecifier, program);
   }
 
   /**
@@ -1246,8 +1265,7 @@ export class Engine extends EventTarget {
     id: string,
     graph: CompiledModuleGraph,
     mainSpecifier: string,
-    files: Source[],
-    dataFiles?: readonly string[],
+    program: Pick<RuntimeProgram, "files" | "dataFiles">,
   ): EvaluateResult {
     const prefix = `/${id}`;
     // Register module hashes up front so the canonical `cf:module/<hash>/<path>`
@@ -1269,10 +1287,10 @@ export class Engine extends EventTarget {
       registerHashes: () => {},
       fileNameForPath: (path) =>
         path.startsWith(prefix) ? path.slice(prefix.length) : path,
-      filesForExports: files,
-      ...(dataFiles === undefined
+      filesForExports: program.files,
+      ...(program.dataFiles === undefined
         ? {}
-        : { dataFilesForExports: [...dataFiles] }),
+        : { dataFilesForExports: [...program.dataFiles] }),
     });
   }
 

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -42,6 +42,15 @@ export class FabricAwareResolver implements ProgramResolver {
     return this.inner.main();
   }
 
+  // Forwarded like the rest of the interface. A wrapper that answers for part
+  // of a resolver and quietly drops the rest is the shape this whole seam
+  // exists to avoid.
+  resolveDataFile(name: string): Promise<Source | undefined> {
+    return this.inner.resolveDataFile
+      ? this.inner.resolveDataFile(name)
+      : this.inner.resolveSource(name);
+  }
+
   async resolveSource(identifier: string): Promise<Source | undefined> {
     if (identifier.startsWith(FABRIC_MOUNT_ROOT)) {
       return this.#mountedFiles.get(identifier);

--- a/packages/runner/src/harness/local-program.deno.ts
+++ b/packages/runner/src/harness/local-program.deno.ts
@@ -12,6 +12,9 @@ import type { RuntimeProgram } from "./types.ts";
  * `main` is the entry module. `testPaths` name additional entry points whose
  * source closures are retained and compiled without being executed.
  * `dataFilePaths` name files stored with the program and never read as code.
+ * A file the source names in a `dataFile()` call is attached without being
+ * listed here; the option is for a path the source cannot state, and for one
+ * a caller wants attached to a program that does not read it.
  *
  * `root` grounds every authored name, and so decides the paths `dataFile()`
  * addresses a data file by. Omitted, it is the common directory containing the
@@ -75,12 +78,16 @@ export async function resolveLocalProgram(
     }
   }
 
+  const declared = new Set(
+    [mainProgram, ...testPrograms].flatMap((p) => p.dataFiles ?? []),
+  );
   const program: RuntimeProgram = {
     main: mainProgram.main,
     files: [...files.values()],
     ...(testPrograms.length === 0
       ? {}
       : { sourceRoots: testPrograms.map((test) => test.main) }),
+    ...(declared.size === 0 ? {} : { dataFiles: [...declared] }),
   };
   const withData = attachDataFiles(program, dataPaths, root);
   if (options.mainExport) withData.mainExport = options.mainExport;
@@ -104,7 +111,7 @@ export function attachDataFiles(
 ): RuntimeProgram {
   if (!dataFilePaths?.length) return program;
   const files = [...program.files];
-  const dataFiles: string[] = [];
+  const dataFiles: string[] = [...(program.dataFiles ?? [])];
   for (const path of dataFilePaths) {
     const source = readDataFileSource(path, rootPath);
     if (dataFiles.includes(source.name)) continue;

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -11,12 +11,6 @@ export type RuntimeProgram = Program & {
   mainExport?: string;
   /** Source entry points retained and compiled without being executed. */
   sourceRoots?: string[];
-  /**
-   * Names of entries in `files` that carry data rather than code. A data file
-   * travels with the source package and binds to the entry module's identity,
-   * and is never transformed, compiled, or executed.
-   */
-  dataFiles?: string[];
 };
 
 export interface TypeScriptHarnessProcessOptions {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -421,7 +421,7 @@ export class PatternManager {
    * module-scope entry ref). The only surviving job of the old
    * `registerPattern`: source-bearing tests/builtins that construct a Pattern in
    * hand can associate its source so `getPatternProgram` (and thus
-   * `getPatternFilesBySync`) returns it. No-op when the pattern already carries a
+   * `getPatternProgramBySync`) returns it. No-op when the pattern already carries a
    * program. Walks to the derivation root so a copy inherits the association.
    */
   associatePatternProgram(
@@ -746,8 +746,7 @@ export class PatternManager {
       id,
       graph,
       mainSpecifier,
-      program.files,
-      program.dataFiles,
+      program,
     );
     return this.patternFromEvaluation(result, program);
   }
@@ -820,8 +819,7 @@ export class PatternManager {
       id,
       graph,
       mainSpecifier,
-      program.files,
-      program.dataFiles,
+      program,
     );
     this.registerEvaluatedModules(result);
     return result;
@@ -888,8 +886,7 @@ export class PatternManager {
         id,
         graph,
         mainSpecifier,
-        program.files,
-        program.dataFiles,
+        program,
       );
       return this.patternFromEvaluation(result, program, entryIdentity);
     }
@@ -1059,8 +1056,7 @@ export class PatternManager {
       id,
       graph,
       mainSpecifier,
-      program.files,
-      program.dataFiles,
+      program,
     );
     logger.time(evalStart, "compile-cache", "evaluate");
 
@@ -1754,22 +1750,24 @@ export class PatternManager {
   }
 
   /**
-   * Best-effort authored source files for a live pattern by its content
+   * Best-effort authored program for a live pattern by its content
    * `{ identity, symbol }` — the source-viewing debug surface
-   * (`getPatternSources`). Returns undefined when the pattern is not live in
-   * this session or carries no program (e.g. a source-free by-identity
-   * reload); callers degrade gracefully (omit the pattern). Source-bearing
-   * cross-session recovery is the source-doc closure's job, not this.
+   * (`getPatternSources`). Returns the program rather than its files, so a
+   * caller can tell which entries carry data. Returns undefined when the
+   * pattern is not live in this session or carries no program (e.g. a
+   * source-free by-identity reload); callers degrade gracefully (omit the
+   * pattern). Source-bearing cross-session recovery is the source-doc
+   * closure's job, not this.
    */
-  getPatternFilesBySync(
+  getPatternProgramBySync(
     identity: string,
     symbol: string,
-  ): { name: string; contents: string }[] | undefined {
+  ): RuntimeProgram | undefined {
     const pattern = this.artifactFromIdentitySync(identity, symbol) as
       | Pattern
       | undefined;
     if (!pattern) return undefined;
-    return getPatternProgram(pattern)?.files;
+    return getPatternProgram(pattern);
   }
 
   /**

--- a/packages/runner/test/cfc-policy-of-label.test.ts
+++ b/packages/runner/test/cfc-policy-of-label.test.ts
@@ -289,7 +289,7 @@ describe("PolicyOf label-time binding", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const emittedSchema = evaluated.main?.schema as JSONSchema;
 
@@ -347,7 +347,7 @@ describe("PolicyOf label-time binding", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const emittedSchema = evaluated.main?.schema as JSONSchema;
 

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -74,3 +74,85 @@ Deno.test("compileAndRun initializes outputs and handles invalid programs", asyn
     await storageManager.close();
   }
 });
+
+Deno.test("compileAndRun runs a program that reads an attached data file", async () => {
+  const identity = await Identity.fromPassphrase("compile and run data file");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = identity.did();
+  const tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const inputs = runtime.getCell<any>(
+      space,
+      "data-file-inputs",
+      undefined,
+      tx,
+    );
+    const parent = runtime.getCell(space, "data-file-parent", undefined, tx);
+    const cancels: Array<() => void> = [];
+    let outputs: any;
+    const action = compileAndRun(
+      inputs,
+      (_tx, result) => {
+        outputs = result;
+      },
+      (cancel) => cancels.push(cancel),
+      { test: "compile-and-run-data-file" },
+      parent,
+      runtime,
+    );
+
+    // `dataFiles` names which of `files` carries data. Dropped anywhere between
+    // here and the compile, the entry is still present with nothing saying it
+    // is data, and the pattern is told at the read that it is not attached.
+    inputs.set({
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'import { dataFile, pattern } from "commonfabric";\n' +
+            "export default pattern(() => ({\n" +
+            '  cities: JSON.parse(dataFile("/data/cities.json")).cities,\n' +
+            "}));\n",
+        },
+        {
+          name: "/data/cities.json",
+          contents: '{ "cities": ["Oslo", "Lima"] }\n',
+        },
+      ],
+      dataFiles: ["/data/cities.json"],
+    });
+    action(tx);
+    await tx.commit();
+
+    // The compile runs outside the scheduler and writes what it produced when
+    // it finishes, so wait on that write. Waiting on `pending` going false
+    // instead would be satisfied by the value it already holds before the
+    // compile starts.
+    // The result cell is written before the pattern's own reactivity has filled
+    // it in, so wait for the field the pattern derives from the data file
+    // rather than for the object that will hold it.
+    const written = Promise.withResolvers<void>();
+    const waits = [
+      outputs.result.sink((value: { cities?: unknown } | undefined) => {
+        if (value?.cities !== undefined) written.resolve();
+      }),
+      outputs.error.sink((value: unknown) => {
+        if (value !== undefined) written.resolve();
+      }),
+    ];
+    await written.promise;
+    for (const cancel of waits) cancel();
+    await runtime.idle();
+
+    assertEquals(outputs.error.get(), undefined);
+    assertEquals(outputs.result.get(), { cities: ["Oslo", "Lima"] });
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/declared-data-files.test.ts
+++ b/packages/runner/test/declared-data-files.test.ts
@@ -1,0 +1,137 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type { ProgramResolver, Source } from "@commonfabric/js-compiler";
+import { attachDeclaredDataFiles } from "../src/harness/declared-data-files.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const READS_CITIES = 'import { dataFile } from "commonfabric";\n' +
+  'export default () => dataFile("/data/cities.json");\n';
+
+/** A resolver over a fixed set of sources, with no data-file read of its own. */
+function sourceOnly(files: Record<string, string>): ProgramResolver {
+  return {
+    main: () => Promise.resolve({ name: "/main.tsx", contents: "" }),
+    resolveSource: (name) =>
+      Promise.resolve(
+        name in files ? { name, contents: files[name] } : undefined,
+      ),
+  };
+}
+
+/** A resolver that reads data files through its own path. */
+function withDataReader(
+  files: Record<string, string>,
+  data: Record<string, string>,
+): ProgramResolver & { dataReads: string[] } {
+  const dataReads: string[] = [];
+  return {
+    dataReads,
+    main: () => Promise.resolve({ name: "/main.tsx", contents: "" }),
+    resolveSource: (name) =>
+      Promise.resolve(
+        name in files ? { name, contents: files[name] } : undefined,
+      ),
+    resolveDataFile: (name): Promise<Source | undefined> => {
+      dataReads.push(name);
+      return Promise.resolve(
+        name in data ? { name, contents: data[name] } : undefined,
+      );
+    },
+  };
+}
+
+const program = (contents: string): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents }],
+});
+
+describe("attachDeclaredDataFiles", () => {
+  it("attaches the file the source declares", async () => {
+    const resolver = withDataReader({}, { "/data/cities.json": '["Oslo"]\n' });
+    const result = await attachDeclaredDataFiles(
+      program(READS_CITIES),
+      resolver,
+    );
+    assertEquals(result.dataFiles, ["/data/cities.json"]);
+    assertEquals(
+      result.files.find((f) => f.name === "/data/cities.json")?.contents,
+      '["Oslo"]\n',
+    );
+    assertEquals(resolver.dataReads, ["/data/cities.json"]);
+  });
+
+  it("reads through resolveSource when the resolver has no data read", async () => {
+    const result = await attachDeclaredDataFiles(
+      program(READS_CITIES),
+      sourceOnly({ "/data/cities.json": '["Lima"]\n' }),
+    );
+    assertEquals(result.dataFiles, ["/data/cities.json"]);
+    assertEquals(
+      result.files.find((f) => f.name === "/data/cities.json")?.contents,
+      '["Lima"]\n',
+    );
+  });
+
+  it("leaves a program whose source declares nothing alone", async () => {
+    const plain = program("export default 1;\n");
+    assertEquals(await attachDeclaredDataFiles(plain, sourceOnly({})), plain);
+  });
+
+  it("refuses a declared name the resolver cannot produce", async () => {
+    await assertRejects(
+      () => attachDeclaredDataFiles(program(READS_CITIES), sourceOnly({})),
+      Error,
+      'reads the data file "/data/cities.json"',
+    );
+  });
+
+  it("names the module that declared the missing file", async () => {
+    const across: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: 'export * from "./reader.ts";\n' },
+        { name: "/reader.ts", contents: READS_CITIES },
+      ],
+    };
+    await assertRejects(
+      () => attachDeclaredDataFiles(across, sourceOnly({})),
+      Error,
+      '"/reader.ts" reads the data file',
+    );
+  });
+
+  it("passes over a name the program already compiles as a module", async () => {
+    // Reading a module's own text is not an attachment: the program would have
+    // to both compile the file and store it uninterpreted.
+    const both: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("/helper.ts");\n',
+        },
+        { name: "/helper.ts", contents: "export const x = 1;\n" },
+      ],
+    };
+    const result = await attachDeclaredDataFiles(both, sourceOnly({}));
+    assertEquals(result.dataFiles, undefined);
+    assertEquals(result.files.length, 2);
+  });
+
+  it("keeps a data file the caller already attached", async () => {
+    const given: RuntimeProgram = {
+      ...program(READS_CITIES),
+      dataFiles: ["/data/notes.txt"],
+    };
+    given.files = [...given.files, {
+      name: "/data/notes.txt",
+      contents: "note\n",
+    }];
+    const result = await attachDeclaredDataFiles(
+      given,
+      sourceOnly({ "/data/cities.json": "[]\n" }),
+    );
+    assertEquals(result.dataFiles, ["/data/notes.txt", "/data/cities.json"]);
+  });
+});

--- a/packages/runner/test/declared-data-files.test.ts
+++ b/packages/runner/test/declared-data-files.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import { describe, it } from "@std/testing/bdd";
+import { beforeAll, describe, it } from "@std/testing/bdd";
 import type { ProgramResolver, Source } from "@commonfabric/js-compiler";
 import { attachDeclaredDataFiles } from "../src/harness/declared-data-files.ts";
+import { ensureCompilerStack } from "../src/harness/deferred-compiler-stack.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 const READS_CITIES = 'import { dataFile } from "commonfabric";\n' +
@@ -46,6 +47,13 @@ const program = (contents: string): RuntimeProgram => ({
 });
 
 describe("attachDeclaredDataFiles", () => {
+  // Reading a `dataFile()` call out of a module is the compiler stack's work,
+  // and every flow that parses awaits it before starting. Here that flow is
+  // the suite.
+  beforeAll(async () => {
+    await ensureCompilerStack();
+  });
+
   it("attaches the file the source declares", async () => {
     const resolver = withDataReader({}, { "/data/cities.json": '["Oslo"]\n' });
     const result = await attachDeclaredDataFiles(

--- a/packages/runner/test/declared-data-files.test.ts
+++ b/packages/runner/test/declared-data-files.test.ts
@@ -142,4 +142,26 @@ describe("attachDeclaredDataFiles", () => {
     );
     assertEquals(result.dataFiles, ["/data/notes.txt", "/data/cities.json"]);
   });
+
+  it("never reads an attached data file as source", async () => {
+    // The bytes of this data file happen to read as a module that declares
+    // another one. It is data, so it is not parsed and declares nothing.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: "export default 1;\n" },
+        {
+          name: "/data/sample.txt",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("/data/absent.json");\n',
+        },
+      ],
+      dataFiles: ["/data/sample.txt"],
+    };
+    const resolved = await attachDeclaredDataFiles(
+      program,
+      sourceOnly({}),
+    );
+    assertEquals(resolved.dataFiles, ["/data/sample.txt"]);
+  });
 });

--- a/packages/runner/test/engine-compile-evaluate.test.ts
+++ b/packages/runner/test/engine-compile-evaluate.test.ts
@@ -71,7 +71,7 @@ describe("Engine compile + evaluate", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(result.main!["default"]).toBe("hello");
   });

--- a/packages/runner/test/engine-compile-record-graph.test.ts
+++ b/packages/runner/test/engine-compile-record-graph.test.ts
@@ -122,7 +122,7 @@ describe("Engine.compileToRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBe(21);
   });
@@ -275,7 +275,7 @@ describe("Engine.compileToRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBe("Open");
   });
@@ -313,7 +313,7 @@ describe("Engine.compileToRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
 
     // The compiled body wired up the gated ambient intrinsics, not the real

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./engine-test-support.ts";
 import type { RuntimeProgram } from "./engine-test-support.ts";
 import { validateCfcPolicyArtifactManifest } from "../src/cfc/policy.ts";
+import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
 describe("Engine.evaluateRecordGraph()", () => {
   let runtime: Runtime;
   let engine: Engine;
@@ -112,7 +113,7 @@ describe("Engine.evaluateRecordGraph()", () => {
         id,
         graph,
         mainSpecifier,
-        program.files,
+        program,
       );
       expect(result.main!["default"]).toBe(42);
     } finally {
@@ -192,7 +193,7 @@ describe("Engine.evaluateRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(result.main?.default).toBe(42);
     expect(
@@ -258,8 +259,7 @@ describe("Engine.evaluateRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
-      program.dataFiles,
+      program,
     );
     expect(result.main?.default).toBe(42);
     expect(
@@ -267,6 +267,38 @@ describe("Engine.evaluateRecordGraph()", () => {
         path.startsWith("/data/")
       ),
     ).toBe(false);
+  });
+
+  it("marks the data files on the program it records for an export", async () => {
+    // Every exported pattern is recorded with the program it came from, and
+    // that program names data entries among its files. Recorded without
+    // `dataFiles`, the entries are there with nothing saying they are data, so
+    // anything that later builds from that program compiles the JSON.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: "import { pattern } from 'commonfabric';\n" +
+            "export const child = pattern(() => ({ value: 1 }));\n" +
+            "export default child;\n",
+        },
+        { name: "/data/cities.json", contents: '["Oslo"]\n' },
+      ],
+      dataFiles: ["/data/cities.json"],
+    };
+
+    const { id, graph, mainSpecifier } = await engine.compileToRecordGraph(
+      program,
+    );
+    const result = engine.evaluateRecordGraph(
+      id,
+      graph,
+      mainSpecifier,
+      program,
+    );
+    const child = (result.main as Record<string, unknown>).child;
+    expect(getPatternProgram(child)?.dataFiles).toEqual(["/data/cities.json"]);
   });
 
   it("reads an attached data file's bytes from the pattern", async () => {
@@ -844,7 +876,7 @@ describe("Engine.evaluateRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBe(25);
   });
@@ -888,7 +920,7 @@ describe("Engine.evaluateRecordGraph()", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBe(25);
   });

--- a/packages/runner/test/engine-ses.test.ts
+++ b/packages/runner/test/engine-ses.test.ts
@@ -94,7 +94,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBeDefined();
   });
@@ -125,7 +125,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBeDefined();
   });
@@ -185,7 +185,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBeDefined();
   });
@@ -218,7 +218,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBeDefined();
   });
@@ -254,7 +254,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toHaveLength(3);
     expect(typeof main?.default?.[0]).toBe("string");
@@ -286,7 +286,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toEqual({
       gmail: { value: "gmail.readonly" },
@@ -316,7 +316,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBeInstanceOf(RegExp);
     expect(main?.default?.test("hello")).toBe(true);
@@ -387,7 +387,7 @@ describe("Engine in SES mode", () => {
       id,
       graph,
       mainSpecifier,
-      program.files,
+      program,
     );
     expect(main?.default).toBe("Person");
   });

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -322,7 +322,7 @@ describe("Engine.compileToRecordGraph", () => {
         compiled.id,
         compiled.graph,
         compiled.mainSpecifier,
-        MULTI.files,
+        MULTI,
       );
       expect((main as { total(): number }).total()).toBe(42);
       expect(coverage.report().totals.coveredRuntimeLines).toBeGreaterThan(0);
@@ -348,7 +348,7 @@ describe("Engine.compileToRecordGraph", () => {
         compiled.id,
         compiled.graph,
         compiled.mainSpecifier,
-        MULTI.files,
+        MULTI,
       );
       expect((main as { total(): number }).total()).toBe(42);
       const report = coverage.report();

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -175,7 +175,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     expect(evaluated.main?.y()).toBe(42);
     expect(await runPattern(evaluated.main?.default, 1)).toEqual({
@@ -232,7 +232,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const reference = (evaluated.main?.schema as {
       ifc?: { confidentiality?: Record<string, unknown>[] };
@@ -285,7 +285,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const findWriterIdentity = (
       value: unknown,
@@ -383,7 +383,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      importerProgram("cf:dep").files,
+      importerProgram("cf:dep"),
     );
     expect(evaluated.main?.y()).toBe(10);
   });
@@ -404,7 +404,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      importerProgram(`cf:dep@${dependency.entryIdentity}`).files,
+      importerProgram(`cf:dep@${dependency.entryIdentity}`),
     );
     expect(evaluated.main?.y()).toBe(12);
   });
@@ -443,7 +443,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     expect(evaluated.main?.total()).toBe(4);
   });
@@ -498,7 +498,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     expect(evaluated.main?.total()).toBe(30);
 
@@ -628,7 +628,7 @@ describe("Engine fabric imports", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     expect(evaluated.main?.y()).toBe(102);
   });
@@ -676,7 +676,7 @@ describe("Engine fabric imports", () => {
       second.id,
       second.graph,
       second.mainSpecifier,
-      program.files,
+      program,
     );
     expect(evaluated.main?.y()).toBe(7);
   });

--- a/packages/runner/test/fabric-imports-snapshot.test.ts
+++ b/packages/runner/test/fabric-imports-snapshot.test.ts
@@ -138,7 +138,7 @@ describe("fabric import snapshot semantics", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const tx = runtime.edit();
     const resultCell = runtime.getCell<{ result: number }>(

--- a/packages/runner/test/local-program.test.ts
+++ b/packages/runner/test/local-program.test.ts
@@ -152,6 +152,47 @@ describe("resolveLocalProgram", () => {
     }
   });
 
+  it("carries the data files the resolve step attached", async () => {
+    const root = await tree({ "main.tsx": "export default 1;\n" });
+    try {
+      const program = await resolveLocalProgram(async (resolver) => {
+        const main = await resolver.main();
+        return {
+          main: main.name,
+          files: [main, { name: "/data/cities.json", contents: "[]\n" }],
+          dataFiles: ["/data/cities.json"],
+        };
+      }, { main: join(root, "main.tsx"), root });
+      assertEquals(program.dataFiles, ["/data/cities.json"]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
+  it("adds a given path to what the resolve step attached", async () => {
+    const root = await tree({
+      "main.tsx": "export default 1;\n",
+      "data/notes.txt": "note\n",
+    });
+    try {
+      const program = await resolveLocalProgram(async (resolver) => {
+        const main = await resolver.main();
+        return {
+          main: main.name,
+          files: [main, { name: "/data/cities.json", contents: "[]\n" }],
+          dataFiles: ["/data/cities.json"],
+        };
+      }, {
+        main: join(root, "main.tsx"),
+        root,
+        dataFilePaths: [join(root, "data/notes.txt")],
+      });
+      assertEquals(program.dataFiles, ["/data/cities.json", "/data/notes.txt"]);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+
   it("carries the named export through", async () => {
     const root = await tree({ "main.tsx": "export const view = 1;\n" });
     try {

--- a/packages/runner/test/manual-compile-wedge.ts
+++ b/packages/runner/test/manual-compile-wedge.ts
@@ -73,7 +73,7 @@ engine.evaluateRecordGraph(
   compiled.id,
   compiled.graph,
   compiled.mainSpecifier,
-  program.files,
+  program,
 );
 const evalMs = performance.now() - evalStart;
 // One macrotask turn so the probe can observe the evaluate stretch.

--- a/packages/runner/test/module-identity-engine.test.ts
+++ b/packages/runner/test/module-identity-engine.test.ts
@@ -50,7 +50,7 @@ describe("Engine implementation identity", () => {
     const { id, graph, mainSpecifier } = await engine.compileToRecordGraph(
       program,
     );
-    engine.evaluateRecordGraph(id, graph, mainSpecifier, program.files);
+    engine.evaluateRecordGraph(id, graph, mainSpecifier, program);
     const moduleIdentity = engine.canonicalModuleSource(`/${id}${modulePath}`);
     return { id, moduleIdentity };
   }
@@ -146,7 +146,7 @@ describe("Engine implementation identity", () => {
       compiled.id,
       compiled.graph,
       compiled.mainSpecifier,
-      program.files,
+      program,
     );
     const findWriterIdentity = (
       value: unknown,

--- a/packages/runner/test/ses-boundary.bench.ts
+++ b/packages/runner/test/ses-boundary.bench.ts
@@ -55,7 +55,7 @@ Deno.bench(
         benchProgram,
       );
       // Warm once outside the timed region (first-load initialization).
-      engine.evaluateRecordGraph(id, graph, mainSpecifier, benchProgram.files);
+      engine.evaluateRecordGraph(id, graph, mainSpecifier, benchProgram);
 
       b.start();
       for (let i = 0; i < 25; i++) {
@@ -63,7 +63,7 @@ Deno.bench(
           id,
           graph,
           mainSpecifier,
-          benchProgram.files,
+          benchProgram,
         );
       }
       b.end();

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -37,6 +37,7 @@ import {
   type CellRef,
   type CfcLabelView,
   ClientNotificationType,
+  type GetPatternSourcesRequest,
   RequestType,
 } from "../protocol/mod.ts";
 import {
@@ -3714,5 +3715,70 @@ describe("RuntimeProcessor.handleNotification", () => {
     expect(warnings.length).toBe(1);
     expect(events).toEqual([]);
     expect(acks).toEqual([]);
+  });
+});
+
+describe("runtime-client pattern source view", () => {
+  // `getPatternSources` reads two things: which patterns the graph is running,
+  // and each one's program. Everything else on the runtime is beside the point
+  // here, so the processor is those two answers and nothing more.
+  const processorOver = (
+    programs: Record<string, unknown>,
+  ): RuntimeProcessor =>
+    ({
+      runtime: {
+        scheduler: {
+          getGraphSnapshot: () => ({
+            nodes: Object.keys(programs).map((identity) => ({
+              patternIdentity: { identity, symbol: "default" },
+            })),
+          }),
+        },
+        patternManager: {
+          getPatternProgramBySync: (identity: string) => programs[identity],
+        },
+      },
+    }) as unknown as RuntimeProcessor;
+
+  const sourcesOf = (processor: RuntimeProcessor) =>
+    RuntimeProcessor.prototype.getPatternSources.call(processor, {
+      type: RequestType.GetPatternSources,
+    } as GetPatternSourcesRequest);
+
+  it("says which of a running pattern's files carry data", () => {
+    const { patterns } = sourcesOf(processorOver({
+      "cf:module/abc": {
+        main: "/main.tsx",
+        files: [
+          { name: "/main.tsx", contents: "export default 1;" },
+          { name: "/data/cities.json", contents: "[]" },
+        ],
+        dataFiles: ["/data/cities.json"],
+      },
+    }));
+    expect(patterns.length).toBe(1);
+    expect(patterns[0].files.map((file) => file.name)).toEqual([
+      "/main.tsx",
+      "/data/cities.json",
+    ]);
+    // Without this the view cannot tell the lookup table from the module.
+    expect(patterns[0].dataFiles).toEqual(["/data/cities.json"]);
+  });
+
+  it("omits the list for a pattern that carries no data", () => {
+    const { patterns } = sourcesOf(processorOver({
+      "cf:module/abc": {
+        main: "/main.tsx",
+        files: [{ name: "/main.tsx", contents: "export default 1;" }],
+      },
+    }));
+    expect(patterns[0].dataFiles).toBe(undefined);
+  });
+
+  it("omits a pattern whose program was never kept", () => {
+    const { patterns } = sourcesOf(
+      processorOver({ "cf:module/abc": undefined }),
+    );
+    expect(patterns).toEqual([]);
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1658,14 +1658,20 @@ export class RuntimeProcessor {
       // module, so the symbol only selects a representative artifact). A
       // source-free by-identity reload carries no program — omit it (same
       // graceful degradation as the prior meta-cell read's try/catch).
-      const files = this.runtime.patternManager.getPatternFilesBySync(
+      const program = this.runtime.patternManager.getPatternProgramBySync(
         ref.identity,
         ref.symbol,
       );
-      if (files) {
+      if (program) {
         patterns.push({
           identity: ref.identity,
-          files: files.map((f) => ({ name: f.name, contents: f.contents })),
+          files: program.files.map((f) => ({
+            name: f.name,
+            contents: f.contents,
+          })),
+          ...(program.dataFiles === undefined
+            ? {}
+            : { dataFiles: program.dataFiles }),
         });
       }
     }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -544,6 +544,8 @@ export type PatternSourceInfo = {
   /** Content identity of the pattern's entry module (`cf:module/<hash>`). */
   identity: string;
   files: PatternSourceFile[];
+  /** Names among `files` that carry data rather than code. */
+  dataFiles?: string[];
 };
 
 export type PatternSourcesResponse = {
@@ -786,6 +788,8 @@ export type PieceSourceView = {
   repository?: string;
   entry?: string;
   files: PatternSourceFile[];
+  /** Names among `files` that carry data rather than code. */
+  dataFiles?: string[];
   history: PieceSourceRevisionView[];
   currentRevisionId?: string;
 };
@@ -797,6 +801,8 @@ export type PieceSourceResponse = {
 export type PieceSourceRevisionSourceView = {
   pattern: PiecePatternRefView;
   files: PatternSourceFile[];
+  /** Names among `files` that carry data rather than code. */
+  dataFiles?: string[];
 };
 
 export type PieceSourceRevisionResponse = {

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -213,16 +213,23 @@ packages and type-checks a test entry but does not run it. Repeat the flag for
 every authored test entry. Each `setsrc` describes a complete new source
 revision, so omitting the flags drops those test roots from that revision.
 
-`--datafile <path>` attaches a file that is not code — a fixture, a lookup
-table, a list of names — so it ships and is recovered with the source. Its bytes
-are stored verbatim: never parsed, type-checked, compiled, or importable, and
-the pattern reads one with `dataFile("/data/cities.json")` from `commonfabric`.
-`cf check` and `cf test` take the same flag, so a pattern that reads a data file
-can be checked and tested before deploying. It must be UTF-8 text and sit inside
-the deployment root, which the CLI infers to cover the main entry, every test
-entry, and every data file unless `--root` says otherwise. Like `--test`, it is
-repeatable and defines part of the revision, so repeat the complete set on every
-`setsrc`. Changing a data file alone still produces a new source revision.
+A file that is not code — a fixture, a lookup table, a list of names — ships and
+is recovered with the source. Its bytes are stored verbatim: never parsed,
+type-checked, compiled, or importable, and the pattern reads one with
+`dataFile("/data/cities.json")` from `commonfabric`. That call is the
+declaration. Store the file under the deployment root at the path it names, and
+`new`, `setsrc`, `check`, `test`, and `dev` all attach it, the way they already
+follow what the source imports. A name with no file behind it fails the build
+and says which module read it.
+
+`--datafile <path>` attaches a file the source cannot name: one read by a
+computed path, or one that ships with a program that does not read it. It adds
+to what the source declares rather than replacing it. A data file must be UTF-8
+text and sit inside the deployment root, which the CLI infers to cover the main
+entry, every test entry, and every data file unless `--root` says otherwise.
+Like `--test`, the flag is repeatable and defines part of the revision, so
+repeat the complete set on every `setsrc`. Changing a data file alone still
+produces a new source revision.
 
 `setsrc` normally rejects incompatible argument/result schema changes and
 retained links whose durable contracts no longer fit. For an intentional

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -15,10 +15,12 @@ every entry with repeatable `--test` flags on `piece new` and every later
 `piece setsrc`. Manual browser or CLI verification does not replace the
 automated tests. Deployment packages and type-checks attached tests but does not
 run them. A file the pattern ships with that is not code — a fixture, a lookup
-table — attaches the same way with repeatable `--datafile` flags, is stored
-verbatim rather than compiled, and is read with `dataFile(path)` from
-`commonfabric`. `cf check` and `cf test` take `--datafile` too, so a pattern
-that reads one is checkable and testable locally.
+table — is read with `dataFile(path)` from `commonfabric` and stored verbatim
+rather than compiled. That call is the whole declaration: store the file under
+the program root at the path it names, and every command that builds the pattern
+attaches it, so a pattern that reads one is checkable, testable, and deployable
+with no extra flag. `--datafile` remains for a file the source cannot name, such
+as one read by a computed path.
 
 Also read the foundational reactivity references before implementing or
 debugging pattern state:

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -124,7 +124,7 @@ async function main() {
         id,
         graph,
         mainSpecifier,
-        program.files,
+        program,
       );
       const pattern = (exports as Record<string, unknown>)?.default as
         | PatternContract


### PR DESCRIPTION
A pattern declares the code it depends on by importing it, and the resolver follows that declaration: nobody passes a flag naming each module. A pattern declares the data it depends on by reading it, with `dataFile("/data/cities.json")` — and until now every command that built the program had to be told the same thing a second time, as `--datafile`. Miss it and the program compiles, type-checks, and runs, and the pattern is told at the read that the file is not there.

That second declaration is what kept being forgotten, and each place that forgot it was a separate report of one bug. The pattern-unit lane was the latest: it runs `cf test --root <patterns>` over every authored test with no data-file handling anywhere in it, so a pattern that reads a data file could not be converted without turning that lane red. Adding the flags there would have fixed that runner and left the next one to be found the same way.

So the scan follows the declaration already in the source. `collectDataFileNames` parses a module and returns the paths its `dataFile()` calls name, as the import scan beside it returns the specifiers its imports name. Only a call to the runtime's own `dataFile` counts: the binding is followed through a renaming import and a namespace import, a type-only import binds no value and declares nothing, and a computed path cannot be read from the source at all.

The scan belongs at the resolver seam rather than in the operation that reads local files. `Engine.resolve` is where a program is assembled from a source of truth — a directory, a web address, the fabric — so that is where a `dataFile()` call is acted on, and every command that builds a program attaches the same files without being told. A program fetched over HTTP therefore carries its data files for the first time, which matters most for a piece whose origin is repointed at a web address: that path resolves the pattern afresh and until now silently dropped everything it read. Reading a data file is the resolver's own job, through a new optional `resolveDataFile`. The file system reads it strictly as UTF-8 and keeps a byte order mark that module reading would consume; a web address fetches it; a resolver without one falls back to reading it as a source, which is right wherever code and data come from the same place.

`--datafile` stays, for the two things the source cannot say: a file read by a computed path, and a file that ships with a program that does not read it. It adds to what the source declares rather than replacing it. A name with no file behind it is now refused while the program is being assembled, saying which module read it and where the file was expected.

An audit of every boundary a program crosses found the same shape in several more places: `files` carried on, and the list saying which of those entries are data left behind. `evaluateRecordGraph` took the files and then, separately, an optional list of the data among them; two callers passed the first and forgot the second, so every pattern they evaluated was recorded with its data entries unmarked. The parameter is now the program itself, and the omission is no longer expressible. `dataFiles` moves from `RuntimeProgram` down onto `Program`, where the files it names already live — the worker request that creates a page is typed `Program`, and structured clone had been carrying the field across that boundary all along with nothing in the type to say so. `compileAndRun` could not run a pattern that reads a data file at all; its parameters and the schema that reads them now carry the list. `getPatternSourceFiles` returned files without the sibling list that classifies them, so no caller could tell code from data: it is gone, and its two callers read the program. `cf piece getsrc` reports any data file the recovered source does not name, since that is exactly what a later `setsrc` cannot work out for itself.

The multi-runtime harness accepted data-file paths and forwarded them to its bootstrap worker, and nothing exercised that. A test now crosses both of its boundaries: the pattern is compiled in a worker process, so the paths travel with the request, and every other session opens the piece by id and loads the pattern from storage in a different process again. One session reads through the runtime that created the piece and another through a runtime that only ever saw the stored source.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

