### PR TITLE
fix(integration): a navigation returns once its shell can be driven

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -81,6 +81,14 @@ composite web component; use a flattened-tree tool or the pierce fallback below.
      probe.collect("cf-input[role='textbox']").length > 0);
    ```
 
+   Every navigation a `ShellIntegration` page performs — `shell.goto()`, and a
+   bare `page.goto()` or `page.reload()` on the page it hands out — returns
+   only once the shell behind it can be driven. The shell publishes
+   `globalThis.app`, the handle a driver reaches it through, as the last step
+   of a bootstrap module whose body runs on past the document's `load` event,
+   so a navigation that settled on `load` would otherwise hand back a page
+   whose shell is still booting.
+
 ## Why This Works
 
 - **Host roles** give single-control `cf-*` components one stable semantic

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -72,7 +72,7 @@ export async function dismissDialogs(e: DialogEvent) {
 export class Page extends EventTarget {
   private page: AstralPage | null;
   private timeout: number;
-  private afterNavigation?: () => Promise<void> | void;
+  private afterNavigation: Array<() => Promise<void> | void> = [];
   private interactionObserver?: InteractionObserver;
   private defaultTypeDelay = 0;
   private decoratedElements = new WeakSet<AstralElementHandle>();
@@ -277,8 +277,21 @@ export class Page extends EventTarget {
     this.defaultTypeDelay = delay;
   }
 
-  setAfterNavigationHook(hook?: () => Promise<void> | void): void {
-    this.afterNavigation = hook;
+  // Registers `hook` to run after every navigation this page performs, once
+  // the navigation itself has settled. Hooks run in the order they were added,
+  // and the returned function removes this one. A page carries several at a
+  // time: the shell driver waits here for the shell to finish booting, and a
+  // presentation run starts its recorder here.
+  addAfterNavigationHook(hook: () => Promise<void> | void): () => void {
+    this.afterNavigation.push(hook);
+    return () => {
+      const index = this.afterNavigation.indexOf(hook);
+      if (index >= 0) this.afterNavigation.splice(index, 1);
+    };
+  }
+
+  private async runAfterNavigationHooks(): Promise<void> {
+    for (const hook of [...this.afterNavigation]) await hook();
   }
 
   async setViewportSize(
@@ -368,7 +381,7 @@ export class Page extends EventTarget {
     if (waitUntil === "none") {
       const result = await celestial.Page.navigate(navigateOptions);
       if (result.errorText) throw new Error(result.errorText);
-      await this.afterNavigation?.();
+      await this.runAfterNavigationHooks();
       return;
     }
     const lifecycleNames = waitUntil === "load"
@@ -535,7 +548,7 @@ export class Page extends EventTarget {
     }
     if (navigationFailed) throw navigationError;
     if (cleanupFailed) throw cleanupError;
-    await this.afterNavigation?.();
+    await this.runAfterNavigationHooks();
   }
 
   // Passthru of `@astral/astral`'s `Page#reload`
@@ -543,7 +556,7 @@ export class Page extends EventTarget {
     this.checkIsOk();
     await this.runNavigation(async () => {
       await this.page!.reload(options);
-      await this.afterNavigation?.();
+      await this.runAfterNavigationHooks();
     });
   }
 

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -291,7 +291,13 @@ export class Page extends EventTarget {
   }
 
   private async runAfterNavigationHooks(): Promise<void> {
-    for (const hook of [...this.afterNavigation]) await hook();
+    // Over a snapshot, so a hook registered by a hook waits for the next
+    // navigation. Each is re-checked against the live list, so a hook whose
+    // remover ran while an earlier hook was awaiting does not run afterwards.
+    for (const hook of [...this.afterNavigation]) {
+      if (!this.afterNavigation.includes(hook)) continue;
+      await hook();
+    }
   }
 
   async setViewportSize(

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -106,7 +106,7 @@ export class PresentationSession {
 
   async start(page: Page): Promise<void> {
     const state = this.#byPage.get(page);
-    if (!state || state.started) return;
+    if (!state || state.started || state.stopped) return;
     await presentationInteractions(page)?.prepareDocument();
     await state.recorder.start();
     state.started = true;

--- a/packages/integration/presentation/session.ts
+++ b/packages/integration/presentation/session.ts
@@ -27,6 +27,7 @@ type ParticipantState = {
   recorder: FrameRecorder;
   started: boolean;
   stopped: boolean;
+  removeAfterNavigationHook: () => void;
 };
 
 const slug = (value: string): string =>
@@ -77,7 +78,9 @@ export class PresentationSession {
     const participantDir = join(this.#config.outputDir, "participants", id);
     await page.setViewportSize(this.#config.viewport);
     installPresentationInteractions(page, this.#config, { label, color });
-    page.setAfterNavigationHook(() => this.start(page));
+    const removeAfterNavigationHook = page.addAfterNavigationHook(
+      () => this.start(page),
+    );
     const recorder = new FrameRecorder(page, {
       participantDir,
       id,
@@ -94,6 +97,7 @@ export class PresentationSession {
       started: false,
       stopped: false,
       manifest: recorder.manifest(),
+      removeAfterNavigationHook,
     };
     this.#participants.push(state);
     this.#byPage.set(page, state);
@@ -129,7 +133,7 @@ export class PresentationSession {
       this.#manifest.status = "capture-failed";
       this.#manifest.error ??= state.manifest.error;
     } finally {
-      page.setAfterNavigationHook(undefined);
+      state.removeAfterNavigationHook();
       presentationInteractions(page)?.uninstall();
       this.#syncManifest();
     }

--- a/packages/integration/shell-page-probe.ts
+++ b/packages/integration/shell-page-probe.ts
@@ -160,6 +160,14 @@ export async function readAndDescribeShellPage(page: Page): Promise<string> {
 }
 
 /**
+ * Whether the document in `page` is the shell, decided by the same
+ * `x-root-view` element {@link assertShellDocument} looks for.
+ */
+export async function isShellDocument(page: Page): Promise<boolean> {
+  return await page.evaluate(() => !!document.querySelector("x-root-view"));
+}
+
+/**
  * Fail unless the document in `page` is the shell.
  *
  * The shell's entry document carries an `x-root-view` element, so a document

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -30,6 +30,7 @@ import {
 import { getPresentationSession } from "./presentation/session.ts";
 import {
   assertShellDocument,
+  isShellDocument,
   readAndDescribeShellPage,
 } from "./shell-page-probe.ts";
 import { waitFor, waitForCondition } from "./utils.ts";
@@ -44,9 +45,31 @@ import "../shell/src/globals.ts";
  * opening the browser key store. That module body runs on past the document's
  * `load` event, so a navigation that resolves on `load` hands back a page whose
  * shell is still booting, for the couple of milliseconds the key store takes.
+ *
+ * A document that is not the shell never publishes the handle, and returns
+ * here without a wait. `goto` reports such a document through
+ * `assertShellDocument`, naming the URL it asked for, as soon as the
+ * navigation this belongs to returns.
  */
 export async function waitForShellReady(page: Page): Promise<void> {
-  await waitForCondition(page, () => globalThis.app !== undefined);
+  if (!await isShellDocument(page)) return;
+  try {
+    await waitForCondition(page, () => globalThis.app !== undefined);
+  } catch (cause) {
+    throw new Error(await describeShellReadyFailure(page), { cause });
+  }
+}
+
+/**
+ * Render what `page` held when the shell it carries never published itself on
+ * `globalThis.app`: the shell's own document loaded, and its bootstrap did not
+ * run to the end. The console tail in the block is where a bootstrap that
+ * threw says so.
+ */
+export async function describeShellReadyFailure(page: Page): Promise<string> {
+  return `The shell never published itself on globalThis.app.\n${await readAndDescribeShellPage(
+    page,
+  )}`;
 }
 
 // Pass the key over the boundary. When the state is returned,
@@ -67,11 +90,8 @@ export async function login(page: Page, identity: Identity): Promise<void> {
   }
 
   // Everything from here on runs against the page, and every way it can fail
-  // says nothing about the page it failed against. The wait below is for the
-  // shell to publish itself, which a document that is not the shell never
-  // does, so it runs to the stuck-condition net reporting only that five
-  // minutes passed. The runtime handshake that follows reports which of its
-  // two stages ran out, and no more than that.
+  // says nothing about the page it failed against. The runtime handshake below
+  // reports which of its two stages ran out, and no more than that.
   try {
     await loginToPublishedApp(page, transferrableId, identity.did());
   } catch (error) {

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -274,6 +274,10 @@ export class ShellIntegration {
     this.checkIsOk();
     const page = await this.#browser!.newPage(url);
     this.#attachPage(page);
+    // Astral navigates to `url` inside its own `newPage`, before this wrapper
+    // exists for an after-navigation hook to run on, so the wait that
+    // navigation would have run happens here.
+    if (url !== undefined) await waitForShellReady(page);
     return page;
   }
 

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -36,6 +36,19 @@ import { waitFor, waitForCondition } from "./utils.ts";
 
 import "../shell/src/globals.ts";
 
+/**
+ * Blocks until the shell behind `page` is there to be driven.
+ *
+ * `globalThis.app` is the handle every driver reaches the shell through, and
+ * the shell publishes it as the last step of its bootstrap module, after
+ * opening the browser key store. That module body runs on past the document's
+ * `load` event, so a navigation that resolves on `load` hands back a page whose
+ * shell is still booting, for the couple of milliseconds the key store takes.
+ */
+export async function waitForShellReady(page: Page): Promise<void> {
+  await waitForCondition(page, () => globalThis.app !== undefined);
+}
+
 // Pass the key over the boundary. When the state is returned,
 // the key is serialized to Uint8Arrays, and then turned into regular arrays,
 // which can then by transferred across the astral boundary.
@@ -78,7 +91,7 @@ async function loginToPublishedApp(
   transferrableId: TransferrableInsecureCryptoKeyPair,
   nextDID: string,
 ): Promise<void> {
-  await waitForCondition(page, () => globalThis.app !== undefined);
+  await waitForShellReady(page);
 
   await page!.evaluate<
     Promise<void>,
@@ -437,6 +450,9 @@ export class ShellIntegration {
   }
 
   #attachPage(page: Page) {
+    // Every navigation this page performs returns only once the shell behind
+    // it can be driven, so a test that reloads reaches a booted shell.
+    page.addAfterNavigationHook(() => waitForShellReady(page));
     page.addEventListener("console", (e: ConsoleEvent) => {
       if (e.detail.type === "error") {
         this.#errorLogs.push(e.detail.text);

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -93,6 +93,44 @@ Deno.test("Page runs every navigation hook, and stops one that is removed", asyn
   assertEquals(order, ["first", "second", "first"]);
 });
 
+Deno.test("Page skips a navigation hook removed while an earlier one waits", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(options: { url: string }): Promise<{ loaderId?: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => Promise.resolve({}),
+  };
+  const astralPage = {
+    timeout: 0,
+    reload: () => Promise.resolve(),
+    unsafelyGetCelestialBindings: () => celestial,
+  };
+  const page = new Page(
+    astralPage as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  const order: string[] = [];
+  // Holds the second hook's remover, which the first hook calls while this
+  // navigation's run is between the two.
+  const second = { remove: () => {} };
+  page.addAfterNavigationHook(async () => {
+    order.push("first");
+    await Promise.resolve();
+    second.remove();
+  });
+  second.remove = page.addAfterNavigationHook(() => {
+    order.push("second");
+  });
+
+  await page.goto("https://example.test/");
+
+  assertEquals(order, ["first"]);
+});
+
 Deno.test("Page navigation does not depend on Astral's retry wrapper", async () => {
   const navigationCalls: unknown[] = [];
   const lifecycleCalls: unknown[] = [];

--- a/packages/integration/test/presentation.test.ts
+++ b/packages/integration/test/presentation.test.ts
@@ -47,7 +47,7 @@ Deno.test("Page runs the navigation hook after goto and reload", async () => {
     { timeout: 10 },
   );
   let hookCalls = 0;
-  page.setAfterNavigationHook(() => {
+  page.addAfterNavigationHook(() => {
     hookCalls++;
   });
 
@@ -56,6 +56,41 @@ Deno.test("Page runs the navigation hook after goto and reload", async () => {
 
   assertEquals(navigations, ["https://example.test/", "reload"]);
   assertEquals(hookCalls, 2);
+});
+
+Deno.test("Page runs every navigation hook, and stops one that is removed", async () => {
+  const celestial = new EventTarget() as EventTarget & {
+    Page: {
+      setLifecycleEventsEnabled(): Promise<Record<string, never>>;
+      navigate(options: { url: string }): Promise<{ loaderId?: string }>;
+    };
+  };
+  celestial.Page = {
+    setLifecycleEventsEnabled: () => Promise.resolve({}),
+    navigate: () => Promise.resolve({}),
+  };
+  const astralPage = {
+    timeout: 0,
+    reload: () => Promise.resolve(),
+    unsafelyGetCelestialBindings: () => celestial,
+  };
+  const page = new Page(
+    astralPage as unknown as ConstructorParameters<typeof Page>[0],
+    { timeout: 10 },
+  );
+  const order: string[] = [];
+  page.addAfterNavigationHook(() => {
+    order.push("first");
+  });
+  const removeSecond = page.addAfterNavigationHook(() => {
+    order.push("second");
+  });
+
+  await page.goto("https://example.test/");
+  removeSecond();
+  await page.reload();
+
+  assertEquals(order, ["first", "second", "first"]);
 });
 
 Deno.test("Page navigation does not depend on Astral's retry wrapper", async () => {
@@ -103,7 +138,7 @@ Deno.test("Page navigation does not depend on Astral's retry wrapper", async () 
     { timeout: 10 },
   );
   let hookCalls = 0;
-  page.setAfterNavigationHook(() => {
+  page.addAfterNavigationHook(() => {
     hookCalls++;
   });
 

--- a/packages/integration/test/shell-failure-reports.test.ts
+++ b/packages/integration/test/shell-failure-reports.test.ts
@@ -11,7 +11,12 @@ import {
   readAndDescribeShellPage,
   readShellPageProbe,
 } from "../shell-page-probe.ts";
-import { describeStateWaitFailure, login } from "../shell-utils.ts";
+import {
+  describeShellReadyFailure,
+  describeStateWaitFailure,
+  login,
+  waitForShellReady,
+} from "../shell-utils.ts";
 
 // What the toolshed answers with when its fetch to the shell dev server fails.
 const PROXY_FAILURE_TEXT =
@@ -180,6 +185,33 @@ describe("shell-failure-reports", () => {
       const url = await load("/shell");
 
       await assertShellDocument(page, url);
+    });
+  });
+
+  describe("waitForShellReady()", () => {
+    it("returns for a document that is not the shell", async () => {
+      await load("/proxy-failure");
+
+      await waitForShellReady(page);
+    });
+
+    it("returns for a shell that has published itself", async () => {
+      await load("/booted-shell");
+
+      await waitForShellReady(page);
+    });
+  });
+
+  describe("describeShellReadyFailure()", () => {
+    it("returns a block naming the shell document that published nothing", async () => {
+      await load("/shell");
+
+      const described = await describeShellReadyFailure(page);
+      expect(described).toContain(
+        "The shell never published itself on globalThis.app.",
+      );
+      expect(described).toContain("x-root-view: present");
+      expect(described).toContain("globalThis.app: absent");
     });
   });
 

--- a/packages/shell/AGENTS.md
+++ b/packages/shell/AGENTS.md
@@ -31,9 +31,11 @@ runtime and gives a user a way to move around their spaces. Entry point is
   that type, which is how integration tests drive the page. That publication is
   the last step of bootstrap, after the key store opens and `Navigation` is
   installed, so a page that has fired `load` has not necessarily reached it. A
-  driver that navigates or reloads and then reaches for `globalThis.app` waits
-  for it to appear first — `login` in `packages/integration/shell-utils.ts`
-  does, and `packages/shell/integration/login.test.ts` holds it to that.
+  navigation through a page `ShellIntegration` attached waits for that
+  publication before it returns, so a test that navigates or reloads through one
+  reaches a shell that is there. A driver holding a page from anywhere else
+  waits for itself — `login` in `packages/integration/shell-utils.ts` does, and
+  `packages/shell/integration/login.test.ts` holds it to that.
 - Navigation is the other way in, and it does not come from a shell view. Anyone
   holding `@commonfabric/navigation` calls `navigate(...)`, which dispatches a
   `cf-navigate` event on `globalThis`; the `Navigation` class in

--- a/packages/shell/integration/reload.test.ts
+++ b/packages/shell/integration/reload.test.ts
@@ -1,0 +1,47 @@
+import { assert } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import { env } from "@commonfabric/integration";
+import { Identity } from "@commonfabric/identity";
+
+import { ShellIntegration } from "../../integration/shell-utils.ts";
+
+const { FRONTEND_URL } = env;
+
+// How many reloads one run holds the harness to. The shell finishes booting a
+// couple of milliseconds after the document's load event, so a single read
+// taken right after a reload can step over that window by luck; several
+// reloads make a navigation that returns early show up.
+const RELOADS = 5;
+
+describe("shell reload tests", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  // `globalThis.app` is the handle every driver reaches the shell through, and
+  // the shell publishes it as the last step of its bootstrap module. That
+  // module body runs on past the document's load event, so a navigation that
+  // returns on load can return while the shell is still booting, and a driver
+  // that reads the shell right then reads nothing. A test that reloads should
+  // not have to know that: when a reload returns, the shell behind it answers.
+  it("answers for its state as soon as a reload returns", async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    const spaceName = globalThis.crypto.randomUUID();
+    const page = shell.page();
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName },
+      identity,
+    });
+
+    for (let reload = 1; reload <= RELOADS; reload++) {
+      await page.reload({ waitUntil: "load" });
+      assert(
+        await shell.state(),
+        `Reload ${reload} returned before the shell was there to drive: ` +
+          `the shell reported no state.`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
The `Pattern Reload Integration Tests` job failed intermittently on main with a browser-side rejection out of the notebook reload test:

    Uncaught (in promise) TypeError: Cannot read properties of undefined
    (reading 'state')

The stack in the CI log carries only anonymous frames, but its shape names the code exactly: a forty-five line function whose second line reads a property called `state` at column forty-four. That is the function the integration harness serializes into the page to log in, and the line is `const currentIdentity = globalThis.app.state().identity;`. The undefined object is `globalThis.app`, not anything the notebook or its notes built, and the rate at which the test creates notes has nothing to do with it.

`globalThis.app` is the handle every browser test reaches the shell through. The shell publishes it as the last step of its bootstrap module, after opening the browser key store, and that module body runs on past the document's `load` event. A navigation that resolves on `load` therefore hands back a page whose shell is still booting, for the couple of milliseconds the key store takes. Measured against a local shell, the handle was missing at `load` on every one of eight reloads.

`ShellIntegration.goto()` never noticed, because it finishes by waiting for the app state to match the view it asked for, which cannot match until the shell is there. A bare `page.reload()` on the page `ShellIntegration` hands out has no such wait, and the notebook reload test reloads that way. When the window stayed open across the reply from the console-formatter call and the key serialization that follow, the login helper read `globalThis.app.state()` on nothing and the test failed.

Make the readiness boundary part of navigation instead of something each call site has to know: `ShellIntegration` registers an after-navigation hook on every page it attaches, and that hook waits for the shell to publish its handle. `goto`, `reload`, and a bare `page.goto()` on that page all now return only once the shell behind them answers.

Registering it needs the hook to be additive. A presentation run (`deno task demo`) already holds the single slot `Page` offered, and it starts each participant's recorder there, so `setAfterNavigationHook` becomes `addAfterNavigationHook`, which appends and returns a function that removes the hook again. Hooks run in the order they were added.

The login helper keeps its own wait. It is exported on its own and used with pages `ShellIntegration` never attached — the topic-board session driver is one — so it cannot rely on the hook being installed.

A new shell integration test states the contract the harness is now held to: when a reload returns, the shell behind it answers for its state. It reloads five times, because the window is only a couple of milliseconds wide and a single read can step over it by luck. Against the harness as it stood, that test failed on the first reload, ten runs out of ten.

deflaked by Hixie's agent Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

