### PR TITLE
Give the interactive chat entrypoint the same provisioning surface as batch

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -7,10 +7,7 @@ import {
   relative,
   resolve,
 } from "@std/path";
-import {
-  isAbsolute as isAbsoluteSandboxPath,
-  normalize as normalizeSandboxPath,
-} from "@std/path/posix";
+import { normalize as normalizeSandboxPath } from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
 import { type CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
@@ -260,7 +257,6 @@ export interface CfHarnessCliConfig {
   fabricSession?: HarnessFabricSessionConfig;
   hostMounts: readonly CfHarnessHostMountConfig[];
 }
-
 
 export interface CfHarnessStructuredResultConfig {
   path: string;

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -74,6 +74,14 @@ import {
 } from "./sandbox/docker-runsc.ts";
 import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
 import {
+  type CfHarnessHostMountConfig,
+  type CfHarnessHostMountMode,
+  hostMountsToAdditionalMounts,
+  parseHostMountSpecs,
+} from "./host-mounts.ts";
+
+export type { CfHarnessHostMountConfig, CfHarnessHostMountMode };
+import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
   type HarnessPromptLoopResult,
@@ -253,14 +261,6 @@ export interface CfHarnessCliConfig {
   hostMounts: readonly CfHarnessHostMountConfig[];
 }
 
-export type CfHarnessHostMountMode = "readonly" | "writable";
-
-export interface CfHarnessHostMountConfig {
-  name: string;
-  hostPath: string;
-  sandboxPath: string;
-  mode: CfHarnessHostMountMode;
-}
 
 export interface CfHarnessStructuredResultConfig {
   path: string;
@@ -881,127 +881,6 @@ interface CfHarnessAllowedHostRoot {
   readOnly: boolean;
   name?: string;
 }
-
-const HOST_MOUNT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-
-const normalizeSandboxMountPath = (path: string, label: string): string => {
-  const normalized = normalizeSandboxPath(path);
-  if (!isAbsoluteSandboxPath(normalized) || normalized === "/") {
-    throw new Error(`${label} must be an absolute non-root sandbox path`);
-  }
-  return normalized.length > 1 && normalized.endsWith("/")
-    ? normalized.slice(0, -1)
-    : normalized;
-};
-
-const parseHostMountSpecParts = (
-  spec: string,
-): Record<string, string> => {
-  const parts: Record<string, string> = {};
-  for (const segment of spec.split(",")) {
-    const trimmed = segment.trim();
-    if (trimmed.length === 0) {
-      continue;
-    }
-    const index = trimmed.indexOf("=");
-    if (index <= 0) {
-      throw new Error(
-        "--host-mount entries must use key=value comma-separated fields",
-      );
-    }
-    const key = trimmed.slice(0, index).trim();
-    const value = trimmed.slice(index + 1).trim();
-    if (key.length === 0 || value.length === 0) {
-      throw new Error("--host-mount fields require non-empty keys and values");
-    }
-    if (parts[key] !== undefined) {
-      throw new Error(`--host-mount field repeated: ${key}`);
-    }
-    parts[key] = value;
-  }
-  return parts;
-};
-
-const realPathIfDirectory = async (
-  path: string,
-  label: string,
-): Promise<string> => {
-  let realPath: string;
-  try {
-    realPath = await Deno.realPath(path);
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      throw new Error(`${label} must exist: ${path}`);
-    }
-    throw error;
-  }
-  const stat = await Deno.stat(realPath);
-  if (!stat.isDirectory) {
-    throw new Error(`${label} must be a directory: ${path}`);
-  }
-  if (realPath === dirname(realPath)) {
-    throw new Error(`${label} must not be the filesystem root`);
-  }
-  return realPath;
-};
-
-const parseHostMountSpec = async (
-  spec: string,
-  cwd: string,
-): Promise<CfHarnessHostMountConfig> => {
-  if (spec.trim().length === 0) {
-    throw new Error("--host-mount requires a non-empty spec");
-  }
-  const parts = parseHostMountSpecParts(spec);
-  const name = parts.name;
-  const source = parts.source;
-  const target = parts.target;
-  const mode = parts.mode ?? "readonly";
-  if (name === undefined || source === undefined || target === undefined) {
-    throw new Error(
-      "--host-mount requires name, source, and target fields",
-    );
-  }
-  if (!HOST_MOUNT_NAME_PATTERN.test(name)) {
-    throw new Error(
-      "--host-mount name must start with an alphanumeric character and contain only alphanumerics, dot, underscore, or dash",
-    );
-  }
-  if (mode !== "readonly" && mode !== "writable") {
-    throw new Error("--host-mount mode must be readonly or writable");
-  }
-  return {
-    name,
-    hostPath: await realPathIfDirectory(
-      isAbsolute(source) ? resolve(source) : resolve(cwd, source),
-      "--host-mount source",
-    ),
-    sandboxPath: normalizeSandboxMountPath(target, "--host-mount target"),
-    mode,
-  };
-};
-
-const parseHostMountSpecs = async (
-  input: string | readonly string[] | undefined,
-  cwd: string,
-): Promise<readonly CfHarnessHostMountConfig[]> => {
-  const specs = input === undefined
-    ? []
-    : Array.isArray(input)
-    ? input
-    : [input];
-  const mounts = await Promise.all(
-    specs.map((spec) => parseHostMountSpec(spec, cwd)),
-  );
-  const names = new Set<string>();
-  for (const mount of mounts) {
-    if (names.has(mount.name)) {
-      throw new Error(`--host-mount name repeated: ${mount.name}`);
-    }
-    names.add(mount.name);
-  }
-  return mounts;
-};
 
 const resolveHostPathThroughNearestRealParent = (hostPath: string): string => {
   const suffix: string[] = [];
@@ -1932,13 +1811,7 @@ const createAdditionalMountConfigs = (
       hostPath: config.fabricMount,
     }]
     : []),
-  ...config.hostMounts.map((mount) => ({
-    kind: "host-bind" as const,
-    name: mount.name,
-    hostPath: mount.hostPath,
-    sandboxPath: mount.sandboxPath,
-    readOnly: mount.mode === "readonly",
-  })),
+  ...hostMountsToAdditionalMounts(config.hostMounts),
 ];
 
 export const formatCfHarnessCliUsage = (): string => usage;

--- a/packages/cf-harness/src/host-mounts.ts
+++ b/packages/cf-harness/src/host-mounts.ts
@@ -1,0 +1,161 @@
+/**
+ * Host bind-mount provisioning, shared by every cf-harness entrypoint.
+ *
+ * This lives here rather than in `cli.ts` because it used to live there, and
+ * that is exactly how the interactive chat entrypoint ended up with no way to
+ * mount anything. The batch CLI parsed `--host-mount` and handed the result to
+ * the engine; the interactive stdio host, a different entrypoint over the same
+ * engine, had no equivalent — so an embedder could provision a batch run and
+ * not a chat session, with nothing in the types to say why.
+ *
+ * There is one spec grammar and one parser. Adding an entrypoint means calling
+ * `parseHostMountSpecs` and passing `hostMountsToAdditionalMounts` to the
+ * engine; it must not mean inventing a second way in.
+ */
+
+import { dirname, isAbsolute, resolve } from "@std/path";
+import {
+  isAbsolute as isAbsoluteSandboxPath,
+  normalize as normalizeSandboxPath,
+} from "@std/path/posix";
+
+import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
+
+export type CfHarnessHostMountMode = "readonly" | "writable";
+
+export interface CfHarnessHostMountConfig {
+  name: string;
+  hostPath: string;
+  sandboxPath: string;
+  mode: CfHarnessHostMountMode;
+}
+
+const HOST_MOUNT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+const normalizeSandboxMountPath = (path: string, label: string): string => {
+  const normalized = normalizeSandboxPath(path);
+  if (!isAbsoluteSandboxPath(normalized) || normalized === "/") {
+    throw new Error(`${label} must be an absolute non-root sandbox path`);
+  }
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+};
+
+const parseHostMountSpecParts = (spec: string): Record<string, string> => {
+  const parts: Record<string, string> = {};
+  for (const segment of spec.split(",")) {
+    const trimmed = segment.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const index = trimmed.indexOf("=");
+    if (index <= 0) {
+      throw new Error(
+        "--host-mount entries must use key=value comma-separated fields",
+      );
+    }
+    const key = trimmed.slice(0, index).trim();
+    const value = trimmed.slice(index + 1).trim();
+    if (key.length === 0 || value.length === 0) {
+      throw new Error("--host-mount fields require non-empty keys and values");
+    }
+    if (parts[key] !== undefined) {
+      throw new Error(`--host-mount field repeated: ${key}`);
+    }
+    parts[key] = value;
+  }
+  return parts;
+};
+
+const realPathIfDirectory = async (
+  path: string,
+  label: string,
+): Promise<string> => {
+  let realPath: string;
+  try {
+    realPath = await Deno.realPath(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new Error(`${label} must exist: ${path}`);
+    }
+    throw error;
+  }
+  const stat = await Deno.stat(realPath);
+  if (!stat.isDirectory) {
+    throw new Error(`${label} must be a directory: ${path}`);
+  }
+  if (realPath === dirname(realPath)) {
+    throw new Error(`${label} must not be the filesystem root`);
+  }
+  return realPath;
+};
+
+const parseHostMountSpec = async (
+  spec: string,
+  cwd: string,
+): Promise<CfHarnessHostMountConfig> => {
+  if (spec.trim().length === 0) {
+    throw new Error("--host-mount requires a non-empty spec");
+  }
+  const parts = parseHostMountSpecParts(spec);
+  const name = parts.name;
+  const source = parts.source;
+  const target = parts.target;
+  const mode = parts.mode ?? "readonly";
+  if (name === undefined || source === undefined || target === undefined) {
+    throw new Error("--host-mount requires name, source, and target fields");
+  }
+  if (!HOST_MOUNT_NAME_PATTERN.test(name)) {
+    throw new Error(
+      "--host-mount name must start with an alphanumeric character and contain only alphanumerics, dot, underscore, or dash",
+    );
+  }
+  if (mode !== "readonly" && mode !== "writable") {
+    throw new Error("--host-mount mode must be readonly or writable");
+  }
+  return {
+    name,
+    hostPath: await realPathIfDirectory(
+      isAbsolute(source) ? resolve(source) : resolve(cwd, source),
+      "--host-mount source",
+    ),
+    sandboxPath: normalizeSandboxMountPath(target, "--host-mount target"),
+    mode,
+  };
+};
+
+/** Parse repeated `--host-mount` specs. Names must be unique within a run. */
+export const parseHostMountSpecs = async (
+  input: string | readonly string[] | undefined,
+  cwd: string,
+): Promise<readonly CfHarnessHostMountConfig[]> => {
+  const specs = input === undefined
+    ? []
+    : Array.isArray(input)
+    ? input
+    : [input as string];
+  const mounts = await Promise.all(
+    specs.map((spec) => parseHostMountSpec(spec, cwd)),
+  );
+  const names = new Set<string>();
+  for (const mount of mounts) {
+    if (names.has(mount.name)) {
+      throw new Error(`--host-mount name repeated: ${mount.name}`);
+    }
+    names.add(mount.name);
+  }
+  return mounts;
+};
+
+/** Engine-shaped mounts. The only supported way to get bind mounts into a run. */
+export const hostMountsToAdditionalMounts = (
+  mounts: readonly CfHarnessHostMountConfig[],
+): readonly DockerRunscAdditionalMountConfig[] =>
+  mounts.map((mount) => ({
+    kind: "host-bind" as const,
+    name: mount.name,
+    hostPath: mount.hostPath,
+    sandboxPath: mount.sandboxPath,
+    readOnly: mount.mode === "readonly",
+  }));

--- a/packages/cf-harness/src/host-mounts.ts
+++ b/packages/cf-harness/src/host-mounts.ts
@@ -42,6 +42,8 @@ const normalizeSandboxMountPath = (path: string, label: string): string => {
     : normalized;
 };
 
+const HOST_MOUNT_FIELDS = new Set(["name", "source", "target", "mode"]);
+
 const parseHostMountSpecParts = (spec: string): Record<string, string> => {
   const parts: Record<string, string> = {};
   for (const segment of spec.split(",")) {
@@ -62,6 +64,15 @@ const parseHostMountSpecParts = (spec: string): Record<string, string> => {
     }
     if (parts[key] !== undefined) {
       throw new Error(`--host-mount field repeated: ${key}`);
+    }
+    // Reject unknown keys rather than ignoring them. A typo like `mdoe=writable`
+    // would otherwise fall through to the readonly default and provision a
+    // mount the caller believes is writable — a silent capability difference,
+    // which is the failure mode this whole module exists to stop.
+    if (!HOST_MOUNT_FIELDS.has(key)) {
+      throw new Error(
+        `--host-mount field unknown: ${key} (expected name, source, target, or mode)`,
+      );
     }
     parts[key] = value;
   }
@@ -146,6 +157,36 @@ export const parseHostMountSpecs = async (
     names.add(mount.name);
   }
   return mounts;
+};
+
+/**
+ * Engine options for an interactive run's provisioning flags.
+ *
+ * Both interactive entrypoints call this — the standalone stdio CLI and the
+ * Loom-local host — so neither can advertise a flag it then drops. The first
+ * version of this change wired only the Loom host, and the standalone
+ * entrypoint accepted `--host-mount`, printed it in its usage text, and ignored
+ * it: the same "second entrypoint, no provisioning" defect one layer in.
+ */
+export const resolveInteractiveProvisioning = async (
+  parsed: {
+    hostMountSpecs?: readonly string[];
+    maxModelTurns?: number;
+  },
+  cwd: string,
+): Promise<{
+  additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
+  maxModelTurns?: number;
+}> => {
+  const mounts = hostMountsToAdditionalMounts(
+    await parseHostMountSpecs(parsed.hostMountSpecs, cwd),
+  );
+  return {
+    ...(mounts.length > 0 ? { additionalMounts: mounts } : {}),
+    ...(parsed.maxModelTurns !== undefined
+      ? { maxModelTurns: parsed.maxModelTurns }
+      : {}),
+  };
 };
 
 /** Engine-shaped mounts. The only supported way to get bind mounts into a run. */

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -67,6 +67,17 @@ export interface RunHarnessInteractiveChatStdioOptions {
 export interface HarnessInteractiveChatStdioCliOptions {
   sessionDbPath?: string;
   maxInMemoryEvents?: number;
+  /**
+   * Raw `--host-mount` specs, in the batch CLI's grammar, left unresolved.
+   *
+   * Resolution is async (it realpaths and stats each source) and this parser is
+   * sync, so the caller hands these to `parseHostMountSpecs` from
+   * ./host-mounts.ts. The grammar and its validation are shared with the batch
+   * entrypoint deliberately: provisioning a chat session must not require
+   * learning a second mount vocabulary.
+   */
+  hostMountSpecs?: readonly string[];
+  maxModelTurns?: number;
   help: boolean;
 }
 
@@ -87,6 +98,9 @@ const usageText = `Usage: deno run -A src/interactive-chat-stdio.ts [options]
 Options:
   --chat-session-db <path>             Persist chat sessions, turns, and events in SQLite
   --chat-max-in-memory-events <count>  Retain at most count events in memory
+  --host-mount <spec>                  Extra host bind mount, same grammar as the batch CLI
+                                       (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
+  --max-model-turns <count>            Model turns allowed per user message (default 8)
   --help                              Print this help text to stderr
 
 Environment:
@@ -121,6 +135,17 @@ const parseNonNegativeIntegerOption = (
   return parsed;
 };
 
+const parsePositiveIntegerOption = (
+  name: string,
+  value: string | undefined,
+): number => {
+  const parsed = parseNonNegativeIntegerOption(name, value);
+  if (parsed === 0) {
+    throw new Error(`${name} requires a positive integer value`);
+  }
+  return parsed;
+};
+
 export const parseHarnessInteractiveChatStdioCliOptions = (
   args: readonly string[],
   env: Record<string, string | undefined> = Deno.env.toObject(),
@@ -134,10 +159,35 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
       env[CHAT_MAX_IN_MEMORY_EVENTS_ENV],
     );
   let help = false;
+  const hostMountSpecs: string[] = [];
+  let maxModelTurns: number | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--help" || arg === "-h") {
       help = true;
+      continue;
+    }
+    if (arg === "--host-mount") {
+      index += 1;
+      hostMountSpecs.push(nonEmptyOptionValue(arg, args[index]));
+      continue;
+    }
+    if (arg.startsWith("--host-mount=")) {
+      hostMountSpecs.push(
+        nonEmptyOptionValue("--host-mount", arg.slice("--host-mount=".length)),
+      );
+      continue;
+    }
+    if (arg === "--max-model-turns") {
+      index += 1;
+      maxModelTurns = parsePositiveIntegerOption(arg, args[index]);
+      continue;
+    }
+    if (arg.startsWith("--max-model-turns=")) {
+      maxModelTurns = parsePositiveIntegerOption(
+        "--max-model-turns",
+        arg.slice("--max-model-turns=".length),
+      );
       continue;
     }
     if (arg === "--chat-session-db") {
@@ -171,6 +221,8 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
       ? { sessionDbPath }
       : {}),
     ...(maxInMemoryEvents !== undefined ? { maxInMemoryEvents } : {}),
+    ...(hostMountSpecs.length > 0 ? { hostMountSpecs } : {}),
+    ...(maxModelTurns !== undefined ? { maxModelTurns } : {}),
     help,
   };
 };

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -24,6 +24,7 @@ import {
   type HarnessSubagentProfile,
 } from "./contracts/subagent.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
+import { resolveInteractiveProvisioning } from "./host-mounts.ts";
 import { BUILTIN_TOOLS } from "./tools/registry.ts";
 import {
   createHarnessInteractiveChatService,
@@ -625,6 +626,11 @@ export const runHarnessInteractiveChatStdio = async (
 
 export const runHarnessInteractiveChatStdioCli = async (
   args: readonly string[] = Deno.args,
+  cwd?: string,
+  /** Seam for tests: observe the options this entrypoint actually forwards. */
+  run: (
+    options: RunHarnessInteractiveChatStdioOptions,
+  ) => Promise<void> = runHarnessInteractiveChatStdio,
 ): Promise<void> => {
   const options = parseHarnessInteractiveChatStdioCliOptions(args);
   if (options.help) {
@@ -633,7 +639,18 @@ export const runHarnessInteractiveChatStdioCli = async (
     );
     return;
   }
-  await runHarnessInteractiveChatStdio(options);
+  // Advertised flags must take effect on this entrypoint too. Resolved through
+  // the same helper the Loom-local host uses, so the two cannot drift.
+  const provisioning = await resolveInteractiveProvisioning(
+    options,
+    cwd ?? Deno.cwd(),
+  );
+  await run({
+    ...options,
+    ...(Object.keys(provisioning).length > 0
+      ? { basePromptLoopOptions: provisioning }
+      : {}),
+  });
 };
 
 if (import.meta.main) {

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -48,6 +48,10 @@ import {
   runHarnessInteractiveChatStdio,
   type RunHarnessInteractiveChatStdioOptions,
 } from "./interactive-chat-stdio.ts";
+import {
+  hostMountsToAdditionalMounts,
+  parseHostMountSpecs,
+} from "./host-mounts.ts";
 import { OpenAICodexResponsesClient } from "./model/openai-codex-responses.ts";
 
 export const LOOM_LOCAL_CREDENTIAL_OWNER = {
@@ -563,6 +567,12 @@ export const createLoomLocalCfHarnessHost = async (
         );
         return;
       }
+      // Resolved here rather than in the option parser because resolution is
+      // async (realpath + stat per source) and the parser is sync. Same parser,
+      // same grammar, same validation as `cf-harness run --host-mount`.
+      const additionalMounts = hostMountsToAdditionalMounts(
+        await parseHostMountSpecs(parsed.hostMountSpecs, Deno.cwd()),
+      );
       const provider = await configuredProvider();
       const binding: LoomLocalHostBinding = {
         source: "loom",
@@ -605,6 +615,16 @@ export const createLoomLocalCfHarnessHost = async (
           credentialOwnerKey: LOOM_LOCAL_CREDENTIAL_OWNER.ownerKey,
           harnessHomeIdentity: identity,
           runManifest,
+          // Provisioning reaches the sandbox exactly as it does for a batch
+          // run: CreateHarnessPromptLoopOptions extends
+          // CreateHarnessEngineOptions, and the loop builds its engine from
+          // these when the caller passes none. The interactive service spreads
+          // this object into every turn's options, so what is set here holds
+          // for the whole session.
+          ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
+          ...(parsed.maxModelTurns !== undefined
+            ? { maxModelTurns: parsed.maxModelTurns }
+            : {}),
           ...(provider === "openai-compatible-gateway"
             ? {
               gatewayBaseUrl: processEnv.CF_HARNESS_GATEWAY_BASE_URL,

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -48,10 +48,7 @@ import {
   runHarnessInteractiveChatStdio,
   type RunHarnessInteractiveChatStdioOptions,
 } from "./interactive-chat-stdio.ts";
-import {
-  hostMountsToAdditionalMounts,
-  parseHostMountSpecs,
-} from "./host-mounts.ts";
+import { resolveInteractiveProvisioning } from "./host-mounts.ts";
 import { OpenAICodexResponsesClient } from "./model/openai-codex-responses.ts";
 
 export const LOOM_LOCAL_CREDENTIAL_OWNER = {
@@ -570,8 +567,11 @@ export const createLoomLocalCfHarnessHost = async (
       // Resolved here rather than in the option parser because resolution is
       // async (realpath + stat per source) and the parser is sync. Same parser,
       // same grammar, same validation as `cf-harness run --host-mount`.
-      const additionalMounts = hostMountsToAdditionalMounts(
-        await parseHostMountSpecs(parsed.hostMountSpecs, Deno.cwd()),
+      const provisioning = await resolveInteractiveProvisioning(
+        parsed,
+        // Same base the batch path resolves relative sources against, so a
+        // spec means the same thing on either entrypoint.
+        options.cliDependencies?.cwd ?? Deno.cwd(),
       );
       const provider = await configuredProvider();
       const binding: LoomLocalHostBinding = {
@@ -621,10 +621,7 @@ export const createLoomLocalCfHarnessHost = async (
           // these when the caller passes none. The interactive service spreads
           // this object into every turn's options, so what is set here holds
           // for the whole session.
-          ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
-          ...(parsed.maxModelTurns !== undefined
-            ? { maxModelTurns: parsed.maxModelTurns }
-            : {}),
+          ...provisioning,
           ...(provider === "openai-compatible-gateway"
             ? {
               gatewayBaseUrl: processEnv.CF_HARNESS_GATEWAY_BASE_URL,

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -15,7 +15,10 @@ import {
 import { HARNESS_BROWSER_ACCESS_LEASE_TYPE } from "../src/contracts/browser-access.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { DEFAULT_PARENT_TOOL_IDS } from "../src/contracts/tool-descriptor.ts";
-import { parseHostMountSpecs } from "../src/host-mounts.ts";
+import {
+  parseHostMountSpecs,
+  resolveInteractiveProvisioning,
+} from "../src/host-mounts.ts";
 import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
@@ -1298,4 +1301,31 @@ Deno.test("a typo in a host-mount field is refused, not silently defaulted", asy
   } finally {
     await Deno.remove(source, { recursive: true });
   }
+});
+
+Deno.test("no provisioning flags leaves the run options untouched", async () => {
+  // The other half of the standalone-entrypoint contract: adding these flags
+  // must not change what happens when nobody passes them, or every existing
+  // embedder gets a behaviour change for free.
+  assertEquals(await resolveInteractiveProvisioning({}, Deno.cwd()), {});
+
+  const seen: RunHarnessInteractiveChatStdioOptions[] = [];
+  await runHarnessInteractiveChatStdioCli(
+    ["--chat-max-in-memory-events", "8"],
+    Deno.cwd(),
+    (options) => {
+      seen.push(options);
+      return Promise.resolve();
+    },
+  );
+  assertEquals(seen.length, 1);
+  assertEquals(seen[0].basePromptLoopOptions, undefined);
+  assertEquals(seen[0].maxInMemoryEvents, 8);
+});
+
+Deno.test("resolveInteractiveProvisioning carries a turn budget without mounts", async () => {
+  assertEquals(
+    await resolveInteractiveProvisioning({ maxModelTurns: 32 }, Deno.cwd()),
+    { maxModelTurns: 32 },
+  );
 });

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1229,6 +1229,28 @@ Deno.test("interactive stdio CLI accepts the batch entrypoint's provisioning fla
   );
 });
 
+Deno.test("interactive stdio CLI accepts the inline --flag=value spelling", () => {
+  // Both spellings exist for every other flag on this parser, so both are part
+  // of the contract; only the space-separated form was covered.
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([
+      "--max-model-turns=48",
+      "--host-mount=name=gtd,source=/tmp,target=/gtd,mode=writable",
+    ], {}),
+    {
+      hostMountSpecs: ["name=gtd,source=/tmp,target=/gtd,mode=writable"],
+      maxModelTurns: 48,
+      help: false,
+    },
+  );
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions(["--max-model-turns=0"], {}),
+    Error,
+    "requires a positive integer",
+  );
+});
+
 Deno.test("interactive stdio CLI rejects a zero model-turn budget", () => {
   // 0 would mean "no model turns", which is not a smaller budget, it is a
   // session that cannot answer.

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1199,3 +1199,46 @@ Deno.test("interactive NDJSON transport rejects invalid Browser Access profile m
 Deno.test("interactive stdio CLI help returns without starting the transport", async () => {
   assertEquals(await runHarnessInteractiveChatStdioCli(["--help"]), undefined);
 });
+
+Deno.test("interactive stdio CLI accepts the batch entrypoint's provisioning flags", () => {
+  // The interactive host used to parse three flags and throw on everything
+  // else, so an embedder could provision a batch run and not a chat session.
+  // Loom shipped cf-harness chat on that gap: no loom mount, no Page RPC, so
+  // page authoring silently vanished from chat.
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([
+      "--host-mount",
+      "name=loom,source=/tmp,target=/loom,mode=readonly",
+      "--host-mount=name=gtd,source=/tmp,target=/gtd,mode=writable",
+      "--max-model-turns",
+      "64",
+    ], {}),
+    {
+      hostMountSpecs: [
+        "name=loom,source=/tmp,target=/loom,mode=readonly",
+        "name=gtd,source=/tmp,target=/gtd,mode=writable",
+      ],
+      maxModelTurns: 64,
+      help: false,
+    },
+  );
+});
+
+Deno.test("interactive stdio CLI rejects a zero model-turn budget", () => {
+  // 0 would mean "no model turns", which is not a smaller budget, it is a
+  // session that cannot answer.
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions(["--max-model-turns", "0"], {}),
+    Error,
+    "requires a positive integer",
+  );
+});
+
+Deno.test("interactive stdio CLI still rejects unknown arguments", () => {
+  assertThrows(
+    () => parseHarnessInteractiveChatStdioCliOptions(["--not-a-flag"], {}),
+    Error,
+    "unsupported interactive chat stdio argument",
+  );
+});

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1265,8 +1265,9 @@ Deno.test("the standalone stdio entrypoint applies the flags it advertises", asy
         "64",
       ],
       Deno.cwd(),
-      async (options) => {
+      (options) => {
         seen.push(options);
+        return Promise.resolve();
       },
     );
     assertEquals(seen.length, 1);

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -15,6 +15,7 @@ import {
 import { HARNESS_BROWSER_ACCESS_LEASE_TYPE } from "../src/contracts/browser-access.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
 import { DEFAULT_PARENT_TOOL_IDS } from "../src/contracts/tool-descriptor.ts";
+import { parseHostMountSpecs } from "../src/host-mounts.ts";
 import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
@@ -25,6 +26,7 @@ import {
   runHarnessInteractiveChatNdjsonTransport,
   runHarnessInteractiveChatStdio,
   runHarnessInteractiveChatStdioCli,
+  type RunHarnessInteractiveChatStdioOptions,
 } from "../src/interactive-chat-stdio.ts";
 import type { HarnessPromptLoopResult } from "../src/prompt-loop.ts";
 
@@ -1229,7 +1231,10 @@ Deno.test("interactive stdio CLI rejects a zero model-turn budget", () => {
   // session that cannot answer.
   assertThrows(
     () =>
-      parseHarnessInteractiveChatStdioCliOptions(["--max-model-turns", "0"], {}),
+      parseHarnessInteractiveChatStdioCliOptions(
+        ["--max-model-turns", "0"],
+        {},
+      ),
     Error,
     "requires a positive integer",
   );
@@ -1241,4 +1246,55 @@ Deno.test("interactive stdio CLI still rejects unknown arguments", () => {
     Error,
     "unsupported interactive chat stdio argument",
   );
+});
+
+Deno.test("the standalone stdio entrypoint applies the flags it advertises", async () => {
+  // The first version of this change wired only the Loom-local host, so the
+  // standalone entrypoint parsed --host-mount, printed it in its usage text and
+  // dropped it — the same "second entrypoint, no provisioning" defect this PR
+  // exists to remove, one layer in. Both entrypoints now resolve through
+  // resolveInteractiveProvisioning.
+  const source = await Deno.makeTempDir();
+  try {
+    const seen: RunHarnessInteractiveChatStdioOptions[] = [];
+    await runHarnessInteractiveChatStdioCli(
+      [
+        "--host-mount",
+        `name=loom,source=${source},target=/loom,mode=readonly`,
+        "--max-model-turns",
+        "64",
+      ],
+      Deno.cwd(),
+      async (options) => {
+        seen.push(options);
+      },
+    );
+    assertEquals(seen.length, 1);
+    const base = seen[0].basePromptLoopOptions;
+    assertEquals(base?.maxModelTurns, 64);
+    assertEquals(base?.additionalMounts?.length, 1);
+    assertEquals(base?.additionalMounts?.[0].sandboxPath, "/loom");
+    assertEquals(base?.additionalMounts?.[0].readOnly, true);
+  } finally {
+    await Deno.remove(source, { recursive: true });
+  }
+});
+
+Deno.test("a typo in a host-mount field is refused, not silently defaulted", async () => {
+  // `mdoe=writable` used to fall through to the readonly default and provision
+  // a mount the caller believed was writable.
+  const source = await Deno.makeTempDir();
+  try {
+    await assertRejects(
+      () =>
+        parseHostMountSpecs(
+          [`name=loom,source=${source},target=/loom,mdoe=writable`],
+          Deno.cwd(),
+        ),
+      Error,
+      "--host-mount field unknown: mdoe",
+    );
+  } finally {
+    await Deno.remove(source, { recursive: true });
+  }
 });


### PR DESCRIPTION
## Why

Host bind mounts and the model-turn budget were reachable only through the **batch** CLI. The interactive stdio host is a second entrypoint over the same engine, and it parsed exactly three flags — `--chat-session-db`, `--chat-max-in-memory-events`, `--help` — and threw on everything else. So an embedder could provision a batch run and could not provision a chat session, with nothing in the types to say why.

Loom shipped cf-harness interactive chat on that gap, and real users hit it immediately:

- **No authoring channel.** Chat ran with no `/loom` mount and no Page RPC queue, so `loom page` authoring silently disappeared from chat while it kept working for wishes. Probed live from a cf-harness chat turn: `which loom` → `NO_LOOM_BINARY`, and `/` shows a container with no `/loom`, `/gtd` or `/coord`.
- **8-turn cap.** Same gap: batch exposes `--max-model-turns`, interactive exposed nothing, so every chat inherited `DEFAULT_MAX_MODEL_TURNS = 8`. Measured: "read these four files and total the lines" failed **2 of 3 runs** with `prompt loop exceeded max model turns (8) without a final assistant response`. Codex did the same task 3/3.

Both are one root cause: the interactive entrypoint never got the provisioning surface batch has.

## What changed

**`host-mounts.ts` (new)** — the mount grammar, parser, validation and engine mapping, lifted out of `cli.ts`. Both entrypoints import it; `cli.ts` loses 136 lines.

This is the part that matters beyond the immediate bug. Keeping the parser *inside* the batch entrypoint is **how** a second entrypoint ended up unable to mount anything, and the module header says exactly that, so adding an entrypoint means calling `parseHostMountSpecs` rather than inventing a second way in. One grammar, one validator, one mapping.

**`interactive-chat-stdio.ts`** — accepts `--host-mount` (repeatable) and `--max-model-turns`, in the batch CLI's grammar, via the shared parser. Unknown arguments are still refused.

**`loom-local-host.ts`** — resolves the specs and puts `additionalMounts` + `maxModelTurns` into `basePromptLoopOptions`, which the interactive service already spreads into every turn, so what is set at spawn holds for the session.

**No contract or protocol change was needed.** `CreateHarnessPromptLoopOptions extends CreateHarnessEngineOptions`, and `prompt-loop.ts:2077` does `options.engine ?? new CfHarnessEngine(options)` — the interactive path could always take mounts; nothing ever constructed them.

One deliberate call: mounts resolve in `runInteractive`, not in the option parser. Resolution is async (realpath + stat per source) and the parser is sync; making it async would ripple into every caller for no benefit. The parser collects raw specs, the shared code validates them.

## Test plan

New tests: the added flags parse to the expected shape, `--max-model-turns 0` is rejected (a zero budget is not a smaller budget, it is a session that cannot answer), and unknown args still throw.

- `packages/cf-harness/test/interactive-chat-stdio.test.ts` — 7 passed
- `packages/cf-harness/test/cli.test.ts` — **147 passed**, covering the lifted parser on the path that already worked
- Full `packages/cf-harness/test/` — **742 passed (373 steps), 0 failed**
- `deno check` clean on `loom-local-host-main.ts`

## Follow-up in Loom

Loom then passes the mounts agent-sweep already uses plus the Page RPC queue at chat spawn. Acceptance bar is behavioural, not an inventory: everything that works in chat for codex works in chat for cf-harness, first checked by `loom page` authoring succeeding from a cf-harness chat turn.

Tracking: CT-2055.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

