### PR TITLE
refactor(tasks): compose a local run's context from stated git facts

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -373,6 +373,34 @@ numeric literal emits a number rather than the string the node carries — so a
 branch that changed what it produced would fail rather than stay green on the
 line count.
 
+### A fact the checkout supplies
+
+A line can also sit behind a fact the code reads from the machine it is
+running on: the branch the checkout is on, the platform, whether some tool is
+installed. `tasks/test-records.ts` stamps a local test run with the branch,
+and records one only when git names one. Continuous integration builds a pull
+request from a detached merge commit, where `git branch --show-current` prints
+nothing, so the arm that records a branch ran on a developer's machine and not
+in that job. Its coverage then came from whatever else in the run happened to
+build a context, which is what made it move.
+
+A test that creates a scratch repository on a named branch does reach the arm,
+and asserting that git's answer reaches the context is worth doing. It does
+not settle the coverage, though, because it buys the line with a subprocess:
+the line is covered where git is installed, behaves as the test expects, and
+is allowed to run, and not elsewhere.
+
+Separate reading the facts from deciding what they mean.
+`buildLocalContext()` asks git for the commit, the branch and the status, and
+hands the three answers to `composeLocalContext()`, which turns them into the
+context. Reaching the arm that records a branch is then a matter of saying
+what git said, so a unit test states the facts and asserts the context they
+compose into. `tasks/test-records-flap-coverage.test.ts` holds one case per
+arm: a branch git named, the empty string a detached checkout produces, and
+the absent answer a directory outside a repository produces. Nothing in that
+file runs a subprocess or reads the surrounding checkout, so every arm runs on
+every machine.
+
 ### What the check says when the regression is not the pull request's
 
 The gate compares whole-group counts, so a flapping line fails whichever pull

--- a/tasks/test-records-flap-coverage.test.ts
+++ b/tasks/test-records-flap-coverage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { composeLocalContext } from "./test-records.ts";
+
+// The arm of composeLocalContext() that records a branch runs when git named
+// one. Nothing but the ambient checkout drove it before: a working checkout
+// sits on a branch, while the detached merge commit continuous integration
+// builds a pull request from reports an empty branch, so the line ran on some
+// runs and not on others. These cases state the facts the composition is given
+// and assert what it makes of them, so each arm runs on every run and under
+// every configuration.
+
+describe("composeLocalContext() flap coverage", () => {
+  it("carries the branch when git named one", () => {
+    const context = composeLocalContext({
+      commit: "a".repeat(40),
+      branch: "probe-branch",
+      status: "",
+    }, () => undefined);
+    expect(context.branch).toBe("probe-branch");
+    expect(context.commit).toBe("a".repeat(40));
+    expect(context.dirty).toBe(false);
+    expect(context.env).toBe("local");
+  });
+
+  it("leaves the branch off a detached checkout", () => {
+    // `git branch --show-current` prints nothing when HEAD is detached, which
+    // reaches the composition as an empty string.
+    const context = composeLocalContext({
+      commit: "b".repeat(40),
+      branch: "",
+      status: "",
+    }, () => undefined);
+    expect(context.branch).toBeUndefined();
+    expect(context.commit).toBe("b".repeat(40));
+  });
+
+  it("records an unknown commit and a dirty tree outside git's reach", () => {
+    // Every fact is absent when git could not answer, and a tree git reported
+    // changes in is dirty.
+    const unnamed = composeLocalContext({}, () => undefined);
+    expect(unnamed.commit).toBe("unknown");
+    expect(unnamed.branch).toBeUndefined();
+    expect(unnamed.dirty).toBe(false);
+
+    const dirty = composeLocalContext({
+      commit: "c".repeat(40),
+      branch: "probe-branch",
+      status: " M tasks/test-records.ts\n",
+    }, () => undefined);
+    expect(dirty.dirty).toBe(true);
+    expect(dirty.branch).toBe("probe-branch");
+  });
+
+  it("carries the agent label the environment names", () => {
+    const context = composeLocalContext(
+      { commit: "d".repeat(40), branch: "probe-branch", status: "" },
+      (name) => name === "CF_TEST_AGENT" ? "probe-agent" : undefined,
+    );
+    expect(context.agent).toBe("probe-agent");
+  });
+});

--- a/tasks/test-records-flap-coverage.test.ts
+++ b/tasks/test-records-flap-coverage.test.ts
@@ -32,7 +32,7 @@ describe("composeLocalContext() flap coverage", () => {
       branch: "",
       status: "",
     }, () => undefined);
-    expect(context.branch).toBeUndefined();
+    expect(Object.hasOwn(context, "branch")).toBe(false);
     expect(context.commit).toBe("b".repeat(40));
   });
 
@@ -41,7 +41,7 @@ describe("composeLocalContext() flap coverage", () => {
     // changes in is dirty.
     const unnamed = composeLocalContext({}, () => undefined);
     expect(unnamed.commit).toBe("unknown");
-    expect(unnamed.branch).toBeUndefined();
+    expect(Object.hasOwn(unnamed, "branch")).toBe(false);
     expect(unnamed.dirty).toBe(false);
 
     const dirty = composeLocalContext({

--- a/tasks/test-records.ts
+++ b/tasks/test-records.ts
@@ -62,35 +62,61 @@ async function git(
   }
 }
 
+/** What git said about the checkout a local run started in. */
+interface CheckoutFacts {
+  /** Output of `git rev-parse HEAD`; absent outside a repository. */
+  commit?: string;
+  /** Output of `git branch --show-current`; empty on a detached checkout. */
+  branch?: string;
+  /** Output of `git status --porcelain`; empty when the tree is clean. */
+  status?: string;
+}
+
 /**
- * The context of a local run, captured at start: the commit and branch the
- * run actually began against, so a branch switch mid-run cannot mis-stamp
- * it.
+ * Composes the context of a local run from what git said about the
+ * checkout. A commit git could not name is recorded as "unknown". The
+ * branch is carried only when git named one, so a detached checkout is
+ * stamped without a branch. Any status output at all marks the tree dirty.
  */
-export async function buildLocalContext(
-  cwd: string,
+export function composeLocalContext(
+  facts: CheckoutFacts,
   env: Environment = Deno.env.get,
-): Promise<RunContext> {
-  const commit = await git(cwd, "rev-parse", "HEAD") ?? "unknown";
-  const branch = await git(cwd, "branch", "--show-current");
-  const status = await git(cwd, "status", "--porcelain");
+): RunContext {
   const context: RunContext = {
     schema: RECORD_SCHEMA_VERSION,
     line: "context",
     reportId: ulid(),
     repo: REPO,
-    commit,
-    dirty: status !== undefined && status.length > 0,
+    commit: facts.commit ?? "unknown",
+    dirty: facts.status !== undefined && facts.status.length > 0,
     env: "local",
     os: Deno.build.os,
     arch: Deno.build.arch,
     denoVersion: Deno.version.deno,
     startedAt: new Date().toISOString(),
   };
-  if (branch !== undefined && branch.length > 0) context.branch = branch;
+  if (facts.branch !== undefined && facts.branch.length > 0) {
+    context.branch = facts.branch;
+  }
   const agent = agentLabel(env);
   if (agent !== undefined) context.agent = agent;
   return context;
+}
+
+/**
+ * The context of a local run, captured at start: the commit and branch the
+ * run actually began against, so a branch switch mid-run cannot mis-stamp
+ * it. Runs git in `cwd` and composes the context from its answers.
+ */
+export async function buildLocalContext(
+  cwd: string,
+  env: Environment = Deno.env.get,
+): Promise<RunContext> {
+  return composeLocalContext({
+    commit: await git(cwd, "rev-parse", "HEAD"),
+    branch: await git(cwd, "branch", "--show-current"),
+    status: await git(cwd, "status", "--porcelain"),
+  }, env);
 }
 
 /** Reads and parses the personal key file the environment names. */


### PR DESCRIPTION
The context stamped on a local test run records the branch the run began against, and records one only when git names a branch. Whether that arm ran was decided by the checkout the tests happened to be running in. A developer's checkout sits on a named branch and reached it; continuous integration builds a pull request from a detached merge commit, where `git branch --show-current` prints nothing and the arm is skipped. The line was therefore covered on some runs and not on others, and the coverage ratchet charged the difference to whichever pull request was in flight.

A test that builds a scratch repository on a named branch already reaches the arm, and it is worth keeping: it is what says that git's answer reaches the context at all. It does not settle the coverage on its own, though, because it buys the line with a subprocess. The line is covered where git is installed, behaves as the test expects, and is allowed to run, and nowhere else.

So the reading and the deciding are now separate. `buildLocalContext()` asks git for the commit, the branch and the status, and hands the three answers to the new `composeLocalContext()`, which turns them into the context: an unnamed commit becomes "unknown", any status output marks the tree dirty, and a branch is recorded only when git named one. This mirrors the shape the continuous integration side of the same module already has, where `composeCiContext()` is a plain function over facts gathered elsewhere.

Reaching each arm is then a matter of stating what git said. `tasks/test-records-flap-coverage.test.ts` has one case per arm: a branch git named, the empty string a detached checkout produces, and the absent answer a directory outside a repository produces. Each case asserts what the composition makes of the facts, so an arm that stopped recording the branch would fail rather than stay green on a line count. Nothing in the file runs a subprocess or reads the surrounding checkout, so every arm runs on every machine and under every configuration.

Measured on its own, that file covers every line of `composeLocalContext()`, with three hits on the line that records the branch.

The coverage guide gains a section on this shape of movement, alongside the ones on wall-clock diagnostics, second occurrences, and racing writes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

