### PR TITLE
feat(runner): the structure-load forever-park is visible — stuck streaks count and warn (OW46)

### DIFF
--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1204,7 +1204,8 @@ escalate.
 Exposed via the existing `/api/health/stats` shape, replacing v1's pool
 block: `servingLoop: { activeSpaces, waves, wavesBudgetExhausted,
 supersededWrites, authoredSeen, effectAcks, derivedCommits,
-structureLoadFailures, structureLoadDeferred, structureLoadTerminal,
+structureLoadFailures, structureLoadDeferred, structureLoadStuck,
+structureLoadTerminal,
 structureLoadRearmed, watermarkClamped,
 unstampedSealRefusals, foreignWriteRefusals, foreignEngineFailures,
 watermarkLag, demandArrivals, undemandedNarrowingRuns, earlyEmitRefusals,
@@ -1225,6 +1226,14 @@ never-a-piece id classes are EXCLUDED from piece demand and count
 nothing, RULED 2026-08-07; `structureLoadFailures` also counts a
 piece-start commit that failed AFTER its start resolved (the §3d
 piece-start site's surfaced fire-and-forget failure, stage P2-F);
+`structureLoadStuck` counts roots whose CONSECUTIVE-deferral streak
+crossed the space server's stuck threshold — once per crossing, with a
+WARN naming the space and root at the crossing and at each doubling of
+the streak — so a forever-parked root (a demanded piece whose program
+docs never materialized, verification-coverage.md OW46) is a
+health-stats fact instead of an undifferentiated share of the
+per-attempt `structureLoadDeferred` aggregate; the streak clears when
+the root starts or terminalizes;
 `structureLoadTerminal`/`structureLoadRearmed` carry the
 demand-cycle terminal state (stage P2-F, the OW19 design): a root
 confirmed synced with no pattern meta parks TERMINAL — counted per

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5076,15 +5076,32 @@ supply; OW29/OW32/OW34 closed):
     `integration/home-profile-reload-durability.test.ts` ON skip
     (jointly with OW31's build if S-A takes the carriage arm).
   - **OW46 — the silent forever-park is invisible (seat S-D;
-    OW19-adjacent detectability).** The "unloadable pattern awaiting
-    its source docs" deferral (`space-server.ts`'s
-    `structureLoadDeferred` branch) parks with NO counter and NO log
-    line — `structureLoadFailures` stays 0, no error names the space
-    — so a whole class of dead spaces (OW45's shape) is undetectable
-    from stats. Owed: the deferral counts and logs after N cycles.
-    Trigger: rides OW45's fix arc — the home-profile lift run must
-    show the park counted/logged (detectability; not itself the lift
-    condition).
+    OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
+    client-durability pass; report:
+    `../../history/plans/server-execution-v2/optimize/ow47-client-durability-report.md`).**
+    The "unloadable pattern awaiting its source docs" deferral
+    (`space-server.ts`'s `structureLoadDeferred` branch) parked with
+    no DISTINGUISHING counter and no visible log line — each attempt
+    fed the per-attempt aggregate `structureLoadDeferred`, where a
+    dead space is indistinguishable from routine one-cycle creation
+    races, the only log line is debug-level, and
+    `structureLoadFailures` stays 0 — so a whole class of dead
+    spaces (OW45's shape) was undetectable from stats. Landed: the
+    space server tracks each root's CONSECUTIVE-deferral streak; at
+    `STRUCTURE_LOAD_STUCK_AFTER` (8 — an observability knob, not a
+    contract) it counts `structureLoadStuck` once per crossing and
+    WARNS (`structure-load-stuck`, naming the space, root, and
+    reason) there and at each doubling of the streak; the streak
+    clears when the root starts or terminalizes (a later re-stuck
+    episode counts again, like `structureLoadTerminal`); the THROW
+    arm is untouched (already loud per attempt). serving-loop.md §7
+    carries the counter. Pinned red-first in
+    `executor-space-server.test.ts` (a pattern-unloadable root
+    deferring per cycle: stuck stays 0 below the threshold, crosses
+    to exactly 1, never re-counts while the streak grows; the OW19
+    terminal/re-arm pins unchanged). Residual (the original
+    trigger): the home-profile lift run should show the park
+    counted/logged — that run belongs to OW45/OW31's joint lift.
   - **OW47 — client own-write durability under ON (seats S-E/S-F/S-G;
     rootcause §2b + the cellset-lww reproducer).** A USER's binding
     write into a serve-owned user-scope doc can be silently LOST:

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -2866,7 +2866,12 @@ export class SpaceServer implements TransactionSealDestination {
             // input-driven cycle retries.
             this.#pendingStructureLoads.add(key);
             stats.structureLoadDeferred += 1;
-            this.#noteStructureLoadDeferral(key, root.id, verdict.reason, stats);
+            this.#noteStructureLoadDeferral(
+              key,
+              root.id,
+              verdict.reason,
+              stats,
+            );
             logger.debug?.("structure-load-deferred", () => [
               `demanded root ${root.id} not loadable yet ` +
               `(${verdict.reason ?? "unclassified"}); ` +

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -121,6 +121,17 @@ import type { PostCommitSideEffect } from "../cfc/types.ts";
 
 const logger = getLogger("space-server", { enabled: true, level: "warn" });
 
+/** Consecutive not-yet-loadable deferrals of ONE demanded root after
+ * which the root counts as STUCK (`stats.structureLoadStuck`, once per
+ * crossing) and the loop WARNS (`structure-load-stuck`, again at each
+ * doubling of the streak). An observability knob, not a contract: the
+ * routine creation race resolves in one or two cycles, so any streak
+ * this long names a root whose piece cannot start — the OW46 class
+ * (a demanded piece whose program docs never materialized parks in the
+ * retry arm forever, invisible in the aggregate `structureLoadDeferred`
+ * and logged only at debug level). */
+export const STRUCTURE_LOAD_STUCK_AFTER = 8;
+
 /** The sanctioned internal stamp kind's durable action id (serving-loop.md
  * §3d, RULED 2026-08-05: stage F names the kinds when it installs the
  * seal destination). */
@@ -402,6 +413,18 @@ export class SpaceServer implements TransactionSealDestination {
    * classes out of piece demand entirely; this covers the remaining
    * `of:` ids, which id classes cannot split. */
   readonly #terminalStructureLoads = new Map<string, ReadonlySet<string>>();
+  /** Consecutive deferral streak per demanded root (keyed by demand
+   * key), feeding `stats.structureLoadStuck` and the
+   * `structure-load-stuck` WARN once a streak crosses
+   * `STRUCTURE_LOAD_STUCK_AFTER` (verification-coverage.md OW46): the
+   * per-attempt aggregate `structureLoadDeferred` cannot distinguish a
+   * forever-parked root — the home-profile shape, a piece whose
+   * program docs never materialized — from routine one-cycle creation
+   * races, and the per-attempt log line is debug-level. Cleared when
+   * the root starts or terminalizes (a later re-stuck stretch counts
+   * again); left untouched by the THROW arm, whose failures are
+   * already loud (`structureLoadFailures` + warn per attempt). */
+  readonly #structureLoadDeferralStreaks = new Map<string, number>();
   /** The single-flighted demand-structure load pass (stage P2-F): the
    * wave cycle races it against the flush deadline; a pass outliving
    * its wave keeps running and later cycles join it. */
@@ -2764,6 +2787,7 @@ export class SpaceServer implements TransactionSealDestination {
       // sound.
       else if (neverAPieceRootId(root.id)) {
         this.#pendingStructureLoads.delete(key);
+        this.#structureLoadDeferralStreaks.delete(key);
         continue;
       } else {
         try {
@@ -2775,6 +2799,7 @@ export class SpaceServer implements TransactionSealDestination {
           const verdict = await this.#attemptStructureLoad(runtime, root);
           if (verdict.started) {
             this.#pendingStructureLoads.delete(key);
+            this.#structureLoadDeferralStreaks.delete(key);
             if (verdict.rootId !== undefined && verdict.rootId !== root.id) {
               // The demand named an argument/derived doc; remember the
               // OWNING piece root so the per-(action × instance) run
@@ -2797,6 +2822,7 @@ export class SpaceServer implements TransactionSealDestination {
             );
             if (confirmed.started) {
               this.#pendingStructureLoads.delete(key);
+              this.#structureLoadDeferralStreaks.delete(key);
               if (
                 confirmed.rootId !== undefined && confirmed.rootId !== root.id
               ) {
@@ -2805,6 +2831,7 @@ export class SpaceServer implements TransactionSealDestination {
               }
             } else if (confirmed.reason === "no-pattern-meta") {
               this.#pendingStructureLoads.delete(key);
+              this.#structureLoadDeferralStreaks.delete(key);
               this.#terminalStructureLoads.set(
                 key,
                 new Set(confirmed.observedDocIds),
@@ -2818,6 +2845,12 @@ export class SpaceServer implements TransactionSealDestination {
             } else {
               this.#pendingStructureLoads.add(key);
               stats.structureLoadDeferred += 1;
+              this.#noteStructureLoadDeferral(
+                key,
+                root.id,
+                confirmed.reason,
+                stats,
+              );
             }
           } else {
             // Not loadable YET for a non-terminal reason (a chain
@@ -2827,6 +2860,7 @@ export class SpaceServer implements TransactionSealDestination {
             // input-driven cycle retries.
             this.#pendingStructureLoads.add(key);
             stats.structureLoadDeferred += 1;
+            this.#noteStructureLoadDeferral(key, root.id, verdict.reason, stats);
             logger.debug?.("structure-load-deferred", () => [
               `demanded root ${root.id} not loadable yet ` +
               `(${verdict.reason ?? "unclassified"}); ` +
@@ -2948,6 +2982,38 @@ export class SpaceServer implements TransactionSealDestination {
    * graph; instances are data slots, scopes.md §2), so a scoped demand
    * on a shared-structure piece must load through the broad slot
    * rather than churn forever on its meta-less instance doc. */
+  /** Track one root's consecutive-deferral streak and surface the
+   * STUCK crossing (OW46): count `stats.structureLoadStuck` once at
+   * `STRUCTURE_LOAD_STUCK_AFTER`, and WARN there and at each doubling
+   * of the streak (8, 16, 32, …) so a forever-parked root keeps
+   * showing up without per-cycle log spam. The streak is cleared by
+   * the resolution arms (started / terminal / never-a-piece), never
+   * here. */
+  #noteStructureLoadDeferral(
+    key: string,
+    rootId: string,
+    reason: string | undefined,
+    stats: { structureLoadStuck: number },
+  ): void {
+    const streak = (this.#structureLoadDeferralStreaks.get(key) ?? 0) + 1;
+    this.#structureLoadDeferralStreaks.set(key, streak);
+    if (streak < STRUCTURE_LOAD_STUCK_AFTER) return;
+    if (streak === STRUCTURE_LOAD_STUCK_AFTER) {
+      stats.structureLoadStuck += 1;
+    }
+    // Log at the crossing and at each doubling (power-of-two streaks).
+    if ((streak & (streak - 1)) === 0) {
+      logger.warn("structure-load-stuck", () => [
+        `demanded root ${rootId} in ${this.#options.space} has deferred ` +
+        `its structure load ${streak} consecutive cycles ` +
+        `(${reason ?? "unclassified"}): the piece cannot start and the ` +
+        "space serves nothing for it — a forever-park unless the " +
+        "missing docs arrive (verification-coverage.md OW46; the " +
+        "home-profile program-write-loss shape)",
+      ]);
+    }
+  }
+
   async #attemptStructureLoad(
     runtime: Runtime,
     root: { id: string; scope?: string },

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -2721,6 +2721,12 @@ export class SpaceServer implements TransactionSealDestination {
       this.#pendingStructureLoads.delete(key);
       this.#terminalStructureLoads.delete(key);
       this.#rearmedAwaitingSettle.delete(key);
+      // The stuck-streak entry retires with the rest of the per-key
+      // load state (review finding): a departed root's streak would
+      // otherwise linger for the space's whole life, and a later
+      // re-demand of the same key would resume an obsolete streak
+      // instead of starting a fresh episode.
+      this.#structureLoadDeferralStreaks.delete(key);
       runtime.scheduler.leaveDemandedEntity(addressOf(key));
     }
     // ENTERED keys and pairs. A NEW key ENTERS the demanded entity (0→1
@@ -2975,20 +2981,13 @@ export class SpaceServer implements TransactionSealDestination {
     }
   }
 
-  /** One structure-load attempt for a demanded root (stage P2-F): the
-   * demanded INSTANCE is tried first (a scoped result doc may carry
-   * its own per-instance pattern pointer), and a scoped no-meta miss
-   * falls back to the SPACE instance — piece structure is shared (one
-   * graph; instances are data slots, scopes.md §2), so a scoped demand
-   * on a shared-structure piece must load through the broad slot
-   * rather than churn forever on its meta-less instance doc. */
   /** Track one root's consecutive-deferral streak and surface the
    * STUCK crossing (OW46): count `stats.structureLoadStuck` once at
    * `STRUCTURE_LOAD_STUCK_AFTER`, and WARN there and at each doubling
    * of the streak (8, 16, 32, …) so a forever-parked root keeps
    * showing up without per-cycle log spam. The streak is cleared by
-   * the resolution arms (started / terminal / never-a-piece), never
-   * here. */
+   * the resolution arms (started / terminal / never-a-piece) and by
+   * demand departure, never here. */
   #noteStructureLoadDeferral(
     key: string,
     rootId: string,
@@ -3014,6 +3013,13 @@ export class SpaceServer implements TransactionSealDestination {
     }
   }
 
+  /** One structure-load attempt for a demanded root (stage P2-F): the
+   * demanded INSTANCE is tried first (a scoped result doc may carry
+   * its own per-instance pattern pointer), and a scoped no-meta miss
+   * falls back to the SPACE instance — piece structure is shared (one
+   * graph; instances are data slots, scopes.md §2), so a scoped demand
+   * on a shared-structure piece must load through the broad slot
+   * rather than churn forever on its meta-less instance doc. */
   async #attemptStructureLoad(
     runtime: Runtime,
     root: { id: string; scope?: string },

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -54,6 +54,20 @@ export type ServingLoopStats = {
    * loadable (e.g. a plain value doc demanded as if it owned a
    * piece). */
   structureLoadDeferred: number;
+  /** Demanded roots whose consecutive-deferral streak crossed
+   * `STRUCTURE_LOAD_STUCK_AFTER` (space-server.ts) — counted ONCE per
+   * crossing, so a nonzero value names roots that are effectively
+   * FOREVER-PARKED in the retry arm (verification-coverage.md OW46,
+   * the home-profile shape: a piece whose program docs never
+   * materialized defers every input-driven cycle, indistinguishable in
+   * the aggregate `structureLoadDeferred` from routine one-cycle
+   * creation races, and invisible on a quiet space where no cycle
+   * runs at all). A root that resolves (starts or terminalizes)
+   * clears its streak, so a later re-stuck stretch counts again —
+   * like `structureLoadTerminal`, per episode, not per root
+   * lifetime. The companion WARN log (`structure-load-stuck`) fires
+   * at the crossing and at each doubling while the streak grows. */
+  structureLoadStuck: number;
   /** Demanded roots that reached the TERMINAL not-loadable state
    * (server-execution v2 stage P2-F, the OW19 demand-cycle design): the
    * root's doc is confirmed synced from the durable store and carries
@@ -333,6 +347,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
   derivedCommits: 0,
   structureLoadFailures: 0,
   structureLoadDeferred: 0,
+  structureLoadStuck: 0,
   structureLoadTerminal: 0,
   structureLoadRearmed: 0,
   watermarkClamped: 0,

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -45,7 +45,10 @@ import type {
   MemorySpace,
 } from "../src/storage/interface.ts";
 import type { PostCommitSideEffect } from "../src/cfc/types.ts";
-import { SpaceServer } from "../src/executor/space-server.ts";
+import {
+  SpaceServer,
+  STRUCTURE_LOAD_STUCK_AFTER,
+} from "../src/executor/space-server.ts";
 import { stampWaveRunContext } from "../src/executor/wave.ts";
 import {
   emptyServingLoopStats,
@@ -867,6 +870,87 @@ describe("stage G SpaceServer recovery seams", () => {
     expect(stats.structureLoadTerminal).toBe(terminalAtTerminal);
     expect(stats.structureLoadRearmed).toBe(0);
     expect(stats.structureLoadFailures).toBe(0);
+  });
+
+  it("a demanded root stuck in per-cycle deferral is counted after the threshold — the forever-park is visible from stats (OW46)", async () => {
+    // The home-profile Ada shape (rootcause §1; verification-coverage.md
+    // OW46): a doc whose pattern pointer names an identity that can
+    // never load — the program docs are missing — defers its structure
+    // load EVERY input-driven cycle, forever. Each attempt lands in the
+    // aggregate structureLoadDeferred, where a dead space is
+    // indistinguishable from routine one-cycle creation races, and the
+    // only log line is debug-level. This pin: after
+    // STRUCTURE_LOAD_STUCK_AFTER consecutive deferrals of ONE root the
+    // loop counts a structureLoadStuck crossing (once per root, not per
+    // cycle) and WARNS with the space and root named.
+    const rootId = "of:ow46-stuck-root";
+    // Direct engine write so the doc carries `patternIdentity` META
+    // beside its value (writeDocument wraps value-only).
+    Engine.applyCommit(engine, {
+      sessionId: "session:ow46-writer",
+      space,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: rootId,
+          value: {
+            value: { plain: 1 },
+            patternIdentity: {
+              identity: "ow46-no-such-pattern",
+              symbol: "default",
+            },
+          },
+        }],
+      },
+      commitClass: "system",
+    });
+
+    const stats = emptyServingLoopStats();
+    const created = newSpaceServer({
+      stats,
+      serverFacade: demandFacade([{ id: rootId }]),
+    });
+    expect(await created.activate()).toBe(true);
+
+    // Drive input cycles; each one re-attempts the pending root and
+    // defers (pattern-unloadable). The crossing must appear at exactly
+    // the threshold — not before (stuck stays 0 while the streak is
+    // short: a routine creation-race deferral never trips it), and only
+    // ONCE for the one stuck root no matter how far past the threshold
+    // the cycles run.
+    for (
+      let i = 0;
+      stats.structureLoadDeferred < STRUCTURE_LOAD_STUCK_AFTER + 4 && i < 40;
+      i++
+    ) {
+      if (stats.structureLoadDeferred < STRUCTURE_LOAD_STUCK_AFTER) {
+        expect(stats.structureLoadStuck).toBe(0);
+      }
+      const applied = await server.writeDocument(
+        space,
+        `of:ow46-noise-${i}`,
+        { n: i },
+      );
+      created.enqueueCommit({
+        space,
+        seq: applied.seq,
+        class: "system",
+        sessionId: "session:ow46-noise",
+        writes: [{ id: `of:ow46-noise-${i}`, scopeKey: "space" }],
+      });
+      await waitUntil(
+        () => created.watermark >= applied.seq,
+        `noise cycle ${i} to settle`,
+      );
+    }
+    expect(stats.structureLoadDeferred).toBeGreaterThanOrEqual(
+      STRUCTURE_LOAD_STUCK_AFTER,
+    );
+    expect(stats.structureLoadStuck).toBe(1);
+    expect(stats.structureLoadFailures).toBe(0);
+    expect(stats.structureLoadTerminal).toBe(0);
   });
 
   it("re-arms a terminal root on a commit touching it and LOADS a piece created after the terminal decision (OW19's not-yet half)", async () => {

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -919,36 +919,59 @@ describe("stage G SpaceServer recovery seams", () => {
     // the threshold — not before (stuck stays 0 while the streak is
     // short: a routine creation-race deferral never trips it), and only
     // ONCE for the one stuck root no matter how far past the threshold
-    // the cycles run.
-    for (
-      let i = 0;
-      stats.structureLoadDeferred < STRUCTURE_LOAD_STUCK_AFTER + 4 && i < 40;
-      i++
-    ) {
-      if (stats.structureLoadDeferred < STRUCTURE_LOAD_STUCK_AFTER) {
-        expect(stats.structureLoadStuck).toBe(0);
+    // the cycles run — driven past the first DOUBLING (2× the
+    // threshold) so the doubling re-warn path runs while the crossing
+    // counter provably does not re-count. The warn is observed through
+    // the console the logger writes to.
+    const warns: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      const line = args.map(String).join(" ");
+      if (line.includes("structure-load-stuck")) warns.push(line);
+      originalWarn.apply(console, args);
+    };
+    try {
+      for (
+        let i = 0;
+        stats.structureLoadDeferred < 2 * STRUCTURE_LOAD_STUCK_AFTER + 2 &&
+        i < 60;
+        i++
+      ) {
+        if (stats.structureLoadDeferred < STRUCTURE_LOAD_STUCK_AFTER) {
+          expect(stats.structureLoadStuck).toBe(0);
+          expect(warns.length).toBe(0);
+        }
+        const applied = await server.writeDocument(
+          space,
+          `of:ow46-noise-${i}`,
+          { n: i },
+        );
+        created.enqueueCommit({
+          space,
+          seq: applied.seq,
+          class: "system",
+          sessionId: "session:ow46-noise",
+          writes: [{ id: `of:ow46-noise-${i}`, scopeKey: "space" }],
+        });
+        await waitUntil(
+          () => created.watermark >= applied.seq,
+          `noise cycle ${i} to settle`,
+        );
       }
-      const applied = await server.writeDocument(
-        space,
-        `of:ow46-noise-${i}`,
-        { n: i },
-      );
-      created.enqueueCommit({
-        space,
-        seq: applied.seq,
-        class: "system",
-        sessionId: "session:ow46-noise",
-        writes: [{ id: `of:ow46-noise-${i}`, scopeKey: "space" }],
-      });
-      await waitUntil(
-        () => created.watermark >= applied.seq,
-        `noise cycle ${i} to settle`,
-      );
+    } finally {
+      console.warn = originalWarn;
     }
     expect(stats.structureLoadDeferred).toBeGreaterThanOrEqual(
-      STRUCTURE_LOAD_STUCK_AFTER,
+      2 * STRUCTURE_LOAD_STUCK_AFTER,
     );
     expect(stats.structureLoadStuck).toBe(1);
+    // The warn fired at the crossing (8) and again at the doubling
+    // (16) — visible persistence without per-cycle spam — and each
+    // line names the root.
+    expect(warns.length).toBe(2);
+    for (const line of warns) {
+      expect(line).toContain("of:ow46-stuck-root");
+    }
     expect(stats.structureLoadFailures).toBe(0);
     expect(stats.structureLoadTerminal).toBe(0);
   });


### PR DESCRIPTION
## Why

verification-coverage.md **OW46** (seat S-D, minted at the first ON CI gate): the home-profile investigation found profile spaces whose serving loop was started, watermark written, piece demanded — and permanently dead, with **nothing** in stats or visible logs naming them. The piece's program docs were lost (OW45's shape), so every input-driven demand cycle re-attempted the structure load and deferred with `pattern-unloadable`, forever. Each attempt fed the per-attempt aggregate `structureLoadDeferred`, where a dead space is indistinguishable from routine one-cycle creation races; the only per-attempt log line is debug-level; `structureLoadFailures` stays 0; and on a quiet space no cycle runs at all. A whole class of dead spaces was undetectable from `/api/health/stats` — the rootcause had to find them by store archaeology.

## What Changed

- **`packages/runner/src/executor/space-server.ts`**: per-root consecutive-deferral streak tracking (`#structureLoadDeferralStreaks`). At `STRUCTURE_LOAD_STUCK_AFTER` (8 — exported, documented as an observability knob, not a contract) the loop counts `stats.structureLoadStuck` **once per crossing** and warns (`structure-load-stuck`, naming the space, root, and deferral reason) at the crossing and at each doubling of the streak (8, 16, 32, …) — visible persistence without per-cycle spam. The streak clears when the root starts or terminalizes (a later re-stuck episode counts again, matching `structureLoadTerminal`'s per-episode semantics); the throw arm is untouched (already loud per attempt).
- **`packages/runner/src/executor/stats.ts`**: the `structureLoadStuck` counter, documented.
- **`docs/specs/server-side-execution/serving-loop.md` §7**: the counter joins the counters block with its semantics.
- **`docs/specs/server-side-execution/verification-coverage.md`**: OW46 row closed (with the residual named: the home-profile lift run showing the park counted/logged belongs to OW45/OW31's joint lift).

## Test plan

- Red-first, watched: the new `executor-space-server.test.ts` pin writes a doc whose `patternIdentity` meta names an identity that can never load (the Ada shape), drives input cycles, and failed pre-fix with `structureLoadStuck` at 0. Post-fix: stuck stays 0 below the threshold (a routine creation-race deferral never trips it), crosses to exactly 1 at the threshold, and never re-counts while the streak grows past it; `structureLoadFailures`/`structureLoadTerminal` stay 0.
- The OW19 terminal/re-arm pins in the same file are unchanged (15/15 steps green).
- Neighborhood green: `executor-serving-loop`, `executor-wave`, `executor-events-down`, `executor-fan-out` (with the runner suite's clock preload).
- `deno check` + `deno lint` clean on touched files.

This is server-side observability only — no client or OFF-arm behavior changes (the counter and log are new; nothing existing moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

