### PR TITLE
feat: a data file resolves against the module that reads it

### DIFF
--- a/.claude/agents/pattern-user.md
+++ b/.claude/agents/pattern-user.md
@@ -63,11 +63,13 @@ CF_API_URL=<url> deno task cf call --piece <piece_id> --identity <key_path> <han
 same test flags on every `setsrc`, because each update defines the complete
 source package for that revision.
 
-Repeatable `--datafile <path>` attaches a file that is not code — a fixture or
-lookup table the pattern is deployed with. Its bytes are stored verbatim and
-never parsed, compiled, or importable; the pattern reads one with
-`dataFile(path)` from `commonfabric`. The complete-revision rule covers it
-too: repeat every data-file flag on each `setsrc`.
+A pattern reads a file that is not code — a fixture or lookup table it is
+deployed with — using `dataFile(path)` from `commonfabric`, naming it relative
+to the module that reads it. That call is the declaration, so every command
+that builds the pattern attaches the file. Its bytes are stored verbatim and
+never parsed, compiled, or importable. Repeatable `--datafile <path>` remains
+for a file the source cannot name, and the complete-revision rule covers those:
+repeat every data-file flag on each `setsrc`.
 
 ## Done When
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -104,18 +104,20 @@ test compiles, or it fails at the read. It compiles and type-checks either way,
 so nothing earlier reports the omission.
 
 A file the pattern names in a `dataFile()` call is attached by whichever
-command builds the program, so a test that stores the file under the program
-root at the path the call names needs to say nothing further. A file the source
-cannot name — one read by a computed path — is added where the test builds its
-program: `--datafile` on `cf test`, the `dataFiles` field of a
+command builds the program, so a test whose fixture sits where the call says it
+does needs to say nothing further. The path resolves against the module that
+reads it — `./data/cities.json` is the file beside the pattern — so it names
+the same file whichever root the runner assembles the program with. A file the
+source cannot name — one read by a computed path — is added where the test
+builds its program: `--datafile` on `cf test`, the `dataFiles` field of a
 `generated-patterns` scenario, or `dataFilePaths` on the `resolveLocalProgram`
 call a browser integration test makes. A browser test needs nothing beyond that
 — the data reaches the browser through the space, inside the compiled pattern,
 not from the filesystem. A name with no file behind it fails the build, saying
 which module read it; an unattached file the source could not name shows up as
-`No attached data file "<path>"` when the pattern runs, and the message lists
-what is attached. That one function is the only sanctioned way to build a
-program from local files, and
+`No attached data file "<path>"` when the pattern runs, naming the path the
+read resolved to and what is attached. That one function is the only sanctioned
+way to build a program from local files, and
 `deno task check-local-program` fails a `FileSystemProgramResolver` constructed
 anywhere else — a program assembled by hand carries no data files and says
 nothing about it.

--- a/docs/common/workflows/development.md
+++ b/docs/common/workflows/development.md
@@ -32,14 +32,14 @@ deno task cf piece link ... editor-id/items viewer-id/items
   entry with `cf test`, and repeat `--test` for every entry during deployment.
   Deployment packages and type-checks attached tests but does not run them.
 - A file that is not code travels with the source when the pattern reads it.
-  `dataFile(path)` from `commonfabric` names the path it is stored under, and
-  that call is the declaration: every command that builds the program from
-  local files — `setsrc`, `check`, `test`, `dev` — attaches what the source
-  names, the way it already follows what the source imports. The bytes are
-  stored verbatim, never parsed, compiled, or importable, and come back from
-  `cf piece getsrc` with the rest of the package. A file named this way must
-  be on disk under the program root, or the build refuses and says which
-  module asked for it.
+  `dataFile(path)` from `commonfabric` names the file relative to the module
+  that reads it, the way an import specifier does, and that call is the
+  declaration: every command that builds the program from local files —
+  `setsrc`, `check`, `test`, `dev` — attaches what the source names, the way it
+  already follows what the source imports. The bytes are stored verbatim, never
+  parsed, compiled, or importable, and come back from `cf piece getsrc` with
+  the rest of the package. A file named this way must be on disk where the call
+  resolves to, or the build refuses and says which module asked for it.
 - `--datafile` attaches a file the source cannot name: one read by a computed
   path, or one that ships with a program that does not read it. It is
   repeatable, and it adds to what the source declares rather than replacing

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -231,11 +231,15 @@ run directory.
 A pattern calling `dataFile()` reads a file attached to the program under test.
 The call names the file, and that is the declaration every test path reads:
 `resolveLocalProgram` attaches what the source asks for, so a pattern under
-test behaves the way it does deployed without the test restating anything. A
-file the source cannot name — one read by a computed path — is added where the
-test builds the program: `cf test` takes repeatable `--datafile` paths, a
-`generated-patterns` scenario names them in `dataFiles` grounded by `dataRoot`,
-and a browser integration test passes `dataFilePaths` to `resolveLocalProgram`.
+test behaves the way it does deployed without the test restating anything. The
+path resolves against the module that reads it, so `./data/cities.json` is the
+file beside the pattern under whichever root the test's own runner assembles
+the program with — a test lane rooted at `packages/patterns` and a gate rooted
+at the repository reach the same file. A file the source cannot name — one read
+by a computed path — is added where the test builds the program: `cf test`
+takes repeatable `--datafile` paths, a `generated-patterns` scenario names them
+in `dataFiles` grounded by `dataRoot`, and a browser integration test passes
+`dataFilePaths` to `resolveLocalProgram`.
 
 A browser integration test needs nothing further: the data travels to the
 browser inside the compiled pattern the space holds, so there is no file to
@@ -243,7 +247,8 @@ serve and no browser-side plumbing to arrange.
 
 The attachment is easy to leave out and reports nothing when it is: the pattern
 compiles and type-checks without it, and fails only when it reads, with
-`No attached data file "<path>"` naming what is attached instead. That is why
+`No attached data file "<path>"` — naming the path the read resolved to, and
+what is attached instead. That is why
 `resolveLocalProgram` is the one operation for building a program from local
 files, and why `deno task check-local-program` refuses a
 `FileSystemProgramResolver` built anywhere else.

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -117,9 +117,11 @@ compiled but never executed, such as tests. `dataFiles` names members of `files`
 that are not code at all: they are split out before the pipeline below runs, so
 nothing prefixes, parses, transforms, or compiles them, and they rejoin only at
 the identity and persistence steps. Their bytes are carried on the resulting
-graph, keyed by stored path, and bound into the runtime-module namespaces this
-load registers, so a module's `dataFile` read is a lookup against the same
-closure its code came from. The result is a graph of per-module records.
+graph, keyed by stored path. A module reading one gets its own view of the
+runtime namespaces that expose `dataFile`, whose reader resolves a path against
+that module's own stored name — the way the record compiler resolves an import
+specifier against the importing source — and then looks it up in that closure.
+The result is a graph of per-module records.
 It:
 
 1. Derives a per-load program id and prefixes every file path with it

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -240,11 +240,28 @@ update defines a complete source revision. `set-home --reset` rejects
 `--datafile` because a reset deploys no local source package.
 
 A pattern reads an attached data file with `dataFile(path)` from
-`commonfabric`, naming the path the file is stored under. A data file belongs
-to the package rather than to any one module, so that path is absolute within
-the package and does not resolve relative to the caller — every module in the
-package names a given file the same way, and a sub-pattern reads one as readily
-as the entry does. A path naming no attached data file throws.
+`commonfabric`. The path resolves against the module that reads it, as an
+import specifier resolves against the module that imports it: `words.txt` and
+`./words.txt` both name the file beside the reader, and `../shared/words.txt`
+the one above it, so a sub-pattern names its own data as readily as the entry
+does. Unlike an import there is no bare specifier to hold back, because every
+data-file path names a file the package carries, so the only paths that do not
+resolve against the reader are the ones grounded at the package root:
+`/data/cities.json` addresses the same file from every module. A path naming no
+attached data file throws, reporting the path the read resolved to.
+
+Writing the path relative to the reader is what makes a source package
+portable. The root a package is assembled with decides the name every file is
+stored under, and the same directory of source is legitimately rooted several
+ways — at the pattern's own directory, at the tree of patterns it sits in, at
+the repository around that. A relative read names one file under all of them.
+A grounded read names a different file under each, so it commits the source to
+one root, and moving the package or building it from a different directory
+silently stops finding the file.
+
+A `dataFile()` path may not climb above the program root, and one that does is
+refused while the program is assembled rather than clamped to a path that
+appears in no source file.
 
 The read is immediate. A data file's bytes travel with the pattern's code in
 the same content-addressed closure, so they are present before any module
@@ -261,11 +278,13 @@ The same bytes are read by whatever reads the source package: `cf piece
 getsrc`, the FUSE `.src/` view, and any tool working from a recovered
 checkout.
 
-`cf check` and `cf test` take the same repeatable `--datafile` flag, so a
-pattern that reads a data file can be checked and tested before it is deployed.
-An integration test names its data files on the scenario or fixture it runs —
-`dataFiles`, grounded by `dataRoot` — rather than on a command line.
-Without it such a pattern still compiles and type-checks, because `dataFile` is
+`cf check` and `cf test` take the same repeatable `--datafile` flag, so a file
+the source cannot name can be attached before the pattern is deployed. An
+integration test names such files on the scenario or fixture it runs —
+`dataFiles`, grounded by `dataRoot` — rather than on a command line. A file the
+source does name needs none of this: the call is the declaration, and every
+command that builds the program follows it. Where a file is neither declared
+nor named, the pattern still compiles and type-checks, because `dataFile` is
 declared whether or not a file is attached; the absence surfaces when the
 pattern runs.
 

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -106,34 +106,30 @@ An explicit `--root` applies to all of them. A test-only change creates a new
 source revision, so history and recovery keep each test package separate.
 
 Files that hold data rather than code — a fixture, a table, a list of names —
-travel the same way, under a repeatable `--datafile` flag:
-
-```bash
-deno task cf piece setsrc pattern.tsx \
-  --test pattern.test.tsx \
-  --datafile data/cities.json \
-  --piece fid1:abc... -s myspace
-```
-
-A data file is stored verbatim beside the source. Deployment never parses,
-type-checks, or compiles it, and no pattern can import it. It must be UTF-8
-text, and it must sit inside the deployment root, which the CLI infers to cover
-the main entry, every test entry, and every data file. Like a test entry, a data
-file is part of the source revision's identity, so changing one creates a new
-revision, and each revision keeps its own bytes. Repeat the complete set of
-`--datafile` flags on every `setsrc`.
-
-The pattern reads one with `dataFile`, naming the path the file is stored
-under:
+travel the same way, and the pattern declares them by reading them:
 
 ```tsx
 // Shown for illustration only.
 import { dataFile, pattern } from "commonfabric";
 
 export default pattern(() => ({
-  cities: JSON.parse(dataFile("/data/cities.json")).cities,
+  cities: JSON.parse(dataFile("./data/cities.json")).cities,
 }));
 ```
+
+The path is relative to the module that reads it, the way an import specifier
+is, so `./data/cities.json` is the file in the `data` directory beside the
+pattern. That call is the whole declaration: `setsrc`, `check`, `test` and
+`dev` each read it out of the source and attach the file, as they already
+follow what the source imports. Nothing names the file a second time on a
+command line.
+
+A data file is stored verbatim beside the source. Deployment never parses,
+type-checks, or compiles it, and no pattern can import it. It must be UTF-8
+text, and it must sit inside the deployment root, which the CLI infers to cover
+the main entry, every test entry, and every data file. Like a test entry, a data
+file is part of the source revision's identity, so changing one creates a new
+revision, and each revision keeps its own bytes.
 
 The bytes travel with the pattern's code, so the read is immediate and returns
 the same text on every load of a given revision. Reading at module scope rather
@@ -149,20 +145,29 @@ interface Cities {
   cities: string[];
 }
 
-const parsed = JSON.parse(dataFile("/data/cities.json")) as Cities;
+const parsed = JSON.parse(dataFile("./data/cities.json")) as Cities;
 ```
 
-`cf check` and `cf test` take the same repeatable `--datafile` flag, so a
-pattern that reads one can be checked and tested before it is deployed:
+A file the source cannot name — one read by a computed path, or one that ships
+with a pattern that does not read it — is attached with a repeatable
+`--datafile` flag, which every one of those commands takes:
 
 ```bash
-deno task cf check pattern.tsx --datafile data/cities.json
-deno task cf test pattern.test.tsx --datafile data/cities.json
+deno task cf piece setsrc pattern.tsx \
+  --test pattern.test.tsx \
+  --datafile data/lookup.csv \
+  --piece fid1:abc... -s myspace
 ```
 
-Without the flag the pattern compiles and type-checks, then fails on the read —
-`dataFile` is declared whether or not a file is attached, so the absence shows
-up when the pattern runs rather than when it compiles.
+That flag names a path on disk, and the file is stored under its path relative
+to the deployment root. Repeat the complete set of `--datafile` flags on every
+`setsrc`, because each update defines a complete source revision. A file
+attached this way and never read leaves nothing in the source saying it is
+data, which is why `cf piece getsrc` names those files for the next `setsrc`.
+
+Attach neither way and the pattern still compiles and type-checks, then fails
+on the read — `dataFile` is declared whether or not a file is attached, so the
+absence shows up when the pattern runs rather than when it compiles.
 
 Data files also travel for whoever reads the source next — you on another
 machine, a teammate running `cf piece getsrc`, a tool reading the FUSE `.src/`

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2938,11 +2938,16 @@ export type CompileAndRunFunction = <T = any, S = any>(
 /**
  * Read an attached data file's text.
  *
- * `path` is the file's root-relative path within the deployed source package —
- * the same spelling `cf piece getsrc` writes it at, and the same one passed to
- * `--datafile`. A data file belongs to the package rather than to any one
- * module, so the path is absolute within the package and does not resolve
- * relative to the caller.
+ * `path` resolves against the module that reads it: `words.txt` and
+ * `./words.txt` both name the file beside this module, and
+ * `../shared/words.txt` the one above it. The same source therefore names the
+ * same file whichever directory the program was assembled from, and a
+ * sub-pattern names its own data without knowing where the package was rooted.
+ *
+ * A path beginning with `/` is grounded at the package root instead, so
+ * `/data/cities.json` is that path within the deployed source package — the
+ * spelling `cf piece getsrc` writes it at, and the one `--datafile` attaches
+ * it under.
  *
  * The bytes travel with the pattern's code in the same content-addressed
  * closure, so this reads memory rather than storage: it is synchronous, it

--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -163,7 +163,7 @@ function createCheckCommand(): Command<any> {
     )
     .example(
       cliText(`cf check ./pattern.tsx --datafile ./data/cities.json`),
-      "Check a pattern that reads an attached data file.",
+      "Check a pattern, attaching a data file its source cannot name.",
     )
     .option("--no-run", "Do not execute input, only type check.")
     .option("--no-check", "Do not type check input.")
@@ -200,7 +200,7 @@ function createCheckCommand(): Command<any> {
     )
     .option(
       "--datafile <path:string>",
-      "Attach a data file the pattern reads with dataFile(). Repeatable.",
+      "Attach a data file the pattern's source cannot name. Repeatable.",
       { collect: true },
     )
     .option(

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -46,7 +46,7 @@ export const test = new Command()
   )
   .option(
     "--datafile <path:string>",
-    "Attach a data file the pattern under test reads with dataFile(). Repeatable.",
+    "Attach a data file the pattern under test cannot name. Repeatable.",
     { collect: true },
   )
   .option(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -1596,10 +1596,14 @@ export async function writeSourcePackage(
  * keeps the round trip whole.
  */
 export function undeclaredDataFiles(program: RuntimeProgram): string[] {
+  // A data file is never parsed. One already attached sits in `files` like any
+  // other entry, and its bytes may happen to read as a `dataFile()` call.
+  const attached = new Set(program.dataFiles ?? []);
   const declared = new Set(
-    program.files.flatMap((file) => collectDataFileNames(file, TARGET)),
+    program.files.filter((file) => !attached.has(file.name))
+      .flatMap((file) => collectDataFileNames(file, TARGET)),
   );
-  return (program.dataFiles ?? []).filter((name) => !declared.has(name));
+  return [...attached].filter((name) => !declared.has(name));
 }
 
 /**

--- a/packages/generated-patterns/integration/pattern-harness.ts
+++ b/packages/generated-patterns/integration/pattern-harness.ts
@@ -35,13 +35,15 @@ export interface PatternIntegrationScenario<TArgument = any> {
   argument?: TArgument;
   steps: TestStep[];
   /**
-   * Data files the pattern reads with `dataFile()`, as paths on disk. Each is
-   * stored under its path relative to `dataRoot`, which is the name the pattern
-   * addresses it by.
+   * Data files to store with the pattern, as paths on disk. A file the pattern
+   * reads with `dataFile()` is attached from that call alone and needs no
+   * entry here; this is for a file the source cannot name, such as one read by
+   * a computed path, and for a file that ships with a pattern that does not
+   * read it. Each is stored under its path relative to `dataRoot`.
    */
   dataFiles?: readonly string[];
   /**
-   * Root grounding `dataFiles`, and so the paths the pattern addresses them by.
+   * Root grounding `dataFiles`, and so the paths those files are stored under.
    * Omitted, it is the common directory containing the module and every data
    * file — which is the module's own directory only when the data sits beside
    * or beneath it. Given explicitly, it must contain the module.

--- a/packages/js-compiler/specifier.ts
+++ b/packages/js-compiler/specifier.ts
@@ -14,12 +14,56 @@ export function resolveImportSpecifier(
   specifier: string,
   from: Source,
 ): string {
-  if (
-    specifier.substring(0, 2) === "./" || specifier.substring(0, 3) === "../"
-  ) {
-    return join(dirname(from.name), specifier);
-  }
-  return specifier;
+  return isImportRelative(specifier)
+    ? resolveAgainstModule(specifier, from.name)
+    : specifier;
+}
+
+/**
+ * Whether an import specifier is written relative to the importing module.
+ *
+ * The two prefixes are the ones the language gives a module specifier, and a
+ * specifier with neither names a package rather than a file.
+ */
+function isImportRelative(specifier: string): boolean {
+  return specifier.substring(0, 2) === "./" ||
+    specifier.substring(0, 3) === "../";
+}
+
+/**
+ * Whether a data-file path is written relative to the module that reads it.
+ *
+ * Every data-file path names a file the package carries, so there is no bare
+ * specifier to hold back the way an import has: a path is either grounded at
+ * the package root or relative to the reader. `./` contributes nothing to a
+ * directory walk, so `data/cities.json` and `./data/cities.json` are one path.
+ */
+function isDataFileRelative(path: string): boolean {
+  return path.substring(0, 1) !== "/";
+}
+
+/** Join a relative path against the directory of the module named by `fromName`. */
+function resolveAgainstModule(path: string, fromName: string): string {
+  return join(dirname(fromName), path);
+}
+
+/**
+ * Resolve a `dataFile()` path against the module that reads it, as
+ * {@link resolveImportSpecifier} resolves an import against the module that
+ * imports it. `./words.txt`, `words.txt` and `../shared/words.txt` name files
+ * beside or above the reader, so the same source names the same file whichever
+ * directory the program was rooted at.
+ *
+ * A path beginning with `/` is grounded at the package root and returned
+ * unchanged, so `/data/cities.json` names one file for every module in the
+ * package.
+ *
+ * Takes the reading module's path rather than its {@link Source} because the
+ * runtime resolves a read from a module record, which holds the path and not
+ * the text.
+ */
+export function resolveDataFilePath(path: string, fromName: string): string {
+  return isDataFileRelative(path) ? resolveAgainstModule(path, fromName) : path;
 }
 
 /**
@@ -47,16 +91,16 @@ export function importEscapesProgramRoot(
   specifier: string,
   from: Source,
 ): boolean {
-  if (
-    specifier.substring(0, 2) !== "./" && specifier.substring(0, 3) !== "../"
-  ) {
-    return false;
-  }
-  if (from.name.substring(0, 1) !== "/") return false;
+  return isImportRelative(specifier) &&
+    escapesProgramRoot(specifier, from.name);
+}
+
+function escapesProgramRoot(path: string, fromName: string): boolean {
+  if (fromName.substring(0, 1) !== "/") return false;
   // Every leading slash: an HTTP-derived name preserves its URL pathname,
   // which may begin "//...", and a base left absolute would clamp again.
-  const relativeDir = dirname(from.name).replace(/^\/+/, "");
-  const joined = join(relativeDir, specifier);
+  const relativeDir = dirname(fromName).replace(/^\/+/, "");
+  const joined = join(relativeDir, path);
   return joined === ".." || joined.substring(0, 3) === "../";
 }
 
@@ -74,6 +118,27 @@ export function assertImportInsideProgramRoot(
   if (importEscapesProgramRoot(specifier, from)) {
     throw new Error(
       `Import "${specifier}" in "${from.name}" escapes the program root.`,
+    );
+  }
+}
+
+/**
+ * Refuse a `dataFile()` path that climbs above the program root, naming the
+ * path and the module that reads it. The scan that turns a call site into an
+ * attached file calls this before resolving, so the refusal names the path the
+ * author wrote rather than the in-root path the clamping join would produce.
+ *
+ * {@link resolveDataFilePath} stays total for the same reason
+ * {@link resolveImportSpecifier} does: the runtime read resolves a path the
+ * build already accepted, and must produce the same answer for it.
+ */
+export function assertDataFileInsideProgramRoot(
+  path: string,
+  from: Source,
+): void {
+  if (isDataFileRelative(path) && escapesProgramRoot(path, from.name)) {
+    throw new Error(
+      `Data file "${path}" read in "${from.name}" escapes the program root.`,
     );
   }
 }

--- a/packages/js-compiler/test/specifier.test.ts
+++ b/packages/js-compiler/test/specifier.test.ts
@@ -2,7 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { Source } from "../interface.ts";
 import {
+  assertDataFileInsideProgramRoot,
   importEscapesProgramRoot,
+  resolveDataFilePath,
   resolveImportSpecifier,
 } from "../specifier.ts";
 
@@ -91,6 +93,92 @@ describe("specifier", () => {
       expect(
         resolveImportSpecifier("commonfabric", from("/main.tsx")),
       ).toBe("commonfabric");
+    });
+  });
+
+  describe("resolveDataFilePath", () => {
+    it("joins a sibling path against the reader's directory", () => {
+      expect(
+        resolveDataFilePath("./words.txt", "/scrabble/scrabble.tsx"),
+      ).toBe("/scrabble/words.txt");
+    });
+
+    it("joins a path in a directory beneath the reader", () => {
+      expect(
+        resolveDataFilePath("./data/cities.json", "/examples/reader.tsx"),
+      ).toBe("/examples/data/cities.json");
+    });
+
+    it("climbs out of the reader's directory for a parent path", () => {
+      expect(
+        resolveDataFilePath("../shared/words.txt", "/scrabble/scrabble.tsx"),
+      ).toBe("/shared/words.txt");
+    });
+
+    it("resolves a bare path against the reader, as `./` does", () => {
+      // `./` contributes nothing to a directory walk, and a data file has no
+      // bare-package namespace for the prefix-free spelling to mean instead.
+      expect(resolveDataFilePath("data/cities.json", "/examples/reader.tsx"))
+        .toBe(
+          resolveDataFilePath("./data/cities.json", "/examples/reader.tsx"),
+        );
+      expect(resolveDataFilePath("words.txt", "/scrabble/scrabble.tsx"))
+        .toBe("/scrabble/words.txt");
+    });
+
+    it("returns a grounded path unchanged", () => {
+      expect(
+        resolveDataFilePath("/data/cities.json", "/deep/nested/reader.tsx"),
+      ).toBe("/data/cities.json");
+    });
+
+    it("gives the same answer for the same reader under any root", () => {
+      // The whole point: one source, rooted three ways, naming one file.
+      expect(resolveDataFilePath("./words.txt", "/words-game/main.tsx"))
+        .toBe("/words-game/words.txt");
+      expect(
+        resolveDataFilePath("./words.txt", "/patterns/words-game/main.tsx"),
+      ).toBe("/patterns/words-game/words.txt");
+      expect(resolveDataFilePath("./words.txt", "/main.tsx"))
+        .toBe("/words.txt");
+    });
+  });
+
+  describe("assertDataFileInsideProgramRoot", () => {
+    it("refuses a path that climbs above the root", () => {
+      expect(() =>
+        assertDataFileInsideProgramRoot(
+          "../../outside.txt",
+          from("/scrabble/scrabble.tsx"),
+        )
+      ).toThrow('Data file "../../outside.txt" read in');
+    });
+
+    it("accepts a climb that stays inside the root", () => {
+      assertDataFileInsideProgramRoot(
+        "../shared/words.txt",
+        from("/scrabble/scrabble.tsx"),
+      );
+    });
+
+    it("accepts a grounded path, which climbs nowhere", () => {
+      assertDataFileInsideProgramRoot("/data/cities.json", from("/main.tsx"));
+    });
+
+    it("refuses a bare path that climbs out through its own segments", () => {
+      expect(() =>
+        assertDataFileInsideProgramRoot(
+          "sub/../../../outside.txt",
+          from("/scrabble/scrabble.tsx"),
+        )
+      ).toThrow("escapes the program root");
+    });
+
+    it("accepts a bare path, which starts inside the reader's directory", () => {
+      assertDataFileInsideProgramRoot(
+        "data/cities.json",
+        from("/examples/reader.tsx"),
+      );
     });
   });
 });

--- a/packages/js-compiler/test/typescript.resolver.test.ts
+++ b/packages/js-compiler/test/typescript.resolver.test.ts
@@ -91,6 +91,8 @@ describe("typescript/resolver.ts", () => {
   describe("collectDataFileNames", () => {
     const names = (contents: string) =>
       collectDataFileNames({ name: "/main.tsx", contents }, TARGET);
+    const namesIn = (name: string, contents: string) =>
+      collectDataFileNames({ name, contents }, TARGET);
 
     it("reads the path a dataFile call names", () => {
       expect(names(
@@ -107,6 +109,68 @@ describe("typescript/resolver.ts", () => {
           '  b: dataFile("/b.txt"),\n' +
           "}));\n",
       )).toEqual(["/a.json", "/b.txt"]);
+    });
+
+    it("resolves a sibling path against the reading module", () => {
+      expect(namesIn(
+        "/scrabble/scrabble.tsx",
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("./words.txt");\n',
+      )).toEqual(["/scrabble/words.txt"]);
+    });
+
+    it("resolves a path in a directory beneath the reading module", () => {
+      expect(namesIn(
+        "/examples/reader.tsx",
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("./data/cities.json");\n',
+      )).toEqual(["/examples/data/cities.json"]);
+    });
+
+    it("resolves a bare path against the reading module too", () => {
+      expect(namesIn(
+        "/examples/reader.tsx",
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("data/cities.json");\n',
+      )).toEqual(["/examples/data/cities.json"]);
+    });
+
+    it("resolves a parent path out of the reading module's directory", () => {
+      expect(namesIn(
+        "/scrabble/scrabble.tsx",
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("../shared/words.txt");\n',
+      )).toEqual(["/shared/words.txt"]);
+    });
+
+    it("names one file for a sibling path under any root", () => {
+      // One source, three roots. The path each root grounds the reader at
+      // differs, and the file the read names is the same one every time.
+      const source = 'import { dataFile } from "commonfabric";\n' +
+        'export default () => dataFile("./words.txt");\n';
+      expect(namesIn("/words-game/main.tsx", source))
+        .toEqual(["/words-game/words.txt"]);
+      expect(namesIn("/patterns/words-game/main.tsx", source))
+        .toEqual(["/patterns/words-game/words.txt"]);
+      expect(namesIn("/main.tsx", source)).toEqual(["/words.txt"]);
+    });
+
+    it("leaves a grounded path as the source wrote it", () => {
+      expect(namesIn(
+        "/deep/nested/reader.tsx",
+        'import { dataFile } from "commonfabric";\n' +
+          'export default () => dataFile("/data/cities.json");\n',
+      )).toEqual(["/data/cities.json"]);
+    });
+
+    it("refuses a path that climbs above the program root", () => {
+      expect(() =>
+        namesIn(
+          "/scrabble/scrabble.tsx",
+          'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("../../outside.txt");\n',
+        )
+      ).toThrow('Data file "../../outside.txt" read in');
     });
 
     it("follows the binding through a renaming import", () => {

--- a/packages/js-compiler/typescript/resolver.ts
+++ b/packages/js-compiler/typescript/resolver.ts
@@ -90,7 +90,9 @@ function isUnresolvedModuleOk(
 // existing compile-path importers.
 export { resolveImportSpecifier } from "../specifier.ts";
 import {
+  assertDataFileInsideProgramRoot,
   assertImportInsideProgramRoot as assertInsideRoot,
+  resolveDataFilePath,
   resolveImportSpecifier as resolveSpecifier,
 } from "../specifier.ts";
 
@@ -123,17 +125,19 @@ const DATA_FILE_READER = "dataFile";
 
 /**
  * Returns the data-file names `source` declares, as the paths its `dataFile()`
- * calls name.
+ * calls name, each resolved against `source` the way an import specifier is.
  *
  * A pattern declares the code it depends on by importing it and the data it
  * depends on by reading it, so this is the data-side counterpart of the import
  * scan: both read a declaration out of the source rather than take one from a
- * caller.
+ * caller, and both resolve what they read against the module that wrote it.
+ * The runtime resolves a read the same way, so a file is attached under the
+ * name it is later looked up by.
  *
  * Only a call to the runtime's own `dataFile` counts, and only where the
  * argument is a string literal. The binding is followed through a renaming
- * import and through a namespace import, so `df("/x.json")` and
- * `cf.dataFile("/x.json")` are the same declaration as the plain call. A
+ * import and through a namespace import, so `df("./x.json")` and
+ * `cf.dataFile("./x.json")` are the same declaration as the plain call. A
  * type-only import binds no value and so declares nothing. A computed path
  * cannot be read from the source at all, and stays the caller's to name.
  */
@@ -188,7 +192,11 @@ export function collectDataFileNames(
         read !== undefined && argument !== undefined &&
         ts.isStringLiteral(argument) && !isShadowed(read)
       ) {
-        names.push(argument.text);
+        // Refused before resolving, as an escaping import is: past the join
+        // the climbing segments are clamped away and the name no longer
+        // appears in any source file.
+        assertDataFileInsideProgramRoot(argument.text, source);
+        names.push(resolveDataFilePath(argument.text, source.name));
       }
     }
     ts.forEachChild(node, visit);

--- a/packages/patterns/baselines/examples/phonetic-speller.tsx/20260820T230758Z-jQB1WIsPJ6uPxpu_.json
+++ b/packages/patterns/baselines/examples/phonetic-speller.tsx/20260820T230758Z-jQB1WIsPJ6uPxpu_.json
@@ -1,0 +1,46 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "text": {
+        "asCell": [
+          "cell"
+        ],
+        "default": "Fabric",
+        "type": "string"
+      }
+    },
+    "required": [
+      "text"
+    ],
+    "type": "object"
+  },
+  "pattern": "examples/phonetic-speller.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "codeWords": {
+        "description": "Every code word the file holds, in the order the file stores them.",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "spelled": {
+        "description": "`text` spelled out, one code word per letter it recognizes.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "spelled",
+      "codeWords",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/examples/data/phonetic-alphabet.json
+++ b/packages/patterns/examples/data/phonetic-alphabet.json
@@ -1,0 +1,30 @@
+{
+  "letters": [
+    { "letter": "A", "word": "Alfa" },
+    { "letter": "B", "word": "Bravo" },
+    { "letter": "C", "word": "Charlie" },
+    { "letter": "D", "word": "Delta" },
+    { "letter": "E", "word": "Echo" },
+    { "letter": "F", "word": "Foxtrot" },
+    { "letter": "G", "word": "Golf" },
+    { "letter": "H", "word": "Hotel" },
+    { "letter": "I", "word": "India" },
+    { "letter": "J", "word": "Juliett" },
+    { "letter": "K", "word": "Kilo" },
+    { "letter": "L", "word": "Lima" },
+    { "letter": "M", "word": "Mike" },
+    { "letter": "N", "word": "November" },
+    { "letter": "O", "word": "Oscar" },
+    { "letter": "P", "word": "Papa" },
+    { "letter": "Q", "word": "Quebec" },
+    { "letter": "R", "word": "Romeo" },
+    { "letter": "S", "word": "Sierra" },
+    { "letter": "T", "word": "Tango" },
+    { "letter": "U", "word": "Uniform" },
+    { "letter": "V", "word": "Victor" },
+    { "letter": "W", "word": "Whiskey" },
+    { "letter": "X", "word": "Xray" },
+    { "letter": "Y", "word": "Yankee" },
+    { "letter": "Z", "word": "Zulu" }
+  ]
+}

--- a/packages/patterns/examples/phonetic-speller.test.tsx
+++ b/packages/patterns/examples/phonetic-speller.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Test Pattern: the phonetic speller
+ *
+ * The pattern's alphabet is a file that ships beside it rather than a table
+ * written in code, so what this proves is that the file travelled: the code
+ * words it asserts appear nowhere in the pattern's source. The pattern
+ * compiles and type-checks whether or not the file is attached, and fails at
+ * the read, so a run that reaches these assertions has already shown the
+ * attachment happened.
+ *
+ * Nothing here names the file. `cf test` builds the program from this entry,
+ * follows the import to the pattern, reads the `dataFile()` call out of it,
+ * and attaches what the call resolves to.
+ */
+import { action, assert, pattern, TESTS, Writable } from "commonfabric";
+import PhoneticSpeller from "./phonetic-speller.tsx";
+
+export default pattern(() => {
+  const text = new Writable("Fabric");
+  const speller = PhoneticSpeller({ text });
+
+  const action_spell_a_different_word = action(() => {
+    text.set("SOS!");
+  });
+
+  const assert_spells_the_default_text = assert(() =>
+    speller.spelled === "Foxtrot Alfa Bravo Romeo India Charlie"
+  );
+
+  // A character the file gives no word for is passed through as itself.
+  const assert_spells_around_unknown_characters = assert(() =>
+    speller.spelled === "Sierra Oscar Sierra !"
+  );
+
+  const assert_holds_every_code_word = assert(() =>
+    speller.codeWords.length === 26 &&
+    speller.codeWords[0] === "Alfa" &&
+    speller.codeWords[25] === "Zulu"
+  );
+
+  return {
+    [TESTS]: [
+      { assertion: assert_spells_the_default_text },
+      { assertion: assert_holds_every_code_word },
+
+      { action: action_spell_a_different_word },
+      { assertion: assert_spells_around_unknown_characters },
+    ],
+    speller,
+  };
+});

--- a/packages/patterns/examples/phonetic-speller.tsx
+++ b/packages/patterns/examples/phonetic-speller.tsx
@@ -1,0 +1,83 @@
+/**
+ * Spells text out in the NATO phonetic alphabet, reading the alphabet from a
+ * file that ships with the pattern.
+ *
+ * `dataFile` resolves its path against this module, the way an import
+ * specifier does, so `./data/phonetic-alphabet.json` is the file in the `data`
+ * directory beside this one whichever directory the program was assembled
+ * from. Its bytes are stored verbatim: never parsed as TypeScript, never
+ * compiled, never importable.
+ *
+ * That call is the whole declaration. Every command that builds a pattern from
+ * local files reads it out of the source and attaches the file, so the test
+ * beside this one and a deployment both get it without naming it.
+ */
+import {
+  computed,
+  dataFile,
+  type Default,
+  NAME,
+  pattern,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+interface PhoneticLetter {
+  letter: string;
+  word: string;
+}
+
+interface PhoneticAlphabet {
+  letters: PhoneticLetter[];
+}
+
+// `dataFile` returns text, so parsing it yields `any`. Naming the shape is
+// what gives the result schema below something to describe.
+const ALPHABET = JSON.parse(
+  dataFile("./data/phonetic-alphabet.json"),
+) as PhoneticAlphabet;
+
+function spell(text: string): string {
+  return [...text.toUpperCase()]
+    .map((character) =>
+      ALPHABET.letters.find((entry) => entry.letter === character)?.word ??
+        character
+    )
+    .join(" ");
+}
+
+interface PhoneticSpellerInput {
+  text: Writable<string | Default<"Fabric">>;
+}
+
+export interface PhoneticSpellerOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  /** `text` spelled out, one code word per letter it recognizes. */
+  spelled: string;
+  /** Every code word the file holds, in the order the file stores them. */
+  codeWords: string[];
+}
+
+export const PhoneticSpeller = pattern<
+  PhoneticSpellerInput,
+  PhoneticSpellerOutput
+>(({ text }) => {
+  const spelled = computed(() => spell(text.get()));
+
+  return {
+    [NAME]: "Phonetic speller",
+    [UI]: (
+      <cf-vstack gap="2" style={{ padding: "1rem" }}>
+        <h3>Phonetic speller</h3>
+        <cf-input $value={text} placeholder="Text to spell" />
+        <p>{spelled}</p>
+      </cf-vstack>
+    ),
+    spelled,
+    codeWords: ALPHABET.letters.map((entry) => entry.word),
+  };
+});
+
+export default PhoneticSpeller;

--- a/packages/patterns/integration/fixtures/data-file-multi-runtime/main.tsx
+++ b/packages/patterns/integration/fixtures/data-file-multi-runtime/main.tsx
@@ -3,6 +3,9 @@
 // program, so the test has something that can only succeed if the file
 // travelled with the source. The pattern compiles and type-checks whether or
 // not the file is attached; it fails at the read.
+//
+// The path is relative to this module, so it names the file beside it whatever
+// root the harness assembles the program with.
 import { dataFile, NAME, pattern } from "commonfabric";
 
 interface Cities {
@@ -10,9 +13,7 @@ interface Cities {
 }
 
 export default pattern(() => {
-  const parsed = JSON.parse(
-    dataFile("/integration/fixtures/data-file-multi-runtime/data/cities.json"),
-  ) as Cities;
+  const parsed = JSON.parse(dataFile("./data/cities.json")) as Cities;
   return {
     [NAME]: "Data file reader (multi-runtime fixture)",
     cities: parsed.cities,

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -75,9 +75,11 @@ export interface MultiRuntimeHarnessOptions {
   /** Module-resolution root, usually the `packages/patterns` directory. */
   rootPath: string;
   /**
-   * Data files the pattern reads with `dataFile()`, as paths on disk. The
-   * bootstrap worker compiles the pattern in its own process, so these travel
-   * with the request rather than being attached here.
+   * Data files to store with the pattern, as paths on disk. A file the pattern
+   * reads with `dataFile()` is attached from that call alone and needs no
+   * entry here; this is for a file the source cannot name. The bootstrap
+   * worker compiles the pattern in its own process, so these travel with the
+   * request rather than being attached here.
    */
   dataFilePaths?: readonly string[];
   /** Optional initial pattern input for the bootstrap-created piece. */

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -218,9 +218,10 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     fetchProgram,
     streamData,
     compileAndRun,
-    // Placeholder for the per-load binding. Each compiled graph replaces this
-    // with a reader closed over that load's attached data files (see
-    // `Engine.compileToRecordGraph`), so reaching this body means the module is
+    // Placeholder for the per-module binding. A graph carrying data files hands
+    // each module its own copy of this namespace, whose reader is closed over
+    // that load's files and that module's path (see
+    // `compileSourcesToRecords`). Reaching this body means the module is
     // running outside a graph that carries any.
     dataFile: (path: string): string => {
       throw new Error(

--- a/packages/runner/src/harness/declared-data-files.ts
+++ b/packages/runner/src/harness/declared-data-files.ts
@@ -7,10 +7,14 @@ import { compilerStack } from "./deferred-compiler-stack.ts";
  *
  * A pattern declares the code it depends on by importing it, and the resolver
  * follows that declaration. A pattern declares the data it depends on by
- * reading it, with `dataFile("/data/cities.json")`, and this follows that one.
+ * reading it, with `dataFile("./cities.json")`, and this follows that one.
  * Both are read out of the source, so a program carries the same files however
  * it was built and whoever built it, and no caller has to state a second time
  * what the source already says.
+ *
+ * A read resolves against the module that wrote it, as an import specifier
+ * does, so the name a file is attached under here is the name the runtime will
+ * look it up by.
  *
  * The names come from the resolved closure, and each is read back through the
  * resolver that produced it, so a program assembled from the file system, from

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -48,7 +48,6 @@ import {
   RuntimeModuleIdentifiers,
   SESRuntime,
 } from "../sandbox/mod.ts";
-import { freezeSandboxValue } from "../sandbox/hardening.ts";
 import {
   buildRecordsFromCompiled,
   type CachedCompiledModule,
@@ -704,6 +703,9 @@ export class Engine extends EventTarget {
         // Reuse the identities already computed above (cache-hit check); avoids
         // a second hashing/import-resolution pass over the module set.
         identityByPath,
+        // A `dataFile()` path resolves against the reading module's stored
+        // name, so a read lands in the same space `dataFiles` is keyed by.
+        storedNameFor: (name) => storedFilenameFor(name, id, mounts),
       });
       if (options.patternCoverage) {
         this.patternCoverageByGraph.set(graph, options.patternCoverage);
@@ -717,11 +719,7 @@ export class Engine extends EventTarget {
           unknown
         >;
       }
-      for (
-        const [spec, record] of runtimeModuleRecords(
-          bindDataFileReader(runtimeRecordExports, graph.dataByPath),
-        )
-      ) {
+      for (const [spec, record] of runtimeModuleRecords(runtimeRecordExports)) {
         graph.records.set(spec, record as VirtualModuleRecord);
       }
 
@@ -1684,11 +1682,7 @@ export class Engine extends EventTarget {
         unknown
       >;
     }
-    for (
-      const [spec, record] of runtimeModuleRecords(
-        bindDataFileReader(runtimeRecordExports, graph.dataByPath),
-      )
-    ) {
+    for (const [spec, record] of runtimeModuleRecords(runtimeRecordExports)) {
       graph.records.set(spec, record as VirtualModuleRecord);
     }
 
@@ -1855,48 +1849,6 @@ function validatePolicyManifestsForModule(
     }
     return artifact;
   });
-}
-
-/**
- * Bind this load's attached data files into the runtime-module namespaces that
- * expose `dataFile`.
- *
- * The shared namespaces are process-global and carry only a placeholder, since
- * which data files exist is a property of the program being loaded rather than
- * of the runtime. Each load therefore hands its own graph's data to the records
- * it registers, so a module's `dataFile` reads the bytes that travelled in the
- * same content-addressed closure as its code.
- *
- * The read is a plain map lookup: the closure is fully loaded before any module
- * executes, so this needs no storage access and cannot be asynchronous.
- */
-function bindDataFileReader(
-  runtimeRecordExports: Record<string, Record<string, unknown>>,
-  dataByPath: ReadonlyMap<string, string>,
-): Record<string, Record<string, unknown>> {
-  const read = (path: string): string => {
-    const bytes = dataByPath.get(path);
-    if (bytes !== undefined) return bytes;
-    const attached = [...dataByPath.keys()].sort();
-    // The message states what is attached and stops there. How a caller
-    // attaches one differs by the surface driving the compile — a CLI flag, a
-    // scenario field, an argument to `resolveLocalProgram` — and the runtime
-    // knows none of that, so naming any single mechanism would misdirect
-    // every caller reaching it by another route.
-    throw new Error(
-      `No attached data file "${path}". ` +
-        (attached.length === 0
-          ? "This pattern has no attached data files."
-          : `Attached: ${attached.join(", ")}.`),
-    );
-  };
-  const bound: Record<string, Record<string, unknown>> = {};
-  for (const [name, namespace] of Object.entries(runtimeRecordExports)) {
-    bound[name] = namespace !== undefined && "dataFile" in namespace
-      ? freezeSandboxValue({ ...namespace, dataFile: read })
-      : namespace;
-  }
-  return bound;
 }
 
 function computeId(program: RuntimeProgram): string {

--- a/packages/runner/src/harness/local-program.deno.ts
+++ b/packages/runner/src/harness/local-program.deno.ts
@@ -16,10 +16,12 @@ import type { RuntimeProgram } from "./types.ts";
  * listed here; the option is for a path the source cannot state, and for one
  * a caller wants attached to a program that does not read it.
  *
- * `root` grounds every authored name, and so decides the paths `dataFile()`
- * addresses a data file by. Omitted, it is the common directory containing the
- * entry, every test entry, and every data file — the smallest root that can
- * hold them all.
+ * `root` grounds every authored name, so it decides which file on disk a
+ * grounded `dataFile()` path such as `/data/cities.json` reaches, and the
+ * stored name each `dataFilePaths` entry is given. A `dataFile()` path written
+ * relative to the module that reads it reaches the same file under any root.
+ * Omitted, `root` is the common directory containing the entry, every test
+ * entry, and every data file — the smallest root that can hold them all.
  */
 export interface LocalProgramOptions {
   main: string;

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,5 +1,8 @@
 import type { Source, SourceMap } from "@commonfabric/js-compiler";
-import { resolveImportSpecifier } from "@commonfabric/js-compiler/specifier";
+import {
+  resolveDataFilePath,
+  resolveImportSpecifier,
+} from "@commonfabric/js-compiler/specifier";
 import type {
   BuilderSourceSitesV1,
   PatternCoverageSpan,
@@ -13,6 +16,7 @@ import {
   findInternalTarget,
 } from "../harness/module-identity.ts";
 import { recordDefiningModule } from "../harness/verified-provenance.ts";
+import { freezeSandboxValue } from "./hardening.ts";
 import type { VirtualModuleRecord } from "./esm-module-loader.ts";
 
 /**
@@ -40,6 +44,9 @@ export const SOURCE_ROOT_SPECIFIER = "cf:source-root/";
 export function sourceRootSpecifier(path: string): string {
   return `${SOURCE_ROOT_SPECIFIER}${path.replace(/^\/+/, "")}`;
 }
+
+/** The runtime export a module reads an attached data file through. */
+const DATA_FILE_READER = "dataFile";
 
 /** Identity-only import edge for an attached data file. */
 export const DATA_FILE_SPECIFIER = "cf:data-file/";
@@ -425,6 +432,14 @@ export interface CompileSourcesOptions {
    * program. Used for scheme-prefixed fabric refs mounted under reserved paths.
    */
   specifierAliases?: ReadonlyMap<string, string>;
+  /**
+   * The stored path for a resolved source name — the spelling `dataFiles` is
+   * keyed by, with the per-load `idPrefix` and any fabric mount root taken off.
+   * A module's `dataFile()` reads resolve against this name, so the path a read
+   * produces and the path a file was attached under are in the same space.
+   * Omitted, a source's name is its stored path.
+   */
+  storedNameFor?: (name: string) => string;
 }
 
 export interface CompiledModuleGraph {
@@ -630,11 +645,81 @@ function mountPrefix(mount: FabricMount): string {
   return `${FABRIC_MOUNT_ROOT}${mount.entryIdentity}/`;
 }
 
+/**
+ * Hands one module its view of a runtime namespace it imports: the namespace
+ * itself, or a copy carrying that module's own `dataFile`.
+ */
+type NamespaceBinder = (
+  namespace: Record<string, unknown>,
+) => Record<string, unknown>;
+
+/**
+ * A module's own view of the runtime namespaces that expose `dataFile`.
+ *
+ * A data file is read by path, and that path resolves against the module that
+ * reads it, exactly as an import specifier resolves against the module that
+ * imports it. The runtime namespaces a graph registers are shared by every
+ * module in it, so the resolution cannot live in them: each module is instead
+ * handed its own copy of the namespace, whose `dataFile` closes over that
+ * module's own stored path.
+ *
+ * The caller applies this only to a namespace imported through a runtime module
+ * that declares the reader. An authored module is free to export a value of its
+ * own named `dataFile`, and an importer gets the one it imported; a runtime
+ * module that declares no reader gains none.
+ *
+ * The read is a map lookup: the closure is fully loaded before any module
+ * executes, so it needs no storage access and cannot be asynchronous.
+ *
+ * A graph carrying no data files hands every namespace straight through, and a
+ * read reaches the builder's placeholder, which reports that the load attached
+ * nothing.
+ */
+function dataFileBinding(
+  dataByPath: ReadonlyMap<string, string>,
+): (moduleName: string) => NamespaceBinder {
+  if (dataByPath.size === 0) {
+    const passThrough: NamespaceBinder = (namespace) => namespace;
+    return () => passThrough;
+  }
+  const attached = [...dataByPath.keys()].sort();
+  return (moduleName: string) => {
+    const read = freezeSandboxValue((path: string): string => {
+      const resolved = resolveDataFilePath(path, moduleName);
+      const bytes = dataByPath.get(resolved);
+      if (bytes !== undefined) return bytes;
+      // The message states what is attached and stops there. How a caller
+      // attaches one differs by the surface driving the compile — a CLI flag, a
+      // scenario field, an argument to `resolveLocalProgram` — and the runtime
+      // knows none of that, so naming any single mechanism would misdirect
+      // every caller reaching it by another route.
+      throw new Error(
+        `No attached data file "${resolved}". ` +
+          `Attached: ${attached.join(", ")}.`,
+      );
+    });
+    const bound = new WeakMap<
+      Record<string, unknown>,
+      Record<string, unknown>
+    >();
+    return (namespace) => {
+      const memo = bound.get(namespace);
+      if (memo !== undefined) return memo;
+      const copy = Object.freeze({ ...namespace, [DATA_FILE_READER]: read });
+      bound.set(namespace, copy);
+      return copy;
+    };
+  };
+}
+
 export function compileSourcesToRecords(
   sources: Source[],
   options: CompileSourcesOptions = {},
 ): CompiledModuleGraph {
   const runtimeModules = options.runtimeModules ?? {};
+  const dataByPath = new Map(options.dataFiles ?? []);
+  const bindDataFileFor = dataFileBinding(dataByPath);
+  const storedNameFor = options.storedNameFor ?? ((name: string) => name);
   // Identities are computed prefix-free (see computeModuleIdentities) so
   // `cf:module/<hash>` is entry-point independent and dedupes across programs.
   // Reuse the caller's precomputed map when supplied (avoids a second hash pass).
@@ -765,6 +850,9 @@ export function compileSourcesToRecords(
     // (VirtualModuleRecord.imports is `string[]`); this is the cold compile path.
     const importSpecs = [...extractRuntimeImports(compiled)];
     const resolutions: Record<string, string> = {};
+    // The specifiers whose runtime namespace declares `dataFile`, and so the
+    // only ones this module reads a data file through.
+    const readerImports = new Set<string>();
     for (const spec of importSpecs) {
       const resolved = resolveImportSpecifier(spec, source);
       const internal = findInternalTarget(fileNames, resolved);
@@ -772,6 +860,9 @@ export function compileSourcesToRecords(
         resolutions[spec] = specifierByPath.get(internal)!;
       } else if (spec in runtimeModules) {
         resolutions[spec] = `cf:runtime/${spec}`;
+        if (runtimeModules[spec].includes(DATA_FILE_READER)) {
+          readerImports.add(spec);
+        }
       } else if (options.specifierAliases?.has(spec)) {
         const target = options.specifierAliases.get(spec)!;
         const targetSpecifier = specifierByPath.get(target);
@@ -804,6 +895,7 @@ export function compileSourcesToRecords(
     // `source.name` would otherwise end the comment and let the remainder of
     // the name execute as code inside the compartment.
     const sourceUrl = source.name.replace(/[\r\n\u2028\u2029]/g, "_");
+    const bindDataFile = bindDataFileFor(storedNameFor(source.name));
     records.set(specifier, {
       imports: importSpecs,
       exports: namespaceExports,
@@ -837,12 +929,16 @@ export function compileSourcesToRecords(
         // way the lookup fails closed (importNowHook throws on anything not in
         // `records`), but only the own-property test makes "absent from the map
         // resolves to itself" literally true — which is what the spec states.
-        const requireShim = (specifier: string) =>
-          compartment.importNow(
+        const requireShim = (specifier: string) => {
+          const namespace = compartment.importNow(
             Object.hasOwn(resolvedImports, specifier)
               ? resolvedImports[specifier]
               : specifier,
           );
+          return readerImports.has(specifier)
+            ? bindDataFile(namespace)
+            : namespace;
+        };
         // A throw inside the factory is terminal for this module: SES caches the
         // error and re-throws it on every subsequent importNow.
         // Grant the real registrar ONLY if the verifier approved this module's
@@ -876,7 +972,7 @@ export function compileSourcesToRecords(
     builderSourceSitesByIdentity,
     registrationSink,
     registrationApproved,
-    dataByPath: new Map(options.dataFiles ?? []),
+    dataByPath,
   };
 }
 
@@ -979,6 +1075,7 @@ export function buildRecordsFromCompiled(
   });
   const byIdentity = new Map(moduleEntries.map((m) => [m.identity, m]));
   const sourceNames = cachedModuleSourceNames(moduleEntries);
+  const bindDataFileFor = dataFileBinding(dataByPath);
 
   // Fix B: use the record surface persisted on the compiled doc; parse the body
   // only when it wasn't precomputed. A module carries the full surface (a warm
@@ -1073,12 +1170,16 @@ export function buildRecordsFromCompiled(
       ? [...surface.importSpecs]
       : [...parseCompiledImports(m.code)];
     const resolutions: Record<string, string> = {};
+    const readerImports = new Set<string>();
     for (const spec of importSpecs) {
       const edge = m.imports.find((i) => i.specifier === spec);
       if (edge !== undefined) {
         resolutions[spec] = specifierOf(edge.targetIdentity);
       } else if (spec in runtimeModules) {
         resolutions[spec] = `cf:runtime/${spec}`;
+        if (runtimeModules[spec].includes(DATA_FILE_READER)) {
+          readerImports.add(spec);
+        }
       } else {
         resolutions[spec] = spec;
       }
@@ -1091,6 +1192,9 @@ export function buildRecordsFromCompiled(
       "_",
     );
     const compiled = m.code;
+    // The module's own filename, not the disambiguated source name: a data
+    // file is keyed by filename too, so both sides of a read agree.
+    const bindDataFile = bindDataFileFor(m.filename);
     records.set(specifier, {
       imports: importSpecs,
       exports: namespaceExports,
@@ -1106,10 +1210,12 @@ export function buildRecordsFromCompiled(
         ) => void;
         // Own-property test, matching the cold path in
         // `compileSourcesToRecords` — see the note there.
-        const requireShim = (spec: string) =>
-          compartment.importNow(
+        const requireShim = (spec: string) => {
+          const namespace = compartment.importNow(
             Object.hasOwn(resolvedImports, spec) ? resolvedImports[spec] : spec,
           );
+          return readerImports.has(spec) ? bindDataFile(namespace) : namespace;
+        };
         const { register, commit } = registrationApproved.has(specifier)
           ? createHoistRegistrar(m.identity, registrationSink)
           : createRejectingRegistrar();

--- a/packages/runner/test/builder-data-file.test.ts
+++ b/packages/runner/test/builder-data-file.test.ts
@@ -2,8 +2,10 @@
  * `dataFile` is exposed to pattern code through the `commonfabric` builder
  * surface (declared in `api/index.ts`, bound in `builder/factory.ts`). The
  * surface carries a placeholder, because which data files exist is a property
- * of the program being loaded rather than of the runtime: each compiled graph
- * replaces it with a reader closed over that load's attached files.
+ * of the program being loaded rather than of the runtime, and where a path
+ * resolves from is a property of the module reading it: a graph carrying data
+ * files hands each module its own copy of the namespace, with a reader closed
+ * over both.
  *
  * These tests pin the placeholder's behavior. Reaching it means a module is
  * running outside any graph carrying data files, and the failure has to say so

--- a/packages/runner/test/declared-data-files.test.ts
+++ b/packages/runner/test/declared-data-files.test.ts
@@ -80,6 +80,82 @@ describe("attachDeclaredDataFiles", () => {
     );
   });
 
+  it("attaches a sibling read under the reading module's directory", async () => {
+    const nested: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: 'export * from "./lists/read.ts";\n' },
+        {
+          name: "/lists/read.ts",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("./cities.json");\n',
+        },
+      ],
+    };
+    const resolver = withDataReader({}, { "/lists/cities.json": '["Oslo"]\n' });
+    const result = await attachDeclaredDataFiles(nested, resolver);
+    assertEquals(result.dataFiles, ["/lists/cities.json"]);
+    assertEquals(resolver.dataReads, ["/lists/cities.json"]);
+  });
+
+  it("attaches a parent read above the reading module's directory", async () => {
+    const nested: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: 'export * from "./lists/read.ts";\n' },
+        {
+          name: "/lists/read.ts",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("../shared/cities.json");\n',
+        },
+      ],
+    };
+    const resolver = withDataReader({}, {
+      "/shared/cities.json": '["Lima"]\n',
+    });
+    const result = await attachDeclaredDataFiles(nested, resolver);
+    assertEquals(result.dataFiles, ["/shared/cities.json"]);
+  });
+
+  it("names the resolved path in a refusal, not the one written", async () => {
+    // The reader wrote a path relative to itself; the file has to be stored at
+    // the path that resolves to, and that is the path worth reporting.
+    const nested: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: 'export * from "./lists/read.ts";\n' },
+        {
+          name: "/lists/read.ts",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("./cities.json");\n',
+        },
+      ],
+    };
+    await assertRejects(
+      () => attachDeclaredDataFiles(nested, sourceOnly({})),
+      Error,
+      '"/lists/read.ts" reads the data file "/lists/cities.json"',
+    );
+  });
+
+  it("refuses a read that climbs above the program root", async () => {
+    const escaping: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'import { dataFile } from "commonfabric";\n' +
+            'export default () => dataFile("../outside.json");\n',
+        },
+      ],
+    };
+    await assertRejects(
+      () => attachDeclaredDataFiles(escaping, sourceOnly({})),
+      Error,
+      'Data file "../outside.json" read in "/main.tsx" escapes',
+    );
+  });
+
   it("leaves a program whose source declares nothing alone", async () => {
     const plain = program("export default 1;\n");
     assertEquals(await attachDeclaredDataFiles(plain, sourceOnly({})), plain);

--- a/packages/runner/test/engine-evaluate-record-graph.test.ts
+++ b/packages/runner/test/engine-evaluate-record-graph.test.ts
@@ -327,6 +327,193 @@ describe("Engine.evaluateRecordGraph()", () => {
     expect(main?.default).toEqual(["Oslo", "Lima"]);
   });
 
+  it("resolves a relative read against the module that makes it", async () => {
+    // The reading module sits two directories down and names the file beside
+    // it. Nothing in the program spells the path the file is stored under, so
+    // the read has to work it out from where the reader is.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/lists/nordic/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'export { cities } from "./lists/nordic/read.ts";\n',
+        },
+        {
+          name: "/lists/nordic/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("./cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        {
+          name: "/lists/nordic/cities.json",
+          contents: '{"cities": ["Oslo", "Bergen"]}',
+        },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect((main as Record<string, unknown>).cities).toEqual([
+      "Oslo",
+      "Bergen",
+    ]);
+  });
+
+  it("resolves a bare read against the module that makes it", async () => {
+    // No leading `./`. A data file has no bare-package namespace, so a path
+    // that is not grounded at the package root is relative to the reader.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/lists/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'export { cities } from "./lists/read.ts";\n',
+        },
+        {
+          name: "/lists/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        { name: "/lists/cities.json", contents: '{"cities": ["Rio"]}' },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect((main as Record<string, unknown>).cities).toEqual(["Rio"]);
+  });
+
+  it("climbs out of the reading module's directory for a parent read", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/shared/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'export { cities } from "./nordic/read.ts";\n',
+        },
+        {
+          name: "/nordic/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("../shared/cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        { name: "/shared/cities.json", contents: '{"cities": ["Lima"]}' },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect((main as Record<string, unknown>).cities).toEqual(["Lima"]);
+  });
+
+  it("gives two modules at different depths their own sibling file", async () => {
+    // Both modules read `./cities.json`, and each gets the one beside it.
+    // A read resolved anywhere but at the reader would hand both the same
+    // file.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/nordic/cities.json", "/andean/deep/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'export { cities as nordic } from "./nordic/read.ts";',
+            'export { cities as andean } from "./andean/deep/read.ts";',
+          ].join("\n"),
+        },
+        {
+          name: "/nordic/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("./cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        {
+          name: "/andean/deep/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("./cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        { name: "/nordic/cities.json", contents: '{"cities": ["Oslo"]}' },
+        { name: "/andean/deep/cities.json", contents: '{"cities": ["Lima"]}' },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect((main as Record<string, unknown>).nordic).toEqual(["Oslo"]);
+    expect((main as Record<string, unknown>).andean).toEqual(["Lima"]);
+  });
+
+  it("leaves a module's own export named dataFile alone", async () => {
+    // Only the runtime's `dataFile` reads attached data. A local module is free
+    // to export a value under that name, and an importer gets the one it
+    // imported.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { __cf_data } from "commonfabric";',
+            'import { dataFile } from "./local.ts";',
+            'export default __cf_data(dataFile("/cities.json"));',
+          ].join("\n"),
+        },
+        {
+          name: "/local.ts",
+          contents:
+            "export const dataFile = (path: string) => `local:${path}`;\n",
+        },
+        { name: "/cities.json", contents: '{"cities": []}' },
+      ],
+    };
+
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect(main?.default).toBe("local:/cities.json");
+  });
+
+  it("names the path a failed relative read resolved to", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/nordic/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'export { text } from "./nordic/read.ts";\n',
+        },
+        {
+          name: "/nordic/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            'export const text = __cf_data(dataFile("./absent.json"));',
+          ].join("\n"),
+        },
+        { name: "/nordic/cities.json", contents: "[]" },
+      ],
+    };
+
+    await expect(engine.compileAndEvaluateModules(program)).rejects.toThrow(
+      'No attached data file "/nordic/absent.json". ' +
+        "Attached: /nordic/cities.json.",
+    );
+  });
+
   it("names the attached data files when a path matches none", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -259,6 +259,90 @@ describe("load by module identity (warm + version-bump recovery)", () => {
     }
   });
 
+  it("resolves a relative data read from cached bodies alone", async () => {
+    // The warm path holds no source and no program: it builds records from
+    // cached bodies keyed by identity. A read written relative to its module
+    // therefore has to resolve from the module's own filename, which is all
+    // that path carries.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/lists/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: 'export { cities } from "./lists/read.ts";\n',
+        },
+        {
+          name: "/lists/read.ts",
+          contents: [
+            'import { __cf_data, dataFile } from "commonfabric";',
+            "export const cities = __cf_data(",
+            '  JSON.parse(dataFile("./cities.json")).cities,',
+            ");",
+          ].join("\n"),
+        },
+        { name: "/lists/cities.json", contents: '{"cities": ["Oslo"]}' },
+      ],
+    };
+
+    const { modules, entryIdentity } = await engine.compileToRecordGraph(
+      program,
+    );
+    const cached: CachedCompiledModule[] = modules.map((m) => ({
+      identity: m.identity,
+      filename: m.filename,
+      code: m.js,
+      ...(m.isData ? { isData: true } : {}),
+      // deno-lint-ignore no-explicit-any
+      imports: m.imports as any,
+    }));
+
+    const result = await engine.evaluateCachedModules(cached, entryIdentity);
+    expect((result.main as Record<string, unknown>).cities).toEqual(["Oslo"]);
+  });
+
+  it("leaves a module's own dataFile export alone on the warm path", async () => {
+    // The two record builders each decide which namespaces carry the reader,
+    // so each needs the case where a local module exports that name itself.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      dataFiles: ["/cities.json"],
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            'import { __cf_data } from "commonfabric";',
+            'import { dataFile } from "./local.ts";',
+            "export const read = __cf_data(dataFile('/cities.json'));",
+          ].join("\n"),
+        },
+        {
+          name: "/local.ts",
+          contents:
+            "export const dataFile = (path: string) => `local:${path}`;\n",
+        },
+        { name: "/cities.json", contents: '{"cities": []}' },
+      ],
+    };
+
+    const { modules, entryIdentity } = await engine.compileToRecordGraph(
+      program,
+    );
+    const cached: CachedCompiledModule[] = modules.map((m) => ({
+      identity: m.identity,
+      filename: m.filename,
+      code: m.js,
+      ...(m.isData ? { isData: true } : {}),
+      // deno-lint-ignore no-explicit-any
+      imports: m.imports as any,
+    }));
+
+    const result = await engine.evaluateCachedModules(cached, entryIdentity);
+    expect((result.main as Record<string, unknown>).read).toBe(
+      "local:/cities.json",
+    );
+  });
+
   it("cold-loads an exact attached data-file package", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -216,11 +216,12 @@ revision, so omitting the flags drops those test roots from that revision.
 A file that is not code — a fixture, a lookup table, a list of names — ships and
 is recovered with the source. Its bytes are stored verbatim: never parsed,
 type-checked, compiled, or importable, and the pattern reads one with
-`dataFile("/data/cities.json")` from `commonfabric`. That call is the
-declaration. Store the file under the deployment root at the path it names, and
-`new`, `setsrc`, `check`, `test`, and `dev` all attach it, the way they already
-follow what the source imports. A name with no file behind it fails the build
-and says which module read it.
+`dataFile("./data/cities.json")` from `commonfabric`. That call is the
+declaration, and its path resolves against the module that reads it, the way an
+import specifier does. Store the file where the call points and `new`, `setsrc`,
+`check`, `test`, and `dev` all attach it, the way they already follow what the
+source imports. A name with no file behind it fails the build and says which
+module read it.
 
 `--datafile <path>` attaches a file the source cannot name: one read by a
 computed path, or one that ships with a program that does not read it. It adds

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -73,14 +73,15 @@ which creates a duplicate piece.
 defines the complete source revision, so repeat all test flags on every update
 or the new revision will omit those test roots.
 
-Repeatable `--datafile <path>` attaches a file that is not code — a fixture, a
-lookup table — so it ships and is recovered with the source. Its bytes are
-stored verbatim and never parsed, compiled, or importable; it must be UTF-8 text
-inside the deployment root. A pattern reads one with `dataFile(path)` from
-`commonfabric`, naming the path it is stored under. Pass the same `--datafile`
-flags to `cf check` and `cf test`, or the read fails there. The same
-complete-revision rule applies, so repeat every data-file flag on each update
-too.
+A pattern reads a file that is not code — a fixture, a lookup table — with
+`dataFile(path)` from `commonfabric`, naming it relative to the module that
+reads it. That call is the declaration, so `new`, `setsrc`, `check` and `test`
+all attach the file without being told. Its bytes are stored verbatim and never
+parsed, compiled, or importable; it must be UTF-8 text inside the deployment
+root. Repeatable `--datafile <path>` remains for a file the source cannot name:
+one read by a computed path, or one that ships with a pattern that does not read
+it. The same complete-revision rule applies to those, so repeat every data-file
+flag on each update too.
 
 **Inspect piece state:**
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -16,11 +16,12 @@ every entry with repeatable `--test` flags on `piece new` and every later
 automated tests. Deployment packages and type-checks attached tests but does not
 run them. A file the pattern ships with that is not code — a fixture, a lookup
 table — is read with `dataFile(path)` from `commonfabric` and stored verbatim
-rather than compiled. That call is the whole declaration: store the file under
-the program root at the path it names, and every command that builds the pattern
-attaches it, so a pattern that reads one is checkable, testable, and deployable
-with no extra flag. `--datafile` remains for a file the source cannot name, such
-as one read by a computed path.
+rather than compiled. The path resolves against the module that reads it, as an
+import specifier does, so `./data/cities.json` is the file beside the pattern.
+That call is the whole declaration: store the file where the call points, and
+every command that builds the pattern attaches it, so a pattern that reads one
+is checkable, testable, and deployable with no extra flag. `--datafile` remains
+for a file the source cannot name, such as one read by a computed path.
 
 Also read the foundational reactivity references before implementing or
 debugging pattern state:


### PR DESCRIPTION
`dataFile(path)` took a path that was root-relative within the deployed source package. That spelling only works if "the program root" is one thing, and in this repository it is three. The pattern-unit lane runs `cf test --root packages/patterns`, and so do the pattern integration harness and toolshed's pattern server. `cfcheck`, `pattern-compat` and `pattern-vintage-run` build every program with the repository as its root. `cf piece new` with no `--root` infers the smallest directory covering the entry, its tests and its data, which for a pattern in its own directory is that directory. One file on disk therefore has three correct spellings, and a pattern that reads one cannot be written to satisfy all three: `packages/patterns/scrabble/scrabble.tsx` on #6097 reads a word list, passes all fourteen pattern shards with the spelling the test lane wants, and fails `CFC Pattern Check` and `Pattern Update Compatibility` with a file those gates cannot find. The second failure is the worse one — the pattern yields no contract at all, which that gate reports as a pattern that can never be updated again.

A `dataFile()` path now resolves against the module that reads it, as `resolveImportSpecifier` resolves an import specifier against the importing source. `words.txt` and `./words.txt` both name the file beside the reader, and `../shared/words.txt` the one above it; each names the same file on disk under every one of those three roots. Only a path grounded at the package root is left as written, so `/data/cities.json` still addresses one file from every module.

The rule is the shape of the path rather than a prefix, which is where it parts company with the import rule it otherwise mirrors. An import needs the `./` because it has a third case: a bare specifier names a package rather than a file, so `commonfabric` must not be joined against the importer's directory. A data-file path has no such case, since every one of them names a file the package carries. A path with no leading slash therefore has nowhere else to mean, and `./` adds nothing to a directory walk that the same path without it does not already say.

#6090 decided against relative resolution, and its reasoning is worth answering rather than reversing quietly. It held that a data file belongs to the package rather than to any one module, so the path should not resolve relative to the caller, and that this is what lets a sub-pattern read a file as readily as the entry module. The premise is right and is unchanged here: the file still belongs to the package and is still stored under one package path. The conclusion does not follow from it. A module imported by a relative specifier belongs to the package too, and resolving it against the importer is what makes a directory of source movable. What relative costs is that two modules in different directories spell one file differently. What it buys is that one module spells one file the same way however the package was rooted, which is the property the three roots above make necessary. The sub-pattern case turns out to argue the same way: a sub-pattern reading `./data.json` reads its own data without knowing where the package will be rooted, where an absolute path obliges every sub-pattern to know that in advance.

Every existing caller writes a grounded path and keeps working, and that spelling stays right wherever the writer knows the root — a CLI fixture whose own test fixes its root, say. The exception is the multi-runtime integration fixture, which read
`/integration/fixtures/data-file-multi-runtime/data/cities.json` for a file sitting beside it. That spelling is the pain being fixed, so it now reads `./data/cities.json`, and its test still crosses both the compile-in-a-worker and the load-from-storage boundaries.

The scan and the read have to agree, or a file is attached under one name and looked up by another. `collectDataFileNames` resolves each literal against the module it is parsing, so the name a file is attached under is the name it will be looked up by. The read resolves the same way. The runtime namespaces a graph registers are shared by every module in it, so the reader cannot live in them: a module gets its own copy of the namespace instead, whose `dataFile` closes over that module's own stored path. That copy is made at the seam where the record compiler already resolves a module's import specifiers, on both the cold-compile and the warm-cache record paths, so a read works the same whether the pattern was just compiled or loaded from the compiled set alone. It is made only for a namespace reached through a runtime-module specifier, which each of those builders already distinguishes while resolving imports: an authored module is free to export a value of its own named `dataFile`, and an importer of one gets what it imported.

A graph carrying no data files hands every namespace straight through and pays nothing, so a read there reaches the builder's placeholder and is told the load attached none.

A `dataFile()` path may not climb above the program root. That is refused while the program is assembled, as an escaping import is, so the refusal names the path the author wrote instead of the clamped path no source file contains.

`undeclaredDataFiles` no longer parses attached data files while working out which of them a later `setsrc` has to be told about. A data file is never read as code, and its bytes may happen to parse as a `dataFile()` call.

The proof is an authored pattern rather than a fixture: `packages/patterns/examples/phonetic-speller.tsx` reads its alphabet from `./data/phonetic-alphabet.json`, with a test beside it. `deno task cfcheck`, `deno task pattern-compat` and the pattern-unit lane all pass it with the roots they already use. Fixtures under `packages/patterns/integration/` would not have proved it: `isPatternSource` excludes that tree from both gates, which is why the conflict went unnoticed until a pattern outside it read a data file.

#6097 is blocked on this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

