### PR TITLE
test(deno-web-test): guard the transcript, and name a killing signal

### DIFF
--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -1,5 +1,28 @@
-import { assertEquals } from "@std/assert";
-import { runDenoWebTest, sanitizeDenoWebTestOutput } from "./utils.ts";
+import {
+  assertEquals,
+  AssertionError,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
+import {
+  HarnessRun,
+  runDenoWebTest,
+  sanitizeDenoWebTestOutput,
+} from "./utils.ts";
+
+// A run built from a stated `Deno.CommandOutput` rather than from a subprocess,
+// so a transcript can be read for an ending no real run in this suite reaches.
+function harnessRun(output: Partial<Deno.CommandOutput>): HarnessRun {
+  const encoder = new TextEncoder();
+  return new HarnessRun("some-project", {
+    code: 1,
+    success: false,
+    signal: null,
+    stdout: encoder.encode("error: Could not load add.test.ts\n"),
+    stderr: encoder.encode("Task test deno run cli.ts *.test.ts\n"),
+    ...output,
+  });
+}
 
 Deno.test("smoke test", async function () {
   const run = await runDenoWebTest("success-project");
@@ -21,6 +44,38 @@ Deno.test("smoke test", async function () {
     run.stderrText.split("\n")[1] === "",
     "stderr has no other messages",
   );
+});
+
+// A harness run can fail for a reason no assertion in this suite anticipates:
+// the browser refuses to boot, a bundle fails, the process is killed. Each of
+// those says what happened on one of the run's two streams, and an assertion
+// that reported only its own words left the reason nowhere.
+Deno.test("a failed assertion carries the whole run", function () {
+  const run = harnessRun({});
+  const error = assertThrows(
+    () => run.assert(run.success, "test successful"),
+    AssertionError,
+  );
+
+  assertStringIncludes(error.message, "test successful");
+  assertStringIncludes(error.message, "some-project");
+  assertStringIncludes(error.message, "code 1");
+  assertStringIncludes(error.message, "Could not load add.test.ts");
+  assertStringIncludes(error.message, "Task test deno run cli.ts *.test.ts");
+});
+
+Deno.test("an assertion that holds says nothing", function () {
+  harnessRun({}).assert(true, "test successful");
+});
+
+// The exit code of a killed process is 128 plus the signal number, which reads
+// as an ordinary exit to anyone not counting. The signal is what says the run
+// was killed rather than that it decided to stop.
+Deno.test("a run the kernel killed names the signal", function () {
+  const transcript = harnessRun({ code: 137, signal: "SIGKILL" }).transcript();
+
+  assertStringIncludes(transcript, "SIGKILL");
+  assertStringIncludes(transcript, "137");
 });
 
 Deno.test("dependency downloads before the harness boundary are removed", function () {

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -10,9 +10,10 @@ import {
   sanitizeDenoWebTestOutput,
 } from "./utils.ts";
 
-// A run built from a stated `Deno.CommandOutput` rather than from a subprocess,
-// so a transcript can be read for an ending no real run in this suite reaches.
-function harnessRun(output: Partial<Deno.CommandOutput>): HarnessRun {
+// A run built from output written out here rather than from a subprocess. It
+// takes no process to make, and it can carry an ending no real run in this
+// suite reaches.
+function runWith(output: Partial<Deno.CommandOutput> = {}): HarnessRun {
   const encoder = new TextEncoder();
   return new HarnessRun("some-project", {
     code: 1,
@@ -51,7 +52,7 @@ Deno.test("smoke test", async function () {
 // those says what happened on one of the run's two streams, and an assertion
 // that reported only its own words left the reason nowhere.
 Deno.test("a failed assertion carries the whole run", function () {
-  const run = harnessRun({});
+  const run = runWith();
   const error = assertThrows(
     () => run.assert(run.success, "test successful"),
     AssertionError,
@@ -65,14 +66,13 @@ Deno.test("a failed assertion carries the whole run", function () {
 });
 
 Deno.test("an assertion that holds says nothing", function () {
-  harnessRun({}).assert(true, "test successful");
+  runWith().assert(true, "test successful");
 });
 
-// The exit code of a killed process is 128 plus the signal number, which reads
-// as an ordinary exit to anyone not counting. The signal is what says the run
-// was killed rather than that it decided to stop.
+// No real run in this suite is killed by a signal, so this states one. The
+// transcript names the signal rather than only the exit code it comes with.
 Deno.test("a run the kernel killed names the signal", function () {
-  const transcript = harnessRun({ code: 137, signal: "SIGKILL" }).transcript();
+  const transcript = runWith({ code: 137, signal: "SIGKILL" }).transcript();
 
   assertStringIncludes(transcript, "SIGKILL");
   assertStringIncludes(transcript, "137");

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -130,6 +130,7 @@ export class HarnessRun {
   readonly projectDir: string;
   readonly success: boolean;
   readonly code: number;
+  readonly signal: Deno.Signal | null;
   readonly stdout: Uint8Array;
   readonly stderr: Uint8Array;
   readonly stdoutText: string;
@@ -139,6 +140,7 @@ export class HarnessRun {
     this.projectDir = projectDir;
     this.success = output.success;
     this.code = output.code;
+    this.signal = output.signal;
     this.stdout = output.stdout;
     this.stderr = output.stderr;
     this.stdoutText = decode(output.stdout);
@@ -156,8 +158,13 @@ export class HarnessRun {
   }
 
   transcript(): string {
+    // A run the kernel killed reports the signal alongside the code, which is
+    // 128 plus the signal number and reads as an ordinary exit on its own.
+    const ending = this.signal === null
+      ? `exited with code ${this.code}`
+      : `was killed by ${this.signal}, exiting with code ${this.code}`;
     return [
-      `deno-web-test in ${this.projectDir} exited with code ${this.code}.`,
+      `deno-web-test in ${this.projectDir} ${ending}.`,
       "--- stdout ---",
       this.stdoutText,
       "--- stderr ---",

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -158,8 +158,8 @@ export class HarnessRun {
   }
 
   transcript(): string {
-    // A run the kernel killed reports the signal alongside the code, which is
-    // 128 plus the signal number and reads as an ordinary exit on its own.
+    // The exit code of a run the kernel killed is 128 plus the signal number.
+    // That reads as an ordinary exit. The ending names the signal as well.
     const ending = this.signal === null
       ? `exited with code ${this.code}`
       : `was killed by ${this.signal}, exiting with code ${this.code}`;


### PR DESCRIPTION
The transcript this package prints when an assertion about a harness run fails
— the project, the exit status, and both streams — landed in #6125 while this
branch was in review, arriving alongside the config-import fix rather than from
here. What is left is what that change did not carry.

Nothing guarded the behavior. Reducing `HarnessRun.assert` to
`throw new AssertionError(message)` leaves every test in the package passing, so
the next simplification would quietly take the transcript back out, and a
harness failure nobody wrote an assertion for would again report only the
assertion's own words. Three tests now cover it, built from a stated
`Deno.CommandOutput` rather than a subprocess: a failed assertion keeps the
caller's words and adds the project, the exit status and both streams; an
assertion that holds throws nothing; and a killed run names its signal. They run
in well under a millisecond and launch nothing.

The last of those is also a fix. A process the kernel kills exits with 128 plus
the signal number, so a run killed by SIGKILL reported `exited with code 137`,
which reads as an ordinary exit to anyone not counting — and that is exactly the
transcript a run killed for exhausting the machine's memory would leave.
`HarnessRun` now keeps `signal`, and the transcript names it.

The CI failure that started this work is still unattributed: three subprocess
runs died well below any healthy duration, and the assertions reported only
their own words, so the evidence was destroyed rather than missing. This branch
and #6125 together mean the next occurrence says what happened.

deflaked by Hixie's agent (Claude Opus 5)