### PR TITLE
fix(piece): ignore the writer claim file spelling in the compat gate

### DIFF
--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -646,12 +646,16 @@ Mechanics:
   `normalizeWriterIdentityFile`). The transformer also handles the direct-root
   `toSchema<WriteAuthorizedBy<T, typeof b>>` form specially so the wrapper's
   value schema remains the root while the same identity marker is attached.
-  The content-addressed identity (`moduleIdentity`, and the legacy `bundleId`)
-  is update-volatile in the piece compat checker: it rehashes on any edit to
-  the authoring module, so `assertPatternSchemasBackwardCompatible` normalizes
-  it out of the `ifc` comparison and compares only the binding `file`/`path`
-  and the `uiContract`. The runner still verifies the live writer's
-  `moduleIdentity` against the claim at write time, so this narrows nothing.
+  The writer identity is update-volatile in the piece compat checker in two
+  ways, and `assertPatternSchemasBackwardCompatible` normalizes both out of the
+  `ifc` comparison. The content-addressed hash (`moduleIdentity`, and the
+  legacy `bundleId`) rehashes on any edit to the authoring module. The
+  source-file spelling (`file`) changes with the resolver that compiled the
+  module (labs#4772), and the runner's write-time authorization ignores it: it
+  anchors on `moduleIdentity` plus the binding `path`. So the comparison holds
+  only the binding `path` and the `uiContract` fixed, and the runner still
+  verifies the live writer's `moduleIdentity` against the claim at write time,
+  so this narrows nothing.
 - `SchemaGeneratorTransformer.resolvePolicyOfMarkers` replaces a valid policy
   marker with the compiled module identity, exported symbol, and policy digest.
   If it cannot match a compiler-verified exported `exchangeRules()` binding,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -154,48 +154,67 @@ const fabricAwareEqual = (left: unknown, right: unknown): boolean => {
 
 /**
  * The keys inside a `writeAuthorizedBy` writer claim's `__ctWriterIdentityOf`
- * that record the content hash of the authoring module rather than the
- * authorization's consumer-facing contract.
+ * that a backward-compatibility comparison ignores, because the runtime's
+ * write-time authorization does not hold them fixed either.
+ *
+ * `moduleIdentity` (and the legacy `bundleId`) is the content hash of the
+ * authoring module. It rehashes on any edit to that module, and the runtime
+ * re-verifies the live writer's `moduleIdentity` against the claim at write
+ * time (`writeAuthorizedByReason`, `packages/runner/src/cfc/prepare.ts`), so the
+ * comparison defers it to that live check rather than reading a recompile as a
+ * contract change.
+ *
+ * `file` is the module's source-file spelling, and that spelling is
+ * resolver-dependent: the same module spells differently across piece-deploy
+ * staging, piece-manifest-relative, and HTTP-resolved compiles
+ * (`packages/runner/src/cfc/writer-claim-correspondence.ts`, labs#4772). The
+ * runtime authorization ignores `file` entirely — it anchors on `moduleIdentity`
+ * plus the binding `path` — so two claims that differ only in `file` authorize
+ * identically, and the comparison must not reject one as the other's
+ * incompatible successor.
  */
-const WRITER_IDENTITY_HASH_KEYS: ReadonlySet<string> = new Set([
+const WRITER_IDENTITY_VOLATILE_KEYS: ReadonlySet<string> = new Set([
   "bundleId",
+  "file",
   "moduleIdentity",
 ]);
 
 /**
- * Return an `ifc` extension with the content-addressed identity of a
- * `writeAuthorizedBy` writer claim removed, so a recompile of the authorizing
- * module does not read as a contract change in the semantic-extension
- * comparison below.
+ * Return an `ifc` extension with the volatile identity of a `writeAuthorizedBy`
+ * writer claim removed, so that neither a recompile of the authorizing module
+ * nor a cross-resolver rebuild of the same module reads as a contract change in
+ * the semantic-extension comparison below.
  *
  * A CFC write authorization (`TrustedActionWrite`) lowers to
- * `ifc.writeAuthorizedBy.__ctWriterIdentityOf`, whose `moduleIdentity` (and the
- * legacy `bundleId`) is the content hash of the module that defines the
- * authorizing handler. When that handler lives in the pattern's own module —
- * the common case — any edit to the pattern rehashes the module, so
- * `moduleIdentity` changes while the binding `file` and `path` and the sibling
- * `uiContract` stay identical. That is the same authorization recompiled, not a
- * narrowed contract. The runtime still re-verifies the live writer's
- * `moduleIdentity` against the claim at write time (`writeAuthorizedByReason`,
- * `packages/runner/src/cfc/prepare.ts`), so dropping it here only stops the
- * schema diff from reading "the code was edited" as "the contract changed"; it
- * does not weaken that enforcement.
+ * `ifc.writeAuthorizedBy.__ctWriterIdentityOf`, which records the authoring
+ * module three ways: its content hash (`moduleIdentity`, and the legacy
+ * `bundleId`), its source-file spelling (`file`), and the binding `path` within
+ * the module. The runtime's write-time authorization anchors on `moduleIdentity`
+ * plus `path` alone (`writeAuthorizedByReason`,
+ * `packages/runner/src/cfc/prepare.ts`): it re-verifies the live writer's
+ * `moduleIdentity` against the claim and never consults `file`. So both the
+ * content hash and the file spelling are volatile against anything a caller can
+ * depend on — the hash rehashes on any edit to the module, and the file spelling
+ * changes with the resolver that compiled it (labs#4772). Removing both here
+ * stops the schema diff from reading "the code was edited" or "a different
+ * resolver compiled it" as "the contract changed"; it weakens no enforcement,
+ * because the runtime holds neither field fixed.
  *
  * Everything a caller can depend on is kept and still compared: the binding
- * `file` and `path` — a handler moving files or being renamed is a real change
- * — and the entire `uiContract` (helper/action/surface/role/kind/
- * trustedPattern/requiredEventIntegrity). The builtin `readonly string[]` form
- * of `writeAuthorizedBy` names trusted builtins rather than a compiled module,
- * so it carries no content hash and is returned unchanged.
+ * `path` — the coordinate the runtime authorizes against — and the entire
+ * `uiContract` (helper/action/surface/role/kind/trustedPattern/
+ * requiredEventIntegrity). The builtin `readonly string[]` form of
+ * `writeAuthorizedBy` names trusted builtins rather than a compiled module, so
+ * it carries no writer identity and is returned unchanged.
  *
  * This runs where the `ifc` extension is compared as a semantic-extension key,
  * which the per-node recursion reaches for a claim placed directly on a
  * property, behind a `$defs` reference, or in an `anyOf` branch. A claim
  * reached only through a composite keyword (`allOf`, `oneOf`, `if`/`then`,
- * `not`) is compared by whole-value equality instead, so its content hash still
- * participates and a recompile there is reported as a change.
+ * `not`) is compared by whole-value equality instead, so its volatile identity
+ * still participates and a recompile there is reported as a change.
  */
-const ifcWithoutWriterContentHash = (ifc: unknown): unknown => {
+const ifcWithoutVolatileWriterIdentity = (ifc: unknown): unknown => {
   if (typeof ifc !== "object" || ifc === null) return ifc;
   const claim = (ifc as Record<string, unknown>).writeAuthorizedBy;
   if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
@@ -205,7 +224,7 @@ const ifcWithoutWriterContentHash = (ifc: unknown): unknown => {
   if (typeof identity !== "object" || identity === null) return ifc;
   const strippedIdentity: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(identity)) {
-    if (WRITER_IDENTITY_HASH_KEYS.has(key)) continue;
+    if (WRITER_IDENTITY_VOLATILE_KEYS.has(key)) continue;
     strippedIdentity[key] = value;
   }
   return {
@@ -256,13 +275,18 @@ const ifcWithoutWriterContentHash = (ifc: unknown): unknown => {
  *
  * The semantic-extension keys (`asCell`, `ifc`, `readOnly`, `scope`,
  * `writeOnly`) are compared for exact equality, with one exception: a
- * `writeAuthorizedBy` writer claim's content-addressed module identity
- * (`moduleIdentity`, and the legacy `bundleId`) is treated as update-volatile
- * and normalized out before the `ifc` comparison, because it rehashes on any
- * edit to the authoring module while the authorization it names is unchanged
- * (see `ifcWithoutWriterContentHash`). The binding `file` and `path` and the
- * whole `uiContract` are still compared, and the runtime re-verifies the live
- * writer's identity at write time, so this narrows nothing.
+ * `writeAuthorizedBy` writer claim's volatile identity is normalized out before
+ * the `ifc` comparison. That identity is the content-addressed module hash
+ * (`moduleIdentity`, and the legacy `bundleId`), which rehashes on any edit to
+ * the authoring module, together with the source-file spelling (`file`), which
+ * changes with the resolver that compiled the module. The runtime authorizes a
+ * write on `moduleIdentity` plus the binding `path` and never on `file`, and it
+ * re-verifies the live writer's `moduleIdentity` against the claim at write
+ * time, so holding those fields fixed here would reject a recompile or a
+ * cross-resolver rebuild of an unchanged authorization (see
+ * `ifcWithoutVolatileWriterIdentity`). The binding `path` and the whole
+ * `uiContract` are still compared, and the runtime enforcement is untouched, so
+ * this narrows nothing.
  */
 export function assertPatternSchemasBackwardCompatible(
   previous: Pattern,
@@ -494,14 +518,14 @@ function schemaSubsetIssue(
 
     for (const key of SEMANTIC_EXTENSION_KEYS) {
       // The `ifc` extension is compared for exact equality except for a
-      // `writeAuthorizedBy` writer claim's content-addressed module identity,
-      // which is volatile across a recompile of the same authorization (see
-      // ifcWithoutWriterContentHash).
+      // `writeAuthorizedBy` writer claim's volatile identity — its content hash
+      // and its resolver-dependent file spelling — which the runtime does not
+      // hold fixed either (see ifcWithoutVolatileWriterIdentity).
       const sourceValue = key === "ifc"
-        ? ifcWithoutWriterContentHash(source[key])
+        ? ifcWithoutVolatileWriterIdentity(source[key])
         : source[key];
       const targetValue = key === "ifc"
-        ? ifcWithoutWriterContentHash(target[key])
+        ? ifcWithoutVolatileWriterIdentity(target[key])
         : target[key];
       if (!fabricAwareEqual(sourceValue, targetValue)) {
         return `${path}: ${key} changed`;

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -83,11 +83,12 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
-  // The identity fields excluded from the comparison are only the content
-  // hashes. The rest of the writer claim and the whole uiContract still name
-  // the real consumer-facing contract, so a change to any of them must still be
-  // rejected. These build two result schemas that differ in exactly one such
-  // field and assert the update is refused.
+  // The identity fields excluded from the comparison are the content hashes
+  // (moduleIdentity/bundleId) and the resolver-dependent file spelling. The
+  // binding path and the whole uiContract still name the real consumer-facing
+  // contract, so a change to either of them must still be rejected. These build
+  // two result schemas that differ in exactly one such field and assert the
+  // update is refused.
   const trustedWriteResult = (
     identity: Record<string, unknown>,
     uiContract: Record<string, unknown>,
@@ -130,7 +131,31 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
-  it("still rejects a writeAuthorizedBy binding file change", () => {
+  // A writer claim's `file` is the module's source-file spelling, and that
+  // spelling is resolver-dependent: the same module compiles to a different
+  // `file` under piece-deploy staging, a piece manifest, and HTTP resolution,
+  // while its content-addressed `moduleIdentity` agrees everywhere (labs#4772).
+  // The runtime authorizes a write on `moduleIdentity` plus the binding `path`
+  // and never on `file`, so a cross-resolver recompile that re-spells only the
+  // `file` — same `moduleIdentity`, same `path`, same `uiContract` — is the same
+  // authorization, and the update is accepted.
+  it("accepts a cross-resolver recompile that only re-spells the writeAuthorizedBy file", () => {
+    const respelled = (file: string): JSONSchema =>
+      trustedWriteResult({ ...baselineIdentity, file }, baselineUiContract);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, respelled("/api/patterns/demo/main.tsx")),
+        pattern({ type: "object" }, respelled("/patterns/demo/main.tsx")),
+      )
+    ).not.toThrow();
+  });
+
+  // `file` carries no authorization signal beyond the content-addressed
+  // `moduleIdentity` (which the runtime re-verifies live) and the binding
+  // `path`, so it is normalized out of the comparison entirely rather than made
+  // spelling-tolerant. Any `file` change is accepted while the `path` and
+  // `uiContract` are unchanged.
+  it("accepts a writeAuthorizedBy binding file change", () => {
     expect(() =>
       assertPatternSchemasBackwardCompatible(
         pattern(
@@ -145,7 +170,7 @@ describe("piece schema compatibility", () => {
           ),
         ),
       )
-    ).toThrow(/flag: ifc changed/);
+    ).not.toThrow();
   });
 
   it("still rejects a writeAuthorizedBy binding path change", () => {

--- a/packages/piece/test/setsrc-writer-file-spelling.test.ts
+++ b/packages/piece/test/setsrc-writer-file-spelling.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import {
+  getPatternIdentityRef,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("setsrc writer file spelling");
+
+const PATTERN_SOURCE = [
+  "import { handler, NAME, pattern, Writable, WriteAuthorizedBy } from 'commonfabric';",
+  "",
+  "const returnMembership = handler<void, { value: Writable<string> }>((_, { value }) => {",
+  "  value.set('Returned loyalty number to hotel@example.com');",
+  "});",
+  "",
+  "interface DemoOutput {",
+  "  [NAME]: string;",
+  "  membershipReturn: WriteAuthorizedBy<string, typeof returnMembership>;",
+  "}",
+  "",
+  "export default pattern<Record<string, never>, DemoOutput>(() => {",
+  "  const membershipReturn = new Writable('');",
+  "  returnMembership({ value: membershipReturn });",
+  "  return { [NAME]: 'Loyalty Return Demo', membershipReturn };",
+  "});",
+  "",
+].join("\n");
+
+// The same pattern content addressed by a chosen source-file name. Only the
+// filename differs between revisions; the handler and its binding path do not.
+function writerAuthorizedProgram(fileName: string): RuntimeProgram {
+  return {
+    main: fileName,
+    files: [{ name: fileName, contents: PATTERN_SOURCE }],
+  };
+}
+
+// End-to-end counterpart to the writer-claim cases in
+// `schema-compatibility.test.ts`, exercised through the real `cf piece setsrc`
+// boundary (`piece.setPattern`) rather than the compatibility helper alone.
+//
+// A field typed `WriteAuthorizedBy` lowers to a writer claim that records the
+// authoring module three ways: its content hash (`moduleIdentity`), its
+// source-file spelling (`file`), and the binding `path` within the module. The
+// runtime authorizes a write on `moduleIdentity` plus the binding `path` and
+// never consults `file`. Relocating the pattern to a new source file, with the
+// handler and its binding path unchanged, re-spells `file` (and, because the
+// hash covers the module's name, re-hashes `moduleIdentity`), while the
+// backward-compatibility gate ignores both of those and holds the `path` and
+// `uiContract` fixed. So the update carries the same authorization and is
+// accepted, and the settled piece points at the relocated pattern.
+describe("setsrc over a writer-authorized field's source-file spelling", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let pieces: PiecesController;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    pieces = new PiecesController(
+      await createSession({
+        identity: signer,
+        spaceName: `setsrc-writer-file-spelling-${crypto.randomUUID()}`,
+      }),
+      runtime,
+    );
+    await pieces.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("accepts an update that only relocates the writer-authorized pattern's source file", async () => {
+    const piece = await pieces.create(
+      writerAuthorizedProgram("/loyalty-return.tsx"),
+      { input: {} },
+    );
+    await runtime.idle();
+    const before = getPatternIdentityRef(piece.getCell());
+
+    // Byte-identical content under a different source-file name. Before the
+    // compat gate stopped comparing the writer claim's `file`, this swap was
+    // refused as `result.membershipReturn: ifc changed`, so the await below
+    // would reject and fail the test.
+    await piece.setPattern(writerAuthorizedProgram("/handlers/membership.tsx"));
+    await runtime.idle();
+
+    expect(
+      getPatternIdentityRef(piece.getCell())?.identity,
+      "the pattern pointer did not move, so the relocation was refused",
+    ).not.toBe(before?.identity);
+  });
+});


### PR DESCRIPTION
A CFC write authorization lowers to an
ifc.writeAuthorizedBy.__ctWriterIdentityOf claim that records the authoring module three ways: its content hash (moduleIdentity, and the legacy bundleId), its source-file spelling (file), and the binding path within the module. The backward-compatibility gate, assertPatternSchemasBackwardCompatible, already normalized the content hash out of its ifc comparison, because that hash rehashes on any edit to the module and the runtime re-verifies it live at write time. It still compared the file spelling exactly.

That over-rejects a cross-resolver recompile of the same module. The file spelling is resolver-dependent: the same module spells differently across piece-deploy staging, a piece manifest, and HTTP resolution, while its content-addressed moduleIdentity agrees everywhere (labs#4772 / CT-1886). The runtime's write-time authorization (writeAuthorizedByReason in packages/runner/src/cfc/prepare.ts) anchors on moduleIdentity plus the binding path and never consults file. So two claims that differ only in file authorize identically, yet the gate reported the update as "ifc changed" and refused it. The rejection was fail-closed and safe, but it blocked a legitimate roll-forward of an unchanged authorization.

Normalize the file spelling out of the ifc writer-claim comparison the same way the content hash already is, rather than making it merely spelling-tolerant. The file carries no authorization signal beyond moduleIdentity (re-verified live) and the binding path (still compared), so dropping it aligns the gate with exactly what the runtime enforces and weakens no enforcement. The binding path and the whole uiContract are still compared, so a genuine binding-path or contract change is still refused.

Rename the helper and its key set to reflect that both the content hash and the file spelling are volatile against the compared contract. Invert the test that pinned the old file-rejection behavior, add a unit regression test for the motivating cross-resolver recompile, and update the schema-generator mapping spec to match.

Add an end-to-end regression test that drives the real cf piece setsrc boundary (piece.setPattern) rather than the compatibility helper alone. It installs a piece with a writer-authorized field, then updates it with byte-identical pattern content relocated to a different source file, with the handler and its binding path unchanged, and confirms the update is accepted and the settled piece points at the relocated pattern. Run against the revision before the file spelling was dropped, the same relocation is refused as "ifc changed", so the guard is not vacuous.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

