### PR TITLE
fix(utils): a log-count snapshot is inert data

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -860,15 +860,8 @@ export class Logger {
    * filters out the message.
    */
   get counts(): LogCounts {
-    return {
-      debug: this.#counts.debug,
-      info: this.#counts.info,
-      warn: this.#counts.warn,
-      error: this.#counts.error,
-      get total(): number {
-        return this.debug + this.info + this.warn + this.error;
-      },
-    };
+    const { debug, info, warn, error } = this.#counts;
+    return { debug, info, warn, error, total: debug + info + warn + error };
   }
 
   /**
@@ -878,14 +871,13 @@ export class Logger {
   get countsByKey(): Record<string, LogCounts> {
     const result: Record<string, LogCounts> = {};
     for (const [key, counts] of Object.entries(this.#countsByKey)) {
+      const { debug, info, warn, error } = counts;
       result[key] = {
-        debug: counts.debug,
-        info: counts.info,
-        warn: counts.warn,
-        error: counts.error,
-        get total(): number {
-          return this.debug + this.info + this.warn + this.error;
-        },
+        debug,
+        info,
+        warn,
+        error,
+        total: debug + info + warn + error,
       };
     }
     return result;

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -630,6 +630,21 @@ describe("logger", () => {
       expect(logger.counts.total).toBe(0);
     });
 
+    it("reports `total` as a data property", () => {
+      const logger = getLogger("count-inert-test");
+      captureConsole("log", () => logger.info("test-key", "test"));
+
+      // A caller may carry the snapshot across a realm boundary, and an
+      // accessor is live code rather than the inert data such a crossing
+      // takes.
+      expect(Object.getOwnPropertyDescriptor(logger.counts, "total")).toEqual({
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    });
+
     it("increments the count for the level logged at", () => {
       const logger = getLogger("count-test");
       logger.level = "debug"; // Enable all levels
@@ -1265,6 +1280,24 @@ describe("logger", () => {
 
       expect(byKey["data-fetch"]!.info).toBe(1);
       expect(byKey["data-fetch"]!.total).toBe(1);
+    });
+
+    it("reports each key's `total` as a data property", () => {
+      const logger = getLogger("key-inert-test");
+
+      captureConsole("log", () => {
+        logger.info("key-1", "Message 1");
+        logger.info("key-1", "Message 2");
+      });
+
+      expect(
+        Object.getOwnPropertyDescriptor(logger.countsByKey["key-1"]!, "total"),
+      ).toEqual({
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     });
 
     it("keeps one key's count clear of another's", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`Logger.counts` and `Logger.countsByKey` each build a fresh snapshot object and
then hang `get total()` on it. An accessor is live code rather than data, so the
snapshot — and the whole `getLoggerCountsBreakdown()` tree above it — is not a
`FabricValue`.

That matters wherever one crosses a realm boundary. Measured on the branch point:

```
TYPE:  LoggerCountsResponse.counts satisfies FabricValue: yes
VALUE: isValidFabricValue(getLoggerCountsBreakdown()): false
VALUE: `total` descriptor kind: accessor
```

So `runtime-client`'s protocol declares that arm as satisfying `FabricValue`
while the value it carries does not. It reaches the far side intact only because
structured cloning reads an accessor and writes data in its place. This makes the
declaration true.

## The change

```diff
-      get total(): number { return this.debug + this.info + this.warn + this.error; },
+      total: debug + info + warn + error,
```

**The totals are unchanged by construction.** Each getter read the snapshot's
own already-fixed fields, on a freshly built object nothing mutates, so it could
only ever return the sum as of when the snapshot was built.

Nothing in the tree depends on the accessor. Every consumer —
`toolshed/routes/health` (which JSON-serializes it, and `JSON.stringify` reads a
getter anyway), `cli/lib/test-runner.ts`, `cli/lib/console-capture.ts`,
`runtime-client`'s `getLoggerCounts` — reads the value once from a snapshot it
did not keep.

## Tests

Two new cases pin the property directly rather than through a consumer, one in
`call counting` for `counts` and one in `countsByKey` for each key's snapshot.
Each asserts the whole property descriptor, so an accessor cannot satisfy it.

**Control:** with the accessor restored, both new tests fail and no others do.

Green: `packages/utils` 99 passed / 685 steps; repo-wide `deno task check`,
`deno fmt --check`, `deno lint`. The full workspace suite passed with this exact
`logger.ts` on a branch that also carried a `codec-realm` change
(`All tests passing!`, 329.8s); it is re-running on this branch alone.

## Why it is its own change

A follow-up converts the multi-runtime pattern-test harness to carry
`codec-realm`-encoded values across its worker boundary. Its `loggerCounts`
command is where this surfaced: validating the breakdown instead of casting it
made the refusal visible, and nothing that runs today calls that command, so no
suite reported it. This fix stands on its own and is not that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqQztQSGSVg5WQpjfHmP7z


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

