### PR TITLE
fix(ts-transformers): assert() hid a field from the check that read it

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1439,15 +1439,19 @@ adjustments:
   which disables shrinking for the whole parameter: its declared shape is
   emitted intact, without the capability wrappers a walked operand would derive
 - capability analysis reads through the operand recording an `assert(...)` body
-  wraps a value in. `AssertDiagnosticsTransformer` (stage 10) rewrites
-  `event.details.includes(text)` so that `includes` is called on
+  wraps a method call's receiver in. `AssertDiagnosticsTransformer` (stage 10)
+  rewrites `event.details.includes(text)` so that `includes` is called on
   `__cfHelpers.assertCapture(parts, "event.details", event.details)` rather
   than on `event.details`. The recording hands its third argument straight
-  back, and the analysis follows it there, so the read is still charged to
-  `event.details` and that field survives the shrink. An `assert(...)` body and
-  the same body under `computed(...)` therefore produce the same read schema
+  back, so the receiver resolves to that argument: the read is charged to
+  `event.details`, the field survives the shrink, and cell-likeness is judged
+  on the value rather than on the recording helper's untyped result
   (`unwrapAssertCapture` in `utils/expression.ts`;
-  `test/assert-diagnostics.test.ts`)
+  `test/assert-diagnostics.test.ts`). Only the receiver is read through. A
+  recording in argument position still hides what it wraps from the callee's
+  capability contract, so `assert(() => helper(count))` charges `count`
+  whatever its own use in the body says, while `computed(() => helper(count))`
+  charges it the wrapper capability `helper` declares for that parameter
 - node-driven shrinking can still shrink the inner type of cell-like wrappers
   when `.get()` contributes an empty path but coexists with more specific
   non-empty paths

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1438,6 +1438,16 @@ adjustments:
   `table[indexes.findIndex(...)]?.mentionedBy ?? []` — marks the root wildcard,
   which disables shrinking for the whole parameter: its declared shape is
   emitted intact, without the capability wrappers a walked operand would derive
+- capability analysis reads through the operand recording an `assert(...)` body
+  wraps a value in. `AssertDiagnosticsTransformer` (stage 10) rewrites
+  `event.details.includes(text)` so that `includes` is called on
+  `__cfHelpers.assertCapture(parts, "event.details", event.details)` rather
+  than on `event.details`. The recording hands its third argument straight
+  back, and the analysis follows it there, so the read is still charged to
+  `event.details` and that field survives the shrink. An `assert(...)` body and
+  the same body under `computed(...)` therefore produce the same read schema
+  (`unwrapAssertCapture` in `utils/expression.ts`;
+  `test/assert-diagnostics.test.ts`)
 - node-driven shrinking can still shrink the inner type of cell-like wrappers
   when `.get()` contributes an empty path but coexists with more specific
   non-empty paths

--- a/packages/patterns/scrabble/scrabble.test.tsx
+++ b/packages/patterns/scrabble/scrabble.test.tsx
@@ -100,7 +100,7 @@ export default pattern(() => {
       scrabble.bagIndex === 9 &&
       player?.score === 4 &&
       lastEvent?.type === "word" &&
-      lastEvent?.details?.includes("AT (+4)") &&
+      lastEvent.details.includes("AT (+4)") &&
       scrabble.message.startsWith("Scored 4:");
   });
 

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -1782,11 +1782,7 @@ export function analyzeFunctionCapabilities(
     const resolveBinding = (
       expression: ts.Expression,
     ): AliasBinding | undefined => {
-      // Reading through an `assert` body's operand recording is what keeps the
-      // receiver of a recorded method call — the `event.details` of
-      // `event.details.includes(text)` — attributed to the source it was read
-      // from, so the field survives into the schema the body is served.
-      const current = unwrapAssertCapture(expression);
+      const current = unwrapExpression(expression);
       if (
         ts.isBinaryExpression(current) &&
         FALLBACK_OPERATORS.has(current.operatorToken.kind)
@@ -3097,9 +3093,11 @@ export function analyzeFunctionCapabilities(
           ts.isElementAccessExpression(node.expression)
         ) {
           // The expression the method is called on, with an `assert` body's
-          // operand recording read through, so cell-likeness is judged on the
-          // value the author wrote rather than on the recording helper's
-          // untyped result.
+          // operand recording read through. Recording the receiver of a method
+          // call puts a call where the member access the author wrote used to
+          // be, and both questions asked of it here — which source it was read
+          // from, and whether it is cell-like — are about the value the
+          // recording hands back rather than about the recording.
           const receiverExpression = unwrapAssertCapture(
             node.expression.expression,
           );

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -19,7 +19,7 @@ import {
   type UnreadableCellArgument,
 } from "../core/mod.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import { unwrapAssertCapture, unwrapExpression } from "../utils/expression.ts";
 import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import {
@@ -1782,7 +1782,11 @@ export function analyzeFunctionCapabilities(
     const resolveBinding = (
       expression: ts.Expression,
     ): AliasBinding | undefined => {
-      const current = unwrapExpression(expression);
+      // Reading through an `assert` body's operand recording is what keeps the
+      // receiver of a recorded method call — the `event.details` of
+      // `event.details.includes(text)` — attributed to the source it was read
+      // from, so the field survives into the schema the body is served.
+      const current = unwrapAssertCapture(expression);
       if (
         ts.isBinaryExpression(current) &&
         FALLBACK_OPERATORS.has(current.operatorToken.kind)
@@ -3092,7 +3096,14 @@ export function analyzeFunctionCapabilities(
           ts.isPropertyAccessExpression(node.expression) ||
           ts.isElementAccessExpression(node.expression)
         ) {
-          const directReceiver = resolveSourceRef(node.expression.expression);
+          // The expression the method is called on, with an `assert` body's
+          // operand recording read through, so cell-likeness is judged on the
+          // value the author wrote rather than on the recording helper's
+          // untyped result.
+          const receiverExpression = unwrapAssertCapture(
+            node.expression.expression,
+          );
+          const directReceiver = resolveSourceRef(receiverExpression);
           const receiver = directReceiver ??
             resolveConservativeCallReceiverRef(node);
           if (receiver) {
@@ -3106,7 +3117,7 @@ export function analyzeFunctionCapabilities(
               // like the unknown-named fallback below.
               if (
                 !checker ||
-                isCellLikeExpression(node.expression.expression)
+                isCellLikeExpression(receiverExpression)
               ) {
                 markUnverifiedCellUse(receiver.root);
               }
@@ -3209,7 +3220,7 @@ export function analyzeFunctionCapabilities(
               OPAQUE_DERIVATION_METHODS.has(methodName) &&
               (
                 !checker ||
-                isCellLikeExpression(node.expression.expression)
+                isCellLikeExpression(receiverExpression)
               )
             ) {
               // These methods are available on opaque cells and return opaque
@@ -3232,7 +3243,7 @@ export function analyzeFunctionCapabilities(
               // write through the cell and stay reads.
               if (
                 !checker ||
-                isCellLikeExpression(node.expression.expression)
+                isCellLikeExpression(receiverExpression)
               ) {
                 markUnverifiedCellUse(receiver.root);
               }

--- a/packages/ts-transformers/src/transformers/assert-diagnostics.ts
+++ b/packages/ts-transformers/src/transformers/assert-diagnostics.ts
@@ -4,7 +4,10 @@ import { HelpersOnlyTransformer } from "../core/transformers.ts";
 import type { TransformationContext } from "../core/mod.ts";
 import { resolvesToCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
 import { getNodeText } from "../ast/utils.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  ASSERT_CAPTURE_HELPER_NAME,
+  unwrapExpression,
+} from "../utils/expression.ts";
 
 /**
  * AssertDiagnosticsTransformer: rewrites the body of an `assert(...)` call so
@@ -567,7 +570,7 @@ function captureValue(
   const source = sourceTextOf(unwrapExpression(labelSource));
 
   return context.cfHelpers.createHelperCall(
-    "assertCapture",
+    ASSERT_CAPTURE_HELPER_NAME,
     labelSource,
     undefined,
     [

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -1,5 +1,7 @@
 import ts from "typescript";
 
+import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
+
 interface UnwrapExpressionOptions {
   readonly includePartiallyEmitted?: boolean;
 }
@@ -61,4 +63,49 @@ export function isValueComputationExpressionKind(
     ts.isPrefixUnaryExpression(expression) ||
     ts.isPostfixUnaryExpression(expression) ||
     ts.isConditionalExpression(expression);
+}
+
+/**
+ * The runtime helper an `assert` body records an operand with. It takes the
+ * operand and hands the same value back.
+ */
+export const ASSERT_CAPTURE_HELPER_NAME = "assertCapture";
+
+/** The `assertCapture` argument holding the operand. */
+const ASSERT_CAPTURE_VALUE_ARGUMENT = 2;
+
+/** True for a `__cfHelpers.assertCapture(parts, src, value)` call. */
+function isAssertCaptureCall(
+  expression: ts.Expression,
+): expression is ts.CallExpression {
+  if (!ts.isCallExpression(expression)) return false;
+  const callee = expression.expression;
+  return ts.isPropertyAccessExpression(callee) &&
+    ts.isIdentifier(callee.expression) &&
+    callee.expression.text === CF_HELPERS_IDENTIFIER &&
+    callee.name.text === ASSERT_CAPTURE_HELPER_NAME &&
+    expression.arguments.length === ASSERT_CAPTURE_VALUE_ARGUMENT + 1;
+}
+
+/**
+ * The expression a value comes from, with the operand recordings an `assert`
+ * body puts in the way removed. It also removes everything
+ * {@link unwrapExpression} removes.
+ *
+ * `AssertDiagnosticsTransformer` rewrites `event.details.includes(text)` into
+ * `__cfHelpers.assertCapture(parts, "event.details", event.details)
+ * .includes(text)`. The method is now called on a call rather than on the
+ * member access the author wrote. An analysis asking which reactive value an
+ * expression reads has to read through that call to reach `event.details`.
+ * Without it the read goes unrecorded, and the field is projected out of the
+ * schema the body is served.
+ */
+export function unwrapAssertCapture(expression: ts.Expression): ts.Expression {
+  let current = unwrapExpression(expression);
+  while (isAssertCaptureCall(current)) {
+    current = unwrapExpression(
+      current.arguments[ASSERT_CAPTURE_VALUE_ARGUMENT]!,
+    );
+  }
+  return current;
 }

--- a/packages/ts-transformers/test/assert-diagnostics.test.ts
+++ b/packages/ts-transformers/test/assert-diagnostics.test.ts
@@ -9,6 +9,7 @@ import {
   callSchemas,
   callsNamed,
   collect,
+  literalToValue,
   parseModule,
 } from "./transformed-ast.ts";
 
@@ -52,6 +53,19 @@ function recordSource(root: ts.SourceFile): string | undefined {
   return assignment && ts.isStringLiteral(assignment.initializer)
     ? assignment.initializer.text
     : undefined;
+}
+
+/**
+ * The input schema of every emitted `lift(callback, input, result)` call, in
+ * source order.
+ */
+function liftInputSchemas(root: ts.SourceFile): unknown[] {
+  return callsNamed(root, "lift").map((call) => {
+    const argument = call.arguments[1];
+    return argument && ts.isSatisfiesExpression(argument)
+      ? literalToValue(argument.expression)
+      : undefined;
+  });
 }
 
 Deno.test("assert records the operands of a comparison", async () => {
@@ -492,4 +506,59 @@ export default pattern(() => {
   // Recording the receiver of `?.` would need the chain rebuilt around the
   // recording call; the operand itself is recorded instead.
   assertEquals(assertCaptureLabels(root), ["maybe.get()?.includes(1)"]);
+});
+
+Deno.test("assert reads the receiver of a recorded method call", async () => {
+  const root = await transformed(
+    `import { assert, computed, pattern } from "commonfabric";
+
+interface Event {
+  type: string;
+  details: string;
+  unused: number;
+}
+
+interface State {
+  events: Event[];
+}
+
+export default pattern((state: State) => {
+  const asserted = assert(() => {
+    const last = state.events.at(-1);
+    return last?.type === "word" && last.details.includes("AT");
+  });
+  const computedCheck = computed(() => {
+    const last = state.events.at(-1);
+    return last?.type === "word" && last.details.includes("AT");
+  });
+  return { asserted, computedCheck };
+});`,
+  );
+
+  const eventFields = {
+    type: "object",
+    properties: {
+      type: { type: "string" },
+      details: { type: "string" },
+    },
+    required: ["type", "details"],
+  };
+  const readSchema = {
+    type: "object",
+    properties: {
+      state: {
+        type: "object",
+        properties: {
+          events: { type: "array", items: eventFields },
+        },
+        required: ["events"],
+      },
+    },
+    required: ["state"],
+  };
+
+  // The recording sits between `last.details` and the `.includes` that reads
+  // it. An analysis that stopped at the recording would drop `details` from
+  // the schema, and the body would be served an event without it.
+  assertEquals(liftInputSchemas(root), [readSchema, readSchema]);
 });


### PR DESCRIPTION
A pattern test writes each of its checks as an `assert()`:

    const assert_word_submitted = assert(() =>
      lastEvent.details.includes("AT (+4)")
    );

A check like that runs as a lift, and a lift is handed only the fields its body uses. The compiler works out which those are by reading the body and noting each field it sees being read. A field it does not note is left out of the lift's input schema, and the body sees `undefined` in its place.

`assert()` also rewrites the body it is given, so that a check which fails can name the parts it was built from and the values they held. Each part is wrapped in a call to `assertCapture`, a helper that stores the value and hands it straight back. The line above becomes:

    __cfHelpers.assertCapture(parts, "lastEvent.details",
      lastEvent.details).includes("AT (+4)")

Those two things disagreed. To learn which field a method call reads, the compiler looks at what the method was called on. Before the rewrite, `includes` is called on `lastEvent.details`, so `details` gets noted. After the rewrite, `includes` is called on the `assertCapture` call instead, which reads no field the compiler recognizes, so nothing gets noted. `details` was left out of the input schema, the body was handed an event without it, and `.includes` threw `Cannot read properties of undefined`.

Only a field used solely as the thing a method is called on was hidden this way. Two lines up in the same check, `lastEvent?.type === "word"` was fine, because `type` is compared rather than called on. The same body written with `computed()` was fine as well, since `computed()` rewrites nothing — which is what made this look like `assert()` changing the meaning of the code it was given.

The fix reads through the recording. `assertCapture` returns its third argument unchanged, so whatever the body does with the result of the call, it is doing to that argument. `unwrapAssertCapture` steps past the call to the argument, and the pass that notes fields now starts there. `includes` is once again seen as called on `lastEvent.details`, and a body under `assert()` and the same body under `computed()` are given the same input schema.

Stepping past the call also decides whether the thing a method was called on is a cell. `assertCapture` reaches the body through `__cfHelpers`, whose type is `any`, so the result of the call said nothing about what it held: a method the compiler does not know, called on a recorded cell, counted as an ordinary read of a plain value. It now counts as whatever it would count as without the recording.

`packages/patterns/scrabble/scrabble.test.tsx` is where this surfaced. Its check of the board after the first word is submitted was written `lastEvent?.details?.includes("AT (+4)")`, on the reading that `details` goes missing for a moment while the pattern settles. It was missing for good, and the extra `?.` worked only by accident: the rewrite leaves the receiver of an optional call alone, so those two question marks kept `lastEvent?.details` a plain field read and put `details` back in the schema. The check reads `lastEvent.details.includes("AT (+4)")` again.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

