### PR TITLE
fix(deno-web-test): a config that fails to import fails the run

### DIFF
--- a/packages/deno-web-test/README.md
+++ b/packages/deno-web-test/README.md
@@ -42,6 +42,10 @@ module is bundled. Reach for `bundle` when the module has to run in a realm the
 test page creates -- an iframe or a worker -- which loads it by URL and so
 cannot share the test's own bundle.
 
+A project with no config file runs on the defaults. A config file that is there
+but cannot be imported ends the run before the browser starts, with a message
+naming the file and the error importing it produced.
+
 ## Stuck tests
 
 A test that waits on something which never arrives would otherwise hang until

--- a/packages/deno-web-test/config.ts
+++ b/packages/deno-web-test/config.ts
@@ -98,17 +98,27 @@ export const extractAstralConfig = (config: Config): LaunchOptions => {
   return astralConfig;
 };
 
+// Reads the project's `deno-web-test.config.ts` and applies the defaults on
+// top of it. A project with no such file runs on the defaults alone. A file
+// that is there but cannot be imported throws, naming the path and the failure
+// importing it produced, so the run ends rather than reaching the browser on
+// settings the project did not ask for.
 export const getConfig = async (projectDir: string): Promise<Config> => {
   const configPath = path.join(projectDir, "deno-web-test.config.ts");
 
-  if (await exists(configPath, { isFile: true })) {
-    // Try to evaluate it
-    try {
-      const config = (await import(configPath)).default;
-      return applyDefaults(config);
-    } catch (_) {
-      console.error(`Unable to execute deno-web-test.config.ts`);
-    }
+  if (!await exists(configPath, { isFile: true })) {
+    return applyDefaults({});
   }
-  return applyDefaults({});
+
+  let config: object;
+  try {
+    config = (await import(configPath)).default;
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      `Unable to import ${configPath}: ${detail}`,
+      { cause },
+    );
+  }
+  return applyDefaults(config);
 };

--- a/packages/deno-web-test/test/base.test.ts
+++ b/packages/deno-web-test/test/base.test.ts
@@ -1,23 +1,26 @@
-import { assert, assertEquals } from "@std/assert";
-import { decode } from "@commonfabric/utils/encoding";
+import { assertEquals } from "@std/assert";
 import { runDenoWebTest, sanitizeDenoWebTestOutput } from "./utils.ts";
 
 Deno.test("smoke test", async function () {
-  const { success, stdout, stderr } = await runDenoWebTest("success-project");
-  const stdoutText = decode(stdout);
-  const stderrText = decode(stderr);
+  const run = await runDenoWebTest("success-project");
 
-  assert(success, "test successful");
-  assert(/add-sync ... ok/.test(stdoutText), "test output ok");
-  assert(/add-async ... ok/.test(stdoutText), "test output ok");
-  assert(/ok | 2 passed | 0 failed/.test(stdoutText), "test output ok");
-  assert(/deno run/.test(stderrText), "stderr has deno task run");
-  assert(
-    !/experimentalDecorators/.test(stderrText),
+  run.assert(run.success, "test successful");
+  run.assert(/add-sync ... ok/.test(run.stdoutText), "test output ok");
+  run.assert(/add-async ... ok/.test(run.stdoutText), "test output ok");
+  run.assert(/ok | 2 passed | 0 failed/.test(run.stdoutText), "test output ok");
+  run.assert(/deno run/.test(run.stderrText), "stderr has deno task run");
+  run.assert(
+    !/experimentalDecorators/.test(run.stderrText),
     "stderr has no compiler options warning",
   );
-  assert(stderrText.split("\n").length === 2, "stderr has no other messages");
-  assert(stderrText.split("\n")[1] === "", "stderr has no other messages");
+  run.assert(
+    run.stderrText.split("\n").length === 2,
+    "stderr has no other messages",
+  );
+  run.assert(
+    run.stderrText.split("\n")[1] === "",
+    "stderr has no other messages",
+  );
 });
 
 Deno.test("dependency downloads before the harness boundary are removed", function () {

--- a/packages/deno-web-test/test/broken-config-project/deno-web-test.config.ts
+++ b/packages/deno-web-test/test/broken-config-project/deno-web-test.config.ts
@@ -1,0 +1,4 @@
+// Importing this config throws, the way a config whose own imports no longer
+// resolve or whose top-level code fails would. The settings it would have
+// produced never reach the harness.
+throw new Error("this config is deliberately broken");

--- a/packages/deno-web-test/test/broken-config-project/deno.jsonc
+++ b/packages/deno-web-test/test/broken-config-project/deno.jsonc
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "<@see deno-web-test/test/utils.ts#runDenoWebTest>"
+  }
+}

--- a/packages/deno-web-test/test/broken-config-project/pass.test.ts
+++ b/packages/deno-web-test/test/broken-config-project/pass.test.ts
@@ -1,0 +1,3 @@
+// This test would pass under the defaults. It reports nothing, because the run
+// ends while reading the config.
+Deno.test("would-pass", function () {});

--- a/packages/deno-web-test/test/bundle.test.ts
+++ b/packages/deno-web-test/test/bundle.test.ts
@@ -1,20 +1,19 @@
-import { assert } from "@std/assert";
-import { decode } from "@commonfabric/utils/encoding";
 import { runDenoWebTest } from "./utils.ts";
 
 Deno.test("a `bundle` entry is bundled onto the server root", async function () {
-  const { success, stdout } = await runDenoWebTest("bundle-project");
-  const stdoutText = decode(stdout);
+  const run = await runDenoWebTest("bundle-project");
 
-  assert(success, stdoutText);
-  assert(
+  run.assert(run.success, "the run succeeds");
+  run.assert(
     /a bundled module loads into a realm the page creates \.\.\. ok/.test(
-      stdoutText,
+      run.stdoutText,
     ),
-    stdoutText,
+    "the worker loads its bundled module",
   );
-  assert(
-    /a bundled module loads into a sandboxed iframe \.\.\. ok/.test(stdoutText),
-    stdoutText,
+  run.assert(
+    /a bundled module loads into a sandboxed iframe \.\.\. ok/.test(
+      run.stdoutText,
+    ),
+    "the sandboxed iframe loads its bundled module",
   );
 });

--- a/packages/deno-web-test/test/config.test.ts
+++ b/packages/deno-web-test/test/config.test.ts
@@ -1,22 +1,47 @@
-import { assert } from "@std/assert";
-import { decode } from "@commonfabric/utils/encoding";
+import { join } from "@std/path";
 import { runDenoWebTest } from "./utils.ts";
 
 Deno.test("config is applied", async function () {
-  const { success, stdout, stderr } = await runDenoWebTest(
-    "project-with-config",
-  );
-  const stdoutText = decode(stdout);
-  const stderrText = decode(stderr);
+  const run = await runDenoWebTest("project-with-config");
 
-  assert(success, "test successfully ran, applying chrome flags");
-  assert(/LOG FROM TEST/.test(stdoutText), "console output propagated");
+  run.assert(run.success, "test successfully ran, applying chrome flags");
+  run.assert(/LOG FROM TEST/.test(run.stdoutText), "console output propagated");
 
-  assert(/deno run/.test(stderrText), "stderr has deno task run");
-  assert(
-    !/experimentalDecorators/.test(stderrText),
+  run.assert(/deno run/.test(run.stderrText), "stderr has deno task run");
+  run.assert(
+    !/experimentalDecorators/.test(run.stderrText),
     "stderr has no compiler options warning",
   );
-  assert(stderrText.split("\n").length === 2, "stderr has no other messages");
-  assert(stderrText.split("\n")[1] === "", "stderr has no other messages");
+  run.assert(
+    run.stderrText.split("\n").length === 2,
+    "stderr has no other messages",
+  );
+  run.assert(
+    run.stderrText.split("\n")[1] === "",
+    "stderr has no other messages",
+  );
+});
+
+// The settings a config carries decide how the whole suite runs: which browser
+// flags it gets, how long a test may take, what is served next to it. A run
+// that cannot read them and continues on the defaults instead fails somewhere
+// else entirely, for a reason that says nothing about the config.
+Deno.test("a config that throws on import fails the run", async function () {
+  const run = await runDenoWebTest("broken-config-project");
+
+  run.assert(!run.success, "the run fails");
+  run.assert(
+    run.stderrText.includes(
+      join("broken-config-project", "deno-web-test.config.ts"),
+    ),
+    "the failure names the config path",
+  );
+  run.assert(
+    /this config is deliberately broken/.test(run.stderrText),
+    "the failure carries the error importing the config produced",
+  );
+  run.assert(
+    !/would-pass/.test(run.stdoutText),
+    "no test ran on the default settings",
+  );
 });

--- a/packages/deno-web-test/test/timeout.test.ts
+++ b/packages/deno-web-test/test/timeout.test.ts
@@ -1,7 +1,5 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 
-import { decode } from "@commonfabric/utils/encoding";
-
 import { applyDefaults, DEFAULT_TEST_TIMEOUT_MS } from "../config.ts";
 import { runDenoWebTest } from "./utils.ts";
 
@@ -11,27 +9,35 @@ import { runDenoWebTest } from "./utils.ts";
 // The harness now stops waiting on a test of its own accord, so a stuck test is
 // one named failure among otherwise normal results.
 Deno.test("a stuck test fails by name and the run continues", async function () {
-  const { success, stdout } = await runDenoWebTest("timeout-project");
-  const stdoutText = decode(stdout);
+  const run = await runDenoWebTest("timeout-project");
 
-  assert(!success, "the run fails");
-  assert(/hangs-forever \.\.\. .*FAILED/.test(stdoutText), "names the test");
-  assert(
-    /Timed out after 1000ms/.test(stdoutText),
+  run.assert(!run.success, "the run fails");
+  run.assert(
+    /hangs-forever \.\.\. .*FAILED/.test(run.stdoutText),
+    "names the test",
+  );
+  run.assert(
+    /Timed out after 1000ms/.test(run.stdoutText),
     "reports how long it waited",
   );
-  assert(
-    /a test at that point and calls it stuck/.test(stdoutText),
+  run.assert(
+    /a test at that point and calls it stuck/.test(run.stdoutText),
     "explains that this is a stuck-test detector",
   );
 
   // The point of failing the test rather than the run: everything else still
   // reports, including the tests queued behind the stuck one.
-  assert(/before-hang \.\.\. .*ok/.test(stdoutText), "earlier test ran");
-  assert(/after-hang \.\.\. .*ok/.test(stdoutText), "later test still ran");
-  assert(/2 passed \| 1 failed/.test(stdoutText), "summary is printed");
-  assert(
-    !/RetryError/.test(stdoutText),
+  run.assert(
+    /before-hang \.\.\. .*ok/.test(run.stdoutText),
+    "earlier test ran",
+  );
+  run.assert(
+    /after-hang \.\.\. .*ok/.test(run.stdoutText),
+    "later test still ran",
+  );
+  run.assert(/2 passed \| 1 failed/.test(run.stdoutText), "summary is printed");
+  run.assert(
+    !/RetryError/.test(run.stdoutText),
     "the harness reports before astral's deadline",
   );
 });

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -1,10 +1,12 @@
 import * as path from "@std/path";
+import { AssertionError } from "@std/assert";
 import { copy } from "@std/fs";
 import { parse as parseJsonc } from "@std/jsonc";
+import { decode } from "@commonfabric/utils/encoding";
 
 const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
-const DenoWebTestCache: Map<string, Promise<Deno.CommandOutput>> = new Map();
+const DenoWebTestCache: Map<string, Promise<HarnessRun>> = new Map();
 const encoder = new TextEncoder();
 const STDERR_BOUNDARY_ENV = "DENO_WEB_TEST_STDERR_BOUNDARY";
 const DOWNLOAD_HTTP_PREFIX = encoder.encode("Download http://");
@@ -121,6 +123,50 @@ export function sanitizeDenoWebTestOutput(
   };
 }
 
+// One completed run of the harness against a test project: how the process
+// exited, both of its streams as bytes and as text, and an `assert` that
+// carries the whole transcript into the failure message.
+export class HarnessRun {
+  readonly projectDir: string;
+  readonly success: boolean;
+  readonly code: number;
+  readonly stdout: Uint8Array;
+  readonly stderr: Uint8Array;
+  readonly stdoutText: string;
+  readonly stderrText: string;
+
+  constructor(projectDir: string, output: Deno.CommandOutput) {
+    this.projectDir = projectDir;
+    this.success = output.success;
+    this.code = output.code;
+    this.stdout = output.stdout;
+    this.stderr = output.stderr;
+    this.stdoutText = decode(output.stdout);
+    this.stderrText = decode(output.stderr);
+  }
+
+  // Fails with `message` followed by the whole transcript. An assertion here
+  // reads one line of what the run printed, and the rest of that output is
+  // what says why the line is not the one it should be.
+  assert(condition: boolean, message: string): void {
+    if (condition) {
+      return;
+    }
+    throw new AssertionError(`${message}\n\n${this.transcript()}`);
+  }
+
+  transcript(): string {
+    return [
+      `deno-web-test in ${this.projectDir} exited with code ${this.code}.`,
+      "--- stdout ---",
+      this.stdoutText,
+      "--- stderr ---",
+      this.stderrText,
+      "--- end of transcript ---",
+    ].join("\n");
+  }
+}
+
 // Runs deno-web-test in `projectDir` and caches
 // the results for multiple test usages.
 //
@@ -130,7 +176,7 @@ export function sanitizeDenoWebTestOutput(
 // before running tests.
 export const runDenoWebTest = async (
   projectDir: string,
-): Promise<Deno.CommandOutput> => {
+): Promise<HarnessRun> => {
   const fromCache = DenoWebTestCache.get(projectDir);
   if (fromCache) {
     return fromCache;
@@ -171,7 +217,7 @@ export const runDenoWebTest = async (
   }
 
   const stderrBoundary = `deno-web-test:${crypto.randomUUID()}`;
-  const output = new Deno.Command(Deno.execPath(), {
+  const run = new Deno.Command(Deno.execPath(), {
     args: [
       "task",
       "test",
@@ -181,8 +227,11 @@ export const runDenoWebTest = async (
       [STDERR_BOUNDARY_ENV]: stderrBoundary,
     },
   }).output().then((output) =>
-    sanitizeDenoWebTestOutput(output, stderrBoundary)
+    new HarnessRun(
+      projectDir,
+      sanitizeDenoWebTestOutput(output, stderrBoundary),
+    )
   );
-  DenoWebTestCache.set(projectDir, output);
-  return output;
+  DenoWebTestCache.set(projectDir, run);
+  return run;
 };


### PR DESCRIPTION
`getConfig()` imported a project's `deno-web-test.config.ts` inside a try/catch. When the import threw, it wrote "Unable to execute deno-web-test.config.ts" to stderr and returned the defaults, so the harness ran as though the project had no config at all.

That hid the failure behind a later, unrelated one. Every setting a config carries shapes the run: which browser flags the suite gets, how long a test may take before the harness calls it stuck, which files are served next to it. This package's own fixtures show the shape of the resulting confusion. `project-with-config` would lose `--enable-experimental-web-platform-features` and fail its ed25519 test, in Chrome, for want of a flag nothing in the output mentions. `timeout-project` would wait the forty-second default instead of the thousand milliseconds it asks for, so the run that exists to exercise the stuck-test detector would take forty times as long and then fail on a message naming the wrong bound.

`getConfig()` now throws when a config file is there but cannot be imported, with a message naming the path and the error that importing it produced, and that error attached as the cause. The run ends before the browser starts. A project with no config file at all still runs on the defaults, which is the intended path and is unchanged.

The new `broken-config-project` fixture pairs a config whose top-level code throws with one test that would pass under the defaults. The test asserts that the run fails, that the message names the config path and carries the underlying error, and that the would-be-passing test never reported.

`runDenoWebTest` now hands back a `HarnessRun` rather than a bare `Deno.CommandOutput`: the same exit status and streams, each stream decoded to text, and an `assert` method that puts the whole transcript into the failure message. The tests that drive the harness read one line of that output at a time and asserted through bare `assert()` calls that named a condition without showing what the run printed; they now assert through the run.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

