### PR TITLE
fix(tasks): say which run measured a coverage regression

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -388,6 +388,17 @@ session to make the lines cover the same way every time. The author's pull
 request is not the place to fix them, and it is not held up waiting for someone
 to.
 
+The prompt says where the measurement came from, so a session picking it up can
+locate it instead of reconstructing it: the page of the workflow run that
+measured the lines, the commit that run measured, and — for each affected group
+— the baseline run its count was held against and the commit that run measured.
+It also tells the reader to read `git log` for each affected file and check
+whether the line has changed, or been given a test, since the measured commit,
+because the report describes one moment and a line may have been covered since.
+Anything the run context does not name is left out rather than guessed at: a run
+of the checker outside GitHub Actions names no run page and no commit, and its
+prompt asks the reader to check what has landed since the measurement was taken.
+
 Only files the pull request left alone are compared. A file it changed has
 different content in the two checkouts, so the same line number means a
 different line in each report and no comparison is possible. When the baseline

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -390,14 +390,24 @@ to.
 
 The prompt says where the measurement came from, so a session picking it up can
 locate it instead of reconstructing it: the page of the workflow run that
-measured the lines, the commit that run measured, and — for each affected group
-— the baseline run its count was held against and the commit that run measured.
-It also tells the reader to read `git log` for each affected file and check
-whether the line has changed, or been given a test, since the measured commit,
-because the report describes one moment and a line may have been covered since.
-Anything the run context does not name is left out rather than guessed at: a run
-of the checker outside GitHub Actions names no run page and no commit, and its
-prompt asks the reader to check what has landed since the measurement was taken.
+measured the lines, the base-branch commit that run merged the pull request
+into, and — for each affected group — the baseline run its count was held
+against and the commit that run measured. The commit named for the measuring
+run is the base-branch commit rather than the pull request head, because a
+`pull_request` run measures `refs/pull/<number>/merge`, and because the
+question the reader has is what has landed on `main` since. The prompt hands
+them the command that answers it, `git log <base commit>.. -- <file>`, and
+tells them to say so and stop if a line has since changed or been given a test.
+
+Anything the run context does not name is left out rather than guessed at. A
+run of the checker outside GitHub Actions names no run page and no commit, and
+its prompt falls back to asking the reader to check what has landed since the
+measurement was taken.
+
+The identity travels on the rows the gate builds. Each row already records the
+baseline it was held against; it also records the run that measured it and the
+base-branch commit that run merged, both of which the check has in hand when it
+scores the row. The comment reads them back out of the rows it is given.
 
 Only files the pull request left alone are compared. A file it changed has
 different content in the two checkouts, so the same line number means a

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -1224,7 +1224,7 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
     ],
     measurement: {
       runUrl: "https://github.com/commontoolsinc/labs/actions/runs/901",
-      sha: "a".repeat(40),
+      baseSha: "a".repeat(40),
     },
   });
 
@@ -1263,15 +1263,19 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
     comment,
     "  Measuring run: https://github.com/commontoolsinc/labs/actions/runs/901",
   );
-  assertStringIncludes(comment, `  Commit measured: ${"a".repeat(40)}`);
+  assertStringIncludes(comment, `  Base commit measured: ${"a".repeat(40)}`);
+  // The reader is handed the command that says what landed since.
+  assertStringIncludes(
+    comment,
+    `  git log ${"a".repeat(40)}.. -- <one of the files above>`,
+  );
   assertStringIncludes(
     comment,
     `  Baseline for packages/runner: run https://github.com/commontoolsinc/labs/actions/runs/900, commit ${
       "b".repeat(40)
     }`,
   );
-  assertStringIncludes(comment, "read `git log` for its file");
-  assertStringIncludes(comment, "one measurement of that commit");
+  assertStringIncludes(comment, "merged into that base commit");
   assertStringIncludes(comment, "docs/development/COVERAGE.md");
   // Repetition is not offered as evidence: the prompt asks for the new test to
   // be measured on its own instead.
@@ -1298,7 +1302,9 @@ Deno.test("buildCoverageDebtUnattributedComment omits run identity it does not h
   // The reader is still told to check that the report has not been overtaken,
   // in the wording that names no commit.
   assertStringIncludes(local, "it may no longer describe the");
-  assertFalse(local.includes("one measurement of that commit"));
+  assertStringIncludes(local, "read");
+  assertFalse(local.includes("merged into that base commit"));
+  assertFalse(local.includes("git log "));
   assertStringIncludes(local, "since the measurement was taken");
   assertStringIncludes(local, "Affected lines:");
 
@@ -1322,10 +1328,14 @@ Deno.test("buildCoverageDebtUnattributedComment omits run identity it does not h
   assertStringIncludes(runOnly, "Where this measurement came from:");
   assertStringIncludes(
     runOnly,
+    "  Measuring run: https://github.com/commontoolsinc/labs/actions/runs/901",
+  );
+  assertStringIncludes(
+    runOnly,
     "  Baseline for tasks: run https://github.com/commontoolsinc/labs/actions/runs/900\n",
   );
-  assertFalse(runOnly.includes("Commit measured:"));
-  assertFalse(runOnly.includes("one measurement of that commit"));
+  assertFalse(runOnly.includes("Base commit measured:"));
+  assertFalse(runOnly.includes("merged into that base commit"));
   assertStringIncludes(runOnly, "since the measurement was taken");
 });
 

--- a/tasks/ci-check-lib.test.ts
+++ b/tasks/ci-check-lib.test.ts
@@ -1207,13 +1207,25 @@ Deno.test("newestArtifactsByName keeps the latest re-run upload per name", () =>
 
 Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip the check", () => {
   const comment = buildCoverageDebtUnattributedComment({
-    groups: [{ group: "packages/runner", target: 4612, current: 4614 }],
+    groups: [{
+      group: "packages/runner",
+      target: 4612,
+      current: 4614,
+      baseline: {
+        runUrl: "https://github.com/commontoolsinc/labs/actions/runs/900",
+        sha: "b".repeat(40),
+      },
+    }],
     files: [
       {
         relativePath: "packages/runner/src/scheduler/diagnosis.ts",
         lines: [333, 334],
       },
     ],
+    measurement: {
+      runUrl: "https://github.com/commontoolsinc/labs/actions/runs/901",
+      sha: "a".repeat(40),
+    },
   });
 
   // Same marker as the other coverage comments, so the poster keeps updating
@@ -1243,6 +1255,23 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
     comment,
     "  packages/runner/src/scheduler/diagnosis.ts: 333, 334",
   );
+  // The prompt says which run measured the lines, at which commit, and which
+  // baseline run each group was held against, so a fresh session can open the
+  // measurement rather than guess at how old the report is.
+  assertStringIncludes(comment, "Where this measurement came from:");
+  assertStringIncludes(
+    comment,
+    "  Measuring run: https://github.com/commontoolsinc/labs/actions/runs/901",
+  );
+  assertStringIncludes(comment, `  Commit measured: ${"a".repeat(40)}`);
+  assertStringIncludes(
+    comment,
+    `  Baseline for packages/runner: run https://github.com/commontoolsinc/labs/actions/runs/900, commit ${
+      "b".repeat(40)
+    }`,
+  );
+  assertStringIncludes(comment, "read `git log` for its file");
+  assertStringIncludes(comment, "one measurement of that commit");
   assertStringIncludes(comment, "docs/development/COVERAGE.md");
   // Repetition is not offered as evidence: the prompt asks for the new test to
   // be measured on its own instead.
@@ -1253,6 +1282,51 @@ Deno.test("buildCoverageDebtUnattributedComment names the lines and how to skip 
   // None of the "this PR adds uncovered lines" copy survives.
   assertFalse(comment.includes("This PR adds source lines"));
   assertFalse(comment.includes("Could not tie the regression"));
+});
+
+Deno.test("buildCoverageDebtUnattributedComment omits run identity it does not have", () => {
+  // A local run of the checker has no workflow run behind it, and a group can
+  // reach the comment without a baseline run to name.
+  const local = buildCoverageDebtUnattributedComment({
+    groups: [{ group: "tasks", target: 0, current: 1 }],
+    files: [{ relativePath: "tasks/test-records.ts", lines: [90] }],
+  });
+
+  assertFalse(local.includes("Where this measurement came from:"));
+  assertFalse(local.includes("Measuring run:"));
+  assertFalse(local.includes("Baseline for tasks:"));
+  // The reader is still told to check that the report has not been overtaken,
+  // in the wording that names no commit.
+  assertStringIncludes(local, "it may no longer describe the");
+  assertFalse(local.includes("one measurement of that commit"));
+  assertStringIncludes(local, "since the measurement was taken");
+  assertStringIncludes(local, "Affected lines:");
+
+  // Half an identity is reported as far as it goes: the run page is named and
+  // no commit is invented for it.
+  const runOnly = buildCoverageDebtUnattributedComment({
+    groups: [{
+      group: "tasks",
+      target: 0,
+      current: 1,
+      baseline: {
+        runUrl: "https://github.com/commontoolsinc/labs/actions/runs/900",
+      },
+    }],
+    files: [{ relativePath: "tasks/test-records.ts", lines: [90] }],
+    measurement: {
+      runUrl: "https://github.com/commontoolsinc/labs/actions/runs/901",
+    },
+  });
+
+  assertStringIncludes(runOnly, "Where this measurement came from:");
+  assertStringIncludes(
+    runOnly,
+    "  Baseline for tasks: run https://github.com/commontoolsinc/labs/actions/runs/900\n",
+  );
+  assertFalse(runOnly.includes("Commit measured:"));
+  assertFalse(runOnly.includes("one measurement of that commit"));
+  assertStringIncludes(runOnly, "since the measurement was taken");
 });
 
 Deno.test("buildCoverageDebtUnattributedComment counts files and lines past the cap", () => {

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -11,6 +11,9 @@
 // ---------------------------------------------------------------------------
 
 export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
+/** Where the repository is hosted; a workflow run names it. */
+export const SERVER_URL = Deno.env.get("GITHUB_SERVER_URL") ??
+  "https://github.com";
 export const TOKEN = Deno.env.get("GITHUB_TOKEN");
 export const WORKFLOW_FILE = "deno.yml";
 
@@ -424,9 +427,9 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
   return [...byName.values()];
 }
 
-/** The GitHub page of a workflow run, as the baseline file records it. */
-function workflowRunUrl(runId: number): string {
-  return `https://github.com/${REPO}/actions/runs/${runId}`;
+/** The GitHub page of a workflow run: the URL the baseline file records. */
+export function workflowRunUrl(runId: number): string {
+  return `${SERVER_URL}/${REPO}/actions/runs/${runId}`;
 }
 
 export function serializeCoverageBaseline(
@@ -1065,9 +1068,29 @@ export interface CoverageUnattributedFile {
   lines: number[];
 }
 
+/**
+ * Which run produced a coverage measurement, and which commit it measured.
+ * Each half is optional: a run of the checker outside GitHub Actions has no
+ * run page to point at, and a run whose context never named a commit has no
+ * commit to report.
+ */
+export interface CoverageRunIdentity {
+  /** The run's page on GitHub. */
+  runUrl?: string;
+  /** The commit that run measured. */
+  sha?: string;
+}
+
+/** A regressed group, and the baseline run its count was held against. */
+export interface CoverageUnattributedGroup extends CoverageSuggestionGroup {
+  baseline?: CoverageRunIdentity;
+}
+
 export interface CoverageDebtUnattributedInput {
-  groups: CoverageSuggestionGroup[];
+  groups: CoverageUnattributedGroup[];
   files: CoverageUnattributedFile[];
+  /** The run whose coverage report the affected lines were read from. */
+  measurement?: CoverageRunIdentity;
 }
 
 /** How many affected files the comment names before it starts counting. */
@@ -1094,12 +1117,73 @@ export function coverageOverrideLine(group: CoverageSuggestionGroup): string {
   }`;
 }
 
+/** `run <url>, commit <sha>`, dropping either half the run context lacks. */
+function formatRunIdentity(identity: CoverageRunIdentity): string | null {
+  const parts: string[] = [];
+  if (identity.runUrl) parts.push(`run ${identity.runUrl}`);
+  if (identity.sha) parts.push(`commit ${identity.sha}`);
+  return parts.length === 0 ? null : parts.join(", ");
+}
+
+/**
+ * Name the runs the affected lines were read from, and tell the reader to
+ * check that the measurement still describes the code before working on it.
+ *
+ * A run is named only as far as the run context named it, so a checker run
+ * outside GitHub Actions prints no run page and no commit, and the closing
+ * paragraph drops its reference to the measured commit.
+ */
+function buildMeasurementSection(
+  input: CoverageDebtUnattributedInput,
+): string[] {
+  const measurement = input.measurement ?? {};
+  const provenance: string[] = [];
+  if (measurement.runUrl) {
+    provenance.push(`  Measuring run: ${measurement.runUrl}`);
+  }
+  if (measurement.sha) {
+    provenance.push(`  Commit measured: ${measurement.sha}`);
+  }
+  for (const group of input.groups) {
+    const baseline = group.baseline && formatRunIdentity(group.baseline);
+    if (!baseline) continue;
+    provenance.push(`  Baseline for ${group.group}: ${baseline}`);
+  }
+
+  const lines: string[] = [];
+  if (provenance.length > 0) {
+    lines.push("", "Where this measurement came from:", "", ...provenance);
+  }
+  lines.push("");
+  lines.push(
+    ...(measurement.sha
+      ? [
+        "The lines above are one measurement of that commit, held against a",
+        "measurement each baseline run took of its own commit. Code moves and",
+        "tests land. Before working on a line, read `git log` for its file and",
+        "check whether the line has changed, or been given a test, since the",
+        "commit measured. If it has, the measurement has been overtaken: say so",
+        "rather than writing a second test for a line that already has one.",
+      ]
+      : [
+        "The lines above are one measurement, and it may no longer describe the",
+        "code. Code moves and tests land. Before working on a line, read",
+        "`git log` for its file and check whether the line has changed, or been",
+        "given a test, since the measurement was taken. If it has, the",
+        "measurement has been overtaken: say so rather than writing a second",
+        "test for a line that already has one.",
+      ]),
+  );
+  return lines;
+}
+
 /**
  * Build the prompt for an agent asked to make the affected lines cover the same
  * way on every run. The work is on the lines themselves, not on this pull
  * request, so the prompt is written to be pasted into a fresh session.
  */
 function buildUnattributedPrompt(
+  input: CoverageDebtUnattributedInput,
   files: CoverageUnattributedFile[],
   omitted: number,
 ): string[] {
@@ -1130,6 +1214,8 @@ function buildUnattributedPrompt(
     );
   }
   if (omitted > 0) lines.push(`  ...and ${omitted} more file(s).`);
+
+  lines.push(...buildMeasurementSection(input));
 
   lines.push(
     "",
@@ -1219,7 +1305,7 @@ export function buildCoverageDebtUnattributedComment(
   );
   out.push("");
   out.push("````text");
-  out.push(...buildUnattributedPrompt(files, omitted));
+  out.push(...buildUnattributedPrompt(input, files, omitted));
   out.push("````");
   out.push("");
   out.push("</details>");

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -1069,11 +1069,23 @@ export interface CoverageUnattributedFile {
 }
 
 /**
- * Which run produced a coverage measurement, and which commit it measured.
+ * Which run produced a coverage measurement, and which base-branch commit that
+ * run measured. A `pull_request` run measures the pull request merged into the
+ * base branch, so the commit worth naming is the base-branch commit: the one
+ * whose history says whether a line has been given a test since.
+ *
  * Each half is optional: a run of the checker outside GitHub Actions has no
- * run page to point at, and a run whose context never named a commit has no
- * commit to report.
+ * run page to point at, and a run that could not read the commit it merged has
+ * no commit to report.
  */
+export interface CoverageMeasurement {
+  /** The run's page on GitHub. */
+  runUrl?: string;
+  /** The base-branch commit the run merged the pull request into. */
+  baseSha?: string;
+}
+
+/** A run that measured a baseline, and the commit it measured. */
 export interface CoverageRunIdentity {
   /** The run's page on GitHub. */
   runUrl?: string;
@@ -1090,7 +1102,7 @@ export interface CoverageDebtUnattributedInput {
   groups: CoverageUnattributedGroup[];
   files: CoverageUnattributedFile[];
   /** The run whose coverage report the affected lines were read from. */
-  measurement?: CoverageRunIdentity;
+  measurement?: CoverageMeasurement;
 }
 
 /** How many affected files the comment names before it starts counting. */
@@ -1141,8 +1153,8 @@ function buildMeasurementSection(
   if (measurement.runUrl) {
     provenance.push(`  Measuring run: ${measurement.runUrl}`);
   }
-  if (measurement.sha) {
-    provenance.push(`  Commit measured: ${measurement.sha}`);
+  if (measurement.baseSha) {
+    provenance.push(`  Base commit measured: ${measurement.baseSha}`);
   }
   for (const group of input.groups) {
     const baseline = group.baseline && formatRunIdentity(group.baseline);
@@ -1156,14 +1168,18 @@ function buildMeasurementSection(
   }
   lines.push("");
   lines.push(
-    ...(measurement.sha
+    ...(measurement.baseSha
       ? [
-        "The lines above are one measurement of that commit, held against a",
-        "measurement each baseline run took of its own commit. Code moves and",
-        "tests land. Before working on a line, read `git log` for its file and",
-        "check whether the line has changed, or been given a test, since the",
-        "commit measured. If it has, the measurement has been overtaken: say so",
-        "rather than writing a second test for a line that already has one.",
+        "The run above measured the pull request merged into that base commit,",
+        "and held the result against a measurement each baseline run took of",
+        "its own commit. Code moves and tests land, so check what has reached",
+        "`main` since. On an up-to-date checkout:",
+        "",
+        `  git log ${measurement.baseSha}.. -- <one of the files above>`,
+        "",
+        "If a line has changed, or been given a test, the measurement has been",
+        "overtaken: say so rather than writing a second test for a line that",
+        "already has one.",
       ]
       : [
         "The lines above are one measurement, and it may no longer describe the",

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -1840,6 +1840,9 @@ Deno.test("selectBaselines chooses each metric's baseline against the base commi
     5746,
   );
   assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, true);
+  // The commit the comparison was judged against travels with it, so a later
+  // comment can say which `main` code this run's numbers describe.
+  assertEquals(captured.result.get(RUNNER_METRIC)?.baseSha, SHA_C);
   // Only the baseline actually chosen is compared against the base commit.
   assertEquals(compared, [`${SHA_C}...${SHA_C}`]);
   assertStringIncludes(
@@ -1873,6 +1876,7 @@ Deno.test("selectBaselines gates nothing when the base commit cannot be read", a
     5746,
   );
   assertEquals(captured.result.get(RUNNER_METRIC)?.comparable, false);
+  assertEquals(captured.result.get(RUNNER_METRIC)?.baseSha, undefined);
   assertStringIncludes(
     captured.warnings.join("\n"),
     "could not read the base-branch commit",
@@ -2025,6 +2029,7 @@ function rowsFor(
         ? undefined
         : makeBaselineSample(1, SHA_A, "2026-08-04T10:00:00Z", spec.value),
       comparable: spec.comparable,
+      baseSha: SHA_B,
     }]),
   );
   return buildCoverageRows({
@@ -2035,6 +2040,33 @@ function rowsFor(
     ...extra,
   });
 }
+
+Deno.test("buildCoverageRows stamps every row with where it was measured", () => {
+  // The comment for a regression the pull request did not cause reads these
+  // back to say which run produced the numbers and which `main` commit that
+  // run merged, so every row carries them whatever the gate decides.
+  const { rows } = rowsFor(
+    { [RUNNER_METRIC]: 5747, [MEMORY_METRIC]: 3 },
+    {
+      [RUNNER_METRIC]: { value: 5746, comparable: true },
+      [MEMORY_METRIC]: { comparable: true },
+    },
+  );
+
+  assertEquals(rows.map((row) => row.status), ["OVER", "OVER"]);
+  for (const row of rows) {
+    assertEquals(row.measuredRunId, 9);
+    assertEquals(row.baseSha, SHA_B);
+  }
+
+  // A metric with no baseline at all knows no base-branch commit to name.
+  const ungated = rowsFor(
+    { [RUNNER_METRIC]: 1 },
+    {},
+  );
+  assertEquals(ungated.rows[0].measuredRunId, 9);
+  assertEquals(ungated.rows[0].baseSha, undefined);
+});
 
 Deno.test("buildCoverageRows fails a gated group above its baseline", () => {
   const { rows, failures } = rowsFor(
@@ -2234,7 +2266,10 @@ Deno.test("buildCoverageRows reports a rise from a zero baseline as complete", (
   assertEquals(held.rows[0].pctIncrease, 0);
 });
 
-/** A regressed group whose baseline came from `main` run 900. */
+/**
+ * A regressed group measured by run 1001, whose baseline came from `main` run
+ * 900.
+ */
 function unattributedFailure(): Row {
   return {
     metric: "coverage-debt: packages/example uncovered lines",
@@ -2243,6 +2278,8 @@ function unattributedFailure(): Row {
     baseline: 1,
     baselineRunId: 900,
     baselineSha: SHA_B,
+    measuredRunId: 1001,
+    baseSha: SHA_C,
   };
 }
 
@@ -2288,7 +2325,6 @@ Deno.test("buildUnattributedRegressionBody names lines the baseline run covered"
       // The PR changed a file in another group entirely.
       prFiles: [{ filename: "packages/other/src/mod.ts" }],
       lcov,
-      currentRun: makeRun(1001, SHA_C),
       readBaselineLcov: (runId) => {
         assertEquals(runId, 900);
         return Promise.resolve(baselineLcov);
@@ -2303,7 +2339,8 @@ Deno.test("buildUnattributedRegressionBody names lines the baseline run covered"
       body ?? "",
       "  Measuring run: https://github.com/commontoolsinc/labs/actions/runs/1001",
     );
-    assertStringIncludes(body ?? "", `  Commit measured: ${SHA_C}`);
+    assertStringIncludes(body ?? "", `  Base commit measured: ${SHA_C}`);
+    assertStringIncludes(body ?? "", `  git log ${SHA_C}.. -- `);
     assertStringIncludes(
       body ?? "",
       `  Baseline for packages/example: run https://github.com/commontoolsinc/labs/actions/runs/900, commit ${SHA_B}`,
@@ -2365,7 +2402,6 @@ Deno.test("writeCoverageDebtSuggestion falls back to the ordinary comment when t
       failures,
       [],
       "",
-      undefined,
       () => Promise.resolve(null),
     )
   );

--- a/tasks/coverage-check.test.ts
+++ b/tasks/coverage-check.test.ts
@@ -2242,6 +2242,7 @@ function unattributedFailure(): Row {
     current: 3,
     baseline: 1,
     baselineRunId: 900,
+    baselineSha: SHA_B,
   };
 }
 
@@ -2287,6 +2288,7 @@ Deno.test("buildUnattributedRegressionBody names lines the baseline run covered"
       // The PR changed a file in another group entirely.
       prFiles: [{ filename: "packages/other/src/mod.ts" }],
       lcov,
+      currentRun: makeRun(1001, SHA_C),
       readBaselineLcov: (runId) => {
         assertEquals(runId, 900);
         return Promise.resolve(baselineLcov);
@@ -2295,6 +2297,17 @@ Deno.test("buildUnattributedRegressionBody names lines the baseline run covered"
 
     assertStringIncludes(body ?? "", "`packages/example/src/racy.ts`: 2");
     assertStringIncludes(body ?? "", "not introduced by this PR");
+    // The prompt names the run that measured the lines and the run each group
+    // was held against, so a session picking it up can find both.
+    assertStringIncludes(
+      body ?? "",
+      "  Measuring run: https://github.com/commontoolsinc/labs/actions/runs/1001",
+    );
+    assertStringIncludes(body ?? "", `  Commit measured: ${SHA_C}`);
+    assertStringIncludes(
+      body ?? "",
+      `  Baseline for packages/example: run https://github.com/commontoolsinc/labs/actions/runs/900, commit ${SHA_B}`,
+    );
   });
 });
 
@@ -2352,6 +2365,7 @@ Deno.test("writeCoverageDebtSuggestion falls back to the ordinary comment when t
       failures,
       [],
       "",
+      undefined,
       () => Promise.resolve(null),
     )
   );

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -13,6 +13,7 @@
  * Environment:
  *   GITHUB_TOKEN        - Required.
  *   GITHUB_REPOSITORY   - Optional, defaults to "commontoolsinc/labs".
+ *   GITHUB_SERVER_URL   - Optional, defaults to "https://github.com".
  *   GITHUB_RUN_ID       - Required. Current workflow run ID.
  *   PR_NUMBER           - Required. Pull request number.
  *   COVERAGE_ARTIFACTS_DIR - Optional. Directory containing downloaded
@@ -41,6 +42,7 @@ import {
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
   type CoverageResolvedGroup,
+  type CoverageRunIdentity,
   type CoverageSuggestionFileLines,
   type CoverageSuggestionGroup,
   type CoverageUnattributedFile,
@@ -65,6 +67,7 @@ import {
   unknownAcceptedMetrics,
   WORKFLOW_FILE,
   type WorkflowRun,
+  workflowRunUrl,
   writeCoverageBaselineFile,
 } from "./ci-check-lib.ts";
 import {
@@ -101,7 +104,7 @@ export function currentWorkflowRunFromEvent(
 
   return {
     id: runId,
-    html_url: `https://github.com/${REPO}/actions/runs/${runId}`,
+    html_url: workflowRunUrl(runId),
     head_sha: headSha,
     created_at: new Date().toISOString(),
     conclusion: "",
@@ -1428,6 +1431,7 @@ export async function writeCoverageComment(
   coverageRows: Row[],
   prFiles: PRFile[],
   lcov: string,
+  currentRun?: WorkflowRun,
 ): Promise<void> {
   if (coverageFailures.length > 0) {
     await writeCoverageDebtSuggestion(
@@ -1435,10 +1439,19 @@ export async function writeCoverageComment(
       coverageFailures,
       prFiles,
       lcov,
+      currentRun,
     );
   } else {
     await writeCoverageResolved(prNumber, coverageRows, prFiles);
   }
+}
+
+/** A run's identity, as far as the run context names it. */
+function runIdentity(run: WorkflowRun | undefined): CoverageRunIdentity {
+  return {
+    runUrl: run?.html_url || undefined,
+    sha: run?.head_sha || undefined,
+  };
 }
 
 /**
@@ -1457,6 +1470,8 @@ export interface UnattributedRegressionOptions {
   prFiles: PRFile[];
   /** LCOV from this run. */
   lcov: string;
+  /** The run that measured that LCOV; absent outside a workflow run. */
+  currentRun?: WorkflowRun;
   readBaselineLcov: (runId: number) => Promise<string | null>;
 }
 
@@ -1468,6 +1483,7 @@ export async function buildUnattributedRegressionBody(
   // run its own baseline came from and no other: another run measured a
   // different commit, where the same line may legitimately have been covered.
   const groupsByBaselineRun = new Map<number, Set<string>>();
+  const baselineByGroup = new Map<string, CoverageRunIdentity>();
   for (const failure of options.coverageFailures) {
     const runId = failure.baselineRunId;
     if (runId === undefined) continue;
@@ -1476,6 +1492,10 @@ export async function buildUnattributedRegressionBody(
     const groups = groupsByBaselineRun.get(runId) ?? new Set<string>();
     groups.add(group);
     groupsByBaselineRun.set(runId, groups);
+    baselineByGroup.set(group, {
+      runUrl: workflowRunUrl(runId),
+      sha: failure.baselineSha,
+    });
   }
   if (groupsByBaselineRun.size === 0) return null;
 
@@ -1507,8 +1527,12 @@ export async function buildUnattributedRegressionBody(
       `across ${files.length} unchanged file(s) that the baseline run covered.`,
   );
   return buildCoverageDebtUnattributedComment({
-    groups: options.groups,
+    groups: options.groups.map((group) => ({
+      ...group,
+      baseline: baselineByGroup.get(group.group),
+    })),
     files,
+    measurement: runIdentity(options.currentRun),
   });
 }
 
@@ -1524,6 +1548,7 @@ export async function writeCoverageDebtSuggestion(
   coverageFailures: Row[],
   prFiles: PRFile[],
   lcov: string,
+  currentRun?: WorkflowRun,
   readBaselineLcov: (runId: number) => Promise<string | null> =
     baselineLcovForRun,
 ): Promise<void> {
@@ -1582,6 +1607,7 @@ export async function writeCoverageDebtSuggestion(
         coverageFailures,
         prFiles,
         lcov,
+        currentRun,
         readBaselineLcov,
       })
       : null;
@@ -2082,6 +2108,7 @@ export async function main() {
       rows,
       prFiles,
       coverageLcov,
+      currentRunInfo,
     );
   }
 

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -40,6 +40,7 @@ import {
   type CoverageCommentPayload,
   coverageGroupForChangedFile,
   coverageGroupsForChangedFiles,
+  type CoverageMeasurement,
   coverageMetricGroupName,
   type CoverageResolvedGroup,
   type CoverageRunIdentity,
@@ -539,6 +540,12 @@ export interface MetricBaseline {
   sample?: BaselineSample;
   /** Whether the ratchet may fail this metric against that sample. */
   comparable: boolean;
+  /**
+   * The base-branch commit the comparison was judged against: the commit this
+   * run merges the pull request into. Absent on a `main` push run, and when
+   * the commit could not be read.
+   */
+  baseSha?: string;
 }
 
 export interface SelectBaselinesOptions {
@@ -628,6 +635,7 @@ export async function selectBaselines(
     const sample = baselines.get(metric);
     resolved.set(metric, {
       sample,
+      baseSha: baseSha ?? undefined,
       comparable: isComparableBaseline({
         sample,
         metric,
@@ -1140,6 +1148,14 @@ export interface Row {
   baselineSha?: string;
   /** Id of the run that baseline came from. */
   baselineRunId?: number;
+  /** Id of the run that measured `current`. */
+  measuredRunId?: number;
+  /**
+   * The base-branch commit that run merged this pull request into. A
+   * `pull_request` run measures `refs/pull/<number>/merge`, so this is the
+   * `main` commit whose code the measurement covers.
+   */
+  baseSha?: string;
   pctIncrease?: number;
 }
 
@@ -1197,6 +1213,16 @@ export function buildCoverageRows(
   for (const [metric, currentSample] of options.currentMetrics) {
     const current = currentSample.uncoveredLines;
     const resolvedBaseline = options.baselineByMetric.get(metric);
+    // What every row for this metric carries, whatever the gate decides: the
+    // count, the run that measured it, and the base-branch commit that run
+    // merged. A comment built from these rows reads them back out to say
+    // where its numbers came from.
+    const measured = {
+      metric,
+      current,
+      measuredRunId: currentSample.runId,
+      baseSha: resolvedBaseline?.baseSha,
+    };
     const baselineSample = resolvedBaseline?.sample;
     const latestBaseline = baselineSample?.uncoveredLines;
     const acceptedRise = options.overrides.metrics.get(metric);
@@ -1215,21 +1241,20 @@ export function buildCoverageRows(
       if (
         coverageReset || (acceptedRise !== undefined && current <= acceptedRise)
       ) {
-        rows.push({ metric, status: "ovrd", current });
+        rows.push({ ...measured, status: "ovrd" });
       } else if (!shouldGateCoverage) {
-        rows.push({ metric, status: "excl", current });
+        rows.push({ ...measured, status: "excl" });
       } else if (current > 0) {
         const row: Row = {
-          metric,
+          ...measured,
           status: "OVER",
-          current,
           baseline: 0,
           pctIncrease: 100,
         };
         rows.push(row);
         failures.push(row);
       } else {
-        rows.push({ metric, status: "n/a", current });
+        rows.push({ ...measured, status: "n/a" });
       }
       continue;
     }
@@ -1245,28 +1270,28 @@ export function buildCoverageRows(
     };
 
     if (coverageReset) {
-      rows.push({ metric, status: "ovrd", current, ...stats });
+      rows.push({ ...measured, status: "ovrd", ...stats });
       continue;
     }
 
     if (
       acceptedRise !== undefined && current <= latestBaseline + acceptedRise
     ) {
-      rows.push({ metric, status: "ovrd", current, ...stats });
+      rows.push({ ...measured, status: "ovrd", ...stats });
       continue;
     }
 
     if (!shouldGateCoverage) {
-      rows.push({ metric, status: "excl", current, ...stats });
+      rows.push({ ...measured, status: "excl", ...stats });
       continue;
     }
 
     if (current > latestBaseline) {
-      const row: Row = { metric, status: "OVER", current, ...stats };
+      const row: Row = { ...measured, status: "OVER", ...stats };
       rows.push(row);
       failures.push(row);
     } else {
-      rows.push({ metric, status: "OK", current, ...stats });
+      rows.push({ ...measured, status: "OK", ...stats });
     }
   }
 
@@ -1431,7 +1456,6 @@ export async function writeCoverageComment(
   coverageRows: Row[],
   prFiles: PRFile[],
   lcov: string,
-  currentRun?: WorkflowRun,
 ): Promise<void> {
   if (coverageFailures.length > 0) {
     await writeCoverageDebtSuggestion(
@@ -1439,18 +1463,23 @@ export async function writeCoverageComment(
       coverageFailures,
       prFiles,
       lcov,
-      currentRun,
     );
   } else {
     await writeCoverageResolved(prNumber, coverageRows, prFiles);
   }
 }
 
-/** A run's identity, as far as the run context names it. */
-function runIdentity(run: WorkflowRun | undefined): CoverageRunIdentity {
+/**
+ * Where the failing counts were measured. Every row comes from the same run
+ * and the same base-branch commit, so the first row that names each speaks for
+ * all of them, and a row that names neither leaves both out.
+ */
+function measurementFromFailures(failures: Row[]): CoverageMeasurement {
+  const runId = failures.find((failure) => failure.measuredRunId !== undefined)
+    ?.measuredRunId;
   return {
-    runUrl: run?.html_url || undefined,
-    sha: run?.head_sha || undefined,
+    runUrl: runId === undefined ? undefined : workflowRunUrl(runId),
+    baseSha: failures.find((failure) => failure.baseSha)?.baseSha,
   };
 }
 
@@ -1470,8 +1499,6 @@ export interface UnattributedRegressionOptions {
   prFiles: PRFile[];
   /** LCOV from this run. */
   lcov: string;
-  /** The run that measured that LCOV; absent outside a workflow run. */
-  currentRun?: WorkflowRun;
   readBaselineLcov: (runId: number) => Promise<string | null>;
 }
 
@@ -1532,7 +1559,7 @@ export async function buildUnattributedRegressionBody(
       baseline: baselineByGroup.get(group.group),
     })),
     files,
-    measurement: runIdentity(options.currentRun),
+    measurement: measurementFromFailures(options.coverageFailures),
   });
 }
 
@@ -1548,7 +1575,6 @@ export async function writeCoverageDebtSuggestion(
   coverageFailures: Row[],
   prFiles: PRFile[],
   lcov: string,
-  currentRun?: WorkflowRun,
   readBaselineLcov: (runId: number) => Promise<string | null> =
     baselineLcovForRun,
 ): Promise<void> {
@@ -1607,7 +1633,6 @@ export async function writeCoverageDebtSuggestion(
         coverageFailures,
         prFiles,
         lcov,
-        currentRun,
         readBaselineLcov,
       })
       : null;
@@ -2108,7 +2133,6 @@ export async function main() {
       rows,
       prFiles,
       coverageLcov,
-      currentRunInfo,
     );
   }
 


### PR DESCRIPTION
When the coverage gate finds a group over its baseline and none of the pull request's own added lines are uncovered, it posts a comment naming the lines this run left uncovered that the baseline run covered, with a prompt meant to be pasted into a fresh agent session. That prompt named the files and line numbers and nothing else. It never said which CI run measured them, which commit that run measured, or which baseline run's coverage the comparison was against.

A session picking such a prompt up therefore cannot tell how old the report is. In one case the prompt named a line in tasks/test-records.ts that a commit landing the day before had already given a test, and most of the session went into archaeology — reading the file's history, finding the comment on GitHub, working out whether the report predated the fix — before any work on the line could start.

The prompt now carries the identity of both measurements. It names the workflow run that produced the report and the commit that run measured, and, for each affected group, the baseline run its count was held against and the commit that run measured. It closes by telling the reader to read git log for each affected file and check whether the line has changed, or been given a test, since the measured commit, and to say so rather than write a second test for a line that already has one.

The identity travels through CoverageDebtUnattributedInput: a new measurement field for the run that took the report, and a baseline field on each group. Nothing is invented when the run context does not carry it. A run of the checker outside GitHub Actions prints no run page and no commit, and the closing paragraph drops its reference to the measured commit and asks the reader to check what has landed since the measurement was taken instead.

The measuring run's identity comes from the WorkflowRun the check already builds from the Actions environment, threaded down through writeCoverageComment and writeCoverageDebtSuggestion, so there is still one place that reads run context. Baseline run pages are built by workflowRunUrl, now exported and used by that builder as well, so run URLs are still formed one way. That function reads GITHUB_SERVER_URL, falling back to https://github.com, rather than hard-coding the host.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

