### PR TITLE
feat(state-inspector): a tombstone reads differently from corruption

### DIFF
--- a/packages/memory/test/v2-stored-payload.test.ts
+++ b/packages/memory/test/v2-stored-payload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The stored-payload rule is shared by two readers that accept different
+ * payloads: the engine reads what it wrote, through `decodeMemoryBoundary`,
+ * while an offline reader over a durable file may also meet untagged
+ * plain-JSON rows. Everything either of them decides ABOUT a payload —
+ * whether an absent one is readable, whether a decoded root is a document —
+ * has to be the same on both sides, or the two disagree about which stored
+ * states exist while claiming to replicate one another.
+ *
+ * So every case here runs under both decoders and asserts they agree. The
+ * trap this guards is a rule that reaches its verdict by handing a fallback
+ * STRING to the decoder: `decodeMemoryBoundary` refuses any untagged payload,
+ * so a `"[]"` fallback rejects for the engine and succeeds for a plain-JSON
+ * reader, and a rule that reads differently per decoder is not shared.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+import type { PatchOp } from "../v2.ts";
+import {
+  decodeMemoryBoundary,
+  decodeStoredDocumentPayload,
+  decodeStoredPatchListPayload,
+  encodeMemoryBoundary,
+} from "../v2.ts";
+
+/** An offline reader's decoder: untagged rows are plain JSON. */
+const plainJson = (source: string): unknown => JSON.parse(source);
+
+/** The two decoders the rule is parameterized over, with a matching encoder. */
+const DECODERS = [
+  {
+    name: "decodeMemoryBoundary",
+    decode: decodeMemoryBoundary as (source: string) => unknown,
+    encode: (value: unknown) => encodeMemoryBoundary(value as never),
+  },
+  { name: "plain JSON", decode: plainJson, encode: JSON.stringify },
+] as const;
+
+describe("v2 stored payload", () => {
+  describe("decodeStoredDocumentPayload()", () => {
+    for (const { name, decode, encode } of DECODERS) {
+      it(`returns the document for a well-formed payload under ${name}`, () => {
+        assertEquals(
+          decodeStoredDocumentPayload(decode, encode({ value: { n: 1 } })),
+          { value: { n: 1 } },
+        );
+      });
+
+      it(`refuses an absent payload under ${name}`, () => {
+        // Never reaches the decoder: an absent document is `null`, and `null`
+        // is not a tree of paths.
+        assertThrows(
+          () => decodeStoredDocumentPayload(decode, null),
+          TypeError,
+          "got null",
+        );
+      });
+
+      it(`refuses a root that is not a document under ${name}`, () => {
+        assertThrows(
+          () => decodeStoredDocumentPayload(decode, encode([1, 2])),
+          TypeError,
+          "got an array",
+        );
+        assertThrows(
+          () => decodeStoredDocumentPayload(decode, encode(null)),
+          TypeError,
+          "got null",
+        );
+      });
+    }
+  });
+
+  describe("decodeStoredPatchListPayload()", () => {
+    const ops: PatchOp[] = [{ op: "replace", path: "/value/n", value: 2 }];
+
+    for (const { name, decode, encode } of DECODERS) {
+      it(`returns the ops for a well-formed payload under ${name}`, () => {
+        assertEquals(decodeStoredPatchListPayload(decode, encode(ops)), ops);
+      });
+
+      it(`refuses an absent payload under ${name}`, () => {
+        // Nothing writes a patch row without a payload, so an absent one is a
+        // malformed row. Reading it as the empty list would apply nothing and
+        // leave the document reading current.
+        assertThrows(
+          () => decodeStoredPatchListPayload(decode, null),
+          TypeError,
+          "must carry a payload",
+        );
+      });
+
+      it(`refuses a payload that is not a list under ${name}`, () => {
+        assertThrows(
+          () => decodeStoredPatchListPayload(decode, encode({ op: "add" })),
+          TypeError,
+          "must be arrays",
+        );
+      });
+    }
+  });
+
+  describe("the two decoders", () => {
+    it("agree on every verdict the rule reaches without them", () => {
+      // The absent cases are the ones a fallback string would split, since
+      // only one decoder accepts an untagged one. Assert the agreement
+      // directly rather than relying on the per-decoder cases above lining up.
+      const verdict = (run: () => unknown): string => {
+        try {
+          return `ok:${JSON.stringify(run())}`;
+        } catch (e) {
+          return `throws:${(e as Error).message}`;
+        }
+      };
+      for (const data of [null]) {
+        assertEquals(
+          verdict(() =>
+            decodeStoredDocumentPayload(decodeMemoryBoundary, data)
+          ),
+          verdict(() => decodeStoredDocumentPayload(plainJson, data)),
+        );
+        assertEquals(
+          verdict(() =>
+            decodeStoredPatchListPayload(decodeMemoryBoundary, data)
+          ),
+          verdict(() => decodeStoredPatchListPayload(plainJson, data)),
+        );
+      }
+    });
+  });
+});

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1904,6 +1904,58 @@ export const isEntityDocument = (
   value: unknown,
 ): value is EntityDocument => isObjectNotArray(value);
 
+/**
+ * How a stored payload reads when its row holds none. A document defaults to
+ * `null`, which {@link decodeStoredDocumentPayload} then refuses as a root — a stored
+ * document is always a tree of paths. A patch list defaults to the empty list,
+ * which IS applicable. The asymmetry is the rule callers get wrong when they
+ * re-derive it, so it lives here rather than at each reader.
+ */
+const ABSENT_DOCUMENT_PAYLOAD = "null";
+const ABSENT_PATCH_LIST_PAYLOAD = "[]";
+
+/**
+ * Read a stored document payload: default an absent one, decode it, and refuse
+ * a root that is not a tree of paths.
+ *
+ * `decode` is the caller's, because the readers disagree on which payloads they
+ * accept and only on that: the engine reads what it wrote, through
+ * {@link decodeMemoryBoundary}, while an offline reader over a durable file may
+ * also meet untagged plain-JSON rows and route accordingly. Everything else —
+ * the default, the root check — is one rule shared here, since a reader that
+ * tests the payload for truthiness instead takes an empty string for an absent
+ * one and rebuilds a document the engine would have rejected.
+ */
+export const decodeStoredDocumentPayload = (
+  decode: (source: string) => unknown,
+  data: string | null,
+): EntityDocument => {
+  const parsed = decode(data ?? ABSENT_DOCUMENT_PAYLOAD);
+  if (!isEntityDocument(parsed)) {
+    const shape = parsed === null
+      ? "null"
+      : Array.isArray(parsed)
+      ? "an array"
+      : `a ${typeof parsed}`;
+    throw new TypeError(
+      `memory v2 stored documents must be plain object roots; got ${shape}`,
+    );
+  }
+  return parsed;
+};
+
+/** Read a stored patch-list payload. Absent means the empty list. */
+export const decodeStoredPatchListPayload = (
+  decode: (source: string) => unknown,
+  data: string | null,
+): PatchOp[] => {
+  const parsed = decode(data ?? ABSENT_PATCH_LIST_PAYLOAD);
+  if (!Array.isArray(parsed)) {
+    throw new TypeError("memory v2 stored patches must be arrays");
+  }
+  return parsed as PatchOp[];
+};
+
 export const getEntityDocumentMetadata = (
   document: EntityDocument,
 ): Record<string, FabricValue> => {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1905,32 +1905,28 @@ export const isEntityDocument = (
 ): value is EntityDocument => isObjectNotArray(value);
 
 /**
- * How a stored payload reads when its row holds none. A document defaults to
- * `null`, which {@link decodeStoredDocumentPayload} then refuses as a root — a stored
- * document is always a tree of paths. A patch list defaults to the empty list,
- * which IS applicable. The asymmetry is the rule callers get wrong when they
- * re-derive it, so it lives here rather than at each reader.
- */
-const ABSENT_DOCUMENT_PAYLOAD = "null";
-const ABSENT_PATCH_LIST_PAYLOAD = "[]";
-
-/**
- * Read a stored document payload: default an absent one, decode it, and refuse
- * a root that is not a tree of paths.
+ * Read a stored document payload: decode it, and refuse a root that is not a
+ * tree of paths.
  *
  * `decode` is the caller's, because the readers disagree on which payloads they
  * accept and only on that: the engine reads what it wrote, through
  * {@link decodeMemoryBoundary}, while an offline reader over a durable file may
- * also meet untagged plain-JSON rows and route accordingly. Everything else —
- * the default, the root check — is one rule shared here, since a reader that
- * tests the payload for truthiness instead takes an empty string for an absent
- * one and rebuilds a document the engine would have rejected.
+ * also meet untagged plain-JSON rows and route accordingly. Everything else is
+ * one rule shared here, since a reader that tests the payload for truthiness
+ * instead takes an empty string for an absent one and rebuilds a document the
+ * engine would have rejected.
+ *
+ * An absent payload never reaches the decoder. Handing one a placeholder string
+ * makes the rule depend on which decoder was passed — `decodeMemoryBoundary`
+ * refuses any untagged payload, a plain-JSON decoder accepts one — and two
+ * readers that disagree about an absent payload do not share a rule at all. An
+ * absent document is `null`, which the root check below refuses on its own.
  */
 export const decodeStoredDocumentPayload = (
   decode: (source: string) => unknown,
   data: string | null,
 ): EntityDocument => {
-  const parsed = decode(data ?? ABSENT_DOCUMENT_PAYLOAD);
+  const parsed = data === null ? null : decode(data);
   if (!isEntityDocument(parsed)) {
     const shape = parsed === null
       ? "null"
@@ -1944,12 +1940,20 @@ export const decodeStoredDocumentPayload = (
   return parsed;
 };
 
-/** Read a stored patch-list payload. Absent means the empty list. */
+/**
+ * Read a stored patch-list payload through the same rule. An absent payload is
+ * refused rather than read as the empty list: nothing writes a patch row
+ * without one, so an absent payload is a malformed row, and applying it as a
+ * no-op would leave the document reading current.
+ */
 export const decodeStoredPatchListPayload = (
   decode: (source: string) => unknown,
   data: string | null,
 ): PatchOp[] => {
-  const parsed = decode(data ?? ABSENT_PATCH_LIST_PAYLOAD);
+  if (data === null) {
+    throw new TypeError("memory v2 stored patches must carry a payload");
+  }
+  const parsed = decode(data);
   if (!Array.isArray(parsed)) {
     throw new TypeError("memory v2 stored patches must be arrays");
   }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -46,6 +46,8 @@ import {
   type CommitClass,
   commitPreconditionValueHash,
   decodeMemoryBoundary,
+  decodeStoredDocumentPayload,
+  decodeStoredPatchListPayload,
   DEFAULT_BRANCH,
   type DeleteOperation,
   type DerivedWriteAnnotation,
@@ -6541,21 +6543,11 @@ const cacheDocumentForRevision = (
   engine.documentCache.set(key, document);
 };
 
-const decodeStoredDocument = (data: string | null): EntityDocument => {
-  const parsed = decodeMemoryBoundary(data ?? "null");
-  if (!isEntityDocument(parsed)) {
-    throw new Error("memory v2 stored documents must be plain object roots");
-  }
-  return parsed;
-};
+const decodeStoredDocument = (data: string | null): EntityDocument =>
+  decodeStoredDocumentPayload(decodeMemoryBoundary, data);
 
-const decodeStoredPatchList = (data: string | null): PatchOp[] => {
-  const parsed = decodeMemoryBoundary(data ?? "[]");
-  if (!Array.isArray(parsed)) {
-    throw new Error("memory v2 stored patches must be arrays");
-  }
-  return parsed as PatchOp[];
-};
+const decodeStoredPatchList = (data: string | null): PatchOp[] =>
+  decodeStoredPatchListPayload(decodeMemoryBoundary, data);
 
 const sameStoredOriginal = (
   stored: string,

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -106,11 +106,16 @@ reconstructs within the resolved branch from the latest
 `set`/`delete`/`snapshot` base, and applies patches through the server's own
 `applyPatch` (`@commonfabric/memory/v2/patch`) — not a re-implementation, since
 that dialect has a custom `splice` op and specific add/missing-key semantics a
-hand-rolled applier gets wrong. `reconstruct-parity.test.ts` **drives the real
-engine** and asserts `reconstructDocument == engine.read()` across branch
-inheritance, child-local patches, tombstones, patch-first, and snapshots.
-Conflict and scope analysis likewise reuse the engine's exported
-`patchOverlapsRead` / `resolveScopeKey` rather than re-deriving them.
+hand-rolled applier gets wrong. Stored payloads are decoded on the engine's
+terms as well: a document root is refused through the engine's own
+`isEntityDocument`, an absent document payload reads as `null` and an absent
+patch payload as `[]`, so a malformed write is rejected here exactly where the
+engine rejects it rather than being read as an absent one.
+`reconstruct-parity.test.ts` **drives the real engine** and asserts
+`reconstructDocument == engine.read()` across branch inheritance, child-local
+patches, tombstones, patch-first, and snapshots. Conflict and scope analysis
+likewise reuse the engine's exported `patchOverlapsRead` / `resolveScopeKey`
+rather than re-deriving them.
 
 The store can't be opened through the live `Engine` (its constructor runs
 migrations that would mutate the durable file), so reconstruction is a
@@ -243,12 +248,16 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   reconstruction FAILURES only. An unfiltered `entities` never has any — it
   returns a row for an unreadable entity rather than dropping it, labeled by why
   it could not be read — while `entities --kind` counts the rows the filter
-  dropped because they would not reconstruct. A row the filter drops on a kind
-  it did determine is not one of them: a tombstone classifies as `deleted` and a
-  document whose shape nothing recognizes as `unknown`, neither is a `piece`,
-  and neither is a gap in the answer. The HTML explorer banners both, because a
-  generated page is a file that outlives the stderr notice — it gets opened
-  later and shared with someone who never ran the command.
+  dropped because they would not reconstruct AND could have been the kind asked
+  for. A row the filter drops on a kind it did determine is not one of them: a
+  tombstone classifies as `deleted` and a document whose shape nothing
+  recognizes as `unknown`, neither is a `piece`, and neither is a gap in the
+  answer. Neither is an unreadable row under `--kind deleted`: what makes an
+  entity deleted is the OP of its visible row, which is read before any payload
+  is, so corruption cannot hide a tombstone and that scan is exhaustive. The
+  HTML explorer banners both, because a generated page is a file that outlives
+  the stderr notice — it gets opened later and shared with someone who never ran
+  the command.
 - **A scan sees what a read sees.** `visibleRevisionRows` is the one enumeration
   of what a branch can see, attributing each (scope, entity) to the nearest
   branch holding it; `visibleEntityRows`, `listScopes`, `scopeOverlay`, the HTML

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -106,11 +106,17 @@ reconstructs within the resolved branch from the latest
 `set`/`delete`/`snapshot` base, and applies patches through the server's own
 `applyPatch` (`@commonfabric/memory/v2/patch`) — not a re-implementation, since
 that dialect has a custom `splice` op and specific add/missing-key semantics a
-hand-rolled applier gets wrong. Stored payloads are decoded on the engine's
-terms as well: a document root is refused through the engine's own
-`isEntityDocument`, an absent document payload reads as `null` and an absent
-patch payload as `[]`, so a malformed write is rejected here exactly where the
-engine rejects it rather than being read as an absent one.
+hand-rolled applier gets wrong. Stored payloads go through the engine's rule
+too: `decodeStoredDocumentPayload` / `decodeStoredPatchListPayload`
+(`@commonfabric/memory/v2`) default an absent payload and refuse a root that is
+not a tree of paths, taking this package's decoder as an argument so an offline
+read still accepts the untagged plain-JSON rows the engine's own boundary
+decoder does not. Patches apply through `applyPatchToDocument` rather than bare
+`applyPatch`, because a root op can replace a document with any value and the
+engine rejects at the FIRST boundary that leaves a non-document — validating
+only the end of a chain would let a later patch restore an object and launder
+the invalid step before it. Every boundary a reconstruction crosses is checked
+where the engine checks it: base, snapshot, and each patch in turn.
 `reconstruct-parity.test.ts` **drives the real engine** and asserts
 `reconstructDocument == engine.read()` across branch inheritance, child-local
 patches, tombstones, patch-first, and snapshots. Conflict and scope analysis

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -27,11 +27,26 @@ exist** and resolves lineage from them:
 | `schema`     | value is a JSONSchema (`{ type, properties\|$defs }`)                    |
 | `owned-cell` | carries a `result` ownership back-link                                   |
 | `free-cell`  | a bare `value`, owned by no piece                                        |
+| `deleted`    | the visible head row is a `delete` — a tombstone                         |
+| `unknown`    | here but unreadable, or a path-set nothing above recognizes              |
 
 Lineage: a piece → its input (`argument`), its pattern (`patternIdentity` → the
 module entity), its owned cells (`internal`); an owned cell → its owner
 (`result`). This is why `entities` / `piece` / `graph` can speak in pieces and
 links rather than raw blobs.
+
+**An entity with no document says which kind of nothing it is.** Reconstruction
+returns no document for four unrelated reasons, and reporting them alike makes
+"show me what is broken" unaskable. A tombstone is its own kind, `deleted`. The
+other three are `unknown`, separated by label: `(undecodable)` for a payload
+that does not decode — which includes a document that decodes to something other
+than a tree of paths — `(no data)` for a `set` that stored none, and `(absent)`
+for an id with no visible row at all. `unknown` covers one further case, the
+only one holding a document it could read: `{paths}` names one that decoded into
+a shape no kind above recognizes. So `--kind deleted` asks for deletions and
+`--kind unknown` asks for trouble. A tombstone's shape is genuinely gone at
+HEAD: `history <id>` shows the delete op, and `value-at --seq` before it
+recovers what the entity was.
 
 **`scope_key` partitions an entity by identity.** The same cell id can hold a
 shared `space` value AND a per-`user:<DID>` override AND a
@@ -226,14 +241,14 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   reconstruct reports it as `extent.unreadable` rather than folding it into
   `truncated`, because raising `--limit` does not recover one. It counts
   reconstruction FAILURES only. An unfiltered `entities` never has any — it
-  returns a row for an unreadable entity rather than dropping it — while
-  `entities --kind` counts the rows the filter dropped because they would not
-  reconstruct. A row the filter drops on a kind it did determine is not one of
-  them: a tombstone and a document whose shape classifies as `unknown` are both
-  definitively not a `piece`, and neither is a gap in the answer. The HTML
-  explorer banners both, because a generated page is a file that outlives the
-  stderr notice — it gets opened later and shared with someone who never ran the
-  command.
+  returns a row for an unreadable entity rather than dropping it, labeled by why
+  it could not be read — while `entities --kind` counts the rows the filter
+  dropped because they would not reconstruct. A row the filter drops on a kind
+  it did determine is not one of them: a tombstone classifies as `deleted` and a
+  document whose shape nothing recognizes as `unknown`, neither is a `piece`,
+  and neither is a gap in the answer. The HTML explorer banners both, because a
+  generated page is a file that outlives the stderr notice — it gets opened
+  later and shared with someone who never ran the command.
 - **A scan sees what a read sees.** `visibleRevisionRows` is the one enumeration
   of what a branch can see, attributing each (scope, entity) to the nearest
   branch holding it; `visibleEntityRows`, `listScopes`, `scopeOverlay`, the HTML
@@ -244,8 +259,11 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   `reconstructDocument` does — a child branch lists the entities it inherited at
   the fork, not only the ones written on it — and drops entities whose visible
   head is a `delete`. `entities` is the exception that keeps tombstones, because
-  it describes the space's records; that is why its `extent.total` can exceed
-  `graph`'s over the same space.
+  it describes the space's records, and it names them `deleted` rather than
+  leaving them among the unreadable; that is why its `extent.total` can exceed
+  `graph`'s over the same space. A tombstone still reaches the graph where an
+  edge points at one, since a link into a deleted entity is a fact about the
+  link.
 - **Everything that describes an ENTITY reads the branch that owns its visible
   row.** `entityHistory`, `entityTimeline`, `hotEntities`, `contendedEntities`,
   the detail version log, `analyzeSpaceSignals`' content searches, and the

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -108,20 +108,23 @@ reconstructs within the resolved branch from the latest
 that dialect has a custom `splice` op and specific add/missing-key semantics a
 hand-rolled applier gets wrong. Stored payloads go through the engine's rule
 too: `decodeStoredDocumentPayload` / `decodeStoredPatchListPayload`
-(`@commonfabric/memory/v2`) default an absent payload and refuse a root that is
-not a tree of paths, taking this package's decoder as an argument so an offline
-read still accepts the untagged plain-JSON rows the engine's own boundary
-decoder does not. Patches apply through `applyPatchToDocument` rather than bare
-`applyPatch`, because a root op can replace a document with any value and the
-engine rejects at the FIRST boundary that leaves a non-document — validating
-only the end of a chain would let a later patch restore an object and launder
-the invalid step before it. Every boundary a reconstruction crosses is checked
-where the engine checks it: base, snapshot, and each patch in turn.
-`reconstruct-parity.test.ts` **drives the real engine** and asserts
-`reconstructDocument == engine.read()` across branch inheritance, child-local
-patches, tombstones, patch-first, and snapshots. Conflict and scope analysis
-likewise reuse the engine's exported `patchOverlapsRead` / `resolveScopeKey`
-rather than re-deriving them.
+(`@commonfabric/memory/v2`) refuse an absent payload and a root that is not a
+tree of paths, taking this package's decoder as an argument so an offline read
+still accepts the untagged plain-JSON rows the engine's own boundary decoder
+does not. The decoder is the ONLY thing the two readers differ on: an absent
+payload never reaches it, since a rule that decided that case through a
+placeholder string would reject for the engine and accept for a plain-JSON
+reader, and read differently per caller. Patches apply through
+`applyPatchToDocument` rather than bare `applyPatch`, because a root op can
+replace a document with any value and the engine rejects at the FIRST boundary
+that leaves a non-document — validating only the end of a chain would let a
+later patch restore an object and launder the invalid step before it. Every
+boundary a reconstruction crosses is checked where the engine checks it: base,
+snapshot, and each patch in turn. `reconstruct-parity.test.ts` **drives the real
+engine** and asserts `reconstructDocument == engine.read()` across branch
+inheritance, child-local patches, tombstones, patch-first, and snapshots.
+Conflict and scope analysis likewise reuse the engine's exported
+`patchOverlapsRead` / `resolveScopeKey` rather than re-deriving them.
 
 The store can't be opened through the live `Engine` (its constructor runs
 migrations that would mutate the durable file), so reconstruction is a

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -25,9 +25,10 @@ import {
   parseSigilLink,
   summarize,
 } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { reconstructOutcome } from "./reconstruct.ts";
 import type { EntityDocument } from "./reconstruct.ts";
 import {
+  absentEntity,
   classifyDocument,
   type EntityKind,
   isModuleValue,
@@ -503,18 +504,17 @@ export function buildAllDetails(
   const moduleIndex = new Map<string, ModuleEntry>();
   const labelOf = new Map<string, { kind: EntityKind; label: string }>();
   for (const r of scanned) {
-    let doc: EntityDocument | undefined;
-    try {
-      doc = reconstructDocument(space, { id: r.id, branch, scope });
-    } catch {
-      doc = undefined;
-    }
-    if (!doc) {
+    const outcome = reconstructOutcome(space, { id: r.id, branch, scope });
+    if (outcome.status !== "present") {
       // Enumerated but not described: counted, never silently dropped, or a pass
-      // that skipped it would report itself complete over a smaller set.
+      // that skipped it would report itself complete over a smaller set. It
+      // still earns a label, so a link INTO it resolves to why it cannot be
+      // read rather than to nothing.
+      labelOf.set(r.id, absentEntity(outcome.status));
       unreadable++;
       continue;
     }
+    const doc = outcome.document;
     docs.set(r.id, doc);
     const v = doc.value;
     if (isModuleValue(v)) {
@@ -598,6 +598,7 @@ export function buildAllDetails(
     "owned-cell": 4,
     "free-cell": 5,
     unknown: 6,
+    deleted: 7,
   };
   return {
     details: out.sort(

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -16,9 +16,10 @@
 
 import type { SpaceDb } from "./db.ts";
 import { collectLinks } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
-import type { EntityDocument } from "./reconstruct.ts";
+import { reconstructOutcome } from "./reconstruct.ts";
+import type { EntityDocument, ReconstructOutcome } from "./reconstruct.ts";
 import {
+  absentEntity,
   classifyDocument,
   type EntityKind,
   isModuleValue,
@@ -109,20 +110,20 @@ export function buildSpaceGraph(
 
   // Pass 1: reconstruct + build the module index (identity → module entity).
   const docs = new Map<string, EntityDocument>();
+  // Why each unplaced entity has no document, so an edge into one can say which
+  // kind of absent it is rather than sharing a single "(absent)".
+  const outcomes = new Map<string, ReconstructOutcome>();
   const moduleIndex = new Map<string, ModuleEntry>();
   for (const r of scanned) {
-    let doc: EntityDocument | undefined;
-    try {
-      doc = reconstructDocument(space, { id: r.id, branch, scope });
-    } catch {
-      doc = undefined;
-    }
-    if (!doc) {
+    const outcome = reconstructOutcome(space, { id: r.id, branch, scope });
+    outcomes.set(r.id, outcome);
+    if (outcome.status !== "present") {
       // Enumerated but not placed in the graph: counted, never silently dropped, or a pass
       // that skipped it would report itself complete over a smaller set.
       unreadable++;
       continue;
     }
+    const doc = outcome.document;
     docs.set(r.id, doc);
     const v = doc.value;
     if (isModuleValue(v)) {
@@ -143,16 +144,26 @@ export function buildSpaceGraph(
   // External targets are keyed by `<space>/<id>` so they never collide with a
   // local entity of the same id (which would silently re-point the edge at the
   // local node and lose the target space). Returns the node key for the edge.
-  const ensureStub = (entityId: string, space?: string): string => {
-    const key = space ? `${space}/${entityId}` : entityId;
+  const ensureStub = (entityId: string, targetSpace?: string): string => {
+    const key = targetSpace ? `${targetSpace}/${entityId}` : entityId;
     if (!nodes.has(key)) {
+      // A local target absent from `nodes` has no readable document; say which
+      // of the reasons it is, so an edge into a tombstone reads differently
+      // from an edge into a corrupt entity. The enumeration drops tombstones,
+      // so a target it did not reach — deleted, past the limit, or owned by a
+      // parent branch — is resolved on demand rather than assumed absent.
+      const local = targetSpace ? undefined : outcomes.get(entityId) ??
+        reconstructOutcome(space, { id: entityId, branch, scope });
+      const absent = local && local.status !== "present"
+        ? absentEntity(local.status)
+        : undefined;
       nodes.set(key, {
         id: key,
         entityId,
-        kind: "unknown",
-        label: space ? "(external)" : "(absent)",
+        kind: absent?.kind ?? "unknown",
+        label: targetSpace ? "(external)" : absent?.label ?? "(absent)",
         present: false,
-        space,
+        space: targetSpace,
       });
     }
     return key;
@@ -316,6 +327,7 @@ const DOT_FILL: Record<string, string> = {
   schema: "#ddd6fe",
   "owned-cell": "#d1fae5",
   "free-cell": "#e5e7eb",
+  deleted: "#e4e4e7",
   unknown: "#f3f4f6",
 };
 

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -167,6 +167,7 @@ const STYLE = `
   --accent:#2563eb; --hover:#eef2ff;
   --piece:#f59e0b; --module:#3b82f6; --stream:#ec4899; --schema:#8b5cf6;
   --owned-cell:#10b981; --free-cell:#9ca3af; --unknown:#d1d5db;
+  --deleted:#71717a;
 }
 @media (prefers-color-scheme: dark) {
   :root { --bg:#0b0f17; --fg:#e5e7eb; --muted:#9ca3af; --line:#1f2937;
@@ -243,7 +244,7 @@ svg { max-width:100%; border:1px solid var(--line); border-radius:8px; backgroun
 const APP = String.raw`
 const B = JSON.parse(document.getElementById("bundle").textContent);
 const KC = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)",
-  schema:"var(--schema)", "owned-cell":"var(--owned-cell)", "free-cell":"var(--free-cell)", unknown:"var(--unknown)" };
+  schema:"var(--schema)", "owned-cell":"var(--owned-cell)", "free-cell":"var(--free-cell)", unknown:"var(--unknown)", deleted:"var(--deleted)" };
 const EC = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
 const byId = new Map(B.details.map(d => [d.id, d]));
 const overlayById = new Map((B.overlays||[]).map(o => [o.id, o]));

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -780,6 +780,14 @@ export function listEntityModels(
   // what happened to it.
   const isUnreadable = (o: ReconstructOutcome): boolean =>
     o.status === "undecodable" || o.status === "empty";
+  // Whether corruption could be hiding the kind that was asked for. It cannot
+  // hide a tombstone: what makes an entity `deleted` is the OP of its visible
+  // row, which is read before any payload is, and an unreadable row's op is a
+  // `set` or a `patch`. So a `deleted` scan is exhaustive even over rows it
+  // could not decode, and counting them would make a complete listing report
+  // itself partial — turning `--require-complete` into a nonzero exit over an
+  // answer that was whole.
+  const concealable = kind !== "deleted";
 
   const kept: EntityScanRow[] = [];
   let truncated = false;
@@ -798,7 +806,7 @@ export function listEntityModels(
     const doc = documentOf(outcome);
     indexModule(r.id, doc);
     if (kind !== undefined && kindOf(outcome) !== kind) {
-      if (isUnreadable(outcome)) unreadable++;
+      if (concealable && isUnreadable(outcome)) unreadable++;
       continue;
     }
     if (kept.length === limit) {

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -746,8 +746,8 @@ export function listEntityModels(
   const kind = opts.kind;
 
   // A listing describes the space's RECORDS, so it keeps tombstones (they model
-  // as `unknown`) — which also keeps `extent.total` counting exactly the set
-  // this pass returns.
+  // as `deleted`, which is why `--kind deleted` can ask for them) — and that
+  // keeps `extent.total` counting exactly the set this pass returns.
   const rows = visibleEntityRows(space, {
     branch,
     scope,

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -60,9 +60,15 @@ import {
   branchReadChain,
   type BranchReadLink,
   reconstructDocument,
+  reconstructOutcome,
   visibleRevisionRows,
 } from "./reconstruct.ts";
-import type { EntityDocument, ReconstructOptions } from "./reconstruct.ts";
+import type {
+  AbsenceStatus,
+  EntityDocument,
+  ReconstructOptions,
+  ReconstructOutcome,
+} from "./reconstruct.ts";
 
 export type EntityKind =
   | "piece" // a running pattern instance (result cell + lineage meta)
@@ -71,7 +77,39 @@ export type EntityKind =
   | "schema" // a JSONSchema stored as a cell value
   | "owned-cell" // a cell owned by a piece (carries a `result` back-link)
   | "free-cell" // a standalone cell, owned by no piece
-  | "unknown";
+  | "deleted" // a tombstone: the visible head row is a `delete`
+  | "unknown"; // present but unreadable, or a shape nothing above recognizes
+
+/** How an entity that carries no document reads: its kind, and its label. */
+export interface AbsentEntity {
+  kind: EntityKind;
+  label: string;
+}
+
+/**
+ * Name an entity by WHY it has no document. `deleted` is its own kind because a
+ * tombstone is an ordinary thing to find and says what happened; the rest are
+ * `unknown`, which therefore means the entity is there and cannot be read. A
+ * tombstone's original shape is genuinely gone at HEAD — recovering "this was a
+ * piece" takes a reconstruction at the seq before the delete.
+ */
+export function absentEntity(status: AbsenceStatus): AbsentEntity {
+  return { kind: ABSENT_KIND[status], label: ABSENT_LABEL[status] };
+}
+
+const ABSENT_KIND: Record<AbsenceStatus, EntityKind> = {
+  deleted: "deleted",
+  empty: "unknown",
+  absent: "unknown",
+  undecodable: "unknown",
+};
+
+const ABSENT_LABEL: Record<AbsenceStatus, string> = {
+  deleted: "(deleted)",
+  empty: "(no data)",
+  absent: "(absent)",
+  undecodable: "(undecodable)",
+};
 
 // LEGACY-PROCESS-CELL: `"legacy"` collapses out when the process-cell era is
 // retired, leaving `"modern" | "n/a"` (see top-of-file retirement note).
@@ -452,7 +490,10 @@ const KIND_ORDER: Record<EntityKind, number> = {
   schema: 3,
   "owned-cell": 4,
   "free-cell": 5,
+  // Unreadable entities sort above tombstones: corruption is worth looking at,
+  // and a deletion is the ordinary end of an entity's life.
   unknown: 6,
+  deleted: 7,
 };
 
 /** Every kind an entity classifies as, in the order a listing presents them. */
@@ -648,9 +689,15 @@ export function countEntities(
   return visibleEntityRows(space, opts).length;
 }
 
-/** An entity's kind without modeling it; `unknown` when it cannot be read. */
-function kindOf(doc: EntityDocument | undefined): EntityKind {
-  return doc === undefined ? "unknown" : classifyDocument(doc).kind;
+/**
+ * An entity's kind without modeling it. An entity carrying no document is named
+ * by WHY it carries none, so a tombstone answers `deleted` and only a genuinely
+ * unreadable one answers `unknown`.
+ */
+function kindOf(outcome: ReconstructOutcome): EntityKind {
+  return outcome.status === "present"
+    ? classifyDocument(outcome.document).kind
+    : absentEntity(outcome.status).kind;
 }
 
 /**
@@ -710,7 +757,7 @@ export function listEntityModels(
   // Single reconstruction pass: cache docs + build the module index inline.
   // Only matching documents are cached; a `kind` scan may pass over far more
   // entities than it keeps, and holding every value would cost the space.
-  const docs = new Map<string, EntityDocument | undefined>();
+  const outcomes = new Map<string, ReconstructOutcome>();
   const moduleIndex = new Map<string, ModuleEntry>();
   const indexModule = (id: string, doc: EntityDocument | undefined): void => {
     const v = doc?.value;
@@ -721,22 +768,18 @@ export function listEntityModels(
       moduleIndex.set(v.identity, { id, filename: v.filename, kind: v.kind });
     }
   };
-  // A throw and a tombstone both yield no document, and only one of them is an
-  // error: a deleted entity is definitively not a `piece`, while an entity that
-  // would not decode might have been one. A `kind` filter drops both, so the
-  // two have to stay distinguishable or the dropped error goes unreported.
-  const read = (
-    id: string,
-  ): { doc: EntityDocument | undefined; failed: boolean } => {
-    try {
-      return {
-        doc: reconstructDocument(space, { id, branch, scope }),
-        failed: false,
-      };
-    } catch {
-      return { doc: undefined, failed: true };
-    }
-  };
+  // A tombstone and a corrupt payload both yield no document, and only one of
+  // them is an error: a deleted entity is definitively not a `piece`, while an
+  // entity that would not decode might have been one. The outcome keeps the two
+  // apart, so a `kind` filter that drops an error can still report it.
+  const read = (id: string): ReconstructOutcome =>
+    reconstructOutcome(space, { id, branch, scope });
+  const documentOf = (o: ReconstructOutcome): EntityDocument | undefined =>
+    o.status === "present" ? o.document : undefined;
+  // An entity that is HERE and cannot be read. A tombstone is not one: it says
+  // what happened to it.
+  const isUnreadable = (o: ReconstructOutcome): boolean =>
+    o.status === "undecodable" || o.status === "empty";
 
   const kept: EntityScanRow[] = [];
   let truncated = false;
@@ -751,10 +794,11 @@ export function listEntityModels(
   // happened to land on the cap.
   for (; scanned < rows.length; scanned++) {
     const r = rows[scanned];
-    const { doc, failed } = read(r.id);
+    const outcome = read(r.id);
+    const doc = documentOf(outcome);
     indexModule(r.id, doc);
-    if (kind !== undefined && kindOf(doc) !== kind) {
-      if (failed) unreadable++;
+    if (kind !== undefined && kindOf(outcome) !== kind) {
+      if (isUnreadable(outcome)) unreadable++;
       continue;
     }
     if (kept.length === limit) {
@@ -762,7 +806,7 @@ export function listEntityModels(
       scanned++;
       break;
     }
-    docs.set(r.id, doc);
+    outcomes.set(r.id, outcome);
     kept.push(r);
   }
 
@@ -779,8 +823,8 @@ export function listEntityModels(
   // and `lineage.argument` already do — so it keeps its cheap scan.
   const wanted = new Set<string>();
   if (kind !== undefined) {
-    for (const doc of docs.values()) {
-      const identity = patternIdentityOf(doc);
+    for (const o of outcomes.values()) {
+      const identity = patternIdentityOf(documentOf(o));
       if (
         identity !== undefined && moduleIndex.get(identity)?.kind !== "source"
       ) {
@@ -798,7 +842,7 @@ export function listEntityModels(
   // The walk ends the moment nothing is still wanted.
   for (; wanted.size > 0 && scanned < rows.length; scanned++) {
     const r = rows[scanned];
-    const { doc } = read(r.id);
+    const doc = documentOf(read(r.id));
     indexModule(r.id, doc);
     const v = doc?.value;
     // A `source` entity supersedes a `compiled` one, so a want is only settled
@@ -807,15 +851,16 @@ export function listEntityModels(
   }
 
   const out: EntityModel[] = kept.map((r): EntityModel => {
-    const doc = docs.get(r.id);
-    if (doc === undefined) {
+    const outcome = outcomes.get(r.id)!;
+    if (outcome.status !== "present") {
+      const { kind, label } = absentEntity(outcome.status);
       return {
         id: r.id,
         scope,
-        kind: "unknown",
+        kind,
         regime: "n/a",
         owned: false,
-        label: "(undecodable)",
+        label,
         paths: [],
         valueShape: "absent",
         lineage: {},
@@ -823,9 +868,13 @@ export function listEntityModels(
         links: 0,
       };
     }
-    const m = modelFromDocument(doc, { id: r.id, scope, moduleIndex });
+    const m = modelFromDocument(outcome.document, {
+      id: r.id,
+      scope,
+      moduleIndex,
+    });
     m.revisions = r.revisions;
-    m.links = countLinks(doc.value);
+    m.links = countLinks(outcome.document.value);
     return m;
   });
 
@@ -905,8 +954,11 @@ export function describePiece(
 ): PieceModel | { error: string } {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const doc = reconstructDocument(space, { id, branch, scope });
-  if (doc === undefined) return { error: "entity absent" };
+  const outcome = reconstructOutcome(space, { id, branch, scope });
+  if (outcome.status !== "present") {
+    return { error: `entity ${absentEntity(outcome.status).label}` };
+  }
+  const doc = outcome.document;
   const c = classifyDocument(doc);
   if (c.kind !== "piece") return { error: `not a piece (kind=${c.kind})` };
 
@@ -942,28 +994,27 @@ export function describePiece(
 
   let input: PieceModel["input"];
   if (c.lineage.argument) {
-    const adoc = reconstructDocument(space, {
+    const a = reconstructOutcome(space, {
       id: c.lineage.argument,
       branch,
       scope,
     });
     input = {
       id: c.lineage.argument,
-      summary: adoc ? summarize(adoc.value) : "(absent)",
+      summary: a.status === "present"
+        ? summarize(a.document.value)
+        : absentEntity(a.status).label,
     };
   }
 
   const ownedCells: PieceCellRef[] = (c.lineage.internal ?? []).map(
     (cid): PieceCellRef => {
-      const cdoc = reconstructDocument(space, { id: cid, branch, scope });
-      if (cdoc === undefined) {
-        return {
-          id: cid,
-          kind: "unknown",
-          label: "(absent)",
-          summary: "(absent)",
-        };
+      const child = reconstructOutcome(space, { id: cid, branch, scope });
+      if (child.status !== "present") {
+        const { kind, label } = absentEntity(child.status);
+        return { id: cid, kind, label, summary: label };
       }
+      const cdoc = child.document;
       const cc = classifyDocument(cdoc);
       return {
         id: cid,

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -17,8 +17,14 @@
 // applier would get subtly wrong. `applyPatch` is offline-safe (pure value ops;
 // no live runtime/cell). See packages/memory/v2/patch.ts.
 
-import { applyPatch } from "@commonfabric/memory/v2/patch";
-import { isEntityDocument, type PatchOp } from "@commonfabric/memory/v2";
+import { applyPatchToDocument } from "@commonfabric/memory/v2/patch";
+import {
+  decodeStoredDocumentPayload,
+  decodeStoredPatchListPayload,
+  type EntityDocument as StoredDocument,
+  isEntityDocument,
+  type PatchOp,
+} from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
@@ -101,41 +107,19 @@ interface RevRow {
 const MAX_SEQ = Number.MAX_SAFE_INTEGER;
 
 /**
- * Decode a stored document the way the engine's `decodeStoredDocument` does: a
- * missing payload reads as `null`, and a root that is not a plain object is
- * refused through the engine's own `isEntityDocument`. Testing the payload for
- * truthiness instead would take an empty string — a malformed write — for an
- * absent one and hand back a document the engine refuses to produce.
+ * Read a stored document payload through the memory layer's rule, with THIS
+ * package's decoder. The rule — default an absent payload, refuse a root that is
+ * not a tree of paths — belongs to the engine and is shared rather than
+ * re-derived. The decoder is ours, because a durable file may hold untagged
+ * plain-JSON rows that the engine's own boundary decoder does not accept.
  */
-function decodeStoredDocument(data: string | null): EntityDocument {
-  const parsed = decodeStored(data ?? "null");
-  if (!isEntityDocument(parsed)) throw notADocument(parsed);
-  return parsed as EntityDocument;
+function storedDocument(data: string | null): StoredDocument {
+  return decodeStoredDocumentPayload(decodeStored, data);
 }
 
-/** The error for a payload that decoded into something other than a document. */
-function notADocument(decoded: unknown): TypeError {
-  const shape = decoded === null
-    ? "null"
-    : Array.isArray(decoded)
-    ? "an array"
-    : `a ${typeof decoded}`;
-  return new TypeError(
-    `memory v2 stored documents must be plain object roots; got ${shape}`,
-  );
-}
-
-/**
- * Decode a stored patch list as the engine's `decodeStoredPatchList` does. Here
- * a missing payload IS an empty list — the asymmetry with a document is the
- * engine's, not a shortcut.
- */
-function decodeStoredPatchList(data: string | null): PatchOp[] {
-  const parsed = decodeStored(data ?? "[]");
-  if (!Array.isArray(parsed)) {
-    throw new TypeError("memory v2 stored patches must be arrays");
-  }
-  return parsed as PatchOp[];
+/** Read a stored patch-list payload through the same shared rule. */
+function storedPatchList(data: string | null): PatchOp[] {
+  return decodeStoredPatchListPayload(decodeStored, data);
 }
 
 /** Does this DB carry a given table? (legacy/partial DBs lack branch/snapshot.) */
@@ -375,7 +359,7 @@ function reconstructWithinBranch(
   id: string,
   rowSeq: number,
   rowOpIndex: number,
-): FabricValue {
+): StoredDocument {
   const base = space.db
     .prepare(
       `SELECT seq, op_index, op, data FROM revision
@@ -385,8 +369,8 @@ function reconstructWithinBranch(
     )
     .get<RevRow>(branch, id, scope, rowSeq, rowSeq, rowOpIndex);
 
-  let doc: FabricValue = base && base.op === "set"
-    ? decodeStoredDocument(base.data) as FabricValue
+  let doc: StoredDocument = base && base.op === "set"
+    ? storedDocument(base.data)
     : {};
   let baseSeq = base ? base.seq : 0;
   let baseOpIndex = base ? base.op_index : -1;
@@ -404,7 +388,10 @@ function reconstructWithinBranch(
       )
       .get<{ seq: number; value: string }>(branch, id, scope, rowSeq);
     if (snap && snap.seq >= baseSeq) {
-      doc = decodeStored(snap.value) as FabricValue;
+      // A snapshot is a materialized document, held to the same root rule as
+      // any other. Decoding it without that check lets a malformed one through
+      // for later patches to rebuild a valid-looking document over.
+      doc = storedDocument(snap.value);
       baseSeq = snap.seq;
       baseOpIndex = MAX_SEQ; // patches with seq > snapshot.seq only
     }
@@ -430,8 +417,11 @@ function reconstructWithinBranch(
       rowOpIndex,
     );
   for (const p of patches) {
-    const ops = decodeStoredPatchList(p.data);
-    doc = applyPatch(doc, ops);
+    // `applyPatchToDocument`, not bare `applyPatch`: a root op can replace the
+    // document with any value, and the engine rejects at the FIRST patch that
+    // leaves a non-document. Checking only the final result would let a later
+    // patch restore an object and launder the invalid step before it.
+    doc = applyPatchToDocument(doc, storedPatchList(p.data));
   }
   return doc;
 }
@@ -440,9 +430,10 @@ function reconstructWithinBranch(
  * The result of reconstructing an entity, naming WHY there is no document when
  * there is none. Four unrelated situations leave an entity without a document
  * at a (branch, seq), and a reader told only "no document" cannot tell a routine
- * deletion from a corrupt payload. `reconstructDocument` collapses them back to
- * `undefined` for callers that do not care; the ones that report entities to a
- * human read this instead.
+ * deletion from a corrupt payload. `reconstructDocument` collapses `deleted`,
+ * `empty` and `absent` back to `undefined` for callers that do not care, and
+ * rethrows an `undecodable` one; the callers that report entities to a human
+ * read this instead, and never have to catch.
  */
 export type ReconstructOutcome =
   | { status: "present"; document: EntityDocument }
@@ -506,7 +497,12 @@ export function reconstructOutcome(
     // an array, a scalar — is malformed, and calling it present hands every
     // reader a value they will dereference as a document.
     if (!isEntityDocument(decoded)) {
-      return { status: "undecodable", error: notADocument(decoded) };
+      return {
+        status: "undecodable",
+        error: new TypeError(
+          "memory v2 stored documents must be plain object roots",
+        ),
+      };
     }
     return { status: "present", document: decoded as EntityDocument };
   } catch (error) {

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -106,10 +106,11 @@ const MAX_SEQ = Number.MAX_SAFE_INTEGER;
 
 /**
  * Read a stored document payload through the memory layer's rule, with THIS
- * package's decoder. The rule — default an absent payload, refuse a root that is
- * not a tree of paths — belongs to the engine and is shared rather than
- * re-derived. The decoder is ours, because a durable file may hold untagged
- * plain-JSON rows that the engine's own boundary decoder does not accept.
+ * package's decoder. The rule — handle an absent payload without asking the
+ * decoder, and refuse a root that is not a tree of paths — belongs to the engine
+ * and is shared rather than re-derived. The decoder is ours, because a durable
+ * file may hold untagged plain-JSON rows that the engine's own boundary decoder
+ * does not accept.
  */
 function storedDocument(data: string | null): StoredDocument {
   return decodeStoredDocumentPayload(decodeStored, data);

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -21,6 +21,7 @@ import { applyPatch } from "@commonfabric/memory/v2/patch";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
 import { decodeStored } from "./decode.ts";
@@ -399,39 +400,96 @@ function reconstructWithinBranch(
 }
 
 /**
+ * The result of reconstructing an entity, naming WHY there is no document when
+ * there is none. Four unrelated situations leave an entity without a document
+ * at a (branch, seq), and a reader told only "no document" cannot tell a routine
+ * deletion from a corrupt payload. `reconstructDocument` collapses them back to
+ * `undefined` for callers that do not care; the ones that report entities to a
+ * human read this instead.
+ */
+export type ReconstructOutcome =
+  | { status: "present"; document: EntityDocument }
+  /** The visible head row is a `delete` — the entity was removed. */
+  | { status: "deleted" }
+  /** The visible head row is a `set` that stored no data. */
+  | { status: "empty" }
+  /** No revision row is visible at this (branch, scope, seq). */
+  | { status: "absent" }
+  /** The stored payload did not decode. `error` is the original throw. */
+  | { status: "undecodable"; error: unknown };
+
+/** The `status` values that carry no document. */
+export type AbsenceStatus = Exclude<ReconstructOutcome["status"], "present">;
+
+/**
  * Reconstruct an entity document at a (branch, seq) by replicating the engine's
  * read path (`read()` → `readRowForBranch` → `reconstructPatchedDocument` in
  * `packages/memory/v2`), proven identical by `reconstruct-parity.test.ts` which
  * drives the real engine. Branch inheritance resolves the visible ROW (not a
  * merged log); patched reconstruction stays within the resolved branch.
+ *
+ * A decode failure is returned as `undecodable` rather than thrown, so that one
+ * corrupt entity does not abort a walk over a whole space.
  */
-export function reconstructDocument(
+export function reconstructOutcome(
   space: SpaceDb,
   opts: ReconstructOptions,
-): EntityDocument | undefined {
+): ReconstructOutcome {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
   const atSeq = opts.atSeq ?? MAX_SEQ;
 
   const resolved = resolveBranchRow(space, branch, scope, opts.id, atSeq);
-  if (!resolved) return undefined;
+  if (!resolved) return { status: "absent" };
 
   const { row, branch: rb } = resolved;
-  if (row.op === "set") {
-    return (row.data ? decodeStored(row.data) : undefined) as
-      | EntityDocument
-      | undefined;
+  if (row.op === "delete") return { status: "deleted" };
+  try {
+    // A `set` stores no data only when `data` is NULL. An empty string is a
+    // payload, and a malformed one — it belongs with the decode failures below.
+    if (row.op === "set" && row.data === null) return { status: "empty" };
+    const decoded = row.op === "set"
+      ? decodeStored(row.data!)
+      // patch: reconstruct within the branch that owns the resolved row.
+      : reconstructWithinBranch(
+        space,
+        rb,
+        scope,
+        opts.id,
+        row.seq,
+        row.op_index,
+      );
+    // A document is a tree of top-level paths. Anything else — a stored `null`,
+    // an array, a scalar — is malformed, and calling it present hands every
+    // reader a value they will dereference as a document.
+    if (!isObjectNotArray(decoded)) {
+      return {
+        status: "undecodable",
+        error: new TypeError(
+          `document is ${
+            decoded === null ? "null" : typeof decoded
+          }, not an object`,
+        ),
+      };
+    }
+    return { status: "present", document: decoded as EntityDocument };
+  } catch (error) {
+    return { status: "undecodable", error };
   }
-  if (row.op === "delete") return undefined;
-  // patch: reconstruct within the branch that owns the resolved row.
-  return reconstructWithinBranch(
-    space,
-    rb,
-    scope,
-    opts.id,
-    row.seq,
-    row.op_index,
-  ) as EntityDocument;
+}
+
+/**
+ * The document an entity holds at a (branch, seq), or `undefined` when it holds
+ * none. Throws the decode error for a payload that does not decode. Callers that
+ * distinguish a tombstone from corruption call {@link reconstructOutcome}.
+ */
+export function reconstructDocument(
+  space: SpaceDb,
+  opts: ReconstructOptions,
+): EntityDocument | undefined {
+  const outcome = reconstructOutcome(space, opts);
+  if (outcome.status === "undecodable") throw outcome.error;
+  return outcome.status === "present" ? outcome.document : undefined;
 }
 
 export interface ValueAtResult {

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -109,12 +109,20 @@ const MAX_SEQ = Number.MAX_SAFE_INTEGER;
  */
 function decodeStoredDocument(data: string | null): EntityDocument {
   const parsed = decodeStored(data ?? "null");
-  if (!isEntityDocument(parsed)) {
-    throw new TypeError(
-      "memory v2 stored documents must be plain object roots",
-    );
-  }
+  if (!isEntityDocument(parsed)) throw notADocument(parsed);
   return parsed as EntityDocument;
+}
+
+/** The error for a payload that decoded into something other than a document. */
+function notADocument(decoded: unknown): TypeError {
+  const shape = decoded === null
+    ? "null"
+    : Array.isArray(decoded)
+    ? "an array"
+    : `a ${typeof decoded}`;
+  return new TypeError(
+    `memory v2 stored documents must be plain object roots; got ${shape}`,
+  );
 }
 
 /**
@@ -498,14 +506,7 @@ export function reconstructOutcome(
     // an array, a scalar — is malformed, and calling it present hands every
     // reader a value they will dereference as a document.
     if (!isEntityDocument(decoded)) {
-      return {
-        status: "undecodable",
-        error: new TypeError(
-          `document is ${
-            decoded === null ? "null" : typeof decoded
-          }, not an object`,
-        ),
-      };
+      return { status: "undecodable", error: notADocument(decoded) };
     }
     return { status: "present", document: decoded as EntityDocument };
   } catch (error) {

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -18,10 +18,9 @@
 // no live runtime/cell). See packages/memory/v2/patch.ts.
 
 import { applyPatch } from "@commonfabric/memory/v2/patch";
-import type { PatchOp } from "@commonfabric/memory/v2";
+import { isEntityDocument, type PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import type { SpaceDb } from "./db.ts";
 import { decodeStored } from "./decode.ts";
@@ -100,6 +99,36 @@ interface RevRow {
 }
 
 const MAX_SEQ = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Decode a stored document the way the engine's `decodeStoredDocument` does: a
+ * missing payload reads as `null`, and a root that is not a plain object is
+ * refused through the engine's own `isEntityDocument`. Testing the payload for
+ * truthiness instead would take an empty string — a malformed write — for an
+ * absent one and hand back a document the engine refuses to produce.
+ */
+function decodeStoredDocument(data: string | null): EntityDocument {
+  const parsed = decodeStored(data ?? "null");
+  if (!isEntityDocument(parsed)) {
+    throw new TypeError(
+      "memory v2 stored documents must be plain object roots",
+    );
+  }
+  return parsed as EntityDocument;
+}
+
+/**
+ * Decode a stored patch list as the engine's `decodeStoredPatchList` does. Here
+ * a missing payload IS an empty list — the asymmetry with a document is the
+ * engine's, not a shortcut.
+ */
+function decodeStoredPatchList(data: string | null): PatchOp[] {
+  const parsed = decodeStored(data ?? "[]");
+  if (!Array.isArray(parsed)) {
+    throw new TypeError("memory v2 stored patches must be arrays");
+  }
+  return parsed as PatchOp[];
+}
 
 /** Does this DB carry a given table? (legacy/partial DBs lack branch/snapshot.) */
 function hasTable(space: SpaceDb, name: string): boolean {
@@ -348,8 +377,8 @@ function reconstructWithinBranch(
     )
     .get<RevRow>(branch, id, scope, rowSeq, rowSeq, rowOpIndex);
 
-  let doc: FabricValue = base && base.op === "set" && base.data
-    ? (decodeStored(base.data) as FabricValue)
+  let doc: FabricValue = base && base.op === "set"
+    ? decodeStoredDocument(base.data) as FabricValue
     : {};
   let baseSeq = base ? base.seq : 0;
   let baseOpIndex = base ? base.op_index : -1;
@@ -393,7 +422,7 @@ function reconstructWithinBranch(
       rowOpIndex,
     );
   for (const p of patches) {
-    const ops = p.data ? (decodeStored(p.data) as PatchOp[]) : [];
+    const ops = decodeStoredPatchList(p.data);
     doc = applyPatch(doc, ops);
   }
   return doc;
@@ -447,6 +476,12 @@ export function reconstructOutcome(
   try {
     // A `set` stores no data only when `data` is NULL. An empty string is a
     // payload, and a malformed one — it belongs with the decode failures below.
+    //
+    // The engine reads a NULL payload as `null` and rejects it as a document,
+    // so this names as `empty` what the engine names an error. Both carry no
+    // document, which is what `reconstructDocument` reports either way; the
+    // status is finer than the engine's because a listing that says "(no data)"
+    // tells a reader something "(undecodable)" does not.
     if (row.op === "set" && row.data === null) return { status: "empty" };
     const decoded = row.op === "set"
       ? decodeStored(row.data!)
@@ -462,7 +497,7 @@ export function reconstructOutcome(
     // A document is a tree of top-level paths. Anything else — a stored `null`,
     // an array, a scalar — is malformed, and calling it present hands every
     // reader a value they will dereference as a document.
-    if (!isObjectNotArray(decoded)) {
+    if (!isEntityDocument(decoded)) {
       return {
         status: "undecodable",
         error: new TypeError(

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -22,10 +22,8 @@ import {
   decodeStoredDocumentPayload,
   decodeStoredPatchListPayload,
   type EntityDocument as StoredDocument,
-  isEntityDocument,
   type PatchOp,
 } from "@commonfabric/memory/v2";
-import type { FabricValue } from "@commonfabric/api";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
 import type { SpaceDb } from "./db.ts";
@@ -482,8 +480,13 @@ export function reconstructOutcome(
     // status is finer than the engine's because a listing that says "(no data)"
     // tells a reader something "(undecodable)" does not.
     if (row.op === "set" && row.data === null) return { status: "empty" };
-    const decoded = row.op === "set"
-      ? decodeStored(row.data!)
+    // Both arms return a document already held to the root rule — `storedDocument`
+    // checks the payload it decodes, and every boundary inside the patch chain is
+    // checked as it is crossed — so a present outcome here carries a document no
+    // reader has to re-test, and a malformed one arrives as the shared rule's own
+    // error, naming the shape it found.
+    const document = row.op === "set"
+      ? storedDocument(row.data)
       // patch: reconstruct within the branch that owns the resolved row.
       : reconstructWithinBranch(
         space,
@@ -493,18 +496,7 @@ export function reconstructOutcome(
         row.seq,
         row.op_index,
       );
-    // A document is a tree of top-level paths. Anything else — a stored `null`,
-    // an array, a scalar — is malformed, and calling it present hands every
-    // reader a value they will dereference as a document.
-    if (!isEntityDocument(decoded)) {
-      return {
-        status: "undecodable",
-        error: new TypeError(
-          "memory v2 stored documents must be plain object roots",
-        ),
-      };
-    }
-    return { status: "present", document: decoded as EntityDocument };
+    return { status: "present", document: document as EntityDocument };
   } catch (error) {
     return { status: "undecodable", error };
   }

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -139,6 +139,25 @@ function seed(path: string) {
   commit.run(14, session, 14, "{}");
   op.run("of:emptystr", 14, "set", "", 14);
 
+  // The same corruption one op deeper, where a patch chain hides it. The engine
+  // decodes a base and a patch payload unconditionally and rejects a malformed
+  // one, so reconstruction has to reach the same verdict rather than reading an
+  // empty payload as an absent one and rebuilding a document over it.
+  commit.run(15, session, 15, "{}");
+  op.run("of:badbase", 15, "set", "", 15);
+  commit.run(16, session, 16, "{}");
+  op.run(
+    "of:badbase",
+    16,
+    "patch",
+    JSON.stringify([{ op: "add", path: "/value", value: { ok: true } }]),
+    16,
+  );
+  commit.run(17, session, 17, "{}");
+  op.run("of:badpatch", 17, "set", JSON.stringify({ value: { n: 1 } }), 17);
+  commit.run(18, session, 18, "{}");
+  op.run("of:badpatch", 18, "patch", "", 18);
+
   // A second piece whose owned cells are a tombstone and a corrupt entity, so
   // `describePiece` has both to tell apart.
   commit.run(12, session, 12, "{}");
@@ -260,6 +279,15 @@ Deno.test("unified entity model + encoded commit decode", async (t) => {
         assertEquals(byId["of:nulldoc"].label, "(undecodable)");
         assertEquals(byId["of:emptystr"].kind, "unknown");
         assertEquals(byId["of:emptystr"].label, "(undecodable)");
+
+        // A patch chain must not launder either one: a malformed base read as
+        // an absent one would rebuild a document the engine refuses to produce,
+        // and a malformed patch read as an empty list would silently apply
+        // nothing and call the result current.
+        assertEquals(byId["of:badbase"].kind, "unknown");
+        assertEquals(byId["of:badbase"].label, "(undecodable)");
+        assertEquals(byId["of:badpatch"].kind, "unknown");
+        assertEquals(byId["of:badpatch"].label, "(undecodable)");
       });
 
       await t.step(

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -2,7 +2,11 @@
  * Hermetic test for the unified entity model + encoded commit decoding. Seeds a
  * modern piece (patternIdentity → module, argument, internal manifest), an
  * owned cell, a stream, and a free cell, then checks classification + lineage.
- * Side-effect free.
+ *
+ * It also seeds one entity for each way an entity ends up carrying no document
+ * — a tombstone, a payload that does not decode, and a `set` that stored no
+ * data — because all three reconstruct to nothing and a listing that reports
+ * them alike cannot answer "show me what is broken". Side-effect free.
  */
 
 import { assert, assertEquals } from "@std/assert";
@@ -112,6 +116,48 @@ function seed(path: string) {
   commit.run(6, session, 6, "{}");
   rev.run("of:free", 6, JSON.stringify({ value: "none" }), 6);
 
+  // The three ways an entity carries no document, plus a fourth entity that
+  // decodes fine into a path-set nothing recognizes.
+  const op = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, ?, ?, ?)`,
+  );
+  commit.run(7, session, 7, "{}");
+  op.run("of:tombstoned", 7, "set", JSON.stringify({ value: { a: 1 } }), 7);
+  commit.run(8, session, 8, "{}");
+  op.run("of:tombstoned", 8, "delete", null, 8);
+  commit.run(9, session, 9, "{}");
+  op.run("of:corrupt", 9, "set", "{not json at all", 9);
+  commit.run(10, session, 10, "{}");
+  op.run("of:nodata", 10, "set", null, 10);
+  commit.run(11, session, 11, "{}");
+  op.run("of:oddshape", 11, "set", JSON.stringify({ cfc: {}, slug: "x" }), 11);
+  // A document is a tree of paths. These two decode to something else, or do
+  // not decode at all — both are corruption, not an entity that stored nothing.
+  commit.run(13, session, 13, "{}");
+  op.run("of:nulldoc", 13, "set", "null", 13);
+  commit.run(14, session, 14, "{}");
+  op.run("of:emptystr", 14, "set", "", 14);
+
+  // A second piece whose owned cells are a tombstone and a corrupt entity, so
+  // `describePiece` has both to tell apart.
+  commit.run(12, session, 12, "{}");
+  op.run(
+    "of:piece2",
+    12,
+    "set",
+    JSON.stringify({
+      value: { $NAME: "Second" },
+      argument: link("of:tombstoned"),
+      internal: [
+        { partialCause: "a", link: link("of:tombstoned") },
+        { partialCause: "b", link: link("of:corrupt") },
+      ],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+    }),
+    12,
+  );
+
   db.close();
 }
 
@@ -182,6 +228,61 @@ Deno.test("unified entity model + encoded commit decode", async (t) => {
       await t.step("describePiece rejects non-pieces", () => {
         const r = describePiece(space, "of:free");
         assert("error" in r);
+      });
+
+      await t.step("an entity with no document says why it has none", () => {
+        const byId = Object.fromEntries(
+          listEntityModels(space).entities.map((e) => [e.id, e]),
+        );
+
+        // A deletion is an ordinary end, and is its own kind — so `--kind
+        // deleted` asks for tombstones and `--kind unknown` no longer answers.
+        assertEquals(byId["of:tombstoned"].kind, "deleted");
+        assertEquals(byId["of:tombstoned"].label, "(deleted)");
+
+        // The rest are `unknown`, which now means the entity is here and
+        // cannot be read. Their labels keep the causes apart.
+        assertEquals(byId["of:corrupt"].kind, "unknown");
+        assertEquals(byId["of:corrupt"].label, "(undecodable)");
+        assertEquals(byId["of:nodata"].kind, "unknown");
+        assertEquals(byId["of:nodata"].label, "(no data)");
+        assertEquals(byId["of:oddshape"].kind, "unknown");
+        assertEquals(byId["of:oddshape"].label, "{cfc,slug}");
+
+        // The tombstone's revision count still includes the delete op, so the
+        // count alone never separated it from a corrupt entity.
+        assertEquals(byId["of:tombstoned"].revisions, 2);
+
+        // A payload that decodes to a non-document, and one that does not
+        // decode at all, are both corruption — neither is "(no data)", which
+        // belongs to a `set` that genuinely stored none.
+        assertEquals(byId["of:nulldoc"].kind, "unknown");
+        assertEquals(byId["of:nulldoc"].label, "(undecodable)");
+        assertEquals(byId["of:emptystr"].kind, "unknown");
+        assertEquals(byId["of:emptystr"].label, "(undecodable)");
+      });
+
+      await t.step(
+        "a piece's absent owned cells keep their causes apart",
+        () => {
+          const piece = describePiece(space, "of:piece2");
+          assert(!("error" in piece));
+          if ("error" in piece) return;
+          assertEquals(piece.input?.summary, "(deleted)");
+          const byId = Object.fromEntries(
+            piece.ownedCells.map((c) => [c.id, c]),
+          );
+          assertEquals(byId["of:tombstoned"].kind, "deleted");
+          assertEquals(byId["of:tombstoned"].label, "(deleted)");
+          assertEquals(byId["of:corrupt"].kind, "unknown");
+          assertEquals(byId["of:corrupt"].label, "(undecodable)");
+        },
+      );
+
+      await t.step("describePiece names a tombstoned entity as deleted", () => {
+        const r = describePiece(space, "of:tombstoned");
+        assert("error" in r);
+        assertEquals(r.error, "entity (deleted)");
       });
     } finally {
       space.close();

--- a/packages/state-inspector/test/graph.test.ts
+++ b/packages/state-inspector/test/graph.test.ts
@@ -65,7 +65,10 @@ function seed(path: string) {
     JSON.stringify({
       value: { $NAME: "My Notebook", $UI: {}, link: link("of:owned") },
       argument: link("of:input"),
-      internal: [{ partialCause: "q", link: link("of:owned") }],
+      internal: [
+        { partialCause: "q", link: link("of:owned") },
+        { partialCause: "d", link: link("of:gone") },
+      ],
       patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
       schema: { type: "object", properties: {}, $defs: {} },
     }),
@@ -83,6 +86,17 @@ function seed(path: string) {
   );
   commit.run(5, 5);
   rev.run("of:free", 5, JSON.stringify({ value: "x" }), 5);
+
+  // A tombstone the piece links to. The enumeration drops it, so the only way
+  // an edge into it can be labeled is by resolving the target on demand.
+  const op = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, ?, ?, ?)`,
+  );
+  commit.run(6, 6);
+  op.run("of:gone", 6, "set", JSON.stringify({ value: 1 }), 6);
+  commit.run(7, 7);
+  op.run("of:gone", 7, "delete", null, 7);
 
   db.close();
 }
@@ -130,6 +144,16 @@ Deno.test("entity graph: nodes, edges, neighborhood, dot", async (t) => {
         assert(ids.has("of:piece"));
         // the unrelated free cell is not within 1 hop of the input cell.
         assert(!ids.has("of:free"));
+      });
+
+      await t.step("an absent target says which kind of absent", () => {
+        const byId = Object.fromEntries(g.nodes.map((n) => [n.id, n]));
+        // `visibleEntityRows` drops tombstones, so this target is not among the
+        // rows the graph walked: the stub resolved it on demand, and says
+        // `deleted` rather than the "(absent)" every absent target once shared.
+        assertEquals(byId["of:gone"].kind, "deleted");
+        assertEquals(byId["of:gone"].label, "(deleted)");
+        assertEquals(byId["of:gone"].present, false);
       });
 
       await t.step("graphToDot emits a digraph with the piece node", () => {

--- a/packages/state-inspector/test/reconstruct.test.ts
+++ b/packages/state-inspector/test/reconstruct.test.ts
@@ -266,3 +266,107 @@ Deno.test("state-inspector autopsy core", async (t) => {
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+/**
+ * Every boundary a reconstruction crosses is a place corruption can be laundered
+ * into a document that looks current. A malformed base, snapshot, or patch is
+ * rejected by memory-v2 at the boundary it appears on — never absorbed and built
+ * over — so reconstruction has to reach the same verdict rather than reporting a
+ * document no read from the engine can produce.
+ */
+const BOUNDARY_SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE snapshot (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  value JSON NOT NULL, PRIMARY KEY (branch, id, scope_key, seq)
+);
+`;
+
+Deno.test("a malformed boundary is not laundered by a later valid one", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-boundary-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    const db = new Database(dbPath, { create: true });
+    db.exec(BOUNDARY_SCHEMA);
+    const commit = db.prepare(
+      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+       VALUES (?, 'sess', ?, '{}', '{}')`,
+    );
+    const rev = db.prepare(
+      `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+       VALUES (?, ?, 0, ?, ?, ?)`,
+    );
+    const snap = db.prepare(
+      `INSERT INTO snapshot (id, seq, value) VALUES (?, ?, ?)`,
+    );
+    const setRoot = (value: unknown) =>
+      JSON.stringify([{ op: "replace", path: "", value }]);
+
+    // A snapshot that is not a document, then a patch replacing the root with
+    // one. The snapshot is the base, so reading it unchecked yields a document.
+    commit.run(1, 1);
+    rev.run("of:snap", 1, "set", JSON.stringify({ value: { n: 0 } }), 1);
+    snap.run("of:snap", 2, "[]");
+    commit.run(2, 2);
+    commit.run(3, 3);
+    rev.run("of:snap", 3, "patch", setRoot({ value: { n: 1 } }), 3);
+
+    // A patch replacing the root with a scalar, then one restoring an object.
+    // Only the intermediate step is invalid, so checking the final result alone
+    // reports this current.
+    commit.run(4, 4);
+    rev.run("of:mid", 4, "set", JSON.stringify({ value: { n: 0 } }), 4);
+    commit.run(5, 5);
+    rev.run("of:mid", 5, "patch", setRoot(0), 5);
+    commit.run(6, 6);
+    rev.run("of:mid", 6, "patch", setRoot({ value: { n: 2 } }), 6);
+
+    // The same chain with every boundary valid still reconstructs.
+    commit.run(7, 7);
+    rev.run("of:ok", 7, "set", JSON.stringify({ value: { n: 0 } }), 7);
+    commit.run(8, 8);
+    rev.run("of:ok", 8, "patch", setRoot({ value: { n: 3 } }), 8);
+    db.close();
+
+    const space = openSpace(dbPath);
+    try {
+      await t.step("a snapshot that is not a document is rejected", () => {
+        assertEquals(
+          reconstructOutcome(space, { id: "of:snap" }).status,
+          "undecodable",
+        );
+      });
+
+      await t.step("a patch leaving a non-document is rejected", () => {
+        assertEquals(
+          reconstructOutcome(space, { id: "of:mid" }).status,
+          "undecodable",
+        );
+      });
+
+      await t.step("a chain whose every boundary holds reconstructs", () => {
+        const ok = reconstructOutcome(space, { id: "of:ok" });
+        assertEquals(ok.status, "present");
+        assert(ok.status === "present");
+        assertEquals(ok.document.value, { n: 3 });
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/reconstruct.test.ts
+++ b/packages/state-inspector/test/reconstruct.test.ts
@@ -13,7 +13,11 @@ import { Database } from "@db/sqlite";
 
 import { openSpace } from "../db.ts";
 import { annotate, parseSigilLink } from "../decode.ts";
-import { getValueAt, reconstructDocument } from "../reconstruct.ts";
+import {
+  getValueAt,
+  reconstructDocument,
+  reconstructOutcome,
+} from "../reconstruct.ts";
 import {
   entityHistory,
   hotEntities,
@@ -215,6 +219,23 @@ Deno.test("state-inspector autopsy core", async (t) => {
           reconstructDocument(space, { id: "of:missing" }),
           undefined,
         );
+      });
+
+      await t.step("an outcome names why there is no document", () => {
+        // `reconstructDocument` answers "no document" for both of these; only
+        // the outcome separates a deletion from an entity that was never here.
+        assertEquals(
+          reconstructOutcome(space, { id: "of:B" }).status,
+          "deleted",
+        );
+        assertEquals(
+          reconstructOutcome(space, { id: "of:missing" }).status,
+          "absent",
+        );
+        const live = reconstructOutcome(space, { id: "of:B", atSeq: 2 });
+        assertEquals(live.status, "present");
+        assert(live.status === "present");
+        assertEquals(live.document.value, { x: true });
       });
 
       await t.step("summary counts match the seed", () => {

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -219,6 +219,7 @@ describe("scan-extent", () => {
         "owned-cell",
         "free-cell",
         "unknown",
+        "deleted",
       ]);
     });
   });

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -918,6 +918,38 @@ describe("scan-extent", () => {
       );
     });
 
+    it("does not count an unreadable row a deleted-only filter dropped", async () => {
+      await withSeeded(
+        [
+          {
+            id: "of:gone",
+            document: { value: "was here" },
+            revisions: 1,
+            deleted: true,
+          },
+          { id: "of:bad", document: UNDECODABLE, revisions: 1 },
+        ],
+        [{ name: "" }],
+        (space) => {
+          // The reverse of the tombstone-vs-piece case below. What makes an
+          // entity `deleted` is the OP of its visible row, read before any
+          // payload is — so a row that would not decode is definitively not a
+          // tombstone, and dropping it leaves nothing out of the answer.
+          const listing = listEntityModels(space, { kind: "deleted" });
+          expect(listing.entities.map((e) => e.id)).toEqual(["of:gone"]);
+          expect(listing.extent.unreadable).toBe(0);
+          expect(isCompleteScan(listing.extent)).toBe(true);
+
+          // The same undecodable row IS a gap for any other kind, which is what
+          // keeps the assertion above from passing for the wrong reason.
+          const pieces = listEntityModels(space, { kind: "piece" });
+          expect(pieces.entities).toEqual([]);
+          expect(pieces.extent.unreadable).toBe(1);
+          expect(isCompleteScan(pieces.extent)).toBe(false);
+        },
+      );
+    });
+
     it("does not count a tombstone the filter dropped, which is no error", async () => {
       await withSeeded(
         [

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -70,6 +70,17 @@ stores state, not things a model infers from the data:
   owned-cell / free-cell) by _which paths exist_, and resolves lineage from them
   — so "what is this entity" is answerable structurally, and `entities` /
   `piece` / `graph` speak that vocabulary.
+- **An entity holding no document says which kind of nothing it is.** A
+  tombstone is its own kind, `deleted`. `unknown` is everything else the tool
+  cannot make sense of, and its label says which: `(undecodable)` for a payload
+  that does not decode, `(no data)` for a `set` that stored none, `(absent)` for
+  an id with no visible row, and `{paths}` for the one case that DID decode — a
+  document whose shape no other kind recognizes. Ask `--kind deleted` for
+  deletions and `--kind unknown` for trouble; do not read a tombstone as damage,
+  and do not read the revision count as evidence either way (it includes the
+  delete op). What the entity WAS is not in the listing — it is gone at HEAD,
+  and `history <id>` plus `value-at --seq` before the delete is what recovers
+  it.
 - **`scope_key` partitions an entity by identity.** The _same_ cell id can hold
   a shared `space` value AND a per-`user:<DID>` override AND a
   per-`session:<DID>:<sid>` override, stored side by side and genuinely


### PR DESCRIPTION
`cf inspect entities` rendered four structurally different situations
identically. Three arrived as `unknown  (undecodable)` — a clean tombstone, a
payload that failed to decode, and a `set` row that stored no data — and the
fourth, a document whose shape nothing recognizes, came through as
`unknown  {paths}`. `--json` was no better: a tombstone and a corrupt entity
differed only by `id` and `revisions`. `--kind unknown` returned all four, so
"show me what is broken" could not be asked without also getting "show me what
was deleted".

Seeded reproduction, before:

```
unknown  (undecodable)  revs=2  of:tombstoned
unknown  (undecodable)  revs=1  of:corrupt
unknown  (undecodable)  revs=1  of:emptyset
unknown  {cfc,slug}     revs=1  of:oddshape
```

After:

```
unknown    (undecodable)  revs=1  of:corrupt
unknown    (no data)      revs=1  of:emptyset
unknown    {cfc,slug}     revs=1  of:oddshape
deleted    (deleted)      revs=2  of:tombstoned
```

## The cause sat upstream of the model

`reconstructDocument` collapsed all four situations into one
`undefined`-or-throw, so no consumer *could* tell them apart. `reconstructOutcome`
returns a discriminated `present | deleted | empty | absent | undecodable`, and
`reconstructDocument` is defined in terms of it, re-throwing the original error
object so callers reading `(e as Error).message` are unaffected.

`EntityKind` gains `deleted`, sorted after `unknown`: corruption is worth looking
at, and a deletion is the ordinary end of an entity's life. `kindOf` answers from
the outcome, so `--kind deleted` selects during the scan the way any other kind
does. A tombstone's original shape is genuinely gone at HEAD, so the kind loses
nothing that was there — `history` and `value-at --seq` before the delete recover it.

Two further surfaces shared the conflation and lose it: a graph edge into a
tombstone reads `(deleted)` rather than sharing `(absent)` with a corrupt target,
and a piece's owned cells and input name their absences the same way.

## Notes for review

- **`extent.unreadable` semantics are untouched.** An earlier revision of this PR
  placed unreadable entities as graph/detail nodes so corruption could not hide.
  `main` has since solved that concern its own way — counting them into
  `extent.unreadable`, marking the scan incomplete, and surfacing it through
  `--require-complete` and the HTML banner. That is the better-integrated
  mechanism, so this PR no longer touches it; `graph.extent.unreadable` still
  counts what it cannot place, and its tests are unchanged.
- **Two of the six affected sites were compiler-enforced.** `KIND_ORDER` and
  `detail.ts`'s `order` are exhaustive `Record<EntityKind, …>`. `nodesByKind`,
  `DOT_FILL`, html's `KC`, and `roleFor`'s `default:` all have fallbacks and were
  handled by hand. `entityKinds` and the `--kind` help derive from `KIND_ORDER`,
  so the CLI needed no change.
- **A stored `null` document was crashing the listing on `main`.** `decodeStored("null")`
  returns `null`, which reaches `classifyDocument` → `Object.keys(null)` outside
  the `read()` try/catch and takes down the whole scan. `reconstructOutcome` now
  rejects any decoded document that is not a tree of paths. Confirmed the new
  test fails without the guard.
- **I could not find a real tombstone to test against.** Across 14 local space DBs
  and the 15 MB staging snapshot in `~/.cache/cf-inspect`: zero `delete` rows
  anywhere, zero null-data `set` rows, and zero `unknown` entities among the
  staging space's 527. The op is fully plumbed, so the path is real — but coverage
  here is hermetic fixtures, not observed data.

## Testing

Coverage went into the existing siblings, extended in their own `Deno.test` style.
`scan-extent.test.ts` gains `deleted` in the `entityKinds` ordering.

- `deno fmt --check` (5044 files) and `deno lint` (4950) — clean
- `deno task check` — exit 0
- `deno task check-skill-facts` — 46 documents OK
- `packages/state-inspector` — 101 passed, 0 failed
- `packages/cli` — 181 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
