### PR TITLE
fix(runner): make the map resume-seed report cover deterministically

### DIFF
--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -60,6 +60,29 @@ const RESULT_PRESENCE_SCHEMA = internSchema({
 const logger = getLogger("runner.map", { enabled: true, level: "warn" });
 
 /**
+ * Report the outcome of seeding an empty result container on resume.
+ *
+ * The seed edit runs against live storage and can lose a commit race, so which
+ * arm of it executes is a property of the run rather than of the code — the
+ * reason it takes the outcome as a parameter and is called on every seed
+ * instead of testing `error` at the call site. That keeps the failure arm
+ * reachable from a unit test that hands it an error directly, rather than
+ * leaving its coverage to whether a race happened to occur (see
+ * `docs/development/COVERAGE.md`, "Coverage must not depend on the execution
+ * environment").
+ *
+ * @internal Exported for testing.
+ */
+export function reportResumeSeedOutcome(error: unknown): void {
+  if (!error) return;
+  logger.warn(
+    "resume-seed",
+    "seeding the empty result container failed",
+    { error },
+  );
+}
+
+/**
  * Implementation of built-in map module. Unlike regular modules, this will be
  * called once at setup and thus sets up its own actions for the scheduler.
  *
@@ -336,15 +359,7 @@ export function map(
           if (!active) return;
           const container = result!.withTx(seedTx);
           if (container.getRaw() === undefined) container.set([]);
-        }).then(({ error }) => {
-          if (error) {
-            logger.warn(
-              "resume-seed",
-              "seeding the empty result container failed",
-              { error },
-            );
-          }
-        });
+        }).then(({ error }) => reportResumeSeedOutcome(error));
       // Run on either outcome (resolve or reject); the seed recovers from the
       // pull's own rejection, so log it rather than dropping it silently.
       pending.finally(seedIfStillAbsent).catch((error) => {

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 
 import { hasDataUriScheme } from "@commonfabric/data-model/data-uri-codec";
 import { Identity } from "@commonfabric/identity";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
 import type { Signer } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
@@ -10,6 +11,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { Cell } from "../src/cell.ts";
 import { ENTITY_URI_SCHEMES } from "../src/entity-kind.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { reportResumeSeedOutcome } from "../src/builtins/map.ts";
 import { Runtime } from "../src/runtime.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import {
@@ -1213,5 +1215,31 @@ describe("list builtin resume container defer", () => {
       (rc) => rc.key("doubled").getAsQueryResult() ?? [],
       [2, 4, 6],
     );
+  });
+
+  // The seed above edits live storage, so whether its edit fails is a property
+  // of the run: the reporting arm is reached only when the edit loses a commit
+  // race, which leaves its coverage to chance and the ratchet reading a
+  // regression on pull requests that touched nothing near it. The report takes
+  // the outcome as a parameter for that reason, so both arms are driveable
+  // here without a race to arrange.
+  describe("reporting the seed's outcome", () => {
+    const seedWarnCount = (): number => {
+      const counts = getLoggerCountsBreakdown()["runner.map"] ?? {};
+      return (counts as Record<string, { warn?: number }>)["resume-seed"]
+        ?.warn ?? 0;
+    };
+
+    it("warns when the seed edit failed", () => {
+      const before = seedWarnCount();
+      reportResumeSeedOutcome(new Error("commit lost the race"));
+      expect(seedWarnCount()).toBe(before + 1);
+    });
+
+    it("stays silent when the seed edit succeeded", () => {
+      const before = seedWarnCount();
+      reportResumeSeedOutcome(undefined);
+      expect(seedWarnCount()).toBe(before);
+    });
   });
 });


### PR DESCRIPTION
## Why

`packages/runner/src/builtins/map.ts` lines 341-346 are covered on some CI runs
and not on others, so the coverage ratchet reads a `packages/runner` regression
on pull requests that touch nothing near them. #6106 is the current one, and the
gate names the lines itself:

> Regression not attributable to this PR's added lines: 5 line(s) across 1
> unchanged file(s) that the baseline run covered.
> - `packages/runner/src/builtins/map.ts`: 341, 342, 343, 344, 346

Those lines are the warn arm of the resume seed:

```ts
}).then(({ error }) => {
  if (error) {
    logger.warn(
      "resume-seed",
      "seeding the empty result container failed",
      { error },
    );
  }
});
```

The seed edits live storage through `editWithRetry`, so whether that arm runs
depends on whether the edit lost a commit race. Nothing about the code decides
it — which is the case `docs/development/COVERAGE.md` describes under "Coverage
must not depend on the execution environment", and which it says to fix with a
test rather than absorb with an override.

## What changed

The report takes the outcome as a parameter and is called on every seed, rather
than the call site testing `error` and the report living inside the branch:

```ts
}).then(({ error }) => reportResumeSeedOutcome(error));
```

That is the shape the document prescribes, and the one `maybeReportSlowTraverse`
already uses for the wall-clock instance it works through. Both arms are then
driveable from a test that hands one an error directly, with no race to arrange.
Behavior is unchanged: same channel (`runner.map`), same label, same message,
same truthiness check.

## Test plan

Two cases in `list-resume-container-defer.test.ts` — the file that already owns
this defer path — one per arm, asserting against the logger's own counts.

Measured on its own, per the gate's instruction rather than by re-running the
suite until it looks settled:

```
rm -rf coverage/raw/line-check
DENO_COVERAGE_DIR=… deno test … test/list-resume-container-defer.test.ts
deno coverage --lcov coverage/raw/line-check
```

```
DA:76,1  DA:77,4  DA:78,1  DA:79,1  DA:80,1  DA:81,1  DA:83,4
```

Every line of `reportResumeSeedOutcome` is hit by that test file alone. (Line 82
is `);`, which is not instrumented — the same reason the original report listed
341-344 and 346 but not 345.)

- `packages/runner` full suite: **1246 passed / 0 failed**
- `deno fmt --check`, `deno lint`, `deno task check`, `check-docs`,
  `check-no-waitfor`, `check-conflict-markers`: clean

No `ACCEPT_COVERAGE_DEBT` anywhere: the point is to make the gate mean something
on the next PR that lands near this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

