### PR TITLE
test(integration): a failed shell login says what the page was

### DIFF
--- a/docs/development/waiting-in-tests.md
+++ b/docs/development/waiting-in-tests.md
@@ -1020,6 +1020,26 @@ instance the toolshed's `Failed to proxy to ...` page, served with a 502 when
 its own fetch to the shell dev server fails. Without the check, every test in
 the run waits out the full minute and reports nothing that names the cause.
 
+`login()` reports the same block, for the same reason. It waits on
+`waitForCondition` for the shell to publish `globalThis.app`, and a document
+that is not the shell never publishes it, so that wait reaches the
+stuck-condition net five minutes later saying only that it did. The runtime
+handshake after it names which of its two stages ran out and nothing about the
+page it ran against. Both are wrapped, so any login failure names the identity
+being logged in as and what the page held. `readAndDescribeShellPage` is the
+whole of what a report needs from a page — it reads the probe, renders it, and
+reports a page it could not read at all rather than replacing the failure being
+reported with a second one. Reach for it, rather than pairing the read and the
+render, when adding page context to an error of your own.
+
+The first line of each of these messages comes from `describeThrown` in
+`packages/integration/describe-thrown.ts`, because a failure inside the page
+does not arrive as an `Error`. The browser protocol reports an uncaught page
+exception as a detail record, and stringifying one yields `[object Object]`.
+`describeThrown` takes an `Error`'s message, the first line of a page
+exception's description, and for anything else points at the cause, which the
+thrower attaches and Deno prints below the message.
+
 ### A human-in-the-loop flow that no CI lane runs
 
 `packages/patterns/google/core/integration/google-calendar-importer.test.ts`

--- a/packages/integration/describe-thrown.ts
+++ b/packages/integration/describe-thrown.ts
@@ -1,0 +1,24 @@
+/**
+ * A one-line summary of a thrown value, for the first line of a failure
+ * message whose thrower carries the value itself as the new error's cause.
+ *
+ * An `Error` is summarized by its message. A page exception does not arrive as
+ * an `Error`: the browser protocol reports it as a detail record, and the
+ * `exception.description` inside that record holds what the page would have
+ * printed — the error's name, its message, and its stack. Its first line is
+ * the name and the message, which is the summary wanted here.
+ *
+ * Anything else points at the cause, which Deno prints below the message.
+ * Stringifying such a value here would put "[object Object]" in its place.
+ */
+export function describeThrown(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    const description = (error as { exception?: { description?: unknown } })
+      .exception?.description;
+    if (typeof description === "string" && description.length > 0) {
+      return description.split("\n")[0];
+    }
+  }
+  return "see the value reported as the cause below";
+}

--- a/packages/integration/describe-thrown.ts
+++ b/packages/integration/describe-thrown.ts
@@ -1,18 +1,20 @@
 /**
  * A one-line summary of a thrown value, for the first line of a failure
- * message whose thrower carries the value itself as the new error's cause.
+ * message.
  *
- * An `Error` is summarized by its message. A page exception does not arrive as
- * an `Error`: the browser protocol reports it as a detail record, and the
- * `exception.description` inside that record holds what the page would have
- * printed — the error's name, its message, and its stack. Its first line is
- * the name and the message, which is the summary wanted here.
+ * An `Error` is summarized by its message, or by its name where it carries no
+ * message. A page exception does not arrive as an `Error`: the browser
+ * protocol reports it as a detail record, whose `exception.description` holds
+ * the error's name, its message, and its stack, as the page renders them. Its
+ * first line is the name and the message, which is the summary wanted here.
  *
- * Anything else points at the cause, which Deno prints below the message.
- * Stringifying such a value here would put "[object Object]" in its place.
+ * Anything else is rendered inline, its top level only, because stringifying it
+ * would read as "[object Object]". The summary stands on its own: a caller
+ * that attaches the value as its error's cause adds the full detail, and a
+ * caller reporting a failure it does not own has nowhere to defer to.
  */
 export function describeThrown(error: unknown): string {
-  if (error instanceof Error) return error.message;
+  if (error instanceof Error) return error.message || error.name;
   if (typeof error === "object" && error !== null) {
     const description = (error as { exception?: { description?: unknown } })
       .exception?.description;
@@ -20,5 +22,10 @@ export function describeThrown(error: unknown): string {
       return description.split("\n")[0];
     }
   }
-  return "see the value reported as the cause below";
+  return Deno.inspect(error, {
+    colors: false,
+    compact: true,
+    depth: 0,
+    breakLength: Infinity,
+  });
 }

--- a/packages/integration/shell-page-probe.ts
+++ b/packages/integration/shell-page-probe.ts
@@ -146,10 +146,10 @@ export function describeShellPage(probe: ShellPageProbe): string {
  * Read `page` and render it as the detail block of a failure message,
  * reporting the reason instead when the page cannot be read at all.
  *
- * This is the whole of what a failure report needs from the page, so a caller
- * adding page context to an error uses this rather than pairing the read and
- * the render itself. A page that has closed, or a browser that has gone away,
- * must not replace the failure being reported with a second one.
+ * This is the whole of what a failure report needs from the page. A page that
+ * has closed, or a browser that has gone away, must not replace the failure
+ * being reported with a second one, so the read is guarded here rather than at
+ * each call site.
  */
 export async function readAndDescribeShellPage(page: Page): Promise<string> {
   try {

--- a/packages/integration/shell-page-probe.ts
+++ b/packages/integration/shell-page-probe.ts
@@ -1,3 +1,4 @@
+import { describeThrown } from "./describe-thrown.ts";
 import type { Page } from "./page.ts";
 
 // How much of the document's text a probe carries back. Enough to read a
@@ -139,6 +140,23 @@ export function describeShellPage(probe: ShellPageProbe): string {
     for (const entry of probe.consoleTail) lines.push(`    ${entry}`);
   }
   return lines.join("\n");
+}
+
+/**
+ * Read `page` and render it as the detail block of a failure message,
+ * reporting the reason instead when the page cannot be read at all.
+ *
+ * This is the whole of what a failure report needs from the page, so a caller
+ * adding page context to an error uses this rather than pairing the read and
+ * the render itself. A page that has closed, or a browser that has gone away,
+ * must not replace the failure being reported with a second one.
+ */
+export async function readAndDescribeShellPage(page: Page): Promise<string> {
+  try {
+    return describeShellPage(await readShellPageProbe(page));
+  } catch (error) {
+    return `  the page could not be probed: ${describeThrown(error)}`;
+  }
 }
 
 /**

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -22,12 +22,12 @@ import {
 } from "@commonfabric/navigation";
 import { AppState, deserialize } from "@commonfabric/shell/app-state";
 
+import { describeThrown } from "./describe-thrown.ts";
 import {
   collectPatternCoverage,
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
 import { getPresentationSession } from "./presentation/session.ts";
-import { describeThrown } from "./describe-thrown.ts";
 import {
   assertShellDocument,
   readAndDescribeShellPage,

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -27,10 +27,10 @@ import {
   enablePatternCoverage,
 } from "./pattern-coverage.ts";
 import { getPresentationSession } from "./presentation/session.ts";
+import { describeThrown } from "./describe-thrown.ts";
 import {
   assertShellDocument,
-  describeShellPage,
-  readShellPageProbe,
+  readAndDescribeShellPage,
 } from "./shell-page-probe.ts";
 import { waitFor, waitForCondition } from "./utils.ts";
 
@@ -53,6 +53,31 @@ export async function login(page: Page, identity: Identity): Promise<void> {
     );
   }
 
+  // Everything from here on runs against the page, and every way it can fail
+  // says nothing about the page it failed against. The wait below is for the
+  // shell to publish itself, which a document that is not the shell never
+  // does, so it runs to the stuck-condition net reporting only that five
+  // minutes passed. The runtime handshake that follows reports which of its
+  // two stages ran out, and no more than that.
+  try {
+    await loginToPublishedApp(page, transferrableId, identity.did());
+  } catch (error) {
+    throw new Error(
+      `Logging in as ${identity.did()} failed: ${
+        describeThrown(error)
+      }\n${await readAndDescribeShellPage(page)}`,
+      { cause: error },
+    );
+  }
+}
+
+// The page half of `login`: wait for the shell to publish itself, then hand it
+// the identity and wait for the runtime to come up under it.
+async function loginToPublishedApp(
+  page: Page,
+  transferrableId: TransferrableInsecureCryptoKeyPair,
+  nextDID: string,
+): Promise<void> {
   await waitForCondition(page, () => globalThis.app !== undefined);
 
   await page!.evaluate<
@@ -105,7 +130,7 @@ export async function login(page: Page, identity: Identity): Promise<void> {
       });
     },
     {
-      args: [transferrableId, identity.did()],
+      args: [transferrableId, nextDID],
     },
   );
 }
@@ -138,17 +163,7 @@ export async function describeStateWaitFailure(
     lines.push(`  awaited identity: ${params.identity.did()}`);
   }
   lines.push(`  last state read: ${describeAppState(lastState)}`);
-  try {
-    lines.push(describeShellPage(await readShellPageProbe(page)));
-  } catch (error) {
-    lines.push(
-      `  the page could not be probed: ${
-        error instanceof Error
-          ? error.message
-          : Deno.inspect(error, { colors: false })
-      }`,
-    );
-  }
+  lines.push(await readAndDescribeShellPage(page));
   return lines.join("\n");
 }
 
@@ -284,13 +299,7 @@ export class ShellIntegration {
         return stateMatches(lastState, params);
       });
     } catch (error) {
-      // A page exception arrives as the protocol's own detail object rather
-      // than an `Error`. Deno prints the cause below the message, so such a
-      // value is reported there rather than stringified into the summary,
-      // where it would read as "[object Object]".
-      const summary = error instanceof Error
-        ? error.message
-        : "the wait threw the value reported as the cause below.";
+      const summary = describeThrown(error);
       const detail = await describeStateWaitFailure(
         this.page(),
         params,

--- a/packages/integration/test/describe-thrown.test.ts
+++ b/packages/integration/test/describe-thrown.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { describeThrown } from "../describe-thrown.ts";
+
+describe("describe-thrown", () => {
+  describe("describeThrown()", () => {
+    it("returns the message of an `Error`", () => {
+      expect(describeThrown(new Error("the key store is not open"))).toBe(
+        "the key store is not open",
+      );
+    });
+
+    it("returns the first line of a page exception's description", () => {
+      // The shape the browser protocol reports an uncaught page exception in.
+      const pageException = {
+        exceptionId: 1,
+        text: "Uncaught",
+        exception: {
+          className: "Error",
+          description:
+            "Error: the key store is not open\n    at globalThis.app.setIdentity (<anonymous>:3:15)",
+        },
+      };
+      expect(describeThrown(pageException)).toBe(
+        "Error: the key store is not open",
+      );
+    });
+
+    it("points at the cause for a value it cannot summarize", () => {
+      expect(describeThrown({ exceptionId: 1, text: "Uncaught" })).toBe(
+        "see the value reported as the cause below",
+      );
+      expect(describeThrown("a bare string")).toBe(
+        "see the value reported as the cause below",
+      );
+      expect(describeThrown(undefined)).toBe(
+        "see the value reported as the cause below",
+      );
+      expect(describeThrown(null)).toBe(
+        "see the value reported as the cause below",
+      );
+    });
+
+    it("points at the cause for an empty description", () => {
+      expect(describeThrown({ exception: { description: "" } })).toBe(
+        "see the value reported as the cause below",
+      );
+    });
+  });
+});

--- a/packages/integration/test/describe-thrown.test.ts
+++ b/packages/integration/test/describe-thrown.test.ts
@@ -11,6 +11,11 @@ describe("describe-thrown", () => {
       );
     });
 
+    it("returns the name of an `Error` carrying no message", () => {
+      expect(describeThrown(new Error())).toBe("Error");
+      expect(describeThrown(new TypeError())).toBe("TypeError");
+    });
+
     it("returns the first line of a page exception's description", () => {
       // The shape the browser protocol reports an uncaught page exception in.
       const pageException = {
@@ -27,25 +32,27 @@ describe("describe-thrown", () => {
       );
     });
 
-    it("points at the cause for a value it cannot summarize", () => {
+    it("renders a value it cannot summarize on one line", () => {
       expect(describeThrown({ exceptionId: 1, text: "Uncaught" })).toBe(
-        "see the value reported as the cause below",
+        '{ exceptionId: 1, text: "Uncaught" }',
       );
-      expect(describeThrown("a bare string")).toBe(
-        "see the value reported as the cause below",
-      );
-      expect(describeThrown(undefined)).toBe(
-        "see the value reported as the cause below",
-      );
-      expect(describeThrown(null)).toBe(
-        "see the value reported as the cause below",
+      expect(describeThrown("a bare string")).toBe('"a bare string"');
+      expect(describeThrown(undefined)).toBe("undefined");
+      expect(describeThrown(null)).toBe("null");
+    });
+
+    it("renders a record whose description is empty", () => {
+      expect(describeThrown({ exception: { description: "" } })).toBe(
+        "{ exception: [Object] }",
       );
     });
 
-    it("points at the cause for an empty description", () => {
-      expect(describeThrown({ exception: { description: "" } })).toBe(
-        "see the value reported as the cause below",
-      );
+    // A caller that reports a failure it does not own — the page probe inside
+    // a state-wait report — attaches someone else's error as the cause, so a
+    // summary that deferred to "the cause" would name the wrong failure.
+    it("keeps a deeply nested value to one line", () => {
+      expect(describeThrown({ a: { b: { c: { d: 1 } } }, list: [1, 2, 3] }))
+        .toBe("{ a: [Object], list: [Array] }");
     });
   });
 });

--- a/packages/integration/test/shell-failure-reports.test.ts
+++ b/packages/integration/test/shell-failure-reports.test.ts
@@ -8,9 +8,10 @@ import type { Page } from "../page.ts";
 import {
   assertShellDocument,
   describeShellPage,
+  readAndDescribeShellPage,
   readShellPageProbe,
 } from "../shell-page-probe.ts";
-import { describeStateWaitFailure } from "../shell-utils.ts";
+import { describeStateWaitFailure, login } from "../shell-utils.ts";
 
 // What the toolshed answers with when its fetch to the shell dev server fails.
 const PROXY_FAILURE_TEXT =
@@ -37,6 +38,20 @@ const BOOTED_SHELL_DOCUMENT = `<!DOCTYPE html>
 </script>
 </body></html>`;
 
+// A booted shell whose `setIdentity` refuses. The login reaches the page and
+// fails there, which is the failure a report has to describe.
+const REFUSING_SHELL_DOCUMENT = `<!DOCTYPE html>
+<html><head><title>Common Fabric</title></head>
+<body><x-root-view></x-root-view>
+<script>
+  globalThis.app = {
+    state: () => ({}),
+    serialize: () => ({ view: { builtin: "home" }, identity: undefined }),
+    setIdentity: () => { throw new Error("the key store is not open"); },
+  };
+</script>
+</body></html>`;
+
 function handle(request: Request): Response {
   const { pathname } = new URL(request.url);
   switch (pathname) {
@@ -51,6 +66,10 @@ function handle(request: Request): Response {
       });
     case "/booted-shell":
       return new Response(BOOTED_SHELL_DOCUMENT, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    case "/refusing-shell":
+      return new Response(REFUSING_SHELL_DOCUMENT, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
   }
@@ -234,6 +253,40 @@ describe("shell-failure-reports", () => {
       expect(described).toContain("globalThis.app: absent");
       expect(described).toContain("response status: 502");
       expect(described).toContain("document text: Failed to proxy to ");
+    });
+  });
+
+  describe("readAndDescribeShellPage()", () => {
+    it("returns the same block describeShellPage() renders", async () => {
+      await load("/booted-shell");
+
+      expect(await readAndDescribeShellPage(page)).toBe(
+        describeShellPage(await readShellPageProbe(page)),
+      );
+    });
+
+    it("returns the reason when the page cannot be read", async () => {
+      const closed = await browser.newPage();
+      await closed.close();
+
+      const described = await readAndDescribeShellPage(closed);
+      expect(described).toContain("the page could not be probed:");
+    });
+  });
+
+  describe("login()", () => {
+    it("throws naming the identity and the page it failed against", async () => {
+      await load("/refusing-shell");
+      const identity = await Identity.generate({ implementation: "noble" });
+
+      const message = await rejectionMessage(login(page, identity));
+      expect(message).toContain(
+        `Logging in as ${identity.did()} failed: Error: the key store is not open`,
+      );
+      expect(message).toContain("x-root-view: present");
+      expect(message).toContain(
+        'globalThis.app: present, holding view {"builtin":"home"}',
+      );
     });
   });
 });


### PR DESCRIPTION
The navigation and state waits in the shell test harness report what the page held when they gave up. `login()` does not, and it has the same two blind spots.

It first waits, through `waitForCondition`, for the shell to publish itself on `globalThis.app`. A document that is not the shell never publishes it, so on such a page that wait reaches the stuck-condition safety net five minutes later saying only "waitForCondition did not resolve within 300000ms". Publishing is now deliberately late — the shell holds it back until Navigation is installed, so that a driver cannot change the view while bootstrap is still awaiting the key store — which makes its absence a normal state for part of boot and a permanent one on the wrong page, with nothing in the message to tell those apart.

The runtime handshake that follows names which of its two stages ran out, "Timed out waiting for runtime logout" or "... login", and nothing about the page it ran against. Anything the handshake itself throws fares worse: a failure inside the page arrives as the browser protocol's own detail record rather than an `Error`, so the harness reported it as the string "[object Object]".

Both are now wrapped. Any login failure names the identity being logged in as and carries the same page block the navigation check and the state wait produce:

    Logging in as did:key:z6MkiMcjVEQqfBo8hoxXUuQv49bq5wxY1vy73cEP
    failed: Error: the key store is not open
      document URL: http://localhost:8000/test-space
      document title: Common Fabric
      response status: 200
      x-root-view: present
      globalThis.app: present, holding view
      {"spaceName":"test-space"} and no identity
      console tail (1 most recent):
        14ms ago [error] worker boot reported a missing bundle

Two pieces are factored out so this reads the same way everywhere it is reported. `readAndDescribeShellPage` is the whole of what a failure report needs from a page: it reads the probe, renders it, and reports a page it could not read at all instead of replacing the failure being reported with a second one. The state wait had that pairing inline and now calls it.

`describeThrown`, in the new packages/integration/describe-thrown.ts, summarizes a thrown value for the first line of a message that carries the value itself as the error's cause. An `Error` gives its message. A page exception gives the first line of the `exception.description` the protocol reports, which is the error's name and message — the part the old wording pushed into the cause because it could not read it. Every other value points at the cause, which Deno prints below the message. That last case is why stringifying is not enough on its own, and it is what produced the "[object Object]" above.

Nothing here adds a retry, a sleep, or a timeout, and no existing bound moves.

The tests drive a real browser against a served document whose `setIdentity` refuses, so the login reaches the page and fails there rather than waiting out a deadline, and check the rendered message. `describeThrown` is covered directly, including the protocol's exception-record shape. Each assertion was checked against deliberately broken production code: with the wrapper removed from `login`, the test sees the bare "[object Object]" this commit replaces; with the page exception's description unread, the summary falls back to pointing at the cause; with the read in `readAndDescribeShellPage` unguarded, a closed page throws instead of reporting.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

