### PR TITLE
docs(runner): name the type in test descriptions and comments

### DIFF
--- a/packages/runner/test/action-result-validation.test.ts
+++ b/packages/runner/test/action-result-validation.test.ts
@@ -12,7 +12,7 @@ import { isReactiveMarker } from "../src/builder/types.ts";
 import { normalizeSandboxResult } from "../src/sandbox/result-normalization.ts";
 
 describe("normalizeSandboxResult", () => {
-  it("canonicalizes native leaves into Fabric values", () => {
+  it("canonicalizes native leaves into `FabricValue`s", () => {
     const input = {
       bytes: new Uint8Array([1, 2, 3]),
       date: new Date(1_234),
@@ -100,8 +100,8 @@ describe("normalizeSandboxResult", () => {
   it("re-roots a bare null-prototype record, nested included", () => {
     // `Object.create(null)` is an ordinary way to build a dictionary, and a
     // pattern may return one. This boundary is a canonicalizing copy, so it
-    // leaves in the one shape a fabric record has, rather than being carried
-    // across intact and refused later by the conversion functions.
+    // leaves in the one shape a `FabricPlainObject` has, rather than being
+    // carried across intact and refused later by the conversion functions.
     const inner = Object.create(null) as Record<string, unknown>;
     inner.v = 42;
     const outer = Object.create(null) as Record<string, unknown>;

--- a/packages/runner/test/attestation-claim-fabric.test.ts
+++ b/packages/runner/test/attestation-claim-fabric.test.ts
@@ -54,7 +54,7 @@ describe("attestation claim(): Fabric-aware consistency check", () => {
     expect(result.error).toBeUndefined();
   });
 
-  it("reports StateInconsistency when the Fabric value actually changed (CT-1770)", () => {
+  it("reports StateInconsistency when the `FabricValue` actually changed (CT-1770)", () => {
     // The attested value and the stored value are distinct `FabricBytes` that
     // differ only in their (private `#fields`) byte content: a genuine change,
     // which must surface as the `StorageTransactionInconsistent` error the

--- a/packages/runner/test/builder-fabric-classes.test.ts
+++ b/packages/runner/test/builder-fabric-classes.test.ts
@@ -1,10 +1,10 @@
 /**
- * The Fabric value classes reach pattern code as `export declare const`s in
- * `api/index.ts`, but the runtime values behind those declarations are bound
- * separately, in `builder/factory.ts`. The two sides are maintained by hand, so
- * a class can be declared without being bound -- which type-checks when the
- * pattern is compiled and then fails once it actually runs. These tests pin the
- * runtime half against the declared half.
+ * The `FabricSpecialObject` classes reach pattern code as `export declare
+ * const`s in `api/index.ts`, but the runtime values behind those declarations
+ * are bound separately, in `builder/factory.ts`. The two sides are maintained
+ * by hand, so a class can be declared without being bound -- which type-checks
+ * when the pattern is compiled and then fails once it actually runs. These
+ * tests pin the runtime half against the declared half.
  *
  * `types/commonfabric.d.ts` is a symlink to `api/index.ts`, and is the exact
  * artifact the sandbox hands a pattern as its view of `commonfabric`. Deriving
@@ -57,7 +57,7 @@ const expectedBindings: Record<string, unknown> = {
   FabricError,
 };
 
-describe("commonfabric Fabric value classes", () => {
+describe("commonfabric `FabricSpecialObject` classes", () => {
   // Viewed as a plain record on purpose: the question here is what the builder
   // surface carries at runtime, which is exactly what its static type cannot
   // answer.

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -840,12 +840,13 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     // case above.
     const { runtime, storageManager } = createRuntime();
     try {
-      // A schema whose `savedBytes` default is a `Uint8Array` cannot be authored
-      // as a plain literal (schema interning deep-freezes it and a raw
-      // `Uint8Array` cannot be frozen). Instead, round-trip the schema through a
-      // cell read as a query result, which interns the native `Uint8Array`
-      // default into a `FabricBytes` -- the realistic way a Fabric value reaches
-      // `schema.default` (see query-result-proxy-fabric-primitive.test.ts).
+      // A schema whose `savedBytes` default is a `Uint8Array` cannot be
+      // authored as a plain literal (schema interning deep-freezes it and a raw
+      // `Uint8Array` cannot be frozen). Instead, round-trip the schema through
+      // a cell read as a query result, which interns the native `Uint8Array`
+      // default into a `FabricBytes` -- the realistic way a `FabricValue`
+      // reaches `schema.default` (see
+      // query-result-proxy-fabric-primitive.test.ts).
       const schemaSource = {
         type: "object",
         properties: {

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -462,7 +462,7 @@ describe("cfc schema sanitization", () => {
       .toBeUndefined();
   });
 
-  it("strictly validates Common Fabric values for schema migrations", () => {
+  it("strictly validates `FabricValue`s for schema migrations", () => {
     expect(validateSchemaValue({ type: "undefined" }, undefined))
       .toBeUndefined();
     expect(validateSchemaValue({ type: "undefined" }, "not undefined"))
@@ -621,16 +621,16 @@ describe("cfc schema sanitization", () => {
     expect(validateSchemaDefinition(localOnlyDefinition)).toBeUndefined();
   });
 
-  it("validates fabric-primitive schema types by prototype", () => {
+  it("validates `FabricPrimitive` schema types by prototype", () => {
     const bytes = new FabricBytes(new Uint8Array([1, 2]));
 
-    // The fabric-primitive names are legal schema definitions.
+    // The `FabricPrimitive` names are legal schema definitions.
     expect(validateSchemaDefinition({ type: "FabricBytes" })).toBeUndefined();
     expect(validateSchemaDefinition({ type: ["FabricHash", "null"] }))
       .toBeUndefined();
 
     // A FabricBytes satisfies its own type, and "object" via the subtype
-    // rule (each fabric-primitive type is a subtype of "object").
+    // rule (each `FabricPrimitive` type is a subtype of "object").
     expect(validateSchemaValue({ type: "FabricBytes" }, bytes))
       .toBeUndefined();
     expect(validateSchemaValue({ type: "object" }, bytes)).toBeUndefined();
@@ -658,15 +658,16 @@ describe("cfc schema sanitization", () => {
     expect(validateSchemaValue({ type: "object", required: ["length"] }, bytes))
       .toBeUndefined();
     // The nominal brand key generated schemas require has no runtime
-    // existence; a fabric value satisfies it by construction. This is the
-    // shape the schema-generator emits for a FabricBytes-typed field today.
+    // existence; a `FabricSpecialObject` satisfies it by construction. This
+    // is the shape the schema-generator emits for a FabricBytes-typed field
+    // today.
     expect(validateSchemaValue({
       type: "object",
       required: ["length", "@commonfabric/FabricSpecialObject"],
     }, bytes)).toBeUndefined();
     expect(validateSchemaValue({ type: "object", required: [] }, bytes))
       .toBeUndefined();
-    // A fabric-primitive-typed schema is not gated by `required`.
+    // A `FabricPrimitive`-typed schema is not gated by `required`.
     expect(validateSchemaValue({ type: "FabricBytes", required: ["x"] }, bytes))
       .toBeUndefined();
   });

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -79,7 +79,7 @@ describe("CFC wildcard policy applicability on unresolvable links", () => {
   });
 });
 
-describe("CFC wildcard policy value conditions on fabric-primitive types", () => {
+describe("CFC wildcard policy value conditions on `FabricPrimitive` types", () => {
   const space = "did:key:wildcard-fabric" as const;
   const target = {
     space,
@@ -92,7 +92,7 @@ describe("CFC wildcard policy value conditions on fabric-primitive types", () =>
   } as unknown as IExtendedStorageTransaction;
   const bytesCondition = { type: "FabricBytes" } as const satisfies JSONSchema;
 
-  it("applies to a value of the named fabric-primitive class", () => {
+  it("applies to a value of the named `FabricPrimitive` class", () => {
     expect(
       wildcardPolicyMatchesValue(
         tx,
@@ -103,7 +103,7 @@ describe("CFC wildcard policy value conditions on fabric-primitive types", () =>
     ).toBe(true);
   });
 
-  it("does not apply to other values, including other fabric primitives", () => {
+  it("does not apply to other values, including other `FabricPrimitive`s", () => {
     expect(wildcardPolicyMatchesValue(tx, target, bytesCondition, { a: 1 }))
       .toBe(false);
     expect(

--- a/packages/runner/test/combine-schema.test.ts
+++ b/packages/runner/test/combine-schema.test.ts
@@ -38,17 +38,17 @@ describe("combineSchema type handling", () => {
       b: { type: "string" },
     },
     {
-      name: "a fabric-primitive type and string are disjoint",
+      name: "a `FabricPrimitive` type and string are disjoint",
       a: { type: "FabricBytes" },
       b: { type: "string" },
     },
     {
-      name: "two different fabric-primitive types are disjoint",
+      name: "two different `FabricPrimitive` types are disjoint",
       a: { type: "FabricBytes" },
       b: { type: "FabricHash" },
     },
     {
-      name: "a fabric-primitive type and array are disjoint",
+      name: "a `FabricPrimitive` type and array are disjoint",
       a: { type: "FabricRegExp" },
       b: { type: "array" },
     },
@@ -130,17 +130,17 @@ describe("combineSchema type handling", () => {
     });
   }
 
-  // Each fabric-primitive type is a subtype of "object" (mirroring
+  // Each `FabricPrimitive` type is a subtype of "object" (mirroring
   // integer under number), so the intersection keeps the narrower member.
   const fabricObjectCases = [
     {
-      name: "object and a fabric-primitive type",
+      name: "object and a `FabricPrimitive` type",
       a: { type: "object" },
       b: { type: "FabricBytes" },
       expectedType: "FabricBytes",
     },
     {
-      name: "type arrays with only an object/fabric-primitive overlap",
+      name: "type arrays with only an object/`FabricPrimitive` overlap",
       a: { type: ["string", "object"] },
       b: { type: ["boolean", "FabricEpochNsec"] },
       expectedType: "FabricEpochNsec",
@@ -148,7 +148,7 @@ describe("combineSchema type handling", () => {
   ] as const;
 
   for (const testCase of fabricObjectCases) {
-    it(`${testCase.name} narrows object to the fabric type in either direction`, () => {
+    it(`${testCase.name} narrows object to the \`FabricPrimitive\` type in either direction`, () => {
       expect(combineSchema(testCase.a, testCase.b)).toEqual({
         type: testCase.expectedType,
       });

--- a/packages/runner/test/create-json-schema.test.ts
+++ b/packages/runner/test/create-json-schema.test.ts
@@ -472,8 +472,9 @@ describe("create-json-schema", () => {
         },
       );
 
-      // `createJsonSchema()` accepts cells as well as fabric data -- which is
-      // exactly what these cases exercise -- so this cannot be `FabricValue`.
+      // `createJsonSchema()` accepts cells as well as `FabricValue`s -- which
+      // is exactly what these cases exercise -- so this cannot be
+      // `FabricValue`.
       const create = (value: unknown) =>
         createJsonSchema(value, false, runtime);
 

--- a/packages/runner/test/exec-value-node-typing.test.ts
+++ b/packages/runner/test/exec-value-node-typing.test.ts
@@ -37,7 +37,7 @@ describe("serialized node binding typing", () => {
     const _nestedAsJson: JSONValue = { blob: bytes };
 
     // Assert assignability rather than mutate: these values are frozen-ish
-    // fabric data, and the declarations above are the actual test.
+    // `FabricValue`s, and the declarations above are the actual test.
     expect(bare).toBeInstanceOf(FabricBytes);
     expect((nested as { blob: unknown }).blob).toBeInstanceOf(FabricBytes);
   });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -4476,7 +4476,7 @@ Deno.test("memory v2 stacked commits: dropping an earlier pending write invalida
   }
 });
 
-Deno.test("memory v2 stacked commits: pending visibility preserves fabric values", async () => {
+Deno.test("memory v2 stacked commits: pending visibility preserves `FabricValue`s", async () => {
   const harness = await createHarness();
   let commitPromise: Promise<any> | undefined;
   try {

--- a/packages/runner/test/pattern-object-member-storage.test.ts
+++ b/packages/runner/test/pattern-object-member-storage.test.ts
@@ -105,8 +105,8 @@ describe("Pattern result object with a function member", () => {
     );
 
     // ...but running it throws synchronously at result-projection time, when
-    // the live function is converted to a fabric value. The error originates in
-    // packages/data-model/src/native-conversion.ts.
+    // the live function is converted to a `FabricValue`. The error originates
+    // in packages/data-model/src/native-conversion.ts.
     expect(() => runtime.run(tx, methodPattern, {}, resultCell)).toThrow(
       "Not representable as a `FabricValue`: function",
     );

--- a/packages/runner/test/to-encodable-form.test.ts
+++ b/packages/runner/test/to-encodable-form.test.ts
@@ -305,7 +305,7 @@ describe("to-encodable-form", () => {
 
     it("leaves ordinary containers alone", () => {
       // The conversion above must not reach an inert plain object or an array;
-      // those are already fabric values and are walked, not converted.
+      // those are already `FabricValue`s and are walked, not converted.
       const obj = withAliasBindings({ a: 1, b: "x" } as any) as any;
       expect(obj).toEqual({ a: 1, b: "x" });
       expect(obj.constructor).toBe(Object);

--- a/packages/runner/test/traverse-fabric-primitive.test.ts
+++ b/packages/runner/test/traverse-fabric-primitive.test.ts
@@ -159,8 +159,8 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
   it("surfaces a FabricPrimitive under the generator's brand-requiring object schema", async () => {
     // The schema-generator emits this exact shape for a FabricBytes-typed
     // field: the nominal brand key is required, but it has no runtime
-    // existence — a fabric value satisfies it by construction. Regression
-    // guard for CT-1836's fetchBinary materialization.
+    // existence — a `FabricSpecialObject` satisfies it by construction.
+    // Regression guard for CT-1836's fetchBinary materialization.
     const schema = {
       type: "object",
       properties: {
@@ -205,7 +205,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     expect(got.blob).toBeInstanceOf(FabricBytes);
   });
 
-  it("returns a FabricPrimitive intact under its specific fabric-primitive type", async () => {
+  it("returns a `FabricPrimitive` intact under its specific type", async () => {
     const schema = {
       type: "object",
       properties: { blob: { type: "FabricBytes" } },
@@ -227,7 +227,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     ).toEqual([1, 2, 3]);
   });
 
-  it("rejects a FabricPrimitive under a different fabric-primitive type", async () => {
+  it("rejects a `FabricPrimitive` under a different `FabricPrimitive` type", async () => {
     // A FabricBytes is not a FabricHash: the specific types don't cross-match
     // even though both validate under "object".
     const schema = {
@@ -249,7 +249,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     expect(got).not.toHaveProperty("blob");
   });
 
-  it("rejects a plain record under a fabric-primitive type", async () => {
+  it("rejects a plain record under a `FabricPrimitive` type", async () => {
     // The subtype relation is one-way: "object" accepts a FabricBytes, but
     // "FabricBytes" does not accept a plain record.
     const schema = {
@@ -270,7 +270,7 @@ describe("FabricPrimitive leaf routing in schema traversal", () => {
     expect(got).not.toHaveProperty("blob");
   });
 
-  it("matches the fabric-primitive branch of an anyOf", async () => {
+  it("matches the `FabricPrimitive` branch of an anyOf", async () => {
     const schema = {
       type: "object",
       properties: {

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1925,7 +1925,7 @@ describe("canBranchMatch", () => {
   it("treats the nominal brand key as present on a `FabricSpecialObject`", () => {
     // The generator's emitted shape for a FabricBytes-typed field: the
     // brand has no runtime existence, so a `FabricSpecialObject` satisfies it
-    // construction; `length` is satisfied by the class accessor.
+    // by construction; `length` is satisfied by the class accessor.
     const branch = {
       type: "object",
       required: ["length", "@commonfabric/FabricSpecialObject"],

--- a/packages/runner/test/traverse.test.ts
+++ b/packages/runner/test/traverse.test.ts
@@ -1922,9 +1922,9 @@ describe("canBranchMatch", () => {
     ).toBe(true);
   });
 
-  it("treats the nominal brand key as present on a fabric value", () => {
+  it("treats the nominal brand key as present on a `FabricSpecialObject`", () => {
     // The generator's emitted shape for a FabricBytes-typed field: the
-    // brand has no runtime existence, so a fabric value satisfies it by
+    // brand has no runtime existence, so a `FabricSpecialObject` satisfies it
     // construction; `length` is satisfied by the class accessor.
     const branch = {
       type: "object",


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Third pass over prose that refers to a `data-model` type without naming it.
This one covers `packages/runner/test`. (`packages/data-model` is #6134;
`packages/runner/src` is #6135.)

### What changed

Test descriptions, table-driven case names, and comments that said "fabric
value", "fabric primitive", "fabric record" or "fabric type" now name the type
they mean.

Three were pointing at a narrower type than the words said, matching the same
corrections on the source side: the nominal-brand cases in `traverse.test.ts`,
`traverse-fabric-primitive.test.ts` and `cfc-schema-sanitization.test.ts` are
about `FabricSpecialObject` — the brand is its — not about `FabricValue` at
large.

### Deliberately left alone

- Identifiers and fixture data that merely contain the words: passphrases
  handed to `Identity.fromPassphrase()`, `Symbol.for()` keys, document URIs,
  cause strings. Changing a passphrase changes the DID it derives.
- "non-fabric specifiers" in `fabric-import-specifier.test.ts` and
  `fabric-resolver.test.ts`, which is about import specifiers rather than about
  the data model.

### Diff property

No executable line changes. Filtering the diff for added or removed lines that
are neither `//` nor doc-comment leaves exactly the `describe()` / `it()` /
`Deno.test()` descriptions and the `name` fields that exist only to be
interpolated into one (`combine-schema.test.ts` builds its `it()` strings from
them; nothing else reads the field).

### Testing

- `deno task test` in `packages/runner`: `ok | 1268 passed (7240 steps) | 0 failed`
- `deno fmt --check` and `deno lint` on the package: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

