### PR TITLE
refactor: break the cli/fuse import cycle at the connection

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -174,7 +174,7 @@ describe("shadow DOM component test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await PiecesController.initialize({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });

--- a/docs/features/authorization-failure-surfacing.md
+++ b/docs/features/authorization-failure-surfacing.md
@@ -6,7 +6,8 @@ denial — must reach a caller waiting on storage sync as a real, typed error
 rather than a silent absent read or an endless wait. Getting there spans three
 layers: the memory protocol classifies the failure, the memory client acts on
 that classification during reconnect, the runner storage layer records it per
-space, and the CLI surfaces it. This document describes how the pieces fit.
+space, and the callers that reach a particular space surface it. This document
+describes how the pieces fit.
 
 ## The classification: recoverable versus permanent
 
@@ -90,6 +91,15 @@ profile yet" absent read.
 The `newPiece` 60-second bound is unrelated and remains. That hang is a scheduler
 `idle()` park in `getResult(piece).pull()` waiting for a pattern to quiesce — a
 different mechanism this signal does not cover.
+
+## Connecting a controller: one check for every client that opens a space
+
+`PiecesController.initialize` builds a client runtime over a deployed API and
+returns a controller for one space. It opens that space's session, reads
+`storageManager.authorizationError(space)`, and throws what it finds, so a
+caller reaching a space this way does not write the check itself. The FUSE
+mount, the agent harness's Fabric session, and the integration suites'
+controllers all connect through it.
 
 ## Scope and trade-offs
 

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -6,14 +6,8 @@
  * enters the docker sandbox.
  */
 
-import { createSession, Identity, isDID } from "@commonfabric/identity";
+import { Identity } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
-import {
-  experimentalOptionsFromEnv,
-  Runtime,
-  runtimePresets,
-} from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache";
 import type { HarnessFabricSessionConfig } from "./config.ts";
 
 export interface HarnessFabricSession {
@@ -29,29 +23,10 @@ export interface HarnessFabricSession {
 export type HarnessFabricSessionFactory = () => Promise<HarnessFabricSession>;
 
 /**
- * Surfaces a permanent authorization denial for the controller's configured
- * space. The storage layer's per-space contract (see
- * `authorizationError()` in `packages/runner/src/storage/v2.ts`) keeps
- * `synced()` quiet on a denial — a denied cross-space link must stay a silent
- * absent read — so a caller that must reach a specific space reads the
- * per-space status after `synced()` and throws it deliberately. Minimal
- * replica of the CLI's post-`synced()` check in `packages/cli/lib/piece.ts`.
- */
-const assertSpaceAuthorized = (pieces: PiecesController): void => {
-  const authorizationError = pieces.runtime.storageManager
-    .authorizationError?.(pieces.getSpace());
-  if (authorizationError) {
-    throw authorizationError;
-  }
-};
-
-/**
  * Default factory over `config`: loads the PKCS#8 identity from disk and
- * connects a `PiecesController` to the deployed API. A space name goes
- * through `PiecesController.initialize`; a `did:key` space needs the manual
- * `createSession` path, since `initialize` accepts only a name. Either way,
- * an unauthorized space fails construction rather than yielding a session
- * whose every read is a silent absence.
+ * connects a `PiecesController` to the deployed API. An unauthorized space
+ * fails construction rather than yielding a session whose every read is a
+ * silent absence.
  */
 export const createHarnessFabricSessionFactory = (
   config: HarnessFabricSessionConfig,
@@ -60,46 +35,17 @@ async () => {
   const identity = await Identity.fromPkcs8(
     await Deno.readFile(config.identityKeyPath),
   );
-  const apiUrl = new URL(config.apiUrl);
-  const cfcDials = {
+  const pieces = await PiecesController.initialize({
+    apiUrl: new URL(config.apiUrl),
+    identity,
+    space: config.space,
     ...(config.cfcEnforcementMode !== undefined
       ? { cfcEnforcementMode: config.cfcEnforcementMode }
       : {}),
     ...(config.cfcFlowLabels !== undefined
       ? { cfcFlowLabels: config.cfcFlowLabels }
       : {}),
-  };
-  if (!isDID(config.space)) {
-    const pieces = await PiecesController.initialize({
-      apiUrl,
-      identity,
-      spaceName: config.space,
-      ...cfcDials,
-    });
-    assertSpaceAuthorized(pieces);
-    return { pieces };
-  }
-  const session = await createSession({ identity, spaceDid: config.space });
-  // Shared first-party posture for client runtimes against a deployed API,
-  // matching `PiecesController.initialize`; trust provenance stays a visible
-  // delta of this session.
-  const runtime = new Runtime(runtimePresets.remoteClient({
-    apiUrl,
-    storageManager: StorageManager.open({
-      as: session.as,
-      memoryHost: apiUrl,
-      spaceIdentity: session.spaceIdentity,
-    }),
-    experimental: experimentalOptionsFromEnv((key) => Deno.env.get(key)),
-    ...cfcDials,
-    trustSnapshotProvider: () => ({
-      id: `principal:${session.as.did()}`,
-      actingPrincipal: session.as.did(),
-    }),
-  }));
-  const pieces = new PiecesController(session, runtime);
-  await pieces.synced();
-  assertSpaceAuthorized(pieces);
+  });
   return { pieces };
 };
 

--- a/packages/cli/test/piece-integration.test.ts
+++ b/packages/cli/test/piece-integration.test.ts
@@ -62,7 +62,7 @@ async function waitForContent(
   const pieces = await PiecesController.initialize({
     apiUrl: new URL(API_URL!),
     identity,
-    spaceName,
+    space: spaceName,
   });
   try {
     const controller = await pieces.get(piece);

--- a/packages/fuse/cell-bridge-default-loader.test.ts
+++ b/packages/fuse/cell-bridge-default-loader.test.ts
@@ -1,0 +1,57 @@
+// cell-bridge-default-loader.test.ts — the loader a bridge uses when the
+// caller injected none: the identity file the mount was started with, opened
+// against the mount's API.
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+
+import { CellBridge } from "./cell-bridge.ts";
+import { FsTree } from "./tree.ts";
+
+describe("CellBridge", () => {
+  describe("instance members", () => {
+    describe("connectSpace()", () => {
+      const apiUrl = "http://toolshed.test/";
+      let identityPath: string;
+      let requested: string[];
+      let realFetch: typeof globalThis.fetch;
+
+      beforeEach(async () => {
+        identityPath = await Deno.makeTempFile({ suffix: ".key" });
+        await Deno.writeFile(identityPath, await Identity.generatePkcs8());
+        requested = [];
+        realFetch = globalThis.fetch;
+        globalThis.fetch = (input: string | URL | Request) => {
+          requested.push(
+            input instanceof Request ? input.url : input.toString(),
+          );
+          return Promise.resolve(new Response(null, { status: 503 }));
+        };
+      });
+
+      afterEach(async () => {
+        globalThis.fetch = realFetch;
+        await Deno.remove(identityPath);
+      });
+
+      it("connects through the mount's API when no loader was injected", async () => {
+        const bridge = new CellBridge(new FsTree());
+        bridge.init({ apiUrl, identity: identityPath });
+        await expect(bridge.connectSpace("home")).rejects.toThrow(
+          'Could not connect to "http://toolshed.test/".',
+        );
+        expect(requested).toEqual(["http://toolshed.test/_health"]);
+      });
+
+      it("throws when the identity file is not readable", async () => {
+        const bridge = new CellBridge(new FsTree());
+        bridge.init({ apiUrl, identity: `${identityPath}.absent` });
+        await expect(bridge.connectSpace("home")).rejects.toThrow(
+          Deno.errors.NotFound,
+        );
+        expect(requested).toEqual([]);
+      });
+    });
+  });
+});

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -5,9 +5,10 @@
 // Subscribes to cell changes and rebuilds subtrees on updates.
 
 import type { JSONSchema } from "@commonfabric/api";
-import type {
-  PieceController,
-  PiecePatternRef,
+import { Identity } from "@commonfabric/identity";
+import {
+  type PieceController,
+  type PiecePatternRef,
   PiecesController,
 } from "@commonfabric/piece/ops";
 import type { Cell } from "@commonfabric/runner";
@@ -87,9 +88,6 @@ function displayCallableInputType(
       : undefined;
   return schemaToTypeString(schema, { defs, maxDepth: 3 });
 }
-// Lazy-imported in connectSpace() to avoid pulling in heavy CLI deps at import
-// time (breaks tests that only use CellBridge for tree/symlink logic).
-// import { loadPieces } from "../cli/lib/piece.ts";
 
 /**
  * Parse YAML frontmatter from a markdown string.
@@ -173,6 +171,19 @@ type PiecesLoader = (config: {
   identity: string;
   deferSpaceCellSync?: boolean;
 }) => Promise<PiecesController>;
+
+/**
+ * Opens one space against the API the mount was started with, authenticating
+ * with the PKCS#8 identity file it was given. Used whenever the caller
+ * injected no loader of its own.
+ */
+const openSpacePieces: PiecesLoader = async (config) =>
+  await PiecesController.initialize({
+    apiUrl: config.apiUrl,
+    space: config.space,
+    identity: await Identity.fromPkcs8(await Deno.readFile(config.identity)),
+    deferSpaceCellSync: config.deferSpaceCellSync,
+  });
 
 export interface CellBridgeOptions {
   cfcAnnotations?: boolean;
@@ -439,11 +450,7 @@ export class CellBridge {
     for (const [spaceName, state] of spaces) {
       try {
         const loadPieces = this.reconnectPiecesLoader ??
-          this.piecesLoader ??
-          // The CLI's loader is the fallback for a caller that injected none,
-          // which keeps the bridge off the CLI's module graph.
-          // deno-lint-ignore cf-imports/no-inline-module-import
-          (await import("../cli/lib/piece.ts")).loadPieces;
+          this.piecesLoader ?? openSpacePieces;
         const probe = await loadPieces({
           apiUrl: this.apiUrl,
           space: spaceName,
@@ -534,11 +541,7 @@ export class CellBridge {
   private async createSpacePieces(
     spaceName: string,
   ): Promise<PiecesController> {
-    const loadPieces = this.piecesLoader ??
-      // The CLI's loader is the fallback for a caller that injected none, which
-      // keeps the bridge off the CLI's module graph.
-      // deno-lint-ignore cf-imports/no-inline-module-import
-      (await import("../cli/lib/piece.ts")).loadPieces;
+    const loadPieces = this.piecesLoader ?? openSpacePieces;
     return await loadPieces({
       apiUrl: this.apiUrl,
       space: spaceName,

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -9,6 +9,7 @@
 
 import { parseArgs } from "@std/cli/parse-args";
 
+import { setLLMUrl } from "@commonfabric/llm";
 import { linkRefFrom } from "@commonfabric/runner/shared";
 
 import {
@@ -705,6 +706,8 @@ export async function main(argv: string[] = Deno.args) {
   try {
     const apiUrl = args["api-url"];
     if (apiUrl) {
+      // Patterns this mount runs reach the LLM through the same deployment.
+      setLLMUrl(apiUrl);
       bridge = new CellBridge(tree, args["exec-cli"] || "", {
         cfcAnnotations: cfcAnnotationsEnabled,
         statusProvider: () => ({

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -9,7 +9,6 @@
 
 import { parseArgs } from "@std/cli/parse-args";
 
-import { setLLMUrl } from "@commonfabric/llm";
 import { linkRefFrom } from "@commonfabric/runner/shared";
 
 import {
@@ -706,8 +705,6 @@ export async function main(argv: string[] = Deno.args) {
   try {
     const apiUrl = args["api-url"];
     if (apiUrl) {
-      // Patterns this mount runs reach the LLM through the same deployment.
-      setLLMUrl(apiUrl);
       bridge = new CellBridge(tree, args["exec-cli"] || "", {
         cfcAnnotations: cfcAnnotationsEnabled,
         statusProvider: () => ({

--- a/packages/patterns/google/core/integration/google-calendar-importer.test.ts
+++ b/packages/patterns/google/core/integration/google-calendar-importer.test.ts
@@ -28,7 +28,7 @@ describe("google calendar importer e2e", () => {
 
     // 2. Initialize PiecesController
     cc = await PiecesController.initialize({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -52,7 +52,7 @@ describe("Compile all patterns", () => {
       // fresh Runtime (via PiecesController) each time to avoid OOM in CI
       const identity = await Identity.generate();
       const cc = await initializePiecesController({
-        spaceName: `${name}-${crypto.randomUUID()}`,
+        space: `${name}-${crypto.randomUUID()}`,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/packages/patterns/integration/cf-checkbox.test.ts
+++ b/packages/patterns/integration/cf-checkbox.test.ts
@@ -33,7 +33,7 @@ testComponents.forEach(({ name, file }) => {
     beforeAll(async () => {
       identity = await Identity.generate({ implementation: "noble" });
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });
@@ -117,7 +117,7 @@ describe("cf-checkbox waitForDisabled fallback integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cf-code-editor.test.ts
+++ b/packages/patterns/integration/cf-code-editor.test.ts
@@ -143,7 +143,7 @@ describe("cf-code-editor cursor stability", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });
@@ -1350,7 +1350,7 @@ describe("cf-code-editor backlink title sync", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cf-render.test.ts
+++ b/packages/patterns/integration/cf-render.test.ts
@@ -62,7 +62,7 @@ describe("cf-render integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });
@@ -196,7 +196,7 @@ describe("cf-render subpath handling", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });

--- a/packages/patterns/integration/cfc-authorized-save.test.ts
+++ b/packages/patterns/integration/cfc-authorized-save.test.ts
@@ -30,7 +30,7 @@ describe("cfc authorized save integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cfc-authorship-chat.test.ts
+++ b/packages/patterns/integration/cfc-authorship-chat.test.ts
@@ -23,7 +23,7 @@ describe("cfc authorship chat integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -99,7 +99,7 @@ describe(
         ),
       );
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identities[0],
       });

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -41,7 +41,7 @@ describe("cfc group chat demo integration test", () => {
     identity = await Identity.generate({ implementation: "noble" });
     secondIdentity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cfc-render-policy-demo.test.ts
+++ b/packages/patterns/integration/cfc-render-policy-demo.test.ts
@@ -32,7 +32,7 @@ describe("cfc render policy demo integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cfc-spec-gallery.test.ts
+++ b/packages/patterns/integration/cfc-spec-gallery.test.ts
@@ -27,7 +27,7 @@ describe("cfc spec gallery integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/cfc-staged-publish.test.ts
+++ b/packages/patterns/integration/cfc-staged-publish.test.ts
@@ -28,7 +28,7 @@ describe("cfc staged publish integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/chat-note.test.ts
+++ b/packages/patterns/integration/chat-note.test.ts
@@ -28,7 +28,7 @@ describe("Chat Note pattern test", () => {
     beforeAll(async () => {
       identity = await Identity.generate({ implementation: "noble" });
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/packages/patterns/integration/chatbot.test.ts
+++ b/packages/patterns/integration/chatbot.test.ts
@@ -34,7 +34,7 @@ describe("Chat pattern test", () => {
     beforeAll(async () => {
       identity = await Identity.generate({ implementation: "noble" });
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/packages/patterns/integration/counter.test.ts
+++ b/packages/patterns/integration/counter.test.ts
@@ -43,7 +43,7 @@ describe("counter direct operations test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });

--- a/packages/patterns/integration/fetch-json.test.ts
+++ b/packages/patterns/integration/fetch-json.test.ts
@@ -32,7 +32,7 @@ describe("fetch json integration test", () => {
     beforeAll(async () => {
       identity = await Identity.generate({ implementation: "noble" });
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/packages/patterns/integration/instantiate-pattern.test.ts
+++ b/packages/patterns/integration/instantiate-pattern.test.ts
@@ -33,7 +33,7 @@ describe("instantiate-pattern integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });

--- a/packages/patterns/integration/llm.test.ts
+++ b/packages/patterns/integration/llm.test.ts
@@ -30,7 +30,7 @@ describe("LLM pattern test", () => {
     beforeAll(async () => {
       identity = await Identity.generate({ implementation: "noble" });
       cc = await initializePiecesController({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/packages/patterns/integration/lunch-poll-vote.test.ts
+++ b/packages/patterns/integration/lunch-poll-vote.test.ts
@@ -98,7 +98,7 @@ describe("lunch poll: two users vote on a shared option", () => {
       Identity.generate({ implementation: "noble" }),
     ]);
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: hostIdentity,
     });

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -226,7 +226,7 @@ const handlers: Record<
     cc = await initializePiecesController({
       apiUrl: new URL(apiUrl as string),
       identity,
-      spaceName: spaceName as string,
+      space: spaceName as string,
     });
     if (diagnostics === true) {
       const scheduler = controller().runtime.scheduler;

--- a/packages/patterns/integration/nested-counter.test.ts
+++ b/packages/patterns/integration/nested-counter.test.ts
@@ -43,7 +43,7 @@ describe("nested counter integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity: identity,
     });

--- a/packages/patterns/integration/note-append-link.test.ts
+++ b/packages/patterns/integration/note-append-link.test.ts
@@ -36,7 +36,7 @@ describe("note appendLink integration", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/parking-coordinator-admin-view.test.ts
+++ b/packages/patterns/integration/parking-coordinator-admin-view.test.ts
@@ -30,7 +30,7 @@ describe("parking coordinator admin view integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/profile-embed.test.ts
+++ b/packages/patterns/integration/profile-embed.test.ts
@@ -62,7 +62,7 @@ describe("profile-embed integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/record-module-chrome.test.ts
+++ b/packages/patterns/integration/record-module-chrome.test.ts
@@ -106,7 +106,7 @@ describe("record module chrome integration test", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/shared-profile.test.ts
+++ b/packages/patterns/integration/shared-profile.test.ts
@@ -33,7 +33,7 @@ describe("shared profile integration test", () => {
     identity = await Identity.generate({ implementation: "noble" });
     secondIdentity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/patterns/integration/topic-board-fixture.ts
+++ b/packages/patterns/integration/topic-board-fixture.ts
@@ -222,7 +222,7 @@ export async function seedTopicBoard(
   };
 
   const cc = await initializePiecesController({
-    spaceName: options.spaceName,
+    space: options.spaceName,
     apiUrl: options.apiUrl,
     identity: options.identity,
   });

--- a/packages/patterns/integration/topics-navigation.test.ts
+++ b/packages/patterns/integration/topics-navigation.test.ts
@@ -33,7 +33,7 @@ describe("Topics durable navigation", () => {
   beforeAll(async () => {
     identity = await Identity.generate({ implementation: "noble" });
     cc = await initializePiecesController({
-      spaceName: SPACE_NAME,
+      space: SPACE_NAME,
       apiUrl: new URL(API_URL),
       identity,
     });

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -14,6 +14,7 @@ import {
   type Session,
 } from "@commonfabric/identity";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
+import { setLLMUrl } from "@commonfabric/llm";
 import {
   applyPieceSourceTransition,
   type Cell,
@@ -275,7 +276,7 @@ export class PiecesController<T = unknown> {
    * and its replica down with it.
    *
    * A pattern that navigates to a piece has that piece recorded in the
-   * space's registry.
+   * space's registry, and one that reaches the LLM reaches this deployment's.
    */
   static async initialize(
     {
@@ -315,6 +316,7 @@ export class PiecesController<T = unknown> {
     },
   ): Promise<PiecesController> {
     const api = new URL(apiUrl);
+    setLLMUrl(api.toString());
     // Holds the controller built below, which the navigate callback reads and
     // the runtime takes at construction. A pattern navigates only from a
     // running piece, and the controller is what starts one.

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -7,7 +7,12 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { homeSchema } from "@commonfabric/home-schemas";
-import { createSession, Identity, type Session } from "@commonfabric/identity";
+import {
+  createSession,
+  Identity,
+  isDID,
+  type Session,
+} from "@commonfabric/identity";
 import { HttpProgramResolver } from "@commonfabric/js-compiler/program";
 import {
   applyPieceSourceTransition,
@@ -188,6 +193,25 @@ const isCfcMigrationRejection = (error: unknown): boolean =>
 const readEnv: EnvReader = (key) =>
   typeof Deno !== "undefined" ? Deno.env.get(key) : undefined;
 
+/**
+ * Records a piece a running pattern navigated to in the space's registry, so a
+ * piece a pattern created inside this runtime is reachable from the space
+ * afterwards. A piece the registry already lists is left alone.
+ */
+export async function registerNavigatedPiece(
+  pieces: PiecesController,
+  target: Cell<unknown>,
+): Promise<void> {
+  const id = pieceId(target);
+  if (id === undefined) {
+    throw new Error("navigateTo: the target carries no piece id");
+  }
+  await pieces.runtime.storageManager.synced();
+  const registry = await pieces.getPieceRegistry();
+  if (registry.get().some((piece) => pieceId(piece) === id)) return;
+  await pieces.add([target]);
+}
+
 export interface PiecesControllerOptions {
   deferSpaceCellSync?: boolean;
 }
@@ -242,19 +266,38 @@ export class PiecesController<T = unknown> {
     this.ready = syncSpaceCellContents.then(() => {});
   }
 
+  /**
+   * Connects a client to one space of a deployed API and returns a controller
+   * over it. The server is asked for its health before any of the space is
+   * read, so an unreachable API fails here rather than as a stream of absent
+   * reads, and a space this identity may not open fails with the server's own
+   * authorization error. A connection that does not complete takes its socket
+   * and its replica down with it.
+   *
+   * A pattern that navigates to a piece has that piece recorded in the
+   * space's registry.
+   */
   static async initialize(
     {
       apiUrl,
       identity,
-      spaceName,
+      space,
+      deferSpaceCellSync,
       moduleByteCache,
       patternCoverage,
       cfcEnforcementMode,
       cfcFlowLabels,
     }: {
-      apiUrl: URL;
+      apiUrl: URL | string;
       identity: Identity;
-      spaceName: string;
+      /** The space to open, as a `did:key:` DID or as a space name. */
+      space: string;
+      /**
+       * Open the space's session without syncing the space cell's contents. A
+       * caller that reaches pieces by id, and never reads the space record,
+       * does not need those contents.
+       */
+      deferSpaceCellSync?: boolean;
       // Optional compiled-module-byte cache to share across controllers. Supplied
       // only by test code (see the integration suite's compile-byte-cache helper);
       // unset in production, so no cache is installed.
@@ -271,31 +314,65 @@ export class PiecesController<T = unknown> {
       cfcFlowLabels?: CfcFlowLabelsMode;
     },
   ): Promise<PiecesController> {
-    const session = await createSession({ identity, spaceName });
+    const api = new URL(apiUrl);
+    // Holds the controller built below, which the navigate callback reads and
+    // the runtime takes at construction. A pattern navigates only from a
+    // running piece, and the controller is what starts one.
+    const piecesRef: { current?: PiecesController } = {};
+    const session = await createSession(
+      isDID(space)
+        ? { identity, spaceDid: space }
+        : { identity, spaceName: space },
+    );
+    const storageManager = StorageManager.open({
+      as: session.as,
+      memoryHost: api,
+      spaceIdentity: session.spaceIdentity,
+    });
     // Shared first-party posture for client runtimes against a deployed API
     // (CT-1814); the CFC pin this site previously restated lives in the
     // preset core. Trust provenance stays a visible delta of this controller.
     const runtime = new Runtime(runtimePresets.remoteClient({
-      apiUrl: new URL(apiUrl),
-      storageManager: StorageManager.open({
-        as: session.as,
-        memoryHost: new URL(apiUrl),
-        spaceIdentity: session.spaceIdentity,
-      }),
+      apiUrl: api,
+      storageManager,
       experimental: experimentalOptionsFromEnv(readEnv),
       moduleByteCache,
       patternCoverage,
       ...(cfcEnforcementMode !== undefined ? { cfcEnforcementMode } : {}),
       ...(cfcFlowLabels !== undefined ? { cfcFlowLabels } : {}),
+      navigateCallback: (target) =>
+        registerNavigatedPiece(piecesRef.current!, target),
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,
         actingPrincipal: session.as.did(),
       }),
     }));
-
-    const pieces = new PiecesController(session, runtime);
-    await pieces.synced();
-    return pieces;
+    try {
+      if (!await runtime.healthCheck()) {
+        throw new Error(`Could not connect to "${api.toString()}".`);
+      }
+      const pieces = new PiecesController(session, runtime, {
+        deferSpaceCellSync,
+      });
+      piecesRef.current = pieces;
+      // Opening the space's session is what turns a permanent denial into an
+      // error: the per-space status below is written while the session opens,
+      // and `synced()` stays quiet about a denial so that a denied cross-space
+      // link can stay a silent absent read.
+      await pieces.ensureSpaceSession();
+      if (!deferSpaceCellSync) await pieces.synced();
+      const denial = storageManager.authorizationError?.(session.space);
+      if (denial) throw denial;
+      return pieces;
+    } catch (error) {
+      // Tear the half-built connection down. `closeNow()` drops the replica and
+      // its socket without waiting on a server that may be the reason this
+      // failed, and `dispose()` takes the rest of the runtime with it. The
+      // error that started the teardown is the one that leaves.
+      await storageManager.closeNow().catch(() => {});
+      await runtime.dispose().catch(() => {});
+      throw error;
+    }
   }
 
   getSpace(): MemorySpace {

--- a/packages/piece/test/pieces-controller-connection.test.ts
+++ b/packages/piece/test/pieces-controller-connection.test.ts
@@ -1,0 +1,116 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import type { Cell } from "@commonfabric/runner";
+
+import {
+  PiecesController,
+  registerNavigatedPiece,
+} from "../src/ops/pieces-controller.ts";
+
+const identity = await Identity.fromPassphrase(
+  "pieces controller connection tests",
+);
+
+describe("pieces-controller", () => {
+  describe("PiecesController", () => {
+    describe("static members", () => {
+      describe("initialize()", () => {
+        const apiUrl = new URL("http://toolshed.test/");
+        let requested: string[];
+        let realFetch: typeof globalThis.fetch;
+
+        beforeEach(() => {
+          requested = [];
+          realFetch = globalThis.fetch;
+          globalThis.fetch = (input: string | URL | Request) => {
+            requested.push(
+              input instanceof Request ? input.url : input.toString(),
+            );
+            return Promise.resolve(new Response(null, { status: 503 }));
+          };
+        });
+
+        afterEach(() => {
+          globalThis.fetch = realFetch;
+        });
+
+        it("throws naming the API when the server is not healthy", async () => {
+          await expect(PiecesController.initialize({
+            apiUrl,
+            identity,
+            space: "unhealthy-space",
+          })).rejects.toThrow('Could not connect to "http://toolshed.test/".');
+        });
+
+        it("asks the API for its health before reading the space", async () => {
+          await expect(PiecesController.initialize({
+            apiUrl,
+            identity,
+            space: "unhealthy-space",
+          })).rejects.toThrow();
+          expect(requested).toEqual(["http://toolshed.test/_health"]);
+        });
+
+        it("takes an apiUrl written as a string", async () => {
+          await expect(PiecesController.initialize({
+            apiUrl: "http://toolshed.test",
+            identity,
+            space: "unhealthy-space",
+          })).rejects.toThrow('Could not connect to "http://toolshed.test/".');
+        });
+
+        it("throws the connection error for a space given as a `did:key:` DID", async () => {
+          const spaceDid = (await Identity.fromPassphrase("a space of its own"))
+            .did();
+          await expect(PiecesController.initialize({
+            apiUrl,
+            identity,
+            space: spaceDid,
+          })).rejects.toThrow('Could not connect to "http://toolshed.test/".');
+        });
+      });
+    });
+  });
+
+  describe("registerNavigatedPiece()", () => {
+    // A piece cell is identified by its entity id, which `pieceId()` reads
+    // through `cellEntityIdString`.
+    const pieceCell = (id: string): Cell<unknown> =>
+      ({ entityId: { "/": id } }) as unknown as Cell<unknown>;
+
+    const controllerListing = (ids: string[]) => {
+      const added: Cell<unknown>[][] = [];
+      const pieces = {
+        runtime: { storageManager: { synced: () => Promise.resolve() } },
+        getPieceRegistry: () =>
+          Promise.resolve({ get: () => ids.map(pieceCell) }),
+        add: (newPieces: Cell<unknown>[]) => {
+          added.push(newPieces);
+          return Promise.resolve();
+        },
+      } as unknown as PiecesController;
+      return { pieces, added };
+    };
+
+    it("adds a piece the registry does not list", async () => {
+      const { pieces, added } = controllerListing(["already-here"]);
+      const target = pieceCell("brand-new");
+      await registerNavigatedPiece(pieces, target);
+      expect(added).toEqual([[target]]);
+    });
+
+    it("leaves a piece the registry already lists alone", async () => {
+      const { pieces, added } = controllerListing(["already-here"]);
+      await registerNavigatedPiece(pieces, pieceCell("already-here"));
+      expect(added).toEqual([]);
+    });
+
+    it("throws for a target carrying no piece id", async () => {
+      const { pieces } = controllerListing([]);
+      await expect(registerNavigatedPiece(pieces, {} as Cell<unknown>))
+        .rejects.toThrow("navigateTo: the target carries no piece id");
+    });
+  });
+});

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -193,7 +193,7 @@ describe("shell piece tests", () => {
 
     try {
       const controller = await PiecesController.initialize({
-        spaceName: SPACE_NAME,
+        space: SPACE_NAME,
         apiUrl: new URL(API_URL),
         identity: identity,
       });

--- a/tasks/check-package-cycles.ts
+++ b/tasks/check-package-cycles.ts
@@ -87,12 +87,6 @@ export const ALLOWLIST: readonly AllowedCycle[] = [
       "runtime-client protocol, while runtime-client's protocol types and " +
       "worker backend are defined in terms of html's VDOM operations.",
   },
-  {
-    packages: ["cli", "fuse"],
-    reason:
-      "cli mounts and drives fuse, while fuse's cell bridge reads pieces " +
-      "through cli's piece and callable helpers.",
-  },
 ];
 
 const CODE_EXTENSIONS = new Set([".ts", ".tsx", ".mts"]);


### PR DESCRIPTION
The FUSE daemon needed a `PiecesController` for each space it mounts, and the only function that built one lived in the CLI. `cell-bridge.ts` reached for it twice through `await import("../cli/lib/piece.ts")`, each site carrying a lint suppression and a comment explaining that a static import would drag the whole CLI in at load time. The CLI, meanwhile, loads the FUSE module to run `cf fuse-daemon`. That is the cycle: a filesystem daemon that cannot open a space without the command-line tool, and a command-line tool that cannot mount without the daemon.

Connecting a client to a deployed space is not a CLI concept. It is a session, a runtime built from the remote-client preset, and a controller over one space -- all of which `packages/piece` already owns, and all of which `PiecesController.initialize` already did for the integration suites. Three places had grown their own version of it. `initialize` handled a space name only. The agent harness hand-rolled the `did:key:` case beside it, restating the preset block and copying the CLI's post-`synced()` authorization check with a comment saying so. And the CLI's `loadPieces` did all of it plus its own reporting.

`initialize` now takes the space as either a DID or a name, accepts the deferred space-cell sync the FUSE mount wants, asks the server for its health before reading anything, surfaces a permanent authorization denial for the space it was asked for, and closes the replica and the runtime when the connection does not complete. A pattern that navigates to a piece has that piece recorded in the space's registry, which is what the CLI's navigate callback was doing for the daemon. With that, the FUSE bridge connects through `piece` and the harness collapses onto one call; both deferred imports and both suppressions go, and so does the `cli`/`fuse` entry in the cycle allowlist.

`loadPieces` stays as it is. Its version check straddles the health check, its runtime error log and JSON console handler are the CLI's own, and folding them in would turn a readable function into a set of hooks.

Two behaviors the daemon inherited from the CLI's loader are now the daemon's: `mod.ts` points the LLM client at the mount's API, and the registry write above rides `initialize`. The space cell's session is now opened explicitly on both paths rather than only the deferred one, so a denial is surfaced for every caller instead of collapsing into absent reads.

The parameter rename from `spaceName` to `space` reaches every caller of `initialize`: the pattern and shell integration suites, and the shell component example in `UI_TESTING.md`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

