### PR TITLE
test(shell): hold login to the app-readiness boundary

### DIFF
--- a/packages/shell/AGENTS.md
+++ b/packages/shell/AGENTS.md
@@ -28,7 +28,12 @@ runtime and gives a user a way to move around their spaces. Entry point is
   and `setConfig`. `src/lib/app-state.ts` names the part of that surface a
   caller outside the element sees as `ShellApp`: the shell's `Navigation` takes
   one, and `src/index.ts` publishes the root element on `globalThis.app` under
-  that type, which is how integration tests drive the page.
+  that type, which is how integration tests drive the page. That publication is
+  the last step of bootstrap, after the key store opens and `Navigation` is
+  installed, so a page that has fired `load` has not necessarily reached it. A
+  driver that navigates or reloads and then reaches for `globalThis.app` waits
+  for it to appear first — `login` in `packages/integration/shell-utils.ts`
+  does, and `packages/shell/integration/login.test.ts` holds it to that.
 - Navigation is the other way in, and it does not come from a shell view. Anyone
   holding `@commonfabric/navigation` calls `navigate(...)`, which dispatches a
   `cf-navigate` event on `globalThis`; the `Navigation` class in

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -1,6 +1,7 @@
-import { assert } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 
+import { Identity } from "@commonfabric/identity";
 import { env, waitForCondition } from "@commonfabric/integration";
 
 import { ShellIntegration } from "../../integration/shell-utils.ts";
@@ -60,6 +61,44 @@ describe("shell login tests", () => {
     assert(!result.beforeKeyStore.hasRegister);
     assert(!result.afterKeyStore.hasLoading);
     assert(result.afterKeyStore.hasRegister);
+  });
+
+  // The shell publishes `globalThis.app` at the end of its bootstrap, after
+  // the key store opens and Navigation is installed, so a driver that
+  // navigates or reloads and logs in straight away can arrive before the app
+  // is published. The property installed below is that window with the timing
+  // taken out of it: the first read of `globalThis.app` answers `undefined`,
+  // and every read after it answers the root element. Logging in through that
+  // property means waiting for the boundary rather than reading through it.
+  it("logs in while the app is still unpublished", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const page = shell.page();
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: "common-knowledge" },
+    });
+
+    await page.evaluate(() => {
+      let published: unknown = globalThis.app;
+      let unread = true;
+      Object.defineProperty(globalThis, "app", {
+        configurable: true,
+        get() {
+          if (!unread) return published;
+          unread = false;
+          return undefined;
+        },
+        set(value: unknown) {
+          published = value;
+        },
+      });
+    });
+
+    await shell.login(identity);
+
+    const state = await shell.state();
+    assertEquals(state?.identity?.did(), identity.did());
   });
 
   it("can create a new user via passphrase", async () => {


### PR DESCRIPTION
`packages/shell/src/index.ts` publishes the shell's root element on `globalThis.app` as the last step of its bootstrap, after the key store opens and `Navigation` is installed. That makes the global a readiness boundary: a page can have fired `load` and still not have reached it.

The integration driver's `login` reads `globalThis.app.state()`. Called straight after a navigation or a reload, it races that bootstrap, and losing the race throws `TypeError: Cannot read properties of undefined (reading 'state')` out of the page and fails the test. The pattern reload shard lost that race three runs in a row on main after the boundary moved in #6066, and won it on that pull request's own CI, so the coverage that caught the fault only catches it when the timing happens to go the wrong way. #6076 gave `login` a wait for the boundary, which fixes the fault and leaves nothing holding it there.

This test takes the timing out of the detection. It logs in normally, then replaces `globalThis.app` with an accessor that answers `undefined` to the first read and the root element to every read after it — the readiness window expressed as a property rather than as a moment in time. Reading the global instead of waiting for it then fails on every machine and every run: with the wait removed the test reproduces the CI failure, with the same message, in under a second; with the wait in place the login completes and the identity lands in application state.

The shell's agent guide gains the same fact, since when the boundary is reached is a property of the bootstrap rather than of the driver.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

