### PR TITLE
docs: name the type across cli, connectors, memory, and runtime-client

### DIFF
--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1318,7 +1318,7 @@ describe("executePieceCallable", () => {
   });
 
   it("returns a keyless instance result instead of reading it as value-less", async () => {
-    // The value-less witness is a PLAIN empty record. A fabric primitive
+    // The value-less witness is a PLAIN empty record. A `FabricPrimitive`
     // whose slots are private — FabricBytes — has no enumerable keys, and a
     // key-count test alone would swallow it as "no result".
     class FakeBytes {

--- a/packages/cli/test/piece-label.test.ts
+++ b/packages/cli/test/piece-label.test.ts
@@ -334,7 +334,7 @@ describe("cf piece CFC labels", () => {
     expect(updated?.entries[0].label.confidentiality).toEqual(["team"]);
   });
 
-  it("preserves raw Fabric values while adding a label", async () => {
+  it("preserves raw `FabricValue`s while adding a label", async () => {
     const original = {
       bytes: new FabricBytes(new Uint8Array([1, 2, 3])),
       timestamp: new FabricEpochNsec(1_725_000_000_000_000_000n),

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -2387,7 +2387,7 @@ describe("cli piece parsing", () => {
     ).toEqual([]);
   });
 
-  it("reports unreadable iterators, cell proxies, and Fabric values", async () => {
+  it("reports unreadable iterators, cell proxies, and `FabricValue`s", async () => {
     const iteratorError = new Error("array keys are not readable");
     const unreadableArray = new Proxy<unknown[]>([], {
       ownKeys: () => {

--- a/packages/connectors/agents/docs/interfaces.md
+++ b/packages/connectors/agents/docs/interfaces.md
@@ -122,7 +122,7 @@ session read succeeded, and every snapshot reported itself complete.
 `prepareSession(sourceId, snapshot, targetChunkBytes?)` is available when a host
 or another target needs the connector's stable key, chunks, and hashes without
 publishing to Fabric. It captures the summary, provider events, and normalized
-messages as immutable Fabric values before it measures chunks or computes
+messages as immutable `FabricValue`s before it measures chunks or computes
 hashes. The returned chunks contain those captured event values.
 
 ### Fabric connection and target
@@ -553,7 +553,7 @@ capabilities, up to 12 recent normalized message previews, a live manifest cell
 link, content hash, and synchronization status. The lifecycle fields describe
 provider state. Synchronization status describes the connector's published copy.
 
-The manifest and chunk fields are stored as Fabric links rather than copied
+The manifest and chunk fields are stored as `FabricLink`s rather than copied
 objects. A consumer whose schema declares those fields as `Cell` values can read
 one session graph without hydrating every session represented by the index. The
 target rejects an index containing an entry without `formatVersion: 1`. It does
@@ -637,12 +637,12 @@ or child value gets its own cell-to-link and native-to-Fabric conversion. These
 are the same conversion boundaries used when the graph is written.
 
 `stableFabricValue()` performs this conversion for both hashing and graph
-writes. It replaces connector-owned cells with complete Fabric links. It then
-captures native plain data as immutable Fabric data. Native `toJSON()` methods
-and property getters run during this capture. Later hashing and writing use the
-captured result, so a mutable native object cannot change between those steps.
-Shared JavaScript references retain their Fabric value semantics and do not
-become path-only links. Circular values and arrays with enumerable named
+writes. It replaces connector-owned cells with complete `FabricLink`s. It then
+captures native plain data as immutable `FabricValue`s. Native `toJSON()`
+methods and property getters run during this capture. Later hashing and writing
+use the captured result, so a mutable native object cannot change between those
+steps. Shared JavaScript references retain their `FabricValue` semantics and do
+not become path-only links. Circular values and arrays with enumerable named
 properties are rejected at this boundary because they have no supported Fabric
 representation. Supported Fabric protocol instances are captured as private
 immutable values. Links and errors are rebuilt around captured state. Unknown
@@ -650,12 +650,12 @@ and problematic tagged values receive the same treatment because their general
 deep-clone methods are not yet implemented. This includes links returned by
 connector-owned cells in the modern cell representation. Mutating an original
 instance, nested state, link, or link payload cannot change a planned hash or
-graph. Captured Fabric links are atomic planner values. Arrays inside a link
+graph. Captured `FabricLink`s are atomic planner values. Arrays inside a link
 payload, including a cell subpath, are not split into child cells.
 
-The Fabric value hash distinguishes undefined values, sparse array holes,
+The `FabricValue` hash distinguishes undefined values, sparse array holes,
 special numbers, bigints, bytes, dates, regular expressions, errors, and other
-accepted Fabric values. Object key order does not affect the hash. Array order
+accepted `FabricValue`s. Object key order does not affect the hash. Array order
 is preserved.
 
 ### Graph commits and hydration
@@ -667,7 +667,7 @@ each deterministic child and places the returned cell in that object.
 
 The materializer writes each child through the graph's runtime edit transaction
 and returns the child cell. The parent conversion replaces that cell with its
-Fabric link. Nested children are written before the child that links to them.
+`FabricLink`. Nested children are written before the child that links to them.
 
 Existing object values use the same field-write approach as Loom's stable graph
 helper. Each property is written at its own path under the cell's `value` field.
@@ -693,7 +693,7 @@ chunks before a manifest cannot mutate the graph reachable from the prior
 manifest.
 
 `readStableCellGraphValue()` synchronizes a root cell and recursively hydrates
-Fabric links. It caches repeated links within one read and synchronizes at most
+`FabricLink`s. It caches repeated links within one read and synchronizes at most
 50 array children concurrently.
 
 Its optional fourth argument accepts `preserveLinkFields`. A link stored under a
@@ -820,7 +820,7 @@ receipts.
 The optional receipt `result` is stored as an `fvj1:` Fabric JSON string inside
 the outer ledger JSON file. The ledger decodes that string before returning a
 receipt. This preserves `undefined`, big integers, special numbers, links, and
-other Fabric values across process restarts.
+other `FabricValue`s across process restarts.
 
 Writes are serialized. Receipts are sorted by command ID. Every committed write
 increments `generation`. On Unix systems, the ledger writes an indented

--- a/packages/connectors/agents/src/stable-fabric-value.ts
+++ b/packages/connectors/agents/src/stable-fabric-value.ts
@@ -242,9 +242,9 @@ function captureFabricValue(
 }
 
 /**
- * Capture a graph value as immutable Fabric data. Stable child cells become
- * links, while native values and shared references retain their Fabric value
- * semantics.
+ * Capture a graph value as an immutable `FabricValue`. Stable child cells
+ * become links, while native values and shared references retain their
+ * `FabricValue` semantics.
  */
 export function stableFabricValue(value: unknown): FabricValue {
   return captureFabricValue(

--- a/packages/connectors/agents/test/canonical-json_test.ts
+++ b/packages/connectors/agents/test/canonical-json_test.ts
@@ -17,7 +17,7 @@ import {
   planStableArrayCells,
 } from "../src/array-cell-identity.ts";
 
-Deno.test("connector hashes distinguish Fabric values that JSON conflates", async () => {
+Deno.test("connector hashes distinguish `FabricValue`s that JSON conflates", async () => {
   assertNotEquals(
     await hashStableArrayValue([{ id: "event", detail: undefined }]),
     await hashStableArrayValue([{ id: "event" }]),
@@ -61,7 +61,7 @@ Deno.test("connector hashes match independently stored array children", async ()
   );
 });
 
-Deno.test("connector hashes preserve native Fabric values", async () => {
+Deno.test("connector hashes preserve native `FabricValue`s", async () => {
   assertNotEquals(
     await hashStableArrayValue(new Date(0)),
     await hashStableArrayValue(new Date(1)),
@@ -85,7 +85,7 @@ Deno.test("deeply nested arrays are hashed without repeated planning", async () 
   );
 });
 
-Deno.test("stable plans freeze modern Fabric links", async () => {
+Deno.test("stable plans freeze modern `FabricLink`s", async () => {
   setModernCellRepConfig(true);
   try {
     const payload = { path: ["before"] };
@@ -116,7 +116,7 @@ Deno.test("stable plans freeze modern Fabric links", async () => {
   }
 });
 
-Deno.test("stable plans privately capture mutable Fabric instances", async () => {
+Deno.test("stable plans privately capture mutable `FabricInstance`s", async () => {
   setModernCellRepConfig(true);
   try {
     const linkPayload = { path: ["before"] };
@@ -155,7 +155,7 @@ Deno.test("stable plans privately capture mutable Fabric instances", async () =>
     const materialized = materializeStableArrayCells(
       plan,
       () => {
-        throw new Error("Fabric instance unexpectedly became an array cell");
+        throw new Error("`FabricInstance` unexpectedly became an array cell");
       },
     ) as {
       error: FabricError;

--- a/packages/connectors/agents/test/commands_test.ts
+++ b/packages/connectors/agents/test/commands_test.ts
@@ -965,7 +965,7 @@ Deno.test("synchronous driver failures publish a terminal receipt", async () => 
   }
 });
 
-Deno.test("receipt ownership compares Fabric values", async () => {
+Deno.test("receipt ownership compares `FabricValue`s", async () => {
   const directory = await Deno.makeTempDir();
   try {
     const ledger = await CommandLedger.open(`${directory}/ledger.json`);

--- a/packages/connectors/agents/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/test/fabric-graph_test.ts
@@ -120,7 +120,7 @@ Deno.test("stable graph writes keep child identity and hydrate linked values", a
   }
 });
 
-Deno.test("stable graph writes preserve native Fabric values", async () => {
+Deno.test("stable graph writes preserve native `FabricValue`s", async () => {
   const signer = await Identity.fromPassphrase(
     "agent connector native graph test",
   );

--- a/packages/memory/test/session-open-auth.test.ts
+++ b/packages/memory/test/session-open-auth.test.ts
@@ -76,7 +76,7 @@ describe("wireAuthorizationOf", () => {
 
   it("rejects a signature that is not `FabricBytes`", () => {
     // Raw bytes are what the in-process `Signature<T>` looks like; the wire
-    // form must be the fabric primitive, so this must not narrow.
+    // form must be the `FabricPrimitive`, so this must not narrow.
     assertEquals(
       wireAuthorizationOf({ signature: new Uint8Array([1, 2, 3]) }),
       undefined,

--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -303,7 +303,7 @@ Deno.test("memory v2 session closed mid-watch-set arms no ack timer", async () =
 
   const transport: Transport = {
     send(payload: string) {
-      // Frames carry the `fvj1:` fabric-value encoding, not bare JSON, so this
+      // Frames carry the `fvj1:` `FabricValue` encoding, not bare JSON, so
       // reads the payload as text.
       if (payload.includes('"session.watch.set"')) {
         setRequestId = /"requestId":"([^"]+)"/.exec(payload)?.[1] ?? null;

--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -304,7 +304,7 @@ Deno.test("memory v2 session closed mid-watch-set arms no ack timer", async () =
   const transport: Transport = {
     send(payload: string) {
       // Frames carry the `fvj1:` `FabricValue` encoding, not bare JSON, so
-      // reads the payload as text.
+      // this reads the payload as text.
       if (payload.includes('"session.watch.set"')) {
         setRequestId = /"requestId":"([^"]+)"/.exec(payload)?.[1] ?? null;
       }

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -25,7 +25,7 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  * generically and its wrapped native `Error` -- whose `message`/`stack`
  * are non-enumerable -- collapses to `{}`, losing the error entirely.
  *
- * `cloneIfNecessary()` deep-clones via the fabric value machinery
+ * `cloneIfNecessary()` deep-clones via the `FabricValue` machinery
  * (`FabricInstance.deepClone()` for wrappers), preserving the class.
  * Its default options (`{ frozen: true, deep: true }`) return an
  * already-deep-frozen input by identity, so replayed engine passes over a

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -71,7 +71,7 @@ export type SessionOpenMessage = {
  * {@link wireAuthorizationOf} may produce this type.
  *
  * The signature crosses the wire as a `FabricBytes` -- the canonical binary
- * fabric value -- not as the `Uint8Array`-derived `Signature<T>` used
+ * `FabricValue` -- not as the `Uint8Array`-derived `Signature<T>` used
  * in-process.
  */
 export type WireSessionOpenAuthorization = {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -2950,12 +2950,13 @@ describe("assertFabricLoggerFlags", () => {
     expect(() => assertFabricLoggerFlags(flags)).not.toThrow();
   });
 
-  it("refuses a flag named with a key no fabric record carries", () => {
+  it("refuses a flag named with a key no `FabricPlainObject` carries", () => {
     // `__proto__` and `constructor` are refused as fabric keys deliberately,
     // and `1-fabric-values.md` specifies it. An IPC payload is a `FabricValue`
-    // per se -- the envelope as much as the metadata, a record of fabric values
-    // being one itself -- so a flag named one of them cannot cross, and saying
-    // so is the point rather than a limitation to route around.
+    // per se -- the envelope as much as the metadata, a record of
+    // `FabricValue`s being one itself -- so a flag named one of them cannot
+    // cross, and saying so is the point rather than a limitation to route
+    // around.
     const flags = { runner: { constructor: { "id:1": { a: 1 } } } };
 
     expect(() => assertFabricLoggerFlags(flags)).toThrow(

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -994,7 +994,7 @@ export class RuntimeProcessor {
     //
     // TODO(danfuzz): `convertCellsToLinks` preserves a `FabricPrimitive` by
     // identity, so despite the `as JSONValue` cast below the response can
-    // hold live fabric objects, and `postMessage`'s structured clone
+    // hold live `FabricSpecialObject`s, and `postMessage`'s structured clone
     // silently strips their prototype and private state to `{}` on the way
     // to the main thread. The inbound direction throws instead
     // (`CellHandle.serialize`; see the `WireCellValue` marker in

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -109,7 +109,7 @@ export function mapCellRefsToSigilLinks(value: FabricValue): FabricValue {
  *
  * Nothing reaches the throw today, de facto rather than by construction: no
  * flag gates it, and every producer that raises a flag with metadata passes
- * fabric data -- one of them a cell's own raw value.
+ * a `FabricValue` -- one of them a cell's own raw value.
  */
 export function assertFabricLoggerFlags(
   breakdown: LoggerFlagsBreakdown,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Seventh pass over prose that refers to a `data-model` type without naming it.
This one covers `cli`, `connectors/agents`, `memory` and `runtime-client`.
(Earlier: #6134 `data-model`, #6135 `runner/src`, #6137 `runner/test`, #6138
the formal spec, #6139 docs, #6140 `api`/`piece`/`schema-generator` and
neighbors.)

### Two collisions deliberately left alone

**`URL of the fabric instance`** — the CLI help text for `CF_API_URL`, in six
command files. That is the running Common Fabric *server*, not a
`FabricInstance`. Naming a type there would be wrong. Worth flagging that the
phrase is genuinely ambiguous in a way the sweep can't fix: resolving it means
changing user-facing wording (e.g. "URL of the Common Fabric server"), which is
a product call rather than a naming one.

**CLI test fixture data** — `"of:fabric-hash"`, `"Fabric hash"`, `"Needle in
encoded Fabric data"`. Input to a search, not prose about a type.

### Two conversions narrower than the words were

- `runtime-processor.ts` says the response can "hold live fabric objects" that
  `postMessage`'s structured clone strips to `{}`. What has that property is a
  `FabricSpecialObject` — state in private fields behind prototype accessors.
- The flags test refuses a key "no fabric record carries", which is
  `FabricPlainObject`.

### Note on the diff size

`connectors/agents/docs/interfaces.md` is reflowed by `deno fmt` after the
substitution, so its diff shows 14 changed lines for 10 edits.

### Testing

`deno task test` in each of the four packages, all `0 failed`: `cli` 175,
`connectors/agents` 114, `memory` 552, `runtime-client` 65 passed.
`deno fmt --check` and `deno lint` across the four: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

