### PR TITLE
A guest iframe and its host hold a channel between them

### DIFF
--- a/packages/iframe-sandbox/README.md
+++ b/packages/iframe-sandbox/README.md
@@ -100,8 +100,11 @@ frame that propagates to the inner (untrusted) frame across browsers.
 
 ## Missing Functionality
 
-- Audit the IPC communication (`postMessage()`) with origin-bounds and ensure
-  other frames can't spoof messages.
+- Audit the remaining `postMessage()` communication with origin-bounds and
+  ensure other frames can't spoof messages. This covers the host's exchange with
+  the outer frame and the alarm route out of a guest; the key/value traffic
+  between host and guest is not among it, a port being reachable only by whoever
+  holds an end.
 - Abort on unsupported browsers.
 - Further testing.
 

--- a/packages/iframe-sandbox/README.md
+++ b/packages/iframe-sandbox/README.md
@@ -38,7 +38,51 @@ via `setIframeContextHandler(handler)`. The handler is called with the `context`
 provided to the iframe, and the handler determines how values are stored and
 retrieved. See [context.ts](/common-iframe-sandbox/src/context.ts).
 
+## The guest side
+
+Guest content reaches the context through
+[guest.ts](/common-iframe-sandbox/src/guest.ts), exported as
+`@commonfabric/iframe-sandbox/guest`:
+
+```js
+import { connectGuestContext } from "@commonfabric/iframe-sandbox/guest";
+
+const guest = connectGuestContext((key, value) => {
+  // `value` is what the host read for `key`.
+});
+
+guest.subscribe("counter");
+guest.write("counter", 1);
+```
+
+The host and the guest hold the two ends of a `MessagePort`, and every message
+of this protocol crosses on it. A guest may call these operations at once: the
+port arrives once the document has loaded, and what is said before it does is
+sent when it comes, in the order it was said.
+
+`read()` does not return the value. The host answers a read the same way it
+announces a subscribed key's change, so both arrive at the handler.
+
+### Raising an alarm without a port
+
+`reportGuestError(error)` reaches the host by the guest's parent rather than by
+the port, so it works from a guest that has no working port — a document whose
+scripts a policy blocked, or one that failed before the handoff. The host
+dispatches it as a `common-iframe-error` event on the element.
+
+That route carries nothing else. It is one-way, and a guest cannot be answered
+on it; anything a guest means to say about the context goes over the port.
+
 ## How it works
+
+Three realms are involved, all in the browser: the **host** page holding the
+element, the **outer frame** it renders, and the **guest** in the inner frame.
+The outer frame carries the CSP and loads documents. It routes nothing of this
+protocol — the host hands each freshly loaded guest one end of a `MessagePort`,
+and the two talk directly.
+
+The one thing the outer frame passes along is whatever the guest posts to it,
+which it forwards without reading, that being the alarm route described above.
 
 `common-iframe-sandbox` is a [Lit] element that manages rendering content in an
 iframe, using [CSP]. Due to

--- a/packages/iframe-sandbox/deno-web-test.config.ts
+++ b/packages/iframe-sandbox/deno-web-test.config.ts
@@ -1,4 +1,9 @@
 export default {
+  // The guest runs in an iframe the test page creates, which loads its module
+  // by URL and so cannot share the test's own bundle.
+  bundle: {
+    "src/guest.ts": "guest.js",
+  },
   esbuildConfig: {
     supported: {
       using: false,

--- a/packages/iframe-sandbox/deno.jsonc
+++ b/packages/iframe-sandbox/deno.jsonc
@@ -2,7 +2,9 @@
   // Dependency guide: ../../docs/development/DEPENDENCIES.md
   "name": "@commonfabric/iframe-sandbox",
   "tasks": {
-    "test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts"
+    // The first two run in Deno; the rest need a browser, so they are named
+    // for `deno-web-test` rather than swept up by a glob.
+    "test": "deno test --allow-read test/guest.test.ts test/ipc.test.ts && deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/iframe.test.ts test/iframe-csp.test.ts"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/iframe-sandbox/deno.jsonc
+++ b/packages/iframe-sandbox/deno.jsonc
@@ -4,5 +4,8 @@
   "tasks": {
     "test": "deno run --allow-env --allow-read --allow-write --allow-run --allow-net ../deno-web-test/cli.ts test/*.test.ts"
   },
-  "exports": "./src/index.ts"
+  "exports": {
+    ".": "./src/index.ts",
+    "./guest": "./src/guest.ts"
+  }
 }

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -53,9 +53,10 @@ export class CommonIframeSandboxElement extends LitElement {
   private subscriptions: Map<string, Receipt> = new Map();
 
   /**
-   * Handles the outer frame reporting itself ready, which it does once per
-   * document it loads into that frame. Loads `src` if there is one to load;
-   * otherwise the next assignment to `src` does it.
+   * Handles the outer frame reporting itself ready, which it does once, on its
+   * own load. The guest documents that follow are each announced by their own
+   * load rather than by this. Loads `src` if there is one; otherwise the next
+   * assignment to `src` does it.
    */
   private onOuterReady() {
     if (this.initialized) {
@@ -69,9 +70,8 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * Gives the newly loaded guest one end of a fresh channel and takes the
-   * other. Each document is its own realm, so each gets its own port; a
-   * previous one is already closed by the time this runs, `loadInnerDoc()`
-   * having closed it as it asked for the replacement.
+   * other. Each document is its own realm, so each gets a port of its own, and
+   * no earlier one is left open behind it.
    */
   private openGuestPort() {
     this.closeGuestPort();

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -53,16 +53,19 @@ export class CommonIframeSandboxElement extends LitElement {
   private subscriptions: Map<string, Receipt> = new Map();
 
   /**
-   * Handles the outer frame reporting itself ready, which it does once, on its
-   * own load. The guest documents that follow are each announced by their own
-   * load rather than by this. Loads `src` if there is one; otherwise the next
-   * assignment to `src` does it.
+   * Handles the outer frame reporting itself ready, which it does on its own
+   * load. That is once for an element that stays where it is, and again each
+   * time the frame reloads -- which detaching the element and reattaching it
+   * does. The guest documents in between are each announced by their own load
+   * rather than by this.
+   *
+   * Whatever the previous frame held went with it, so this lets go of that
+   * guest and loads `src` into the new frame. With no `src`, the next
+   * assignment to one does the loading.
    */
   private onOuterReady() {
-    if (this.initialized) {
-      throw new Error(`common-iframe-sandbox: Already initialized.`);
-    }
     this.initialized = true;
+    this.releaseGuest();
     if (this.src) {
       this.loadInnerDoc();
     }
@@ -283,17 +286,14 @@ export class CommonIframeSandboxElement extends LitElement {
   }
 
   /**
-   * Asks the outer frame to load `src`, and lets go of the guest that is being
-   * replaced: its subscriptions are cancelled and its port is closed here
-   * rather than when the replacement arrives, so it cannot write over the
-   * interval in which it is still running and already superseded.
+   * Lets go of the current guest, if there is one: its subscriptions are
+   * cancelled and its port is closed. Called where a guest stops being this
+   * element's, which is when one is asked to be replaced and when the frame
+   * holding it has gone.
    */
-  private loadInnerDoc() {
-    this.loadState = "loading";
+  private releaseGuest() {
     this.closeGuestPort();
 
-    // Remove all active subscriptions when navigating
-    // to a new document.
     const IframeHandler = getIframeContextHandler();
     if (IframeHandler != null) {
       for (const [_, receipt] of this.subscriptions) {
@@ -301,7 +301,16 @@ export class CommonIframeSandboxElement extends LitElement {
       }
       this.subscriptions.clear();
     }
+  }
 
+  /**
+   * Asks the outer frame to load `src`, letting go of the guest being replaced
+   * first, so that guest cannot write over the interval in which it is still
+   * running and already superseded.
+   */
+  private loadInnerDoc() {
+    this.loadState = "loading";
+    this.releaseGuest();
     this.toOuterFrame({
       type: IPC.IPCHostMessageType.LoadDocument,
       data: this.src,

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -45,14 +45,18 @@ export class CommonIframeSandboxElement extends LitElement {
   `;
 
   #src = "";
+
+  /** The host's end of the channel to the current guest, while there is one. */
   private guestPort: MessagePort | undefined;
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
   private initialized: boolean = false;
   private subscriptions: Map<string, Receipt> = new Map();
 
-  // Called when the outer frame emits
-  // `IPCGuestMessageType.Ready`, only once, upon
-  // the initial render.
+  /**
+   * Handles the outer frame reporting itself ready, which it does once per
+   * document it loads into that frame. Loads `src` if there is one to load;
+   * otherwise the next assignment to `src` does it.
+   */
   private onOuterReady() {
     if (this.initialized) {
       throw new Error(`common-iframe-sandbox: Already initialized.`);
@@ -63,13 +67,14 @@ export class CommonIframeSandboxElement extends LitElement {
     }
   }
 
-  // Gives the newly loaded guest one end of a fresh channel, and takes the
-  // other. Each document is its own realm, so each gets its own port and the
-  // previous one is closed rather than left to be answered by a realm that no
-  // longer exists.
+  /**
+   * Gives the newly loaded guest one end of a fresh channel and takes the
+   * other. Each document is its own realm, so each gets its own port; a
+   * previous one is already closed by the time this runs, `loadInnerDoc()`
+   * having closed it as it asked for the replacement.
+   */
   private openGuestPort() {
-    this.guestPort?.close();
-    this.guestPort = undefined;
+    this.closeGuestPort();
 
     // The guest is the inner frame, which is a frame of the outer one. A
     // cross-origin frame is unreachable for anything but this: indexed access
@@ -87,7 +92,26 @@ export class CommonIframeSandboxElement extends LitElement {
     guestWindow.postMessage(IPC.GUEST_PORT_HANDOFF, "*", [channel.port2]);
   }
 
+  /**
+   * Closes the port to the current guest, if there is one. What the guest sends
+   * afterwards reaches nothing, which is the point: the guest on the other end
+   * of a closed port is one this element is done with.
+   */
+  private closeGuestPort() {
+    this.guestPort?.close();
+    this.guestPort = undefined;
+  }
+
+  /**
+   * Handles a message on the port to the guest. A detached element ignores
+   * one: the guest may have sent it before the element left the document, and
+   * a write reaching the context handler from outside the document's lifetime
+   * is not this element's to make.
+   */
   private onGuestPortMessage = (event: MessageEvent) => {
+    if (!this.isConnected) {
+      return;
+    }
     if (!IPC.isGuestMessage(event.data)) {
       console.error(
         "common-iframe-sandbox: Malformed message from guest.",
@@ -98,7 +122,7 @@ export class CommonIframeSandboxElement extends LitElement {
     this.onGuestMessage(event.data);
   };
 
-  // Message from the outer frame.
+  /** Handles a message from the outer frame. */
   private onMessage = (event: MessageEvent) => {
     if (event.source !== this.iframeRef.value?.contentWindow) {
       return;
@@ -153,6 +177,10 @@ export class CommonIframeSandboxElement extends LitElement {
     }
   };
 
+  /**
+   * Dispatches `common-iframe-error` for an error the guest raised, by either
+   * of the routes one can arrive on.
+   */
   private dispatchGuestError(
     { description, source, lineno, colno, stacktrace }: IPC.GuestError,
   ) {
@@ -173,7 +201,7 @@ export class CommonIframeSandboxElement extends LitElement {
     );
   }
 
-  // Message from the inner frame.
+  /** Handles a message the guest sent, on whichever route carried it. */
   private onGuestMessage(message: IPC.GuestMessage) {
     const IframeHandler = getIframeContextHandler();
     if (IframeHandler == null) {
@@ -254,8 +282,16 @@ export class CommonIframeSandboxElement extends LitElement {
     }
   }
 
+  /**
+   * Asks the outer frame to load `src`, and lets go of the guest that is being
+   * replaced: its subscriptions are cancelled and its port is closed here
+   * rather than when the replacement arrives, so it cannot write over the
+   * interval in which it is still running and already superseded.
+   */
   private loadInnerDoc() {
     this.loadState = "loading";
+    this.closeGuestPort();
+
     // Remove all active subscriptions when navigating
     // to a new document.
     const IframeHandler = getIframeContextHandler();
@@ -272,30 +308,40 @@ export class CommonIframeSandboxElement extends LitElement {
     });
   }
 
+  /** Tells the guest that `key` now holds `value`. */
   private notifySubscribers(key: string, value: unknown) {
     this.toGuest({ type: IPC.HostMessageType.Update, data: [key, value] });
   }
 
+  /** Sends `message` to the outer frame. */
   private toOuterFrame(message: IPC.IPCHostMessage) {
     this.iframeRef.value?.contentWindow?.postMessage(message, "*");
   }
 
+  /**
+   * Sends `message` to the guest. Does nothing when there is no port, which is
+   * every moment outside a loaded guest's lifetime.
+   */
   private toGuest(message: IPC.HostMessage) {
     this.guestPort?.postMessage(message);
   }
 
+  /** The outer frame's message listener, as `globalThis` holds it. */
   private boundOnMessage = this.onMessage.bind(this);
 
+  /** @inheritDoc */
   override connectedCallback() {
     super.connectedCallback();
     globalThis.addEventListener("message", this.boundOnMessage);
   }
 
+  /** @inheritDoc */
   override disconnectedCallback() {
     super.disconnectedCallback();
     globalThis.removeEventListener("message", this.boundOnMessage);
   }
 
+  /** @inheritDoc */
   override render() {
     return html`
       <iframe

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 import { createRef, Ref, ref } from "lit/directives/ref.js";
 import * as IPC from "./ipc.ts";
-import { getIframeContextHandler, Receipt } from "./context.ts";
+import { type Context, getIframeContextHandler, Receipt } from "./context.ts";
 import OuterFrame from "./outer-frame.ts";
 
 type CommonIframeLoadState = "" | "loading" | "loaded";
@@ -56,7 +56,14 @@ export class CommonIframeSandboxElement extends LitElement {
    * context, so the frame reattaching brings is a different window.
    */
   private readyWindow: Window | undefined;
-  private subscriptions: Map<string, Receipt> = new Map();
+  /**
+   * The guest's live subscriptions by key, each held with the context it was
+   * taken out against. A receipt is only good to the context that issued it,
+   * and `context` is a property a consumer may reassign, so what cancels a
+   * subscription is the pair rather than the receipt alone.
+   */
+  private subscriptions: Map<string, { context: Context; receipt: Receipt }> =
+    new Map();
 
   /**
    * Handles the outer frame reporting itself ready, which it does on its own
@@ -278,7 +285,7 @@ export class CommonIframeSandboxElement extends LitElement {
             (key, value) => this.notifySubscribers(key, value),
             doNotSendMyDataBack,
           );
-          this.subscriptions.set(key, receipt);
+          this.subscriptions.set(key, { context: this.context, receipt });
         }
         return;
       }
@@ -291,11 +298,11 @@ export class CommonIframeSandboxElement extends LitElement {
         for (const key of keys) {
           // A receipt is opaque and may be any value the handler returns,
           // including falsy ones like `0`. Test for the entry, not the value.
-          if (!this.subscriptions.has(key)) {
+          const entry = this.subscriptions.get(key);
+          if (entry === undefined) {
             continue;
           }
-          const receipt = this.subscriptions.get(key);
-          IframeHandler.unsubscribe(this, this.context, receipt);
+          IframeHandler.unsubscribe(this, entry.context, entry.receipt);
           this.subscriptions.delete(key);
         }
         return;
@@ -305,7 +312,8 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * Lets go of the current guest, if there is one: its subscriptions are
-   * cancelled and its port is closed. Called where a guest stops being this
+   * cancelled, each against the context it was taken out against, and its port
+   * is closed. Called where a guest stops being this
    * element's, which is when one is asked to be replaced and when the frame
    * holding it has gone.
    */
@@ -314,8 +322,8 @@ export class CommonIframeSandboxElement extends LitElement {
 
     const IframeHandler = getIframeContextHandler();
     if (IframeHandler != null) {
-      for (const [_, receipt] of this.subscriptions) {
-        IframeHandler.unsubscribe(this, this.context, receipt);
+      for (const { context, receipt } of this.subscriptions.values()) {
+        IframeHandler.unsubscribe(this, context, receipt);
       }
       this.subscriptions.clear();
     }

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -5,8 +5,6 @@ import * as IPC from "./ipc.ts";
 import { getIframeContextHandler, Receipt } from "./context.ts";
 import OuterFrame from "./outer-frame.ts";
 
-let FRAME_IDS = 0;
-
 type CommonIframeLoadState = "" | "loading" | "loaded";
 
 // @summary A sandboxed iframe to execute arbitrary scripts.
@@ -46,9 +44,8 @@ export class CommonIframeSandboxElement extends LitElement {
     }
   `;
 
-  // Static id for this component for its lifetime.
-  private frameId: number = ++FRAME_IDS;
   #src = "";
+  private guestPort: MessagePort | undefined;
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
   private initialized: boolean = false;
   private subscriptions: Map<string, Receipt> = new Map();
@@ -61,14 +58,45 @@ export class CommonIframeSandboxElement extends LitElement {
       throw new Error(`common-iframe-sandbox: Already initialized.`);
     }
     this.initialized = true;
-    this.toGuest({
-      id: this.frameId,
-      type: IPC.IPCHostMessageType.Init,
-    });
     if (this.src) {
       this.loadInnerDoc();
     }
   }
+
+  // Gives the newly loaded guest one end of a fresh channel, and takes the
+  // other. Each document is its own realm, so each gets its own port and the
+  // previous one is closed rather than left to be answered by a realm that no
+  // longer exists.
+  private openGuestPort() {
+    this.guestPort?.close();
+    this.guestPort = undefined;
+
+    // The guest is the inner frame, which is a frame of the outer one. A
+    // cross-origin frame is unreachable for anything but this: indexed access
+    // and `postMessage`, which is what a transfer rides.
+    const guestWindow = this.iframeRef.value?.contentWindow?.frames[0];
+    if (!guestWindow) {
+      console.error("common-iframe-sandbox: No guest frame to open a port to.");
+      return;
+    }
+
+    const channel = new MessageChannel();
+    this.guestPort = channel.port1;
+    channel.port1.onmessage = this.onGuestPortMessage;
+    channel.port1.start();
+    guestWindow.postMessage(IPC.GUEST_PORT_HANDOFF, "*", [channel.port2]);
+  }
+
+  private onGuestPortMessage = (event: MessageEvent) => {
+    if (!IPC.isGuestMessage(event.data)) {
+      console.error(
+        "common-iframe-sandbox: Malformed message from guest.",
+        event.data,
+      );
+      return;
+    }
+    this.onGuestMessage(event.data);
+  };
 
   // Message from the outer frame.
   private onMessage = (event: MessageEvent) => {
@@ -88,26 +116,62 @@ export class CommonIframeSandboxElement extends LitElement {
 
     switch (outerMessage.type) {
       case IPC.IPCGuestMessageType.Load: {
+        this.openGuestPort();
         this.loadState = "loaded";
         this.dispatchEvent(new CustomEvent("load"));
         return;
       }
-      case IPC.IPCGuestMessageType.Error: {
+      case IPC.IPCGuestMessageType.OuterError: {
         console.error(
-          `common-iframe-sandbox: Error from outer frame: ${outerMessage.data}`,
+          "common-iframe-sandbox: Error from outer frame:",
+          outerMessage.data,
         );
+        return;
+      }
+      case IPC.IPCGuestMessageType.GuestError: {
+        // The guest raised this outside its port, and the outer frame passed
+        // it along without reading it, so this is the first look anything has
+        // had at it.
+        const raised = outerMessage.data;
+        if (
+          IPC.isGuestMessage(raised) &&
+          raised.type === IPC.GuestMessageType.Error
+        ) {
+          this.dispatchGuestError(raised.data);
+        } else {
+          console.error(
+            "common-iframe-sandbox: Unreadable alarm from guest.",
+            raised,
+          );
+        }
         return;
       }
       case IPC.IPCGuestMessageType.Ready: {
         this.onOuterReady();
         return;
       }
-      case IPC.IPCGuestMessageType.Passthrough: {
-        this.onGuestMessage(outerMessage.data);
-        return;
-      }
     }
   };
+
+  private dispatchGuestError(
+    { description, source, lineno, colno, stacktrace }: IPC.GuestError,
+  ) {
+    this.dispatchEvent(
+      new CustomEvent("common-iframe-error", {
+        detail: {
+          description,
+          message: description,
+          source,
+          lineno,
+          colno,
+          stacktrace,
+          stack: stacktrace,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
 
   // Message from the inner frame.
   private onGuestMessage(message: IPC.GuestMessage) {
@@ -124,38 +188,14 @@ export class CommonIframeSandboxElement extends LitElement {
 
     switch (message.type) {
       case IPC.GuestMessageType.Error: {
-        const { description, source, lineno, colno, stacktrace } = message.data;
-        const error = {
-          description,
-          message: description,
-          source,
-          lineno,
-          colno,
-          stacktrace,
-          stack: stacktrace,
-        };
-
-        this.dispatchEvent(
-          new CustomEvent("common-iframe-error", {
-            detail: error,
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        this.dispatchGuestError(message.data);
         return;
       }
 
       case IPC.GuestMessageType.Read: {
         const key = message.data;
         const value = IframeHandler.read(this, this.context, key);
-        this.toGuest({
-          id: this.frameId,
-          type: IPC.IPCHostMessageType.Passthrough,
-          data: {
-            type: IPC.HostMessageType.Update,
-            data: [key, value],
-          },
-        });
+        this.toGuest({ type: IPC.HostMessageType.Update, data: [key, value] });
         return;
       }
 
@@ -226,27 +266,22 @@ export class CommonIframeSandboxElement extends LitElement {
       this.subscriptions.clear();
     }
 
-    this.toGuest({
-      id: this.frameId,
+    this.toOuterFrame({
       type: IPC.IPCHostMessageType.LoadDocument,
       data: this.src,
     });
   }
 
   private notifySubscribers(key: string, value: unknown) {
-    const response: IPC.IPCHostMessage = {
-      id: this.frameId,
-      type: IPC.IPCHostMessageType.Passthrough,
-      data: {
-        type: IPC.HostMessageType.Update,
-        data: [key, value],
-      },
-    };
-    this.toGuest(response);
+    this.toGuest({ type: IPC.HostMessageType.Update, data: [key, value] });
   }
 
-  private toGuest(event: IPC.IPCHostMessage) {
-    this.iframeRef.value?.contentWindow?.postMessage(event, "*");
+  private toOuterFrame(message: IPC.IPCHostMessage) {
+    this.iframeRef.value?.contentWindow?.postMessage(message, "*");
+  }
+
+  private toGuest(message: IPC.HostMessage) {
+    this.guestPort?.postMessage(message);
   }
 
   private boundOnMessage = this.onMessage.bind(this);

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -62,12 +62,14 @@ export class CommonIframeSandboxElement extends LitElement {
    * Handles the outer frame reporting itself ready, which it does on its own
    * load. That is once for an element that stays where it is, and again each
    * time the frame reloads -- which detaching the element and reattaching it
-   * does. The guest documents in between are each announced by their own load
+   * across a turn of the event loop does, a move within one leaving the frame
+   * alone. The guest documents in between are each announced by their own load
    * rather than by this.
    *
    * Whatever the previous frame held went with it, so this lets go of that
-   * guest and loads `src` into the new frame. With no `src`, the next
-   * assignment to one does the loading.
+   * guest and loads `src` into the new frame. With no `src` there is nothing
+   * to load and nothing loaded, which is what the load state then says; the
+   * next assignment to one does the loading.
    *
    * `source` is the window that reported it, and a second report from the one
    * already in hand is refused: a frame says this once, so hearing it twice
@@ -82,6 +84,8 @@ export class CommonIframeSandboxElement extends LitElement {
     this.releaseGuest();
     if (this.src) {
       this.loadInnerDoc();
+    } else {
+      this.loadState = "";
     }
   }
 
@@ -319,8 +323,10 @@ export class CommonIframeSandboxElement extends LitElement {
 
   /**
    * Asks the outer frame to load `src`, letting go of the guest being replaced
-   * first, so that guest cannot write over the interval in which it is still
-   * running and already superseded.
+   * before asking rather than once the replacement arrives. What that guest
+   * sends over the interval between the two reaches a closed port, which is
+   * the whole of what this end can promise about a document still running in a
+   * frame it has asked to be rid of.
    */
   private loadInnerDoc() {
     this.loadState = "loading";

--- a/packages/iframe-sandbox/src/common-iframe-sandbox.ts
+++ b/packages/iframe-sandbox/src/common-iframe-sandbox.ts
@@ -23,7 +23,7 @@ export class CommonIframeSandboxElement extends LitElement {
     const previousValue = this.#src;
     this.#src = value;
     this.requestUpdate("src", previousValue);
-    if (this.initialized && value !== previousValue) {
+    if (this.readyWindow && value !== previousValue) {
       this.loadInnerDoc();
     }
   }
@@ -49,7 +49,13 @@ export class CommonIframeSandboxElement extends LitElement {
   /** The host's end of the channel to the current guest, while there is one. */
   private guestPort: MessagePort | undefined;
   private iframeRef: Ref<HTMLIFrameElement> = createRef();
-  private initialized: boolean = false;
+  /**
+   * The outer-frame window whose `ready` this element last acted on, once one
+   * has. Its identity is what tells a frame that has been replaced from the
+   * one already in hand: detaching the element discards the frame's browsing
+   * context, so the frame reattaching brings is a different window.
+   */
+  private readyWindow: Window | undefined;
   private subscriptions: Map<string, Receipt> = new Map();
 
   /**
@@ -62,9 +68,17 @@ export class CommonIframeSandboxElement extends LitElement {
    * Whatever the previous frame held went with it, so this lets go of that
    * guest and loads `src` into the new frame. With no `src`, the next
    * assignment to one does the loading.
+   *
+   * `source` is the window that reported it, and a second report from the one
+   * already in hand is refused: a frame says this once, so hearing it twice
+   * from the same window is this element's model of the frame's lifetime being
+   * wrong rather than a frame having been replaced.
    */
-  private onOuterReady() {
-    this.initialized = true;
+  private onOuterReady(source: Window) {
+    if (source === this.readyWindow) {
+      throw new Error(`common-iframe-sandbox: Already initialized.`);
+    }
+    this.readyWindow = source;
     this.releaseGuest();
     if (this.src) {
       this.loadInnerDoc();
@@ -174,7 +188,7 @@ export class CommonIframeSandboxElement extends LitElement {
         return;
       }
       case IPC.IPCGuestMessageType.Ready: {
-        this.onOuterReady();
+        this.onOuterReady(event.source as Window);
         return;
       }
     }

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -71,15 +71,26 @@ export function connectGuestContext(onUpdate: UpdateHandler): GuestContext {
     }
   };
 
+  // The port's far end is the host, so what arrives on it is not the open
+  // question a window message is. It is still checked before being taken
+  // apart: a shape this does not recognize is one this guest has no reading
+  // of, and guessing at it would put an unnamed key in front of `onUpdate`.
   const onPortMessage = (event: MessageEvent): void => {
     const message = event.data as HostMessage | undefined;
-    if (message?.type !== HostMessageType.Update) {
+    if (
+      message?.type !== HostMessageType.Update ||
+      !Array.isArray(message.data) || message.data.length !== 2 ||
+      typeof message.data[0] !== "string"
+    ) {
       return;
     }
     const [key, value] = message.data;
     onUpdate(key, value);
   };
 
+  // A guest window receives whatever anyone able to reach it posts, so the
+  // handoff is recognized by what it says and taken only once. A second one
+  // would replace a live port with one the host is not listening on.
   const onHandoff = (event: MessageEvent): void => {
     if (port || event.data !== GUEST_PORT_HANDOFF || !event.ports[0]) {
       return;

--- a/packages/iframe-sandbox/src/guest.ts
+++ b/packages/iframe-sandbox/src/guest.ts
@@ -1,0 +1,137 @@
+/**
+ * The guest side of the `common-iframe-sandbox` boundary.
+ *
+ * A guest runs in its own realm and reaches the host's key/value context over
+ * a `MessagePort` the host hands it once its document has loaded. This module
+ * is the client for that: it takes the port when it arrives, builds the
+ * messages `./ipc.ts` describes, and hands the guest each value the host sends.
+ *
+ * The API is deliberately minimal -- it covers the operations the protocol
+ * has, plus the teardown of its own listener.
+ */
+
+import {
+  GUEST_PORT_HANDOFF,
+  type GuestError,
+  type GuestMessage,
+  GuestMessageType,
+  type HostMessage,
+  HostMessageType,
+} from "./ipc.ts";
+
+/**
+ * Called with each value the host sends: the answer to a {@link
+ * GuestContext.read}, and each update on a subscribed key.
+ */
+export type UpdateHandler = (key: string, value: unknown) => void;
+
+/**
+ * A guest's handle on the host's key/value context.
+ *
+ * `read()` does not return the value. The host answers a read the same way it
+ * announces a subscribed key's change, so both arrive at the handler given to
+ * {@link connectGuestContext}.
+ */
+export type GuestContext = {
+  /** Ask the host for `key`'s value, which arrives at the update handler. */
+  read(key: string): void;
+
+  /** Write `value` to `key`. */
+  write(key: string, value: unknown): void;
+
+  /**
+   * Subscribe to each of `keys`. A change to one reaches the update handler;
+   * the guest's own writes do not.
+   */
+  subscribe(...keys: string[]): void;
+
+  /** Unsubscribe from each of `keys`. */
+  unsubscribe(...keys: string[]): void;
+
+  /** Stop listening for the host's messages. */
+  disconnect(): void;
+};
+
+/**
+ * Connects to the host, calling `onUpdate` with each value it sends.
+ *
+ * A guest may call the result's operations at once. The port arrives after the
+ * document has loaded, and what is said before it does is sent when it comes,
+ * in the order it was said.
+ */
+export function connectGuestContext(onUpdate: UpdateHandler): GuestContext {
+  let port: MessagePort | undefined;
+  const unsent: GuestMessage[] = [];
+
+  const send = (message: GuestMessage): void => {
+    if (port) {
+      port.postMessage(message);
+    } else {
+      unsent.push(message);
+    }
+  };
+
+  const onPortMessage = (event: MessageEvent): void => {
+    const message = event.data as HostMessage | undefined;
+    if (message?.type !== HostMessageType.Update) {
+      return;
+    }
+    const [key, value] = message.data;
+    onUpdate(key, value);
+  };
+
+  const onHandoff = (event: MessageEvent): void => {
+    if (port || event.data !== GUEST_PORT_HANDOFF || !event.ports[0]) {
+      return;
+    }
+    port = event.ports[0];
+    port.onmessage = onPortMessage;
+    port.start();
+    for (const message of unsent) {
+      port.postMessage(message);
+    }
+    unsent.length = 0;
+  };
+
+  globalThis.addEventListener("message", onHandoff);
+
+  return {
+    read(key: string): void {
+      send({ type: GuestMessageType.Read, data: key });
+    },
+
+    write(key: string, value: unknown): void {
+      send({ type: GuestMessageType.Write, data: [key, value] });
+    },
+
+    subscribe(...keys: string[]): void {
+      send({ type: GuestMessageType.Subscribe, data: keys });
+    },
+
+    unsubscribe(...keys: string[]): void {
+      send({ type: GuestMessageType.Unsubscribe, data: keys });
+    },
+
+    disconnect(): void {
+      globalThis.removeEventListener("message", onHandoff);
+      port?.close();
+      port = undefined;
+    },
+  };
+}
+
+/**
+ * Raises an alarm the host dispatches as a `common-iframe-error` event on the
+ * element.
+ *
+ * This goes to the guest's parent rather than over the port, so it reaches the
+ * host from a guest that has no working port -- a document whose scripts a
+ * policy blocked, or one that failed before the handoff. It is the one thing
+ * that route carries, and it is one-way: a guest cannot be answered on it.
+ */
+export function reportGuestError(error: GuestError): void {
+  globalThis.parent.postMessage(
+    { type: GuestMessageType.Error, data: error },
+    "*",
+  );
+}

--- a/packages/iframe-sandbox/src/ipc.ts
+++ b/packages/iframe-sandbox/src/ipc.ts
@@ -1,93 +1,86 @@
 // Types used by the `common-iframe-sandbox` IPC.
 
-// Diagram of the IPC messages between the Host
-// environment, and the intermediary guest iframe.
+// Diagram of the messages between the Host environment, the intermediary outer
+// frame, and the guest in the inner frame.
 //
-// ┌──────────────┐              ┌───────────────┐
-// │     Host     │              │     Guest     │
-// └───────┬──────┘              └───────┬───────┘
-//         │                             │
-//         │◄───────────READY────────────┤
-//         │                             │
-//         ├────────────INIT────────────►│
-//    ┌───►│                             │
-//    │    ├────────LOAD-DOCUMENT───────►│
-//    │    │                             │
-//    │    │◄───────────LOAD─────────────┤
-//    │    │                             │◄───┐
-//    │    │◄────────PASSTHROUGH────────►│    │
-//    │    ▼                             ▼    │
-//    └────┘                             └────┘
+// ┌──────────────┐        ┌───────────────┐        ┌───────────────┐
+// │     Host     │        │  Outer frame  │        │     Guest     │
+// └───────┬──────┘        └───────┬───────┘        └───────┬───────┘
+//         │                       │                        │
+//         │◄────────READY─────────┤                        │
+//         │                       │                        │
+//         ├─────LOAD-DOCUMENT────►│                        │
+//         │                       ├────────srcdoc─────────►│
+//         │◄─────────LOAD─────────┤                        │
+//         │                       │                        │
+//         ├──────────────────PORT (transferred)───────────►│
+//         │◄═════════════════════ port ═══════════════════►│
+//         │                       │                        │
+//         │◄──────ERROR───────────┤◄───────(unread)────────┤
+//
+// The host and the guest hold the two ends of a `MessagePort` and every
+// message of the key/value protocol -- `HostMessage` and `GuestMessage` --
+// crosses on it. The outer frame carries the CSP and loads documents; it
+// relays nothing that protocol says.
+//
+// The one thing it does pass along is whatever the guest posts to it, which it
+// forwards without reading. A guest has a port for everything it means to say,
+// so a message arriving by that route is a guest reporting that it could not
+// use the port -- a way to raise an alarm, not a second way to talk.
+
+/**
+ * Sent alongside the transferred port, so a guest recognizes the handoff by
+ * what the message says rather than by having to treat every arriving message
+ * as a candidate.
+ */
+export const GUEST_PORT_HANDOFF = "common-iframe-sandbox:port";
 
 export enum IPCHostMessageType {
-  // Host initializing guest with data (namely, ID).
-  Init = "init",
-  // Host instructing guest to load a new document.
+  // Host instructing the outer frame to load a new document.
   LoadDocument = "load-document",
-  // Host instructing guest to pass through a `HostMessage`.
-  Passthrough = "passthrough",
 }
 
-/**
- * Messages from the system to the host. In case of passthrough it is system
- * sending message to the guest through the host.
- */
-export type IPCHostMessage =
-  | { id: number; type: IPCHostMessageType.Init }
-  | { id: number; type: IPCHostMessageType.LoadDocument; data: string }
-  | { id: number; type: IPCHostMessageType.Passthrough; data: HostMessage };
+/** A message from the host to the outer frame. */
+export type IPCHostMessage = {
+  type: IPCHostMessageType.LoadDocument;
+  data: string;
+};
 
 export enum IPCGuestMessageType {
-  // Guest alerting the host that it is ready.
+  // Outer frame alerting the host that it is ready.
   Ready = "ready",
-  // An error occurred in the outer frame.
-  Error = "error",
-  // Guest inner frame has loaded.
+  // Outer frame's inner document has loaded, so there is a guest to hand a
+  // port to.
   Load = "load",
-  // Guest passing a `GuestMessage`.
-  Passthrough = "passthrough",
+  // An error in the outer frame itself.
+  OuterError = "outer-error",
+  // An error the guest raised outside its port.
+  GuestError = "guest-error",
 }
 
-/**
- * Messages from the host to the system and in case of pass through it is guest
- * message routed through the host.
- */
+/** A message from the outer frame to the host. */
 export type IPCGuestMessage =
   | { type: IPCGuestMessageType.Ready }
-  | { id: number; type: IPCGuestMessageType.Load }
-  | { id: number; type: IPCGuestMessageType.Error; data: unknown }
-  | { id: number; type: IPCGuestMessageType.Passthrough; data: GuestMessage };
+  | { type: IPCGuestMessageType.Load }
+  | { type: IPCGuestMessageType.OuterError; data: unknown }
+  | { type: IPCGuestMessageType.GuestError; data: unknown };
 
 export function isIPCGuestMessage(
   message: unknown,
 ): message is IPCGuestMessage {
-  if (typeof message !== "object" || message === null) {
-    return false;
-  }
-  if (!("type" in message)) {
+  if (
+    typeof message !== "object" || message === null || !("type" in message)
+  ) {
     return false;
   }
   switch (message.type) {
-    case IPCGuestMessageType.Ready: {
+    case IPCGuestMessageType.Ready:
+    case IPCGuestMessageType.Load: {
       return true;
     }
-    case IPCGuestMessageType.Error:
-    case IPCGuestMessageType.Passthrough:
-    case IPCGuestMessageType.Load: {
-      if (
-        message.type !== IPCGuestMessageType.Load &&
-        (!("data" in message) || message.data == null)
-      ) {
-        return false;
-      }
-      if (
-        message.type === IPCGuestMessageType.Passthrough &&
-        "data" in message &&
-        !isGuestMessage(message.data)
-      ) {
-        return false;
-      }
-      return ("id" in message) && message.id != null;
+    case IPCGuestMessageType.OuterError:
+    case IPCGuestMessageType.GuestError: {
+      return "data" in message && message.data != null;
     }
   }
   return false;

--- a/packages/iframe-sandbox/src/outer-frame.ts
+++ b/packages/iframe-sandbox/src/outer-frame.ts
@@ -36,6 +36,7 @@ const iframe = document.querySelector("iframe");
 const HOST_ORIGIN = "${HOST_ORIGIN}";
 const HOST_WINDOW = window.parent;
 const INNER_WINDOW = iframe.contentWindow;
+let documentAsked = false;
 
 iframe.addEventListener("load", onInnerLoad);
 window.addEventListener("message", onMessage);
@@ -57,11 +58,19 @@ function onMessage(e) {
   }
 
   if (e.data && e.data.type === "load-document") {
+    documentAsked = true;
     iframe.srcdoc = e.data.data;
   }
 }
 
 function onInnerLoad(e) {
+  // The frame fires this for the empty document it starts on, before there is
+  // a guest at all. Reporting that one would announce a load the host never
+  // asked for and offer a port to nothing, so the first document the host asks
+  // for is where this starts counting.
+  if (!documentAsked) {
+    return;
+  }
   // The host takes this as its cue to hand the new document a port: a fresh
   // document is a fresh realm, and the port the previous one held died with
   // it.

--- a/packages/iframe-sandbox/src/outer-frame.ts
+++ b/packages/iframe-sandbox/src/outer-frame.ts
@@ -36,7 +36,6 @@ const iframe = document.querySelector("iframe");
 const HOST_ORIGIN = "${HOST_ORIGIN}";
 const HOST_WINDOW = window.parent;
 const INNER_WINDOW = iframe.contentWindow;
-let FRAME_ID = null;
 
 iframe.addEventListener("load", onInnerLoad);
 window.addEventListener("message", onMessage);
@@ -45,76 +44,47 @@ window.addEventListener("error", onOuterError);
 toHost({ type: "ready" });
 
 function onMessage(e) {
-  if (!e.data || typeof e.data.type !== "string") {
-    return;
-  }
-
+  // Anything the guest posts here is forwarded without being read. It has a
+  // port for everything the key/value protocol says, so this route carries
+  // only a guest reporting that it could not use that port.
   if (e.source === INNER_WINDOW) {
-    assertInitialized();
-    toHost({
-      id: FRAME_ID,
-      type: "passthrough",
-      data: e.data,
-    });
+    toHost({ type: "guest-error", data: e.data });
     return;
   }
 
-  if (e.source === HOST_WINDOW && e.origin === HOST_ORIGIN) {
-    // Handle initialization, receiving the frame ID.
-    if (FRAME_ID == null && e.data.type === "init") {
-      FRAME_ID = e.data.id;
-      return;
-    }
+  if (e.source !== HOST_WINDOW || e.origin !== HOST_ORIGIN) {
+    return;
+  }
 
-    if (FRAME_ID == null || FRAME_ID !== e.data.id) {
-      return;
-    }
-
-    switch (e.data.type) {
-      case "init": {
-        // There shouldn't be a second "init" command.
-        return;
-      }
-      case "load-document": {
-        iframe.srcdoc = e.data.data;
-        return;
-      }
-      case "passthrough": {
-        toInner(e.data.data);
-        return;
-      }
-    }
+  if (e.data && e.data.type === "load-document") {
+    iframe.srcdoc = e.data.data;
   }
 }
 
 function onInnerLoad(e) {
-  // The iframe can fire its load event before
-  // loading the srcdoc contents in some browsers.
-  // Ignore, and wait for initialization to occur.
-  if (FRAME_ID == null) {
-    return;
-  }
-  toHost({ type: "load", id: FRAME_ID });
+  // The host takes this as its cue to hand the new document a port: a fresh
+  // document is a fresh realm, and the port the previous one held died with
+  // it.
+  toHost({ type: "load" });
 }
 
 function onOuterError({ message, filename, lineno, colno, error }) {
-  // Not all browsers can directly send the \`ErrorEvent\` object.
-  toHost({ type: "error", id: FRAME_ID, data: { message, filename, lineno, colno, error }})
-}
-
-function assertInitialized() {
-  if (FRAME_ID == null) {
-    throw new Error("Expected frame to be assigned an id.");
-  }
+  // Not all browsers can directly send the \`ErrorEvent\` object, and the one
+  // named \`error\` does not survive the crossing with its class, so what goes
+  // is what reads back.
+  toHost({ type: "outer-error", data: {
+    message,
+    filename,
+    lineno,
+    colno,
+    error: error && error.stack ? error.stack : String(error),
+  }})
 }
 
 function toHost(data) {
   HOST_WINDOW.postMessage(data, HOST_ORIGIN);
 }
 
-function toInner(data) {
-  INNER_WINDOW.postMessage(data, "*");
-}
 	<\/script>
 <\/body>
 <\/html>

--- a/packages/iframe-sandbox/test/guest.test.ts
+++ b/packages/iframe-sandbox/test/guest.test.ts
@@ -1,0 +1,176 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { connectGuestContext, reportGuestError } from "../src/guest.ts";
+import {
+  GUEST_PORT_HANDOFF,
+  type GuestMessage,
+  GuestMessageType,
+  HostMessageType,
+} from "../src/ipc.ts";
+
+// Stands in for the host: holds the far end of the channel, and delivers the
+// handoff the way a window message carrying a transferred port arrives.
+function handOffPort(): MessagePort {
+  const channel = new MessageChannel();
+  channel.port1.start();
+  globalThis.dispatchEvent(
+    new MessageEvent("message", {
+      data: GUEST_PORT_HANDOFF,
+      ports: [channel.port2],
+    }),
+  );
+  return channel.port1;
+}
+
+// Resolves with the next `count` messages the host end receives.
+function received(port: MessagePort, count: number): Promise<GuestMessage[]> {
+  const messages: GuestMessage[] = [];
+  return new Promise((resolve) => {
+    port.onmessage = (event: MessageEvent) => {
+      messages.push(event.data as GuestMessage);
+      if (messages.length === count) resolve(messages);
+    };
+  });
+}
+
+// Lets whatever the ports have queued be delivered.
+function settled(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("guest", () => {
+  describe("connectGuestContext", () => {
+    it("sends what was said before the port arrived, in the order said", async () => {
+      const guest = connectGuestContext(() => {});
+      try {
+        guest.read("first");
+        guest.write("second", 2);
+        guest.subscribe("third");
+
+        const host = handOffPort();
+        expect(await received(host, 3)).toEqual([
+          { type: GuestMessageType.Read, data: "first" },
+          { type: GuestMessageType.Write, data: ["second", 2] },
+          { type: GuestMessageType.Subscribe, data: ["third"] },
+        ]);
+      } finally {
+        guest.disconnect();
+      }
+    });
+
+    it("sends an unsubscribe naming every key given", async () => {
+      const guest = connectGuestContext(() => {});
+      try {
+        const host = handOffPort();
+        guest.unsubscribe("a", "b");
+        expect(await received(host, 1)).toEqual([
+          { type: GuestMessageType.Unsubscribe, data: ["a", "b"] },
+        ]);
+      } finally {
+        guest.disconnect();
+      }
+    });
+
+    it("passes an update's key and value to the handler", async () => {
+      const seen: [string, unknown][] = [];
+      const guest = connectGuestContext((key, value) =>
+        seen.push([key, value])
+      );
+      try {
+        const host = handOffPort();
+        host.postMessage({
+          type: HostMessageType.Update,
+          data: ["counted", 9n],
+        });
+        await settled();
+        expect(seen).toEqual([["counted", 9n]]);
+      } finally {
+        guest.disconnect();
+      }
+    });
+
+    it("ignores port traffic that is not an update it can read", async () => {
+      const seen: [string, unknown][] = [];
+      const guest = connectGuestContext((key, value) =>
+        seen.push([key, value])
+      );
+      try {
+        const host = handOffPort();
+        for (
+          const bad of [
+            undefined,
+            { type: "something-else" },
+            { type: HostMessageType.Update },
+            { type: HostMessageType.Update, data: ["solo"] },
+            { type: HostMessageType.Update, data: [7, "non-string key"] },
+          ]
+        ) {
+          host.postMessage(bad);
+        }
+        await settled();
+        expect(seen).toEqual([]);
+      } finally {
+        guest.disconnect();
+      }
+    });
+
+    it("keeps the first port it is given", async () => {
+      const guest = connectGuestContext(() => {});
+      try {
+        const host = handOffPort();
+        handOffPort();
+        guest.write("k", 1);
+        expect(await received(host, 1)).toEqual([
+          { type: GuestMessageType.Write, data: ["k", 1] },
+        ]);
+      } finally {
+        guest.disconnect();
+      }
+    });
+
+    it("stops listening once disconnected", async () => {
+      const seen: [string, unknown][] = [];
+      const guest = connectGuestContext((key, value) =>
+        seen.push([key, value])
+      );
+      const host = handOffPort();
+      guest.disconnect();
+
+      host.postMessage({ type: HostMessageType.Update, data: ["late", 1] });
+      await settled();
+      expect(seen).toEqual([]);
+    });
+  });
+
+  describe("reportGuestError", () => {
+    it("posts the error to the guest's parent", () => {
+      const posted: unknown[] = [];
+      const parent = { postMessage: (data: unknown) => posted.push(data) };
+      const original = Reflect.get(globalThis, "parent");
+      Reflect.set(globalThis, "parent", parent);
+      try {
+        reportGuestError({
+          description: "boom",
+          source: "s",
+          lineno: 1,
+          colno: 2,
+          stacktrace: "st",
+        });
+      } finally {
+        Reflect.set(globalThis, "parent", original);
+      }
+
+      expect(posted).toEqual([{
+        type: GuestMessageType.Error,
+        data: {
+          description: "boom",
+          source: "s",
+          lineno: 1,
+          colno: 2,
+          stacktrace: "st",
+        },
+      }]);
+    });
+  });
+});

--- a/packages/iframe-sandbox/test/iframe-csp.test.ts
+++ b/packages/iframe-sandbox/test/iframe-csp.test.ts
@@ -1,3 +1,5 @@
+import { defer } from "@commonfabric/utils/defer";
+
 import {
   assert,
   assertDeepEquals,
@@ -82,13 +84,11 @@ window.onerror = function (message, source, lineno, colno, error) {
 //
 // `barrierControls` below holds the conversions to it honest.
 const BARRIER = `
-<script>
-addEventListener('load', () => {
-  window.parent.postMessage({
-    type: 'write',
-    data: ['barrier', true],
-  }, '*');
-});
+<script type="module">
+import { connectGuestContext } from "/guest.js";
+
+const guest = connectGuestContext(() => {});
+addEventListener('load', () => guest.write('barrier', true));
 </script>
 `;
 
@@ -408,11 +408,27 @@ function defineTest(
     // The event bubbles and is composed, so the document sees it. Listening
     // there rather than on the element catches an error the host dispatches
     // before `render` hands the element back.
-    const errors: unknown[] = [];
+    const errors: string[] = [];
+    let noticeError: (() => void) | undefined;
     const onError = (event: Event) => {
       errors.push((event as CustomEvent).detail.description);
+      noticeError?.();
     };
     document.addEventListener("common-iframe-error", onError);
+
+    // Resolves with the first error's description, from the collection this
+    // listener has been filling since before the frame existed. A case whose
+    // error is dispatched during the load `render` waits on has already been
+    // recorded by the time this is called.
+    const firstErrorDescription = (): Promise<string> => {
+      if (errors.length > 0) {
+        return Promise.resolve(errors[0]);
+      }
+      const deferred = defer<string>();
+      noticeError = () => deferred.resolve(errors[0]);
+      return deferred.promise;
+    };
+
     try {
       const context = new ContextShim();
       const body = `
@@ -430,14 +446,11 @@ function defineTest(
         );
         assertDeepEquals(errors, []);
       } else {
-        const event = await waitForEvent(
-          iframe,
-          "common-iframe-error",
-        ) as CustomEvent;
+        const description = await firstErrorDescription();
         if (typeof expected === "string") {
-          assertEquals(event.detail.description, expected);
+          assertEquals(description, expected);
         } else {
-          assert(expected.test(event.detail.description));
+          assert(expected.test(description));
         }
       }
     } finally {

--- a/packages/iframe-sandbox/test/iframe-csp.test.ts
+++ b/packages/iframe-sandbox/test/iframe-csp.test.ts
@@ -9,7 +9,6 @@ import {
   invertPromise,
   render,
   setIframeTestHandler,
-  waitForContextValue,
   waitForEvent,
 } from "./utils.ts";
 
@@ -62,14 +61,16 @@ window.onerror = function (message, source, lineno, colno, error) {
 </script>
 `;
 
-// Writes "barrier" into the context once the guest has passed the point where
-// a case's error would already have been posted.
+// Raises a recognizable alarm once the guest has passed the point where a
+// case's error would already have been posted.
 //
-// An error leaves the guest as a postMessage to the outer frame, which forwards
-// it to the host on a second fixed pair of windows; the barrier write takes
-// that same path. Each hop preserves the order it received messages in, so a
-// barrier posted after an error arrives after it, and a test that has seen the
-// barrier has seen any error that fired.
+// It is an alarm rather than a write, and that is what makes it a barrier. An
+// error leaves the guest as a postMessage to its parent, which forwards it to
+// the host on a second fixed pair of windows; this takes that same route, and
+// each hop preserves the order it received messages in, so an alarm posted
+// after an error arrives after it. A write would not do: it rides the guest's
+// port, which is a channel of its own with no ordering against this one, and a
+// barrier that can arrive before an error already sent bounds nothing.
 //
 // The load event is the point the cases below share. It fires once the document
 // has parsed and its subresources have settled, and it lands after the
@@ -83,12 +84,22 @@ window.onerror = function (message, source, lineno, colno, error) {
 // of those shapes belongs in `unbarrierable` below rather than here.
 //
 // `barrierControls` below holds the conversions to it honest.
-const BARRIER = `
-<script type="module">
-import { connectGuestContext } from "/guest.js";
+const BARRIER_DESCRIPTION = "barrier";
 
-const guest = connectGuestContext(() => {});
-addEventListener('load', () => guest.write('barrier', true));
+const BARRIER = `
+<script>
+addEventListener('load', () => {
+  window.parent.postMessage({
+    type: 'error',
+    data: {
+      description: '${BARRIER_DESCRIPTION}',
+      source: "",
+      lineno: 0,
+      colno: 0,
+      stacktrace: "",
+    },
+  }, '*');
+});
 </script>
 `;
 
@@ -408,10 +419,20 @@ function defineTest(
     // The event bubbles and is composed, so the document sees it. Listening
     // there rather than on the element catches an error the host dispatches
     // before `render` hands the element back.
+    // The barrier arrives as an alarm like any other, and is separated from
+    // the errors a case is asserting about rather than counted among them.
     const errors: string[] = [];
+    let barrierArrived = false;
     let noticeError: (() => void) | undefined;
+    let noticeBarrier: (() => void) | undefined;
     const onError = (event: Event) => {
-      errors.push((event as CustomEvent).detail.description);
+      const description = (event as CustomEvent).detail.description as string;
+      if (description === BARRIER_DESCRIPTION) {
+        barrierArrived = true;
+        noticeBarrier?.();
+        return;
+      }
+      errors.push(description);
       noticeError?.();
     };
     document.addEventListener("common-iframe-error", onError);
@@ -429,6 +450,16 @@ function defineTest(
       return deferred.promise;
     };
 
+    // Resolves once the barrier has arrived, which the same listener records.
+    const barrierSeen = (): Promise<void> => {
+      if (barrierArrived) {
+        return Promise.resolve();
+      }
+      const deferred = defer();
+      noticeBarrier = () => deferred.resolve();
+      return deferred.promise;
+    };
+
     try {
       const context = new ContextShim();
       const body = `
@@ -436,14 +467,9 @@ function defineTest(
           ${html}
           ${BARRIER}
         `;
-      const iframe = await render(body, context);
+      await render(body, context);
       if (expected == null) {
-        await waitForContextValue(
-          context,
-          iframe,
-          "barrier",
-          (value) => value === true,
-        );
+        await barrierSeen();
         assertDeepEquals(errors, []);
       } else {
         const description = await firstErrorDescription();
@@ -470,11 +496,29 @@ function defineBarrierControl(
 ) {
   Deno.test(`barrier control: ${name}`, async () => {
     cleanupFixtures();
-    const errors: unknown[] = [];
+    const errors: string[] = [];
+    let barrierArrived = false;
+    let noticeBarrier: (() => void) | undefined;
     const onError = (event: Event) => {
-      errors.push((event as CustomEvent).detail.description);
+      const description = (event as CustomEvent).detail.description as string;
+      if (description === BARRIER_DESCRIPTION) {
+        barrierArrived = true;
+        noticeBarrier?.();
+        return;
+      }
+      errors.push(description);
     };
     document.addEventListener("common-iframe-error", onError);
+
+    const barrierSeen = (): Promise<void> => {
+      if (barrierArrived) {
+        return Promise.resolve();
+      }
+      const deferred = defer();
+      noticeBarrier = () => deferred.resolve();
+      return deferred.promise;
+    };
+
     try {
       const context = new ContextShim();
       const body = `
@@ -482,13 +526,8 @@ function defineBarrierControl(
           ${html}
           ${BARRIER}
         `;
-      const iframe = await render(body, context);
-      await waitForContextValue(
-        context,
-        iframe,
-        "barrier",
-        (value) => value === true,
-      );
+      await render(body, context);
+      await barrierSeen();
       assertDeepEquals(errors, [expected]);
     } finally {
       document.removeEventListener("common-iframe-error", onError);

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -1,5 +1,6 @@
 import { CommonIframeSandboxElement as _ } from "../src/common-iframe-sandbox.ts";
 import {
+  assert,
   assertDeepEquals,
   assertEquals,
   cleanupFixtures,
@@ -293,6 +294,40 @@ write("ran", 1);
     // The guest in the new frame runs the same document, so its write is what
     // says the element found its way back rather than going quietly mute.
     await waitForContextValue(context, iframe, "ran", (value) => value === 1);
+  } finally {
+    cleanupFixtures();
+  }
+});
+
+Deno.test("a second ready from the frame already in hand is refused", async () => {
+  cleanupFixtures();
+  try {
+    const context = new ContextShim();
+    const body = GUEST_PROLOG + `
+write("ran", 1);
+` + GUEST_EPILOG;
+    const iframe = await render(body, context);
+    await waitForContextValue(context, iframe, "ran", (value) => value === 1);
+
+    // Reached into rather than driven, because the outer frame reports itself
+    // ready once and nothing outside it can send that message: the element
+    // takes it only from the window it rendered. So the refusal is asserted
+    // where it is made.
+    const inner = iframe as unknown as {
+      iframeRef: { value?: HTMLIFrameElement };
+      onOuterReady: (source: Window) => void;
+      readyWindow?: Window;
+    };
+    const reporting = inner.iframeRef.value!.contentWindow!;
+    assertEquals(inner.readyWindow, reporting);
+
+    let refusal = "";
+    try {
+      inner.onOuterReady(reporting);
+    } catch (error) {
+      refusal = String(error);
+    }
+    assert(refusal.includes("Already initialized"));
   } finally {
     cleanupFixtures();
   }

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -359,3 +359,45 @@ ${GUEST_EPILOG}`;
     cleanupFixtures();
   }
 });
+
+Deno.test("a subscription is cancelled against the context that issued it", async () => {
+  cleanupFixtures();
+  try {
+    const first = new ContextShim({ watched: 1 });
+    const body = `${GUEST_PROLOG}
+subscribe("watched");
+write("ready", true);
+${GUEST_EPILOG}`;
+    const iframe = await render(body, first);
+    await waitForContextValue(
+      first,
+      iframe,
+      "ready",
+      (value) => value === true,
+    );
+    assertEquals(first.callbacks.length, 1);
+
+    // A receipt is only good to the context that issued it, and `context` is a
+    // property a consumer may reassign. Swapping it here and then asking for a
+    // new document is what separates cancelling against the context the
+    // subscription was taken out against from cancelling against whichever one
+    // happens to be current.
+    const second = new ContextShim();
+    // @ts-ignore This is a lit property.
+    iframe.context = second;
+    // @ts-ignore This is a lit property.
+    iframe.src = `${GUEST_PROLOG}
+write("second-ran", true);
+${GUEST_EPILOG}`;
+
+    await waitForContextValue(
+      second,
+      iframe,
+      "second-ran",
+      (value) => value === true,
+    );
+    assertEquals(first.callbacks.length, 0);
+  } finally {
+    cleanupFixtures();
+  }
+});

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -12,55 +12,36 @@ import {
 
 setIframeTestHandler();
 
-const API_SHIM = `<script>
-window.onUpdate = function(key, value){};
-window.addEventListener('message', e => {
-  if (e.data.type === "update") {
-    window.onUpdate(...e.data.data);
-  }
-});
-window.read = (key) => {
-  window.parent.postMessage({
-    type: 'read',
-    data: key, 
-  }, '*');
-};
-window.write = (key, value) => {
-  window.parent.postMessage({
-    type: 'write',
-    data: [key, value],
-  }, '*');
-};
-window.subscribe = (key) => {
-  window.parent.postMessage({
-    type: 'subscribe',
-    data: key,
-  }, '*');
-};
-window.unsubscribe = (key) => {
-  window.parent.postMessage({
-    type: 'unsubscribe',
-    data: key,
-  }, '*');
-};
-</script>
+// Each guest document is one module script: this prolog, the test's own body,
+// and `GUEST_EPILOG`. The prolog names the guest API's operations as the body
+// uses them, so a body reads as the guest code it is.
+const GUEST_PROLOG = `<script type="module">
+import { connectGuestContext } from "/guest.js";
+
+let onUpdate = (key, value) => {};
+const guest = connectGuestContext((key, value) => onUpdate(key, value));
+const read = (key) => guest.read(key);
+const write = (key, value) => guest.write(key, value);
+const subscribe = (key) => guest.subscribe(key);
+const unsubscribe = (key) => guest.unsubscribe(key);
 `;
+
+const GUEST_EPILOG = `
+</script>`;
 
 Deno.test("read and writes", async () => {
   cleanupFixtures();
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body = `
-${API_SHIM}
-<script>
+    const body = GUEST_PROLOG + `
 onUpdate = (key, value) => {
   if (key === "a" && value === 1) {
     write(key, value + 1); 
   }
 };
 read('a');
-</script>`;
+` + GUEST_EPILOG;
     const iframe = await render(body, context);
 
     await waitForContextValue(context, iframe, "a", (value) => value === 2);
@@ -78,9 +59,7 @@ Deno.test("subscribes", async () => {
     // can be used to mark a point in the update stream. It reports arrivals
     // under its own key to leave `updates` holding only what the test asserts
     // on.
-    const body = `
-${API_SHIM}
-<script>
+    const body = GUEST_PROLOG + `
 const updates = [];
 onUpdate = (key, value) => {
   if (key === "barrier") {
@@ -97,7 +76,7 @@ onUpdate = (key, value) => {
 subscribe("a");
 subscribe("barrier");
 write("ready", true);
-</script>`;
+` + GUEST_EPILOG;
     const iframe = await render(body, context);
     await waitForContextValue(
       context,
@@ -147,22 +126,18 @@ Deno.test("handles multiple iframes", async () => {
     const context1 = new ContextShim({ a: 1 });
     const context2 = new ContextShim({ b: 100 });
 
-    const body1 = `
-${API_SHIM}
-<script>
+    const body1 = GUEST_PROLOG + `
 write("b", 1);
-</script>`;
+` + GUEST_EPILOG;
 
-    const body2 = `
-${API_SHIM}
-<script>
+    const body2 = GUEST_PROLOG + `
 onUpdate = (key, value) => {
   if (key === "b" && value === 100) {
     write("a", 200); 
   }
 };
 read("b");
-</script>`;
+` + GUEST_EPILOG;
     const iframe1 = await render(body1, context1);
     const iframe2 = await render(body2, context2);
     // Each frame writes one key: iframe1 writes "b" into context1, and iframe2
@@ -184,16 +159,12 @@ Deno.test("handles loading new documents", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body1 = `
-${API_SHIM}
-<script>
+    const body1 = GUEST_PROLOG + `
 write("b", 1);
-</script>`;
-    const body2 = `
-${API_SHIM}
-<script>
+` + GUEST_EPILOG;
+    const body2 = GUEST_PROLOG + `
 write("c", 1);
-</script>`;
+` + GUEST_EPILOG;
     const iframe = await render(body1, context);
     await waitForContextValue(context, iframe, "b", (value) => value === 1);
     // @ts-ignore This is a lit property.
@@ -209,15 +180,11 @@ Deno.test("cancels subscriptions between documents", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body1 = `
-${API_SHIM}
-<script>
+    const body1 = GUEST_PROLOG + `
 subscribe("a");
 write("ready1", true);
-</script>`;
-    const body2 = `
-${API_SHIM}
-<script>
+` + GUEST_EPILOG;
+    const body2 = GUEST_PROLOG + `
 onUpdate = (key, value) => {
   if (key === "b") {
     write("got-b-update", true);
@@ -228,7 +195,7 @@ onUpdate = (key, value) => {
 };
 subscribe("b");
 write("ready2", true);
-</script>`;
+` + GUEST_EPILOG;
     const iframe = await render(body1, context);
     await waitForContextValue(
       context,
@@ -256,6 +223,48 @@ write("ready2", true);
       (value) => value === true,
     );
     assertEquals(context.get(iframe, "got-a-update"), undefined);
+  } finally {
+    cleanupFixtures();
+  }
+});
+
+Deno.test("what a guest posts outside its port raises an alarm, not a write", async () => {
+  cleanupFixtures();
+  try {
+    const context = new ContextShim();
+    const errors: string[] = [];
+    const onError = (event: Event) =>
+      errors.push((event as CustomEvent).detail.description);
+    document.addEventListener("common-iframe-error", onError);
+
+    // The first post is a protocol message sent the way a guest reaches its
+    // parent rather than over its port. Nothing routes it there any more, so
+    // it cannot become a write; it is an alarm whose contents are not an
+    // error, and it is dropped. The second is the alarm a guest with no
+    // working port has, which is the whole reason that route still exists.
+    // The third is an ordinary write, and it lands last.
+    const body = GUEST_PROLOG + `
+parent.postMessage({ type: "write", data: ["relayed", 1] }, "*");
+parent.postMessage({ type: "error", data: {
+  description: "raised without a port",
+  source: "", lineno: 0, colno: 0, stacktrace: "",
+} }, "*");
+write("after", 1);
+` + GUEST_EPILOG;
+    const iframe = await render(body, context);
+
+    try {
+      await waitForContextValue(
+        context,
+        iframe,
+        "after",
+        (value) => value === 1,
+      );
+      assertEquals(context.get(iframe, "relayed"), undefined);
+      assertDeepEquals(errors, ["raised without a port"]);
+    } finally {
+      document.removeEventListener("common-iframe-error", onError);
+    }
   } finally {
     cleanupFixtures();
   }

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -35,14 +35,14 @@ Deno.test("read and writes", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body = GUEST_PROLOG + `
+    const body = `${GUEST_PROLOG}
 onUpdate = (key, value) => {
   if (key === "a" && value === 1) {
     write(key, value + 1); 
   }
 };
 read('a');
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body, context);
 
     await waitForContextValue(context, iframe, "a", (value) => value === 2);
@@ -60,7 +60,7 @@ Deno.test("subscribes", async () => {
     // can be used to mark a point in the update stream. It reports arrivals
     // under its own key to leave `updates` holding only what the test asserts
     // on.
-    const body = GUEST_PROLOG + `
+    const body = `${GUEST_PROLOG}
 const updates = [];
 onUpdate = (key, value) => {
   if (key === "barrier") {
@@ -77,7 +77,7 @@ onUpdate = (key, value) => {
 subscribe("a");
 subscribe("barrier");
 write("ready", true);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body, context);
     await waitForContextValue(
       context,
@@ -127,18 +127,18 @@ Deno.test("handles multiple iframes", async () => {
     const context1 = new ContextShim({ a: 1 });
     const context2 = new ContextShim({ b: 100 });
 
-    const body1 = GUEST_PROLOG + `
+    const body1 = `${GUEST_PROLOG}
 write("b", 1);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
 
-    const body2 = GUEST_PROLOG + `
+    const body2 = `${GUEST_PROLOG}
 onUpdate = (key, value) => {
   if (key === "b" && value === 100) {
     write("a", 200); 
   }
 };
 read("b");
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe1 = await render(body1, context1);
     const iframe2 = await render(body2, context2);
     // Each frame writes one key: iframe1 writes "b" into context1, and iframe2
@@ -160,12 +160,12 @@ Deno.test("handles loading new documents", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body1 = GUEST_PROLOG + `
+    const body1 = `${GUEST_PROLOG}
 write("b", 1);
-` + GUEST_EPILOG;
-    const body2 = GUEST_PROLOG + `
+${GUEST_EPILOG}`;
+    const body2 = `${GUEST_PROLOG}
 write("c", 1);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body1, context);
     await waitForContextValue(context, iframe, "b", (value) => value === 1);
     // @ts-ignore This is a lit property.
@@ -181,11 +181,11 @@ Deno.test("cancels subscriptions between documents", async () => {
   try {
     const context = new ContextShim({ a: 1 });
 
-    const body1 = GUEST_PROLOG + `
+    const body1 = `${GUEST_PROLOG}
 subscribe("a");
 write("ready1", true);
-` + GUEST_EPILOG;
-    const body2 = GUEST_PROLOG + `
+${GUEST_EPILOG}`;
+    const body2 = `${GUEST_PROLOG}
 onUpdate = (key, value) => {
   if (key === "b") {
     write("got-b-update", true);
@@ -196,7 +196,7 @@ onUpdate = (key, value) => {
 };
 subscribe("b");
 write("ready2", true);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body1, context);
     await waitForContextValue(
       context,
@@ -244,14 +244,14 @@ Deno.test("what a guest posts outside its port raises an alarm, not a write", as
     // error, and it is dropped. The second is the alarm a guest with no
     // working port has, which is the whole reason that route still exists.
     // The third is an ordinary write, and it lands last.
-    const body = GUEST_PROLOG + `
+    const body = `${GUEST_PROLOG}
 parent.postMessage({ type: "write", data: ["relayed", 1] }, "*");
 parent.postMessage({ type: "error", data: {
   description: "raised without a port",
   source: "", lineno: 0, colno: 0, stacktrace: "",
 } }, "*");
 write("after", 1);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body, context);
 
     try {
@@ -275,9 +275,9 @@ Deno.test("a reattached element loads its document into the frame it gets", asyn
   cleanupFixtures();
   try {
     const context = new ContextShim();
-    const body = GUEST_PROLOG + `
+    const body = `${GUEST_PROLOG}
 write("ran", 1);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body, context);
     await waitForContextValue(context, iframe, "ran", (value) => value === 1);
 
@@ -303,9 +303,9 @@ Deno.test("a second ready from the frame already in hand is refused", async () =
   cleanupFixtures();
   try {
     const context = new ContextShim();
-    const body = GUEST_PROLOG + `
+    const body = `${GUEST_PROLOG}
 write("ran", 1);
-` + GUEST_EPILOG;
+${GUEST_EPILOG}`;
     const iframe = await render(body, context);
     await waitForContextValue(context, iframe, "ran", (value) => value === 1);
 
@@ -328,6 +328,33 @@ write("ran", 1);
       refusal = String(error);
     }
     assert(refusal.includes("Already initialized"));
+  } finally {
+    cleanupFixtures();
+  }
+});
+
+Deno.test("an element that gets a frame and has no source says nothing is loaded", async () => {
+  cleanupFixtures();
+  try {
+    const context = new ContextShim();
+    const body = `${GUEST_PROLOG}
+write("ran", 1);
+${GUEST_EPILOG}`;
+    const iframe = await render(body, context);
+    await waitForContextValue(context, iframe, "ran", (value) => value === 1);
+
+    // Driven rather than staged, for the reason the refusal test gives: a
+    // frame reports itself ready once, and the report cannot be sent from
+    // anywhere else. A window this element has not seen stands for the frame a
+    // reattach would bring.
+    const inner = iframe as unknown as {
+      onOuterReady: (source: Window) => void;
+      loadState: string;
+    };
+    // @ts-ignore This is a lit property.
+    iframe.src = "";
+    inner.onOuterReady({} as Window);
+    assertEquals(inner.loadState, "");
   } finally {
     cleanupFixtures();
   }

--- a/packages/iframe-sandbox/test/iframe.test.ts
+++ b/packages/iframe-sandbox/test/iframe.test.ts
@@ -269,3 +269,31 @@ write("after", 1);
     cleanupFixtures();
   }
 });
+
+Deno.test("a reattached element loads its document into the frame it gets", async () => {
+  cleanupFixtures();
+  try {
+    const context = new ContextShim();
+    const body = GUEST_PROLOG + `
+write("ran", 1);
+` + GUEST_EPILOG;
+    const iframe = await render(body, context);
+    await waitForContextValue(context, iframe, "ran", (value) => value === 1);
+
+    // Detaching destroys the frame the element rendered, and reattaching gets
+    // it a new one -- which reports itself ready, as the first one did. The
+    // teardown lands on a later task than the removal, so the two have to be
+    // told apart by a turn of the event loop rather than by adjacency.
+    const parent = iframe.parentElement!;
+    context.set(iframe, "ran", undefined);
+    parent.remove();
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    document.body.appendChild(parent);
+
+    // The guest in the new frame runs the same document, so its write is what
+    // says the element found its way back rather than going quietly mute.
+    await waitForContextValue(context, iframe, "ran", (value) => value === 1);
+  } finally {
+    cleanupFixtures();
+  }
+});

--- a/packages/iframe-sandbox/test/ipc.test.ts
+++ b/packages/iframe-sandbox/test/ipc.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  type GuestError,
+  GuestMessageType,
+  IPCGuestMessageType,
+  isGuestError,
+  isGuestMessage,
+  isIPCGuestMessage,
+} from "../src/ipc.ts";
+
+const ERROR: GuestError = {
+  description: "d",
+  source: "s",
+  lineno: 1,
+  colno: 2,
+  stacktrace: "st",
+};
+
+describe("ipc", () => {
+  describe("isIPCGuestMessage", () => {
+    it("returns true for a message the outer frame writes", () => {
+      expect(isIPCGuestMessage({ type: IPCGuestMessageType.Ready })).toBe(true);
+      expect(isIPCGuestMessage({ type: IPCGuestMessageType.Load })).toBe(true);
+      expect(
+        isIPCGuestMessage({
+          type: IPCGuestMessageType.OuterError,
+          data: ERROR,
+        }),
+      ).toBe(true);
+      expect(
+        isIPCGuestMessage({
+          type: IPCGuestMessageType.GuestError,
+          data: "anything at all",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false for an error arm carrying nothing", () => {
+      expect(isIPCGuestMessage({ type: IPCGuestMessageType.OuterError }))
+        .toBe(false);
+      expect(
+        isIPCGuestMessage({
+          type: IPCGuestMessageType.GuestError,
+          data: null,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false for anything that is not one of the arms", () => {
+      expect(isIPCGuestMessage(undefined)).toBe(false);
+      expect(isIPCGuestMessage(null)).toBe(false);
+      expect(isIPCGuestMessage("ready")).toBe(false);
+      expect(isIPCGuestMessage({})).toBe(false);
+      expect(isIPCGuestMessage({ type: "load-document" })).toBe(false);
+    });
+  });
+
+  describe("isGuestMessage", () => {
+    it("returns true for each arm the protocol has", () => {
+      expect(isGuestMessage({ type: GuestMessageType.Error, data: ERROR }))
+        .toBe(true);
+      expect(isGuestMessage({ type: GuestMessageType.Read, data: "k" }))
+        .toBe(true);
+      expect(isGuestMessage({ type: GuestMessageType.Subscribe, data: "k" }))
+        .toBe(true);
+      expect(
+        isGuestMessage({
+          type: GuestMessageType.Unsubscribe,
+          data: ["a", "b"],
+        }),
+      ).toBe(true);
+      expect(isGuestMessage({ type: GuestMessageType.Write, data: ["k", 1] }))
+        .toBe(true);
+    });
+
+    it("returns false for an arm whose payload is the wrong shape", () => {
+      expect(isGuestMessage({ type: GuestMessageType.Error, data: {} }))
+        .toBe(false);
+      expect(isGuestMessage({ type: GuestMessageType.Read, data: 1 }))
+        .toBe(false);
+      expect(isGuestMessage({ type: GuestMessageType.Subscribe, data: [1] }))
+        .toBe(false);
+      expect(isGuestMessage({ type: GuestMessageType.Write, data: ["k"] }))
+        .toBe(false);
+      expect(isGuestMessage({ type: GuestMessageType.Write, data: [1, 1] }))
+        .toBe(false);
+    });
+
+    it("returns false for anything that names no arm", () => {
+      expect(isGuestMessage(undefined)).toBe(false);
+      expect(isGuestMessage(null)).toBe(false);
+      expect(isGuestMessage({ type: "update", data: ["k", 1] })).toBe(false);
+      expect(isGuestMessage({ data: ["k", 1] })).toBe(false);
+      expect(isGuestMessage({ type: GuestMessageType.Write })).toBe(false);
+    });
+  });
+
+  describe("isGuestError", () => {
+    it("returns true for a report carrying every field", () => {
+      expect(isGuestError(ERROR)).toBe(true);
+    });
+
+    it("returns false when a field is missing or mistyped", () => {
+      expect(isGuestError({ ...ERROR, description: 1 })).toBe(false);
+      expect(isGuestError({ ...ERROR, lineno: "1" })).toBe(false);
+      const { stacktrace: _dropped, ...missing } = ERROR;
+      expect(isGuestError(missing)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5 (1M context))

Every message between the host page and a guest crossed by way of the outer
frame, wrapped in an envelope addressed with a frame id so it could be routed
there. Three costs came with that: the outer frame had to read what it
forwarded, every value was structured-cloned twice, and the host's only reach
to a guest ran through a third party that any window able to find it could also
post to.

The host now hands each freshly loaded guest one end of a `MessagePort` and
keeps the other, and the whole key/value protocol crosses on it. The outer
frame's part becomes what only it can do — it carries the CSP, and it loads
documents. Its "the document is up" notice is what tells the host there is a
new realm to hand a port to, a fresh document being a fresh realm whose
predecessor's port died with it.

The envelopes shrink to what is left. No passthrough arm on either side, and no
frame id: both ends already address each other by window, so the id duplicated
something already true, and a port is an identity nothing else can name.

## Why this is worth doing on its own

Holding a port is what makes a message unforgeable. The old route accepted
whatever arrived bearing the right source and origin, which is the spoofing
item this package's README lists under "Missing Functionality". That is the
change's own reason, independent of anything downstream of it.

It also halves the clones on the path, and it is what lets a future encoding
put a byte buffer in a transfer list rather than copying it through a relay
that deliberately does not inspect payloads.

## The alarm route, and why it stays

What a guest posts to its parent still reaches the host, forwarded unread. A
guest whose scripts a policy blocked has no port and still has to be able to
say so. That route carries an alarm and nothing else — it is one-way, the host
answers nothing on it, and everything a guest means to say about the context
goes over the port. It is deliberately not a second way to talk.

## The guest client

`@commonfabric/iframe-sandbox/guest` is new, and is what a guest uses to hold
its end. It may be called at once: what a guest says before the handoff is sent
when the port arrives, in the order it was said, so a guest never has to know
the port is asynchronous.

## Tests

The guest documents drive the real client rather than a hand-rolled
`postMessage` shim. A new case posts a protocol message the old way, asserting
it can no longer become a write, beside an alarm that must still arrive; the
control is letting that route carry the protocol again, which fails it with `1
does not equal undefined`.

The CSP suite's positive cases now read the error collection that has been
filling since before the frame existed, rather than attaching a listener after
`render()` resolved. That was already a race, and a guest document with a
module to fetch turns it into a reliable failure — eleven tests failing one run
and passing the next before the fix, three consecutive clean runs after.

Local gates: `deno task check`, `deno fmt --check`, `deno lint`, the standalone
`check-*` gates, the package suite (42 passed, three consecutive runs), and the
full workspace suite.

## Scope

Nothing in production runs any of this. The package's only importer in labs is
`packages/ui/src/v2/components/cf-iframe/`, nothing mounts `<cf-iframe>`, and
no code in Loom outside its vendored copy of labs refers to either.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

