### PR TITLE
refactor(runner): one module-scope factory for str, and pin two untested shapes

### DIFF
--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -481,9 +481,13 @@ export function wish<T = unknown>(
   })(param);
 }
 
-let strFactory:
-  | NodeFactory<{ strings: string[]; values: unknown[] }, string>
-  | undefined;
+const strFactory = createNodeFactory<
+  { strings: string[]; values: unknown[] },
+  string
+>({
+  type: "ref",
+  implementation: "str",
+});
 
 // Example:
 // str`Hello, ${name}!`
@@ -492,15 +496,10 @@ export function str(
   strings: TemplateStringsArray,
   ...values: unknown[]
 ): Reactive<string> {
-  strFactory ||= createNodeFactory({
-    type: "ref",
-    implementation: "str",
-  });
-
   // Spread the template strings into a plain array: a `TemplateStringsArray`
   // carries a `raw` property that the binding walk does not preserve, and the
   // interpolation reads only the indexed chunks.
-  return strFactory({ strings: [...strings], values }) as Reactive<string>;
+  return strFactory({ strings: [...strings], values });
 }
 
 /**

--- a/packages/runner/src/builtins/index.ts
+++ b/packages/runner/src/builtins/index.ts
@@ -18,13 +18,13 @@ import {
 import { filter } from "./filter.ts";
 import { flatMap } from "./flatmap.ts";
 import { IF_ELSE_ARGUMENT_SCHEMA, ifElse } from "./if-else.ts";
-import { str, STR_ARGUMENT_SCHEMA } from "./str.ts";
 import { inspectConfLabel } from "./inspect-conf-label.ts";
 import { llmDialog } from "./llm-dialog.ts";
 import { generateObject, generateText, llm } from "./llm.ts";
 import { map } from "./map.ts";
 import { navigateTo } from "./navigate-to.ts";
 import { sqliteDatabase, sqliteQuery } from "./sqlite-builtins.ts";
+import { str, STR_ARGUMENT_SCHEMA } from "./str.ts";
 import { streamData } from "./stream-data.ts";
 import { unless } from "./unless.ts";
 import { when } from "./when.ts";

--- a/packages/runner/test/str-builtin.test.ts
+++ b/packages/runner/test/str-builtin.test.ts
@@ -23,6 +23,23 @@ export default pattern<{ who?: Writable<string | Default<"world">> }>(({ who }) 
   }],
 });
 
+const programOf = (
+  props: string,
+  destructure: string,
+  body: string,
+): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: `/// <cts-enable />
+import { NAME, pattern, str, Writable, Default } from "commonfabric";
+export default pattern<${props}>((${destructure}) => {
+  ${body}
+});
+`,
+  }],
+});
+
 const GREETING = "return { who, greeting: str`Hello, ${who}!` };";
 
 describe("str builtin", () => {
@@ -42,14 +59,12 @@ describe("str builtin", () => {
     await storageManager?.close();
   });
 
-  const runProgram = async (
+  const runSource = async (
     runtime: Runtime,
-    body: string,
+    program: RuntimeProgram,
     label: string,
   ) => {
-    const compiled = await runtime.patternManager.compilePattern(
-      programFor(body),
-    );
+    const compiled = await runtime.patternManager.compilePattern(program);
     const tx = runtime.edit();
     const resultCell = runtime.getCell<Record<string, unknown>>(
       space,
@@ -63,6 +78,9 @@ describe("str builtin", () => {
     await result.pull();
     return { compiled, result };
   };
+
+  const runProgram = (runtime: Runtime, body: string, label: string) =>
+    runSource(runtime, programFor(body), label);
 
   it("interpolates a reactive substitution", async () => {
     const runtime = newRuntime();
@@ -134,6 +152,105 @@ describe("str builtin", () => {
       );
     } finally {
       await runtime.dispose();
+    }
+  });
+
+  it("reads a substituted array as its value, not as a link", async () => {
+    const runtime = newRuntime();
+    try {
+      const { result } = await runSource(
+        runtime,
+        programOf(
+          `{
+  list?: Writable<string[] | Default<["a", "b"]>>;
+  n?: Writable<number | Default<0>>;
+  flag?: Writable<boolean | Default<false>>;
+}`,
+          "{ list, n, flag }",
+          "return { list, n, flag, greeting: str`${list} ${n} ${flag}` };",
+        ),
+        "value-read",
+      );
+      // An array renders through its own `toString` ("a,b") only if the
+      // substitution arrived as a VALUE. `STR_ARGUMENT_SCHEMA` leaves `values`
+      // without an `items` schema precisely so its elements resolve; were that
+      // to stop, the element would arrive as an unresolved link sigil and
+      // render "[object Object]" instead. Numbers and booleans pin the two
+      // falsy substitutions the interpolation must not treat as absent.
+      expect(result.key("greeting").get()).toBe(`${["a", "b"]} ${0} ${false}`);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("interpolates per element inside a map", async () => {
+    const runtime = newRuntime();
+    try {
+      const { result } = await runSource(
+        runtime,
+        programOf(
+          `{ items?: Writable<string[] | Default<["a", "b"]>> }`,
+          "{ items }",
+          "return { items, labels: items.map((item) => str`<${item}>`) };",
+        ),
+        "map-op",
+      );
+      // The shape shipped patterns actually use: one `str` node per element,
+      // minted inside the map's op sub-pattern rather than at pattern scope.
+      expect(result.key("labels").get()).toEqual(["<a>", "<b>"]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("renders with native parity after resuming the piece in a cold runtime", async () => {
+    const cause = "native-parity-resume";
+    const body = "return { who, greeting: str`v=${undefined} ${null}` };";
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      const tx1 = rt1.edit();
+      const compiled = await rt1.patternManager.compilePattern(
+        programFor(body),
+        { space, tx: tx1 },
+      );
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        cause,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, compiled, {}, resultCell1) as any;
+      await tx1.commit();
+      await r1.pull();
+      expect(r1.key("greeting").get()).toBe(`v=${undefined} ${null}`);
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // The substitutions cross into the data model on the way to the inputs
+      // cell, and `undefined` is the value a JSON round-trip would quietly
+      // turn into `null` — which would render "null" here and diverge from the
+      // template literal only AFTER a resume, long past the fresh-run test
+      // above.
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        cause,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+      await resultCell2.sync();
+      expect(await rt2.start(resultCell2)).toBe(true);
+      await resultCell2.pull();
+      expect(
+        (resultCell2.getAsQueryResult() as { greeting: string }).greeting,
+      ).toBe(`v=${undefined} ${null}`);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
     }
   });
 

--- a/packages/runner/test/str-builtin.test.ts
+++ b/packages/runner/test/str-builtin.test.ts
@@ -203,57 +203,6 @@ describe("str builtin", () => {
     }
   });
 
-  it("renders with native parity after resuming the piece in a cold runtime", async () => {
-    const cause = "native-parity-resume";
-    const body = "return { who, greeting: str`v=${undefined} ${null}` };";
-    const rt1 = newRuntime();
-    const rt2 = newRuntime();
-    try {
-      const tx1 = rt1.edit();
-      const compiled = await rt1.patternManager.compilePattern(
-        programFor(body),
-        { space, tx: tx1 },
-      );
-      const resultCell1 = rt1.getCell<Record<string, unknown>>(
-        space,
-        cause,
-        undefined,
-        tx1,
-      );
-      // deno-lint-ignore no-explicit-any
-      const r1 = rt1.run(tx1, compiled, {}, resultCell1) as any;
-      await tx1.commit();
-      await r1.pull();
-      expect(r1.key("greeting").get()).toBe(`v=${undefined} ${null}`);
-
-      await rt1.patternManager.flushCompileCacheWrites();
-      await rt1.storageManager.synced();
-
-      // The substitutions cross into the data model on the way to the inputs
-      // cell, and `undefined` is the value a JSON round-trip would quietly
-      // turn into `null` — which would render "null" here and diverge from the
-      // template literal only AFTER a resume, long past the fresh-run test
-      // above.
-      const tx2 = rt2.edit();
-      const resultCell2 = rt2.getCell<Record<string, unknown>>(
-        space,
-        cause,
-        undefined,
-        tx2,
-      );
-      await tx2.commit();
-      await resultCell2.sync();
-      expect(await rt2.start(resultCell2)).toBe(true);
-      await resultCell2.pull();
-      expect(
-        (resultCell2.getAsQueryResult() as { greeting: string }).greeting,
-      ).toBe(`v=${undefined} ${null}`);
-    } finally {
-      await rt2.dispose();
-      await rt1.dispose();
-    }
-  });
-
   it("compiles to a ref node naming the builtin, leaving no unverified module", async () => {
     const runtime = newRuntime();
     try {


### PR DESCRIPTION
## Why

Review follow-ups on #6071. Two things: one shape `str` should have had from the
start, and two behaviors its tests did not reach.

## `str` gets one module-scope node factory

`str` built its ref factory into module-scope mutable state on first call:

```ts
let strFactory: NodeFactory<…> | undefined;
export function str(…) {
  strFactory ||= createNodeFactory({ type: "ref", implementation: "str" });
  …
}
```

Every other ref builtin in this file — `llm`, `llmDialog`, `fetchJson`,
`compileAndRun`, and a dozen more directly above it — is a plain `const`
evaluated at import. `createNodeFactory` reaches `assertNotInActionExecution`
only when `implementation` is a function, so a `type: "ref"` spec has nothing
to defer for; the lazy form bought nothing and left a mutable module binding
behind.

Declaring it alongside its siblings also retires the `as Reactive<string>`
cast: with the type arguments on `createNodeFactory`, the factory's return type
is already `Reactive<string>`.

The `./str.ts` import in `builtins/index.ts` had landed between `./if-else.ts`
and `./inspect-conf-label.ts`; it is sorted into place here. (`deno fmt` sorts
within the braces but not across import lines, so nothing was going to say so.)

## Two shapes the tests did not reach

- **A substituted ARRAY.** It renders through its own `toString` ("a,b") only
  when the substitution arrives as a VALUE. `STR_ARGUMENT_SCHEMA` leaves
  `values` without an `items` schema precisely so its elements resolve; nothing
  failed if that stopped and an element arrived as an unresolved link sigil,
  rendering `[object Object]`. Numbers and booleans ride along, pinning the two
  falsy substitutions the interpolation must not treat as absent.
- **`str` inside a `map`.** One node per element, minted in the op sub-pattern
  rather than at pattern scope. It is the shape shipped patterns use, and no
  test built it.

Both go red against a deliberately regressed `values` schema
(`items: { asCell: ["cell"], type: "unknown" }`), so they measure what they
claim to.

## A third case was tried and removed

An earlier revision added a case asserting that a `str` rendering `undefined`
still renders "undefined" after a cold resume, said to guard a persistence
round-trip turning it into `null`. @mathpirate falsified that coverage in
review, and the reason turns out to be stronger than a badly chosen fixture:
**`.set(undefined)` on a key REMOVES the key**, so an `undefined` substitution
always arrives by absence and `UndefinedCodec` is never on the path. Decoding
a persisted `undefined` as `null` leaves the case green.

Three shapes were tried against that falsification and all three stayed green
— the source-literal original, a variant reading a cleared cell back in a
second session holding its own replica of a shared server, and one that also
wrote in the second session to force the node to run there. The regression
class the case named is not reachable through a pattern field, so the case is
removed rather than reworded. The resume rendering it did exercise is already
covered by the existing "interpolates after resuming the piece in a cold
runtime".

## On #6071's two open questions

Both were checked against `origin/main` rather than argued:

- **Baseline churn.** For a pattern with three `str` nodes (one of them
  `[NAME]`), node COUNT is unchanged and all three `computed:fid1:…` cell ids
  plus the pattern's `of:fid1:…` entity id are byte-identical across the two
  revisions. Only the module type flips `javascript` → `ref`. Worth knowing
  separately: the pattern baselines record `argumentSchema`, `pattern`, and
  `resultSchema` only, so they could not have reported node-shape churn either
  way — the lanes that would are Pattern Update Compatibility and Baseline
  Integrity, and those passed.
- **`undefined` rendering.** Unchanged on a fresh run, which the existing
  native-parity case pins. Its behavior across persistence is not something
  this suite can speak to, per the section above.

## Test plan

- `packages/runner` full suite: **1246 passed / 0 failed**
- `deno task integration pattern-tests record` (the six `str`-covering record
  tests, five of which fall outside shard 1/8): **65 passed / 0 failed**
- `deno fmt --check`, `deno lint`, `deno task check`, `check-docs`,
  `check-docs-history-index`, `check-conflict-markers`, `check-no-waitfor`,
  `check-skill-facts`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
