### PR TITLE
docs(cfc): the strict rung of the enforcement ladder has a reject

### DIFF
--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -46,8 +46,9 @@ defaults `cfcEnforcementMode` to `enforce-explicit`
 ([`types.ts:42`](../../packages/runner/src/cfc/types.ts)) is only the
 bare-transaction fallback. What *is* dormant: flow-labels default `off`
 ([`types.ts:331`](../../packages/runner/src/cfc/types.ts)) everywhere, the render
-confidentiality ceiling is plumbed end-to-end but no host populates it, and
-`enforce-strict` has no distinct behavior. So the flow-taint and display
+confidentiality ceiling is plumbed end-to-end but no host populates it, and no
+host runs at `enforce-strict`, leaving the one reject that rung adds — the
+writer-fit misfit — unexercised in deployment. So the flow-taint and display
 protections below are *built but dormant* until a host turns them on — see Epic H.
 
 ---
@@ -242,7 +243,7 @@ collaborative-doc model as a downgraded/future area. Ref: §14.4.8, §3.1.6.
 
 ## Epic H — Enforcement & flow activation (smaller than the engines, high leverage)
 
-**Size: medium. Partly just flipping defaults + finishing the ladder — do early.**
+**Size: medium. Mostly flipping defaults onto conforming states — do early.**
 
 Not new machinery so much as turning the system on:
 
@@ -250,11 +251,21 @@ Not new machinery so much as turning the system on:
   (§10's own worked example) is not stamped by default. Move deployments to
   propagation `persist`; note trigger-read confidentiality (SC-3) currently never
   reaches the enforcement side or the egress ceiling even when the dial is on.
-- **`enforce-strict` undifferentiated.** The effective deployment default is
-  already `enforce-explicit` (Runtime + lib-shell; the types-level `disabled` is
-  the bare-transaction fallback), but the strict rung is rankable with no
-  additional reject behavior in the commit gate (SC-13). Finish the ladder and
-  pick conforming default deployment states.
+- **`enforce-strict` default deployment states.** The effective deployment
+  default is `enforce-explicit` (Runtime + lib-shell; the types-level `disabled`
+  is the bare-transaction fallback). The strict rung carries one differentiated
+  reject: the SC-18b writer-fit misfit. The per-transaction flow join landing on
+  a written document must fit that document's declared store policy; under
+  strict a misfit rejects the commit, and under every mode below it persists the
+  measurement and flags a diagnostic. Implemented in `prepareBoundaryCommit`
+  ([`prepare.ts`](../../packages/runner/src/cfc/prepare.ts)), contract in
+  [`cfc-enforcement-matrix.md`](./cfc-enforcement-matrix.md) §4, asserted under
+  both modes in
+  [`cfc-writer-fit.test.ts`](../../packages/runner/test/cfc-writer-fit.test.ts).
+  What remains is picking the conforming default deployment states from that
+  matrix's §3 progression and moving the shipped hosts onto them; strict
+  presupposes `cfcFlowLabels: persist`, since the writer-fit measurement exists
+  only where the flow join is stamped.
 - **Display-ceiling "shell flip."** The render ceiling is built and fail-closed but
   **no host populates it**, and it admits atoms by raw structural equality rather
   than §15.2 acting-user shapes (`User`/`PersonalSpace`/`Space`-via-`HasRole`).
@@ -375,7 +386,7 @@ Epic A (CNF clauses)  ──┬──►  Epic B (exchange-rule evaluator)  ─�
 
 Epic C (observation classes)   — independent, start any time
 Epic D (write/agent integrity) — independent (D1 wants B's matcher); highest security urgency
-Epic H activation (flip defaults, finish ladder) — do early, cheap, high leverage
+Epic H activation (flip defaults onto conforming states) — cheap, high leverage
 Epic F (range-scoped integrity) — last of the big epics; most speculative
 ```
 

--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -263,9 +263,13 @@ Not new machinery so much as turning the system on:
   both modes in
   [`cfc-writer-fit.test.ts`](../../packages/runner/test/cfc-writer-fit.test.ts).
   What remains is picking the conforming default deployment states from that
-  matrix's §3 progression and moving the shipped hosts onto them; strict
-  presupposes `cfcFlowLabels: persist`, since the writer-fit measurement exists
-  only where the flow join is stamped.
+  matrix's §3 progression and moving the shipped hosts onto them. Strict
+  presupposes `cfcFlowLabels: persist`: §18.6.3's conformance matrix marks
+  `enforce-strict` without `persist` non-conforming, and the writer-fit
+  measurement exists only where the flow join is stamped. §18.6.3 also puts the
+  standard-profile display ceiling (§8.10.6) on the strict rung, where the
+  runner has it as a host-passed option the enforcement ladder does not reach —
+  so a deployment that moves to strict does not thereby get it.
 - **Display-ceiling "shell flip."** The render ceiling is built and fail-closed but
   **no host populates it**, and it admits atoms by raw structural equality rather
   than §15.2 acting-user shapes (`User`/`PersonalSpace`/`Space`-via-`HasRole`).


### PR DESCRIPTION
`docs/specs/cfc-runner-future-work.md` is a live document, so it has to describe the runner as it stands. Its Epic H section described the `enforce-strict` enforcement level as a rung that a deployment can rank above `enforce-explicit` but that changes nothing about which transactions commit, and asked a reader to finish the ladder before picking deployment states.

The commit gate does differentiate that rung. Under `enforce-strict` a writer-fit confidentiality misfit rejects the commit: the per-transaction flow join that lands on a written document as its `derived` label component is measured against the store policy that document declares at that path, using the same clause-subsumption predicate the egress gates use, and a join carrying atoms the declared policy does not admit is a reason. Under every enforcement level below strict the same measurement is persisted and flagged as a diagnostic instead. The check lives in `prepareBoundaryCommit` in `packages/runner/src/cfc/prepare.ts`, its contract is section 4 of `docs/specs/cfc-enforcement-matrix.md`, and
`packages/runner/test/cfc-writer-fit.test.ts` asserts the reject under strict and the persist-and-flag under explicit.

So the remaining Epic H work on this dial is not building a behavior. It is picking which of the conforming deployment states in section 3 of the enforcement matrix the shipped hosts should default to, and advancing them along that progression. Strict presupposes `cfcFlowLabels: persist`, because the writer-fit measurement only exists where the flow join is stamped onto the written document.

Changes:

- Rewrite the `enforce-strict` bullet in Epic H to state the reject the rung carries and to name the remaining work as deployment-state selection, with links to the implementation, the contract, and the test.
- Correct the "Default posture" paragraph: what is dormant about strict is that no shipped host runs at it, not that the level is empty.
- Drop "finish the ladder" from the Epic H size line and from the critical-path appendix, both of which restated the same claim.

Other claims in the document that are stale for reasons unrelated to this one are left alone and reported separately, so that each correction can be verified against the landing that invalidated it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

