### PR TITLE
feat(runner,piece,patterns): a host can set the CFC write floor

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -611,6 +611,11 @@ latter's for its fabric session from `--fabric-cfc-enforcement-mode`
 (raise-only: `enforce-explicit` or `enforce-strict`) and
 `--fabric-cfc-flow-labels`, with `CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE` and
 `CF_HARNESS_FABRIC_CFC_FLOW_LABELS` as their environment defaults.
+`remoteClient` takes a host-controlled `cfcWriteFloor` on top of those two,
+which `PiecesController.initialize` forwards and the pattern multi-runtime
+harness routes on to each worker runtime, per session or for the whole
+harness. That dial is how a caller reaches the floor's `observe` rung, which
+the named bundle below sets only to `enforce`.
 
 One named bundle sits beside the per-dial rollout: every preset's `CoreParams`
 accepts `cfcPosture: "max-enforcement"`, which spreads

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -741,7 +741,11 @@ the per-epic implementation notes).
 
 ### `cfcWriteFloor`
 
-- **Toggle via.** `RuntimeOptions.cfcWriteFloor`.
+- **Toggle via.** `RuntimeOptions.cfcWriteFloor`; per-environment through the
+  `remoteClient` preset param, which `PiecesController.initialize` accepts and
+  forwards. The pattern multi-runtime harness routes it on to each worker
+  runtime, per session or for the whole harness, so an integration test can
+  drive real patterns against an enforcing floor.
 - **Added by.** Bernhard Seefeld, in "write-side requiredIntegrity floor (Epic
   D3, SC-18)" (#4479, 2026-07-02).
 - **Purpose.** A write-side minimum-integrity check. Values are `off`,
@@ -752,7 +756,7 @@ the per-epic implementation notes).
 - **Current default and planned end state.** `off` by default. The target is to
   move toward `enforce` once field testing confirms the floor does not
   over-reject legitimate writes.
-- **Status on 2026-07-08.** Implemented and in staged rollout.
+- **Status on 2026-08-19.** Implemented and in staged rollout.
 - **Path to removal.** Once integrity propagation is complete and the floor is
   proven safe, the check could fold into the base enforcement ladder and the
   separate dial could be retired.

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -51,6 +51,7 @@ import { Identity } from "@commonfabric/identity";
 import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import type { CfcWriteFloorMode } from "@commonfabric/runner/cfc";
 import { PatternsRoute } from "@commonfabric/runner/patterns-route.deno";
 import {
   type RuntimeDiagnosticsSnapshot,
@@ -79,6 +80,13 @@ export interface MultiRuntimeSessionSpec {
    * near-zero in-process latency hides.
    */
   wsDelayMs?: number;
+  /**
+   * Write-side `requiredIntegrity` floor for this session's runtime,
+   * overriding the harness-wide setting. Set it per session to model a fleet
+   * partway through the staged rollout, where one client already enforces the
+   * floor and another does not.
+   */
+  cfcWriteFloor?: CfcWriteFloorMode;
 }
 
 export interface MultiRuntimeHarnessOptions {
@@ -110,6 +118,12 @@ export interface MultiRuntimeHarnessOptions {
    * self-hosted in-process storage server.
    */
   apiUrl?: URL;
+  /**
+   * Write-side `requiredIntegrity` floor for every runtime this harness
+   * creates, the bootstrap worker that authors the piece included. Defaults to
+   * the runtime's own default, which is `off`.
+   */
+  cfcWriteFloor?: CfcWriteFloorMode;
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -494,6 +508,7 @@ export class MultiRuntimeHarness {
             `multi-runtime-harness ${normalized.label}`,
             { implementation: "noble" },
           );
+        const cfcWriteFloor = normalized.cfcWriteFloor ?? options.cfcWriteFloor;
         const client = new WorkerClient(normalized.label);
         await client.call("init", {
           identity: identity.keyPair,
@@ -503,6 +518,7 @@ export class MultiRuntimeHarness {
           ...(normalized.wsDelayMs !== undefined
             ? { wsDelayMs: normalized.wsDelayMs }
             : {}),
+          ...(cfcWriteFloor !== undefined ? { cfcWriteFloor } : {}),
         });
         sessions.push(
           new MultiRuntimeSession(normalized.label, identity, client),
@@ -520,6 +536,9 @@ export class MultiRuntimeHarness {
         spaceName,
         apiUrl,
         diagnostics: options.diagnostics === true,
+        ...(options.cfcWriteFloor !== undefined
+          ? { cfcWriteFloor: options.cfcWriteFloor }
+          : {}),
       });
       const { pieceId } = await bootstrap.call("createPiece", {
         programPath: options.programPath,

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -28,7 +28,10 @@ import {
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
-import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
+import {
+  type CfcWriteFloorMode,
+  markRendererTrustedEvent,
+} from "@commonfabric/runner/cfc";
 import { Identity } from "@commonfabric/identity";
 import {
   initializePiecesController,
@@ -200,7 +203,16 @@ const handlers: Record<
   string,
   (args: Record<string, unknown>) => Promise<FabricValue>
 > = {
-  async init({ identity: keyPair, spaceName, apiUrl, diagnostics, wsDelayMs }) {
+  async init(
+    {
+      identity: keyPair,
+      spaceName,
+      apiUrl,
+      diagnostics,
+      wsDelayMs,
+      cfcWriteFloor,
+    },
+  ) {
     const identity = await Identity.fromKeyPair(
       keyPair as FabricKeyPair,
     );
@@ -209,6 +221,9 @@ const handlers: Record<
       apiUrl: new URL(apiUrl as string),
       identity,
       space: spaceName as string,
+      ...(cfcWriteFloor !== undefined
+        ? { cfcWriteFloor: cfcWriteFloor as CfcWriteFloorMode }
+        : {}),
     });
     if (diagnostics === true) {
       const scheduler = controller().runtime.scheduler;

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -62,6 +62,7 @@ import type { CfcPosture } from "@commonfabric/runner";
 import type {
   CfcEnforcementMode,
   CfcFlowLabelsMode,
+  CfcWriteFloorMode,
 } from "@commonfabric/runner/cfc";
 import { CFC_SCHEMA_MIGRATION_INCOMPATIBLE_REASON } from "@commonfabric/runner/cfc/migration-reason";
 import { hashStringForEntityAddress } from "@commonfabric/runner/entity-kind";
@@ -289,6 +290,7 @@ export class PiecesController<T = unknown> {
       cfcEnforcementMode,
       cfcFlowLabels,
       cfcPosture,
+      cfcWriteFloor,
     }: {
       apiUrl: URL | string;
       identity: Identity;
@@ -333,9 +335,10 @@ export class PiecesController<T = unknown> {
       cfcEnforcementMode?: CfcEnforcementMode;
       cfcFlowLabels?: CfcFlowLabelsMode;
       // Named CFC posture bundle for this controller's runtime (the
-      // remoteClient preset's `cfcPosture` opt-in); the two dials above still
-      // apply over it.
+      // remoteClient preset's `cfcPosture` opt-in); the dials above and below
+      // still apply over it.
       cfcPosture?: CfcPosture;
+      cfcWriteFloor?: CfcWriteFloorMode;
     },
   ): Promise<PiecesController> {
     const api = new URL(apiUrl);
@@ -369,6 +372,7 @@ export class PiecesController<T = unknown> {
       ...(cfcEnforcementMode !== undefined ? { cfcEnforcementMode } : {}),
       ...(cfcFlowLabels !== undefined ? { cfcFlowLabels } : {}),
       ...(cfcPosture !== undefined ? { cfcPosture } : {}),
+      ...(cfcWriteFloor !== undefined ? { cfcWriteFloor } : {}),
       ...(navigateCallback !== undefined ? { navigateCallback } : {}),
       ...(onPatternInstantiated !== undefined ? { onPatternInstantiated } : {}),
       trustSnapshotProvider: () => ({

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -64,9 +64,11 @@
  * |                            | rollout)                                         |
  * | cfcFlowLabels              | core-default (off); remoteClient / browserWorker |
  * |                            | delta (host-controlled rollout)                  |
- * | cfcWriteFloor              | core-default (off) — flip in coreOptions when a  |
+ * | cfcWriteFloor              | core-default (off); remoteClient delta           |
+ * |                            | (host-controlled rollout) — flip in coreOptions  |
+ * |                            | when a first-party rollout begins                |
+ * | cfcTriggerReadGating       | core-default (off) — flip in coreOptions when a  |
  * |                            | first-party rollout begins                       |
- * | cfcTriggerReadGating       | core-default (off) — same                        |
  * | cfcDecomposedEnvelopes     | core-default (off) — flip after every deployed   |
  * |                            | reader resolves stored roots' references         |
  * | cfcPolicyEvaluation        | core-default (off) — same                        |
@@ -118,14 +120,17 @@
  * One named departure a caller can opt into: `cfcPosture: "max-enforcement"`
  * (a `CoreParams` field) swaps the core-default CFC dial rows above for the
  * {@link MAX_ENFORCEMENT_CFC_OPTIONS} bundle, for that one runtime. The
- * per-preset host dials (`cfcEnforcementMode`, `cfcFlowLabels`) still apply
- * over the bundle, so a session-level raise wins either way.
+ * per-preset host dials (`cfcEnforcementMode`, `cfcFlowLabels`,
+ * `cfcWriteFloor`) still apply over the bundle, so a session-level raise wins
+ * either way, and a session that wants the floor's `observe` rung rather than
+ * the bundle's `enforce` asks for it the same way.
  */
 
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import {
   type CfcEnforcementMode,
   type CfcFlowLabelsMode,
+  type CfcWriteFloorMode,
   sinkCeilingsOf,
   type SinkGovernanceRegistry,
   type SinkMaxConfidentiality,
@@ -815,6 +820,14 @@ export interface RemoteClientPresetParams extends CoreParams {
 
   /** The other such dial: flow-label persistence, on the same terms. */
   cfcFlowLabels?: CfcFlowLabelsMode;
+
+  /**
+   * A third: the write-side `requiredIntegrity` floor, which the pattern
+   * integration harness sets per session. It is also how a caller reaches the
+   * floor's `observe` rung, since the `max-enforcement` posture names only
+   * `enforce`.
+   */
+  cfcWriteFloor?: CfcWriteFloorMode;
 }
 
 export interface PatternTestPresetParams extends CoreParams {
@@ -911,6 +924,9 @@ export const runtimePresets = {
         : {}),
       ...(params.cfcFlowLabels !== undefined
         ? { cfcFlowLabels: params.cfcFlowLabels }
+        : {}),
+      ...(params.cfcWriteFloor !== undefined
+        ? { cfcWriteFloor: params.cfcWriteFloor }
         : {}),
       ...(params.errorHandlers !== undefined
         ? { errorHandlers: params.errorHandlers }

--- a/packages/runner/test/harness/console.test.ts
+++ b/packages/runner/test/harness/console.test.ts
@@ -1,0 +1,144 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  Console,
+  ConsoleEvent,
+  ConsoleMethod,
+} from "../../src/harness/console.ts";
+
+const ALL_METHODS = Object.values(ConsoleMethod);
+
+/** Every `console` event `emitter` dispatches, in order, as they arrive. */
+function recordEvents(emitter: EventTarget): ConsoleEvent[] {
+  const seen: ConsoleEvent[] = [];
+  emitter.addEventListener("console", (event) => {
+    seen.push(event as ConsoleEvent);
+  });
+  return seen;
+}
+
+/**
+ * Calls `method` on `subject`. The enum's values are the method names, which
+ * the last test in this file pins; the cast is what carries that fact into the
+ * type system.
+ */
+function callMethod(
+  subject: Console,
+  method: ConsoleMethod,
+  ...args: unknown[]
+): void {
+  const fn = subject[method as keyof Console] as (...a: unknown[]) => void;
+  fn.apply(subject, args);
+}
+
+describe("console", () => {
+  describe("ConsoleEvent", () => {
+    describe("constructor()", () => {
+      it("names the event type `console`", () => {
+        expect(new ConsoleEvent(ConsoleMethod.Log, []).type).toBe("console");
+      });
+
+      it("carries the method it was given", () => {
+        expect(new ConsoleEvent(ConsoleMethod.Warn, []).method)
+          .toBe(ConsoleMethod.Warn);
+      });
+
+      it("carries the argument list it was given", () => {
+        const args = [1, "two", null];
+        expect(new ConsoleEvent(ConsoleMethod.Log, args).args).toEqual(args);
+      });
+    });
+  });
+
+  describe("Console", () => {
+    describe("instance members", () => {
+      it("dispatches one event per call, naming the method called", () => {
+        for (const method of ALL_METHODS) {
+          const emitter = new EventTarget();
+          const seen = recordEvents(emitter);
+          callMethod(new Console(emitter), method);
+          expect(seen.length, method).toBe(1);
+          expect(seen[0].method, method).toBe(method);
+        }
+      });
+
+      it("passes each call's arguments through unchanged", () => {
+        for (const method of ALL_METHODS) {
+          const emitter = new EventTarget();
+          const seen = recordEvents(emitter);
+          const marker = { nested: [1, 2] };
+          callMethod(new Console(emitter), method, "a", 2, null, marker);
+          expect(seen[0].args, method).toEqual(["a", 2, null, marker]);
+          // The event holds the caller's own object, not a copy of it: a
+          // handler that inspects a logged value sees what was logged.
+          expect(seen[0].args[3], method).toBe(marker);
+        }
+      });
+
+      it("dispatches an event for a call with no arguments", () => {
+        for (const method of ALL_METHODS) {
+          const emitter = new EventTarget();
+          const seen = recordEvents(emitter);
+          callMethod(new Console(emitter), method);
+          expect(seen[0].args, method).toEqual([]);
+        }
+      });
+
+      it("dispatches once per call rather than coalescing repeats", () => {
+        const emitter = new EventTarget();
+        const seen = recordEvents(emitter);
+        const subject = new Console(emitter);
+        subject.log("first");
+        subject.log("first");
+        subject.warn("second");
+        expect(seen.map((event) => event.method)).toEqual([
+          ConsoleMethod.Log,
+          ConsoleMethod.Log,
+          ConsoleMethod.Warn,
+        ]);
+        expect(seen.map((event) => event.args)).toEqual([
+          ["first"],
+          ["first"],
+          ["second"],
+        ]);
+      });
+
+      it("dispatches nothing when constructed without an emitter", () => {
+        for (const method of ALL_METHODS) {
+          expect(() => callMethod(new Console(), method, "a"), method)
+            .not.toThrow();
+        }
+      });
+
+      it("reaches only its own emitter", () => {
+        const mine = new EventTarget();
+        const other = new EventTarget();
+        const seenByMine = recordEvents(mine);
+        const seenByOther = recordEvents(other);
+        new Console(mine).log("a");
+        expect(seenByMine.length).toBe(1);
+        expect(seenByOther.length).toBe(0);
+      });
+    });
+  });
+
+  describe("ConsoleMethod", () => {
+    it("gives every member the name of the `Console` method it stands for", () => {
+      // The enum value is what a handler switches on, and the method body is
+      // what supplies it. A member whose value drifted from its method name
+      // would route a call under another method's name.
+
+      for (const method of ALL_METHODS) {
+        expect(typeof new Console()[method as keyof Console], method)
+          .toBe("function");
+      }
+    });
+
+    it("covers every method `Console` exposes", () => {
+      const exposed = Object.getOwnPropertyNames(Console.prototype)
+        .filter((name) => name !== "constructor")
+        .toSorted();
+      expect(exposed).toEqual([...ALL_METHODS].toSorted());
+    });
+  });
+});

--- a/packages/runner/test/reactivity.test.ts
+++ b/packages/runner/test/reactivity.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { Cell } from "../src/cell.ts";
+import { effect } from "../src/reactivity.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("reactivity", () => {
+  describe("effect()", () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /** A committed cell holding `value`, ready to be observed. */
+    async function seededCell(
+      name: string,
+      value: number,
+    ): Promise<Cell<number>> {
+      const tx = runtime.edit();
+      const cell = runtime.getCell<number>(space, name, undefined, tx);
+      cell.withTx(tx).set(value);
+      await tx.commit();
+      return cell;
+    }
+
+    /** Writes `value` into `cell` in its own committed transaction. */
+    async function write(cell: Cell<number>, value: number): Promise<void> {
+      const tx = runtime.edit();
+      cell.withTx(tx).set(value);
+      await tx.commit();
+      await runtime.idle();
+    }
+
+    it("runs the callback immediately for a plain value", () => {
+      const seen: number[] = [];
+      effect(7, (value) => {
+        seen.push(value);
+      });
+      expect(seen).toEqual([7]);
+    });
+
+    it("passes a plain value through without unwrapping it", () => {
+      const value = { nested: [1, 2] };
+      let received: unknown;
+      effect(value, (observed) => {
+        received = observed;
+      });
+      expect(received).toBe(value);
+    });
+
+    it("returns the cancel the callback produced for a plain value", () => {
+      let cancelled = false;
+      const cancel = effect(1, () => () => {
+        cancelled = true;
+      });
+      cancel();
+      expect(cancelled).toBe(true);
+    });
+
+    it("returns a callable cancel when the callback returns nothing", () => {
+      const cancel = effect(1, () => {});
+      expect(typeof cancel).toBe("function");
+      // The no-op still has to be safe to call, and to stay safe when a
+      // caller cancels twice.
+      expect(() => {
+        cancel();
+        cancel();
+      }).not.toThrow();
+    });
+
+    it("runs the callback with a cell's current value", async () => {
+      const cell = await seededCell("effect-initial", 1);
+      const seen: number[] = [];
+      const cancel = effect(cell, (value) => {
+        seen.push(value);
+      });
+      await runtime.idle();
+      expect(seen).toEqual([1]);
+      cancel();
+    });
+
+    it("runs the callback again when the cell changes", async () => {
+      const cell = await seededCell("effect-updates", 1);
+      const seen: number[] = [];
+      const cancel = effect(cell, (value) => {
+        seen.push(value);
+      });
+      await runtime.idle();
+      await write(cell, 2);
+      expect(seen).toEqual([1, 2]);
+      cancel();
+    });
+
+    it("stops running the callback once cancelled", async () => {
+      const cell = await seededCell("effect-cancel", 1);
+      const seen: number[] = [];
+      const cancel = effect(cell, (value) => {
+        seen.push(value);
+      });
+      await runtime.idle();
+      cancel();
+      await write(cell, 2);
+      expect(seen).toEqual([1]);
+    });
+  });
+});

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -269,6 +269,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         onPatternInstantiated,
         cfcEnforcementMode: "enforce-strict",
         cfcFlowLabels: "persist",
+        cfcWriteFloor: "enforce",
       })).toEqual({
         ...minimalOutputs.remoteClient,
         errorHandlers,
@@ -279,6 +280,7 @@ describe("runtimePresets conformance (CT-1814)", () => {
         onPatternInstantiated,
         cfcEnforcementMode: "enforce-strict",
         cfcFlowLabels: "persist",
+        cfcWriteFloor: "enforce",
       });
     });
 
@@ -824,6 +826,19 @@ describe("runtimePresets conformance (CT-1814)", () => {
       expect(output.cfcEnforcementMode).toBe("enforce-strict");
       // The bundle's persist is what makes the strict raise conform.
       expect(output.cfcFlowLabels).toBe("persist");
+    });
+
+    it("lets a host session hold the write floor at observe over the bundle", () => {
+      // The floor's rollout runs observe before enforce (§8.12.4.1 / SC-18),
+      // a rung the all-or-nothing bundle cannot name. The host dial is what
+      // reaches it, so it has to win over the bundle's enforcing value.
+      const output = runtimePresets.remoteClient({
+        ...minimalCore,
+        ...posture,
+        cfcWriteFloor: "observe",
+      });
+      expect(output.cfcWriteFloor).toBe("observe");
+      expect(postureOutputs.remoteClient.cfcWriteFloor).toBe("enforce");
     });
 
     it("ceilings every network-fetch sink public-only and no llm sink", () => {


### PR DESCRIPTION
The write-side requiredIntegrity floor has a runtime dial, `cfcWriteFloor`, with three settings: `off`, `observe`, and `enforce`. Every first-party runtime rides the constructor default of `off`. Until now nothing short of a hand-rolled `RuntimeOptions` could change that. The two other CFC rollout dials are already host-settable through the `remoteClient` preset and `PiecesController.initialize`, namely `cfcEnforcementMode` and `cfcFlowLabels`. The floor was not.

The consequence was that no pattern integration test could run against an enforcing floor. The multi-runtime harness builds each worker's runtime through `initializePiecesController`, so every pattern the harness runs saw the floor off. The floor's effect on a real pattern could only be exercised at the runner unit level, against runtimes constructed by hand in `packages/runner/test/cfc-write-floor.test.ts`. That is an awkward place to be while
`docs/specs/cfc-enforcement-matrix.md` and SC-18 in `docs/specs/cfc-spec-changes.md` prepare to move the dial toward `enforce`.

This adds `cfcWriteFloor` to the `remoteClient` preset params and to `PiecesController.initialize`, in the same conditional-spread style the other two dials use, and carries it on through the pattern integration surface. The multi-runtime harness takes it two ways. As a harness-wide setting it covers every runtime the harness creates, including the bootstrap worker that authors the piece. As a per-session setting it overrides the harness-wide one. A test can therefore model a fleet partway through the staged rollout, where one client already enforces the floor and another has not yet turned it on.

Running the CFC group chat demo's multi-runtime test with the floor enforced shows the dial reaching the pattern runtimes. Trusted profile saves, trusted message sends, and the everyone-is-admin toggle all commit unchanged. Two writes are rejected, both of them landing on a list whose type is declared with `RequiresIntegrity`: `/rooms/list` from the room-add gesture, and `/adminRegistry/admins` from the admin grant. The demo mints its integrity atom onto each element of those lists rather than onto the list value the floor tests, so the rejection is a gap in the demo's own types rather than in this plumbing. No committed test turns the floor on until that gap closes; the preset conformance goldens in `packages/runner/test/runtime-presets.test.ts` guard the routing in the meantime.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

