### PR TITLE
fix(runner): a tool that shadows a built-in keeps its own declaration

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1256,46 +1256,46 @@ function flattenTools(
     return flattened;
   }
 
-  flattened[READ_TOOL_NAME] = {
+  defineBuiltinTool(flattened, READ_TOOL_NAME, {
     description:
       'Read data from any cell. Input: { "@link": "/of:bafyabc123/path" }. ' +
       "Returns the cell's data with nested cells as link objects. " +
       "Compose with invoke(): invoke() returns a link, then read(link) gets the data. ",
     inputSchema: READ_INPUT_SCHEMA,
-  };
-  flattened[INVOKE_TOOL_NAME] = {
+  });
+  defineBuiltinTool(flattened, INVOKE_TOOL_NAME, {
     description:
       'Invoke a handler or pattern. If you do not know the schema of the the handler, use schema() first. Input: { "@link": "/of:bafyabc123/doThing" }, plus optional args. ' +
       'Returns { "@link": "/of:xyz/result" } pointing to the result cell. ',
     inputSchema: INVOKE_INPUT_SCHEMA,
-  };
-  flattened[PIN_TOOL_NAME] = {
+  });
+  defineBuiltinTool(flattened, PIN_TOOL_NAME, {
     description:
       'Pin a cell for easy reference. Input: { "@link": "/of:bafyabc123" } and a name. ' +
       "Pinned cells and their values appear in the system prompt. " +
       "Use to track important cells you're working with.",
     inputSchema: PIN_INPUT_SCHEMA,
-  };
-  flattened[UNPIN_TOOL_NAME] = {
+  });
+  defineBuiltinTool(flattened, UNPIN_TOOL_NAME, {
     description: 'Unpin a cell. Input: { "@link": "/of:bafyabc123" }. ' +
       "Use when you no longer need quick access to a cell.",
     inputSchema: UNPIN_INPUT_SCHEMA,
-  };
-  flattened[UPDATE_ARGUMENT_TOOL_NAME] = {
+  });
+  defineBuiltinTool(flattened, UPDATE_ARGUMENT_TOOL_NAME, {
     description:
       'Update arguments of a running pattern instance. Input: { "@link": "/of:bafyabc123" } and updates object. ' +
       "The pattern will automatically re-execute with the new arguments. " +
       "Use after invoke() creates a pattern, or to modify attached pattern instances. " +
       'Example: updateArgument({ "@link": "/of:xyz" }, { "query": "new search" })',
     inputSchema: UPDATE_ARGUMENT_INPUT_SCHEMA,
-  };
-  flattened[SCHEMA_TOOL_NAME] = {
+  });
+  defineBuiltinTool(flattened, SCHEMA_TOOL_NAME, {
     description:
       "Get the JSON schema for a cell to understand its structure, fields, and handlers. " +
       'Input: { "@link": "/of:bafyabc123" }. ' +
       "Returns schema showing what data can be read and what handlers can be invoked. ",
     inputSchema: SCHEMA_INPUT_SCHEMA,
-  };
+  });
 
   return flattened;
 }
@@ -1362,29 +1362,32 @@ function _toolsHaveChanged(
  * Advertises a built-in tool, unless a pattern-supplied tool already holds the
  * name.
  *
- * `resolveToolCall` consults `dynamicToolCells` first, so on a name collision
- * the pattern's tool is what runs and the built-in is unreachable. The catalog
- * has to say the same thing, because the advertised schema is what the model
- * writes its input against AND what the CFC gates read policy from:
- * `toolAllowsObservedConfidentiality` takes `ifc.maxConfidentiality` from it,
- * and `integrityGateTarget` takes the `requiredIntegrity` floors. Letting a
- * built-in overwrite the entry would describe one tool while another executes,
- * enforcing the built-in's (absent) policy against the pattern's tool.
+ * `resolveToolCall` consults the pattern's tools before the built-in names, so
+ * on a collision the pattern's tool is what runs and the built-in is
+ * unreachable. Every description of the tools has to say the same thing. The
+ * advertised schema is what the model writes its input against, and it is also
+ * where the CFC gates read policy from — `toolAllowsObservedConfidentiality`
+ * takes `ifc.maxConfidentiality` from it and `integrityGateTarget` takes the
+ * `requiredIntegrity` floors — so letting a built-in overwrite the entry
+ * describes one tool while another executes, enforcing the built-in's absent
+ * policy against the pattern's tool.
+ *
+ * Callers pass a record holding only the pattern-supplied tools, so a name
+ * already present is a shadowed built-in.
  */
-function defineBuiltinTool(
-  llmTools: ToolCatalog["llmTools"],
-  dynamicToolCells: ToolCatalog["dynamicToolCells"],
+function defineBuiltinTool<T>(
+  tools: Record<string, T>,
   name: string,
-  definition: { description: string; inputSchema: JSONSchema },
+  definition: T,
 ): void {
-  if (dynamicToolCells.has(name)) {
+  if (Object.hasOwn(tools, name)) {
     logger.warn(
       "llm",
       `Tool "${name}" shadows the built-in of the same name; the pattern's tool is what runs. Rename it to reach the built-in.`,
     );
     return;
   }
-  llmTools[name] = definition;
+  tools[name] = definition;
 }
 
 function buildToolCatalog(
@@ -1442,32 +1445,32 @@ function buildToolCatalog(
     return { llmTools, dynamicToolCells };
   }
 
-  defineBuiltinTool(llmTools, dynamicToolCells, READ_TOOL_NAME, {
+  defineBuiltinTool(llmTools, READ_TOOL_NAME, {
     description:
       'Read data from any cell. Input: { "@link": "/of:bafyabc123/path" }. ' +
       "Returns the cell's data with nested cells as link objects. " +
       "Compose with invoke(): invoke() returns a link, then read(link) gets the data. ",
     inputSchema: READ_INPUT_SCHEMA,
   });
-  defineBuiltinTool(llmTools, dynamicToolCells, INVOKE_TOOL_NAME, {
+  defineBuiltinTool(llmTools, INVOKE_TOOL_NAME, {
     description:
       'Invoke a handler or pattern. Input: { "@link": "/of:bafyabc123/doThing" }, plus optional args. ' +
       'Returns { "@link": "/of:xyz/result" } pointing to the result cell. ',
     inputSchema: INVOKE_INPUT_SCHEMA,
   });
-  defineBuiltinTool(llmTools, dynamicToolCells, PIN_TOOL_NAME, {
+  defineBuiltinTool(llmTools, PIN_TOOL_NAME, {
     description:
       'Pin a cell for easy reference. Input: { "@link": "/of:bafyabc123" } and a name. ' +
       "Pinned cells and their values appear in the system prompt. " +
       "Use to track important cells you're working with.",
     inputSchema: PIN_INPUT_SCHEMA,
   });
-  defineBuiltinTool(llmTools, dynamicToolCells, UNPIN_TOOL_NAME, {
+  defineBuiltinTool(llmTools, UNPIN_TOOL_NAME, {
     description: 'Unpin a cell. Input: { "@link": "/of:bafyabc123" }. ' +
       "Use when you no longer need quick access to a cell.",
     inputSchema: UNPIN_INPUT_SCHEMA,
   });
-  defineBuiltinTool(llmTools, dynamicToolCells, UPDATE_ARGUMENT_TOOL_NAME, {
+  defineBuiltinTool(llmTools, UPDATE_ARGUMENT_TOOL_NAME, {
     description:
       'Update arguments of a running pattern instance. Input: { "@link": "/of:bafyabc123" } and updates object. ' +
       "The pattern will automatically re-execute with the new arguments. " +
@@ -1475,7 +1478,7 @@ function buildToolCatalog(
       'Example: updateArgument({ "@link": "/of:xyz" }, { "query": "new search" })',
     inputSchema: UPDATE_ARGUMENT_INPUT_SCHEMA,
   });
-  defineBuiltinTool(llmTools, dynamicToolCells, SCHEMA_TOOL_NAME, {
+  defineBuiltinTool(llmTools, SCHEMA_TOOL_NAME, {
     description:
       "Get the JSON schema for a cell to understand its structure, fields, and handlers. " +
       'Input: { "@link": "/of:bafyabc123" }. ' +
@@ -1517,18 +1520,13 @@ function materializeDialogRequestSnapshot(
     | JSONSchema
     | undefined;
   if (userResultSchema) {
-    defineBuiltinTool(
-      toolCatalog.llmTools,
-      toolCatalog.dynamicToolCells,
-      PRESENT_RESULT_TOOL_NAME,
-      {
-        description:
-          "Call this tool to present a structured result. This stores the result for the caller.",
-        inputSchema: prepareSchemaForLLM(
-          toDeepFrozenSchema(userResultSchema),
-        ),
-      },
-    );
+    defineBuiltinTool(toolCatalog.llmTools, PRESENT_RESULT_TOOL_NAME, {
+      description:
+        "Call this tool to present a structured result. This stores the result for the caller.",
+      inputSchema: prepareSchemaForLLM(
+        toDeepFrozenSchema(userResultSchema),
+      ),
+    });
   }
 
   // A DECLARED bound — even the empty one — engages observation-aware
@@ -2471,6 +2469,7 @@ export const llmDialogTestHelpers = {
 export const llmToolExecutionHelpers = {
   PRESENT_RESULT_TOOL_NAME,
   buildToolCatalog,
+  flattenTools,
   executeToolCalls,
   extractToolCallParts,
   buildAssistantMessage,
@@ -3682,18 +3681,13 @@ async function startRequest(
   const userResultSchema = capturedRequest?.userResultSchema ??
     (inputs.key("resultSchema").get() as JSONSchema | undefined);
   if (userResultSchema && capturedRequest === undefined) {
-    defineBuiltinTool(
-      toolCatalog.llmTools,
-      toolCatalog.dynamicToolCells,
-      PRESENT_RESULT_TOOL_NAME,
-      {
-        description:
-          "Call this tool to present a structured result. This stores the result for the caller.",
-        inputSchema: prepareSchemaForLLM(
-          toDeepFrozenSchema(userResultSchema),
-        ),
-      },
-    );
+    defineBuiltinTool(toolCatalog.llmTools, PRESENT_RESULT_TOOL_NAME, {
+      description:
+        "Call this tool to present a structured result. This stores the result for the caller.",
+      inputSchema: prepareSchemaForLLM(
+        toDeepFrozenSchema(userResultSchema),
+      ),
+    });
   }
 
   // Build available cells documentation (both context and pinned cells).

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1358,6 +1358,35 @@ function _toolsHaveChanged(
   return false;
 }
 
+/**
+ * Advertises a built-in tool, unless a pattern-supplied tool already holds the
+ * name.
+ *
+ * `resolveToolCall` consults `dynamicToolCells` first, so on a name collision
+ * the pattern's tool is what runs and the built-in is unreachable. The catalog
+ * has to say the same thing, because the advertised schema is what the model
+ * writes its input against AND what the CFC gates read policy from:
+ * `toolAllowsObservedConfidentiality` takes `ifc.maxConfidentiality` from it,
+ * and `integrityGateTarget` takes the `requiredIntegrity` floors. Letting a
+ * built-in overwrite the entry would describe one tool while another executes,
+ * enforcing the built-in's (absent) policy against the pattern's tool.
+ */
+function defineBuiltinTool(
+  llmTools: ToolCatalog["llmTools"],
+  dynamicToolCells: ToolCatalog["dynamicToolCells"],
+  name: string,
+  definition: { description: string; inputSchema: JSONSchema },
+): void {
+  if (dynamicToolCells.has(name)) {
+    logger.warn(
+      "llm",
+      `Tool "${name}" shadows the built-in of the same name; the pattern's tool is what runs. Rename it to reach the built-in.`,
+    );
+    return;
+  }
+  llmTools[name] = definition;
+}
+
 function buildToolCatalog(
   toolsCell:
     | Cell<Record<string, Schema<typeof LLMToolSchema>>>
@@ -1413,46 +1442,46 @@ function buildToolCatalog(
     return { llmTools, dynamicToolCells };
   }
 
-  llmTools[READ_TOOL_NAME] = {
+  defineBuiltinTool(llmTools, dynamicToolCells, READ_TOOL_NAME, {
     description:
       'Read data from any cell. Input: { "@link": "/of:bafyabc123/path" }. ' +
       "Returns the cell's data with nested cells as link objects. " +
       "Compose with invoke(): invoke() returns a link, then read(link) gets the data. ",
     inputSchema: READ_INPUT_SCHEMA,
-  };
-  llmTools[INVOKE_TOOL_NAME] = {
+  });
+  defineBuiltinTool(llmTools, dynamicToolCells, INVOKE_TOOL_NAME, {
     description:
       'Invoke a handler or pattern. Input: { "@link": "/of:bafyabc123/doThing" }, plus optional args. ' +
       'Returns { "@link": "/of:xyz/result" } pointing to the result cell. ',
     inputSchema: INVOKE_INPUT_SCHEMA,
-  };
-  llmTools[PIN_TOOL_NAME] = {
+  });
+  defineBuiltinTool(llmTools, dynamicToolCells, PIN_TOOL_NAME, {
     description:
       'Pin a cell for easy reference. Input: { "@link": "/of:bafyabc123" } and a name. ' +
       "Pinned cells and their values appear in the system prompt. " +
       "Use to track important cells you're working with.",
     inputSchema: PIN_INPUT_SCHEMA,
-  };
-  llmTools[UNPIN_TOOL_NAME] = {
+  });
+  defineBuiltinTool(llmTools, dynamicToolCells, UNPIN_TOOL_NAME, {
     description: 'Unpin a cell. Input: { "@link": "/of:bafyabc123" }. ' +
       "Use when you no longer need quick access to a cell.",
     inputSchema: UNPIN_INPUT_SCHEMA,
-  };
-  llmTools[UPDATE_ARGUMENT_TOOL_NAME] = {
+  });
+  defineBuiltinTool(llmTools, dynamicToolCells, UPDATE_ARGUMENT_TOOL_NAME, {
     description:
       'Update arguments of a running pattern instance. Input: { "@link": "/of:bafyabc123" } and updates object. ' +
       "The pattern will automatically re-execute with the new arguments. " +
       "Use after invoke() creates a pattern, or to modify attached pattern instances. " +
       'Example: updateArgument({ "@link": "/of:xyz" }, { "query": "new search" })',
     inputSchema: UPDATE_ARGUMENT_INPUT_SCHEMA,
-  };
-  llmTools[SCHEMA_TOOL_NAME] = {
+  });
+  defineBuiltinTool(llmTools, dynamicToolCells, SCHEMA_TOOL_NAME, {
     description:
       "Get the JSON schema for a cell to understand its structure, fields, and handlers. " +
       'Input: { "@link": "/of:bafyabc123" }. ' +
       "Returns schema showing what data can be read and what handlers can be invoked. ",
     inputSchema: SCHEMA_INPUT_SCHEMA,
-  };
+  });
 
   return { llmTools, dynamicToolCells };
 }
@@ -1488,13 +1517,18 @@ function materializeDialogRequestSnapshot(
     | JSONSchema
     | undefined;
   if (userResultSchema) {
-    toolCatalog.llmTools[PRESENT_RESULT_TOOL_NAME] = {
-      description:
-        "Call this tool to present a structured result. This stores the result for the caller.",
-      inputSchema: prepareSchemaForLLM(
-        toDeepFrozenSchema(userResultSchema),
-      ),
-    };
+    defineBuiltinTool(
+      toolCatalog.llmTools,
+      toolCatalog.dynamicToolCells,
+      PRESENT_RESULT_TOOL_NAME,
+      {
+        description:
+          "Call this tool to present a structured result. This stores the result for the caller.",
+        inputSchema: prepareSchemaForLLM(
+          toDeepFrozenSchema(userResultSchema),
+        ),
+      },
+    );
   }
 
   // A DECLARED bound — even the empty one — engages observation-aware
@@ -3648,13 +3682,18 @@ async function startRequest(
   const userResultSchema = capturedRequest?.userResultSchema ??
     (inputs.key("resultSchema").get() as JSONSchema | undefined);
   if (userResultSchema && capturedRequest === undefined) {
-    toolCatalog.llmTools[PRESENT_RESULT_TOOL_NAME] = {
-      description:
-        "Call this tool to present a structured result. This stores the result for the caller.",
-      inputSchema: prepareSchemaForLLM(
-        toDeepFrozenSchema(userResultSchema),
-      ),
-    };
+    defineBuiltinTool(
+      toolCatalog.llmTools,
+      toolCatalog.dynamicToolCells,
+      PRESENT_RESULT_TOOL_NAME,
+      {
+        description:
+          "Call this tool to present a structured result. This stores the result for the caller.",
+        inputSchema: prepareSchemaForLLM(
+          toDeepFrozenSchema(userResultSchema),
+        ),
+      },
+    );
   }
 
   // Build available cells documentation (both context and pinned cells).

--- a/packages/runner/test/llm-dialog-tool-shadowing.test.ts
+++ b/packages/runner/test/llm-dialog-tool-shadowing.test.ts
@@ -6,7 +6,7 @@ import {
   llmToolExecutionHelpers,
 } from "../src/builtins/llm-dialog.ts";
 
-const { buildToolCatalog } = llmToolExecutionHelpers;
+const { buildToolCatalog, flattenTools } = llmToolExecutionHelpers;
 const { toolAllowsObservedConfidentiality } = llmDialogTestHelpers;
 
 // A pattern may supply a tool whose name is also a built-in's — `read` and
@@ -67,6 +67,17 @@ describe("llmDialog built-in tool shadowing", () => {
     for (const name of ["invoke", "pin", "unpin", "updateArgument", "schema"]) {
       expect(name in catalog.llmTools).toBe(true);
     }
+  });
+
+  it("flattens the pattern's tool, not the built-in it shadows", () => {
+    const { toolsCell } = shadowingToolsCell(patternSchema);
+
+    const flattened = flattenTools(toolsCell as any);
+
+    // `flattenedTools` is what the UI lists, and it has to name the same tool
+    // the model is offered and the runtime will run.
+    expect(flattened.read.description).toBe("the pattern's own read");
+    expect(flattened.invoke.description).toContain("Invoke a handler");
   });
 
   it("enforces the shadowing tool's confidentiality ceiling", () => {

--- a/packages/runner/test/llm-dialog-tool-shadowing.test.ts
+++ b/packages/runner/test/llm-dialog-tool-shadowing.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  llmDialogTestHelpers,
+  llmToolExecutionHelpers,
+} from "../src/builtins/llm-dialog.ts";
+
+const { buildToolCatalog } = llmToolExecutionHelpers;
+const { toolAllowsObservedConfidentiality } = llmDialogTestHelpers;
+
+// A pattern may supply a tool whose name is also a built-in's — `read` and
+// `schema` are names an author reaches for. `resolveToolCall` consults the
+// pattern's tools first, so the pattern's tool is what runs; the catalog has
+// to advertise that same tool. When a built-in overwrote the entry instead,
+// the model was shown the built-in's input schema while the pattern's tool
+// executed, and both CFC gates read their policy off the built-in's schema,
+// which declares none.
+describe("llmDialog built-in tool shadowing", () => {
+  const shadowingToolsCell = (inputSchema: unknown) => {
+    const cells = new Map<string, unknown>();
+    return {
+      cells,
+      toolsCell: {
+        get: () => ({
+          read: { description: "the pattern's own read", inputSchema },
+        }),
+        key(name: string) {
+          const cell = { get: () => undefined };
+          cells.set(name, cell);
+          return cell;
+        },
+      },
+    };
+  };
+
+  const patternSchema = {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  };
+
+  it("advertises the pattern's tool, not the built-in it shadows", () => {
+    const { toolsCell } = shadowingToolsCell(patternSchema);
+
+    const catalog = buildToolCatalog(toolsCell as any);
+
+    expect(catalog.llmTools.read.description).toBe("the pattern's own read");
+    expect((catalog.llmTools.read.inputSchema as any).properties).toEqual({
+      query: { type: "string" },
+    });
+  });
+
+  it("keeps the pattern's tool as the execution target", () => {
+    const { toolsCell, cells } = shadowingToolsCell(patternSchema);
+
+    const catalog = buildToolCatalog(toolsCell as any);
+
+    expect(catalog.dynamicToolCells.get("read")).toBe(cells.get("read"));
+  });
+
+  it("still advertises the built-ins the pattern did not shadow", () => {
+    const { toolsCell } = shadowingToolsCell(patternSchema);
+
+    const catalog = buildToolCatalog(toolsCell as any);
+
+    for (const name of ["invoke", "pin", "unpin", "updateArgument", "schema"]) {
+      expect(name in catalog.llmTools).toBe(true);
+    }
+  });
+
+  it("enforces the shadowing tool's confidentiality ceiling", () => {
+    const { toolsCell } = shadowingToolsCell({
+      ...patternSchema,
+      ifc: { maxConfidentiality: [] },
+    });
+
+    const catalog = buildToolCatalog(toolsCell as any);
+
+    // The built-in `read` schema declares no ceiling, so before the catalog
+    // agreed with dispatch this read as allow-all and the tool's declared
+    // "public only" ceiling was discarded.
+    expect(
+      toolAllowsObservedConfidentiality(catalog as any, "read", ["secret"]),
+    ).toBe(false);
+    expect(toolAllowsObservedConfidentiality(catalog as any, "read", [])).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Found while fact-checking documentation claims during the review of #6113, where it was documented as a hazard. It is a real bug, so this fixes it.

Topic: [llmDialog tool-name collision drops CFC gates](https://estuary.saga-castor.ts.net/topics-dev-476ea34f/fid1:aygXJiQX3EEbznDA7txNxDloitpYtcKr_HLlJA4x8uQ)

## The bug

`buildToolCatalog` maintains two structures meant to describe the same tool: `llmTools[name]`, the model-facing declaration, and `dynamicToolCells[name]`, the execution target. An external tool writes both together. The six built-in entries were then assigned unconditionally, overwriting `llmTools[name]` at a colliding key while leaving `dynamicToolCells` pointing at the pattern's tool. `resolveToolCall` consults `dynamicToolCells` first, so the pattern's tool ran while the model had been shown the built-in's schema and description.

## Why it mattered beyond a wrong input shape

Both CFC gates read policy off `llmTools`, keyed by the raw tool name:

- `toolAllowsObservedConfidentiality` takes `ifc.maxConfidentiality` from the advertised schema. Built-in schemas such as `READ_INPUT_SCHEMA` carry no `ifc` block, so a colliding tool's declared ceiling read as undefined and the check returned allow.
- `integrityGateTarget` returns the advertised schema for every non-`invoke` resolution, so the Epic D2 gate had no `requiredIntegrity` floors to enforce.

The confidentiality check also runs *before* `resolveToolCall`, so the decision to permit was made against one tool's declaration while a different tool executed.

The six names are `read`, `invoke`, `schema`, `pin`, `unpin`, and `updateArgument` — ordinary names for a tool, so this did not require malice. **No pattern in the tree currently registers a colliding name, so this was latent.**

## The fix

Built-in definitions go through a new `defineBuiltinTool`, which takes the record it is writing into and leaves alone any name already present, warning that the built-in is being shadowed. This restores the invariant that policy follows execution: every description of the tools now names the tool that will actually run, so the gates read that tool's declared `ifc`.

Four write sites share the guard — the catalog, `flattenTools`, and the two `presentResult` writes — so a built-in cannot later be added at one site while missing it. `flattenTools` (found by cubic's review) holds a third copy of the built-in block and feeds `result.flattenedTools`, which the UI lists; no CFC gate reads it, which makes it milder, but it was the same divergence.

Nothing that used to resolve stops resolving — dispatch already preferred the external tool, so the built-in was unreachable at a colliding name and only its wrong advertisement was in use.

I did not change dispatch order. Making the built-in win instead would be the other coherent resolution, but it would remove the ability to override a built-in that dispatch has always granted.

## Tests

New `packages/runner/test/llm-dialog-tool-shadowing.test.ts`, five cases. **Three are verified red when the guard's condition is neutered**: the tool is advertised with its own description and schema, the flattened list names it too, and its `maxConfidentiality: []` ceiling is enforced (previously allow-all). Two guard invariants that must not regress: the pattern's tool remains the execution target, and unshadowed built-ins are still advertised.

## Checks

`deno fmt`, `deno lint`, `deno check` on the touched files. Full CI green, Coverage Check included.

A note on coverage, since the first push failed that gate: the regression was reformatting, not untested code. Spreading the two `presentResult` assignments over more lines added uncovered lines to a path no unit test drives; restoring their original shape (the file is net −6 lines against main) cleared it.

Correction to an earlier version of this description: I reported `generate-object-tools.test.ts` as failing on main. It did fail locally, twice, including with this change stashed — but it passes in CI on this branch, so it is a flake rather than a standing failure on main.