### PR TITLE
docs(spec): name the type where the formal spec means the type

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -61,7 +61,7 @@ layer (Section 8) and represented in `FabricValue` trees as `FabricInstance`
 wrapper classes (Section 1.4).
 
 > **Package note:** The data model implementation lives in
-> `packages/data-model/`. The fabric-value types and the base classes
+> `packages/data-model/`. The `FabricValue` types and the base classes
 > (`FabricSpecialObject`, `FabricInstance`, `FabricPrimitive`) are declared in
 > `interface.ts`, and the in-process lifecycle symbols (`DEEP_FREEZE`,
 > `IS_DEEP_FROZEN`) in `fabric-bases/`, on `BaseFabricInstance` alongside the
@@ -108,7 +108,7 @@ type FabricValue =
   | boolean
   | number    // any number, including `-0`, `NaN`, and `±Infinity`; see Section 1.3
   | string
-  | undefined // first-class fabric value; requires tagged representation in formats lacking native `undefined`
+  | undefined // first-class `FabricValue`; requires tagged representation in formats lacking native `undefined`
   | bigint    // large integers; rides through without wrapping (like `undefined`)
   | symbol    // registry-interned symbols only (`Symbol.keyFor(s)` returns a string); see Section 1.3
 
@@ -171,7 +171,7 @@ elaboration of one implementation arm.
 >
 > - `symbol` — **Conditionally** part of the universe. Registry-interned
 >   symbols (`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string)
->   are first-class fabric values: they are portable across realms and
+>   are first-class `FabricValue`s: they are portable across realms and
 >   processes via their registry key. **Unique** symbols (`Symbol(desc)`,
 >   where `Symbol.keyFor(s)` returns `undefined`) have no portable
 >   representation and are rejected. The TypeScript `symbol` type cannot
@@ -180,7 +180,7 @@ elaboration of one implementation arm.
 >   and 5). Symbol-keyed *properties* on plain objects are a separate
 >   matter — see Section 1.5 (Recursive Containers / Objects).
 > - `function` — Functions are opaque closures with no portable representation.
->   They are explicitly **not** representable as fabric values, eliciting a
+>   They are explicitly **not** representable as `FabricValue`s, eliciting a
 >   thrown error from `fabricFromNativeValue()` and a `false` return value from
 >   `isValidFabricConvertibleValue()`. (`FabricInstance`s are not functions in
 >   this sense — they are class instances whose encoding is handled by their
@@ -188,7 +188,7 @@ elaboration of one implementation arm.
 >
 >   A proposed, deliberately narrow exception adds a `FabricFactory` arm for
 >   builder-created factories and codec-decoded factory shells admitted to the
->   internal data-model brand table. The function itself is the Fabric value
+>   internal data-model brand table. The function itself is the `FabricValue`
 >   and encodes through `Factory@1`; there is no non-callable wrapper class.
 >   This data-type brand does not grant executable trust, which is established
 >   separately by resolving a content-addressed builder artifact. The exception
@@ -280,12 +280,12 @@ function-valued member is not representable.
 | `boolean` | None | `true` or `false` |
 | `number` | None | Any IEEE 754 binary64 value, including `-0`, `NaN`, and `±Infinity`. See the callout below. |
 | `string` | None | Unicode text |
-| `undefined` | None | First-class fabric value; see note below |
+| `undefined` | None | First-class `FabricValue`; see note below |
 | `bigint` | None | Large integers; JSON-encoded as base64url (RFC 4648, Section 5) of two's complement big-endian bytes (Section 3 of `3-json-encoding.md`) |
 | `symbol` | Registry-interned only | Only symbols for which `Symbol.keyFor(s)` returns a string (i.e., `Symbol.for(key)` symbols) are admitted. Unique symbols (`Symbol(desc)`) are rejected. See the callout below. |
 
 > **`undefined` as a first-class fabric value.** `undefined` is a first-class
-> fabric value that round-trips faithfully through encoding. Because most
+> `FabricValue` that round-trips faithfully through encoding. Because most
 > wire formats (including JSON) have no native `undefined` representation, the
 > codec system uses a dedicated tagged form for `undefined` — the same
 > tagged form regardless of context (array element, object property value, or
@@ -1105,7 +1105,7 @@ content-addressing schemes. The algorithm tag is part of the content ID's
 identity — two `FabricHash` instances with the same hash bytes but
 different algorithm tags are distinct values.
 
-Like every fabric primitive, `FabricHash` hosts a `[JSON_CODEC]` (tag
+Like every `FabricPrimitive`, `FabricHash` hosts a `[JSON_CODEC]` (tag
 `Hash@1`).
 Its encoded state is `{ tag, hash }` — the algorithm tag plus the hash as
 an unpadded base64url string (i.e., `.hashString`); `canDecode()` refuses a
@@ -1185,7 +1185,8 @@ dedicated `TAG_BYTES` primitive tag (Section 6.3).
 
 `FabricLink` is a fabric-native `FabricInstance` — like the wrapper classes of
 Sections 1.4.2–1.4.4, but not wrapping any native JS type — that represents a
-**link**: the modern, object-shaped form of a reference to fabric data. It
+**link**: the modern, object-shaped form of a reference to data stored in the
+fabric. It
 wraps a single **payload**, a plain object (`FabricPlainObject`) of addressing
 fields, as its sole nested `FabricValue`.
 
@@ -1263,7 +1264,7 @@ Section 4.5.
 > native objects. Code that needs the underlying native type uses
 > `nativeFromFabricValue()` (Section 8) as a separate step.
 >
-> **File organization.** Each fabric-instance and fabric-primitive class
+> **File organization.** Each `FabricInstance` and `FabricPrimitive` class
 > lives in its own file: the `FabricInstance` subclasses (including the
 > native object wrappers `FabricError`, `FabricMap`, `FabricSet`
 > and the explicit-tag-value family) under
@@ -1285,7 +1286,7 @@ Section 4.5.
   change that. Plain objects are governed by the same principle; see the
   object rule below.
 - May be dense or sparse
-- Elements may be `undefined` (a first-class fabric value; see Section 1.3)
+- Elements may be `undefined` (a first-class `FabricValue`; see Section 1.3)
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
   `undefined` and are represented using run-length encoding in serialized forms
   (see below and Section 3 of `3-json-encoding.md` for the specific JSON encoding)
@@ -1333,15 +1334,16 @@ Section 4.5.
   live code rather than an inert value, and a non-enumerable key causes
   rejection because it has no representation as a property name in
   name-driven copying or encoding
-- Values must be valid fabric values; properties whose value is `undefined` are preserved
+- Values must be valid `FabricValue`s; properties whose value is `undefined` are preserved
   (not omitted) — `undefined` is a first-class value, not a signal for deletion
 - **Host restriction, not a model rule:** the property names `__proto__` and
   `constructor` cause rejection in the JavaScript implementation. See the
   callout below
 - Decoding produces regular plain objects, which is the only object
-  shape a fabric value has
+  shape a `FabricValue` has
 
-> **Property names this implementation reserves.** A fabric record's keys are
+> **Property names this implementation reserves.** A `FabricPlainObject`'s keys
+> are
 > strings, and the model attaches no meaning to any particular one: a property
 > name is data. Two names are nonetheless refused by the JavaScript
 > implementation, `__proto__` and `constructor`, for two different reasons —
@@ -1395,7 +1397,8 @@ to a different graph than the one encoded, with nothing at either end saying
 so.
 
 **Conversion is decided separately from encoding, and refuses a cycle.**
-`fabricFromNativeValue()` builds a fabric value out of native data, and will not
+`fabricFromNativeValue()` builds a `FabricValue` out of native data, and will
+not
 build one containing a cycle; it preserves shared references, so the converted
 form for a given original is reused and structural sharing survives. That is a
 third answer under the same rule, not an exception to it: membership admits a
@@ -1409,7 +1412,7 @@ objects are `===` to each other is a further promise, which an engine states
 only if it makes it.
 
 Cycles *across* documents are a separate matter, and are supported whatever an
-engine does within one. They are written as explicit links (fabric instances
+engine does within one. They are written as explicit links (`FabricInstance`s
 referencing other documents), so two cells may reference each other and form a
 cycle in the broader data graph without any single cell's content containing
 one.
@@ -1485,7 +1488,7 @@ export const JSON_CODEC: unique symbol =
 // file: packages/data-model/fabric-bases/BaseFabricInstance.ts
 
 /**
- * Well-known symbol for deeply freezing a fabric instance in place. The
+ * Well-known symbol for deeply freezing a `FabricInstance` in place. The
  * implementation freezes the instance's own internal slot(s) and recurses
  * into any nested `FabricValue`s via a `subFreeze` callback supplied by the
  * generic `deepFreeze()` utility. See Section 8.6.
@@ -1493,7 +1496,7 @@ export const JSON_CODEC: unique symbol =
 export const DEEP_FREEZE: unique symbol = Symbol('data-model.deepFreeze');
 
 /**
- * Well-known symbol for checking whether a fabric instance is already
+ * Well-known symbol for checking whether a `FabricInstance` is already
  * deeply frozen, without mutating it. The side-effect-free sibling of
  * `[DEEP_FREEZE]`: verifies the instance's own internal slot(s) are in
  * canonical deep-frozen form and recurses into any nested `FabricValue`s
@@ -1542,7 +1545,7 @@ class-side `[CODEC]` (Section 2.4).
  * value types.
  *
  * This is the pure abstract protocol — the `instanceof`-able contract that
- * external code is written against. Concrete fabric-instance classes
+ * external code is written against. Concrete `FabricInstance` classes
  * extend `BaseFabricInstance` (a subclass of this one) rather than this
  * class directly; `BaseFabricInstance` is where shared template-method
  * scaffolding (such as `shallowClone()`) lives.
@@ -1686,7 +1689,7 @@ export abstract class BaseFabricInstance extends FabricInstance {
 > implementation detail of the data-model package. External code written
 > against `FabricInstance` is therefore stable against changes to the
 > template-method scaffolding, and the `instanceof FabricInstance` brand
-> check still catches every concrete fabric-instance value.
+> check still catches every concrete `FabricInstance` value.
 
 ### 2.4 Codec Protocol
 
@@ -1837,7 +1840,7 @@ export interface FabricCodec<Encoded> {
 
 /**
  * A codec whose essential state is **nonterminal**: it is itself made of
- * fabric values, which the walker goes on to expand in turn. Instantiating
+ * `FabricValue`s, which the walker goes on to expand in turn. Instantiating
  * `FabricCodec` at `FabricValue` is what says so, because that is the
  * walker's own input domain. One instance serves every wire format.
  */
@@ -1936,7 +1939,7 @@ works over the whole of `Encoded` leaves it at the default.
 subclass of `BaseTerminalCodec` declared at `FabricValue` would satisfy the
 nonterminal half of every signature while classifying as terminal at run time,
 and its state would reach the wire unexpanded. Nothing enforces this; a codec
-whose state is made of fabric values extends `BaseNonterminalCodec`.
+whose state is made of `FabricValue`s extends `BaseNonterminalCodec`.
 
 Lookup goes through **`codecOf(value, altCodec?)`**
 (`codec-common/codecOf.ts`), which returns a value's class's `[CODEC]`,
@@ -2205,7 +2208,7 @@ The system follows an **immutable-forward** design:
 - **`FabricInstance`s** should ideally be frozen as well — this is the north
   star, though not yet a strict requirement.
 - Decoding always produces regular plain objects, that being the only
-  object shape a fabric value has.
+  object shape a `FabricValue` has.
 
 This immutability guarantee enables safe sharing of decoded values and
 aligns with the reactive system's assumption that values don't mutate in place.
@@ -2973,7 +2976,7 @@ recognizer for text in it, live one layer down in
 // file: packages/data-model/src/codecs.ts
 
 /**
- * Encodes a fabric value to a JSON string in the standard `FabricValue`
+ * Encodes a `FabricValue` to a JSON string in the standard `FabricValue`
  * JSON-embedded encoding, prefixed with the format-identifying tag
  * `fvj1:`.
  */
@@ -3025,7 +3028,7 @@ The `memory` package wraps these at its encoding boundary
 
 ### 4.9 Fabric Value Conversion
 
-The native-to-fabric-value boundary is managed by
+The native-to-`FabricValue` boundary is managed by
 `packages/data-model/native-conversion.ts`. This module provides
 `fabricFromNativeValue()` / `nativeFromFabricValue()` functions that bridge
 the left layer (JS wild west) and the middle layer (`FabricValue`) at the
@@ -3054,7 +3057,7 @@ export function fabricFromNativeValue(
 ): FabricValue;
 
 /**
- * Convert a fabric value back to native form, unwrapping fabric wrappers
+ * Convert a `FabricValue` back to native form, unwrapping fabric wrappers
  * back to native JS types (Section 8.4).
  */
 export function nativeFromFabricValue(
@@ -3078,7 +3081,7 @@ The implementation is split across several files for separation of concerns:
 |------|---------|
 | `fabric-value.ts` | Public surface: re-exports the conversion functions (from `native-conversion.ts`), the type declarations (from `interface.ts`), and the clone helpers (from `value-clone.ts`); defines `valueEqual()` |
 | `native-conversion.ts` | Conversion: `fabricFromNativeValue`, `shallowFabricFromNativeValue`, `nativeFromFabricValue`, `isValidFabricConvertibleValue` |
-| `fabric-bases/` | The abstract bases a concrete fabric value extends, one per branch of the type hierarchy: `BaseFabricInstance.ts`, `BaseFabricPrimitive.ts` (plus an `index.ts` barrel). These are the implementer's half of the hierarchy; `interface.ts` is the client's, and reaching it does not reach these. |
+| `fabric-bases/` | The abstract bases a concrete `FabricValue` extends, one per branch of the type hierarchy: `BaseFabricInstance.ts`, `BaseFabricPrimitive.ts` (plus an `index.ts` barrel). These are the implementer's half of the hierarchy; `interface.ts` is the client's, and reaching it does not reach these. |
 | `fabric-instances/` | Concrete `FabricInstance` subclasses, each in its own file: `FabricNativeWrapper.ts`, `FabricError.ts`, `FabricLink.ts`, `FabricMap.ts`, `FabricSet.ts` (plus an `index.ts` barrel). `UnknownValue` and `ProblematicValue` are `FabricInstance`s too, but live in `codec-common/`, existing only as products of a decode fault. |
 | `fabric-primitives/` | Concrete `FabricPrimitive` subclasses, each in its own file: `FabricBytes.ts`, `FabricHash.ts`, `FabricEpochNsec.ts`, `FabricEpochDay.ts`, `FabricRegExp.ts` (plus an `index.ts` barrel). |
 
@@ -3086,7 +3089,7 @@ The implementation is split across several files for separation of concerns:
 
 ## 5. JSON Encoding for Special Types
 
-The JSON encoding for fabric values — the `/<Type>@<Version>` wire format,
+The JSON encoding for `FabricValue`s — the `/<Type>@<Version>` wire format,
 type encodings, escaping mechanisms, and the `/`-key reservation rule — is
 specified in a dedicated document:
 
@@ -3176,7 +3179,7 @@ regardless of nibble range.
 // file: packages/data-model/value-hash.ts
 
 /**
- * Compute a hash for a fabric value. The hash is encoding-independent:
+ * Compute a hash for a `FabricValue`. The hash is encoding-independent:
  * the same identity whether later serialized to JSON, CBOR, or any
  * other format.
  *
@@ -3358,7 +3361,7 @@ most current version of the data. Hashes are not used as entity addresses.
 `FabricValue`s are compared for logical (content) equality by
 `valueEqual(a: FabricValue, b: FabricValue): boolean`. This is the equality
 the reactive system's change-detection and no-op gates depend on, and the
-equality that `Map` / `Set` key behavior over fabric values is expected to
+equality that `Map` / `Set` key behavior over `FabricValue`s is expected to
 follow.
 
 **Governing principle.** Value-equality follows `Object.is()` at the primitive
@@ -3369,7 +3372,7 @@ names, and the two disagree in exactly the two cases the hashing layer already
 distinguishes:
 
 - **`-0` ≠ `+0`.** `Object.is(-0, +0)` is `false`, so `-0` and `+0` are
-  distinct fabric values and hash distinctly (Section 6.4;
+  distinct `FabricValue`s and hash distinctly (Section 6.4;
   `2-hash-byte-format.md` Section 4.3). (`===` would conflate them, treating
   `-0 === +0` as `true`.)
 - **All `NaN`s are value-equal.** `Object.is(NaN, NaN)` is `true`, so every
@@ -3383,7 +3386,7 @@ Every other primitive falls through to ordinary same-value equality:
 else, and likewise for `string`, `boolean`, `bigint`, interned `symbol`,
 `null`, and `undefined`.
 
-**Objects, arrays, and instances.** Non-primitive fabric values are compared
+**Objects, arrays, and instances.** Non-primitive `FabricValue`s are compared
 by canonical content hash: `valueEqual(a, b)` holds exactly when
 `hashStringOf(a) === hashStringOf(b)` (Section 6.4). Because the content hash
 reflects logical content and carries the primitive-leaf distinctions above, a
@@ -4120,7 +4123,7 @@ spec from being implementable.
   that `Cell.getRaw()` and `Cell.setRaw()` should traffic in `FabricValue`
   (middle layer), not arbitrary native JS values (wild west). A usage survey
   of all call sites in the codebase found that every existing caller operates
-  on well-defined fabric data (plain objects, arrays, strings, links, stream
+  on well-defined `FabricValue`s (plain objects, arrays, strings, links, stream
   markers) — no call site stores or retrieves raw native types like `Error`,
   `Date`, `RegExp`, `Map`, `Set`, or `Uint8Array` through these methods.
   Formalizing this contract (e.g., refining the type parameter `T` of

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -128,13 +128,13 @@ four special values that JSON cannot represent natively (`-0`, `NaN`,
   payload `7F F8 00 00 00 00 00 00`. Any input NaN bit pattern (signaling,
   quiet, with arbitrary payload bits) hashes via this canonical 8-byte
   sequence. This ensures all NaN values produce identical hashes, matching
-  fabric value-equality, under which all `NaN`s are equal (`Object.is(NaN,
+  `FabricValue` equality, under which all `NaN`s are equal (`Object.is(NaN,
   NaN)` is `true`; see `1-fabric-values.md` Section 6.7). Note this is
   distinct from the `===` operator, under which a `NaN` compares unequal even
   to itself.
 
 > **Conversion-gate cross-reference.** Whether `-0`, `NaN`, or `±Infinity`
-> reach this layer depends on the fabric-value conversion gate; see
+> reach this layer depends on the `FabricValue` conversion gate; see
 > `1-fabric-values.md` Section 4.9. The byte-level encoding above is the
 > hasher's contract regardless of how the values arrived.
 
@@ -243,7 +243,7 @@ hashes, while inheriting the short/long string-encoding delegation
 unchanged.
 
 > **Conversion-gate cross-reference.** Whether a symbol value reaches this
-> layer depends on the fabric-value conversion gate; see
+> layer depends on the `FabricValue` conversion gate; see
 > `1-fabric-values.md` Section 4.9. The byte-level encoding above is the
 > hasher's contract regardless of how the value arrived.
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -212,7 +212,7 @@ like any other malformation: a lenient decode yields a `ProblematicValue`
 describing that decode, and a strict one raises. A well-formed record is a
 record of a *past* failure and reads back as one under either setting, this
 decode having succeeded. `state` is checked for presence rather than for type,
-because every `FabricValue` is a valid state, `undefined` among them; filling
+because every `FabricValue` is a valid state, `undefined` among them; filling in
 an absent one would put a reshaped record back on the wire.
 
 See `1-fabric-values.md` Section 3.5.

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -1,7 +1,7 @@
 # JSON Encoding for Fabric Values
 
 This document specifies the JSON-compatible wire format used to represent
-fabric values, including the `fvj1:` encoding prefix, the tagged-object
+`FabricValue`s, including the `fvj1:` encoding prefix, the tagged-object
 convention, escaping mechanisms, codec engine responsibilities, and
 the reservation rules for `/`-prefixed keys.
 
@@ -20,7 +20,7 @@ types more directly without layering on JSON.
 
 ### 1.1 Encoding Prefix
 
-Every encoded fabric value carries an unambiguous textual prefix, before the
+Every encoded `FabricValue` carries an unambiguous textual prefix, before the
 JSON itself:
 
 ```
@@ -30,7 +30,7 @@ fvj1:<json>
 The literal string `fvj1:` stands for "Fabric Value JSON, version 1". Its
 purpose is to make the encoded form distinguishable, on inspection, from
 arbitrary JSON produced by some other source — a brief peek at the start of
-a string is sufficient to tell whether it carries a fabric-value payload.
+a string is sufficient to tell whether it carries a `FabricValue` payload.
 
 - A conforming **encoder** emits the prefix exactly once, immediately before
   the JSON body, on every encoded value (including encoded primitives — e.g.,
@@ -173,7 +173,7 @@ be lossy through the JSON layer: `JSON.stringify` emits `null` for `NaN` and
 the infinities, and drops the sign of `-0`. On decoding, any other state —
 including one that is not a string — produces a `ProblematicValue`.
 
-Whether such a value reaches the encoder at all depends on the fabric-value
+Whether such a value reaches the encoder at all depends on the `FabricValue`
 conversion gate (`1-fabric-values.md` Section 4.9). The encoding above is the
 encoder's contract however the value arrived.
 
@@ -188,7 +188,7 @@ A symbol with no registry key has no portable representation, and the codec
 declines to encode one rather than coercing it to a key. On decoding, a state
 that is not a string produces a `ProblematicValue`.
 
-Whether such a value reaches the encoder at all depends on the fabric-value
+Whether such a value reaches the encoder at all depends on the `FabricValue`
 conversion gate (`1-fabric-values.md` Section 4.9). The encoding above is the
 encoder's contract however the value arrived.
 
@@ -212,7 +212,7 @@ like any other malformation: a lenient decode yields a `ProblematicValue`
 describing that decode, and a strict one raises. A well-formed record is a
 record of a *past* failure and reads back as one under either setting, this
 decode having succeeded. `state` is checked for presence rather than for type,
-because every fabric value is a valid state, `undefined` among them; filling in
+because every `FabricValue` is a valid state, `undefined` among them; filling
 an absent one would put a reshaped record back on the wire.
 
 See `1-fabric-values.md` Section 3.5.
@@ -268,7 +268,7 @@ built-in escape, or an encoding error.
 > **JS implementation note.** "Any keys" is the format's rule and this
 > implementation does not yet meet it: a plain object carrying `__proto__` or
 > `constructor` is refused rather than encoded, on both sides of the wire and
-> in the inert check that decides what a fabric value is at all. Neither name
+> in the inert check that decides what a `FabricValue` is at all. Neither name
 > is reserved by the format, and neither is a limit of JavaScript. Both are
 > about copying: this implementation rebuilds a record by assignment, which for
 > `__proto__` reaches a prototype accessor instead of creating a property, and

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -1,6 +1,6 @@
 # Realm-Crossing Encoding for Fabric Values
 
-This document specifies the wire format used to carry fabric values between
+This document specifies the wire format used to carry `FabricValue`s between
 realms over a structured-clone transport — `structuredClone()` and
 `postMessage()` — including the outer envelope and its marker, the tagged
 form, per-type encodings, the ownership contract on decode, and what the
@@ -128,7 +128,7 @@ subtree through unchanged, into a data position. A long-lived marker sitting
 there would be read as a tagged form, and user data would decode as a tagged
 value.
 
-The marker must itself be an encodable fabric value, for that same reason: a
+The marker must itself be an encodable `FabricValue`, for that same reason: a
 value holding an earlier call's marker has to encode without complaint, being
 ordinary data.
 
@@ -274,7 +274,7 @@ JSON carries base64url text.
 
 Types binding a format-neutral codec — `FabricError`, `UnknownValue`,
 `ProblematicValue`, and every `FabricInstance` — encode the same way under both
-formats, their state being fabric values all the way down.
+formats, their state being `FabricValue`s all the way down.
 
 ## 4. Cycles and Shared References
 

--- a/docs/specs/space-model-formal-spec/README.md
+++ b/docs/specs/space-model-formal-spec/README.md
@@ -22,7 +22,7 @@ This spec covers:
 - **Realm-crossing encoding** -- the wire format for a structured-clone
   transport: the envelope and the marker that identifies it, per-type
   encodings, the ownership contract on decode, and what the format refuses
-- **Hashing** (Section 6) -- content-based identity for fabric values
+- **Hashing** (Section 6) -- content-based identity for `FabricValue`s
 - **Implementation guidance** (Section 7) -- migration from legacy formats
 
 Out of scope: CRDT-based storage layer, network sync protocols, the reactive
@@ -37,7 +37,7 @@ system, schemas.
 - [2-hash-byte-format.md](./2-hash-byte-format.md) --
   Byte-level encoding for the hash algorithm.
 - [3-json-encoding.md](./3-json-encoding.md) -- The JSON wire format for
-  fabric values: the `fvj1:` encoding prefix, `/<Type>@<Version>` tagged
+  `FabricValue`s: the `fvj1:` encoding prefix, `/<Type>@<Version>` tagged
   objects, standard type encodings, detection, escaping, and the `/`-key
   reservation rule.
 - [4-realm-encoding.md](./4-realm-encoding.md) -- The realm-crossing wire


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Fourth pass over prose that refers to a `data-model` type without naming it.
This one covers `docs/specs/space-model-formal-spec/`. (`packages/data-model`
is #6134; `packages/runner/src` is #6135; `packages/runner/test` is #6137.)

### Deliberately partial

The formal spec is where "fabric value" and "special primitive" are *coined*,
so a blanket conversion would take away the English term the document exists to
introduce. Kept as-is:

- Document titles and section headings ("Fabric Values", "1. Fabric Value
  Types", "4.9 Fabric Value Conversion").
- The defining sentence: "The system stores **fabric values** — data that can
  flow through the runtime…".
- Bolded callout titles ("**Fabric values are deeply read-only…**",
  "**`undefined` as a first-class fabric value.**").
- The `fvj1` / `fvr1` acronym expansions — "Fabric Value JSON, version 1" is
  what the letters stand for.
- The paragraphs introducing "special primitive" as a term, and the
  "Special Primitive Type" table heading.
- Category language: "the fabric type system", "the fabric type hierarchy",
  "branded fabric types".

### Converted

Prose that names a type rather than coining one. "Values must be valid fabric
values" → `FabricValue`s; "a fabric record's keys are strings" →
`FabricPlainObject`'s; "Like every fabric primitive, `FabricHash` hosts a
`[JSON_CODEC]`" → `FabricPrimitive`; "explicit links (fabric instances
referencing other documents)" → `FabricInstance`s.

### One went the other way

Section 1.4.7 called a link "a reference to fabric data". A link addresses a
*document*, not a `FabricValue`, so naming the type there would have been
wrong. It now reads "a reference to data stored in the fabric" — unambiguous
about *not* naming a type, which is the same goal reached from the other side.

### Quoted source blocks

`1-fabric-values.md` reproduces doc comments from `packages/data-model`. Those
copies are re-synced with the versions in #6134, so the two agree again.

### Testing

- `deno task check-docs`: `All 564 checked code block(s) passed.`
- No line exceeds 80 columns that did not already; the file has 116 such lines
  on `main` (mostly table rows and code blocks) and this adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

