### PR TITLE
test(runner): the retry tests wait on the runs they count

### DIFF
--- a/packages/runner/test/scheduler-retries.test.ts
+++ b/packages/runner/test/scheduler-retries.test.ts
@@ -1,5 +1,7 @@
 // Scheduler reactive retry tests.
 
+import { defer } from "@commonfabric/utils/defer";
+
 import {
   afterEach,
   beforeEach,
@@ -18,6 +20,7 @@ import type {
   ReactivityLog,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
 import { watchReactiveActionCommit } from "../src/scheduler/run.ts";
 
 describe("reactive retries", () => {
@@ -49,14 +52,21 @@ describe("reactive retries", () => {
       await tx.commit();
       tx = runtime.edit();
 
-      // Count runs; force commit failure each time
+      // Count runs; force commit failure each time. The action reports its
+      // own runs: the run that spends the last of the retry budget resolves
+      // `budgetExhausted`, and the run that a later input change triggers
+      // resolves `retriggered`.
       let attempts = 0;
+      const budgetExhausted = defer();
+      const retriggered = defer();
       const reactiveAction: Action = (actionTx) => {
         attempts++;
         // Read to establish dependency so later changes re-trigger
         source.withTx(actionTx).get();
         // Force commit to fail so scheduler retries
         actionTx.abort("force-abort-for-reactive-retry");
+        if (attempts === MAX_RETRIES_FOR_REACTIVE) budgetExhausted.resolve();
+        if (attempts === MAX_RETRIES_FOR_REACTIVE + 1) retriggered.resolve();
       };
 
       // Subscribe and run immediately
@@ -66,24 +76,27 @@ describe("reactive retries", () => {
         { isEffect: true },
       );
 
-      // Allow retries to process. Idle may resolve before re-queue occurs,
-      // so loop a few times until attempts reach the expected amount.
-      for (let i = 0; i < 20 && attempts < 10; i++) {
-        await runtime.idle();
-      }
+      // The initial run plus its retries spend the whole budget.
+      await budgetExhausted.promise;
+      // The commit of that run is still in flight, and whether to retry is
+      // decided in that commit's continuation. The commit-aware barrier spans
+      // both, so a run past the budget is counted before the assertion reads
+      // the count.
+      await runtime.scheduler.idleWithPendingCommits();
 
-      // MAX_RETRIES_FOR_REACTIVE is 10; expect initial + retries == 10 attempts
-      expect(attempts).toBe(10);
+      expect(attempts).toBe(MAX_RETRIES_FOR_REACTIVE);
 
       // After reaching retry limit, a subsequent input change should re-trigger
       source.withTx(tx).send(2);
       await tx.commit();
       tx = runtime.edit();
 
-      // Wait for the follow-up run
-      await runtime.idle();
+      // Wait for the run the change triggers, then span its commit as well.
+      // The budget is spent, so nothing is retried after that run.
+      await retriggered.promise;
+      await runtime.scheduler.idleWithPendingCommits();
 
-      expect(attempts).toBe(11);
+      expect(attempts).toBe(MAX_RETRIES_FOR_REACTIVE + 1);
     },
   );
 
@@ -314,6 +327,10 @@ describe("reactive retries", () => {
       let action1Attempts = 0;
       let action2Attempts = 0;
       const action2Values: number[] = [];
+      // Action 1 commits on its third run, and action 2 then re-runs against
+      // the value that run wrote. Action 2's second run is the end of that
+      // cascade, and resolves `cascadeComplete`.
+      const cascadeComplete = defer();
 
       // Action 1: reads source, writes intermediate (will fail first 2 times)
       const action1: Action = (actionTx) => {
@@ -333,6 +350,7 @@ describe("reactive retries", () => {
         const val = intermediate.withTx(actionTx).get();
         action2Values.push(val);
         output.withTx(actionTx).send(val + 5);
+        if (action2Attempts === 2) cascadeComplete.resolve();
       };
 
       // Subscribe both actions with correct dependencies
@@ -357,10 +375,16 @@ describe("reactive retries", () => {
         {},
       );
 
-      // Allow all actions to complete (action1 will retry twice)
-      for (let i = 0; i < 20 && action1Attempts < 3; i++) {
-        await output.pull();
-      }
+      // Neither action is an effect, so the scheduler runs one only while
+      // something demands what it writes. The sink holds that demand for the
+      // whole wait: it reaches action 2 through `output`, and action 1 through
+      // action 2's read of `intermediate`.
+      const cancel = output.sink(() => {});
+      await cascadeComplete.promise;
+      // Span the commit of action 2's second run, so a run past the cascade is
+      // counted before the assertions read the counters.
+      await runtime.scheduler.idleWithPendingCommits();
+      cancel();
 
       // Verify action1 ran 3 times (2 aborts + 1 success)
       expect(action1Attempts).toBe(3);


### PR DESCRIPTION
Both reactive-retry tests in
packages/runner/test/scheduler-retries.test.ts waited by calling a settle barrier over and over inside a bounded loop, stopping once a counter reached the number the assertion afterwards demanded. One looped twenty times on runtime.idle() until an action had run ten times; the other looped twenty times on output.pull() until an action had run three times. That is the shape the repository forbids, for the reasons docs/development/waiting-in-tests.md gives: the iteration cap puts a ceiling on what the test can observe, so a run that was going to happen but had not happened yet reads as a failure, and the loop reports the same pass whether it went round once or nineteen times. Neither loop needed its bound in the tree as it stood, both converging on the first iteration, so what the cap bought was the failure mode and nothing else.

Both actions belong to the test, so each can report the run the test is waiting for. The first test's action now resolves one deferred promise on the run that spends the last of the retry budget, and a second on the run that a later input change triggers; the test awaits each in turn. The second test's downstream action resolves a deferred promise on its second run, which is the end of the cascade the test sets up: the upstream action commits on its third run, and the downstream one then re-runs against the value that run wrote.

The retry limit is now imported as MAX_RETRIES_FOR_REACTIVE from the scheduler's constants rather than written as the literal 10, so the action and the assertion can no longer disagree with the scheduler.

Each wait is followed by scheduler.idleWithPendingCommits() rather than idle(). Whether a reactive action is retried is decided in its failed commit's continuation, which scheduler/run.ts registers as a pending commit of its own so that the commit-aware barrier spans it; plain idle() returns while a commit is still in flight. With the barrier in place, a run past the number the test expects is counted before the assertion reads the counter rather than arriving after the test has finished.

The second test's loop was doing one thing besides waiting. Neither of its actions is registered as an effect, so the scheduler runs them only while something demands what they write, and each pull() supplied that demand for one scheduler cycle. A sink on the output cell supplies the same demand and holds it for the whole wait, so the loop is not needed to keep the cascade running. Removing the sink and leaving everything else in place makes the test fail immediately, with Deno reporting the wait as a promise that can no longer resolve, which is what confirms the demand is what the pull was for.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

