### PR TITLE
fix(runner): settle on the list builtins' resume container seed

### DIFF
--- a/packages/runner/src/builtins/list-result-container-seed.ts
+++ b/packages/runner/src/builtins/list-result-container-seed.ts
@@ -35,6 +35,16 @@ import type { Runtime } from "../runtime.ts";
  * leaves the container as absent as a resolved one does. A rejected pull and a
  * failed seed are each reported through `logger`. The returned promise resolves
  * once the pull and the seed have both settled, and rejects for neither.
+ *
+ * The chain is registered with the storage manager's settle barrier, so
+ * `Cell.pull()` and `storageManager.synced()` hold until the seed's write has
+ * settled. The pull reaches that barrier through the replica's own sync
+ * bookkeeping, and this registration carries the wait across the span between
+ * the pull settling and the seed's commit being issued.
+ * `Runtime.dispose({ closeStorage: false })` drains the runtime through
+ * `settled(Infinity)` before it tears anything down, so the store a reader is
+ * handed afterwards carries whatever the seed wrote. A caller does not register
+ * the returned promise; this function registers the chain.
  */
 export function seedResultContainerWhenPullSettles(
   runtime: Runtime,
@@ -59,7 +69,12 @@ export function seedResultContainerWhenPullSettles(
       }
     });
   };
-  return pull.finally(seedIfStillAbsent).then(() => {}, (error: unknown) => {
-    logger.warn("resume-pull", "resume container pull rejected", { error });
-  });
+  const settled = pull.finally(seedIfStillAbsent).then(
+    () => {},
+    (error: unknown) => {
+      logger.warn("resume-pull", "resume container pull rejected", { error });
+    },
+  );
+  runtime.storageManager.trackUntilSettled(settled);
+  return settled;
 }

--- a/packages/runner/test/list-result-container-seed.test.ts
+++ b/packages/runner/test/list-result-container-seed.test.ts
@@ -133,6 +133,33 @@ describe("list-result-container-seed", () => {
       expect(logger.warnings).toEqual([]);
     });
 
+    it("counts against the storage settle barrier until the seed has landed", async () => {
+      const container = newContainer("barrier-held-until-seeded");
+      const pull = Promise.withResolvers<void>();
+      const seeded = seedResultContainerWhenPullSettles(
+        runtime,
+        container,
+        () => true,
+        pull.promise,
+        logger,
+      );
+      // The cross-space promise set is what `Cell.pull()`,
+      // `storageManager.synced()` and the `settled(Infinity)` drain in
+      // `Runtime.dispose({ closeStorage: false })` consult, so membership in it
+      // is what places the seed's write inside each of those barriers. The
+      // coordinator drops the returned promise, so this registration is the
+      // only thing holding the chain.
+      expect(storageManager.pendingCrossSpacePromiseCount()).toBe(1);
+      pull.resolve();
+      await storageManager.synced();
+      // Out of the set once the chain settles, and the container carries the
+      // seed the chain wrote.
+      expect(storageManager.pendingCrossSpacePromiseCount()).toBe(0);
+      expect(valueOf(container)).toEqual([]);
+      await seeded;
+      expect(logger.warnings).toEqual([]);
+    });
+
     it("leaves a container that arrived during the pull at the value it arrived with", async () => {
       const container = newContainer("arrived-during-pull");
       const pull = Promise.withResolvers<void>();


### PR DESCRIPTION
The three list coordinators — map, filter and flatMap — each run two asynchronous recovery paths after a resume reconcile defers, and the two disagreed about whether the storage manager's settle barrier knows about them. `awaitInputThenSettle` wraps its whole chain in `trackUntilSettled`, and so does the resume republisher beside it. The empty-container seed did not: all three coordinators called `seedResultContainerWhenPullSettles` and dropped the promise it returns, so nothing held the chain.

The seed is the recovery for a result container that was never persisted. The reconcile reads the container as undefined, pulls it, and defers. When the pull settles with the container still undefined there is no arrival left to re-trigger the reconcile, so the seed writes the empty array a fresh coordinator would have written and the reconcile runs again on that. This is the kind of work the barrier exists for: it starts inside a scheduler action, outlives it, and `idle()` does not wait for it.

Leaving it unregistered left one span uncovered rather than the whole chain. The pull is already inside the barrier on its own, because a replica records every pull in the set its `synced()` awaits. What fell outside was the stretch from the pull settling to the seed's commit being issued, and a barrier consulted during that stretch answers from the pull alone. `Runtime.dispose({ closeStorage: false })` is where that matters. It drains the runtime through `settled(Infinity)` before teardown precisely so a caller who keeps the store can read the state this runtime reached, and the teardown right after clears the coordinator's hold on the container, so a seed still owed at that moment writes nothing and the container stays absent for the reader that option exists to serve.

The registration goes inside `seedResultContainerWhenPullSettles` rather than at the three call sites, which is where `awaitInputThenSettle` and the resume republisher put theirs. The function still returns the settled promise, which never rejects, and its JSDoc now says a caller does not register it.

This adds no new way for teardown to wedge. The pull half already sat inside `synced()`, and the write half is an `editWithRetry` with a bounded retry count whose commit that same barrier already awaits once it is issued — the composition `awaitInputThenSettle` has carried all along.

The new case in `list-result-container-seed.test.ts` pins the registration rather than a timing: the chain counts against the manager's cross-space promise set while it is in flight and is gone from that set once the seed has landed. `Cell.pull()`, `synced()` and the dispose drain all consult that set, so membership is the fact worth asserting, and the case reads a count of zero against the previous code.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

