### PR TITLE
fix(ts-transformers): a result may not declare its own screen opaque

### DIFF
--- a/docs/common/concepts/types-and-schemas/unknown.md
+++ b/docs/common/concepts/types-and-schemas/unknown.md
@@ -86,6 +86,13 @@ schema. The loss shows up wherever the tree is read as a value instead — a
 pattern that reads another pattern's screen, a pattern test that inspects one —
 and what those get is an empty object.
 
+The compiler refuses that declaration, at the root of a result and only there:
+`pattern-result:opaque-reserved-key`, one diagnostic naming every reserved key
+the result leaves opaque. It covers every key the framework puts on a result —
+`[TYPE]`, `[NAME]`, `[UI]`, `[TILE_UI]`, `[CHIP_UI]`, `[FS]`, `[TESTS]` — for
+the same reason: a key whose spelling the framework fixed holds a value this
+pattern produced.
+
 The consuming side of the same field goes the other way, and the two
 declarations are independent of each other. A pattern that takes another
 pattern's result as an argument and only renders it declares that position

--- a/docs/development/debugging/gotchas/unknown-typed-field-reads-a-reference.md
+++ b/docs/development/debugging/gotchas/unknown-typed-field-reads-a-reference.md
@@ -1,12 +1,14 @@
 # A field typed `unknown` reads back as a reference
 
-**Symptom:** a field holds a real value — another piece, a nested object — and
-every read of it through the declaring type carries none of that value: it is
-truthy and compares equal to what it names, but every property of it is
-`undefined`. No compile error, no runtime error, no warning. Rendering the same
-path still works, which is what makes this confusing:
+**Symptom:** a field holds a real value — another piece, a nested object, the
+screen a pattern just built — and every read of it through the declaring type
+carries none of that value: it is truthy and compares equal to what it names,
+but every property of it is `undefined`. No runtime error and no warning.
+Rendering the same path still works, which is what makes this confusing:
 `<cf-render $cell={entry.piece} />` shows the piece while `entry.piece.label`
-right beside it is undefined.
+right beside it is undefined. In a pattern test the same shape reads as `{}`:
+`textContent(piece[UI])` is empty even though the piece on screen shows the
+tree.
 
 ```typescript
 // Shown at module scope.
@@ -37,12 +39,48 @@ it under a schema of its own (`asSchema(rendererVDOMSchema)` —
 `html/src/in-process.ts` when the reconciler runs in the caller's own process),
 while every read of the *value* comes back empty.
 
-Two transformer diagnostics cover neighboring cases and neither catches this
+Three transformer diagnostics cover neighboring cases and none catches this
 one: `reactive-capture:unknown-type` reports a closure capture whose inferred
-type is `unknown`, and `schema:unknown-type-access` reports a property typed
+type is `unknown`, `schema:unknown-type-access` reports a property typed
 `unknown` accessed directly on a lift or handler parameter
-(`ts-transformers/src/transformers/type-shrinking.ts`). Reaching the field
-through an array element inside a callback, as below, is outside both.
+(`ts-transformers/src/transformers/type-shrinking.ts`), and
+`pattern-result:opaque-reserved-key` reports the reserved-key case below.
+Reaching the field through an array element inside a callback, as further
+below, is outside all three.
+
+## When the opaque field is the pattern's own screen
+
+The same reference semantics reach `[UI]` and `[NAME]`, and at the root of a
+pattern's own result they are the wrong reading. A reserved key's spelling
+belongs to the framework rather than to whoever described it, so the value
+under it there is one that pattern produced: the screen it built, the name it
+chose. Declared `unknown`, that value is gone for every reader, while the piece
+goes on rendering — the renderer reads `$UI` under a schema of its own. A
+pattern test inspecting the screen, or another pattern reading it, gets `{}`.
+
+```typescript
+// Shown as alternative snippets.
+// The screen this pattern renders, declared as a reference to someone else's.
+type Wrong = { [NAME]: unknown; [UI]: unknown; label: string };
+```
+
+```typescript
+// Shown as alternative snippets.
+// The same result, naming what each field holds.
+type Right = { [NAME]: string; [UI]: VNode; label: string };
+```
+
+The compiler rejects the first form: `pattern-result:opaque-reserved-key`,
+raised at the `pattern()` call by `reserved-result-keys.ts` in
+`packages/ts-transformers`. It reaches the root of a **result** schema and
+nothing else, which leaves two shapes legal and needed. Below the root, a
+reserved key names a field of another piece, where `unknown` is what keeps the
+field a reference to that piece's own screen rather than a copy, so the
+controls in it stay bound to the piece that owns them. On the argument side, a
+declaration has to keep accepting every value it accepted before, so a consumer
+view of a result type holds `unknown` even where the producing type names
+`VNode`. `unknown`'s own page states that producer/consumer split:
+[`docs/common/concepts/types-and-schemas/unknown.md`](../../../common/concepts/types-and-schemas/unknown.md).
 
 ## What decides whether a read materializes
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -112,6 +112,14 @@ present; no stage handles a missing one.
      idempotency guards. It uses a plain presence check with **no**
      `getOriginalNode` fallback (it tags synthetic nodes whose original is the
      pre-injection user call).
+   - `patternResultAnchor` — for a `toSchema` call SchemaInjection created to
+     describe a pattern's **result**, the authored node a diagnostic about that
+     schema points at. It is what tells SchemaGeneration which of a file's
+     `toSchema` calls is a result rather than an argument, a handler's event or
+     a nested claim; §6.12 is the rule that reads it. Like `schemaInjected` it
+     is a plain identity lookup with **no** `getOriginalNode` fallback: the
+     marker sits on the synthetic call SchemaInjection built, and that node
+     reaches SchemaGeneration as the same object.
 3. **Marker family** — node/symbol-keyed `WeakSet`s whose membership checks fall
    back through `getOriginalNode`, and whose mutators are coupled to the
    context's reactive-analysis cache invalidation (invalidation is a
@@ -848,6 +856,10 @@ report these through the same collector (deduplicated via §2.2's
   reactive-root read at a position that stage cannot lower
 - **Error** `pattern-result:unknown-type` (`schema-injection.ts:2621`) — see
   §6.6
+- **Error** `pattern-result:opaque-reserved-key`
+  (`reserved-result-keys.ts`, called from `schema-generator.ts`) — a pattern's
+  own result declares one of the framework's reserved keys `unknown` at its
+  root; see §6.12
 - **Error** `reactive-capture:unknown-type` (`src/ast/type-building.ts:681`) —
   a captured reactive value's inferred type is `unknown`, so its schema would
   be `{ type: "unknown" }` and the runner would not materialize it, reading it
@@ -868,6 +880,58 @@ report these through the same collector (deduplicated via §2.2's
   rework); the internal throw remains only for compiler-synthesized culprits
   (a true pipeline bug) and for the culprit-already-compute disagreement
   shape.
+
+### 6.12 Reserved keys at the root of a pattern's own result
+
+A reserved key's spelling belongs to the framework rather than to whoever
+described it: a pattern result carries `$UI` and `$NAME` whatever the author's
+type says. At the root of a result, then, the value under such a key is one
+this pattern produced — the screen it built, the name it chose. `unknown` is
+the declaration for a field holding a reference to another piece, and it
+projects to an empty object carrying only a back-to-cell annotation, so a
+result that declares a reserved key `unknown` loses that value for every reader
+of it. Rendering is unaffected: a piece's screen is read under a schema the
+renderer supplies, and the pattern's declared result schema never enters that
+path. That is what makes the defect invisible until something reads the screen
+as a value.
+
+`reportOpaqueReservedResultKeys` (`src/transformers/reserved-result-keys.ts`)
+reports it as **Error** `pattern-result:opaque-reserved-key`, naming every
+offending key in one diagnostic. It runs from SchemaGeneration, which is the
+one place a declared result exists as the schema it generated — whatever type
+the author named, and whichever inference path §10.2 took to reach it.
+SchemaInjection records the result schema calls and the node to point at
+(§2.2's `patternResultAnchor`).
+
+The rule reaches the root of a result schema and nothing else. Two shapes stay
+legal, and a rule written without them breaks working patterns:
+
+- **The argument side.** An argument schema is checked contravariantly by
+  `deno task pattern-compat` — it has to keep accepting every value it
+  accepted before — so a consumer that takes stored pieces of any vintage
+  cannot narrow it. `BackwardsCompatibleProfile` in
+  `packages/patterns/system/profile-home.tsx` is such a seam.
+- **Below the root.** A reserved key one level down names a field of another
+  piece, where `unknown` is what keeps the field a reference to that piece's own
+  screen rather than a copy, so the controls in it stay bound to the piece that
+  owns them. `packages/patterns/record.tsx` reads a sub-piece's settings screen
+  that way.
+
+Root-ness follows a `$ref` into `$defs`, because a `$ref` measures the same
+value against another schema — a recursive result type emits exactly that
+shape. It follows nothing else: a `$ref` the generator cannot resolve locally,
+or a root that is a combinator rather than an object, is left alone.
+
+The list of reserved keys is `FRAMEWORK_RESULT_KEYS`
+(`packages/utils/src/framework-result-keys.ts`). The runner builds pattern
+results and reads those keys back off them, this package decides what a
+pattern may declare about them, and neither may import the other, so the
+spelling sits in a package below both and the runner's builder surface
+re-exports it.
+
+A `pattern()` call that already carries both schemas as arguments is left as
+SchemaInjection finds it (§10.2), so no result schema is recorded for it and
+the rule does not reach a hand-written schema literal.
 
 ## 7. JSX Expression Site Routing And Early Rewriting
 
@@ -1693,7 +1757,10 @@ Behavior:
 3. extract `widenLiterals` generation option
 4. generate schema via a `SchemaGenerator` instance
 5. merge non-generation options into resulting schema object
-6. emit literal as:
+6. report `pattern-result:opaque-reserved-key` when this call describes a
+   pattern's result and the generated schema leaves a reserved key opaque at
+   its root (§6.12)
+7. emit literal as:
    - `<schemaAst> as const satisfies __cfHelpers.JSONSchema`
 
 Special path:
@@ -3311,6 +3378,7 @@ re-listing it. The enforced sources of truth:
 | Recognized runtime exports + which are reactive origins (§5, §6.3) | `COMMONFABRIC_RUNTIME_EXPORT_REGISTRY` (`src/core/commonfabric-runtime-registry.ts`) | `test/core/commonfabric-runtime-registry.test.ts` asserts coverage of the runner builder factory |
 | SES self-contained callback boundaries (§6.5) | `SES_SELF_CONTAINED_CALLBACK_BOUNDARIES` (`src/transformers/pattern-context-validation.ts`) | excludes `sqlite-row-label-rule` by design |
 | Lowerable expression-site container kinds (§6.7) | `getExpressionContainerKind` (`expression-site-policy.ts`) | — |
+| Reserved keys the framework puts on a pattern result (§6.12) | `FRAMEWORK_RESULT_KEYS` (`packages/utils/src/framework-result-keys.ts`) | imported by both readers rather than restated: this package cannot import the runner, which imports it, so the shared spelling sits below both and `packages/runner/src/builder/types.ts` re-exports it onto the builder surface |
 | Diagnostic `type:` strings | the emitting transformer's `reportDiagnostic` calls | grep `type: "…"` per validator |
 | Auto-`.for()` cause triggers, cause-path grammar, and the `__patternResult` root (§13) | `shouldAddReactiveFor` / `createForCall` / `PATTERN_RESULT_CAUSE` (`src/transformers/reactive-variable-for.ts`) | emitted shapes pinned by the stable-cause tests in `test/transform.test.ts` |
 | Shadow-guard binding set + canonical guard text (§14) | `SHADOWED_FACTORY_BINDINGS` / `createFactoryShadowGuardSource()` (`packages/utils/src/sandbox-contract.ts`); insertion point `findFactoryGuardInsertionIndex` (`src/transformers/module-scope-shadowing.ts`) | emission byte-pinned by ~all fixture expected outputs; verifier consumes the same constants via `RESERVED_FACTORY_BINDINGS` (`packages/runner/src/sandbox/compiled-bundle-verifier.ts`); `cf view`'s `SCAFFOLDING_NAMES` (`packages/cli/lib/view/languages/typescript/vocab.ts`) is an unimported copy — check for drift |

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -86,6 +86,16 @@ import type {
   toCompactDebugString,
   toIndentedDebugString,
 } from "@commonfabric/data-model/value-debug";
+import {
+  CHIP_UI,
+  FRAMEWORK_RESULT_KEYS,
+  FS,
+  NAME,
+  TESTS,
+  TILE_UI,
+  TYPE,
+  UI,
+} from "@commonfabric/utils/framework-result-keys";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { ImplementationIdentity } from "../cfc/types.ts";
@@ -101,37 +111,11 @@ import { AuthSchema, WebhookConfigSchema } from "./schema-lib.ts";
 
 // Define runtime constants here - actual runtime values
 
-// Should be Symbol("UI") or so, but this makes repeat() use these when
-// iterating over patterns.
-export const TYPE = "$TYPE";
-export const NAME = "$NAME";
-export const UI = "$UI";
-// UI variants (CT-1321): optional sibling renderings addressed alongside [UI].
-// chip = inline, tile = gallery/grid card; absent variants fail over to a
-// per-variant default (see uiVariant()), with [UI] as the universal floor.
-export const TILE_UI = "$TILE_UI";
-export const CHIP_UI = "$CHIP_UI";
-export const FS = "$FS";
-// The reserved key a test pattern addresses its test steps under; the test
-// runner reads `[TESTS]` off the pattern output.
-export const TESTS = "$TESTS";
-
-/**
- * Every reserved key the framework puts on a pattern result: the type marker,
- * the display name, the rendering variants, the filesystem view, and the test
- * steps. Their spellings belong to the framework rather than to anything the
- * pattern computed, which is what lets a reader that describes only the
- * computed fields excuse them by name instead of failing on them.
- */
-export const FRAMEWORK_RESULT_KEYS = [
-  TYPE,
-  NAME,
-  UI,
-  TILE_UI,
-  CHIP_UI,
-  FS,
-  TESTS,
-] as const;
+// The reserved result keys are spelled in `@commonfabric/utils`, where the
+// transformer that polices what a pattern may declare about them reads the
+// same list. They are re-exported here because this is the builder surface a
+// pattern sees them through.
+export { CHIP_UI, FRAMEWORK_RESULT_KEYS, FS, NAME, TESTS, TILE_UI, TYPE, UI };
 
 // Symbol for accessing self-reference in patterns
 export const SELF: typeof SELFSymbol = Symbol("SELF") as any;

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -829,18 +829,18 @@ export default pattern((_) => {
       cancel();
     });
 
-    it("renders nested pattern components when page UI is typed unknown", async () => {
-      const unknownUiPattern =
-        `import { NAME, pattern, UI } from "commonfabric";
+    it("renders a nested pattern component placed in a parent's tree", async () => {
+      const nestedPattern =
+        `import { NAME, pattern, UI, type VNode } from "commonfabric";
 
 interface ChildOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
 }
 
 interface ParentOutput {
   [NAME]: string;
-  [UI]: unknown;
+  [UI]: VNode;
 }
 
 const Child = pattern<unknown, ChildOutput>(() => {
@@ -863,18 +863,18 @@ export default pattern<unknown, ParentOutput>(() => {
   };
 });`;
 
-      const unknownUiProgram: Program = {
+      const nestedProgram: Program = {
         main: "/main.tsx",
         files: [{
           name: "/main.tsx",
-          contents: unknownUiPattern,
+          contents: nestedPattern,
         }],
       };
 
       const session = await createTestSession();
       await using rt = await createRuntimeClient(session);
 
-      const page = await rt.createPage(unknownUiProgram, session.space, {
+      const page = await rt.createPage(nestedProgram, session.space, {
         run: true,
       });
       const mock = new MockDoc(

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -34,6 +34,19 @@ export interface NodeTypeLinks {
    * pre-injection user call, which must NOT read as injected.
    */
   schemaInjected?: true;
+  /**
+   * For a `toSchema` call SchemaInjection created to describe a pattern's
+   * RESULT, the authored node a diagnostic about that schema points at. The
+   * schema call is synthetic and carries no source position of its own, so the
+   * anchor is what gives the reader a line to look at.
+   *
+   * SchemaGeneration is the stage that turns the call into a schema literal,
+   * and it is the only stage that can see what the declared result type
+   * generated. This channel is what tells it which of the many `toSchema` calls
+   * in a file is a pattern result rather than an argument, a handler's event,
+   * or a nested claim.
+   */
+  patternResultAnchor?: ts.Node;
 }
 
 /**
@@ -207,6 +220,19 @@ export class CrossStageState {
 
   lookupCapabilitySummary(fn: ts.Node): FunctionCapabilitySummary | undefined {
     return this.nodeLinks.get(fn)?.capabilitySummary;
+  }
+
+  // --- patternResultAnchor (nodeLinks-backed) ---
+
+  recordPatternResultSchemaCall(schemaCall: ts.Node, anchor: ts.Node): void {
+    this.#linksFor(schemaCall).patternResultAnchor = anchor;
+  }
+
+  lookupPatternResultSchemaAnchor(schemaCall: ts.Node): ts.Node | undefined {
+    // Plain identity lookup with NO getOriginalNode fallback: the marker sits
+    // on the synthetic call SchemaInjection built, and that node reaches
+    // SchemaGeneration as the same object.
+    return this.nodeLinks.get(schemaCall)?.patternResultAnchor;
   }
 
   // --- schemaInjected (nodeLinks-backed) ---

--- a/packages/ts-transformers/src/transformers/reserved-result-keys.ts
+++ b/packages/ts-transformers/src/transformers/reserved-result-keys.ts
@@ -1,0 +1,114 @@
+import { FRAMEWORK_RESULT_KEYS } from "@commonfabric/utils/framework-result-keys";
+import type ts from "typescript";
+
+import type { TransformationContext } from "../core/mod.ts";
+
+/** The type to name instead, for the keys whose value has a fixed shape. */
+const SUGGESTED_TYPE: Readonly<Record<string, string>> = {
+  $TYPE: "string",
+  $NAME: "string",
+  $UI: "VNode",
+  $TILE_UI: "VNode",
+  $CHIP_UI: "VNode",
+};
+
+/**
+ * The schema describing the root value, following `$ref` indirection into
+ * `$defs`. A `$ref` measures the same value against another schema, so the
+ * root is still the root however many schemas describe it — the same rule the
+ * runner's schema sanitizer applies when it decides which value's keys are the
+ * framework's to name.
+ */
+function resolveRootSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const seen = new Set<string>();
+  let current = schema;
+  while (typeof current.$ref === "string") {
+    const ref = current.$ref;
+    if (seen.has(ref)) return undefined;
+    seen.add(ref);
+    const path = ref.split("/");
+    if (path.length !== 3 || path[0] !== "#" || path[1] !== "$defs") {
+      return undefined;
+    }
+    const defs = schema.$defs;
+    if (typeof defs !== "object" || defs === null) return undefined;
+    const target = (defs as Record<string, unknown>)[path[2]!];
+    if (
+      typeof target !== "object" || target === null || Array.isArray(target)
+    ) {
+      return undefined;
+    }
+    current = target as Record<string, unknown>;
+  }
+  return current;
+}
+
+/** Whether a property schema leaves the value it describes unmaterialized. */
+function isOpaque(schema: unknown): boolean {
+  return typeof schema === "object" && schema !== null &&
+    !Array.isArray(schema) &&
+    (schema as Record<string, unknown>).type === "unknown";
+}
+
+/**
+ * Report a pattern whose own result declares a reserved key opaque.
+ *
+ * A reserved key's spelling belongs to the framework rather than to whoever
+ * described it, so at the root of a result the value under it is one this
+ * pattern produced: the screen it just built, the name it chose. `unknown` is
+ * the declaration for a field that holds a reference to another piece, and it
+ * projects to an empty object carrying only a back-to-cell annotation. For a
+ * field holding a value this pattern produced, that is the whole value gone
+ * for every reader of it.
+ *
+ * The rule reaches the root of a result schema and nothing else. A reserved
+ * key one level down names a field of another piece, where staying a reference
+ * is what keeps the controls in it bound to the piece that owns them. An
+ * argument schema is checked contravariantly — it has to keep accepting every
+ * value it accepted before — so a consumer seam cannot narrow it either.
+ */
+export function reportOpaqueReservedResultKeys(
+  context: Pick<TransformationContext, "reportDiagnosticOnce">,
+  schema: unknown,
+  anchor: ts.Node,
+): void {
+  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+    return;
+  }
+  const root = resolveRootSchema(schema as Record<string, unknown>);
+  const properties = root?.properties;
+  if (typeof properties !== "object" || properties === null) return;
+  const offenders = FRAMEWORK_RESULT_KEYS.filter((key) =>
+    isOpaque((properties as Record<string, unknown>)[key])
+  );
+  if (offenders.length === 0) return;
+
+  const plural = offenders.length > 1;
+  const names = offenders.map((key) => `\`${key}\``).join(", ");
+  const suggestions = offenders.flatMap((key) => {
+    const type = SUGGESTED_TYPE[key];
+    return type === undefined ? [] : [`${key} holds a \`${type}\``];
+  });
+  const advice = suggestions.length > 0
+    ? ` Name the type the field holds: ${suggestions.join(", ")}.`
+    : " Name the type the field holds.";
+
+  context.reportDiagnosticOnce({
+    severity: "error",
+    type: "pattern-result:opaque-reserved-key",
+    message: `pattern() output ${plural ? "fields" : "field"} ${names} ` +
+      `${plural ? "are" : "is"} declared \`unknown\`, so the result schema ` +
+      `carries \`{ type: "unknown" }\` there. \`unknown\` declares a field ` +
+      `that holds a reference to another piece: a reader gets back an opaque ` +
+      `reference carrying no properties rather than the value. A reserved ` +
+      `key at the root of a result holds what this pattern produced — the ` +
+      `screen it built, the name it chose — so declaring it that way loses ` +
+      `that value for every reader, while the renderer, which supplies its ` +
+      `own schema, goes on working.${advice} Below the root, and on the ` +
+      `argument side, a reserved key may stay \`unknown\`: there it does ` +
+      `name another piece's field.`,
+    node: anchor,
+  });
+}

--- a/packages/ts-transformers/src/transformers/reserved-result-keys.ts
+++ b/packages/ts-transformers/src/transformers/reserved-result-keys.ts
@@ -101,12 +101,13 @@ export function reportOpaqueReservedResultKeys(
     message: `pattern() output ${plural ? "fields" : "field"} ${names} ` +
       `${plural ? "are" : "is"} declared \`unknown\`, so the result schema ` +
       `carries \`{ type: "unknown" }\` there. \`unknown\` declares a field ` +
-      `that holds a reference to another piece: a reader gets back an opaque ` +
-      `reference carrying no properties rather than the value. A reserved ` +
-      `key at the root of a result holds what this pattern produced — the ` +
-      `screen it built, the name it chose — so declaring it that way loses ` +
-      `that value for every reader, while the renderer, which supplies its ` +
-      `own schema, goes on working.${advice} Below the root, and on the ` +
+      `that holds a reference to another piece. A reader of such a field ` +
+      `gets an opaque reference carrying no properties rather than the ` +
+      `value. A reserved key at the root of a result holds what this ` +
+      `pattern produced: the screen it built, the name it chose. Declaring ` +
+      `it \`unknown\` throws that value away for every reader. The screen ` +
+      `goes on rendering, because the renderer supplies its own schema and ` +
+      `never reads the declared one.${advice} Below the root, and on the ` +
       `argument side, a reserved key may stay \`unknown\`: there it does ` +
       `name another piece's field.`,
     node: anchor,

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -19,6 +19,7 @@ import { unwrapExpression } from "../utils/expression.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
 import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 import { compileCfcPolicyManifestsForSource } from "./cfc-policy-authoring.ts";
+import { reportOpaqueReservedResultKeys } from "./reserved-result-keys.ts";
 
 export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -161,6 +162,19 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         const emittedSchema = typeof finalSchema === "boolean"
           ? finalSchema
           : { ...(finalSchema as Record<string, unknown>), ...optionsObj };
+        // This is the one place a pattern's declared result exists as the
+        // schema it generated, whatever type the author named and whichever
+        // inference path SchemaInjection took to reach it. SchemaInjection
+        // recorded which calls describe a result, and the node to point at.
+        const patternResultAnchor = context.state
+          .lookupPatternResultSchemaAnchor(node);
+        if (patternResultAnchor) {
+          reportOpaqueReservedResultKeys(
+            context,
+            emittedSchema,
+            patternResultAnchor,
+          );
+        }
         const schemaAst = createSchemaAst(emittedSchema, context.factory);
 
         // Wrap in `as const satisfies JSONSchema` so that schema-inference

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2985,6 +2985,10 @@ function handlePatternSchemaInjection(
 
       // Use existing schema directly as input, create result schema from type
       const toSchemaResult = createToSchemaCall(context, resultTypeNode);
+      context.state.recordPatternResultSchemaCall(
+        toSchemaResult,
+        node.expression,
+      );
       preserveUiContractHint(
         resultTypeNode,
         toSchemaResult,
@@ -3085,6 +3089,10 @@ function handlePatternSchemaInjection(
     resultTypeNode,
     checker,
     typeRegistry,
+  );
+  context.state.recordPatternResultSchemaCall(
+    resultSchemaCall,
+    node.expression,
   );
   if (
     unwrappedPatternReturnExpr &&

--- a/packages/ts-transformers/test/reserved-result-keys.test.ts
+++ b/packages/ts-transformers/test/reserved-result-keys.test.ts
@@ -1,0 +1,168 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import ts from "typescript";
+
+import type { DiagnosticInput } from "../src/core/mod.ts";
+import { reportOpaqueReservedResultKeys } from "../src/transformers/reserved-result-keys.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { validateSource } from "./utils.ts";
+
+const DIAGNOSTIC_TYPE = "pattern-result:opaque-reserved-key";
+
+/** The diagnostics one schema draws, reported straight rather than compiled. */
+function diagnosticsFor(schema: unknown): DiagnosticInput[] {
+  const reported: DiagnosticInput[] = [];
+  reportOpaqueReservedResultKeys(
+    { reportDiagnosticOnce: (input) => void reported.push(input) },
+    schema,
+    ts.factory.createIdentifier("anchor"),
+  );
+  return reported;
+}
+
+/** A result schema whose root is a reference to the one definition it holds. */
+function rootRef(ref: string, definition?: unknown): Record<string, unknown> {
+  return {
+    $ref: ref,
+    ...(definition === undefined ? {} : { $defs: { Held: definition } }),
+  };
+}
+
+const OPAQUE_SCREEN = {
+  type: "object",
+  properties: { $UI: { type: "unknown" }, label: { type: "string" } },
+} as const;
+
+/** The reserved-key diagnostics a source produces, in emission order. */
+async function reservedKeyDiagnostics(lines: string[]) {
+  const { diagnostics } = await validateSource(lines.join("\n"), {
+    types: COMMONFABRIC_TYPES,
+  });
+  const unexpected = diagnostics.filter((d) =>
+    d.severity === "error" && d.type !== DIAGNOSTIC_TYPE
+  );
+  expect(unexpected.map((d) => `${d.type}: ${d.message}`)).toEqual([]);
+  return diagnostics.filter((d) => d.type === DIAGNOSTIC_TYPE);
+}
+
+describe("reserved-result-keys", () => {
+  describe("reportOpaqueReservedResultKeys()", () => {
+    it("ignores a schema that describes no properties", () => {
+      expect(diagnosticsFor(true)).toEqual([]);
+      expect(diagnosticsFor(null)).toEqual([]);
+      expect(diagnosticsFor([OPAQUE_SCREEN])).toEqual([]);
+      expect(diagnosticsFor({ type: "object" })).toEqual([]);
+    });
+
+    it("follows a root reference into the definition it names", () => {
+      const reported = diagnosticsFor(
+        rootRef("#/$defs/Held", OPAQUE_SCREEN),
+      );
+      expect(reported.length).toBe(1);
+      expect(reported[0]!.message).toContain("`$UI`");
+    });
+
+    it("follows a chain of root references", () => {
+      expect(
+        diagnosticsFor({
+          $ref: "#/$defs/Outer",
+          $defs: { Outer: { $ref: "#/$defs/Held" }, Held: OPAQUE_SCREEN },
+        }).length,
+      ).toBe(1);
+    });
+
+    it("leaves a root reference it cannot resolve alone", () => {
+      // An external reference, one with no definitions to resolve against, one
+      // naming a definition that is not there, and one that names itself.
+      expect(diagnosticsFor(rootRef("https://example.test/vnode.json")))
+        .toEqual(
+          [],
+        );
+      expect(diagnosticsFor({ $ref: "#/$defs/Held" })).toEqual([]);
+      expect(diagnosticsFor(rootRef("#/$defs/Absent", OPAQUE_SCREEN))).toEqual(
+        [],
+      );
+      expect(diagnosticsFor(rootRef("#/$defs/Held", { $ref: "#/$defs/Held" })))
+        .toEqual([]);
+    });
+
+    it("reports a declared result that leaves its own screen opaque", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { pattern, UI } from "commonfabric";',
+        "type Out = { [UI]: unknown; label: string };",
+        "export default pattern<{ label: string }, Out>(",
+        "  (s) => ({ [UI]: s.label, label: s.label }),",
+        ");",
+      ]);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]!.severity).toBe("error");
+      expect(diagnostics[0]!.message).toContain("`$UI`");
+      expect(diagnostics[0]!.message).toContain("VNode");
+    });
+
+    it("names every offending key in one diagnostic", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { NAME, pattern, UI } from "commonfabric";',
+        "type Out = { [NAME]: unknown; [UI]: unknown; label: string };",
+        "export default pattern<{ label: string }, Out>(",
+        "  (s) => ({ [NAME]: s.label, [UI]: s.label, label: s.label }),",
+        ");",
+      ]);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]!.message).toContain("`$NAME`, `$UI`");
+    });
+
+    it("reports a recursive result whose root is a reference into $defs", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { pattern, UI } from "commonfabric";',
+        "type Branch = { [UI]: unknown; label: string; children: Branch[] };",
+        "export default pattern<{ label: string }, Branch>(",
+        "  (s) => ({ [UI]: s.label, label: s.label, children: [] }),",
+        ");",
+      ]);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]!.message).toContain("`$UI`");
+    });
+
+    it("accepts a result that names the type its reserved key holds", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { NAME, pattern } from "commonfabric";',
+        "type Out = { [NAME]: string; label: string };",
+        "export default pattern<{ label: string }, Out>(",
+        "  (s) => ({ [NAME]: s.label, label: s.label }),",
+        ");",
+      ]);
+      expect(diagnostics).toEqual([]);
+    });
+
+    it("accepts an argument whose root leaves a reserved key opaque", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { NAME, pattern } from "commonfabric";',
+        "type StoredPiece = { [NAME]: unknown; label: string };",
+        "export default pattern<StoredPiece, { label: string }>(",
+        "  (s) => ({ label: s.label }),",
+        ");",
+      ]);
+      expect(diagnostics).toEqual([]);
+    });
+
+    it("accepts a reserved key left opaque below the root of a result", async () => {
+      const diagnostics = await reservedKeyDiagnostics([
+        "/// <cts-enable />",
+        'import { NAME, pattern } from "commonfabric";',
+        "type Held = { [NAME]: unknown; label: string };",
+        "type Out = { held: Held; label: string };",
+        "export default pattern<{ label: string }, Out>(",
+        "  (s) => ({ held: { [NAME]: s.label, label: s.label }, label: s.label }),",
+        ");",
+      ]);
+      expect(diagnostics).toEqual([]);
+    });
+  });
+});

--- a/packages/utils/deno.jsonc
+++ b/packages/utils/deno.jsonc
@@ -27,6 +27,7 @@
     "./encoding": "./src/encoding.ts",
     "./env": "./src/env.ts",
     "./equal-ignoring-symbols": "./src/equal-ignoring-symbols.ts",
+    "./framework-result-keys": "./src/framework-result-keys.ts",
     "./logger": "./src/logger.ts",
     "./markdown": "./src/markdown.ts",
     "./objects": "./src/objects.ts",

--- a/packages/utils/src/framework-result-keys.ts
+++ b/packages/utils/src/framework-result-keys.ts
@@ -1,0 +1,41 @@
+/**
+ * The reserved keys the framework puts on a pattern result.
+ *
+ * Their spellings belong to the framework rather than to anything the pattern
+ * computed. Two packages act on that fact and neither may import the other —
+ * the runner builds the results and reads the keys back off them, and the
+ * transformer decides what a pattern may declare about them — so the spelling
+ * lives here, where both reach it.
+ */
+
+// Should be Symbol("UI") or so, but this makes repeat() use these when
+// iterating over patterns.
+export const TYPE = "$TYPE";
+export const NAME = "$NAME";
+export const UI = "$UI";
+// UI variants: optional sibling renderings addressed alongside [UI].
+// chip = inline, tile = gallery/grid card; absent variants fail over to a
+// per-variant default (see uiVariant()), with [UI] as the universal floor.
+export const TILE_UI = "$TILE_UI";
+export const CHIP_UI = "$CHIP_UI";
+export const FS = "$FS";
+// The reserved key a test pattern addresses its test steps under; the test
+// runner reads `[TESTS]` off the pattern output.
+export const TESTS = "$TESTS";
+
+/**
+ * Every reserved key the framework puts on a pattern result: the type marker,
+ * the display name, the rendering variants, the filesystem view, and the test
+ * steps. A reader that describes only the computed fields excuses these by
+ * name instead of failing on them, and a pattern that declares one of them at
+ * the root of its own result is describing a value it produced.
+ */
+export const FRAMEWORK_RESULT_KEYS = [
+  TYPE,
+  NAME,
+  UI,
+  TILE_UI,
+  CHIP_UI,
+  FS,
+  TESTS,
+] as const;


### PR DESCRIPTION
Ten patterns declared the screen they render as `[UI]: unknown`, and four of those declared their piece's name `[NAME]: unknown` alongside it. They were repaired by hand; nothing stopped the next pattern from doing it again, and this is that.

The defect is invisible from the running product, which is why it accumulated. A piece's screen is rendered by reading its `$UI` under a schema the renderer supplies, at a single override point every render path funnels through — the shell, cf-render's tile and chip variants, the drag preview, the CLI's renderer, and the in-process reconciler. The pattern's declared result schema never enters that path. So the app looks right and only value-reads break: another pattern reading the screen, or a pattern test inspecting it, gets `{}`.

Nor did either type-check environment catch it. Patterns compile under the classic-JSX runtime that `deno task cfcheck` runs, and there a result type declaring `[UI]: unknown` is accepted both on its own and with the pattern embedded in JSX. The automatic-JSX environment of a standalone `deno check` rejects only the embedded form, through `UIRenderable`, and `[NAME]` is never placed in JSX so it has no backstop at all. What the checker does catch is the INFERRED result: an object literal returned without a declared output type is measured against `VNode`, and an `unknown` there fails. The gap is exactly the declared type.

The new diagnostic `pattern-result:opaque-reserved-key` closes it. A reserved key's spelling belongs to the framework rather than to whoever described it, so at the root of a result the value under it is one this pattern produced — the screen it built, the name it chose. `unknown` is the declaration for a field holding a reference to another piece, and since "an `unknown` field keeps the reference it holds" such a field projects to an empty object carrying only a back-to-cell annotation. For a field holding a value this pattern produced, that is the whole value gone.

The rule reaches the root of a result schema and nothing else, because two shapes have to stay legal and a rule written without them breaks working patterns. An argument schema is checked the other way round — it has to keep accepting every value it accepted before — so a consumer seam that takes stored pieces of any vintage cannot narrow it; `BackwardsCompatibleProfile` in `system/profile-home.tsx` is such a seam and keeps `[UI]` opaque on purpose. And a reserved key below the root names a field of ANOTHER piece, where staying a reference is what keeps the controls in it bound to the piece that owns them; `record.tsx` reads a sub-piece's settings screen that way. Compiling all 337 authored patterns and inspecting their generated schemas finds no result-side root occurrence, no argument-side root occurrence, and three nested ones — `system/home.tsx`, `system/profile-create.tsx` and `system/profile-picker.tsx`, the three consumers of that weakened profile type, and precisely the population a careless rule would break. One of those three carries its nested occurrence inside the `$defs` of its own RESULT schema, so even "walk the result schema" would be too wide.

The check runs from SchemaGeneration rather than from the declaration site. That stage is the one place a declared result exists as the schema it generated, whatever type the author named and whichever of SchemaInjection's inference paths reached it, so the rule is stated once against the artifact the defect is defined in terms of. SchemaInjection, which is where the argument/result distinction is native, records which `toSchema` calls describe a result and which authored node a diagnostic about one should point at; it passes that along the NodeLinks-shaped side table the pipeline already uses for per-node facts. That channel is a plain identity lookup, with no `getOriginalNode` fallback: the marker sits on the synthetic call SchemaInjection built, and that node reaches SchemaGeneration as the same object. Instrumenting a fallback and compiling all 420 pattern files takes it zero times.

Root-ness follows a `$ref` into `$defs`, since a `$ref` measures the same value against another schema. That is load-bearing rather than defensive: a recursive result type emits its root as exactly that shape, and would otherwise slip through. A reference the generator cannot resolve locally, one with no definitions to resolve against, one naming a definition that is not there, and one naming itself are each left alone rather than guessed at or looped on.

The list of reserved keys is all seven the framework puts on a result, not just the two that went wrong: the argument that a reserved key at a result root holds a produced value applies to every one of them. The wider list costs nothing today — the same survey run over all seven keys reports the same three nested hits and no root ones, and `deno task cfcheck` passes over all 420 pattern files, which includes the pattern tests the survey's file set leaves out.

Two packages now act on that list, and neither may import the other: the runner builds pattern results and reads the keys back off them, and this one decides what a pattern may declare about them. So the spelling lives in `@commonfabric/utils`, which sits below both, and which this package already reaches for the sandbox contract it shares with the runner the same way. `packages/runner/src/builder/types.ts` re-exports it, since that is the builder surface a pattern sees these keys through, and nothing downstream of it changes. Restating the list in the transformer and adding a test to catch the two copies drifting would have been a second source of truth for something with one spelling.

Two bounds on the rule are stated in the spec rather than left for a reader to derive. The diagnostic cannot fire under a standalone `deno check`, which runs no transformer; that environment is not where patterns are checked, and `deno task cfcheck` fails on the defect now. And a `pattern()` call that already carries both schemas as arguments is left exactly as schema injection finds it, so nothing records a result schema for it and a hand-written schema literal declaring `$UI` opaque goes unreported.

The tests come in two halves. The pipeline half compiles the pattern forms — a declared result that leaves its screen opaque, one that leaves several keys opaque, a recursive one, one that names its types, an argument that leaves a reserved key opaque at its own root, and a reserved key left opaque below a result root. The schema half hands the reporter a schema directly, which is what reaches the resolver's give-up branches; that is why the reporter asks for `Pick<TransformationContext, "reportDiagnosticOnce">` rather than a whole context, the same narrowing the schema-injection helpers use.

Also included:

- The gotcha page `unknown-typed-field-reads-a-reference.md`, under `docs/development/debugging/gotchas/`, is where someone lands after a field that holds something reads back carrying nothing, and it framed the whole problem as a field holding a link to another piece. A reader arriving from a blank screen in a pattern test — `textContent(piece[UI])` empty while the piece on screen shows the tree — found no case matching theirs. The reserved keys are now their own section there, with the wrong and right declarations side by side, the diagnostic that rejects the wrong one, and the two shapes the rule leaves alone so the section is not read as licence to narrow either. Its symptom paragraph gains the pattern-test spelling, and its list of neighboring diagnostics gains this one.
- `docs/common/concepts/types-and-schemas/unknown.md` already carried the rule and the producer/consumer split. It now says the compiler enforces the producing half, names the diagnostic, and lists the keys it covers.
- The current-behavior spec gains §6.12 for the rule, a §6.11 entry, the new cross-stage channel in §2.2, the post-generation step in §12, and a §21.1 sources-of-truth row for the mirrored key list.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

