### PR TITLE
docs(development): `LH` does not move when lines are ignored

### DIFF
--- a/docs/development/deno-coverage-guard-line-artifact.md
+++ b/docs/development/deno-coverage-guard-line-artifact.md
@@ -110,8 +110,14 @@ removes one line and leaves five. A block wants the `-start` / `-stop` pair.
 
 The directive reaches the lcov report and not merely the terminal one, which
 is what makes it usable here: the ignored lines carry no `DA:` records at all,
-so `LF` drops with `LH` and the CI ratchet sees nothing uncovered rather than
-seeing a gap it has been told to forgive.
+so `LF` falls while `LH` stays put — the lines removed were uncovered ones,
+never counted in `LH` to begin with — and the CI ratchet sees nothing
+uncovered rather than seeing a gap it has been told to forgive.
+
+Measure a "before" figure while the source still lacks the directive. The
+ignore directives are applied when `deno coverage` builds the **report**, not
+when `deno test` writes the profile, so re-running `deno coverage` over a
+profile collected earlier still reports the post-directive numbers.
 
 **What this is not for.** It suppresses a measurement, so it is only honest
 where the measurement is meaningless — code that *cannot* execute, by


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Follow-up to #6121, deferred from it deliberately: the finding arrived after that PR was green and ready, and one wrong sentence was not worth reopening a settled review.

The `deno-coverage-ignore` section that #6121 added to `deno-coverage-guard-line-artifact.md` says the ignored lines make **"`LF` drops with `LH`"**. That reads as though both fall. Only `LF` does — the lines the directive removes are uncovered ones, so they were never counted in `LH` to begin with.

#6121's own measurement is what refutes it: `241/247` before the directive, `241/241` after. `LF` fell by six; `LH` did not move.

Also adds the note that made reproducing that measurement awkward. The ignore directives are applied when `deno coverage` builds the **report**, not when `deno test` writes the profile — so re-running the report over a profile collected before the directive existed still yields the post-directive numbers. A "before" figure has to come from a run made while the source lacked the directive.

Found by cubic on #6121.

Documentation only; no code changes. `deno task check-docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WtPdpQHjmPHzTK4KLehE3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

