### PR TITLE
docs: name the type across api, piece, schema-generator, and neighbors

### DIFF
--- a/packages/api/index.test.ts
+++ b/packages/api/index.test.ts
@@ -19,7 +19,7 @@ Deno.test("api module loads and re-exports the CFC canonical alias names", () =>
   }
 });
 
-Deno.test("isFabricPrimitiveSchemaType accepts exactly the fabric-primitive vocabulary", () => {
+Deno.test("isFabricPrimitiveSchemaType accepts exactly the `FabricPrimitive` vocabulary", () => {
   expect(FABRIC_PRIMITIVE_SCHEMA_TYPES.length).toBeGreaterThan(0);
   for (const name of FABRIC_PRIMITIVE_SCHEMA_TYPES) {
     expect(isFabricPrimitiveSchemaType(name)).toBe(true);

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -42,8 +42,8 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
  * The nominal brand key declared on `FabricSpecialObject`. It exists only in
  * the type system — a runtime instance never carries the key; `instanceof
  * FabricSpecialObject` is its runtime form. Schema `required` presence
- * checks must therefore treat this key as satisfied by any fabric value
- * rather than probing for it with `in`.
+ * checks must therefore treat this key as satisfied by any
+ * `FabricSpecialObject` rather than probing for it with `in`.
  */
 export const FABRIC_SPECIAL_OBJECT_BRAND = "@commonfabric/FabricSpecialObject";
 
@@ -87,7 +87,7 @@ export declare const FabricInstance:
   & FabricInstanceConstructor
   & (abstract new (...args: any) => FabricInstance);
 
-/** Abstract base class for fabric primitive types. */
+/** Abstract base class for `FabricPrimitive` types. */
 export interface FabricPrimitive extends FabricSpecialObject {}
 
 export interface FabricPrimitiveConstructor {
@@ -239,7 +239,7 @@ export type FabricErrorState = {
 };
 
 /**
- * An error carried as fabric data. Extends `FabricInstance` (not
+ * An error carried as a `FabricValue`. Extends `FabricInstance` (not
  * `FabricPrimitive`): it holds fixed-schema slots plus a bag of extras, and
  * `cause` may be an arbitrary `FabricValue`, so it is a small object graph
  * rather than a leaf.
@@ -299,13 +299,13 @@ export type FabricValue =
   | FabricPlainObject
   | undefined;
 
-/** A fabric value other than `null` or `undefined`. */
+/** A `FabricValue` other than `null` or `undefined`. */
 export type NonNullableFabricValue = NonNullable<FabricValue>;
 
-/** Read-only array of fabric values. */
+/** Read-only array of `FabricValue`s. */
 export interface FabricArray extends ReadonlyArray<FabricValue> {}
 
-/** Read-only object/record of fabric values. */
+/** Read-only object/record of `FabricValue`s. */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}
 
@@ -1815,12 +1815,13 @@ export interface JSONObject extends Readonly<Record<string, JSONValue>> {}
 export type MutableJSONValue = Mutable<JSONValue>;
 
 /**
- * Fabric-primitive validation types -- a non-standard addition to the JSON
+ * `FabricPrimitive` validation types -- a non-standard addition to the JSON
  * Schema `type` vocabulary. Each name identifies a concrete `FabricPrimitive`
  * class from the data-model, and a value matches by prototype (`instanceof`),
- * not by structure. `"object"` also accepts these values -- every fabric
- * primitive is a subtype of `"object"` the way an `"integer"` value satisfies
- * a `"number"` schema -- so schemas that predate this vocabulary keep working.
+ * not by structure. `"object"` also accepts these values -- every
+ * `FabricPrimitive` is a subtype of `"object"` the way an `"integer"` value
+ * satisfies a `"number"` schema -- so schemas that predate this vocabulary keep
+ * working.
  */
 export const FABRIC_PRIMITIVE_SCHEMA_TYPES = Object.freeze(
   [

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -279,7 +279,7 @@ type SchemaInner<
  * - $ref resolution (both "#" and "#/path/to/def")
  * - anyOf unions
  * - Primitive types (string, number, boolean, null)
- * - Fabric-primitive types ("FabricBytes", "FabricEpochDay",
+ * - `FabricPrimitive` types ("FabricBytes", "FabricEpochDay",
  *   "FabricEpochNsec", "FabricHash", "FabricRegExp"), each inferring the
  *   corresponding `FabricPrimitive` interface from this package
  * - Arrays with typed items

--- a/packages/html/test/worker-keying.test.ts
+++ b/packages/html/test/worker-keying.test.ts
@@ -84,7 +84,7 @@ Deno.test("keying - generateKey", async (t) => {
     assertNotEquals(key({ n: NaN }), key({ n: null }));
     assertNotEquals(key({ n: -0 }), key({ n: 0 }));
 
-    // A `bigint` is a fabric value, so it keys precisely even though
+    // A `bigint` is a `FabricValue`, so it keys precisely even though
     // `WorkerProps` does not admit one.
     assertNotEquals(key({ n: 1n }), key({ n: 2n }));
     assertNotEquals(key({ n: 1n }), key({ n: 1 }));

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -525,7 +525,7 @@ export class LLMClient {
 
     const endpoint = opts?.endpoint?.toString() ?? llmApiUrl;
     // TODO(danfuzz): `assertJsonTransportSafe` above covers the SCHEMA, but
-    // the request's `messages` cross unchecked: a fabric value in message
+    // the request's `messages` cross unchecked: a `FabricValue` in message
     // content (assembled runner-side from live cell reads) stringifies to
     // `{}` here, silently. The payload wants the same transport-safety
     // check the schema gets.
@@ -634,7 +634,7 @@ export class LLMClient {
 
     // TODO(danfuzz): same gap as `generateObject` above — tool input schemas
     // are checked with `assertJsonTransportSafe`, but the request's
-    // `messages`/`system` data is not, and a fabric value in it stringifies
+    // `messages`/`system` data is not, and a `FabricValue` in it stringifies
     // to `{}` here, silently.
     const response = await fetch(opts?.endpoint?.toString() ?? llmApiUrl, {
       method: "POST",

--- a/packages/llm/src/schema-transport.ts
+++ b/packages/llm/src/schema-transport.ts
@@ -11,7 +11,7 @@ import { findJsonUnfaithfulValues } from "@commonfabric/pure-json";
  * provider: the request is sent as ordinary JSON (`JSON.stringify`), so any
  * value it carries that plain JSON cannot represent faithfully reaches the
  * provider altered, dropped, or not at all -- or crashes the serialization.
- * The Common Fabric value model is a superset of JSON, so a generated schema
+ * The `FabricValue` model is a superset of JSON, so a generated schema
  * (a `generateObject` schema, or a tool's `inputSchema`) may legitimately hold
  * values JSON cannot carry. Those are fine internally. Crossing to a provider,
  * they are not. The generic detection of JSON-unfaithful values lives in
@@ -32,7 +32,7 @@ export function assertJsonTransportSafe(value: unknown, label: string): void {
   throw new Error(
     `${label} holds ${problems.length} value(s) that ordinary JSON ` +
       `serialization would not carry faithfully:\n${lines.join("\n")}\n` +
-      `These are valid Common Fabric values, but the request reaches the ` +
+      `These are valid \`FabricValue\`s, but the request reaches the ` +
       `provider as ordinary JSON. Remove or replace the value(s) above.`,
   );
 }

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -84,7 +84,7 @@ export type LLMToolResult = {
  * Request metadata. This crosses a JSON boundary to a general LLM API, so
  * values must be values ordinary JSON serialization carries faithfully -- not
  * merely `FabricValue`s, which admit `bigint`, interned symbols, `NaN` / `-0`,
- * and fabric primitives that no model API can receive.
+ * and `FabricPrimitive`s that no model API can receive.
  *
  * `isLLMRequestMetadata()` is the authority: it checks with `isPureJson()`. An `undefined` value means "absent" -- JSON
  * drops such a key, so it never crosses the boundary and is not checked.

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -623,7 +623,8 @@ export function linkPathContracts(
           throw new Error(`array link path contains non-index segment ${part}`);
         }
         const index = Number(part);
-        // Fabric arrays preserve sparse holes. `minItems` constrains length,
+        // A `FabricArray` preserves sparse holes. `minItems` constrains
+        // length,
         // not own-property presence, so every indexed source path can still
         // yield Fabric `undefined` even for an unconditionally shaped array.
         const mayBeMissing = contract.mayBeMissing === true ||

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -492,14 +492,14 @@ function schemaSubsetIssue(
     }
 
     // A brand-marked structural emission (the pre-vocabulary generator's
-    // shape for a fabric special object) moving to a fabric-primitive-typed
+    // shape for a `FabricSpecialObject`) moving to a `FabricPrimitive`-typed
     // schema is deliberately NOT allowed through here, even under
     // `allowEvolutionPolicy`. The structural schema is an ordinary object
     // schema, so its value population is decided structurally: a plain
     // record carrying the brand key as an own property satisfies it, and the
     // presence-only `required` checks admit primitives of other classes
     // (`FabricHash` has `length`, so it inhabits the `FabricBytes` emission).
-    // A fabric-primitive-typed schema matches by prototype, and a pattern
+    // A `FabricPrimitive`-typed schema matches by prototype, and a pattern
     // update rewrites the stored argument verbatim -- nothing converts -- so
     // every such inhabitant would survive the update only to be rejected by
     // reads. The transition therefore narrows for every class, and it is
@@ -987,7 +987,7 @@ function typeSubsetIssue(
     !targetTypes.some((targetType) =>
       sourceType === targetType ||
       (sourceType === "integer" && targetType === "number") ||
-      // Each fabric-primitive type is a subtype of "object" (mirrors
+      // Each `FabricPrimitive` type is a subtype of "object" (mirrors
       // schemaTypeMatchesValueType in the runner's traverse).
       (isFabricPrimitiveSchemaType(sourceType) && targetType === "object")
     )

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1235,7 +1235,7 @@ describe("piece schema compatibility", () => {
     ).toThrow(/enum\/const became more restrictive/);
   });
 
-  it("treats fabric-primitive types as subtypes of object (one-way)", () => {
+  it("treats `FabricPrimitive` types as subtypes of object (one-way)", () => {
     // A "FabricBytes" source widens safely into an "object" target; the
     // reverse narrows and must be flagged. Same-type stays compatible.
     expect(() =>
@@ -2212,15 +2212,15 @@ describe("piece schema compatibility", () => {
     }
   });
 
-  describe("fabric-primitive schema vocabulary transitions", () => {
+  describe("`FabricPrimitive` schema vocabulary transitions", () => {
     // The schema generator used to describe a fabric special object
     // structurally: an object schema whose `required` carries the
     // `FabricSpecialObject` nominal brand key. It now emits the
-    // fabric-primitive type name instead. That transition is refused, for
+    // `FabricPrimitive` type name instead. That transition is refused, for
     // pattern evolution too: the structural schema admits values by shape
     // (a plain record carrying the brand key as an own property, or a
     // primitive of another class whose members cover `required`), the
-    // fabric-primitive-typed schema matches by prototype, and a pattern
+    // `FabricPrimitive`-typed schema matches by prototype, and a pattern
     // update rewrites stored data verbatim -- so any such value would
     // survive the update only to be rejected by every subsequent read.
     // See the note in `schemaSubsetIssue`.
@@ -2237,7 +2237,7 @@ describe("piece schema compatibility", () => {
       required: ["blob"],
     });
 
-    it("refuses an argument field moving from the brand-marked structural emission to its fabric-primitive type", () => {
+    it("refuses an argument field moving from the brand-marked structural emission to its `FabricPrimitive` type", () => {
       expect(() =>
         assertPatternSchemasBackwardCompatible(
           pattern(withField(oldBytes), true),
@@ -2246,10 +2246,10 @@ describe("piece schema compatibility", () => {
       ).toThrow(/type object is not accepted/);
     });
 
-    it("accepts a result field moving from the brand-marked structural emission to its fabric-primitive type", () => {
+    it("accepts a result field moving from the brand-marked structural emission to its `FabricPrimitive` type", () => {
       // The result direction proves candidate-within-previous: the new
       // schema's population is prototype-matched primitives, and every one
-      // satisfies the old structural contract (fabric-primitive types are
+      // satisfies the old structural contract (`FabricPrimitive` types are
       // subtypes of "object", members are present via `in`, and the brand
       // is exempt for instances). Nothing is stranded, so no allowance is
       // involved -- this holds through the ordinary subset machinery.
@@ -2277,7 +2277,7 @@ describe("piece schema compatibility", () => {
       }
     });
 
-    it("refuses a plain object schema without the brand against a fabric-primitive type", () => {
+    it("refuses a plain object schema without the brand against a `FabricPrimitive` type", () => {
       const plainObject: JSONSchema = {
         type: "object",
         properties: { length: { type: "number" } },

--- a/packages/pure-json/src/json-faithfulness.ts
+++ b/packages/pure-json/src/json-faithfulness.ts
@@ -165,7 +165,7 @@ function walk(
       // it, so it is not an offender.
       //
       // A hole is a separate matter, reported by the element loop below: JSON
-      // cannot carry one, while a fabric value can. The two checks disagree
+      // cannot carry one, while a `FabricValue` can. The two checks disagree
       // there on purpose.
       for (const key of Object.getOwnPropertyNames(obj)) {
         if ((key !== "length") && !isArrayIndexPropertyName(key)) {

--- a/packages/schema-generator/AGENTS.md
+++ b/packages/schema-generator/AGENTS.md
@@ -29,7 +29,7 @@ via subpath exports. Entry point is `src/index.ts` (not `mod.ts`).
 - Semantic sentinels: `any` → `true`; `unknown` → `{ type: "unknown" }`; `never`
   → `false`; `void` → `{ asCell: ["opaque"] }`; `undefined` survives in unions
   (`{ type: "undefined" }`). The `unknown`/`undefined` type values are
-  deliberate non-standard extensions, as are the fabric-primitive type names
+  deliberate non-standard extensions, as are the `FabricPrimitive` type names
   (`{ type: "FabricBytes" }` and friends — see `FABRIC_PRIMITIVE_SCHEMA_TYPES`
   in `packages/api/index.ts`), emitted for fields authored against those
   classes.

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -15,14 +15,14 @@ const NATIVE_TYPE_SCHEMAS: Record<string, MutableJSONSchema> = {
   // does not: the read projects to `undefined`, which is what the `Date`
   // mapping used to do to every value read through the schema its own TS type
   // generates.) These deliberately stay `"object"` rather than adopting the
-  // fabric-primitive type names below: a field authored against a NATIVE TS
+  // `FabricPrimitive` type names below: a field authored against a NATIVE TS
   // type can hold a raw native value on the way into the fabric boundary, and
-  // the fabric-primitive types validate by prototype only.
+  // the `FabricPrimitive` types validate by prototype only.
   Date: { type: "object" },
   RegExp: { type: "object" },
   Uint8Array: { type: "object" },
-  // Fields authored against the fabric-primitive classes themselves emit the
-  // fabric-primitive schema vocabulary (`FABRIC_PRIMITIVE_SCHEMA_TYPES` in
+  // Fields authored against the `FabricPrimitive` classes themselves emit
+  // the `FabricPrimitive` schema vocabulary (`FABRIC_PRIMITIVE_SCHEMA_TYPES` in
   // `@commonfabric/api`): a value matches by prototype, not by structure.
   // Guarded in `supportsType` by the `FabricSpecialObject` brand so an
   // unrelated user type sharing a name keeps its structural schema.
@@ -167,7 +167,9 @@ export class NativeTypeFormatter implements TypeFormatter {
     return type.aliasSymbol;
   }
 
-  /** Whether the name is one of the fabric-primitive schema-vocabulary names. */
+  /**
+   * Whether the name is one of the `FabricPrimitive` schema-vocabulary names.
+   */
   public static isFabricPrimitiveTypeName(
     typeName: string | undefined,
   ): boolean {
@@ -177,7 +179,7 @@ export class NativeTypeFormatter implements TypeFormatter {
   /**
    * Whether the type carries the `FabricSpecialObject` nominal brand
    * (directly or by inheritance). This is what makes a type named e.g.
-   * `FabricBytes` actually BE the fabric-primitive class rather than an
+   * `FabricBytes` actually BE the `FabricPrimitive` class rather than an
    * unrelated user type that happens to share the name. Both this formatter's
    * `supportsType` and named-type hoisting (`getNamedTypeKey`,
    * `type-utils.ts`) classify by it, so an unbranded name-sharer keeps its

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -513,7 +513,7 @@ export function getNamedTypeKey(
 
   // If we are overriding the type, don't return a named type key.
   // This makes it so we include these inline instead of as $defs. The
-  // fabric-primitive names are only claimed by NativeTypeFormatter when the
+  // `FabricPrimitive` names are only claimed by NativeTypeFormatter when the
   // type carries the FabricSpecialObject brand; hoisting classifies the same
   // way, so an unbranded user type sharing a name hoists normally.
   if (NativeTypeFormatter.isNativeType(name)) {

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -133,7 +133,7 @@ defineFixtureSuite<SchemaResult, string>({
       );
     }
 
-    // A generated schema is a fabric value; `normalizeArrayOrdering` is typed
+    // A generated schema is a `FabricValue`; `normalizeArrayOrdering` is typed
     // loosely because it walks arbitrary structure.
     const normalizedActual = normalizeArrayOrdering(
       actual.normalized,

--- a/packages/schema-generator/test/fixtures/schema/fabric-primitive-name-collision.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/fabric-primitive-name-collision.input.ts
@@ -1,5 +1,5 @@
-// A user type that shares a fabric-primitive class name but does NOT carry
-// the `FabricSpecialObject` brand is not claimed by the fabric-primitive
+// A user type that shares a `FabricPrimitive` class name but does NOT carry
+// the `FabricSpecialObject` brand is not claimed by the `FabricPrimitive`
 // schema vocabulary: it keeps its structural schema and its normal
 // named-type hoisting.
 interface FabricBytes {

--- a/packages/schema-generator/test/fixtures/schema/fabric-special-object-brand.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/fabric-special-object-brand.input.ts
@@ -2,8 +2,8 @@
 // only in the type system -- no runtime value carries it -- so the generator
 // must not surface it as a schema property or requirement.
 //
-// A concrete fabric-primitive class (`FabricBytes`) emits its
-// fabric-primitive schema type (`{ type: "FabricBytes" }`, matched by
+// A concrete `FabricPrimitive` class (`FabricBytes`) emits its
+// `FabricPrimitive` schema type (`{ type: "FabricBytes" }`, matched by
 // prototype at validation time). A branded type OUTSIDE that vocabulary
 // (the `FabricPrimitive` base here) still emits a structural object schema,
 // with the brand skipped.

--- a/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.expected.jsx
@@ -12,8 +12,8 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 // FIXTURE: fabric-special-object-brand
-// Verifies: a field authored against a fabric-primitive class emits its
-// fabric-primitive schema type (`{ type: "FabricBytes" }`, matched by
+// Verifies: a field authored against a `FabricPrimitive` class emits its
+// `FabricPrimitive` schema type (`{ type: "FabricBytes" }`, matched by
 // prototype at validation time), and the `FabricSpecialObject` nominal brand
 // -- a type-system-only key -- never reaches a generated schema.
 export default pattern((state: {

--- a/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/fabric-special-object-brand.input.tsx
@@ -1,8 +1,8 @@
 import { type FabricBytes, pattern, UI } from "commonfabric";
 
 // FIXTURE: fabric-special-object-brand
-// Verifies: a field authored against a fabric-primitive class emits its
-// fabric-primitive schema type (`{ type: "FabricBytes" }`, matched by
+// Verifies: a field authored against a `FabricPrimitive` class emits its
+// `FabricPrimitive` schema type (`{ type: "FabricBytes" }`, matched by
 // prototype at validation time), and the `FabricSpecialObject` nominal brand
 // -- a type-system-only key -- never reaches a generated schema.
 export default pattern((state: { blob: FabricBytes }) => {

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -8,7 +8,7 @@ import { isPlainObject } from "./types.ts";
  *
  * Intended use is to canonicalize an object shape for stable comparison
  * (e.g. content-hashing), where a property that's present-but-`undefined`
- * should be treated the same as an omitted property. The fabric-value layer
+ * should be treated the same as an omitted property. The `FabricValue` layer
  * preserves `undefined`-valued properties, so callers that need this
  * normalization must apply it directly.
  */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -293,7 +293,7 @@ export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
 // callable `then` is adopted by promise resolution, and a layer that answers a
 // property with a function can make a data key callable -- which is why the
 // value proxies in `runner` guard the name. But JSON Schema uses `if` / `then`
-// / `else`, and this system's schemas are themselves fabric values, so
+// / `else`, and this system's schemas are themselves `FabricValue`s, so
 // reserving the name would stop an ordinary schema being one. The hazard is
 // real and is handled where a property becomes callable, not here.
 const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Sixth pass over prose that refers to a `data-model` type without naming it.
This one covers `api`, `piece`, `schema-generator`, `ts-transformers`, `llm`,
`html`, `pure-json` and `utils`. (Earlier: #6134 `data-model`, #6135
`runner/src`, #6137 `runner/test`, #6138 the formal spec, #6139 docs.)

### `packages/api/index.ts`

It mirrors `data-model/src/interface.ts` by design, so its doc comments get the
same treatment the originals got in #6134 — including the same narrowing: the
nominal brand key is "satisfied by any `FabricSpecialObject`", not by any
fabric value. A `FabricValue` that is a plain object or a scalar does not carry
the brand.

### One error message

`llm/src/schema-transport.ts` said "These are valid Common Fabric values"; it
now says "valid `FabricValue`s". The literal has exactly one occurrence in the
tree and no test pins it.

### One golden moved with its fixture

`schema-transform/fabric-special-object-brand.input.tsx` has its comment
reproduced verbatim in `fabric-special-object-brand.expected.jsx`, so the two
move together. The transformer fixture suite is what checks that they agree,
and it is green.

### Testing

`deno task test` in each of the eight packages, all `0 failed`:

| package | passed |
| --- | --- |
| `api` | 26 |
| `piece` | 39 |
| `schema-generator` | 56 |
| `ts-transformers` | 1162 |
| `llm` | 7 |
| `html` | 39 |
| `pure-json` | 1 |
| `utils` | 99 |

`deno fmt --check` and `deno lint` across the eight: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

