### PR TITLE
fix(runner): keep a ref builtin's policy identity when it declares a scope

### DIFF
--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -71,10 +71,7 @@ export class ModuleRegistry {
     const target = Object.isExtensible(module)
       ? module
       : cloneModuleRecord(module);
-    Object.defineProperty(target, "debugName", {
-      value: ref,
-      configurable: true,
-    });
+    defineDebugName(target, ref);
     this.moduleMap.set(ref, target);
   }
 
@@ -86,12 +83,11 @@ export class ModuleRegistry {
    * that declared it (`.asScope("user")`, or the `PerUser<>` annotation the
    * transformer lowers to it).
    *
-   * The copy restates `debugName`, which is what proves the module's
-   * `{ kind: "builtin", builtinId }` policy identity to
-   * `resolvePolicyFacingImplementationIdentity`. `addModuleByRef` defines it
-   * non-enumerable, so that it stays out of `moduleToEncodableForm`'s key set
-   * and off every content-derived id built from a module; nothing copies it
-   * implicitly, and a scoped module with no name on it writes unattributed.
+   * The copy restates `debugName` through {@link defineDebugName}, which is
+   * what proves the module's `{ kind: "builtin", builtinId }` policy identity
+   * to `resolvePolicyFacingImplementationIdentity`. Being non-enumerable, the
+   * name is not among the members a spread carries, and a scoped module with
+   * no name on it writes unattributed.
    */
   getModule(ref: string, defaultScope?: CellScope): Module {
     if (typeof ref !== "string") throw new Error(`Unknown module ref: ${ref}`);
@@ -99,16 +95,37 @@ export class ModuleRegistry {
     if (!module) throw new Error(`Unknown module ref: ${ref}`);
     if (defaultScope === undefined) return module;
     const scoped: Module = { ...module, defaultScope };
-    Object.defineProperty(scoped, "debugName", {
-      value: ref,
-      configurable: true,
-    });
+    defineDebugName(scoped, ref);
     return scoped;
   }
 
   clear(): void {
     this.moduleMap.clear();
   }
+}
+
+/**
+ * Name a module with the ref it is registered under.
+ *
+ * The name is the module's policy identity: it is what
+ * `resolvePolicyFacingImplementationIdentity` reads to resolve
+ * `{ kind: "builtin", builtinId }`, so the writes a builtin's node makes are
+ * attributable to it.
+ *
+ * It is defined rather than assigned, and every attribute is stated rather
+ * than left to default, because `Object.defineProperty` carries forward the
+ * attributes an existing property already had. A module carrying an ordinary
+ * `debugName` of its own would otherwise keep it enumerable, which puts the
+ * name in `moduleToEncodableForm`'s key set and so into every content-derived
+ * id built from that module.
+ */
+function defineDebugName(module: Module, ref: string): void {
+  Object.defineProperty(module, "debugName", {
+    value: ref,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
 }
 
 function cloneModuleRecord(module: Module): Module {

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -1,5 +1,6 @@
 import { createNodeFactory } from "./builder/module.ts";
 import {
+  type CellScope,
   type JSONSchema,
   Module,
   type ModuleFactory,
@@ -77,11 +78,32 @@ export class ModuleRegistry {
     this.moduleMap.set(ref, target);
   }
 
-  getModule(ref: string): Module {
+  /**
+   * The module registered under `ref`.
+   *
+   * A `defaultScope` is applied to a COPY: the registered module is shared by
+   * every node that names the ref, while a scope belongs to the one call site
+   * that declared it (`.asScope("user")`, or the `PerUser<>` annotation the
+   * transformer lowers to it).
+   *
+   * The copy restates `debugName`, which is what proves the module's
+   * `{ kind: "builtin", builtinId }` policy identity to
+   * `resolvePolicyFacingImplementationIdentity`. `addModuleByRef` defines it
+   * non-enumerable, so that it stays out of `moduleToEncodableForm`'s key set
+   * and off every content-derived id built from a module; nothing copies it
+   * implicitly, and a scoped module with no name on it writes unattributed.
+   */
+  getModule(ref: string, defaultScope?: CellScope): Module {
     if (typeof ref !== "string") throw new Error(`Unknown module ref: ${ref}`);
     const module = this.moduleMap.get(ref);
     if (!module) throw new Error(`Unknown module ref: ${ref}`);
-    return module;
+    if (defaultScope === undefined) return module;
+    const scoped: Module = { ...module, defaultScope };
+    Object.defineProperty(scoped, "debugName", {
+      value: ref,
+      configurable: true,
+    });
+    return scoped;
   }
 
   clear(): void {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5076,16 +5076,19 @@ export class Runner {
       switch (module.type) {
         case "ref": {
           const refName = module.implementation as string;
-          const resolved = this.runtime.moduleRegistry.getModule(refName);
           // `.asScope(scope)` records its scope on the *ref* module (the node's
           // module), but resolving the ref swaps in the registry's module — so
-          // carry the declared default scope across, or it is silently dropped
-          // and the node falls back to "space".
+          // hand the declared default scope to the registry, or it is silently
+          // dropped and the node falls back to "space". The registry owns
+          // applying it, because the copy it takes to do so must also carry
+          // the module's `debugName` (its policy identity) across.
+          const resolved = this.runtime.moduleRegistry.getModule(
+            refName,
+            module.defaultScope,
+          );
           this.instantiateNode(
             tx,
-            module.defaultScope !== undefined
-              ? { ...resolved, defaultScope: module.defaultScope }
-              : resolved,
+            resolved,
             inputBindings,
             outputBindings,
             resultCell,

--- a/packages/runner/test/cfc-implementation-identity.test.ts
+++ b/packages/runner/test/cfc-implementation-identity.test.ts
@@ -116,6 +116,47 @@ describe("CFC builtin implementation identity", () => {
     tx.abort("test-complete");
   });
 
+  it("keeps the name off the serialized key set of a module that carried one", () => {
+    storageManager = StorageManager.emulate({
+      as: signer,
+    });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+
+    // The name is what the policy identity is read from, and it stays out of
+    // `moduleToEncodableForm`'s key set — which is `...rest`, so the name must
+    // be non-enumerable wherever it is set. A module arriving with an ordinary
+    // `debugName` of its own is the case that tests it: `defineProperty`
+    // carries forward an existing property's attributes, so anything that
+    // leaves `enumerable` to default would keep this one enumerable and put
+    // the name into every content-derived id built from the module.
+    const carriesItsOwn = Object.assign(
+      raw(() => () => undefined),
+      { debugName: "stale" },
+    );
+    runtime.moduleRegistry.addModuleByRef("named-test-builtin", carriesItsOwn);
+
+    const plain = runtime.moduleRegistry.getModule("named-test-builtin");
+    const scoped = runtime.moduleRegistry.getModule(
+      "named-test-builtin",
+      "user",
+    );
+
+    for (const module of [plain, scoped]) {
+      expect(Object.keys(module)).not.toContain("debugName");
+      expect(
+        Object.getOwnPropertyDescriptor(module, "debugName")?.enumerable,
+      ).toBe(false);
+      expect(resolvePolicyFacingImplementationIdentity(module)).toEqual({
+        kind: "builtin",
+        builtinId: "named-test-builtin",
+      });
+    }
+  });
+
   it("threads builtin implementation identity through the active execution frame", async () => {
     storageManager = StorageManager.emulate({
       as: signer,

--- a/packages/runner/test/cfc-implementation-identity.test.ts
+++ b/packages/runner/test/cfc-implementation-identity.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { raw } from "../src/module.ts";
+import { createNodeFactory } from "../src/builder/module.ts";
 import { Runtime } from "../src/runtime.ts";
 import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
 import { getTopFrame } from "../src/builder/pattern.ts";
@@ -62,6 +63,55 @@ describe("CFC builtin implementation identity", () => {
     expect(captured[0]).toEqual({
       kind: "builtin",
       builtinId: "test-builtin",
+    });
+    tx.abort("test-complete");
+  });
+
+  it("keeps the builtin identity when the ref declares a scope", () => {
+    storageManager = StorageManager.emulate({
+      as: signer,
+    });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+
+    const captured: Array<unknown> = [];
+    runtime.moduleRegistry.addModuleByRef(
+      "scoped-test-builtin",
+      raw((inputsCell) => {
+        captured.push(inputsCell.tx?.getCfcState().implementationIdentity);
+        return () => undefined;
+      }),
+    );
+
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell(
+      signer.did(),
+      "cfc-scoped-builtin-identity",
+      undefined,
+      tx,
+    );
+    // `.asScope("user")` — what the transformer lowers a `PerUser<>` result
+    // annotation to — records the scope on the REF module, so resolving the
+    // ref has to carry the registry module's `debugName` onto the scoped copy.
+    // That name is the whole proof of the builtin identity, and it is
+    // non-enumerable (so it stays out of the serialized key set), so a copy
+    // that does not go out of its way to keep it drops the identity.
+    runtime.runner.run(
+      tx,
+      createNodeFactory({
+        type: "ref",
+        implementation: "scoped-test-builtin",
+      }).asScope("user"),
+      {},
+      resultCell,
+    );
+
+    expect(captured[0]).toEqual({
+      kind: "builtin",
+      builtinId: "scoped-test-builtin",
     });
     tx.abort("test-complete");
   });


### PR DESCRIPTION
## Why

A ref builtin loses its CFC policy identity the moment an author declares a
scope on it.

`resolvePolicyFacingImplementationIdentity` reads a module's `debugName` to give
it `{ kind: "builtin", builtinId }`. That identity is what
`cfc/prepare.ts` verifies a `writeAuthorizedBy` claim against on its
trusted-builtin arm, and what `instantiateRawNode` stamps on the transaction so
every write the builtin makes is attributable. `addModuleByRef` installs the
name with `Object.defineProperty` and no `enumerable`, deliberately: it has to
stay out of `moduleToEncodableForm`'s `...rest` key set, which
`to-encodable-form.test.ts` pins and which every content-derived id built from a
module depends on.

Resolving a `type: "ref"` node whose module carries a `defaultScope` took a copy
of the registry module to apply the scope to, and it made that copy by
spreading — which takes only enumerable own properties. Measured across the
registry:

```
sqliteDatabase  direct={"kind":"builtin","builtinId":"sqliteDatabase"}  scoped=undefined
str             direct={"kind":"builtin","builtinId":"str"}             scoped=undefined
ifElse          direct={"kind":"builtin","builtinId":"ifElse"}          scoped=undefined
navigateTo      direct={"kind":"builtin","builtinId":"navigateTo"}      scoped=undefined
```

It is reachable from ordinary pattern source, not just from a direct
`.asScope()` call: `packages/api/index.ts` documents the transformer lowering
`const db: PerUser<SqliteDb> = sqliteDatabase(...)` to `.asScope("user")`, and
`sqlite-builtins.test.ts` exercises that path. `PerUser<SqliteDb>` is the shape
where attribution matters most, and the annotation is what removed it.

The direction is fail closed — an absent identity denies a `writeAuthorizedBy`
claim, it never grants one — so this is not an escalation. But the writes went
out unattributed and nothing said so.

## What changed

`ModuleRegistry.getModule` takes the scope and owns applying it. The copy, and
the name that has to ride it, now live in the file that defines the convention
(next to the `addModuleByRef` that installs the name), and the single caller in
`runner.ts` cannot get it wrong:

```ts
const resolved = this.runtime.moduleRegistry.getModule(
  refName,
  module.defaultScope,
);
```

Making `debugName` enumerable would also fix the drop, and is the wrong fix: it
would put the name into the serialized module and move every content-derived id
that carries one.

## Test plan

- New case in `cfc-implementation-identity.test.ts`, alongside the existing
  "stamps registered raw builtins with a stable builtin identity". It runs a
  registered builtin through `.asScope("user")` and asserts the identity the
  builtin observes on its own transaction. **Confirmed to fail on unmodified
  main** and pass with the fix — it reproduces end to end through
  `instantiateNode`, not against the helper in isolation.
- `packages/runner` full suite: **1246 passed / 0 failed**. Both suites that
  could have caught a regression here pass: `encodable-form` (which pins the
  serialized key set) and sqlite's "forwards a user-scoped db (.asScope) to the
  query wire", which is the behavior the copy exists for in the first place.
- `deno fmt --check`, `deno lint`, `deno task check`, `check-docs`,
  `check-conflict-markers`, `check-no-waitfor`, `check-skill-facts`,
  `check-package-cycles`: clean.

Found while reviewing #6071, but it predates it and is independent of #6104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

