### PR TITLE
docs: name `FabricSpecialObject` where the prose spells it out

### DIFF
--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -2213,7 +2213,7 @@ describe("piece schema compatibility", () => {
   });
 
   describe("`FabricPrimitive` schema vocabulary transitions", () => {
-    // The schema generator used to describe a fabric special object
+    // The schema generator used to describe a `FabricSpecialObject`
     // structurally: an object schema whose `required` carries the
     // `FabricSpecialObject` nominal brand key. It now emits the
     // `FabricPrimitive` type name instead. That transition is refused, for

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -32,7 +32,7 @@ import { fromFileUrl } from "@std/path/from-file-url";
 
 // The comparison's two leaf cases. A materialized root is not plain data: at an
 // `asCell`/`asStream` position it holds a live cell, and a durable doc may hold
-// a fabric special object (bytes, an epoch). Neither survives a structural
+// a `FabricSpecialObject` (bytes, an epoch). Neither survives a structural
 // comparison unaided — see `comparableState`.
 import { FabricSpecialObject } from "@commonfabric/data-model/fabric-value";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
@@ -628,7 +628,7 @@ function isVNode(value: object): boolean {
  *   here to the DOCUMENT the cell points at, which is the durable thing about
  *   it: a stream that moved to a different doc still shows up, and the schema
  *   is deliberately dropped, being a view rather than data.
- * - **A fabric special object** (`FabricBytes`, an epoch). These hold their
+ * - **A `FabricSpecialObject`** (`FabricBytes`, an epoch). These hold their
  *   state in private fields, so a structural comparison sees two objects with
  *   no properties and calls them equal REGARDLESS of contents —
  *   `deepEqual`'s own documentation says so, and it is the quietest way a
@@ -1028,7 +1028,7 @@ export interface StateFinding {
  * and reads-as-something checks instead.
  *
  * Everything else is compared by SHAPE rather than by name. A value the
- * comparison cannot see through — a live cell, a fabric special object, a
+ * comparison cannot see through — a live cell, a `FabricSpecialObject`, a
  * cycle, a rendering — is reduced by `comparableState` on both sides rather
  * than skipped.
  *
@@ -1053,7 +1053,7 @@ export interface StateFinding {
  * exists for. Both comparators work once the reduction has run, and this one is
  * kept because it needs no value to be a well-formed `FabricValue` and
  * short-circuits instead of hashing a whole VNode tree; the one class it cannot
- * judge, a fabric special object with its state in private fields, is reduced
+ * judge, a `FabricSpecialObject` with its state in private fields, is reduced
  * to a content hash before it gets here rather than being compared by it.
  */
 export function strandedKeys(

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -690,7 +690,7 @@ function mergeSchemaDefaultsInternal(
       return valuePresent ? value : defaults;
     }
     // Defaults only fill absent values or recursively merge plain records. A
-    // defined scalar, sparse array, Fabric special object, or sigil link is
+    // defined scalar, sparse array, `FabricSpecialObject`, or sigil link is
     // durable user state, not an empty object to replace with defaults.
     if (
       valuePresent &&

--- a/packages/schema-generator/test/fixtures-runner.test.ts
+++ b/packages/schema-generator/test/fixtures-runner.test.ts
@@ -290,8 +290,8 @@ Deno.test("plain JSON would lose exactly those values", () => {
   assertThrows(() => JSON.stringify({ v: 1n }), TypeError);
 });
 
-Deno.test("golden compare keeps Fabric special objects distinct, not flattened to {}", () => {
-  // Both normalizers walk objects by key. A Fabric special object has no
+Deno.test("golden compare keeps `FabricSpecialObject`s distinct, not flattened to {}", () => {
+  // Both normalizers walk objects by key. A `FabricSpecialObject` has no
   // enumerable own properties, so walking it flattens it to `{}` -- and then
   // `valueEqual` sees only `{}` on each side and calls two different values
   // equal. That is exactly the silent agreement this whole harness exists to


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

Found while summarizing the residual for Dan to double-check — the summary is
what surfaced it.

### A third blind spot

**"fabric special object" was never in any of the sweep's scan patterns.** Every
term list ran `fabric[ -](primitive|value|object|record|…)`, which cannot match
a phrase whose second word is `special`. The handful converted across
#6134–#6146 were caught *incidentally*, because their line happened to contain
something else the pattern did match.

### Eight prose sites, all naming the class

- `runner-utils.ts:693` — the list of value kinds that count as durable user
  state.
- `state-continuity-harness.ts` ×4 — its file header comment imports
  `FabricSpecialObject` two lines below itself.
- `schema-compatibility.test.ts:2216` — describes the pre-vocabulary emission.
- `fixtures-runner.test.ts` — a test name and the comment under it.

### Left alone

- `interface.ts:174`'s `// -- Fabric special objects --`, a banner parallel to
  `// -- Primitives --` and `// -- Containers --`; it reads as a category label
  the way they do, and converting only this one would break the parallel.
- `describe("fabric-special-object")`, naming the module under test.
- The CLI fixture pieces named `"Fabric special object"`.

### How it was found

By enumerating **every distinct word that follows "fabric"** in the tree — 353
of them — rather than extending the guessed term list a fourth time. The long
tail is product vocabulary (`fabric session`, `fabric space`, `fabric url`,
`fabric mount`) that names no type, which is why the guessed lists kept looking
complete.

### Testing

- `deno task test`: runner `1268 passed`, piece `39 passed`,
  schema-generator `56 passed` — all `0 failed`.
- `deno fmt --check`, `deno lint`: clean.
- Whole-diff checks: zero word-multiset differences, zero introduced orphans.
  The single line over 80 columns is a `Deno.test` name that was 94 characters
  before this change and is 93 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewqs1iNBnMkSgTh6Wvy6W


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

