### PR TITLE
fix: rewrap two comments the naming sweep left ragged

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1343,9 +1343,8 @@ Section 4.5.
   shape a `FabricValue` has
 
 > **Property names this implementation reserves.** A `FabricPlainObject`'s keys
-> are
-> strings, and the model attaches no meaning to any particular one: a property
-> name is data. Two names are nonetheless refused by the JavaScript
+> are strings, and the model attaches no meaning to any particular one: a
+> property name is data. Two names are nonetheless refused by the JavaScript
 > implementation, `__proto__` and `constructor`, for two different reasons —
 > neither of which is a limit of the language, and both of which are removable.
 >

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -623,8 +623,7 @@ export function linkPathContracts(
           throw new Error(`array link path contains non-index segment ${part}`);
         }
         const index = Number(part);
-        // A `FabricArray` preserves sparse holes. `minItems` constrains
-        // length,
+        // A `FabricArray` preserves sparse holes. `minItems` constrains length,
         // not own-property presence, so every indexed source path can still
         // yield Fabric `undefined` even for an unconditionally shaped array.
         const mayBeMissing = contract.mayBeMissing === true ||


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Two ragged comments left behind by the naming sweep, in the parts of it that
have already landed (#6138 and #6140). Dan spotted the same defect in #6135 and
that one is fixed on its own branch.

### The defect

Substituting a longer type name into wrapped prose splits the line, and the
block around the split was left unwrapped. It produces a short orphan:

- `1-fabric-values.md:1346` — a five-character `> are`.
- `piece-controller.ts:627` — `// length,`.

### How the rest were found

Rather than fix the one Dan pointed at, I ran a check over each branch's diff
for short mid-paragraph comment lines that do not appear in the file on `main`
— the same shape of whole-diff check that caught the dropped words earlier,
aimed at raggedness instead.

It reports **nine across the whole sweep**. Eight are artifacts and are now
fixed: two here, one in #6135, five in #6142. The ninth,
`2-hash-byte-format.md:246`, is the original author's own line break before a
long code span — it was 56 characters before this sweep and is 57 after — so it
is left alone.

Re-running both checks against the pre-sweep commit (`71e99fc33`) with this
branch applied: **one orphan remains, and it is that deliberate one.** The
word-multiset check reports five differences, all of them substitutions the
sweep intends.

### Testing

- `deno task test` in `packages/piece`: `39 passed (477 steps) | 0 failed`
- `deno task check-docs`: `All 564 checked code block(s) passed.`
- `deno fmt --check` and `deno lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

