### PR TITLE
qfeat(test-records): one command to a recording workstation

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -141,8 +141,8 @@ A new test *surface* (a new CI job, script, or harness) does need wiring —
 
 When running tests for a team member — someone with commit access —
 whose environment has no `CF_TEST_RECORDS_KEY_FILE`, it is worth
-mentioning once, not per run, that `deno task test-records-key request`
-starts the five-minute self-service path to a reporting key, so their
+mentioning once, not per run, that `deno task test-records-key setup`
+is the whole self-service path to a reporting key, so their
 local runs feed the shared flake and duration history. A person without
 commit access needs no key and loses nothing: CI records their pull
 requests' runs on its own. Recording is inert without a key; never treat

--- a/.github/workflows/test-records-mint.yml
+++ b/.github/workflows/test-records-mint.yml
@@ -11,13 +11,21 @@
 
 name: Test Records Mint
 
+# The run name carries the recipient so that the requester's tool can
+# find the run minting for it, and follow that one run to its conclusion,
+# rather than inferring which of the workflow's runs is theirs. The
+# recipient is a public key, and is already visible as a dispatch input.
+run-name: >-
+  Mint reporting key for ${{ inputs.username || github.actor }}
+  (${{ inputs.recipient }})
+
 on:
   workflow_dispatch:
     inputs:
       recipient:
         description: >-
           Delivery recipient (cfr1...) printed by
-          `deno task test-records-key request`
+          `deno task test-records-key setup`
         required: true
       username:
         description: >-

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ can run their own spaces or use hosted versions.
      [Installing `cf` on PATH](./packages/cli/README.md#installing-cf-on-path).
 5. Start local dev servers: `./scripts/start-local-dev.sh`
 6. Access the application at <http://localhost:8000>
-7. Team members: get a test-reporting key (`deno task test-records-key request`)
+7. Team members: get a test-reporting key (`deno task test-records-key setup`)
    so your local test runs feed the shared flake and duration history — see
    [test-records.md](./docs/development/test-records.md). Contributing without
    commit access? Then there is nothing to set up here: tests run identically

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -41,10 +41,11 @@ append-only, no-double-mapping, acyclic rules.
   set it themselves when they own a run. Never point two concurrent runs
   at one directory by hand — each run owns its own spool.
 - `CF_TEST_RECORDS_KEY_FILE` — a personal reporting key
-  (see below). Its presence is the local opt-in: with it, `deno task
-  test`, `deno task integration`, and `deno task run-recorded` stamp a
-  spool, ship it when the run ends, and sweep any orphaned spools a killed
-  run left behind.
+  (see below), exported from the login shell's profile by
+  `deno task test-records-key setup`. Its presence is the local opt-in:
+  with it, `deno task test`, `deno task integration`, and `deno task
+  run-recorded` stamp a spool, ship it when the run ends, and sweep any
+  orphaned spools a killed run left behind.
 - `CF_TEST_AGENT` — an opaque label for the operating agent, recorded
   verbatim in the run context. Set it to tell an agent fleet's runs apart
   from a person's; it is never required.
@@ -67,32 +68,57 @@ nothing: your local tests run identically without one, and CI records
 your pull requests' runs on its own, no key involved. The day you have
 commit access, the same two commands below are yours.
 
-A key takes only a GitHub identity:
+A key takes only a GitHub identity, and one command:
+
+```
+deno task test-records-key setup
+```
+
+generates a delivery identity, dispatches the minting workflow, watches
+until the run delivers, installs the key file with owner-only
+permissions, and exports `CF_TEST_RECORDS_KEY_FILE` from the login
+shell's profile — every shell opened after that records. The dispatch is
+the authorization check, which is why it takes repository write access.
+With a token that can only read, the command prints the workflow page to
+open in a browser and the recipient string to paste into it, then keeps
+watching for the run that click starts. The wait has no bound, since a
+run takes as long as it takes; Ctrl-C stops watching and running the
+command again picks up where it left off. Run it on a workstation that
+already holds a key and it re-checks the shell profile rather than
+minting a second one.
+
+`request` and `collect` are the same path in two invocations, for
+somewhere a watching command is unwanted — a shell without a terminal to
+interrupt, or a delivery collected on a different day than it was asked
+for:
 
 ```
 deno task test-records-key request
-```
-
-generates a delivery identity and dispatches the minting workflow — the
-dispatch is the authorization check, which is why it takes repository
-write access. With a token that can only read, the tool instead prints
-the workflow page to open in a browser and the recipient string to paste
-into it. Once the run finishes:
-
-```
 deno task test-records-key collect
 ```
 
-downloads the sealed delivery, installs the key file with owner-only
-permissions, and prints the `CF_TEST_RECORDS_KEY_FILE` line to add to your
-shell. Keys stay valid while you stay active: a daily janitor disables the
-accounts of people with no pull-request activity for a month and re-enables
-them when they return — the same key file simply starts working again.
+The key travels sealed. The delivery identity is an X25519 key pair whose
+public half is the `cfr1...` recipient string the tool prints and the
+workflow takes as its input; the private half stays in
+`~/.config/common-fabric/test-records-identity.json` and never leaves the
+workstation. The workflow seals the minted key to that recipient —
+ephemeral-sender X25519, HKDF-SHA256, AES-256-GCM, with both public keys
+bound into the derivation — and publishes the box as a workflow artifact
+named by the recipient's fingerprint. Everyone who can read the
+repository's artifacts, GitHub included, holds a box that only the
+requester's stored identity opens. What comes out is then checked
+against the collector's own GitHub login, so a key minted for one person
+does not install for another.
 
-You hold one live key: minting revokes the previous ones, so running
-`request` again is how a lost or leaked key is rotated, and a second
-machine gets the existing key file copied to it rather than a fresh
-mint that would kill the first machine's.
+Keys stay valid while you stay active: a daily janitor disables the
+accounts of people with no pull-request activity for a month and
+re-enables them when they return — the same key file simply starts
+working again.
+
+You hold one live key: minting revokes the previous ones, so
+`deno task test-records-key setup --rotate` is how a lost or leaked key
+is rotated, and a second machine gets the existing key file copied to it
+rather than a fresh mint that would kill the first machine's.
 
 ## How records move
 

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -66,7 +66,7 @@ a couple of minutes. Contributing without commit access? Then keys are
 simply not part of your workflow yet, and skipping them costs you
 nothing: your local tests run identically without one, and CI records
 your pull requests' runs on its own, no key involved. The day you have
-commit access, the same two commands below are yours.
+commit access, the one command below is yours.
 
 A key takes only a GitHub identity, and one command:
 
@@ -77,8 +77,16 @@ deno task test-records-key setup
 generates a delivery identity, dispatches the minting workflow, watches
 until the run delivers, installs the key file with owner-only
 permissions, and exports `CF_TEST_RECORDS_KEY_FILE` from the login
-shell's profile — every shell opened after that records. The dispatch is
-the authorization check, which is why it takes repository write access.
+shell's profile — every shell opened after that records. A profile that
+already sets the variable is reported and left alone, whether it points
+somewhere else or sets it without exporting it, and so is a login
+profile that does not exist yet, since creating one is what stops a
+login shell reading the file it falls back to. Rerun the command and it
+takes up whatever run is already minting for you rather than starting a
+second one, which is what makes an interrupted setup resume.
+
+The dispatch is the authorization check, which is why it takes
+repository write access.
 With a token that can only read, the command prints the workflow page to
 open in a browser and the recipient string to paste into it, then keeps
 watching for the run that click starts. The wait has no bound, since a

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -507,6 +507,63 @@ describe("test-records-key", () => {
       expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(line);
     });
 
+    it("keeps the key beside the identity under a plain home", async () => {
+      const identity = await generateIdentity();
+      await Deno.mkdir(join(home, ".config", "common-fabric"), {
+        recursive: true,
+      });
+      await Deno.writeTextFile(
+        join(home, ".config", "common-fabric", "test-records-identity.json"),
+        JSON.stringify(identity),
+      );
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      deps.env = (name) => name === "HOME" ? home : undefined;
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, ".config", "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("reports a profile that sets the variable without exporting it", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      const line = `CF_TEST_RECORDS_KEY_FILE="$HOME/common-fabric/` +
+        `test-records-key.json"\n`;
+      await Deno.writeTextFile(join(home, ".zshrc"), line);
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(line);
+    });
+
+    it("reports the login profile a shell reads and does not have", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/bash";
+        return inner(name);
+      };
+      await Deno.writeTextFile(join(home, ".bashrc"), "");
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(join(home, ".bashrc"))).toContain(
+        "CF_TEST_RECORDS_KEY_FILE",
+      );
+    });
+
     it("throws with nowhere to keep the identity", async () => {
       withStub({});
       deps.env = () => undefined;
@@ -694,33 +751,84 @@ describe("test-records-key", () => {
     it("ignores a run that predates the dispatch", async () => {
       const identity = await storeIdentity();
       const published = await delivery(identity);
+      const failed = mintRun(identity.recipient, {
+        id: 1,
+        conclusion: "failure",
+        created_at: "2026-08-21T02:00:00Z",
+      });
       withStub({
         dispatchDate: "Fri, 21 Aug 2026 03:00:00 GMT",
         runPages: [
-          [mintRun(identity.recipient, {
-            id: 1,
-            created_at: "2026-08-21T02:00:00Z",
-          })],
+          [failed],
           [
             mintRun(identity.recipient, {
               id: 2,
               created_at: "2026-08-21T03:00:01Z",
             }),
-            mintRun(identity.recipient, {
-              id: 1,
-              created_at: "2026-08-21T02:00:00Z",
-            }),
+            failed,
           ],
         ],
         ...published,
       });
 
+      // The failed run is the one this dispatch answers, so the watch
+      // must not report it as this attempt's outcome.
       expect(await setupCommand(deps)).toBe(0);
       expect(urls.some((line) => line.includes("/runs/2/artifacts"))).toBe(
         true,
       );
-      expect(urls.some((line) => line.includes("/runs/1/artifacts"))).toBe(
-        false,
+    });
+
+    it("takes up a run already going instead of starting another", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      const going = mintRun(identity.recipient, {
+        id: 5,
+        status: "in_progress",
+        conclusion: undefined,
+        created_at: "2026-08-21T03:00:00Z",
+      });
+      withStub({
+        runPages: [
+          [going],
+          [going],
+          [mintRun(identity.recipient, {
+            id: 5,
+            created_at: "2026-08-21T03:00:00Z",
+          })],
+        ],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("collects a delivery an earlier run left waiting", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("raises a dispatch that failed for any other reason", async () => {
+      await storeIdentity();
+      withStub({ dispatchStatus: 500 });
+
+      await expect(setupCommand(deps)).rejects.toThrow(
+        "Dispatching the minting workflow failed: HTTP 500",
       );
     });
 
@@ -791,7 +899,7 @@ describe("test-records-key", () => {
       );
     });
 
-    it("mints again when the installed key file is not one", async () => {
+    it("installs over a key file that will not parse", async () => {
       const identity = await storeIdentity();
       await Deno.writeTextFile(
         join(home, "common-fabric", "test-records-key.json"),
@@ -801,19 +909,51 @@ describe("test-records-key", () => {
       withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
 
       expect(await setupCommand(deps)).toBe(0);
-      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
     });
 
     it("says it is waiting once, however long it waits", async () => {
       const identity = await storeIdentity();
       const published = await delivery(identity);
       withStub({
-        runPages: [[], [], [mintRun(identity.recipient)]],
+        runPages: [[], [], [], [mintRun(identity.recipient)]],
         ...published,
       });
 
       expect(await setupCommand(deps)).toBe(0);
-      expect(urls.filter((line) => line.includes("/runs?")).length).toBe(3);
+      expect(urls.filter((line) => line.includes("/runs?")).length).toBe(4);
+    });
+
+    it("watches a run it can only attribute by who started it", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      const going = mintRun(identity.recipient, {
+        id: 8,
+        named: false,
+        status: "in_progress",
+        conclusion: undefined,
+        created_at: "2026-08-21T03:00:01Z",
+      });
+      withStub({
+        dispatchDate: "Fri, 21 Aug 2026 03:00:00 GMT",
+        runPages: [
+          [],
+          [going],
+          [mintRun(identity.recipient, {
+            id: 8,
+            named: false,
+            created_at: "2026-08-21T03:00:01Z",
+          })],
+        ],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
     });
 
     it("stops examining runs from before the watch began", async () => {

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -4,8 +4,12 @@ import { join } from "@std/path";
 
 import {
   collectCommand,
+  defaultDeps,
+  defaultGithubToken,
+  INTERRUPT_NOTICE,
   type KeyToolDeps,
   requestCommand,
+  runCli,
   setupCommand,
 } from "./test-records-key.ts";
 import {
@@ -132,8 +136,12 @@ function mintRun(
 
 interface StubOptions {
   login?: string;
+  loginStatus?: number;
   /** One page of runs per listing call; the last repeats. */
   runPages?: Record<string, unknown>[][];
+  runsStatus?: number;
+  /** GitHub's clock, as the runs listing reports it. */
+  listDate?: string;
   artifacts?: { id: number; name: string; expired?: boolean }[];
   artifactStatus?: number;
   zip?: Uint8Array;
@@ -168,7 +176,7 @@ describe("test-records-key", () => {
           return Promise.resolve(
             new Response(
               JSON.stringify({ login: options.login ?? "octocat" }),
-              { status: 200 },
+              { status: options.loginStatus ?? 200 },
             ),
           );
         }
@@ -186,9 +194,13 @@ describe("test-records-key", () => {
         if (url.includes("/runs?")) {
           const pages = options.runPages ?? [[]];
           const runs = pages[Math.min(page++, pages.length - 1)]!;
+          const headers = options.listDate !== undefined
+            ? { date: options.listDate }
+            : undefined;
           return Promise.resolve(
             new Response(JSON.stringify({ workflow_runs: runs }), {
-              status: 200,
+              status: options.runsStatus ?? 200,
+              ...(headers !== undefined ? { headers } : {}),
             }),
           );
         }
@@ -291,6 +303,14 @@ describe("test-records-key", () => {
 
       await requestCommand(deps);
       expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+    });
+
+    it("prints instructions when the token cannot name its owner", async () => {
+      await storeIdentity();
+      withStub({ loginStatus: 403 });
+
+      await requestCommand(deps);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
     });
   });
 
@@ -443,6 +463,152 @@ describe("test-records-key", () => {
       deps.githubToken = () => Promise.resolve(undefined);
       await expect(collectCommand(deps)).rejects.toThrow(
         "A GitHub token is needed",
+      );
+    });
+
+    it("reports a profile that points somewhere else", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        'export CF_TEST_RECORDS_KEY_FILE="/somewhere/else.json"\n',
+      );
+
+      expect(await collectCommand(deps)).toBe(0);
+
+      // The profile is a person's file: the line that disagrees stays.
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+        'export CF_TEST_RECORDS_KEY_FILE="/somewhere/else.json"\n',
+      );
+    });
+
+    it("leaves a profile that already exports the key file alone", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      const line = `export CF_TEST_RECORDS_KEY_FILE="$HOME/common-fabric/` +
+        `test-records-key.json"\n`;
+      await Deno.writeTextFile(join(home, ".zshrc"), line);
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(line);
+    });
+
+    it("throws with nowhere to keep the identity", async () => {
+      withStub({});
+      deps.env = () => undefined;
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "Neither XDG_CONFIG_HOME nor HOME is set.",
+      );
+    });
+
+    it("throws when the token cannot read the collector's login", async () => {
+      await storeIdentity();
+      withStub({ loginStatus: 403 });
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "Cannot read your GitHub login",
+      );
+    });
+
+    it("names the status when the run listing fails", async () => {
+      await storeIdentity();
+      withStub({ runsStatus: 500 });
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "Listing minting runs failed: HTTP 500",
+      );
+    });
+
+    it("names the endpoint it could not reach", async () => {
+      await storeIdentity();
+      withFetch(
+        (() =>
+          Promise.reject(new TypeError("connection refused"))) as typeof fetch,
+      );
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "Cannot reach https://api.github.com: connection refused",
+      );
+    });
+
+    it("refuses a delivery sealed to another identity", async () => {
+      const identity = await storeIdentity();
+      const stranger = await generateIdentity();
+      const fingerprint = await recipientFingerprint(identity.recipient);
+      const sealed = await seal(
+        stranger.recipient,
+        new TextEncoder().encode(KEY_TEXT),
+      );
+      withStub({
+        runPages: [[mintRun(identity.recipient)]],
+        artifacts: [{ id: 7, name: `test-records-key-${fingerprint}` }],
+        zip: storedZip(
+          `${fingerprint}.sealed`,
+          new TextEncoder().encode(JSON.stringify(sealed)),
+        ),
+      });
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "does not open with the identity",
+      );
+    });
+
+    it("refuses a delivery that is not a key file", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity, JSON.stringify({ hi: 1 }));
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      await expect(collectCommand(deps)).rejects.toThrow(
+        "not a personal test-records key file",
+      );
+    });
+
+    it("passes over an unnamed run of its own that delivered nothing", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[
+          mintRun(identity.recipient, { id: 9, named: false }),
+          mintRun(identity.recipient, { id: 3 }),
+        ]],
+        ...published,
+      });
+
+      // The newest run is this person's, but it published nothing for
+      // this recipient, so the delivery of the older named run is the
+      // one collected.
+      let artifactsFor: string | undefined;
+      const inner = deps.fetchImpl;
+      deps.fetchImpl = ((input: URL | RequestInfo, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/runs/9/artifacts")) {
+          artifactsFor = url;
+          return Promise.resolve(
+            new Response(JSON.stringify({ artifacts: [] }), { status: 200 }),
+          );
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(artifactsFor).toBeDefined();
+      expect(urls.some((line) => line.includes("/runs/3/artifacts"))).toBe(
+        true,
       );
     });
   });
@@ -603,6 +769,212 @@ describe("test-records-key", () => {
       await expect(setupCommand(deps)).rejects.toThrow(
         "A GitHub token is needed",
       );
+    });
+
+    it("throws when the token cannot name its owner", async () => {
+      withStub({ loginStatus: 403 });
+
+      await expect(setupCommand(deps)).rejects.toThrow(
+        "Cannot read your GitHub login",
+      );
+    });
+
+    it("says so when the run it watched delivered nothing", async () => {
+      const identity = await storeIdentity();
+      withStub({
+        runPages: [[mintRun(identity.recipient)]],
+        artifacts: [],
+      });
+
+      await expect(setupCommand(deps)).rejects.toThrow(
+        "published no delivery",
+      );
+    });
+
+    it("mints again when the installed key file is not one", async () => {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        "not a key file",
+      );
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+    });
+
+    it("says it is waiting once, however long it waits", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[], [], [mintRun(identity.recipient)]],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.filter((line) => line.includes("/runs?")).length).toBe(3);
+    });
+
+    it("stops examining runs from before the watch began", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      const stale = mintRun(identity.recipient, {
+        id: 1,
+        named: false,
+        created_at: "2026-08-21T02:00:00Z",
+      });
+      withStub({
+        dispatchStatus: 403,
+        listDate: "Fri, 21 Aug 2026 03:00:00 GMT",
+        runPages: [
+          [stale],
+          [
+            mintRun(identity.recipient, {
+              id: 2,
+              created_at: "2026-08-21T03:00:01Z",
+            }),
+            stale,
+          ],
+        ],
+        artifacts: [],
+        zip: published.zip,
+      });
+      const inner = deps.fetchImpl;
+      deps.fetchImpl = ((input: URL | RequestInfo, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/runs/2/artifacts")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ artifacts: published.artifacts }), {
+              status: 200,
+            }),
+          );
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+
+      expect(await setupCommand(deps)).toBe(0);
+      // The stale run is examined on the first round, which is what
+      // fixes the clock, and left alone on every round after it.
+      expect(
+        urls.filter((line) => line.includes("/runs/1/artifacts")).length,
+      ).toBe(1);
+    });
+  });
+
+  describe("defaultGithubToken()", () => {
+    const noCommand = () => {
+      throw new Error("no command expected");
+    };
+
+    it("returns the token the environment carries", async () => {
+      expect(
+        await defaultGithubToken(
+          (name) => name === "GH_TOKEN" ? "from-gh-token" : undefined,
+          noCommand,
+        ),
+      ).toBe("from-gh-token");
+      expect(
+        await defaultGithubToken(
+          (name) => name === "GITHUB_TOKEN" ? "from-github-token" : undefined,
+          noCommand,
+        ),
+      ).toBe("from-github-token");
+    });
+
+    it("returns what the signed-in command line holds", async () => {
+      expect(
+        await defaultGithubToken(
+          () => undefined,
+          (command, args) => {
+            expect(command).toBe("gh");
+            expect(args).toEqual(["auth", "token"]);
+            return Promise.resolve({
+              code: 0,
+              stdout: new TextEncoder().encode("from-gh\n"),
+            });
+          },
+        ),
+      ).toBe("from-gh");
+    });
+
+    it("returns undefined when no source holds one", async () => {
+      const empty = () => undefined;
+      expect(
+        await defaultGithubToken(
+          empty,
+          () => Promise.resolve({ code: 1, stdout: new Uint8Array() }),
+        ),
+      ).toBeUndefined();
+      expect(
+        await defaultGithubToken(
+          empty,
+          () =>
+            Promise.resolve({ code: 0, stdout: new TextEncoder().encode(" ") }),
+        ),
+      ).toBeUndefined();
+      expect(
+        await defaultGithubToken(empty, () => Promise.reject(new Error("no"))),
+      ).toBeUndefined();
+      expect(
+        await defaultGithubToken(
+          (name) => name === "GH_TOKEN" ? "" : undefined,
+          () => Promise.resolve({ code: 1, stdout: new Uint8Array() }),
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("defaultDeps()", () => {
+    it("returns the wiring the command line runs against", () => {
+      const wiring = defaultDeps();
+      expect(wiring.env).toBe(Deno.env.get);
+      expect(wiring.fetchImpl).toBe(fetch);
+      expect(typeof wiring.githubToken).toBe("function");
+      expect(typeof wiring.pause).toBe("function");
+    });
+  });
+
+  describe("INTERRUPT_NOTICE", () => {
+    it("says how to pick the key up again", () => {
+      expect(INTERRUPT_NOTICE).toContain("deno task test-records-key setup");
+    });
+  });
+
+  describe("runCli()", () => {
+    it("returns 2 and prints usage for a command it does not have", async () => {
+      withStub({});
+      expect(await runCli(["wat"], deps)).toBe(2);
+      expect(await runCli([], deps)).toBe(2);
+    });
+
+    it("returns 2 for an argument the command does not take", async () => {
+      withStub({});
+      expect(await runCli(["setup", "--wat"], deps)).toBe(2);
+      expect(await runCli(["request", "--wat"], deps)).toBe(2);
+      expect(await runCli(["collect", "--wat"], deps)).toBe(2);
+    });
+
+    it("returns 1 and reports a failure a person can hit", async () => {
+      withStub({});
+      expect(await runCli(["collect"], deps)).toBe(1);
+    });
+
+    it("returns what the command it ran returned", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      expect(await runCli(["setup"], deps)).toBe(0);
+      expect(await runCli(["request"], deps)).toBe(0);
+    });
+
+    it("lets a fault in the tool keep its stack", async () => {
+      await storeIdentity();
+      withStub({});
+      deps.githubToken = () => Promise.reject(new RangeError("bug"));
+
+      await expect(runCli(["collect"], deps)).rejects.toThrow(RangeError);
     });
   });
 });

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -6,6 +6,7 @@ import {
   collectCommand,
   type KeyToolDeps,
   requestCommand,
+  setupCommand,
 } from "./test-records-key.ts";
 import {
   generateIdentity,
@@ -99,6 +100,48 @@ function storedZip(name: string, content: Uint8Array): Uint8Array {
   ]);
 }
 
+/**
+ * A run as the API lists it. `named: false` is a run of a workflow
+ * version whose run name does not carry the recipient, which is what the
+ * delivery artifact has to identify instead.
+ */
+function mintRun(
+  recipient: string,
+  run: {
+    id?: number;
+    status?: string;
+    conclusion?: string;
+    created_at?: string;
+    named?: boolean;
+    actor?: string;
+  } = {},
+): Record<string, unknown> {
+  const id = run.id ?? 42;
+  return {
+    id,
+    status: run.status ?? "completed",
+    conclusion: run.conclusion ?? "success",
+    created_at: run.created_at ?? "2026-08-21T02:00:00Z",
+    html_url: `https://github.com/commontoolsinc/labs/actions/runs/${id}`,
+    display_title: run.named === false
+      ? "Test Records Mint"
+      : `Mint reporting key for octocat (${recipient})`,
+    actor: { login: run.actor ?? "octocat" },
+  };
+}
+
+interface StubOptions {
+  login?: string;
+  /** One page of runs per listing call; the last repeats. */
+  runPages?: Record<string, unknown>[][];
+  artifacts?: { id: number; name: string; expired?: boolean }[];
+  artifactStatus?: number;
+  zip?: Uint8Array;
+  zipStatus?: number;
+  dispatchStatus?: number;
+  dispatchDate?: string;
+}
+
 describe("test-records-key", () => {
   let home: string;
   let deps: KeyToolDeps;
@@ -112,7 +155,63 @@ describe("test-records-key", () => {
         return fetchImpl(input, init);
       }) as typeof fetch,
       githubToken: () => Promise.resolve(token),
+      pause: () => Promise.resolve(),
     };
+  }
+
+  function withStub(options: StubOptions, token = "gh-token"): void {
+    let page = 0;
+    withFetch(
+      ((input: URL | RequestInfo) => {
+        const url = String(input);
+        if (url.endsWith("/user")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ login: options.login ?? "octocat" }),
+              { status: 200 },
+            ),
+          );
+        }
+        if (url.endsWith("/dispatches")) {
+          const headers = options.dispatchDate !== undefined
+            ? { date: options.dispatchDate }
+            : undefined;
+          return Promise.resolve(
+            new Response(null, {
+              status: options.dispatchStatus ?? 204,
+              ...(headers !== undefined ? { headers } : {}),
+            }),
+          );
+        }
+        if (url.includes("/runs?")) {
+          const pages = options.runPages ?? [[]];
+          const runs = pages[Math.min(page++, pages.length - 1)]!;
+          return Promise.resolve(
+            new Response(JSON.stringify({ workflow_runs: runs }), {
+              status: 200,
+            }),
+          );
+        }
+        if (url.includes("/artifacts?")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ artifacts: options.artifacts ?? [] }),
+              { status: options.artifactStatus ?? 200 },
+            ),
+          );
+        }
+        if (url.endsWith("/zip")) {
+          return Promise.resolve(
+            new Response(
+              (options.zip ?? new Uint8Array()) as unknown as BodyInit,
+              { status: options.zipStatus ?? 200 },
+            ),
+          );
+        }
+        return Promise.resolve(new Response("unexpected", { status: 500 }));
+      }) as typeof fetch,
+      token,
+    );
   }
 
   async function storeIdentity(): Promise<KeyDeliveryIdentity> {
@@ -123,6 +222,25 @@ describe("test-records-key", () => {
       JSON.stringify(identity),
     );
     return identity;
+  }
+
+  /** The delivery a successful run publishes for an identity. */
+  async function delivery(
+    identity: KeyDeliveryIdentity,
+    keyText = KEY_TEXT,
+  ): Promise<{ artifacts: { id: number; name: string }[]; zip: Uint8Array }> {
+    const fingerprint = await recipientFingerprint(identity.recipient);
+    const sealed = await seal(
+      identity.recipient,
+      new TextEncoder().encode(keyText),
+    );
+    return {
+      artifacts: [{ id: 7, name: `test-records-key-${fingerprint}` }],
+      zip: storedZip(
+        `${fingerprint}.sealed`,
+        new TextEncoder().encode(JSON.stringify(sealed)),
+      ),
+    };
   }
 
   beforeEach(async () => {
@@ -136,19 +254,7 @@ describe("test-records-key", () => {
 
   describe("requestCommand()", () => {
     it("stores an identity with owner-only permissions and dispatches", async () => {
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          return Promise.resolve(new Response(null, { status: 204 }));
-        }) as typeof fetch,
-      );
+      withStub({});
 
       await requestCommand(deps);
 
@@ -181,19 +287,7 @@ describe("test-records-key", () => {
 
     it("falls back to instructions when the dispatch is refused", async () => {
       await storeIdentity();
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          return Promise.resolve(new Response("forbidden", { status: 403 }));
-        }) as typeof fetch,
-      );
+      withStub({ dispatchStatus: 403 });
 
       await requestCommand(deps);
       expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
@@ -202,320 +296,312 @@ describe("test-records-key", () => {
 
   describe("collectCommand()", () => {
     it("throws without a stored identity", async () => {
-      withFetch(fetch);
+      withStub({});
       await expect(collectCommand(deps)).rejects.toThrow(
-        "no delivery identity",
+        "No delivery identity",
       );
     });
 
     it("downloads, opens, validates, and installs the delivered key", async () => {
       const identity = await storeIdentity();
-      const fingerprint = await recipientFingerprint(identity.recipient);
-      const sealed = await seal(
-        identity.recipient,
-        new TextEncoder().encode(KEY_TEXT),
-      );
-      const zip = storedZip(
-        `${fingerprint}.sealed`,
-        new TextEncoder().encode(JSON.stringify(sealed)),
-      );
-
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "OctoCat" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.includes("/artifacts?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  artifacts: [{
-                    id: 7,
-                    name: `test-records-key-${fingerprint}`,
-                  }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.endsWith("/zip")) {
-            return Promise.resolve(
-              new Response(zip as unknown as BodyInit, { status: 200 }),
-            );
-          }
-          return Promise.resolve(new Response("unexpected", { status: 500 }));
-        }) as typeof fetch,
-      );
+      const published = await delivery(identity);
+      withStub({
+        login: "OctoCat",
+        runPages: [[mintRun(identity.recipient)]],
+        ...published,
+      });
 
       expect(await collectCommand(deps)).toBe(0);
 
       const installed = join(home, "common-fabric", "test-records-key.json");
       expect(await Deno.readTextFile(installed)).toBe(KEY_TEXT);
       expect(Deno.statSync(installed).mode! & 0o777).toBe(0o600);
-      expect(urls.some((line) => line.includes("actor=OctoCat"))).toBe(true);
     });
 
     it("asks to retry while the minting run is still going", async () => {
-      await storeIdentity();
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                workflow_runs: [{ id: 42, status: "in_progress" }],
-              }),
-              { status: 200 },
-            ),
-          );
-        }) as typeof fetch,
-      );
+      const identity = await storeIdentity();
+      withStub({
+        runPages: [[mintRun(identity.recipient, { status: "in_progress" })]],
+      });
 
       expect(await collectCommand(deps)).toBe(1);
     });
 
+    it("names the run that failed", async () => {
+      const identity = await storeIdentity();
+      withStub({
+        runPages: [[mintRun(identity.recipient, { conclusion: "failure" })]],
+      });
+
+      await expect(collectCommand(deps)).rejects.toThrow("finished as failure");
+    });
+
+    it("throws when no run is minting for this recipient", async () => {
+      await storeIdentity();
+      withStub({
+        runPages: [[mintRun("cfr1someone-else", { actor: "someone-else" })]],
+      });
+
+      await expect(collectCommand(deps)).rejects.toThrow("No minting run");
+    });
+
+    it("identifies a run that does not name the recipient by its delivery", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[mintRun(identity.recipient, { named: false })]],
+        ...published,
+      });
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("passes over a delivery-less run someone else dispatched", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[
+          mintRun("cfr1someone-else", { id: 9, actor: "someone-else" }),
+          mintRun(identity.recipient, { named: false }),
+        ]],
+        ...published,
+      });
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/runs/9/artifacts"))).toBe(
+        false,
+      );
+    });
+
     it("refuses a key minted for someone else", async () => {
       const identity = await storeIdentity();
-      const fingerprint = await recipientFingerprint(identity.recipient);
-      const sealed = await seal(
-        identity.recipient,
-        new TextEncoder().encode(KEY_TEXT),
-      );
-      const zip = storedZip(
-        `${fingerprint}.sealed`,
-        new TextEncoder().encode(JSON.stringify(sealed)),
-      );
-
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "someone-else" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.includes("/artifacts?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  artifacts: [{
-                    id: 7,
-                    name: `test-records-key-${fingerprint}`,
-                  }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.endsWith("/zip")) {
-            return Promise.resolve(
-              new Response(zip as unknown as BodyInit, { status: 200 }),
-            );
-          }
-          return Promise.resolve(new Response("unexpected", { status: 500 }));
-        }) as typeof fetch,
-      );
+      const published = await delivery(identity);
+      withStub({
+        login: "someone-else",
+        runPages: [[mintRun(identity.recipient)]],
+        ...published,
+      });
 
       await expect(collectCommand(deps)).rejects.toThrow("minted for");
     });
 
-    it("throws when no completed run delivered to this identity", async () => {
-      await storeIdentity();
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          return Promise.resolve(
-            new Response(JSON.stringify({ artifacts: [] }), { status: 200 }),
-          );
-        }) as typeof fetch,
-      );
+    it("throws when the run published no delivery", async () => {
+      const identity = await storeIdentity();
+      withStub({ runPages: [[mintRun(identity.recipient)]], artifacts: [] });
 
       await expect(collectCommand(deps)).rejects.toThrow(
-        "no completed minting run",
+        "published no delivery",
       );
     });
 
-    it("skips a run whose artifact listing fails, then reports no delivery", async () => {
-      await storeIdentity();
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          return Promise.resolve(new Response("down", { status: 500 }));
-        }) as typeof fetch,
-      );
+    it("names the status when the artifact listing fails", async () => {
+      const identity = await storeIdentity();
+      withStub({
+        runPages: [[mintRun(identity.recipient)]],
+        artifactStatus: 500,
+      });
+
       await expect(collectCommand(deps)).rejects.toThrow(
-        "no completed minting run",
+        "Listing the artifacts of run 42 failed: HTTP 500",
       );
     });
 
     it("throws when the delivery download fails", async () => {
       const identity = await storeIdentity();
-      const fingerprint = await recipientFingerprint(identity.recipient);
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.includes("/artifacts?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  artifacts: [{
-                    id: 7,
-                    name: `test-records-key-${fingerprint}`,
-                  }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          return Promise.resolve(new Response("gone", { status: 410 }));
-        }) as typeof fetch,
-      );
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[mintRun(identity.recipient)]],
+        artifacts: published.artifacts,
+        zipStatus: 410,
+      });
+
       await expect(collectCommand(deps)).rejects.toThrow(
-        "downloading the delivery failed",
+        "Downloading the delivery failed",
       );
     });
 
     it("throws when the delivery zip holds no sealed key", async () => {
       const identity = await storeIdentity();
-      const fingerprint = await recipientFingerprint(identity.recipient);
-      const zip = storedZip("readme.txt", new TextEncoder().encode("hi"));
-      withFetch(
-        ((input: URL | RequestInfo) => {
-          const url = String(input);
-          if (url.endsWith("/user")) {
-            return Promise.resolve(
-              new Response(JSON.stringify({ login: "octocat" }), {
-                status: 200,
-              }),
-            );
-          }
-          if (url.includes("/runs?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  workflow_runs: [{ id: 42, status: "completed" }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.includes("/artifacts?")) {
-            return Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  artifacts: [{
-                    id: 7,
-                    name: `test-records-key-${fingerprint}`,
-                  }],
-                }),
-                { status: 200 },
-              ),
-            );
-          }
-          if (url.endsWith("/zip")) {
-            return Promise.resolve(
-              new Response(zip as unknown as BodyInit, { status: 200 }),
-            );
-          }
-          return Promise.resolve(new Response("unexpected", { status: 500 }));
-        }) as typeof fetch,
-      );
-      await expect(collectCommand(deps)).rejects.toThrow(
-        "holds no sealed key",
-      );
+      const published = await delivery(identity);
+      withStub({
+        runPages: [[mintRun(identity.recipient)]],
+        artifacts: published.artifacts,
+        zip: storedZip("readme.txt", new TextEncoder().encode("hi")),
+      });
+
+      await expect(collectCommand(deps)).rejects.toThrow("holds no sealed key");
     });
 
     it("throws without any usable token", async () => {
       await storeIdentity();
-      withFetch(fetch);
+      withStub({});
       deps.githubToken = () => Promise.resolve(undefined);
       await expect(collectCommand(deps)).rejects.toThrow(
-        "a GitHub token is needed",
+        "A GitHub token is needed",
+      );
+    });
+  });
+
+  describe("setupCommand()", () => {
+    /** A workstation whose login shell is zsh, profile and all. */
+    function withShell(): string {
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      return join(home, ".zshrc");
+    }
+
+    it("dispatches, waits for the run, installs, and exports the key", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        runPages: [
+          [],
+          [mintRun(identity.recipient, { status: "queued" })],
+          [mintRun(identity.recipient, { status: "in_progress" })],
+          [mintRun(identity.recipient)],
+        ],
+        ...published,
+      });
+      const profile = withShell();
+
+      expect(await setupCommand(deps)).toBe(0);
+
+      const installed = join(home, "common-fabric", "test-records-key.json");
+      expect(await Deno.readTextFile(installed)).toBe(KEY_TEXT);
+      expect(await Deno.readTextFile(profile)).toContain(
+        'export CF_TEST_RECORDS_KEY_FILE="$HOME/common-fabric/' +
+          'test-records-key.json"',
+      );
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+    });
+
+    it("follows a run that does not name the recipient to its delivery", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        dispatchDate: "Fri, 21 Aug 2026 01:00:00 GMT",
+        runPages: [
+          [mintRun(identity.recipient, {
+            named: false,
+            status: "in_progress",
+            conclusion: undefined,
+          })],
+          [mintRun(identity.recipient, { named: false })],
+        ],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("keeps watching when the dispatch is refused", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        dispatchStatus: 403,
+        runPages: [[], [mintRun(identity.recipient)]],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+    });
+
+    it("ignores a run that predates the dispatch", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({
+        dispatchDate: "Fri, 21 Aug 2026 03:00:00 GMT",
+        runPages: [
+          [mintRun(identity.recipient, {
+            id: 1,
+            created_at: "2026-08-21T02:00:00Z",
+          })],
+          [
+            mintRun(identity.recipient, {
+              id: 2,
+              created_at: "2026-08-21T03:00:01Z",
+            }),
+            mintRun(identity.recipient, {
+              id: 1,
+              created_at: "2026-08-21T02:00:00Z",
+            }),
+          ],
+        ],
+        ...published,
+      });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/runs/2/artifacts"))).toBe(
+        true,
+      );
+      expect(urls.some((line) => line.includes("/runs/1/artifacts"))).toBe(
+        false,
+      );
+    });
+
+    it("names the run that failed instead of waiting on it", async () => {
+      const identity = await storeIdentity();
+      withStub({
+        runPages: [[mintRun(identity.recipient, { conclusion: "failure" })]],
+      });
+
+      await expect(setupCommand(deps)).rejects.toThrow("finished as failure");
+    });
+
+    it("exports the installed key rather than minting a second one", async () => {
+      await Deno.mkdir(join(home, "common-fabric"), { recursive: true });
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      withStub({});
+      const profile = withShell();
+
+      expect(await setupCommand(deps)).toBe(0);
+
+      expect(await Deno.readTextFile(profile)).toContain(
+        "CF_TEST_RECORDS_KEY_FILE",
+      );
+      expect(urls).toEqual([]);
+    });
+
+    it("mints a replacement when asked to rotate", async () => {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      expect(await setupCommand(deps, { rotate: true })).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+    });
+
+    it("throws without any usable token", async () => {
+      withStub({});
+      deps.githubToken = () => Promise.resolve(undefined);
+      await expect(setupCommand(deps)).rejects.toThrow(
+        "A GitHub token is needed",
       );
     });
   });

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -809,6 +809,40 @@ describe("test-records-key", () => {
       ).toBe(KEY_TEXT);
     });
 
+    it("starts its own run rather than one it cannot identify", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      const opaque = mintRun(identity.recipient, {
+        id: 4,
+        named: false,
+        status: "in_progress",
+        conclusion: undefined,
+        created_at: "2026-08-21T02:00:00Z",
+      });
+      withStub({
+        dispatchDate: "Fri, 21 Aug 2026 03:00:00 GMT",
+        runPages: [
+          [opaque],
+          [
+            mintRun(identity.recipient, {
+              id: 6,
+              created_at: "2026-08-21T03:00:01Z",
+            }),
+            opaque,
+          ],
+        ],
+        ...published,
+      });
+
+      // A run of this person's under a name that says nothing about
+      // what it is minting could be for another identity of theirs.
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(true);
+      expect(urls.some((line) => line.includes("/runs/6/artifacts"))).toBe(
+        true,
+      );
+    });
+
     it("collects a delivery an earlier run left waiting", async () => {
       const identity = await storeIdentity();
       const published = await delivery(identity);

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -414,6 +414,8 @@ function namesRecipient(run: MintRun, recipient: string): boolean {
  * Failing both, the newest run this person dispatched within this
  * attempt is the one they are waiting on, which is all that can be said
  * of a run that is still going and does not name what it is minting.
+ * That last test needs the bound this attempt sets, so a search without
+ * one answers only when it can identify the run outright.
  */
 async function findMintRun(
   deps: KeyToolDeps,
@@ -443,16 +445,15 @@ async function findMintRun(
     if (named) return { ...result, match: { run } };
   }
 
-  if (search.notBefore !== undefined) {
-    const attributed = candidates[0];
-    return attributed === undefined
-      ? result
-      : { ...result, match: { run: attributed } };
-  }
-  const running = candidates.find((run) => run.status !== "completed");
-  return running === undefined
+  // Attributing a run by who started it and when takes a bound to be
+  // safe: without one, a run this person started for some other
+  // recipient, under a name that says nothing about what it is minting,
+  // cannot be told from theirs.
+  if (search.notBefore === undefined) return result;
+  const attributed = candidates[0];
+  return attributed === undefined
     ? result
-    : { ...result, match: { run: running } };
+    : { ...result, match: { run: attributed } };
 }
 
 /** The id of a run's sealed delivery, when it published an unexpired one. */

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -45,6 +45,7 @@ import {
 import { readZip } from "./test-records-zip.ts";
 import {
   exportFromProfiles,
+  exportLine,
   type ProfileUpdate,
   reloadHint,
   shellKind,
@@ -54,6 +55,16 @@ const API = "https://api.github.com";
 
 /** How often the watch asks GitHub what the minting run is doing. */
 const POLL_INTERVAL_MS = 5_000;
+
+/** Runs per listing page; a hundred is what the API will serve. */
+const RUNS_PER_PAGE = 100;
+
+/**
+ * How far back a search looks when nothing narrower bounds it. A
+ * delivery artifact is kept for seven days, and the extra day covers the
+ * two clocks disagreeing.
+ */
+const DELIVERY_WINDOW_MS = 8 * 24 * 60 * 60 * 1_000;
 
 /**
  * A failure whose message is the whole report. Everything a person can
@@ -139,6 +150,10 @@ function configDir(env: Environment): string {
     throw new KeyToolError("Neither XDG_CONFIG_HOME nor HOME is set.");
   }
   return join(home, ".config", "common-fabric");
+}
+
+function home(env: Environment): string | undefined {
+  return readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
 }
 
 function identityPath(env: Environment): string {
@@ -255,16 +270,27 @@ async function dispatchMint(
     { ref: "main", inputs: { recipient, username } },
   );
   const at = Date.parse(dispatched.headers.get("date") ?? "");
-  await dispatched.text();
-  if (dispatched.status === 204) {
-    const result: DispatchResult = { dispatched: true, username };
-    if (!Number.isNaN(at)) result.at = at;
-    return result;
+  const body = await dispatched.text();
+  const result: DispatchResult = { dispatched: dispatched.status === 204 };
+  if (result.dispatched) result.username = username;
+  // The clock is kept whether the dispatch was taken or refused: a run
+  // that appears after this moment is this attempt's either way, and a
+  // refusal is followed by the same person starting the run themselves.
+  if (!Number.isNaN(at)) result.at = at;
+  if (result.dispatched) return result;
+  // A token that may only read is answered 401, 403, or — on a
+  // repository it cannot see — 404. Anything else is the workflow or
+  // GitHub failing, which no amount of clicking in a browser fixes.
+  if (![401, 403, 404].includes(dispatched.status)) {
+    throw new KeyToolError(
+      `Dispatching the minting workflow failed: HTTP ${dispatched.status} ` +
+        `${body.slice(0, 200)}`,
+    );
   }
   console.log(
     `This token cannot dispatch the workflow (HTTP ${dispatched.status}).`,
   );
-  return { dispatched: false };
+  return result;
 }
 
 /** What to print when the dispatch has to happen in a browser. */
@@ -322,6 +348,64 @@ interface RunSearchResult {
 }
 
 /**
+ * The runs worth examining, newest first, over as many pages as the
+ * window holds.
+ */
+async function listCandidateRuns(
+  deps: KeyToolDeps,
+  search: RunSearch,
+): Promise<{ candidates: MintRun[]; serverDate?: number }> {
+  // A delivery is kept for seven days, so a run older than that has
+  // nothing left to collect; asking GitHub for that window keeps the
+  // search to the runs that could still be answered, however many the
+  // workflow has accumulated.
+  const since = new Date(
+    search.notBefore ?? Date.now() - DELIVERY_WINDOW_MS,
+  ).toISOString();
+  const candidates: MintRun[] = [];
+  let serverDate: number | undefined;
+  for (let page = 1;; page += 1) {
+    const res = await github(
+      deps,
+      search.token,
+      "GET",
+      `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/runs` +
+        `?per_page=${RUNS_PER_PAGE}&page=${page}` +
+        `&created=${encodeURIComponent(`>=${since}`)}`,
+    );
+    if (!res.ok) {
+      await res.text();
+      throw new KeyToolError(`Listing minting runs failed: HTTP ${res.status}`);
+    }
+    const listed = Date.parse(res.headers.get("date") ?? "");
+    if (serverDate === undefined && !Number.isNaN(listed)) serverDate = listed;
+    const runs = (await res.json() as { workflow_runs?: MintRun[] })
+      .workflow_runs ?? [];
+    for (const run of runs) {
+      if (!isCandidate(run, search)) continue;
+      candidates.push(run);
+    }
+    if (runs.length < RUNS_PER_PAGE) break;
+  }
+  return serverDate === undefined ? { candidates } : { candidates, serverDate };
+}
+
+/** Whether a run could be the one this search is for. */
+function isCandidate(run: MintRun, search: RunSearch): boolean {
+  const mine = namesRecipient(run, search.recipient) ||
+    run.actor?.login?.toLowerCase() === search.login.toLowerCase();
+  if (!mine) return false;
+  if (search.notBefore === undefined) return true;
+  const created = Date.parse(run.created_at ?? "");
+  return !Number.isNaN(created) && created >= search.notBefore;
+}
+
+/** Whether a run says which recipient it is minting for. */
+function namesRecipient(run: MintRun, recipient: string): boolean {
+  return `${run.display_title ?? ""}\n${run.name ?? ""}`.includes(recipient);
+}
+
+/**
  * The requester's own minting run, newest first, by three tests in
  * descending order of certainty. A run whose name carries the recipient
  * is minting for it. A completed run that published this recipient's
@@ -335,35 +419,12 @@ async function findMintRun(
   deps: KeyToolDeps,
   search: RunSearch,
 ): Promise<RunSearchResult> {
-  const res = await github(
-    deps,
-    search.token,
-    "GET",
-    `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/runs?per_page=50`,
-  );
-  if (!res.ok) {
-    await res.text();
-    throw new KeyToolError(`Listing minting runs failed: HTTP ${res.status}`);
-  }
-  const listed = Date.parse(res.headers.get("date") ?? "");
+  const { candidates, serverDate } = await listCandidateRuns(deps, search);
   const result: RunSearchResult = {};
-  if (!Number.isNaN(listed)) result.serverDate = listed;
-  const runs = (await res.json() as { workflow_runs?: MintRun[] })
-    .workflow_runs ?? [];
-
-  const namesRecipient = (run: MintRun): boolean =>
-    `${run.display_title ?? ""}\n${run.name ?? ""}`.includes(search.recipient);
-  const candidates = runs.filter((run) => {
-    const mine = namesRecipient(run) ||
-      run.actor?.login?.toLowerCase() === search.login.toLowerCase();
-    if (!mine) return false;
-    if (search.notBefore === undefined) return true;
-    const created = Date.parse(run.created_at ?? "");
-    return !Number.isNaN(created) && created >= search.notBefore;
-  });
+  if (serverDate !== undefined) result.serverDate = serverDate;
 
   for (const run of candidates) {
-    const named = namesRecipient(run);
+    const named = namesRecipient(run, search.recipient);
     if (run.status === "completed" && run.conclusion === "success") {
       const artifact = await deliveryArtifact(
         deps,
@@ -513,6 +574,22 @@ No shell profile to update. Export the key file yourself:
       console.log(`${RECORDS_KEY_FILE_VARIABLE} exported from ${update.path}`);
     } else if (update.outcome === "present") {
       console.log(`${update.path} already exports the key file.`);
+    } else if (update.outcome === "unexported") {
+      console.log(`
+${update.path} sets ${RECORDS_KEY_FILE_VARIABLE} without exporting it:
+
+    ${update.existing}
+
+Left alone. A test run is a program the shell starts, and it sees only
+what the shell exports.`);
+    } else if (update.outcome === "absent") {
+      console.log(`
+${update.path} does not exist, and a login shell here reads it before the
+profile just written. Create it and it will be read instead of the file
+your login shells fall back to, so that one is yours to make; the line
+to put in it is:
+
+    ${exportLine(kind, RECORDS_KEY_FILE_VARIABLE, path, home(deps.env))}`);
     } else {
       console.log(`
 ${update.path} already sets ${RECORDS_KEY_FILE_VARIABLE} elsewhere:
@@ -686,26 +763,58 @@ To rotate deliberately:
   }
 
   const identity = await ensureIdentity(deps);
-  console.log(`recipient: ${identity.recipient}`);
-  const dispatch = await dispatchMint(deps, token, identity.recipient, login);
-  if (dispatch.dispatched) {
-    console.log(`Minting workflow dispatched for ${login}`);
-  } else {
-    console.log(`${browserInstructions(identity.recipient)}
-
-Waiting for that run — this command collects the key on its own once it
-finishes. Ctrl-C stops watching; rerunning picks up where it left off.
-`);
-  }
-
+  console.log(`Recipient: ${identity.recipient}`);
   const search: RunSearch = {
     token,
     recipient: identity.recipient,
     artifactName: await deliveryName(identity.recipient),
     login,
   };
-  if (dispatch.at !== undefined) search.notBefore = dispatch.at;
-  const artifact = await awaitDelivery(deps, search);
+
+  // A run already minting for this recipient is this person's own
+  // earlier attempt — a watch they stopped, or a browser dispatch — and
+  // taking it up is what makes rerunning resume rather than start
+  // again. Minting a second time would revoke the key the first is
+  // about to deliver. Rotating deliberately is the one case that wants
+  // a new run whatever is already going.
+  const inFlight = options.rotate === true
+    ? undefined
+    : (await findMintRun(deps, search)).match;
+  let artifact: number;
+  if (inFlight?.artifact !== undefined) {
+    console.log(
+      `An earlier run has the key waiting: ${runUrl(inFlight.run)}`,
+    );
+    artifact = inFlight.artifact;
+  } else {
+    if (inFlight !== undefined && inFlight.run.status !== "completed") {
+      console.log(
+        `A minting run for this recipient is already going: ${
+          runUrl(inFlight.run)
+        }`,
+      );
+      const created = Date.parse(inFlight.run.created_at ?? "");
+      if (!Number.isNaN(created)) search.notBefore = created;
+    } else {
+      const dispatch = await dispatchMint(
+        deps,
+        token,
+        identity.recipient,
+        login,
+      );
+      if (dispatch.dispatched) {
+        console.log(`Minting workflow dispatched for ${login}`);
+      } else {
+        console.log(`${browserInstructions(identity.recipient)}
+
+Waiting for that run — this command collects the key on its own once it
+finishes. Ctrl-C stops watching; rerunning picks up where it left off.
+`);
+      }
+      if (dispatch.at !== undefined) search.notBefore = dispatch.at;
+    }
+    artifact = await awaitDelivery(deps, search);
+  }
   const path = await installDelivery(deps, token, identity, login, artifact);
   console.log(`Key installed: ${path}`);
   await exportKeyFile(deps, path);

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -1,22 +1,24 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run=gh
 /**
- * The two-invocation personal key tool, with no waiting built in.
+ * The personal key tool, in one command that finishes the job and two that
+ * split it.
+ *
+ *   deno task test-records-key setup
+ *     Generates a delivery identity, dispatches the minting workflow —
+ *     or prints the page to run it in a browser, which is the supported
+ *     minimum of a read-only token — then watches until the run delivers,
+ *     installs the key, and exports it from the login shell's profiles.
+ *     It waits as long as the run takes and stops on Ctrl-C; running it
+ *     again resumes from wherever it got to. Pass --rotate to mint a
+ *     replacement for a key that is already installed.
  *
  *   deno task test-records-key request
- *     Generates and stores a fresh delivery identity, then dispatches the
- *     minting workflow when the token allows it — and prints the exact
- *     page to open and the recipient string to paste when it does not,
- *     which is the supported minimum of a read-only token plus a web
- *     browser.
+ *     The first half alone: store the identity and dispatch the workflow.
  *
  *   deno task test-records-key collect
- *     Finds the completed minting run's delivery by the recipient's
- *     fingerprint, downloads and opens it, installs the key file with
- *     owner-only permissions, and prints the line to add to the shell.
- *     If the run has not finished, it says so and exits; running it again
- *     is the retry.
+ *     The second half alone: install the delivery of a finished run.
  *
- * Keys are a team-member workflow, and both halves are self-service. A
+ * Keys are a team-member workflow, and every part is self-service. A
  * person contributing without commit access needs no key: local tests run
  * identically without one, and CI records their pull requests' runs on
  * its own.
@@ -41,17 +43,41 @@ import {
   REPO,
 } from "./test-records-config.ts";
 import { readZip } from "./test-records-zip.ts";
+import {
+  exportFromProfiles,
+  type ProfileUpdate,
+  reloadHint,
+  shellKind,
+} from "./test-records-shell-config.ts";
 
 const API = "https://api.github.com";
 
+/** How often the watch asks GitHub what the minting run is doing. */
+const POLL_INTERVAL_MS = 5_000;
+
 /**
- * What the two commands reach outside the process through, injectable so
- * tests run them against stubs.
+ * A failure whose message is the whole report. Everything a person can
+ * hit — no token, a refused dispatch, a run that failed, a delivery that
+ * expired — is raised as one of these and printed as a message; anything
+ * else keeps its stack, because a stack is the report for a bug in this
+ * tool.
  */
+export class KeyToolError extends Error {
+  override name = "KeyToolError";
+}
+
+/** What the two commands reach outside the process through, injectable so
+ * tests run them against stubs. */
 export interface KeyToolDeps {
   env: Environment;
   fetchImpl: typeof fetch;
   githubToken: () => Promise<string | undefined>;
+  /** Waits out one polling interval. */
+  pause: () => Promise<void>;
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function defaultGithubToken(): Promise<string | undefined> {
@@ -78,6 +104,8 @@ function defaultDeps(): KeyToolDeps {
     env: Deno.env.get,
     fetchImpl: fetch,
     githubToken: defaultGithubToken,
+    pause: () =>
+      new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS)),
   };
 }
 
@@ -88,7 +116,7 @@ function configDir(env: Environment): string {
   }
   const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
   if (home === undefined || home.length === 0) {
-    throw new Error("neither XDG_CONFIG_HOME nor HOME is set");
+    throw new KeyToolError("Neither XDG_CONFIG_HOME nor HOME is set.");
   }
   return join(home, ".config", "common-fabric");
 }
@@ -108,15 +136,21 @@ async function github(
   path: string,
   body?: unknown,
 ): Promise<Response> {
-  return await deps.fetchImpl(`${API}${path}`, {
-    method,
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      ...(body !== undefined ? { "content-type": "application/json" } : {}),
-    },
-    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-  });
+  try {
+    return await deps.fetchImpl(`${API}${path}`, {
+      method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (error) {
+    throw new KeyToolError(
+      `Cannot reach ${API}: ${reason(error)}`,
+    );
+  }
 }
 
 async function loadIdentity(
@@ -131,72 +165,531 @@ async function loadIdentity(
   }
 }
 
-export async function requestCommand(
-  deps: KeyToolDeps = defaultDeps(),
-): Promise<void> {
-  let identity = await loadIdentity(deps.env);
-  if (identity === undefined) {
-    identity = await generateIdentity();
-    await Deno.mkdir(configDir(deps.env), { recursive: true });
-    await Deno.writeTextFile(
-      identityPath(deps.env),
-      JSON.stringify(identity, null, 2) + "\n",
-      { mode: 0o600 },
-    );
-    console.log(`delivery identity stored: ${identityPath(deps.env)}`);
-  } else {
-    console.log(`delivery identity already stored: ${identityPath(deps.env)}`);
+/** Loads the stored delivery identity, generating one the first time. */
+async function ensureIdentity(
+  deps: KeyToolDeps,
+): Promise<KeyDeliveryIdentity> {
+  const stored = await loadIdentity(deps.env);
+  if (stored !== undefined) {
+    console.log(`Delivery identity: ${identityPath(deps.env)}`);
+    return stored;
   }
-  const recipient = identity.recipient;
-  console.log(`recipient: ${recipient}`);
+  const identity = await generateIdentity();
+  await Deno.mkdir(configDir(deps.env), { recursive: true });
+  await Deno.writeTextFile(
+    identityPath(deps.env),
+    JSON.stringify(identity, null, 2) + "\n",
+    { mode: 0o600 },
+  );
+  console.log(`Delivery identity stored: ${identityPath(deps.env)}`);
+  return identity;
+}
 
-  const token = await deps.githubToken();
-  let username: string | undefined;
-  if (token !== undefined) {
-    const who = await github(deps, token, "GET", "/user");
-    if (who.ok) {
-      username = (await who.json() as { login?: string }).login;
-    } else {
-      await who.text();
-    }
+/** The GitHub login a token belongs to. */
+async function githubLogin(
+  deps: KeyToolDeps,
+  token: string,
+): Promise<string | undefined> {
+  const who = await github(deps, token, "GET", "/user");
+  if (!who.ok) {
+    await who.text();
+    return undefined;
   }
-  if (token !== undefined && username !== undefined) {
-    const dispatched = await github(
-      deps,
-      token,
-      "POST",
-      `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/dispatches`,
-      { ref: "main", inputs: { recipient, username } },
-    );
-    await dispatched.text();
-    if (dispatched.status === 204) {
-      console.log(
-        `minting workflow dispatched for ${username}; ` +
-          "run `deno task test-records-key collect` once it finishes.",
-      );
-      return;
-    }
-    console.log(
-      `this token cannot dispatch the workflow (HTTP ${dispatched.status}).`,
-    );
-  } else {
-    console.log("no GitHub token that identifies you was found.");
+  return (await who.json() as { login?: string }).login;
+}
+
+/** The name the workflow gives this recipient's sealed delivery. */
+async function deliveryName(recipient: string): Promise<string> {
+  return `test-records-key-${await recipientFingerprint(recipient)}`;
+}
+
+/** Where a browser runs the minting workflow by hand. */
+function mintWorkflowUrl(): string {
+  return `https://github.com/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}`;
+}
+
+interface DispatchResult {
+  dispatched: boolean;
+  username?: string;
+  /** GitHub's clock at the dispatch, which bounds the run's creation. */
+  at?: number;
+}
+
+/**
+ * Asks GitHub to run the minting workflow. Dispatching takes repository
+ * write access — that call is the authorization check — so a token that
+ * can only read comes back undispatched and the caller falls back to the
+ * browser.
+ */
+async function dispatchMint(
+  deps: KeyToolDeps,
+  token: string,
+  recipient: string,
+  username: string,
+): Promise<DispatchResult> {
+  const dispatched = await github(
+    deps,
+    token,
+    "POST",
+    `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/dispatches`,
+    { ref: "main", inputs: { recipient, username } },
+  );
+  const at = Date.parse(dispatched.headers.get("date") ?? "");
+  await dispatched.text();
+  if (dispatched.status === 204) {
+    const result: DispatchResult = { dispatched: true, username };
+    if (!Number.isNaN(at)) result.at = at;
+    return result;
   }
-  console.log(`
-Open the minting workflow in a browser and run it with your recipient:
+  console.log(
+    `This token cannot dispatch the workflow (HTTP ${dispatched.status}).`,
+  );
+  return { dispatched: false };
+}
 
-    https://github.com/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}
+/** What to print when the dispatch has to happen in a browser. */
+function browserInstructions(recipient: string): string {
+  return `
+Open the minting workflow and run it with your recipient:
 
-    recipient: ${recipient}
+    ${mintWorkflowUrl()}
+
+    Recipient: ${recipient}
 
 Dispatching the workflow takes repository write access — that click is
 the authorization step. If you do not have commit access, no key is
 needed: your local tests run the same without one, and CI records your
-pull requests' runs on its own. Otherwise, once the dispatched run
-finishes:
+pull requests' runs on its own.`;
+}
+
+interface MintRun {
+  id: number;
+  status: string;
+  conclusion?: string;
+  html_url?: string;
+  created_at?: string;
+  actor?: { login?: string };
+  display_title?: string;
+  name?: string;
+}
+
+/** A minting run this requester's, and the delivery it published. */
+interface RunMatch {
+  run: MintRun;
+  /** The delivery artifact, when one identified the run. */
+  artifact?: number;
+}
+
+/** What a search for the requester's own minting run works from. */
+interface RunSearch {
+  token: string;
+  recipient: string;
+  artifactName: string;
+  login: string;
+  /**
+   * GitHub's clock at the moment this attempt began, bounding how far
+   * back a run can be and still be this attempt's. Unset examines every
+   * run listed, which is what one collection wants and a repeating watch
+   * does not.
+   */
+  notBefore?: number;
+}
+
+interface RunSearchResult {
+  match?: RunMatch;
+  /** GitHub's clock at the listing, for bounding later searches. */
+  serverDate?: number;
+}
+
+/**
+ * The requester's own minting run, newest first, by three tests in
+ * descending order of certainty. A run whose name carries the recipient
+ * is minting for it. A completed run that published this recipient's
+ * delivery minted for it, whatever its name says — which is what a run
+ * from a workflow version that does not name its recipient is found by.
+ * Failing both, the newest run this person dispatched within this
+ * attempt is the one they are waiting on, which is all that can be said
+ * of a run that is still going and does not name what it is minting.
+ */
+async function findMintRun(
+  deps: KeyToolDeps,
+  search: RunSearch,
+): Promise<RunSearchResult> {
+  const res = await github(
+    deps,
+    search.token,
+    "GET",
+    `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/runs?per_page=50`,
+  );
+  if (!res.ok) {
+    await res.text();
+    throw new KeyToolError(`Listing minting runs failed: HTTP ${res.status}`);
+  }
+  const listed = Date.parse(res.headers.get("date") ?? "");
+  const result: RunSearchResult = {};
+  if (!Number.isNaN(listed)) result.serverDate = listed;
+  const runs = (await res.json() as { workflow_runs?: MintRun[] })
+    .workflow_runs ?? [];
+
+  const namesRecipient = (run: MintRun): boolean =>
+    `${run.display_title ?? ""}\n${run.name ?? ""}`.includes(search.recipient);
+  const candidates = runs.filter((run) => {
+    const mine = namesRecipient(run) ||
+      run.actor?.login?.toLowerCase() === search.login.toLowerCase();
+    if (!mine) return false;
+    if (search.notBefore === undefined) return true;
+    const created = Date.parse(run.created_at ?? "");
+    return !Number.isNaN(created) && created >= search.notBefore;
+  });
+
+  for (const run of candidates) {
+    const named = namesRecipient(run);
+    if (run.status === "completed" && run.conclusion === "success") {
+      const artifact = await deliveryArtifact(
+        deps,
+        search.token,
+        run.id,
+        search.artifactName,
+      );
+      if (artifact !== undefined) {
+        return { ...result, match: { run, artifact } };
+      }
+      // A run that named this recipient and delivered nothing is still
+      // the run to report on; one that named nothing is unidentifiable.
+      if (named) return { ...result, match: { run } };
+      continue;
+    }
+    if (named) return { ...result, match: { run } };
+  }
+
+  if (search.notBefore !== undefined) {
+    const attributed = candidates[0];
+    return attributed === undefined
+      ? result
+      : { ...result, match: { run: attributed } };
+  }
+  const running = candidates.find((run) => run.status !== "completed");
+  return running === undefined
+    ? result
+    : { ...result, match: { run: running } };
+}
+
+/** The id of a run's sealed delivery, when it published an unexpired one. */
+async function deliveryArtifact(
+  deps: KeyToolDeps,
+  token: string,
+  runId: number,
+  artifactName: string,
+): Promise<number | undefined> {
+  const res = await github(
+    deps,
+    token,
+    "GET",
+    `/repos/${REPO}/actions/runs/${runId}/artifacts?per_page=100`,
+  );
+  if (!res.ok) {
+    await res.text();
+    throw new KeyToolError(
+      `Listing the artifacts of run ${runId} failed: HTTP ${res.status}`,
+    );
+  }
+  const artifacts = (await res.json() as {
+    artifacts?: { id: number; name: string; expired?: boolean }[];
+  }).artifacts ?? [];
+  return artifacts.find((artifact) =>
+    artifact.name === artifactName && artifact.expired !== true
+  )?.id;
+}
+
+/**
+ * Downloads one sealed delivery, opens it with the stored identity, and
+ * installs the key file. Decrypting proves the delivery was sealed to
+ * this identity, not that its content is a key worth installing:
+ * validate the shape — which requires exactly Google's HTTPS token
+ * endpoint, since the uploader authenticates wherever that URL points —
+ * and require the key to be for whoever collects it.
+ */
+async function installDelivery(
+  deps: KeyToolDeps,
+  token: string,
+  identity: KeyDeliveryIdentity,
+  login: string,
+  artifactId: number,
+): Promise<string> {
+  const download = await github(
+    deps,
+    token,
+    "GET",
+    `/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
+  );
+  if (!download.ok) {
+    await download.text();
+    throw new KeyToolError(
+      `Downloading the delivery failed: HTTP ${download.status}`,
+    );
+  }
+  const zip = new Uint8Array(await download.arrayBuffer());
+  const members = await readZip(zip);
+  const sealedMember = members.find((member) =>
+    member.name.endsWith(".sealed")
+  );
+  if (sealedMember === undefined) {
+    throw new KeyToolError("The delivery artifact holds no sealed key.");
+  }
+  const box = JSON.parse(
+    new TextDecoder().decode(sealedMember.data),
+  ) as SealedBox;
+  let keyFile: Uint8Array;
+  try {
+    keyFile = await openSealed(identity, box);
+  } catch (error) {
+    throw new KeyToolError(
+      `The delivery does not open with the identity at ` +
+        `${identityPath(deps.env)}: ${reason(error)}`,
+    );
+  }
+  const keyText = new TextDecoder().decode(keyFile);
+  const parsedKey = parsePersonalKeyFile(keyText);
+  if (parsedKey === undefined) {
+    throw new KeyToolError(
+      "The delivery is not a personal test-records key file.",
+    );
+  }
+  if (parsedKey.cf_username.toLowerCase() !== login.toLowerCase()) {
+    throw new KeyToolError(
+      `The delivered key was minted for ${parsedKey.cf_username}, but ` +
+        `this token belongs to ${login}; refusing to install it`,
+    );
+  }
+  await Deno.mkdir(configDir(deps.env), { recursive: true });
+  const path = keyFilePath(deps.env);
+  await Deno.writeTextFile(path, keyText, { mode: 0o600 });
+  return path;
+}
+
+/**
+ * Exports the key file from the login shell's profiles and says what
+ * each file's update did.
+ */
+async function exportKeyFile(
+  deps: KeyToolDeps,
+  path: string,
+): Promise<ProfileUpdate[]> {
+  const updates = await exportFromProfiles(
+    RECORDS_KEY_FILE_VARIABLE,
+    path,
+    deps.env,
+  );
+  if (updates.length === 0) {
+    console.log(`
+No shell profile to update. Export the key file yourself:
+
+    ${RECORDS_KEY_FILE_VARIABLE}=${path}`);
+    return updates;
+  }
+  const kind = shellKind(deps.env);
+  for (const update of updates) {
+    if (update.outcome === "added") {
+      console.log(`${RECORDS_KEY_FILE_VARIABLE} exported from ${update.path}`);
+    } else if (update.outcome === "present") {
+      console.log(`${update.path} already exports the key file.`);
+    } else {
+      console.log(`
+${update.path} already sets ${RECORDS_KEY_FILE_VARIABLE} elsewhere:
+
+    ${update.existing}
+
+Left alone. Point it at ${path} to record from this key.`);
+    }
+  }
+  const added = updates.filter((update) => update.outcome === "added");
+  if (added.length > 0) {
+    console.log(`
+Every new shell records its test runs. For the one you are in:
+
+    ${reloadHint(added[0]!.path, kind)}`);
+  }
+  return updates;
+}
+
+/** The key already installed on this workstation, when there is one. */
+async function installedKey(
+  env: Environment,
+): Promise<{ path: string; username: string } | undefined> {
+  const path = keyFilePath(env);
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch {
+    return undefined;
+  }
+  const parsed = parsePersonalKeyFile(text);
+  if (parsed === undefined) return undefined;
+  return { path, username: parsed.cf_username };
+}
+
+export async function requestCommand(
+  deps: KeyToolDeps = defaultDeps(),
+): Promise<void> {
+  const identity = await ensureIdentity(deps);
+  console.log(`Recipient: ${identity.recipient}`);
+
+  const token = await deps.githubToken();
+  const username = token === undefined
+    ? undefined
+    : await githubLogin(deps, token);
+  if (token === undefined) {
+    console.log(
+      "No GitHub token was found; set GH_TOKEN or sign in with " +
+        "`gh auth login` to dispatch from here.",
+    );
+  } else if (username === undefined) {
+    console.log("This token cannot read your GitHub login.");
+  } else {
+    const dispatch = await dispatchMint(
+      deps,
+      token,
+      identity.recipient,
+      username,
+    );
+    if (dispatch.dispatched) {
+      console.log(
+        `Minting workflow dispatched for ${username}; ` +
+          "run `deno task test-records-key collect` once it finishes.",
+      );
+      return;
+    }
+  }
+  console.log(`${browserInstructions(identity.recipient)}
+
+Once the run finishes:
 
     deno task test-records-key collect
 `);
+}
+
+/**
+ * Watches until the minting run delivers, printing what it is doing as
+ * that changes. There is no bound on the wait: a run takes as long as it
+ * takes, and Ctrl-C is how a person stops watching.
+ */
+async function awaitDelivery(
+  deps: KeyToolDeps,
+  search: RunSearch,
+): Promise<number> {
+  let said: string | undefined;
+  const say = (line: string): void => {
+    if (line === said) return;
+    said = line;
+    console.log(line);
+  };
+  for (;;) {
+    const { match, serverDate } = await findMintRun(deps, search);
+    // Once the first listing has said what time GitHub thinks it is,
+    // every later one is bounded by it, so a watch left running does not
+    // re-examine runs from before it started.
+    if (search.notBefore === undefined && serverDate !== undefined) {
+      search.notBefore = serverDate;
+    }
+    if (match === undefined) {
+      say("Waiting for the minting run to appear...");
+    } else if (match.artifact !== undefined) {
+      say(`Minting run succeeded: ${runUrl(match.run)}`);
+      return match.artifact;
+    } else if (match.run.status !== "completed") {
+      say(
+        `Minting run ${match.run.status.replace("_", " ")}: ${
+          runUrl(match.run)
+        }`,
+      );
+    } else if (match.run.conclusion === "success") {
+      throw new KeyToolError(
+        `The minting run published no delivery for this recipient, or it ` +
+          `has expired: ${runUrl(match.run)}\n` +
+          "Deliveries are kept for seven days; mint a fresh one with " +
+          "`deno task test-records-key setup --rotate`.",
+      );
+    } else {
+      throw new KeyToolError(
+        `The minting run finished as ${match.run.conclusion ?? "unfinished"}: ${
+          runUrl(match.run)
+        }\n` +
+          "Open it to see which step failed. Run " +
+          "`deno task test-records-key setup` again once the cause is fixed.",
+      );
+    }
+    await deps.pause();
+  }
+}
+
+function runUrl(run: MintRun): string {
+  return run.html_url ?? `https://github.com/${REPO}/actions/runs/${run.id}`;
+}
+
+/**
+ * The whole opt-in: identity, dispatch, watch, install, export. Rerunning
+ * it resumes — the identity is reused, and a run already under way is the
+ * one it watches.
+ */
+export async function setupCommand(
+  deps: KeyToolDeps = defaultDeps(),
+  options: { rotate?: boolean } = {},
+): Promise<number> {
+  const existing = await installedKey(deps.env);
+  if (existing !== undefined && options.rotate !== true) {
+    console.log(
+      `A reporting key for ${existing.username} is installed at ` +
+        `${existing.path}`,
+    );
+    await exportKeyFile(deps, existing.path);
+    console.log(`
+Minting another key revokes this one, on every machine holding a copy.
+To rotate deliberately:
+
+    deno task test-records-key setup --rotate
+`);
+    return 0;
+  }
+
+  const token = await deps.githubToken();
+  if (token === undefined) {
+    throw new KeyToolError(
+      "A GitHub token is needed to mint and collect a key; set GH_TOKEN " +
+        "or sign in with `gh auth login`",
+    );
+  }
+  const login = await githubLogin(deps, token);
+  if (login === undefined) {
+    throw new KeyToolError(
+      "Cannot read your GitHub login; use a token that can GET /user.",
+    );
+  }
+
+  const identity = await ensureIdentity(deps);
+  console.log(`recipient: ${identity.recipient}`);
+  const dispatch = await dispatchMint(deps, token, identity.recipient, login);
+  if (dispatch.dispatched) {
+    console.log(`Minting workflow dispatched for ${login}`);
+  } else {
+    console.log(`${browserInstructions(identity.recipient)}
+
+Waiting for that run — this command collects the key on its own once it
+finishes. Ctrl-C stops watching; rerunning picks up where it left off.
+`);
+  }
+
+  const search: RunSearch = {
+    token,
+    recipient: identity.recipient,
+    artifactName: await deliveryName(identity.recipient),
+    login,
+  };
+  if (dispatch.at !== undefined) search.notBefore = dispatch.at;
+  const artifact = await awaitDelivery(deps, search);
+  const path = await installDelivery(deps, token, identity, login, artifact);
+  console.log(`Key installed: ${path}`);
+  await exportKeyFile(deps, path);
+  return 0;
 }
 
 export async function collectCommand(
@@ -204,151 +697,129 @@ export async function collectCommand(
 ): Promise<number> {
   const identity = await loadIdentity(deps.env);
   if (identity === undefined) {
-    throw new Error(
-      `no delivery identity at ${identityPath(deps.env)}; ` +
-        "run `deno task test-records-key request` first",
+    throw new KeyToolError(
+      `No delivery identity at ${identityPath(deps.env)}; ` +
+        "run `deno task test-records-key setup` first",
     );
   }
   const token = await deps.githubToken();
   if (token === undefined) {
-    throw new Error(
-      "a GitHub token is needed to download the delivery artifact; " +
+    throw new KeyToolError(
+      "A GitHub token is needed to download the delivery artifact; " +
         "set GH_TOKEN or sign in with `gh auth login`",
     );
   }
   // The collector's login is read first: the delivered key must be for
-  // whoever collects it, and listing only the collector's own dispatches
-  // keeps the delivery findable however many other minting runs happened
-  // since the request.
-  const whoAmI = await github(deps, token, "GET", "/user");
-  const login = whoAmI.ok
-    ? (await whoAmI.json() as { login?: string }).login
-    : undefined;
-  if (!whoAmI.ok) await whoAmI.text();
+  // whoever collects it.
+  const login = await githubLogin(deps, token);
   if (login === undefined) {
-    throw new Error(
-      "cannot read your GitHub login to confirm the key is yours; " +
+    throw new KeyToolError(
+      "Cannot read your GitHub login to confirm the key is yours; " +
         "use a token that can GET /user",
     );
   }
-  const fingerprint = await recipientFingerprint(identity.recipient);
-  const artifactName = `test-records-key-${fingerprint}`;
-
-  const runsRes = await github(
-    deps,
+  const { match } = await findMintRun(deps, {
     token,
-    "GET",
-    `/repos/${REPO}/actions/workflows/${MINT_WORKFLOW_FILE}/runs` +
-      `?actor=${encodeURIComponent(login)}&per_page=100`,
-  );
-  if (!runsRes.ok) {
-    throw new Error(`listing minting runs failed: HTTP ${runsRes.status}`);
+    recipient: identity.recipient,
+    artifactName: await deliveryName(identity.recipient),
+    login,
+  });
+  if (match === undefined) {
+    throw new KeyToolError(
+      "No minting run for this recipient; dispatch one with " +
+        "`deno task test-records-key setup`.",
+    );
   }
-  const runs = (await runsRes.json() as {
-    workflow_runs?: { id: number; status?: string; conclusion?: string }[];
-  }).workflow_runs ?? [];
-  let sawUnfinished = false;
-  for (const run of runs) {
-    if (run.status !== "completed") {
-      sawUnfinished = true;
-      continue;
+  if (match.artifact === undefined) {
+    if (match.run.status !== "completed") {
+      console.log(
+        `The minting run is ${match.run.status.replace("_", " ")}: ${
+          runUrl(match.run)
+        }\nRun this command again once it has finished, or wait for it ` +
+          "with `deno task test-records-key setup`.",
+      );
+      return 1;
     }
-    const artifactsRes = await github(
-      deps,
-      token,
-      "GET",
-      `/repos/${REPO}/actions/runs/${run.id}/artifacts?per_page=100`,
-    );
-    if (!artifactsRes.ok) {
-      await artifactsRes.text();
-      continue;
-    }
-    const artifacts = (await artifactsRes.json() as {
-      artifacts?: { id: number; name: string; expired?: boolean }[];
-    }).artifacts ?? [];
-    const delivery = artifacts.find((artifact) =>
-      artifact.name === artifactName && artifact.expired !== true
-    );
-    if (delivery === undefined) continue;
-
-    const download = await github(
-      deps,
-      token,
-      "GET",
-      `/repos/${REPO}/actions/artifacts/${delivery.id}/zip`,
-    );
-    if (!download.ok) {
-      throw new Error(
-        `downloading the delivery failed: HTTP ${download.status}`,
+    if (match.run.conclusion !== "success") {
+      throw new KeyToolError(
+        `The minting run finished as ${match.run.conclusion ?? "unfinished"}: ${
+          runUrl(match.run)
+        }\n` +
+          "Open it to see which step failed, then run " +
+          "`deno task test-records-key setup` again.",
       );
     }
-    const zip = new Uint8Array(await download.arrayBuffer());
-    const members = await readZip(zip);
-    const sealedMember = members.find((member) =>
-      member.name.endsWith(".sealed")
+    throw new KeyToolError(
+      `The minting run published no delivery for this recipient, or it has ` +
+        `expired: ${runUrl(match.run)}\n` +
+        "Deliveries are kept for seven days; mint a fresh one with " +
+        "`deno task test-records-key setup --rotate`.",
     );
-    if (sealedMember === undefined) {
-      throw new Error("the delivery artifact holds no sealed key");
-    }
-    const box = JSON.parse(
-      new TextDecoder().decode(sealedMember.data),
-    ) as SealedBox;
-    const keyFile = await openSealed(identity, box);
-    // Decrypting proves the delivery was sealed to this identity, not that
-    // its content is a key worth installing: validate the shape — which
-    // requires exactly Google's HTTPS token endpoint, since the uploader
-    // authenticates wherever that URL points — and require the key to be
-    // for whoever collects it.
-    const keyText = new TextDecoder().decode(keyFile);
-    const parsedKey = parsePersonalKeyFile(keyText);
-    if (parsedKey === undefined) {
-      throw new Error("the delivery is not a personal test-records key file");
-    }
-    if (parsedKey.cf_username.toLowerCase() !== login.toLowerCase()) {
-      throw new Error(
-        `the delivered key was minted for ${parsedKey.cf_username}, but ` +
-          `this token belongs to ${login}; refusing to install it`,
-      );
-    }
-    await Deno.mkdir(configDir(deps.env), { recursive: true });
-    await Deno.writeTextFile(
-      keyFilePath(deps.env),
-      keyText,
-      { mode: 0o600 },
-    );
-    console.log(`key installed: ${keyFilePath(deps.env)}
-
-Add this line to your shell profile to opt in to test reporting:
-
-    export ${RECORDS_KEY_FILE_VARIABLE}="${keyFilePath(deps.env)}"
-`);
-    return 0;
   }
-  if (sawUnfinished) {
-    console.log(
-      "the minting run has not finished; run this command again once it has.",
-    );
-    return 1;
-  }
-  throw new Error(
-    `no completed minting run delivered ${artifactName}; ` +
-      "dispatch the workflow first with `deno task test-records-key request`",
-  );
+  const artifact = match.artifact;
+  const path = await installDelivery(deps, token, identity, login, artifact);
+  console.log(`Key installed: ${path}`);
+  await exportKeyFile(deps, path);
+  return 0;
 }
 
 function usage(): never {
-  console.error("usage: deno task test-records-key <request|collect>");
+  console.error(
+    "usage: deno task test-records-key <setup [--rotate]|request|collect>",
+  );
   Deno.exit(2);
 }
 
+/**
+ * Reports a stop as a stop rather than as a stack, and returns the call
+ * that takes the listener back off: a live signal listener holds the
+ * event loop open, so the command would not end on its own with one
+ * still registered.
+ */
+function watchForInterrupt(): () => void {
+  const stop = () => {
+    console.log(`
+Stopped watching. The minting run carries on; pick the key up with
+
+    deno task test-records-key setup
+`);
+    Deno.exit(130);
+  };
+  try {
+    Deno.addSignalListener("SIGINT", stop);
+  } catch {
+    // A platform without SIGINT delivery stops the way it always did.
+    return () => {};
+  }
+  return () => Deno.removeSignalListener("SIGINT", stop);
+}
+
 if (import.meta.main) {
-  const command = Deno.args[0];
-  if (command === "request") {
-    await requestCommand();
-  } else if (command === "collect") {
-    const code = await collectCommand();
-    if (code !== 0) Deno.exit(code);
-  } else {
-    usage();
+  const [command, ...rest] = Deno.args;
+  try {
+    if (command === "setup") {
+      const rotate = rest.includes("--rotate");
+      if (rest.some((argument) => argument !== "--rotate")) usage();
+      const stopWatching = watchForInterrupt();
+      try {
+        const code = await setupCommand(defaultDeps(), { rotate });
+        if (code !== 0) Deno.exit(code);
+      } finally {
+        stopWatching();
+      }
+    } else if (command === "request") {
+      if (rest.length > 0) usage();
+      await requestCommand();
+    } else if (command === "collect") {
+      if (rest.length > 0) usage();
+      const code = await collectCommand();
+      if (code !== 0) Deno.exit(code);
+    } else {
+      usage();
+    }
+  } catch (error) {
+    if (!(error instanceof KeyToolError)) throw error;
+    console.error(`\n${error.message}\n`);
+    Deno.exit(1);
   }
 }

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -80,16 +80,35 @@ function reason(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function defaultGithubToken(): Promise<string | undefined> {
+/** Runs a command for its output; injectable so tests run no commands. */
+export type CommandRunner = (
+  command: string,
+  args: string[],
+) => Promise<{ code: number; stdout: Uint8Array }>;
+
+const runCommand: CommandRunner = async (command, args) => {
+  const { code, stdout } = await new Deno.Command(command, {
+    args,
+    stdout: "piped",
+    stderr: "null",
+  }).output();
+  return { code, stdout };
+};
+
+/**
+ * The GitHub token to work with: the environment's, and otherwise
+ * whatever the `gh` command line is signed in as. A machine with
+ * neither has no token, which each command reports in its own terms.
+ */
+export function defaultGithubToken(
+  env: Environment = Deno.env.get,
+  run: CommandRunner = runCommand,
+): Promise<string | undefined> {
   return (async () => {
-    const fromEnv = readEnv("GH_TOKEN") ?? readEnv("GITHUB_TOKEN");
+    const fromEnv = readEnv("GH_TOKEN", env) ?? readEnv("GITHUB_TOKEN", env);
     if (fromEnv !== undefined && fromEnv.length > 0) return fromEnv;
     try {
-      const { code, stdout } = await new Deno.Command("gh", {
-        args: ["auth", "token"],
-        stdout: "piped",
-        stderr: "null",
-      }).output();
+      const { code, stdout } = await run("gh", ["auth", "token"]);
       if (code !== 0) return undefined;
       const token = new TextDecoder().decode(stdout).trim();
       return token.length > 0 ? token : undefined;
@@ -99,11 +118,12 @@ function defaultGithubToken(): Promise<string | undefined> {
   })();
 }
 
-function defaultDeps(): KeyToolDeps {
+/** The wiring the command line runs against. */
+export function defaultDeps(): KeyToolDeps {
   return {
     env: Deno.env.get,
     fetchImpl: fetch,
-    githubToken: defaultGithubToken,
+    githubToken: () => defaultGithubToken(),
     pause: () =>
       new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS)),
   };
@@ -763,12 +783,19 @@ export async function collectCommand(
   return 0;
 }
 
-function usage(): never {
+function usage(): number {
   console.error(
     "usage: deno task test-records-key <setup [--rotate]|request|collect>",
   );
-  Deno.exit(2);
+  return 2;
 }
+
+/** What a stopped watch says on its way out. */
+export const INTERRUPT_NOTICE = `
+Stopped watching. The minting run carries on; pick the key up with
+
+    deno task test-records-key setup
+`;
 
 /**
  * Reports a stop as a stop rather than as a stack, and returns the call
@@ -778,11 +805,7 @@ function usage(): never {
  */
 function watchForInterrupt(): () => void {
   const stop = () => {
-    console.log(`
-Stopped watching. The minting run carries on; pick the key up with
-
-    deno task test-records-key setup
-`);
+    console.log(INTERRUPT_NOTICE);
     Deno.exit(130);
   };
   try {
@@ -794,32 +817,42 @@ Stopped watching. The minting run carries on; pick the key up with
   return () => Deno.removeSignalListener("SIGINT", stop);
 }
 
-if (import.meta.main) {
-  const [command, ...rest] = Deno.args;
+/**
+ * Runs one command line and returns the status the process exits with.
+ * A failure a person can hit arrives here as a KeyToolError, whose
+ * message is the whole report; anything else keeps its stack, because a
+ * stack is the report for a bug in this tool.
+ */
+export async function runCli(
+  args: readonly string[],
+  deps: KeyToolDeps = defaultDeps(),
+): Promise<number> {
+  const [command, ...rest] = args;
   try {
     if (command === "setup") {
-      const rotate = rest.includes("--rotate");
-      if (rest.some((argument) => argument !== "--rotate")) usage();
+      if (rest.some((argument) => argument !== "--rotate")) return usage();
       const stopWatching = watchForInterrupt();
       try {
-        const code = await setupCommand(defaultDeps(), { rotate });
-        if (code !== 0) Deno.exit(code);
+        return await setupCommand(deps, { rotate: rest.includes("--rotate") });
       } finally {
         stopWatching();
       }
-    } else if (command === "request") {
-      if (rest.length > 0) usage();
-      await requestCommand();
-    } else if (command === "collect") {
-      if (rest.length > 0) usage();
-      const code = await collectCommand();
-      if (code !== 0) Deno.exit(code);
-    } else {
-      usage();
     }
+    if (command === "request") {
+      if (rest.length > 0) return usage();
+      await requestCommand(deps);
+      return 0;
+    }
+    if (command === "collect") {
+      if (rest.length > 0) return usage();
+      return await collectCommand(deps);
+    }
+    return usage();
   } catch (error) {
     if (!(error instanceof KeyToolError)) throw error;
     console.error(`\n${error.message}\n`);
-    Deno.exit(1);
+    return 1;
   }
 }
+
+if (import.meta.main) Deno.exit(await runCli(Deno.args));

--- a/tasks/test-records-mint.test.ts
+++ b/tasks/test-records-mint.test.ts
@@ -7,6 +7,7 @@ import {
   displayNameFor,
   ensurePersonFolder,
   ensureServiceAccount,
+  isAccountNotVisible,
   isGitHubUsername,
   mintKey,
   parseMintArgs,
@@ -185,6 +186,89 @@ describe("test-records-mint", () => {
         "sa@x",
       );
       expect(log.length).toBe(2);
+    });
+
+    it("grants once the account has reached Cloud Storage", async () => {
+      const log: { method: string; url: string; body?: string }[] = [];
+      let waits = 0;
+      await ensurePersonFolder(
+        {
+          token: "t",
+          fetchImpl: sequenceFetch([
+            { status: 200, json: {} },
+            { status: 200, json: { bindings: [], etag: "e1" } },
+            {
+              status: 400,
+              json: {
+                error: {
+                  code: 400,
+                  message: "Service account sa@x does not exist.",
+                },
+              },
+            },
+            { status: 200, json: {} },
+          ], log),
+          awaitVisibility: () => {
+            waits++;
+            return Promise.resolve();
+          },
+        },
+        "cf-ci-metadata",
+        "labs/test-records",
+        "octocat",
+        "sa@x",
+      );
+      expect(waits).toBe(1);
+      expect(log.length).toBe(4);
+      expect(log[3]?.method).toBe("PUT");
+    });
+
+    it("throws for a grant refused on any other ground", async () => {
+      const log: { method: string; url: string; body?: string }[] = [];
+      await expect(ensurePersonFolder(
+        {
+          token: "t",
+          fetchImpl: sequenceFetch([
+            { status: 200, json: {} },
+            { status: 200, json: { bindings: [], etag: "e1" } },
+            { status: 403, json: { error: { message: "forbidden" } } },
+          ], log),
+          awaitVisibility: () => {
+            throw new Error("no wait expected");
+          },
+        },
+        "cf-ci-metadata",
+        "labs/test-records",
+        "octocat",
+        "sa@x",
+      )).rejects.toThrow("granting roles/storage.objectCreator");
+    });
+  });
+
+  describe("isAccountNotVisible()", () => {
+    it("returns true for a create the service has not seen yet", () => {
+      expect(isAccountNotVisible(
+        400,
+        { error: { message: "Service account sa@x does not exist." } },
+        "sa@x",
+      )).toBe(true);
+      expect(isAccountNotVisible(404, "sa@x does not exist", "sa@x"))
+        .toBe(true);
+    });
+
+    it("returns false for any other refusal", () => {
+      expect(isAccountNotVisible(403, { error: { message: "no" } }, "sa@x"))
+        .toBe(false);
+      expect(isAccountNotVisible(
+        400,
+        { error: { message: "Service account other@x does not exist." } },
+        "sa@x",
+      )).toBe(false);
+      expect(isAccountNotVisible(
+        400,
+        { error: { message: "Role roles/storage.objectCreator is not valid" } },
+        "sa@x",
+      )).toBe(false);
     });
   });
 

--- a/tasks/test-records-mint.ts
+++ b/tasks/test-records-mint.ts
@@ -74,6 +74,19 @@ export function usernameOfDisplayName(displayName: string): string | undefined {
 export interface GcpClient {
   token: string;
   fetchImpl: typeof fetch;
+  /**
+   * Waits out the window in which a just-created service account is not
+   * yet visible to the other services that name it. Tests pass a no-op.
+   */
+  awaitVisibility?: () => Promise<void>;
+}
+
+/** How long a create is given to reach the services that consume it. */
+const VISIBILITY_INTERVAL_MS = 5_000;
+
+function awaitVisibility(client: GcpClient): Promise<void> {
+  if (client.awaitVisibility !== undefined) return client.awaitVisibility();
+  return new Promise((resolve) => setTimeout(resolve, VISIBILITY_INTERVAL_MS));
 }
 
 async function gcp(
@@ -200,17 +213,43 @@ export async function ensurePersonFolder(
   } else {
     bindings.push({ role, members: [member] });
   }
-  const updated = await gcp(client, "PUT", iamUrl, {
-    bindings,
-    etag: policy.etag,
-  });
-  if (updated.status !== 200) {
-    throw new Error(
-      `granting ${role} on ${folder} failed: HTTP ${updated.status} ${
-        JSON.stringify(updated.json).slice(0, 200)
-      }`,
-    );
+  // An account exists in IAM the moment its create returns, and reaches
+  // the services that consume it some time after that: Cloud Storage
+  // rejects a binding naming an account it has not seen yet, saying the
+  // account does not exist. That answer is the signal to wait, and it is
+  // the only one this loop accepts — every other status fails the mint.
+  // The wait has no bound, because the account does exist and the grant
+  // is going to work; only the moment is out of the caller's hands.
+  for (;;) {
+    const updated = await gcp(client, "PUT", iamUrl, {
+      bindings,
+      etag: policy.etag,
+    });
+    if (updated.status === 200) return;
+    if (!isAccountNotVisible(updated.status, updated.json, email)) {
+      throw new Error(
+        `granting ${role} on ${folder} failed: HTTP ${updated.status} ${
+          JSON.stringify(updated.json).slice(0, 200)
+        }`,
+      );
+    }
+    console.log(`${email} has not reached Cloud Storage yet; waiting`);
+    await awaitVisibility(client);
   }
+}
+
+/**
+ * Whether a response is a service the account has not propagated to yet,
+ * which answers a binding that names it as though it did not exist.
+ */
+export function isAccountNotVisible(
+  status: number,
+  json: unknown,
+  email: string,
+): boolean {
+  if (status !== 400 && status !== 404) return false;
+  const text = typeof json === "string" ? json : JSON.stringify(json ?? "");
+  return text.includes(email) && text.includes("does not exist");
 }
 
 /**

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import type { Environment } from "@commonfabric/test-support/records";
+
+import {
+  exportFromProfiles,
+  exportLine,
+  homeRelative,
+  MARKER,
+  profileCandidates,
+  reloadHint,
+  settingLine,
+  shellKind,
+} from "./test-records-shell-config.ts";
+
+const VARIABLE = "CF_TEST_RECORDS_KEY_FILE";
+
+function environment(values: Record<string, string>): Environment {
+  return (name) => values[name];
+}
+
+describe("test-records-shell-config", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await Deno.makeTempDir({ prefix: "test-records-profile-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(home, { recursive: true }).catch(() => {});
+  });
+
+  describe("shellKind()", () => {
+    it("returns the family named by SHELL", () => {
+      expect(shellKind(environment({ SHELL: "/bin/zsh" }))).toBe("zsh");
+      expect(shellKind(environment({ SHELL: "/usr/bin/bash" }))).toBe("bash");
+      expect(shellKind(environment({ SHELL: "/opt/homebrew/bin/fish" })))
+        .toBe("fish");
+    });
+
+    it("returns posix for an unset or unfamiliar shell", () => {
+      expect(shellKind(environment({}))).toBe("posix");
+      expect(shellKind(environment({ SHELL: "/bin/ksh" }))).toBe("posix");
+    });
+  });
+
+  describe("profileCandidates()", () => {
+    it("returns the zsh profile under ZDOTDIR when one is set", () => {
+      expect(
+        profileCandidates(
+          environment({ SHELL: "/bin/zsh", HOME: "/h", ZDOTDIR: "/z" }),
+          "linux",
+        ),
+      ).toEqual(["/z/.zshrc"]);
+    });
+
+    it("returns the home zsh profile without ZDOTDIR", () => {
+      expect(
+        profileCandidates(environment({ SHELL: "/bin/zsh", HOME: "/h" })),
+      ).toEqual(["/h/.zshrc"]);
+    });
+
+    it("orders the bash profiles by the ones the platform reads first", () => {
+      const env = environment({ SHELL: "/bin/bash", HOME: "/h" });
+      expect(profileCandidates(env, "darwin")).toEqual([
+        "/h/.bash_profile",
+        "/h/.bashrc",
+      ]);
+      expect(profileCandidates(env, "linux")).toEqual([
+        "/h/.bashrc",
+        "/h/.bash_profile",
+      ]);
+    });
+
+    it("returns the fish configuration under the configuration home", () => {
+      expect(
+        profileCandidates(
+          environment({
+            SHELL: "/bin/fish",
+            HOME: "/h",
+            XDG_CONFIG_HOME: "/c",
+          }),
+        ),
+      ).toEqual(["/c/fish/config.fish"]);
+      expect(
+        profileCandidates(environment({ SHELL: "/bin/fish", HOME: "/h" })),
+      ).toEqual(["/h/.config/fish/config.fish"]);
+    });
+
+    it("returns the shared profile for anything else", () => {
+      expect(profileCandidates(environment({ HOME: "/h" }))).toEqual([
+        "/h/.profile",
+      ]);
+    });
+
+    it("returns nothing without a home directory", () => {
+      expect(profileCandidates(environment({ SHELL: "/bin/zsh" }))).toEqual([]);
+    });
+  });
+
+  describe("exportLine()", () => {
+    it("returns an export for posix shells", () => {
+      expect(exportLine("zsh", VARIABLE, "/k.json")).toBe(
+        `export ${VARIABLE}="/k.json"`,
+      );
+    });
+
+    it("returns a global set for fish", () => {
+      expect(exportLine("fish", VARIABLE, "/k.json")).toBe(
+        `set -gx ${VARIABLE} "/k.json"`,
+      );
+    });
+  });
+
+  describe("homeRelative()", () => {
+    it("returns a path under the home directory through $HOME", () => {
+      expect(homeRelative("/h/.config/k.json", "/h")).toBe(
+        "$HOME/.config/k.json",
+      );
+      expect(homeRelative("/h/.config/k.json", "/h/")).toBe(
+        "$HOME/.config/k.json",
+      );
+    });
+
+    it("returns a path outside the home directory unchanged", () => {
+      expect(homeRelative("/etc/k.json", "/h")).toBe("/etc/k.json");
+      expect(homeRelative("/home2/k.json", "/h")).toBe("/home2/k.json");
+      expect(homeRelative("/h/k.json", undefined)).toBe("/h/k.json");
+    });
+  });
+
+  describe("settingLine()", () => {
+    it("returns the line that sets the variable", () => {
+      expect(settingLine(`export ${VARIABLE}="/k.json"\n`, VARIABLE)).toBe(
+        `export ${VARIABLE}="/k.json"`,
+      );
+      expect(settingLine(`${VARIABLE}=/k.json\n`, VARIABLE)).toBe(
+        `${VARIABLE}=/k.json`,
+      );
+      expect(settingLine(`set -gx ${VARIABLE} "/k.json"\n`, VARIABLE)).toBe(
+        `set -gx ${VARIABLE} "/k.json"`,
+      );
+    });
+
+    it("returns undefined for a mention that sets nothing", () => {
+      expect(settingLine(`# ${VARIABLE} is the opt-in\n`, VARIABLE))
+        .toBeUndefined();
+      expect(settingLine(`echo "$${VARIABLE}"\n`, VARIABLE)).toBeUndefined();
+      expect(settingLine("", VARIABLE)).toBeUndefined();
+    });
+  });
+
+  describe("exportFromProfiles()", () => {
+    function zsh(): Environment {
+      return environment({ SHELL: "/bin/zsh", HOME: home });
+    }
+
+    it("appends the marked line to the profile", async () => {
+      const key = join(home, ".config", "k.json");
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates).toEqual([
+        { path: join(home, ".zshrc"), outcome: "added" },
+      ]);
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+        `${MARKER}\nexport ${VARIABLE}="$HOME/.config/k.json"\n`,
+      );
+    });
+
+    it("keeps an existing profile's contents and its trailing newline", async () => {
+      await Deno.writeTextFile(join(home, ".zshrc"), "alias l=ls");
+      const key = join(home, ".config", "k.json");
+
+      await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+        `alias l=ls\n\n${MARKER}\nexport ${VARIABLE}="$HOME/.config/k.json"\n`,
+      );
+    });
+
+    it("reports the same value as already present and writes nothing", async () => {
+      const key = join(home, ".config", "k.json");
+      await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+      const before = await Deno.readTextFile(join(home, ".zshrc"));
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates).toEqual([
+        { path: join(home, ".zshrc"), outcome: "present" },
+      ]);
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(before);
+    });
+
+    it("reports a line pointing elsewhere as a conflict", async () => {
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `export ${VARIABLE}="/somewhere/else.json"\n`,
+      );
+      const key = join(home, ".config", "k.json");
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates).toEqual([{
+        path: join(home, ".zshrc"),
+        outcome: "conflict",
+        existing: `export ${VARIABLE}="/somewhere/else.json"`,
+      }]);
+    });
+
+    it("updates every bash profile that exists", async () => {
+      await Deno.writeTextFile(join(home, ".bashrc"), "");
+      await Deno.writeTextFile(join(home, ".bash_profile"), "");
+      const env = environment({ SHELL: "/bin/bash", HOME: home });
+
+      const updates = await exportFromProfiles(
+        VARIABLE,
+        join(home, "k.json"),
+        env,
+        "darwin",
+      );
+
+      expect(updates.map((update) => update.path)).toEqual([
+        join(home, ".bash_profile"),
+        join(home, ".bashrc"),
+      ]);
+      for (const update of updates) expect(update.outcome).toBe("added");
+    });
+
+    it("creates the first profile when the shell has none", async () => {
+      const env = environment({ SHELL: "/bin/fish", HOME: home });
+
+      const updates = await exportFromProfiles(
+        VARIABLE,
+        join(home, "k.json"),
+        env,
+        "linux",
+      );
+
+      const path = join(home, ".config", "fish", "config.fish");
+      expect(updates).toEqual([{ path, outcome: "added" }]);
+      expect(await Deno.readTextFile(path)).toBe(
+        `${MARKER}\nset -gx ${VARIABLE} "$HOME/k.json"\n`,
+      );
+    });
+
+    it("returns nothing when there is no home directory to write in", async () => {
+      expect(
+        await exportFromProfiles(VARIABLE, "/k.json", environment({})),
+      ).toEqual([]);
+    });
+  });
+
+  describe("reloadHint()", () => {
+    it("returns the command that loads the profile", () => {
+      expect(reloadHint("/h/.zshrc", "zsh")).toBe(". /h/.zshrc");
+      expect(reloadHint("/h/config.fish", "fish")).toBe(
+        "source /h/config.fish",
+      );
+    });
+  });
+});

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -4,13 +4,14 @@ import { join } from "@std/path";
 import type { Environment } from "@commonfabric/test-support/records";
 
 import {
+  expandHome,
   exportFromProfiles,
   exportLine,
   homeRelative,
   MARKER,
+  parseSetting,
   profileCandidates,
   reloadHint,
-  settingLine,
   shellKind,
 } from "./test-records-shell-config.ts";
 
@@ -111,6 +112,41 @@ describe("test-records-shell-config", () => {
         `set -gx ${VARIABLE} "/k.json"`,
       );
     });
+
+    it("writes a path under the home directory through $HOME", () => {
+      expect(exportLine("zsh", VARIABLE, "/h/.config/k.json", "/h")).toBe(
+        `export ${VARIABLE}="$HOME/.config/k.json"`,
+      );
+    });
+
+    it("escapes what a shell would otherwise act on", () => {
+      expect(exportLine("zsh", VARIABLE, '/h/$(id)/`id`/"q"/b\\s/k.json', "/h"))
+        .toBe(
+          `export ${VARIABLE}=` +
+            '"$HOME/\\$(id)/\\`id\\`/\\"q\\"/b\\\\s/k.json"',
+        );
+    });
+
+    it("escapes for fish, which has no backtick", () => {
+      expect(exportLine("fish", VARIABLE, "/h/$(id)/`id`/k.json", "/h")).toBe(
+        `set -gx ${VARIABLE} "$HOME/\\$(id)/\`id\`/k.json"`,
+      );
+    });
+  });
+
+  describe("expandHome()", () => {
+    it("returns the path a value naming $HOME stands for", () => {
+      expect(expandHome("$HOME/.config/k.json", "/h")).toBe(
+        "/h/.config/k.json",
+      );
+      expect(expandHome("${HOME}/k.json", "/h")).toBe("/h/k.json");
+    });
+
+    it("returns any other value unchanged", () => {
+      expect(expandHome("/etc/k.json", "/h")).toBe("/etc/k.json");
+      expect(expandHome("$HOMEBREW/k.json", "/h")).toBe("$HOMEBREW/k.json");
+      expect(expandHome("$HOME/k.json", undefined)).toBe("$HOME/k.json");
+    });
   });
 
   describe("homeRelative()", () => {
@@ -130,24 +166,48 @@ describe("test-records-shell-config", () => {
     });
   });
 
-  describe("settingLine()", () => {
-    it("returns the line that sets the variable", () => {
-      expect(settingLine(`export ${VARIABLE}="/k.json"\n`, VARIABLE)).toBe(
-        `export ${VARIABLE}="/k.json"`,
+  describe("parseSetting()", () => {
+    it("returns the value an export carries", () => {
+      expect(parseSetting(`export ${VARIABLE}="/k.json"\n`, VARIABLE)).toEqual({
+        line: `export ${VARIABLE}="/k.json"`,
+        exported: true,
+        value: "/k.json",
+      });
+    });
+
+    it("reports an assignment that is never exported", () => {
+      expect(parseSetting(`${VARIABLE}=/k.json\n`, VARIABLE)).toEqual({
+        line: `${VARIABLE}=/k.json`,
+        exported: false,
+        value: "/k.json",
+      });
+    });
+
+    it("reads fish's set, exported only with -x", () => {
+      expect(parseSetting(`set -gx ${VARIABLE} "/k.json"\n`, VARIABLE)).toEqual(
+        {
+          line: `set -gx ${VARIABLE} "/k.json"`,
+          exported: true,
+          value: "/k.json",
+        },
       );
-      expect(settingLine(`${VARIABLE}=/k.json\n`, VARIABLE)).toBe(
-        `${VARIABLE}=/k.json`,
-      );
-      expect(settingLine(`set -gx ${VARIABLE} "/k.json"\n`, VARIABLE)).toBe(
-        `set -gx ${VARIABLE} "/k.json"`,
-      );
+      expect(parseSetting(`set -g ${VARIABLE} "/k.json"\n`, VARIABLE)?.exported)
+        .toBe(false);
+    });
+
+    it("takes one level of quoting off the value", () => {
+      expect(parseSetting(`export ${VARIABLE}='/k.json'\n`, VARIABLE)?.value)
+        .toBe("/k.json");
+      expect(
+        parseSetting(`export ${VARIABLE}="/a\\$b/k.json"\n`, VARIABLE)?.value,
+      ).toBe("/a$b/k.json");
     });
 
     it("returns undefined for a mention that sets nothing", () => {
-      expect(settingLine(`# ${VARIABLE} is the opt-in\n`, VARIABLE))
+      expect(parseSetting(`# ${VARIABLE} is the opt-in\n`, VARIABLE))
         .toBeUndefined();
-      expect(settingLine(`echo "$${VARIABLE}"\n`, VARIABLE)).toBeUndefined();
-      expect(settingLine("", VARIABLE)).toBeUndefined();
+      expect(parseSetting(`echo "$${VARIABLE}"\n`, VARIABLE)).toBeUndefined();
+      expect(parseSetting("", VARIABLE)).toBeUndefined();
     });
   });
 
@@ -190,6 +250,53 @@ describe("test-records-shell-config", () => {
         { path: join(home, ".zshrc"), outcome: "present" },
       ]);
       expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(before);
+    });
+
+    it("reports a value that only starts the same as a conflict", async () => {
+      const key = join(home, ".config", "k.json");
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `export ${VARIABLE}="${key}.backup"\n`,
+      );
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates[0]?.outcome).toBe("conflict");
+    });
+
+    it("reports an assignment that is never exported", async () => {
+      const key = join(home, ".config", "k.json");
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `${VARIABLE}="$HOME/.config/k.json"\n`,
+      );
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates).toEqual([{
+        path: join(home, ".zshrc"),
+        outcome: "unexported",
+        existing: `${VARIABLE}="$HOME/.config/k.json"`,
+      }]);
+    });
+
+    it("reports a missing login profile rather than creating one", async () => {
+      await Deno.writeTextFile(join(home, ".bashrc"), "");
+      const env = environment({ SHELL: "/bin/bash", HOME: home });
+
+      const updates = await exportFromProfiles(
+        VARIABLE,
+        join(home, "k.json"),
+        env,
+        "darwin",
+      );
+
+      expect(updates).toEqual([
+        { path: join(home, ".bash_profile"), outcome: "absent" },
+        { path: join(home, ".bashrc"), outcome: "added" },
+      ]);
+      // Creating it is what stops a login shell reading .profile.
+      await expect(Deno.stat(join(home, ".bash_profile"))).rejects.toThrow();
     });
 
     it("reports a line pointing elsewhere as a conflict", async () => {

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -4,7 +4,7 @@ import { join } from "@std/path";
 import type { Environment } from "@commonfabric/test-support/records";
 
 import {
-  expandHome,
+  effectiveValue,
   exportFromProfiles,
   exportLine,
   homeRelative,
@@ -134,18 +134,32 @@ describe("test-records-shell-config", () => {
     });
   });
 
-  describe("expandHome()", () => {
+  describe("effectiveValue()", () => {
     it("returns the path a value naming $HOME stands for", () => {
-      expect(expandHome("$HOME/.config/k.json", "/h")).toBe(
+      expect(effectiveValue('"$HOME/.config/k.json"', "/h")).toBe(
         "/h/.config/k.json",
       );
-      expect(expandHome("${HOME}/k.json", "/h")).toBe("/h/k.json");
+      expect(effectiveValue("${HOME}/k.json", "/h")).toBe("/h/k.json");
     });
 
-    it("returns any other value unchanged", () => {
-      expect(expandHome("/etc/k.json", "/h")).toBe("/etc/k.json");
-      expect(expandHome("$HOMEBREW/k.json", "/h")).toBe("$HOMEBREW/k.json");
-      expect(expandHome("$HOME/k.json", undefined)).toBe("$HOME/k.json");
+    it("holds a single-quoted value literally", () => {
+      expect(effectiveValue("'$HOME/k.json'", "/h")).toBe("$HOME/k.json");
+    });
+
+    it("holds an escaped dollar sign literally", () => {
+      expect(effectiveValue('"\\$HOME/k.json"', "/h")).toBe("$HOME/k.json");
+    });
+
+    it("returns a name that only starts like $HOME unchanged", () => {
+      expect(effectiveValue("$HOMEBREW/k.json", "/h")).toBe("$HOMEBREW/k.json");
+      expect(effectiveValue("$HOME/k.json", undefined)).toBe("$HOME/k.json");
+    });
+
+    it("drops a comment that follows the value", () => {
+      expect(effectiveValue('"/k.json" # the reporting key', "/h")).toBe(
+        "/k.json",
+      );
+      expect(effectiveValue('"/a#b.json"', "/h")).toBe("/a#b.json");
     });
   });
 
@@ -201,6 +215,29 @@ describe("test-records-shell-config", () => {
       expect(
         parseSetting(`export ${VARIABLE}="/a\\$b/k.json"\n`, VARIABLE)?.value,
       ).toBe("/a$b/k.json");
+    });
+
+    it("reports fish's --unexport as not exported", () => {
+      expect(
+        parseSetting(`set --unexport ${VARIABLE} "/k.json"\n`, VARIABLE)
+          ?.exported,
+      ).toBe(false);
+      expect(
+        parseSetting(`set --export ${VARIABLE} "/k.json"\n`, VARIABLE)
+          ?.exported,
+      ).toBe(true);
+      expect(
+        parseSetting(`set -gx -u ${VARIABLE} "/k.json"\n`, VARIABLE)?.exported,
+      ).toBe(false);
+    });
+
+    it("reads past a comment that follows the value", () => {
+      expect(
+        parseSetting(
+          `export ${VARIABLE}="/k.json" # the reporting key\n`,
+          VARIABLE,
+        )?.value,
+      ).toBe("/k.json");
     });
 
     it("returns undefined for a mention that sets nothing", () => {
@@ -261,6 +298,32 @@ describe("test-records-shell-config", () => {
 
       const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
+      expect(updates[0]?.outcome).toBe("conflict");
+    });
+
+    it("accepts an export that carries a comment after it", async () => {
+      const key = join(home, ".config", "k.json");
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `export ${VARIABLE}="$HOME/.config/k.json" # the reporting key\n`,
+      );
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      expect(updates[0]?.outcome).toBe("present");
+    });
+
+    it("reports a single-quoted $HOME as the other value it is", async () => {
+      const key = join(home, ".config", "k.json");
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `export ${VARIABLE}='$HOME/.config/k.json'\n`,
+      );
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      // Single quotes expand nothing, so that line names a file called
+      // "$HOME/.config/k.json" and not the one being installed.
       expect(updates[0]?.outcome).toBe("conflict");
     });
 

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -1,0 +1,198 @@
+/**
+ * Putting an environment variable into the shell profiles a person's
+ * terminals actually read. The key tool uses it to finish the opt-in:
+ * installing a key file does nothing on its own, because recording turns
+ * on when CF_TEST_RECORDS_KEY_FILE names it in the environment every
+ * later shell inherits.
+ *
+ * The lines carry a marker comment, so a second run recognizes its own
+ * work and appends nothing. A line that sets the variable to something
+ * else is reported and left alone: a profile is a person's file, and the
+ * tool's job there is to say what it found.
+ */
+
+import { dirname, join } from "@std/path";
+import { type Environment, readEnv } from "@commonfabric/test-support/records";
+
+/** The comment that marks the lines this tool wrote. */
+export const MARKER = "# common-fabric test-records reporting key";
+
+/** Shell families with their own profile paths and assignment syntax. */
+export type ShellKind = "zsh" | "bash" | "fish" | "posix";
+
+/** What one profile file's update did. */
+export type ProfileOutcome =
+  /** The line was appended. */
+  | "added"
+  /** The variable was already exported with this value. */
+  | "present"
+  /** The variable is already set to something else; nothing was written. */
+  | "conflict";
+
+export interface ProfileUpdate {
+  path: string;
+  outcome: ProfileOutcome;
+  /** The line already in the file, for a conflict. */
+  existing?: string;
+}
+
+/** The login shell's family, read from SHELL. */
+export function shellKind(env: Environment = Deno.env.get): ShellKind {
+  const shell = readEnv("SHELL", env) ?? "";
+  const name = shell.split("/").pop() ?? "";
+  if (name.includes("zsh")) return "zsh";
+  if (name.includes("fish")) return "fish";
+  if (name.includes("bash")) return "bash";
+  return "posix";
+}
+
+/**
+ * The profile files to hold the export, in the order a shell reads them.
+ * Every one of these that exists is updated, and the first is created
+ * when none does: bash splits its startup between two files differently
+ * on macOS than on Linux, and a person whose terminal reads only one of
+ * them would otherwise get a line that never runs.
+ */
+export function profileCandidates(
+  env: Environment = Deno.env.get,
+  os: string = Deno.build.os,
+): string[] {
+  const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
+  if (home === undefined || home.length === 0) return [];
+  switch (shellKind(env)) {
+    case "zsh": {
+      const zdotdir = readEnv("ZDOTDIR", env);
+      const dir = zdotdir !== undefined && zdotdir.length > 0 ? zdotdir : home;
+      return [join(dir, ".zshrc")];
+    }
+    case "bash":
+      return os === "darwin"
+        ? [join(home, ".bash_profile"), join(home, ".bashrc")]
+        : [join(home, ".bashrc"), join(home, ".bash_profile")];
+    case "fish": {
+      const xdg = readEnv("XDG_CONFIG_HOME", env);
+      const dir = xdg !== undefined && xdg.length > 0
+        ? xdg
+        : join(home, ".config");
+      return [join(dir, "fish", "config.fish")];
+    }
+    case "posix":
+      return [join(home, ".profile")];
+  }
+}
+
+/** A path under the home directory written through $HOME. */
+export function homeRelative(path: string, home: string | undefined): string {
+  if (home === undefined || home.length === 0) return path;
+  const root = home.endsWith("/") ? home.slice(0, -1) : home;
+  return path === root || path.startsWith(`${root}/`)
+    ? `$HOME${path.slice(root.length)}`
+    : path;
+}
+
+/** The line that exports one variable in a shell's own syntax. */
+export function exportLine(
+  kind: ShellKind,
+  name: string,
+  value: string,
+): string {
+  return kind === "fish"
+    ? `set -gx ${name} "${value}"`
+    : `export ${name}="${value}"`;
+}
+
+/** The line in a profile that already sets the variable, if there is one. */
+export function settingLine(
+  text: string,
+  name: string,
+): string | undefined {
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || !trimmed.includes(name)) continue;
+    if (
+      new RegExp(`(^|\\s)(export\\s+)?${name}=`).test(trimmed) ||
+      new RegExp(`(^|\\s)set\\s+[^\\n]*\\b${name}\\s`).test(trimmed)
+    ) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+async function readIfPresent(path: string): Promise<string | undefined> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return undefined;
+    throw error;
+  }
+}
+
+async function updateOne(
+  path: string,
+  name: string,
+  line: string,
+  value: string,
+  literalValue: string,
+  create: boolean,
+): Promise<ProfileUpdate | undefined> {
+  const text = await readIfPresent(path);
+  if (text === undefined && !create) return undefined;
+  const existing = settingLine(text ?? "", name);
+  if (existing !== undefined) {
+    return existing.includes(value) || existing.includes(literalValue)
+      ? { path, outcome: "present" }
+      : { path, outcome: "conflict", existing };
+  }
+  const separator = text === undefined || text.length === 0
+    ? ""
+    : text.endsWith("\n")
+    ? "\n"
+    : "\n\n";
+  await Deno.mkdir(dirname(path), { recursive: true });
+  await Deno.writeTextFile(path, `${separator}${MARKER}\n${line}\n`, {
+    append: true,
+  });
+  return { path, outcome: "added" };
+}
+
+/**
+ * Exports one variable from the login shell's profiles, returning what
+ * each file's update did. The value is written through $HOME when it
+ * sits under the home directory, so the line survives a move between
+ * machines.
+ */
+export async function exportFromProfiles(
+  name: string,
+  value: string,
+  env: Environment = Deno.env.get,
+  os: string = Deno.build.os,
+): Promise<ProfileUpdate[]> {
+  const candidates = profileCandidates(env, os);
+  if (candidates.length === 0) return [];
+  const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
+  const literal = homeRelative(value, home);
+  const line = exportLine(shellKind(env), name, literal);
+  const updates: ProfileUpdate[] = [];
+  for (const path of candidates) {
+    const update = await updateOne(path, name, line, value, literal, false);
+    if (update !== undefined) updates.push(update);
+  }
+  if (updates.length === 0) {
+    const created = await updateOne(
+      candidates[0]!,
+      name,
+      line,
+      value,
+      literal,
+      true,
+    );
+    if (created !== undefined) updates.push(created);
+  }
+  return updates;
+}
+
+/** The command that loads a profile into the shell already running. */
+export function reloadHint(path: string, kind: ShellKind): string {
+  return kind === "fish" ? `source ${path}` : `. ${path}`;
+}

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -7,8 +7,9 @@
  *
  * The lines carry a marker comment, so a second run recognizes its own
  * work and appends nothing. A line that sets the variable to something
- * else is reported and left alone: a profile is a person's file, and the
- * tool's job there is to say what it found.
+ * else, or sets it without exporting it, is reported and left alone: a
+ * profile is a person's file, and the tool's job there is to say what it
+ * found.
  */
 
 import { dirname, join } from "@std/path";
@@ -24,16 +25,37 @@ export type ShellKind = "zsh" | "bash" | "fish" | "posix";
 export type ProfileOutcome =
   /** The line was appended. */
   | "added"
-  /** The variable was already exported with this value. */
+  /** The variable is already exported with this value. */
   | "present"
   /** The variable is already set to something else; nothing was written. */
-  | "conflict";
+  | "conflict"
+  /**
+   * The variable is set to this value but never exported, so the
+   * programs the shell starts do not see it; nothing was written.
+   */
+  | "unexported"
+  /**
+   * A login shell reads this file first and it does not exist. Creating
+   * it would stop the shell reading the file it falls back to, so the
+   * person is told rather than the file written.
+   */
+  | "absent";
 
 export interface ProfileUpdate {
   path: string;
   outcome: ProfileOutcome;
-  /** The line already in the file, for a conflict. */
+  /** The line already in the file, for a conflict or an unexported set. */
   existing?: string;
+}
+
+/** An assignment of one variable found in a profile. */
+export interface ProfileSetting {
+  /** The line, as the profile carries it. */
+  line: string;
+  /** Whether the assignment reaches the programs the shell starts. */
+  exported: boolean;
+  /** The value, with one level of the shell's quoting taken off. */
+  value: string;
 }
 
 /** The login shell's family, read from SHELL. */
@@ -47,11 +69,11 @@ export function shellKind(env: Environment = Deno.env.get): ShellKind {
 }
 
 /**
- * The profile files to hold the export, in the order a shell reads them.
- * Every one of these that exists is updated, and the first is created
- * when none does: bash splits its startup between two files differently
- * on macOS than on Linux, and a person whose terminal reads only one of
- * them would otherwise get a line that never runs.
+ * The profile files to hold the export, the one a login shell reads
+ * first at the head. Every one of these that exists is updated, because
+ * bash splits its startup between two files differently on macOS than on
+ * Linux and a person whose terminal reads only one of them would
+ * otherwise get a line that never runs.
  */
 export function profileCandidates(
   env: Environment = Deno.env.get,
@@ -81,39 +103,109 @@ export function profileCandidates(
   }
 }
 
-/** A path under the home directory written through $HOME. */
-export function homeRelative(path: string, home: string | undefined): string {
-  if (home === undefined || home.length === 0) return path;
-  const root = home.endsWith("/") ? home.slice(0, -1) : home;
-  return path === root || path.startsWith(`${root}/`)
-    ? `$HOME${path.slice(root.length)}`
-    : path;
+/** A path split at the home directory, when it sits under one. */
+function splitHome(
+  path: string,
+  home: string | undefined,
+): { underHome: boolean; rest: string } {
+  if (home === undefined || home.length === 0) {
+    return { underHome: false, rest: path };
+  }
+  const separators = /[\\/]/g;
+  const root = home.replace(/[\\/]+$/, "");
+  const normalized = path.replace(separators, "/");
+  const normalizedRoot = root.replace(separators, "/");
+  if (normalized === normalizedRoot) return { underHome: true, rest: "" };
+  return normalized.startsWith(`${normalizedRoot}/`)
+    ? { underHome: true, rest: path.slice(root.length) }
+    : { underHome: false, rest: path };
 }
 
-/** The line that exports one variable in a shell's own syntax. */
+/** A path under the home directory written through $HOME. */
+export function homeRelative(path: string, home: string | undefined): string {
+  const split = splitHome(path, home);
+  return split.underHome ? `$HOME${split.rest}` : split.rest;
+}
+
+/** The path a value naming $HOME stands for. */
+export function expandHome(value: string, home: string | undefined): string {
+  if (home === undefined || home.length === 0) return value;
+  // A name only ends at $HOME when what follows cannot continue it,
+  // which is what keeps $HOMEBREW from reading as $HOME plus BREW.
+  const match = value.match(/^\$(?:\{HOME\}|HOME(?![A-Za-z0-9_]))(.*)$/);
+  return match === null ? value : `${home.replace(/[\\/]+$/, "")}${match[1]}`;
+}
+
+/**
+ * A value inside double quotes, with everything the shell would still
+ * act on there escaped, so a path holding a dollar sign, a quote, a
+ * backslash, or a backtick names the file it says.
+ */
+function escapeInDoubleQuotes(kind: ShellKind, text: string): string {
+  // Backticks open a command substitution in every shell here except
+  // fish, which has none.
+  const special = kind === "fish" ? /[\\"$]/g : /[\\"$`]/g;
+  return text.replace(special, (character) => `\\${character}`);
+}
+
+/**
+ * The line that exports one variable in a shell's own syntax, writing
+ * the home directory as $HOME so the line survives a move between
+ * machines.
+ */
 export function exportLine(
   kind: ShellKind,
   name: string,
   value: string,
+  home?: string,
 ): string {
+  const split = splitHome(value, home);
+  const escaped = escapeInDoubleQuotes(kind, split.rest);
+  const quoted = split.underHome ? `"$HOME${escaped}"` : `"${escaped}"`;
   return kind === "fish"
-    ? `set -gx ${name} "${value}"`
-    : `export ${name}="${value}"`;
+    ? `set -gx ${name} ${quoted}`
+    : `export ${name}=${quoted}`;
 }
 
-/** The line in a profile that already sets the variable, if there is one. */
-export function settingLine(
+/** One level of a shell's quoting taken off a value. */
+function unquote(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  return trimmed;
+}
+
+/** The assignment of a variable a profile already carries, if any. */
+export function parseSetting(
   text: string,
   name: string,
-): string | undefined {
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("#") || !trimmed.includes(name)) continue;
-    if (
-      new RegExp(`(^|\\s)(export\\s+)?${name}=`).test(trimmed) ||
-      new RegExp(`(^|\\s)set\\s+[^\\n]*\\b${name}\\s`).test(trimmed)
-    ) {
-      return trimmed;
+): ProfileSetting | undefined {
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("#")) continue;
+    const assignment = line.match(
+      new RegExp(`^(export\\s+)?${name}=(.*)$`),
+    );
+    if (assignment !== null) {
+      return {
+        line,
+        exported: assignment[1] !== undefined,
+        value: unquote(assignment[2] ?? ""),
+      };
+    }
+    const set = line.match(
+      new RegExp(`^set\\s+((?:-\\S+\\s+)*)${name}\\s+(.*)$`),
+    );
+    if (set !== null) {
+      return {
+        line,
+        exported: /-\S*x/.test(set[1] ?? ""),
+        value: unquote(set[2] ?? ""),
+      };
     }
   }
   return undefined;
@@ -133,16 +225,19 @@ async function updateOne(
   name: string,
   line: string,
   value: string,
-  literalValue: string,
+  home: string | undefined,
   create: boolean,
 ): Promise<ProfileUpdate | undefined> {
   const text = await readIfPresent(path);
   if (text === undefined && !create) return undefined;
-  const existing = settingLine(text ?? "", name);
+  const existing = parseSetting(text ?? "", name);
   if (existing !== undefined) {
-    return existing.includes(value) || existing.includes(literalValue)
+    if (expandHome(existing.value, home) !== value) {
+      return { path, outcome: "conflict", existing: existing.line };
+    }
+    return existing.exported
       ? { path, outcome: "present" }
-      : { path, outcome: "conflict", existing };
+      : { path, outcome: "unexported", existing: existing.line };
   }
   const separator = text === undefined || text.length === 0
     ? ""
@@ -158,9 +253,11 @@ async function updateOne(
 
 /**
  * Exports one variable from the login shell's profiles, returning what
- * each file's update did. The value is written through $HOME when it
- * sits under the home directory, so the line survives a move between
- * machines.
+ * each file's update did. Every profile that exists is written; when
+ * none does, the one a login shell reads first is created. A first
+ * profile that is missing while a later one exists is reported and not
+ * created, since creating it is what stops a login shell reading the
+ * file it falls back to.
  */
 export async function exportFromProfiles(
   name: string,
@@ -171,11 +268,10 @@ export async function exportFromProfiles(
   const candidates = profileCandidates(env, os);
   if (candidates.length === 0) return [];
   const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
-  const literal = homeRelative(value, home);
-  const line = exportLine(shellKind(env), name, literal);
+  const line = exportLine(shellKind(env), name, value, home);
   const updates: ProfileUpdate[] = [];
   for (const path of candidates) {
-    const update = await updateOne(path, name, line, value, literal, false);
+    const update = await updateOne(path, name, line, value, home, false);
     if (update !== undefined) updates.push(update);
   }
   if (updates.length === 0) {
@@ -184,10 +280,15 @@ export async function exportFromProfiles(
       name,
       line,
       value,
-      literal,
+      home,
       true,
     );
     if (created !== undefined) updates.push(created);
+    return updates;
+  }
+  const first = candidates[0]!;
+  if (!updates.some((update) => update.path === first)) {
+    updates.unshift({ path: first, outcome: "absent" });
   }
   return updates;
 }

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -54,7 +54,7 @@ export interface ProfileSetting {
   line: string;
   /** Whether the assignment reaches the programs the shell starts. */
   exported: boolean;
-  /** The value, with one level of the shell's quoting taken off. */
+  /** The path it names, read the way the shell reads it. */
   value: string;
 }
 
@@ -127,15 +127,6 @@ export function homeRelative(path: string, home: string | undefined): string {
   return split.underHome ? `$HOME${split.rest}` : split.rest;
 }
 
-/** The path a value naming $HOME stands for. */
-export function expandHome(value: string, home: string | undefined): string {
-  if (home === undefined || home.length === 0) return value;
-  // A name only ends at $HOME when what follows cannot continue it,
-  // which is what keeps $HOMEBREW from reading as $HOME plus BREW.
-  const match = value.match(/^\$(?:\{HOME\}|HOME(?![A-Za-z0-9_]))(.*)$/);
-  return match === null ? value : `${home.replace(/[\\/]+$/, "")}${match[1]}`;
-}
-
 /**
  * A value inside double quotes, with everything the shell would still
  * act on there escaped, so a path holding a dollar sign, a quote, a
@@ -167,34 +158,112 @@ export function exportLine(
     : `export ${name}=${quoted}`;
 }
 
-/** One level of a shell's quoting taken off a value. */
-function unquote(text: string): string {
-  const trimmed = text.trim();
-  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+/** A value with any comment that follows it on the line taken off. */
+function stripComment(text: string): string {
+  let quote: string | undefined;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === "\\" && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    const preceding = text[index - 1];
+    if (
+      character === "#" &&
+      (index === 0 || preceding === undefined || /\s/.test(preceding))
+    ) {
+      return text.slice(0, index);
+    }
+  }
+  return text;
+}
+
+/**
+ * The path an assignment names, read the way the shell reads it: single
+ * quotes hold their contents literally, double quotes and bare text
+ * expand $HOME and act on backslashes, and an escaped dollar sign is a
+ * dollar sign.
+ */
+export function effectiveValue(
+  text: string,
+  home: string | undefined,
+): string {
+  const trimmed = stripComment(text).trim();
+  if (
+    trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")
+  ) {
     return trimmed.slice(1, -1);
   }
-  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return trimmed.slice(1, -1).replace(/\\(.)/g, "$1");
+  const body = trimmed.length >= 2 && trimmed.startsWith('"') &&
+      trimmed.endsWith('"')
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  const root = home === undefined || home.length === 0
+    ? undefined
+    : home.replace(/[\\/]+$/, "");
+  let value = "";
+  for (let index = 0; index < body.length; index += 1) {
+    const character = body[index]!;
+    if (character === "\\") {
+      value += body[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    // A name only ends at $HOME when what follows cannot continue it,
+    // which is what keeps $HOMEBREW from reading as $HOME plus BREW.
+    const home$ = body.slice(index).match(
+      /^\$(?:\{HOME\}|HOME(?![A-Za-z0-9_]))/,
+    );
+    if (home$ !== null && root !== undefined) {
+      value += root;
+      index += home$[0].length - 1;
+      continue;
+    }
+    value += character;
   }
-  return trimmed;
+  return value;
+}
+
+/** Whether the flags of a fish `set` export the variable. */
+function fishExports(flags: string): boolean {
+  let exported = false;
+  for (const flag of flags.trim().split(/\s+/)) {
+    if (flag.startsWith("--")) {
+      if (flag === "--export") exported = true;
+      if (flag === "--unexport") exported = false;
+      continue;
+    }
+    if (!flag.startsWith("-")) continue;
+    const letters = flag.slice(1);
+    if (letters.includes("x")) exported = true;
+    if (letters.includes("u")) exported = false;
+  }
+  return exported;
 }
 
 /** The assignment of a variable a profile already carries, if any. */
 export function parseSetting(
   text: string,
   name: string,
+  home?: string,
 ): ProfileSetting | undefined {
   for (const raw of text.split("\n")) {
     const line = raw.trim();
     if (line.startsWith("#")) continue;
-    const assignment = line.match(
-      new RegExp(`^(export\\s+)?${name}=(.*)$`),
-    );
+    const assignment = line.match(new RegExp(`^(export\\s+)?${name}=(.*)$`));
     if (assignment !== null) {
       return {
         line,
         exported: assignment[1] !== undefined,
-        value: unquote(assignment[2] ?? ""),
+        value: effectiveValue(assignment[2] ?? "", home),
       };
     }
     const set = line.match(
@@ -203,8 +272,8 @@ export function parseSetting(
     if (set !== null) {
       return {
         line,
-        exported: /-\S*x/.test(set[1] ?? ""),
-        value: unquote(set[2] ?? ""),
+        exported: fishExports(set[1] ?? ""),
+        value: effectiveValue(set[2] ?? "", home),
       };
     }
   }
@@ -230,9 +299,9 @@ async function updateOne(
 ): Promise<ProfileUpdate | undefined> {
   const text = await readIfPresent(path);
   if (text === undefined && !create) return undefined;
-  const existing = parseSetting(text ?? "", name);
+  const existing = parseSetting(text ?? "", name, home);
   if (existing !== undefined) {
-    if (expandHome(existing.value, home) !== value) {
+    if (existing.value !== value) {
       return { path, outcome: "conflict", existing: existing.line };
     }
     return existing.exported


### PR DESCRIPTION
Minting a personal reporting key failed the first time someone asked for one. The workflow created the person's service account, then immediately granted it create-only access to its own folder in the store, and Cloud Storage refused the grant saying the account does not exist. It did exist. An account is in IAM the moment its create returns, and reaches the other services that name it some time after that, so a binding written half a second later can name something Cloud Storage has not seen. The grant now treats that one answer — a 400 or 404 naming this account and saying it does not exist — as the signal to wait and ask again, and every other status still fails the mint where it stands. The wait has no bound, because the account does exist and the grant is going to work; only the moment is out of the caller's hands.

The tool people run gains `setup`, which is the whole opt-in in one command. It stores a delivery identity, dispatches the minting workflow, watches the run to its conclusion, installs the delivered key, and exports CF_TEST_RECORDS_KEY_FILE from the login shell's profiles, which is the step that actually turns recording on and the one a person was previously left to do by hand. Dispatching takes repository write access, so a token that can only read gets the workflow page to open and the recipient to paste into it — and the command keeps watching for the run that click starts, rather than ending and asking to be run again. The watch has no bound either; Ctrl-C stops it, and running the command again picks up wherever it got to. Run on a workstation that already holds a key, it re-checks the shell profile instead of minting a second one, since minting revokes the first; `--rotate` is the deliberate replacement.

Finding the requester's own run works down three tests, in descending order of certainty. A run whose name carries the recipient is minting for it, which is what the run name this change gives the workflow is for. A successful run that published this recipient's delivery minted for it whatever its name says, which is what identifies a run from a workflow version that names nothing, and the delivery is the thing being waited for anyway. With neither available — a run still going, under a name that says nothing — the newest run this person dispatched since this attempt began is the one they are waiting on, which is as much as can be known and enough to print the URL to watch. Only the first two install anything. A one-shot collection searches without the time bound, so it can still pick up a delivery from a run dispatched on another day; a repeating watch takes its bound from GitHub's own clock at its first listing, so each round examines only the runs that could be this attempt's, and so a fresh dispatch is never confused with the run it replaces.

Every failure a person can hit — no token, a refused dispatch, a run that failed, a delivery that expired, an unreachable API — is now reported as a message and an exit status. A stack trace is left to mean what it should mean, which is a bug in the tool. Messages that address the reader are sentences, with a capital at the start and a full stop where one belongs.

Profile editing is its own module, with the shell families and their files and syntax in one place: zsh under ZDOTDIR, both bash files on the platform that reads them in either order, fish with its own set -gx, and .profile for anything else. Every candidate that exists is updated and the first is created when none does, since bash splits its startup between two files differently across platforms and a line in the file a terminal does not read is a line that never runs. The line carries a marker comment so a second run recognizes its own work, and a line already pointing somewhere else is reported and left alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

