### PR TITLE
test(patterns): note appendLink waits for the piece it links to

### DIFF
--- a/packages/patterns/integration/note-append-link.test.ts
+++ b/packages/patterns/integration/note-append-link.test.ts
@@ -12,6 +12,7 @@
  * machinery to recompute the id with.
  */
 import { env } from "@commonfabric/integration";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import { assert, assertStringIncludes } from "@std/assert";
@@ -56,6 +57,17 @@ describe("note appendLink integration", () => {
     // Keep both pieces reactive (pull mode) so handlers run on send.
     cancels.push(cc.getResult(host.getCell()).sink(() => {}));
     cancels.push(cc.getResult(target.getCell()).sink(() => {}));
+    // `create` resolves once the piece exists, not once its result has been
+    // derived: the pattern runs on whichever side the space's execution
+    // posture puts it, so under server execution the value arrives over the
+    // wire afterwards. Sending the event reads through the payload's link to
+    // hold it against the stream's contract, so the target has to be loaded
+    // before it can be linked to.
+    await waitForCellValue(
+      cc.runtime,
+      target.getCell(),
+      (v) => v !== undefined,
+    );
   });
 
   afterAll(async () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`Pattern Integration Tests / server-execution ON (4/10)` is red on `main`,
so every pull request opened since #6096 landed inherits it through the
merge ref. The surface is `integration/note-append-link.test.ts`, and it is
racy rather than deterministic — it passed the first ON-lane CI gate (run
32447348664), which is why it carries no ON-skip entry, and since then it
has gone red on some runs and green on others across unrelated branches.

## What it is

Not a semantic conflict. #6096 added the ON lanes themselves; nothing in
`piece-controller.ts`'s stream branch or in the note pattern changed under
it, and only three unrelated commits reached `main` between the gate run's
tree and the merge. The case has a missing precondition that only the ON
posture can expose.

`beforeAll` creates two note pieces and the case sends `appendLink` on one
with the other's cell as the event payload. `create` resolves once the
piece exists, not once its result has been derived, and the pattern runs on
whichever side the space's execution posture puts it — so under server
execution the derived value arrives over the wire after `create` returns.

Sending the event reads through the payload's link to hold it against the
stream's contract. A probe at the throw, on a locally reproduced failure:

```text
PROBE materialized: { piece: undefined }
PROBE links:  [ { path: ["piece"], preserved: false, ... } ]
PROBE contract: { type: "object",
                  properties: { piece: { "$ref": "#/$defs/MentionablePiece" } },
                  required: [ "piece" ] }
```

which is the CI error verbatim:

```text
updated result does not match its schema: piece: value does not match type object
  at packages/piece/src/ops/piece-controller.ts:3145
  at PiecePropIo.set (packages/piece/src/ops/piece-controller.ts:2806)
  at integration/note-append-link.test.ts:69
```

The target cell reads `undefined` at that moment — asserted directly with a
second probe in `beforeAll`.

## The change

One `waitForCellValue` on the target before it is linked to. That helper
sleeps on the cell's sink rather than on a timer, so it adds no poll and no
sleep. It is a precondition, not an assertion: what the case asserts — that
the id inside the `[[name (id)]]` link is the target's authoritative id —
is untouched, and the case keeps running (and asserting) under both
postures rather than being skip-listed.

## Verification

Measured against two local toolsheds, one started with
`EXPERIMENTAL_SERVER_EXECUTION=true` and one at the default posture:

| | server-execution ON | default posture |
| --- | --- | --- |
| unchanged (control) | 2 of 15 passed | 5 of 5 passed |
| with the wait | 15 of 15 passed | 5 of 5 passed |

`deno task check`, `deno task cfcheck`, `deno lint`, `deno fmt`,
`deno task check-no-waitfor` — all clean.

## One thing left open, for the owner

The controller's stream branch dereferences a supplied link purely to
validate the event payload — the write itself keeps the link
(`setTerminalValue(value)`). `assertSuppliedLinkSchemasCompatible` has
already proven the link's schema compatibility without reading it, so the
value-level read adds nothing about the link and re-reads it at whatever
instant the replica happens to hold. Whether that read should be able to
refuse a send because the target has not synced yet looks like the same
question the 2026-08-07 ruling settled for the sibling property-write
branch, and it is @seefeldb's call rather than something to change here. This
change fixes the case's own precondition and leaves that question open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe5XoGsXvbPZEAh9bZG1HC


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


