### PR TITLE
fix(runner): CFC metadata probes read surfaces, not document roots

### DIFF
--- a/docs/features/mergeable-collection-writes.md
+++ b/docs/features/mergeable-collection-writes.md
@@ -448,6 +448,16 @@ lunch poll's `addUser`
 ([participant-identity-card.tsx](../../packages/patterns/lunch-poll/participant-identity-card.tsx))
 is a deliberate read-then-push that relies on it.
 
+The narrowing keys on the read's path, and does not care which layer issued the
+read. Runtime machinery that runs during a commit is bound by the same rule as
+handler code. A recursive read at a document's root depends on every path in
+that document, so a concurrent write anywhere in it — including the mergeable
+append the commit is carrying — invalidates that read and conflicts the commit.
+A runtime pass that needs one member of a document reads that member's own path
+instead. The CFC label envelope at `["cfc"]` and the schema meta at
+`["schema"]` are each read at their own path, so each depends on that member
+alone and a concurrent append to the document's value leaves it undisturbed.
+
 Two further responses make the keyed case cheaper and catch misuse (see
 `keyed-collection-writes.md`):
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4286,19 +4286,22 @@ const setupResultSchemaFor = (
   tx: IExtendedStorageTransaction,
   source: LinkWritePolicyInput["source"],
 ): JSONSchema | undefined => {
-  const document = tx.readOrThrow({
+  // Read AT ["schema"], never the whole document: the same commit-time
+  // concurrency scoping `storedMetadataFor` above applies here. A path-[]
+  // recursive read makes the whole source document a value dependency, so
+  // a concurrent write to the source's value — an append to a collection
+  // this link points into among them — conflicts the commit. The
+  // ["schema"] read depends on that member alone, which such a write
+  // leaves undisturbed.
+  const schema = tx.readOrThrow({
     space: source.space,
     id: source.id as URI,
     scope: source.scope,
     type: "application/json",
-    path: [],
+    path: ["schema"],
   }, {
     meta: INTERNAL_VERIFIER_META,
   });
-  if (!isObjectOrArray(document)) {
-    return undefined;
-  }
-  const schema = (document as Record<string, unknown>).schema;
   return schema === undefined || schema === null
     ? undefined
     : schema as JSONSchema;

--- a/packages/runner/test/cfc-probe-mergeable-append.test.ts
+++ b/packages/runner/test/cfc-probe-mergeable-append.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { cfcAtom } from "@commonfabric/api/cfc";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("cfc-probe-mergeable-append");
+const space = signer.did();
+const CAUSE = "probe-mergeable-append-list";
+const LABELED_CAUSE = "probe-mergeable-append-labeled-list";
+const LINK_SOURCE_CAUSE = "probe-mergeable-append-link-source";
+const LINK_TARGET_CAUSE = "probe-mergeable-append-link-target";
+
+const stringListSchema = {
+  type: "array",
+  items: { type: "string" },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+// The same list shape with a schema-declared element label. Writes through this
+// schema record a schema write-policy input and mark the transaction
+// CFC-relevant, so the prepare pass runs and persists label metadata onto the
+// document's `["cfc"]` envelope — with no dial set.
+const labeledListSchema = {
+  type: "array",
+  items: {
+    type: "string",
+    ifc: { confidentiality: [cfcAtom.resource("Secret")] },
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+// Read the durable array from a fresh session that pulls it straight off the
+// shared server, so the assertion reflects committed/durable state rather than
+// any one writer's optimistic local view.
+async function readDurable(
+  server: MemoryV2Server.Server,
+  cause: string,
+  // deno-lint-ignore no-explicit-any
+  schema: any,
+): Promise<string[]> {
+  const storage = EmulatedStorageManager.connectTo(server, { as: signer });
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: storage,
+  });
+  try {
+    const cell = rt.getCell<string[]>(space, cause, schema);
+    await cell.sync();
+    await cell.pull();
+    return (cell.get() ?? []) as string[];
+  } finally {
+    await rt.dispose();
+    await storage.close();
+  }
+}
+
+// The CFC prepare pass reads a document's stored label metadata through
+// `storedMetadataFor`, and its result schema through `setupResultSchemaFor`.
+// Both must read the member surface they want — `["cfc"]` and `["schema"]` —
+// rather than the document root: a recursive root read depends on every path
+// in the document, so it enters the commit's confirmed conflict reads. The
+// read-set builder exempts only exact `["cfc"]` reads, the mergeable
+// operation's own reads, and reads below the operation's path. A root read
+// therefore survives on a document a mergeable operation targets, and two
+// concurrent appends — writes the mergeable machinery exists to let both land
+// — conflict, silently dropping one side's data.
+describe("CFC metadata probes under mergeable appends", () => {
+  let server: MemoryV2Server.Server;
+  let storage1: EmulatedStorageManager;
+  let storage2: EmulatedStorageManager;
+
+  beforeEach(() => {
+    // Manual fan-out: controlled staleness is a gated state, not a timing
+    // accident.
+    server = newSharedServer({ subscriptionRefreshDelayMs: "manual" });
+    storage1 = EmulatedStorageManager.connectTo(server, { as: signer });
+    storage2 = EmulatedStorageManager.connectTo(server, { as: signer });
+  });
+  afterEach(async () => {
+    await storage1?.close();
+    await storage2?.close();
+    await server?.close();
+  });
+
+  // deno-lint-ignore no-explicit-any
+  const runtimes = (options: Record<string, any> = {}) =>
+    [
+      new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage1,
+        ...options,
+      }),
+      new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage2,
+        ...options,
+      }),
+    ] as const;
+
+  // The shape that reaches every document once the flow dial defaults on: the
+  // list carries no labels at all, but the relevance probe still reads its
+  // metadata on every commit.
+  it("commits both of two concurrent appends while the flow-labels probe runs", async () => {
+    const [rt1, rt2] = runtimes({ cfcFlowLabels: "persist" });
+    try {
+      // Seed the list with one element and get it durable on the server.
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+
+      // Both sessions load the seeded list, so both replicas hold ["seed"] at
+      // the same basis sequence.
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+      expect(cell2.get()).toEqual(["seed"]);
+
+      // Session 1 appends "A".
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+
+      // Session 2 appends "B" WITHOUT having observed session 1's "A": its
+      // replica still holds ["seed"] at the pre-"A" basis. The probe's
+      // metadata read of the concurrently bumped document must not conflict
+      // this commit.
+      const txB = rt2.edit();
+      rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB).push("B");
+      const result = await txB.commit({ resolveAt: "verdict" });
+      await rt2.storageManager.synced();
+
+      expect(result.error).toBeUndefined();
+      const durable = await readDurable(server, CAUSE, stringListSchema);
+      expect(durable.length).toBe(3);
+      expect(durable).toContain("seed");
+      expect(durable).toContain("A");
+      expect(durable).toContain("B");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The same loss with every dial left at its default: a write through a
+  // labeled schema marks the transaction CFC-relevant on its own, so the
+  // prepare pass runs and reads the document's stored metadata without any
+  // flow-labels setting.
+  it("commits both of two concurrent appends to a labeled list under default dials", async () => {
+    const [rt1, rt2] = runtimes();
+    try {
+      // Seed through the labeled schema; the prepare pass persists the derived
+      // label metadata onto the document.
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, LABELED_CAUSE, labeledListSchema, tx0)
+        .set(["seed"]);
+      tx0.prepareCfc();
+      const result0 = await tx0.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+      expect(result0.error).toBeUndefined();
+
+      // The document really does carry persisted CFC metadata, so this
+      // scenario is the labeled one rather than a copy of the case above.
+      const labeledId = rt1
+        .getCell<string[]>(space, LABELED_CAUSE, labeledListSchema)
+        .getAsNormalizedFullLink().id;
+      const replica = storage1.open(space).replica as unknown as {
+        getDocument(
+          id: string,
+        ): { cfc?: { labelMap?: { entries: unknown[] } } } | undefined;
+      };
+      expect(replica.getDocument(labeledId)?.cfc?.labelMap?.entries.length ?? 0)
+        .toBeGreaterThan(0);
+
+      const cell2 = rt2.getCell<string[]>(
+        space,
+        LABELED_CAUSE,
+        labeledListSchema,
+      );
+      await cell2.sync();
+      await cell2.pull();
+      expect(cell2.get()).toEqual(["seed"]);
+
+      // Session 1 appends "A" through the prepare pass.
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, LABELED_CAUSE, labeledListSchema, txA)
+        .push("A");
+      txA.prepareCfc();
+      const resultA = await txA.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+      expect(resultA.error).toBeUndefined();
+
+      // Session 2 appends "B" against the pre-"A" basis, again through the
+      // prepare pass. The pass's metadata reads must not conflict this commit.
+      const txB = rt2.edit();
+      rt2.getCell<string[]>(space, LABELED_CAUSE, labeledListSchema, txB)
+        .push("B");
+      txB.prepareCfc();
+      const resultB = await txB.commit({ resolveAt: "verdict" });
+      await rt2.storageManager.synced();
+
+      expect(resultB.error).toBeUndefined();
+      const durable = await readDurable(
+        server,
+        LABELED_CAUSE,
+        labeledListSchema,
+      );
+      expect(durable.length).toBe(3);
+      expect(durable).toContain("seed");
+      expect(durable).toContain("A");
+      expect(durable).toContain("B");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The link-label derivation reads the link source's `schema` meta. It must
+  // read that member rather than the source document's root: a link whose
+  // source is a collection another session appends to would otherwise take a
+  // whole-document dependency on it, and the link write would conflict on an
+  // append that says nothing about the schema it consulted.
+  it("commits a link write whose source a concurrent append targets", async () => {
+    const [rt1, rt2] = runtimes();
+    try {
+      // Seed the labeled source list. Its persisted metadata is what makes
+      // the link write below CFC-relevant and routes it through the
+      // link-label derivation.
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, LINK_SOURCE_CAUSE, labeledListSchema, tx0)
+        .set(["seed"]);
+      tx0.prepareCfc();
+      expect((await tx0.commit({ resolveAt: "verdict" })).error)
+        .toBeUndefined();
+      await rt1.storageManager.synced();
+
+      const sourceId = rt1
+        .getCell<string[]>(space, LINK_SOURCE_CAUSE, labeledListSchema)
+        .getAsNormalizedFullLink().id;
+
+      // Session 2 appends to that list, durably.
+      const cell2 = rt2.getCell<string[]>(
+        space,
+        LINK_SOURCE_CAUSE,
+        labeledListSchema,
+      );
+      await cell2.sync();
+      await cell2.pull();
+      const txA = rt2.edit();
+      rt2.getCell<string[]>(space, LINK_SOURCE_CAUSE, labeledListSchema, txA)
+        .push("A");
+      txA.prepareCfc();
+      expect((await txA.commit({ resolveAt: "verdict" })).error)
+        .toBeUndefined();
+      await rt2.storageManager.synced();
+
+      // Session 1, still at the pre-append basis, writes a link whose source
+      // is that list. Only the source's `schema` meta is consulted, so the
+      // concurrent append does not conflict this commit.
+      const txB = rt1.edit();
+      const target = rt1.getCell(space, LINK_TARGET_CAUSE, undefined, txB);
+      const targetId = target.getAsNormalizedFullLink().id;
+      const targetAddress = {
+        space,
+        scope: "space" as const,
+        id: targetId,
+        path: ["value", "field"],
+      };
+      txB.markCfcRelevant("link-write");
+      txB.writeValueOrThrow(targetAddress, "v");
+      txB.recordCfcWritePolicyInput({
+        kind: "link-write",
+        target: targetAddress,
+        source: { space, scope: "space", id: sourceId, path: [] },
+      });
+      txB.prepareCfc();
+      const result = await txB.commit({ resolveAt: "verdict" });
+
+      expect(result.error).toBeUndefined();
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The opposite direction: the surface read is exempt, but a handler's own
+  // explicit read of the list is not, so the dedup-then-push shape still
+  // conflicts and retries.
+  it("returns a conflict error for a conditional push racing a concurrent append", async () => {
+    const [rt1, rt2] = runtimes({ cfcFlowLabels: "persist" });
+    try {
+      const tx0 = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, tx0).set(["seed"]);
+      await tx0.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+
+      const cell2 = rt2.getCell<string[]>(space, CAUSE, stringListSchema);
+      await cell2.sync();
+      await cell2.pull();
+
+      const txA = rt1.edit();
+      rt1.getCell<string[]>(space, CAUSE, stringListSchema, txA).push("A");
+      await txA.commit({ resolveAt: "verdict" });
+      await rt1.storageManager.synced();
+
+      // Session 2, still at the pre-"A" basis, reads the list explicitly and
+      // then pushes — the dedup-then-push shape. The explicit read is
+      // retained, so the commit conflicts with session 1's append.
+      const txB = rt2.edit();
+      const cellB = rt2.getCell<string[]>(space, CAUSE, stringListSchema, txB);
+      cellB.get();
+      cellB.push("B");
+      const result = await txB.commit({ resolveAt: "verdict" });
+
+      expect(result.error).toBeDefined();
+      const durable = await readDurable(server, CAUSE, stringListSchema);
+      expect(durable).toEqual(["seed", "A"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Two prepare-pass helpers read a whole document to reach a single member. `storedMetadataFor` wants the `cfc` label-metadata envelope, and `setupResultSchemaFor` wants the `schema` meta. Both issued a recursive read at storage path `[]`.

A recursive root read depends on every path in the document, so it enters the commit's confirmed conflict reads. The read-set builder exempts only exact `["cfc"]` reads, a mergeable operation's own reads, and reads below the operation's path, so a root read survives even on a document that a mergeable operation targets. The consequence is data loss. Two sessions that concurrently append to the same document — writes the mergeable machinery exists to let both land — end with one side rejected as a stale confirmed read, and that side's append is dropped rather than merged.

This is reachable as the runtime ships. A write through a schema that declares a label marks the transaction CFC-relevant on its own, so the prepare pass runs over any labeled document with every dial left at its default; turning flow labels on extends the same probe to every commit.

Read the member surfaces instead: `["cfc"]` in `storedMetadataFor` and `["schema"]` in `setupResultSchemaFor`. On a document a mergeable operation targets, the `["cfc"]` read is exempt outright; the `["schema"]` read is kept, but it depends on that member alone, which a concurrent append to the document's value leaves undisturbed.

A `["cfc"]` read is answered with the member by a caller that resolves the path and with the whole envelope by a path-blind one, so the shape decision that `readStoredCfcMetadata` already made moves into a shared `cfcMetadataFromCfcRead` and both readers use it. The two keep their own read metadata rather than sharing a reader: the label view's read feeds the scheduler, while a prepare-pass read is hidden from it, and prepare writes the very member it reads.

The existing cross-session mergeable-array suites do not cover this, because they exercise no labeled document and leave the flow dial off. The new suite drives the cross-session append scenario twice: once on a labeled list with every dial at its default, and once with flow labels persisting over an unlabeled list. A third case pins the opposite direction, that the exemption covers only the probe's own read, so a handler's explicit read before a push still conflicts and retries.

The mergeable collection writes document gains the rule the fix rests on: the read-set narrowing keys on a read's path and not on the layer that issued it, so runtime machinery reads the member surface it needs rather than a document root.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

