### PR TITLE
fix(piece): an argument may drop a field the pattern no longer reads

### DIFF
--- a/docs/plans/pattern-verb-contract.md
+++ b/docs/plans/pattern-verb-contract.md
@@ -656,13 +656,15 @@ applies to — it must be authored open-world so protocol fields such as a
 payload digest or retention metadata can be added later.
 
 "Results may narrow freely" governs *values*, not *named fields*. Removing a
-named property is rejected outright in either direction — `objectSubsetIssue`
+named property from a **result** is rejected outright — `objectSubsetIssue`
 returns "existing result field was removed" whenever the comparison is an
-evolution, on the stated principle that "pattern evolution preserves named
-fields as part of the public contract, even when the candidate object is
-otherwise open" (`objectSubsetIssue`,
-`packages/piece/src/schema-compatibility.ts`). The removed-field check
-recurses, so a nested removal is rejected on a nested path
+evolution, on the stated principle that a result's named fields are the
+contract consumers read (`objectSubsetIssue`,
+`packages/piece/src/schema-compatibility.ts`). An argument's named fields are
+not held that way: dropping one gives up a demand, which the same function
+accepts wherever the candidate object can still hold the value the piece
+carries. The removed-field check recurses, so a nested removal is rejected on
+a nested path
 (`result.topic.title: existing result field was removed`) exactly as a flat one
 is. Adding a **required** field is rejected at any depth unless it carries a
 default; adding an **optional** one is allowed at any depth; narrowing a

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -93,31 +93,38 @@ deploy's output beside the next, so output changes are governed by convention
 alone.
 
 The same gate also governs the *holder* — what a pattern may change about
-what it demands from the pieces it stores — and there is the fourth bad
-outcome:
+what it demands from the pieces it stores — where the first outcome above
+arrives from the other side:
 
 | Change a holder makes to its own demand | Result |
 | --- | --- |
 | Demand a new optional field or verb | allowed |
 | Demand a new required field that carries a default | allowed |
 | Demand a new **required verb** | **refused** |
-| Stop demanding a field or verb it no longer uses | **refused** |
+| Stop demanding a field or verb it no longer uses | allowed |
 
-Both refusals come from `packages/piece/src/schema-compatibility.ts`.
-Dropping a named field is rejected as `existing argument field was removed`
-— the gate has no notion of narrowing, so giving up a demand looks exactly
-like breaking one. Raising one hits `newly required argument field has no
-default`, and a verb is a stream, which cannot carry a default: the refusal
-above, arriving from the other direction.
+The refusal comes from `packages/piece/src/schema-compatibility.ts`: raising
+a demand hits `newly required argument field has no default`, and a verb is
+a stream, which cannot carry a default, so a newly required verb is the same
+refusal arriving from the other direction.
+
+Giving a demand up is narrowing, and the gate reads it as narrowing. A field
+the pattern stopped reading leaves a writer's value unread rather than
+breaking a reader, so the argument side drops named fields freely; what it
+still proves is that the candidate can hold the value the piece already
+carries, which a closed candidate object fails as `source field is rejected
+by the target object`. The result side preserves every named field it
+published.
 
 Stated plainly, because much of the design rests on it: **a deployed
-holder's required demands are write-once.** They cannot be added to and
-cannot be given up; only optional demands can evolve, and only by growing.
-(The provider side is looser on purpose: a pattern may add a newly required
-field to its own *result*, because the new code materializes it when it
-runs. A demand has no such escape — the piece it points at already exists.)
+holder's required demands can be given up but never raised.** Only optional
+demands can be added, and a required one, once made, is kept or dropped
+whole. (The provider side is looser on that axis: a pattern may add a newly
+required field to its own *result*, because the new code materializes it
+when it runs. A demand has no such escape — the piece it points at already
+exists.)
 
-Behind all four outcomes is the fact that makes this hard: **pieces
+Behind all three outcomes is the fact that makes this hard: **pieces
 persist.** Each carries the interface it was created with while the code
 around it moves on. Sooner or later some caller holds a piece older than the
 interface it wants, and no declaration style makes that impossible.
@@ -421,8 +428,8 @@ version boundary with its name erased; versioning names the vintage, and
 moves the maybe from every seam to bind time.
 
 **The columns are not reachable from one another.** A deployed holder cannot
-move rightward — every such move hits the write-once wall in the holder
-table, and escalating a versioned demand from v1 to v2 is the same event. So
+move rightward — every such move raises a demand, which the holder table
+refuses, and escalating a versioned demand from v1 to v2 is the same event. So
 the design is complete for holders that do not exist yet and — until scoped
 acknowledgment and migration exist — inert for every holder already
 deployed: requirement 6 unmet, and both mechanisms on the critical path for
@@ -468,11 +475,9 @@ record which demands exist, which is what everything below needs.
 
 Today a holder's demand is indistinguishable from its own state — the
 refusal path `argument.notes[].append` *is* the demand subtree, unmarked.
-That single gap is why the impact report below cannot count anything, why
-the gate treats giving up a demand as a break rather than the safe narrowing
-it is, and why a deliberate break can only be acknowledged by turning the
-whole gate off. Marking demands is the substrate the rest of the tooling
-stands on.
+That single gap is why the impact report below cannot count anything, and
+why a deliberate break can only be acknowledged by turning the whole gate
+off. Marking demands is the substrate the rest of the tooling stands on.
 
 [#5746] prototypes both halves: a `Demand<T>` marker whose stamp rides the
 referencing node — a shared definition stays neutral; each use site declares
@@ -480,9 +485,11 @@ its own demand-ness — and an advisory warning when a contract embeds a
 foreign Output type, with self-reference still legal and `@sharedContract`
 opting a genuine protocol type out.
 
-Adopting narrow demands across already-deployed patterns is itself a break
-— a deployed holder cannot drop what it stopped needing — so that migration
-rides the scoped acknowledgment below, not a quiet edit.
+Adopting narrow demands across already-deployed patterns is a holder
+dropping what it stopped needing, which the gate accepts on its own. Where
+the holder republishes the demanded type, the same narrowing reaches its
+result, and that side still refuses — so those adoptions ride the scoped
+acknowledgment below rather than a quiet edit.
 
 ### Authoring time shows the blast radius
 
@@ -619,13 +626,11 @@ pattern, a move across spaces — is creation, not evolution.
 ## What is not settled here
 
 One question is open by design, and it is the one the cross product exposes:
-**how a deployed holder moves.** Narrow demands, required-verb demands and
-versioned demands are all reachable when a holder is written and none of
-them afterwards, so every adoption path runs through a scoped acknowledgment
-or a migration that rewrites holders. Which carries it — and whether the
-gate should learn that removal beneath a demand marker is narrowing rather
-than breakage — decides how much of this design applies to what is already
-running.
+**how a deployed holder moves.** Required-verb demands and versioned demands
+are reachable when a holder is written and not afterwards, so every adoption
+path that raises a demand runs through a scoped acknowledgment or a
+migration that rewrites holders. Which carries it decides how much of this
+design applies to what is already running.
 
 One direction belongs in that conversation, recorded as intent rather than
 mechanism: **the provider tells holders how to move.** A pattern that

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -117,9 +117,11 @@ by the target object`. The result side preserves every named field it
 published.
 
 Stated plainly, because much of the design rests on it: **a deployed
-holder's required demands can be given up but never raised.** Only optional
-demands can be added, and a required one, once made, is kept or dropped
-whole. (The provider side is looser on that axis: a pattern may add a newly
+holder's demands can be given up freely, and added only where an existing
+piece still meets them** — optional, or a required field whose default fills
+it in, which a verb cannot be, having no default to carry. What is already
+demanded is kept or dropped whole, never tightened. (The provider side is
+looser on that axis: a pattern may add a newly
 required field to its own *result*, because the new code materializes it
 when it runs. A demand has no such escape — the piece it points at already
 exists.)

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -188,14 +188,17 @@ result cell and its populated inputs. **Adding a new `PerSpace` field is safe**
 — on an existing piece it hydrates to its `Default<>` while populated fields
 keep their data.
 
-**Removing one is refused.** The compatibility check reads the deployed schema
-and rejects a source that drops a field, without touching the piece:
+**Removing one is refused wherever the pattern publishes it.** A `PerSpace`
+field that also reaches the result is held by the result contract, and the
+compatibility check rejects a source that drops it, without touching the piece:
 
 ```
 Pattern schemas are not backward compatible:
-- argument.motto: existing argument field was removed
 - result.motto: existing result field was removed
 ```
+
+A field the pattern only reads goes freely: giving up an input leaves whatever
+the piece stored unread rather than breaking a reader.
 
 `--dangerously-allow-incompatible-schema` replaces the source anyway. Adding
 fields is safe, but heavily **reordering or renaming** pattern inputs can shift

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -197,8 +197,10 @@ Pattern schemas are not backward compatible:
 - result.motto: existing result field was removed
 ```
 
-A field the pattern only reads goes freely: giving up an input leaves whatever
-the piece stored unread rather than breaking a reader.
+A field the pattern only reads goes freely while the argument object stays open,
+which is the default: giving up an input leaves whatever the piece stored unread
+rather than breaking a reader. A closed argument object refuses it, since it
+could no longer hold the value the piece is carrying.
 
 `--dangerously-allow-incompatible-schema` replaces the source anyway. Adding
 fields is safe, but heavily **reordering or renaming** pattern inputs can shift

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -241,9 +241,14 @@ const ifcWithoutVolatileWriterIdentity = (ifc: unknown): unknown => {
  * contracts of the currently running pattern.
  *
  * Arguments are contravariant and results are covariant. Open argument objects
- * may still gain optional/defaulted named fields as the piece-evolution policy.
- * What keeps that allowance sound is a second check at update time rather than
- * anything provable here: pattern setup re-stages the piece's stored argument
+ * may still gain optional/defaulted named fields as the piece-evolution policy,
+ * and may drop named fields the pattern no longer reads — a demand given up
+ * leaves a writer's value unread, where a dropped result field breaks a reader,
+ * so only the result side preserves its named fields outright. A candidate that
+ * cannot hold a dropped field's value is still refused, by the ordinary
+ * named-property proof against its additionalProperties contract. What keeps
+ * those allowances sound is a second check at update time rather than anything
+ * provable here: pattern setup re-stages the piece's stored argument
  * against the incoming schema and validates it inside the setup transaction, so
  * an update whose durable argument the new schema cannot read is refused
  * instead of landing over unreadable state. Two sites do the checking, and the
@@ -670,15 +675,21 @@ function objectSubsetIssue(
     ? source.patternProperties
     : target.patternProperties;
 
-  // Pattern evolution preserves named fields as part of the public contract,
-  // even when the candidate object is otherwise open. A durable-link subset
-  // proof is different: a source may name additional fields that an open
-  // target accepts through patternProperties/additionalProperties. Treating
-  // those fields as "removed" rejects valid Fabric projections such as $FS.
-  if (context.defaultComparison === "evolution") {
+  // A result's named fields are the contract consumers read, so evolution
+  // preserves every one of them even when the candidate object is otherwise
+  // open. An argument's are not: dropping one gives up a demand, which leaves a
+  // writer's value unread rather than breaking a reader. What the stored
+  // argument still needs — that the candidate can hold the value the piece
+  // already carries — the named-property proof below decides per field,
+  // accepting it under an open candidate and reporting it under a closed one. A
+  // durable-link subset proof reaches that same proof from the other side: a
+  // source may name additional fields that an open target accepts through
+  // patternProperties/additionalProperties, and treating those as "removed"
+  // rejects valid Fabric projections such as $FS.
+  if (context.defaultComparison === "evolution" && context.role === "result") {
     for (const property of Object.keys(previousProperties)) {
       if (Object.hasOwn(candidateProperties, property)) continue;
-      return `${path}.${property}: existing ${context.role} field was removed`;
+      return `${path}.${property}: existing result field was removed`;
     }
   }
 

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -1063,8 +1063,8 @@ describe("piece schema compatibility", () => {
       .toThrow(/result\.doubled/);
   });
 
-  it("rejects removing existing argument or result fields", () => {
-    const missingArgument = pattern(
+  it("accepts dropping an argument field the pattern no longer reads", () => {
+    const droppedArgument = pattern(
       {
         type: "object",
         properties: { value: { type: "number" } },
@@ -1073,9 +1073,28 @@ describe("piece schema compatibility", () => {
       oldPattern.resultSchema,
     );
     expect(() =>
-      assertPatternSchemasBackwardCompatible(oldPattern, missingArgument)
-    ).toThrow(/argument\.format: existing argument field was removed/);
+      assertPatternSchemasBackwardCompatible(oldPattern, droppedArgument)
+    ).not.toThrow();
+  });
 
+  it("rejects dropping an argument field a closed candidate cannot hold", () => {
+    const droppedArgument = pattern(
+      {
+        type: "object",
+        properties: { value: { type: "number" } },
+        required: ["value"],
+        additionalProperties: false,
+      },
+      oldPattern.resultSchema,
+    );
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(oldPattern, droppedArgument)
+    ).toThrow(
+      /argument\.format: source field is rejected by the target object/,
+    );
+  });
+
+  it("rejects removing an existing result field", () => {
     const missingResult = pattern(
       oldPattern.argumentSchema,
       {

--- a/tasks/pattern-compat-lib.test.ts
+++ b/tasks/pattern-compat-lib.test.ts
@@ -408,7 +408,8 @@ describe("partitionAcceptedBreaks", () => {
     }`,
   });
   const REMOVED = "result.crossrefs: existing result field was removed";
-  const UNRELATED = "argument.seed: existing argument field was removed";
+  const UNRELATED =
+    "argument.seed: newly required argument field has no default";
   const accepted = new Map<string, ReadonlySet<string>>([
     [acceptedBreakKey("a.tsx", "old"), new Set(["result.crossrefs"])],
   ]);


### PR DESCRIPTION
## What

`objectSubsetIssue` refuses removing a named field under `defaultComparison === "evolution"`, and `context.role` appears in that check **only in the error message**. The rule is role-blind, so a pattern update that stopped reading an argument field was refused by a rule written for results:

```
argument.format: existing argument field was removed
```

Giving up a demand leaves a writer's value unread. It does not break a reader, which is what the result side is protecting.

## The change

Gate the blanket check on `role === "result"`. The argument side then falls through to the named-property proof already further down the same function, which decides per field whether the candidate can still hold the value the piece carries:

- candidate object open (the default) → the dropped field is accepted
- candidate object closed → `argument.format: source field is rejected by the target object`

So removal is not waved through — it is proved against the candidate's `additionalProperties` contract instead of against a field-name diff. `Runner.applySetupState` still validates the durable stored argument inside the setup transaction at update time, unchanged.

## Docs

Live documents that stated the old behavior, updated in the same change:

- `docs/plans/verb-evolution.md` — the holder table's "stop demanding a field or verb" row, the write-once framing that rested on it, and the two later sections that cited it
- `docs/plans/pattern-verb-contract.md` — "removing a named property is rejected outright in either direction"
- `packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md` — the `setsrc` refusal example, which now shows only the result-side line

## Testing

- `packages/piece` — `deno task test`: 39 passed, 0 failed. The removal case is split into three: an argument field dropped under an open candidate is accepted, one dropped under a closed candidate is refused, and a result field removal is still refused.
- `deno task pattern-compat --only topics --only parking-coordinator` — exit 0, all 25 accepted contract breaks still forgiven and none stale. Every argument-side finding in that registry is a defaults, `asCell` or `ifc` change, never a removal, so relaxing removal takes nothing out of use.
- `deno test -A packages/runner/test/pattern-update-argument-validation.test.ts` — passes; this is the check that carries the durable-argument guarantee.
- `tasks/pattern-compat-lib.test.ts`, `pattern-compat-accepted-breaks.test.ts`, `pattern-break-registry-guards.test.ts` — pass. One fixture in the first cited a message the gate can no longer emit; it now cites one it can.
- `deno fmt --check`, `deno lint`, `deno check` on the changed files, `deno task check-docs`, `check-skill-facts`, `check-control-characters`, `check-conflict-markers` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

