### PR TITLE
server-exec v2 loss-triage: OW52 settle-race fix + step lift; OW51 root-caused (flagged); sx2 gate verified + per-space derivedCommits

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
@@ -1,0 +1,143 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "The sx2-events rapid-fire coalescing gate (derivedDelta < N) flake: both read claims from the danfuzz-side writeup VERIFIED (the append queue serializes arrivals, so the ratio is a load observation the test cannot control; derivedCommits is host-global). Per-space derivedCommitsBySpace landed as observability. Three dispositions evaluated; recommendation (owner ruling required): constructed-queue-depth pin in the runner suite + demote the sx2 ratio assert to the logged line."
+---
+
+# The sx2-events rapid-fire coalescing gate — verification and dispositions
+
+Origin: a danfuzz-side agent's writeup (2026-08-21, routed by the
+coordinator into the OW51/OW52 loss-triage pass — same machinery, same
+instrumentation). The flake: `packages/patterns/integration/
+sx2-events.test.ts`, assert `derivedDelta < N` ("rapid-fire coalescing:
+10 derived commits for 10 events must stay well under N"),
+intermittently red on the ON pattern lane on unrelated PRs; re-run
+clears it. Their measurements: CI passing runs log exactly 7, the
+failing run 10; locally 4–5 over ~20 runs.
+
+Relation to OW52, stated first because the two were plausibly one
+question: they are NOT. The OW52 storm accounting
+([ow52-storm-loss-report.md](ow52-storm-loss-report.md)) shows
+coalescing collapses WAVE BOUNDARIES only, never handler runs — every
+event runs its handler and lands its consequence exactly once
+(40/40, zero duplicate `consequenceOf` entries). Nothing in the storm
+dies at coalescing; its red was a harness settle race. So sx2's ratio
+gate is purely a batching-EFFICIENCY observation, with no loss
+question attached anywhere.
+
+## 1. The two read claims, verified (main @ ce92b445f)
+
+**Claim 1 — the client cannot control server-side arrival pacing:
+VERIFIED.** `EventAppendQueue.#drain()`
+(`packages/runner/src/storage/event-append-queue.ts`) sends STRICTLY
+ONE entry per `ClientCommit`, sequentially — `#nextSendable()` →
+`await this.#transact(this.#commitFor(next))`, one append patch + one
+`EventAppendDecl` per commit, "strictly one in-flight append per
+space" (the file's own ordering contract). OW27 pacing (default 20/s,
+burst 20) never holds the test's 10 fires (burst covers them), so the
+serialization is the one-in-flight rule alone: the 10 appends arrive
+at the server spaced by one client→server commit round trip each,
+regardless of the 0.4 ms fire loop. How many appends a wave finds
+queued is therefore the ratio of round-trip time to wave time — a
+LOAD RATIO the test has no lever on. A server fast enough to cover
+each append individually derives 10× and coalesces nothing while
+breaking no contract — from this counter, indistinguishable from the
+v1 no-coalescing failure the bound exists to catch. Corroborating
+runs from this triage: an idle dev machine logged exactly **7** (the
+CI passing value); the OW52 storm (40 events, two writers pipelining)
+produced 16 waves with `coalescedPerWaveMax` 11 — the ratio moves
+with load and nothing else. Note the acceptance criterion's own
+wording presumes what the test cannot enforce: "N events fired
+**faster than wave time**" (testing.md §5 row 3) — over the wire, the
+fire rate does not set the arrival rate.
+
+**Claim 2 — `derivedCommits` is host-global: VERIFIED.**
+`ServingLoopStats` is ONE process-wide object (the ExecutorHost
+registers a single provider; `stats()` merges per-space state only
+for `activeSpaces`/`watermarkLag` — `packages/runner/src/executor/
+stats.ts`, `host.ts`). Both increment sites
+(`space-server.ts` — the wave commit and the served-intent seal path)
+add into the same total across every space. Two concrete cross-space
+pollution paths exist on a shared lane toolshed even with files
+running sequentially: (i) the S1 drain-settle quiescence advance — an
+advance-only derived commit a PREVIOUS file's space mints when it
+goes quiet; the OW52 archaeology directly observed one landing AFTER
+its test process exited (commit 59, zero consequences); (ii) a parked
+space reactivating and re-deriving. No evidence either caused the
+observed 7→10 (concurring with the writeup); the path is open, and
+retroactive decomposition is impossible precisely because the counter
+is global — which is the observability hole below.
+
+Kept regardless (concurring): the case's two DETERMINISTIC asserts —
+`events.processed` delta ≥ N, and the final-only value
+`assertEquals(latestValue, beforeRapid + N)` — are real contract
+pins and stay.
+
+## 2. Per-space scoping: LANDED (observability, not a fix)
+
+`derivedCommitsBySpace: Record<string, number>` +
+`derivedCommitsBySpaceDropped` in `ServingLoopStats`, bumped at both
+`derivedCommits += 1` sites through one helper
+(`bumpDerivedCommits` — total and row in lockstep, conservation
+tested), bounded like `settle.series` (256 spaces, oldest row evicted
+into the dropped fold), deep-copied in the host's `stats()` snapshot
+like the settle series. Red-first unit test:
+`packages/runner/test/executor-stats.test.ts` (lockstep, cap
+eviction + conservation, evicted-space re-entry). Verified live: the
+health route serves the block, and an sx2-events ON run attributes
+all its derived commits to its one space.
+
+This also serves the OW52-style accounting directly: the storm triage
+needed a dedicated fresh toolshed purely because the counters were
+host-global; per-space rows make that accounting possible against the
+shared lane toolshed. It does NOT fix the flake — claim 1's load-ratio
+sensitivity is untouched.
+
+## 3. The gate: three dispositions (owner ruling required)
+
+The bound is named in the Phase-3 acceptance criterion (testing.md §5
+row 3: "rapid-fire coalescing: N events fired faster than wave time
+yield ≪N derived commits and final-only values") and the Phase-7 flip
+bar leans on that table — so retiring OR re-tensing it is an owner
+call. Evaluated:
+
+1. **The writeup's fix — drop the `derivedDelta < N` assert, keep the
+   log + the two deterministic asserts.** Kills the flake honestly
+   (the assert measures load, not contract) but retires the
+   criterion's coalescing half with NO replacement assert anywhere —
+   D-v2-2's commit-level batching would be gate-less.
+2. **Per-space scoping alone** (landed above). Closes only the
+   claim-2 pollution path; claim 1's load sensitivity survives — a
+   fast idle server still legitimately derives 10× and reds the
+   assert. Concurring with the writeup: it does not fix the flake.
+3. **Replace the raced ratio with a CONSTRUCTED-queue-depth pin —
+   FEASIBLE, and the recommendation.** The runner suite already has
+   the exact lever: `executor-events-down.test.ts`'s
+   `GatedStorageManager` `syncGate`/`syncGateWhen` parks the serving
+   DRAIN at the sidecar-doc sync, deterministically, before any
+   entry's guard check (built for the seal→outcome-window pin). The
+   pin: park the drain, commit K=10 event appends (K durable entries
+   accumulate pending), release — the drain scans all K in one pass;
+   assert (i) K completed runs, one consequence naming each
+   (exactly-once, deterministic), and (ii) the K consequences land in
+   ≪K derived commits. The premise the current test races
+   ("faster than wave time") becomes CONSTRUCTED ("K entries queued
+   ahead of one drain"), so a red means batching is actually broken
+   (one commit per queued handler run — the v1 failure shape), never
+   that the server was fast. The criterion RE-TENSES instead of
+   retiring.
+
+**Recommendation (not decided here): (3) + (1)-at-the-sx2-surface.**
+Land the constructed-depth pin in the runner suite as the criterion's
+coalescing assert; demote sx2's `derivedDelta < N` to its already-
+present logged line (the browser-facing surface keeps processed ≥ N
+and the final-only value as its asserts). With §2 landed, the sx2 log
+can also scope its reported delta to the test's own space. The
+testing.md row change ships only after the ruling; the replacement
+pin can be prepared on a branch meanwhile.
+
+Status here: claims verified, §2 landed, dispositions written. The
+option-3 pin is NOT built in this pass (the OW51 investigation is the
+queue's remaining mandated item); its feasibility evidence is the
+existing gate machinery cited above.

--- a/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
@@ -62,8 +62,13 @@ add into the same total across every space. Two concrete cross-space
 pollution paths exist on a shared lane toolshed even with files
 running sequentially: (i) the S1 drain-settle quiescence advance — an
 advance-only derived commit a PREVIOUS file's space mints when it
-goes quiet; the OW52 archaeology directly observed one landing AFTER
-its test process exited (commit 59, zero consequences); (ii) a parked
+goes quiet, with no client input; the OW52 archaeology records one
+(its run's commit seq 59: sole write the watermark doc, `replace
+/value/seq → 58`, `derived_through: 58`, no `consequence_of` — the
+S1 signature), landing after that test's assert had already read and
+within the same second its process exited — see
+[ow52-storm-loss-report.md](ow52-storm-loss-report.md) §3's
+advance-only bullet; (ii) a parked
 space reactivating and re-deriving. No evidence either caused the
 observed 7→10 (concurring with the writeup); the path is open, and
 retroactive decomposition is impossible precisely because the counter

--- a/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
@@ -2,7 +2,7 @@
 status: historical
 created: 2026-08-21
 archived: 2026-08-21
-reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read under ON — which ON read shape reaches the note.tsx lift undefined (served value vintage, schema default not applied, or arrival ordering), and the fix or flag."
+reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read is the ARRIVAL-ORDERING shape — a scheduler lift on a freshly served-instantiated note runs while its input's link chain (through the piece's result/process doc) is still materializing; the mid-chain resolution yields undefined and the leaf schema's default:null never applies. Crashes BOTH the shell worker AND the toolshed's serving runtime. Fix is a flagged contract fork (defer-on-unresolved-chain vs lifts-tolerate-undefined) — not decided here; skip stays."
 ---
 
 # OW51 — the default-app `splitDefinitions` undefined-read: triage
@@ -10,82 +10,142 @@ reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read under
 Register row: `docs/specs/server-side-execution/verification-coverage.md`
 §3 OW51. Evidence base:
 `docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md`
-row 1; the same console error W4 §6.2 recorded on the note workload
-(17 and 6 occurrences per run, attributed pre-existing there).
-
-Surface: `packages/patterns/integration/default-app.test.ts` (file-level
-ON skip). The browser console gate trips on a deterministic
-`TypeError: Cannot read properties of undefined (reading 'split')` at
-`splitDefinitions` (`api/patterns/notes/reference-block.ts:62`) inside
-note.tsx lift callbacks.
+row 1; W4 §6.2 (the same console error on the note workload, 17 and 6
+occurrences per ON rep, 2-for-2 at n=20).
 
 ## 1. Reproduction (ON binary, this worktree's tip)
 
 Built the ON binary (`EXPERIMENTAL_SERVER_EXECUTION=true deno task
-build-binaries toolshed`; `/api/meta` verified `shellServerExecutionDefine
-"true"` + servingLoop present, gitSha = branch tip) and ran
-`default-app.test.ts` against it: **both steps fail the console gate**
-with the exact registered error, while the FUNCTIONAL flow succeeds
-(note created, listed, reload survives) — the crash is a background
-failure of two computeds, not a flow-blocker.
-
-The stack traces pin BOTH crash sites to the two `pendingEdit.get()`
-readers in note.tsx:
-
-- `pendingAddresses` (note.tsx:428, `splitDefinitions(body)` at 431);
-- the staged-edit apply computed (note.tsx:444, `splitDefinitions(body)`
-  at 448)
-
-running in the SHELL WORKER's scheduler (`runPullSchedulerSettleLoop`
-→ `invokeReactiveAction` → the lift callback), reported over the
-runtime-client protocol as `callback:error`. No `editProjection` is
-ever driven by the test — the crash happens on a FRESH note during the
+build-binaries toolshed`; `/api/meta` verified
+`shellServerExecutionDefine "true"`, servingLoop present, gitSha =
+branch tip) and ran `default-app.test.ts` against it, fresh store:
+**both steps failed the console gate** on the registered error while
+the FUNCTIONAL flow succeeded (notes created, listed, reload
+survives). Stacks pin both crash sites to note.tsx's two
+`pendingEdit.get()` readers — `pendingAddresses` (note.tsx:428,
+`splitDefinitions` at 431) and the staged-edit apply computed
+(note.tsx:444/448) — no `editProjection` is ever driven; the crash is
+a background failure of a FRESH note's computeds during the
 create/open flow.
 
-## 2. What the reads mean
+**The crash is not client-only.** The same run's TOOLSHED log carries
+the identical TypeError from the SERVER's own serving runtime
+(`[ERROR][scheduler] Action failed: cf:module/…:__cfLift_18/19` →
+`splitDefinitions` → the pull-settle loop, `settle.ts`
+`runPullSettleOrder`), seconds after `event-view-lag` warnings
+("replica view holds undefined at index N" — the serving replica's
+view lagging its store during the creation burst). The serving
+runtime has NO speculation overlay and no runtime-client protocol —
+so every overlay-, protocol-, and reconciliation-specific hypothesis
+dies here: the undefined read happens in the CORE runner's
+scheduler-driven lift evaluation, on both sides.
+
+**The trigger is RACY, not deterministic**: 1 of 6 local browser runs
+reproduced (5 occurrences); five fresh-store re-runs — including the
+W4 n=20 series shape (`CF_NOTE_CREATE_TIMING_SERIES=20`) — stayed
+green on this quiet box. CI, the stage-c agents' boxes, and W4's
+loaded bench reproduced it near-reliably; W4 recorded loads. The
+window is load-sensitive.
+
+## 2. What the crashing read is
 
 `pendingEdit` is `new Writable<string | null>(null)` in the pattern
-body. `createWithDefault` (runner cell.ts) puts the initial `null`
-into the cell's SCHEMA as `default` — there is NO durable write of the
-initial value; every read depends on schema-default application. Both
-readers guard `body === null` only, so a read that yields `undefined`
-(default not applied, or value not there to read) falls through into
-`splitDefinitions(undefined)` → the TypeError at reference-block.ts:62
-(`body.split`).
+body. `createWithDefault` (runner `cell.ts`) carries the initial
+`null` as the cell SCHEMA's `default` — there is NO durable write of
+the initial value. Both readers guard `body === null` only, so an
+`undefined` falls through into `splitDefinitions(undefined)`.
 
-## 3. Negative results (they narrow the seam)
+Every leaf-level default-application site in the read path is
+null-safe (`schema.default !== undefined` — `traverse.ts`
+`applyDefault`/3696, `schema.ts` 737/1673/831): a read that REACHES
+the leaf schema cannot yield undefined for this cell. The undefined
+therefore enters ABOVE the leaf — the read dies mid-chain, before
+the leaf schema (and its default) is ever consulted.
 
-Two headless reproduction attempts against the same ON toolshed, both
-GREEN — the crash needs something the browser flow has and these do
-not:
+## 3. Which ON read shape: ARRIVAL ORDERING through the piece-doc chain
 
-- A PiecesController client instantiating notes/note.tsx directly
-  (client-authored creation) and driving `editProjection`: no crash,
-  edit applies.
-- A MultiRuntimeHarness run (bootstrap worker creates the piece,
-  session opens it BY ID from storage): no crash.
+Store archaeology on the crashed run's space (102 commits):
 
-So client-created pieces read their schema defaults fine under ON,
-including open-by-id from another runtime's creation. The browser
-difference: the note is created INSIDE a HANDLER run
-(`menuNewNote` in system/default-app.tsx does
-`navigateTo(Note({...}))`) — under ON that handler runs SERVER-side
-(authoritative instantiation in the wave) while the client runs it
-speculatively (overlay-local child; per speculation.md §4's W2.1
-clarification, the two runs' handler-frame-caused entity ids DIFFER) —
-and the shell then renders the note through that convergence.
+- Healthy `__cfLift_18` (pendingAddresses) instances record exactly
+  two basis docs each, both at their note's instantiation-wave seq,
+  and the docs' values are `result`-REDIRECT links into the note
+  piece's result/process doc — the lift's input read reaches
+  `pendingEdit` THROUGH the piece's result-doc chain, one hop past
+  the redirect.
+- The crashed action instance (`__cfLift_18:0ipYKhGE9KG4`) has NO
+  basis rows (a throwing run commits none); its crash lands at
+  18:08:31.5 exactly amid the creation burst's commit train
+  (seq 92–102, 18:08:30–32) and the server's own replica-VIEW lag
+  warnings.
+- Under ON the note is instantiated by a SERVED handler run
+  (default-app's `menuNewNote` → `navigateTo(Note({...}))` runs
+  authoritatively in the wave); the client's speculative
+  instantiation of the same child is refused at commit
+  (`piece-start-commit-failed … read basis names speculative overlay
+  layer(s)` — observed directly in the headless probe) and per
+  speculation.md §4 (W2.1) the two runs' handler-frame-caused entity
+  ids DIFFER — so every reader materializes the authoritative child's
+  doc chain from pushes/store, and there is a real window in which a
+  scheduler lift runs while the chain (result/process doc → internal
+  cell) is not yet resolvable in the reading runtime's replica view.
 
-## 4. In-situ probe
+Negative results that complete the picture (all green ON, same
+toolshed): a client-authored creation of note.tsx (PiecesController),
+an open-by-id from a bootstrap-created piece (MultiRuntimeHarness),
+and a served `createNewNote` child creation that nothing demanded —
+single-piece, low-contention flows in which the chain materializes
+before any lift runs.
 
-(running — note.tsx's two readers instrumented in the working tree to
-log the undefined read with the cell's normalized link and raw value,
-then decline instead of crashing, so subsequent runs show whether the
-read recovers; binary rebuilt with the probe)
+Against the register row's three candidates:
 
-## 5. Root cause
+- **served value vintage** — NO: nothing stale is served; the read
+  dies on a not-yet-materialized chain, and the durable state is
+  complete and correct moments later (the functional flow passes).
+- **schema default not applied** — as a SYMPTOM only: the leaf
+  default is unreachable because the read never gets there; every
+  leaf application site handles `default: null` correctly.
+- **arrival ordering** — YES: a lift evaluated against a replica view
+  in which its input's link chain is still arriving reads
+  `undefined` where the OFF arm — which instantiates and reads in
+  one runtime, synchronously with its own committed docs — always
+  supplies the value.
 
-(pending)
+## 4. The fix fork — FLAGGED, not decided (flag-don't-fill)
 
-## 6. Fix (or flag)
+The root cause honestly names the RUNNER's read-dispatch semantics,
+and the remedy is a contract decision between two arms:
 
-(pending)
+1. **Defer-on-unresolved-chain (runner side).** A scheduler lift
+   whose input chain is not yet materialized does not RUN with
+   `undefined` — the run defers and re-arms on arrival. For the
+   CLIENT this direction is arguably already SPEC-STATED:
+   speculation.md §2's "Unreplicated inputs: a speculative read of a
+   doc/path the client has not replicated is PENDING for that branch
+   … the branch renders its ordinary loading state" — running the
+   callback with `undefined` is at odds with that sentence. For the
+   SERVER's serving runtime the equivalent is UNSTATED (the
+   demanded-structure machinery defers loads, serving-loop.md §1/§3,
+   but nothing states the lift-input pending rule) — new spec
+   wording, scheduler-semantics blast radius, and a liveness design
+   question (what re-arms the deferred run) make this an owner call.
+2. **Lifts tolerate undefined during arrival (pattern contract).**
+   Guard `body == null` in note.tsx (and every pattern like it).
+   Small and immediately effective — but under OFF a schema-defaulted
+   input NEVER reads undefined, so this quietly rewrites the pattern
+   author contract ("your lift may see undefined for any input while
+   docs arrive") for every pattern, exactly the change the register
+   row says must be flagged rather than made.
+
+Both arms change a stated or relied-upon semantic; neither is landed
+here. The `integration/default-app.test.ts` ON skip STAYS (its entry
+now points at this report); the OW51 register row records the root
+cause and the flagged fork, and stays OWED pending the ruling.
+
+## 5. Verification of what landed
+
+No product code changed for OW51 (triage only — probes were
+working-tree instruments, reverted). Docs: this report; the register
+row updated in place; the skip entry's reason updated to carry the
+root cause. The reproduction assets (crashing run's store + toolshed
+log with the server-side stack) are preserved off-repo on the triage
+bench.

--- a/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
@@ -1,0 +1,44 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read under ON — which ON read shape reaches the note.tsx lift undefined (served value vintage, schema default not applied, or arrival ordering), and the fix or flag."
+---
+
+# OW51 — the default-app `splitDefinitions` undefined-read: triage
+
+Register row: `docs/specs/server-side-execution/verification-coverage.md`
+§3 OW51. Evidence base:
+`docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md`
+row 1.
+
+Surface: `packages/patterns/integration/default-app.test.ts` (file-level
+ON skip). The browser console gate trips on a deterministic
+`TypeError: Cannot read properties of undefined (reading 'split')` at
+`splitDefinitions` (`api/patterns/notes/reference-block.ts:62`) inside
+note.tsx lift callbacks — an ON read-semantics seam: the lift's input
+arrives `undefined` where the OFF arm always supplies it. Reproduced
+locally ON; OFF green. NOT a demand hole.
+
+Question this report answers: WHICH ON read shape reaches the lift
+undefined — served value vintage, schema default not applied, or
+arrival ordering — and the fix at the producer or the lift contract,
+whichever the root cause honestly names (a "lifts must tolerate
+undefined during arrival" contract change would be FLAGGED, not
+decided here).
+
+## 1. Status
+
+QUEUED — OW52 (data-loss class) runs first.
+
+## 2. Reproduction
+
+(pending)
+
+## 3. Root cause
+
+(pending)
+
+## 4. Fix (or flag)
+
+(pending)

--- a/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
@@ -10,35 +10,82 @@ reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read under
 Register row: `docs/specs/server-side-execution/verification-coverage.md`
 §3 OW51. Evidence base:
 `docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md`
-row 1.
+row 1; the same console error W4 §6.2 recorded on the note workload
+(17 and 6 occurrences per run, attributed pre-existing there).
 
 Surface: `packages/patterns/integration/default-app.test.ts` (file-level
 ON skip). The browser console gate trips on a deterministic
 `TypeError: Cannot read properties of undefined (reading 'split')` at
 `splitDefinitions` (`api/patterns/notes/reference-block.ts:62`) inside
-note.tsx lift callbacks — an ON read-semantics seam: the lift's input
-arrives `undefined` where the OFF arm always supplies it. Reproduced
-locally ON; OFF green. NOT a demand hole.
+note.tsx lift callbacks.
 
-Question this report answers: WHICH ON read shape reaches the lift
-undefined — served value vintage, schema default not applied, or
-arrival ordering — and the fix at the producer or the lift contract,
-whichever the root cause honestly names (a "lifts must tolerate
-undefined during arrival" contract change would be FLAGGED, not
-decided here).
+## 1. Reproduction (ON binary, this worktree's tip)
 
-## 1. Status
+Built the ON binary (`EXPERIMENTAL_SERVER_EXECUTION=true deno task
+build-binaries toolshed`; `/api/meta` verified `shellServerExecutionDefine
+"true"` + servingLoop present, gitSha = branch tip) and ran
+`default-app.test.ts` against it: **both steps fail the console gate**
+with the exact registered error, while the FUNCTIONAL flow succeeds
+(note created, listed, reload survives) — the crash is a background
+failure of two computeds, not a flow-blocker.
 
-QUEUED — OW52 (data-loss class) runs first.
+The stack traces pin BOTH crash sites to the two `pendingEdit.get()`
+readers in note.tsx:
 
-## 2. Reproduction
+- `pendingAddresses` (note.tsx:428, `splitDefinitions(body)` at 431);
+- the staged-edit apply computed (note.tsx:444, `splitDefinitions(body)`
+  at 448)
+
+running in the SHELL WORKER's scheduler (`runPullSchedulerSettleLoop`
+→ `invokeReactiveAction` → the lift callback), reported over the
+runtime-client protocol as `callback:error`. No `editProjection` is
+ever driven by the test — the crash happens on a FRESH note during the
+create/open flow.
+
+## 2. What the reads mean
+
+`pendingEdit` is `new Writable<string | null>(null)` in the pattern
+body. `createWithDefault` (runner cell.ts) puts the initial `null`
+into the cell's SCHEMA as `default` — there is NO durable write of the
+initial value; every read depends on schema-default application. Both
+readers guard `body === null` only, so a read that yields `undefined`
+(default not applied, or value not there to read) falls through into
+`splitDefinitions(undefined)` → the TypeError at reference-block.ts:62
+(`body.split`).
+
+## 3. Negative results (they narrow the seam)
+
+Two headless reproduction attempts against the same ON toolshed, both
+GREEN — the crash needs something the browser flow has and these do
+not:
+
+- A PiecesController client instantiating notes/note.tsx directly
+  (client-authored creation) and driving `editProjection`: no crash,
+  edit applies.
+- A MultiRuntimeHarness run (bootstrap worker creates the piece,
+  session opens it BY ID from storage): no crash.
+
+So client-created pieces read their schema defaults fine under ON,
+including open-by-id from another runtime's creation. The browser
+difference: the note is created INSIDE a HANDLER run
+(`menuNewNote` in system/default-app.tsx does
+`navigateTo(Note({...}))`) — under ON that handler runs SERVER-side
+(authoritative instantiation in the wave) while the client runs it
+speculatively (overlay-local child; per speculation.md §4's W2.1
+clarification, the two runs' handler-frame-caused entity ids DIFFER) —
+and the shell then renders the note through that convergence.
+
+## 4. In-situ probe
+
+(running — note.tsx's two readers instrumented in the working tree to
+log the undefined read with the cell's normalized link and raw value,
+then decline instead of crashing, so subsequent runs show whether the
+read recovers; binary rebuilt with the probe)
+
+## 5. Root cause
 
 (pending)
 
-## 3. Root cause
-
-(pending)
-
-## 4. Fix (or flag)
+## 6. Fix (or flag)
 
 (pending)

--- a/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow51-undefined-read-report.md
@@ -2,7 +2,7 @@
 status: historical
 created: 2026-08-21
 archived: 2026-08-21
-reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read is the ARRIVAL-ORDERING shape — a scheduler lift on a freshly served-instantiated note runs while its input's link chain (through the piece's result/process doc) is still materializing; the mid-chain resolution yields undefined and the leaf schema's default:null never applies. Crashes BOTH the shell worker AND the toolshed's serving runtime. Fix is a flagged contract fork (defer-on-unresolved-chain vs lifts-tolerate-undefined) — not decided here; skip stays."
+reason: "OW51 loss-triage: the default-app splitDefinitions undefined-read is the ARRIVAL-ORDERING shape (mechanism CLASS established by elimination; the exact failing hop is inferred, not traced — see the evidence-status block) — a scheduler lift on a freshly served-instantiated note runs while its input's link chain (through the piece's result/process doc) is still materializing; the mid-chain resolution yields undefined and the leaf schema's default:null never applies. Crashes BOTH the shell worker AND the toolshed's serving runtime. Fix is a flagged contract fork (defer-on-unresolved-chain vs lifts-tolerate-undefined) — not decided here; skip stays."
 ---
 
 # OW51 — the default-app `splitDefinitions` undefined-read: triage
@@ -109,6 +109,30 @@ Against the register row's three candidates:
   `undefined` where the OFF arm — which instantiates and reads in
   one runtime, synchronously with its own committed docs — always
   supplies the value.
+
+**Evidence status — established vs inferred (#6158 review F6; read
+"root-caused" as "mechanism CLASS established", not "failing hop
+pinned").** ESTABLISHED, directly: the crash sites and the undefined
+value (stacks, both runtimes); the schema-default-only seeding of
+`pendingEdit` (`createWithDefault`, no durable write); the null-safety
+of every leaf default-application site (so a read REACHING the leaf
+cannot yield undefined — the undefined enters above it); the
+serving-runtime crash (which eliminates overlay / runtime-client /
+reconciliation mechanisms — none exists in that stack); the raciness
+and load sensitivity (which eliminate deterministic-strip mechanisms);
+the served-handler instantiation shape and the healthy instances'
+through-the-result-doc basis rows. INFERRED, honestly but without a
+captured trace: (a) WHICH mid-chain hop resolves undefined — no
+instrument caught the failing read in the act (the in-situ probe
+binary never reproduced; the race is load-sensitive); (b) that the
+browser and serving-runtime crashes are ONE mechanism — concluded
+from symptom+stack identity plus the shared lagging-replica-view
+family, not from a shared trace. Neither residual affects the fix
+fork below: both arms treat "input chain not yet resolvable"
+generically, whichever hop it is, and the skip stays either way. A
+fix build on the ruled arm should start by capturing the failing hop
+(one targeted read-path instrument under load), which also retires
+residual (a).
 
 ## 4. The fix fork — FLAGGED, not decided (flag-don't-fill)
 

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -82,6 +82,18 @@ Store archaeology (run 1's space, sqlite commit log):
   landed=23; the store reached 40/40 about a second later, with the
   test process already gone — so the loop drains on its own, no
   client-wake dependency).
+- The 16th derived commit (seq 59, 17:35:49) is the run's one
+  ADVANCE-ONLY commit: its sole write is the watermark doc
+  (`of:server-execution-watermark`, `replace /value/seq → 58`),
+  `derived_through: 58`, no `consequence_of` — the S1 drain-settle
+  quiescence-advance signature (protocol.md §4), minted by the
+  serving loop at space quiescence with no client input, after the
+  test's assert had already read (and within the same second the
+  test process exited). Recorded here because it is also the concrete
+  cross-space-pollution witness the sx2 coalescing-gate report
+  (`ow-sx2-coalescing-gate.md` §1 claim 2) cites: such advance-only
+  commits tick the host-global `derivedCommits` for a space whose
+  test is already done.
 
 Probe convergence poll (run 2), reading the observer after the failing
 `settle(20)` and then again per extra `settle(5)` round:
@@ -150,8 +162,12 @@ The fix (test infrastructure only, no product semantics touched):
   inserts the quiescence wait between the sessions' idle and the
   barrier — one shared budget (10 s) per `settle()` call across all
   rounds, so a genuinely wedged consequence degrades to today's
-  behavior (the assert speaks) instead of hanging the harness. The OFF
-  arm's settle is byte-identical.
+  behavior (the assert speaks) instead of hanging the harness — and
+  degrades LOUDLY (#6158 review F1): budget exhaustion with intents
+  still outstanding warns once with the per-session counts, so a red
+  assert on a slow box self-identifies as budget exhaustion (a
+  mid-drain read) rather than presenting as the loss shape this
+  report disproves. The OFF arm's settle is byte-identical.
 
 Ordering argument: after step 1's idle every fired echo is sealed and
 every append is discharging; the quiescence wait then ends only when
@@ -163,10 +179,18 @@ idle re-derives. The observer's schema-read demand for newly-linked
 element docs resolves across the remaining rounds (the storm step runs
 20).
 
-This restores settle PARITY between the arms — the ON settle now means
-what the OFF settle always meant ("the server has drained what I
+This restores settle parity between the arms FOR FIRST-ORDER
+CONSEQUENCES — the ON settle now means what the OFF settle always
+meant for a session's own sends ("the server has drained what I
 sent") — and does not weaken the step's assertion: the step still
 asserts full 40/40 reader convergence on a session that never wrote.
+Scope caveat (#6158 review F2): the wait is NOT full `server.idle()`
+parity — a server-side cascade child (an event a served handler
+itself emits) is no session's intent and commits in a later wave,
+outside the wait; cascades ride the ordinary barrier rounds. The
+storm's `post` handler emits no cascades, so nothing here depends on
+that gap; a future harness test asserting on cascade results needs
+enough rounds or a `waitFor`.
 
 Red-first: the step (skip lifted) is the red test — red twice locally
 pre-fix (landed=22, 23), green 5/5 post-fix (see §6).

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -1,0 +1,66 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "OW52 loss-triage: the convergence-storm ON loss (observer landed=23/40 under 2x20 pipelined posts) — full 40-event accounting across append admission, drain, dispatch, and consequence commit; where the 17 die and the fix."
+---
+
+# OW52 — the convergence-storm ON loss (landed 23/40): loss triage
+
+Register row: `docs/specs/server-side-execution/verification-coverage.md`
+§3 OW52. Evidence base:
+`docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md`
+row 8 and §3 (the harness posture fix that made the red honest — the
+pre-fix mixed posture refused all 40 appends, masking a real 17-message
+loss).
+
+Surface: `packages/patterns/integration/convergence-storm.test.ts`,
+step "a non-writing session sees every concurrently-posted message"
+(step-level ON skip; the file's 3 element-schema tests are green ON).
+Under the TRUE ON topology (MultiRuntimeHarness targeting the
+integration environment's toolshed), 2×20 pipelined `post` events
+(`idle:false`) per writer leave the non-writing observer at
+landed=23/40.
+
+Question this report answers: WHERE do the 17 die — append admission,
+queue, dispatch, or consequence commit under pipelined contention —
+and whether the collapse (if any) is CoalescedDocListener-style
+coalescing-by-design vs a genuine loss against the test's
+every-message-must-land contract.
+
+## 1. Method
+
+- Local toolshed run from this worktree
+  (`EXPERIMENTAL_SERVER_EXECUTION=true deno run --no-lock -A index.ts`,
+  fresh `MEMORY_DIR` per run, port 8891), serving loop verified present
+  via `/api/health/stats`.
+- Storm step run against it (`API_URL=http://localhost:8891/`,
+  `EXPERIMENTAL_SERVER_EXECUTION=true`), step-skip entry neutered in
+  the working tree for triage runs only.
+- Accounting instruments: the serving loop's own `events.*` stats
+  (appended / processed / coalescedPerWaveMax / skippedIdempotent /
+  drainInFlightSkips / lt1LeftoversPurged / lt1LateSealsRefused /
+  orphanDeliveriesRefused), plus store-side archaeology (stream sidecar
+  entries vs `messages` array) and targeted instrumentation at the seam
+  the counters implicate.
+
+## 2. Status
+
+IN PROGRESS — triage running. Sections below fill in as evidence
+lands.
+
+## 3. Reproduction runs
+
+(pending)
+
+## 4. The 40-event accounting
+
+(pending)
+
+## 5. Where the 17 die
+
+(pending)
+
+## 6. Fix (or flag)
+
+(pending)

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -182,4 +182,25 @@ something this fix decides.
 
 ## 6. Verification
 
-(pending — filled after the fix runs)
+All local, this worktree, against the ON toolshed on port 8891 (fresh
+store), `--no-lock` throughout:
+
+- Storm step ON (skip entry lifted): **5/5 green**, ~7–8 s per run —
+  the ~2 s over the red runs' ~5 s is exactly the serving drain the
+  settle now honestly waits for.
+- `convergence-storm.test.ts` full file: **4/4 ON**, **4/4 OFF**.
+- Harness family under the settle change:
+  `cfc-group-chat-demo-multi-runtime` 7/7 ON, 7/7 OFF;
+  `cellset-lww` 3 green + OW47 step skipped ON, 4/4 OFF;
+  `data-file-multi-runtime` 2/2 ON, 2/2 OFF;
+  `cellset-lww-lost-update` 2/2 ON, 2/2 OFF.
+- `tasks/server-execution-on-skips.ts patterns` self-run: exit 0, the
+  convergence-storm step entry gone, every remaining entry validated
+  (the cellset step guard still bound).
+- `deno check` on the harness + worker: clean.
+
+Register row OW52 CLOSED in the same change (docs-move-together);
+skip-entry status: the `integration/convergence-storm.test.ts` step
+entry LIFTED. The in-file guard wiring stays (designed binding for any
+future entry; a guard without an entry is a no-op and the validator
+only checks the other direction).

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -2,7 +2,7 @@
 status: historical
 created: 2026-08-21
 archived: 2026-08-21
-reason: "OW52 loss-triage: the convergence-storm ON loss (observer landed=23/40 under 2x20 pipelined posts) — full 40-event accounting across append admission, drain, dispatch, and consequence commit; where the 17 die and the fix."
+reason: "OW52 loss-triage: the convergence-storm ON 'loss' (observer landed=23/40) is NOT a loss — full 40-event accounting shows append admission 40/40, exactly-once processing 40/40, all 40 pushes durable; the observer converges to 40/40. The red is the harness settle racing the serving loop: the ON topology's settle has no server-drain step. Fix: a bounded intent-quiescence step in the harness's served-topology settle."
 ---
 
 # OW52 — the convergence-storm ON loss (landed 23/40): loss triage
@@ -10,9 +10,9 @@ reason: "OW52 loss-triage: the convergence-storm ON loss (observer landed=23/40 
 Register row: `docs/specs/server-side-execution/verification-coverage.md`
 §3 OW52. Evidence base:
 `docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md`
-row 8 and §3 (the harness posture fix that made the red honest — the
-pre-fix mixed posture refused all 40 appends, masking a real 17-message
-loss).
+row 8 and §3 (the harness posture fix that made this red honest — the
+pre-fix mixed posture refused all 40 appends, masking what was recorded
+as a real 17-message loss).
 
 Surface: `packages/patterns/integration/convergence-storm.test.ts`,
 step "a non-writing session sees every concurrently-posted message"
@@ -20,47 +20,166 @@ step "a non-writing session sees every concurrently-posted message"
 Under the TRUE ON topology (MultiRuntimeHarness targeting the
 integration environment's toolshed), 2×20 pipelined `post` events
 (`idle:false`) per writer leave the non-writing observer at
-landed=23/40.
-
-Question this report answers: WHERE do the 17 die — append admission,
-queue, dispatch, or consequence commit under pipelined contention —
-and whether the collapse (if any) is CoalescedDocListener-style
-coalescing-by-design vs a genuine loss against the test's
-every-message-must-land contract.
+landed=23/40 at assert time.
 
 ## 1. Method
 
-- Local toolshed run from this worktree
+- Local toolshed from this worktree
   (`EXPERIMENTAL_SERVER_EXECUTION=true deno run --no-lock -A index.ts`,
-  fresh `MEMORY_DIR` per run, port 8891), serving loop verified present
-  via `/api/health/stats`.
+  port 8891, fresh `MEMORY_DIR` per run), serving loop verified present
+  via `/api/health/stats` (`servingLoop != null`).
 - Storm step run against it (`API_URL=http://localhost:8891/`,
   `EXPERIMENTAL_SERVER_EXECUTION=true`), step-skip entry neutered in
-  the working tree for triage runs only.
-- Accounting instruments: the serving loop's own `events.*` stats
-  (appended / processed / coalescedPerWaveMax / skippedIdempotent /
-  drainInFlightSkips / lt1LeftoversPurged / lt1LateSealsRefused /
-  orphanDeliveriesRefused), plus store-side archaeology (stream sidecar
-  entries vs `messages` array) and targeted instrumentation at the seam
-  the counters implicate.
+  the working tree for triage runs.
+- Accounting instruments: the serving loop's own `events.*` /
+  wave stats; sqlite store archaeology (the space's full commit log:
+  `commit`, `revision`, `head`, `snapshot` tables); a probe test
+  (storm shape + read-path dissection + convergence polling).
 
-## 2. Status
+## 2. Reproduction
 
-IN PROGRESS — triage running. Sections below fill in as evidence
-lands.
+Two independent local reproductions, both red at the assert:
 
-## 3. Reproduction runs
+- Run 1 (the unmodified step): FAILED, observer missing `bob-9` et al.
+  — assert fired ~5 s into the step.
+- Run 2 (probe): shaped read landed=**22/40** after the test's exact
+  storm + `settle(20)`; missing set = `alice-11..19` + `bob-11..19` —
+  **a contiguous per-writer SUFFIX**, not a scattered subset. At the
+  same instant the two writers' own shaped reads were 31/40 each and
+  the observer's raw replica read of the messages doc matched its
+  shaped read (22 links) — the observer's replica was simply at an
+  older head, not failing to resolve anything it held.
 
-(pending)
+## 3. The 40-event accounting
 
-## 4. The 40-event accounting
+Serving-loop counters after run 1 (fresh store, this run only):
 
-(pending)
+| counter | value | meaning |
+|---|---|---|
+| `events.appended` | **40** | every append admitted; admission lost nothing |
+| `events.processed` | **40** | every durable entry delivered and run |
+| `events.skippedIdempotent` | 0 | no watermark skips |
+| `events.drainInFlightSkips` | 73 | the drain's self-dedupe working (at-most-one-copy) |
+| `events.lt1LeftoversPurged` / `lt1LateSealsRefused` / `orphanDeliveriesRefused` | 0/0/0 | no purge-path involvement |
+| `waves` / `derivedCommits` | 16 / 16 | |
+| `wavesBudgetExhausted` | 9 | the honest flush deadline cutting busy waves — routine under storm |
+| `supersededWrites` | 0 | no per-doc supersede drops |
 
-## 5. Where the 17 die
+Store archaeology (run 1's space, sqlite commit log):
 
-(pending)
+- 43 authored commits (40 event appends, seq 9–52) + 16 derived
+  commits.
+- The 40 eventIds appear in `consequence_of` across 10 derived commits
+  (1+5+4+4+6+4+3+4+5+4), **each exactly once, zero duplicates** — the
+  (α) exactly-once invariant held under storm depth.
+- The messages array doc carries **all 40 `append` patches**, one per
+  event, each linking a distinct hoisted element doc; all 40 element
+  docs exist. Nothing in the durable state is missing.
+- Timeline: first append 17:35:47, last consequence-carrying derived
+  commit 17:35:49 — the server consequenced the whole 40-event
+  pipelined backlog in **~2 s**, finishing AFTER the test's assert
+  (the step read its observer view mid-drain and the test failed at
+  landed=23; the store reached 40/40 about a second later, with the
+  test process already gone — so the loop drains on its own, no
+  client-wake dependency).
 
-## 6. Fix (or flag)
+Probe convergence poll (run 2), reading the observer after the failing
+`settle(20)` and then again per extra `settle(5)` round:
+22 → 28 → 28 → 33 → 33 → **40/40**. `messageCount` and the raw reads
+agree at every sample.
 
-(pending)
+## 4. Where the 17 "die": they don't
+
+**No event and no message is lost at any seam.** Append admission
+40/40, drain/dispatch 40/40 with exactly-once consequences, all 40
+pushes durable in the messages doc, and the non-writing observer
+CONVERGES to 40/40. Against the register row's four candidate seams
+(append admission, queue, dispatch, consequence commit): all four are
+clean.
+
+On the CoalescedDocListener question the register row raises:
+coalescing is real (`coalescedPerWaveMax=11`; up to 11 events
+consequenced by one wave commit) but collapses only WAVE BOUNDARIES,
+never handler runs — each of the 40 events ran its own handler and
+produced its own durable array append. Coalescing-by-design changes
+nothing the observer counts.
+
+The red's actual mechanism is the TEST HARNESS's settle contract under
+the served topology:
+
+- OFF: `MultiRuntimeHarness.settle` runs
+  idle → **`server.idle()` (drain the in-process server fully)** →
+  barrier → idle. The server-drain step makes settle terminate only at
+  system quiescence.
+- ON (toolshed-backed): there is no in-process server handle, so
+  settle degrades to N client round trips (idle → barrier → idle).
+  Each round completes in milliseconds while the serving loop needs
+  ~2–3 s to drain a 40-event pipelined backlog (16 waves, 9 of them
+  deadline-cut, by design — serving-loop.md §3's honest flush
+  deadline). `settle(20)` therefore returns well before the last waves
+  commit, and the assert reads a mid-drain head. The harness's own doc
+  comment promised "successive rounds converge" — a promise a FIXED
+  round count cannot keep against an asynchronous serving loop.
+
+So the register row's premise ("a REAL loss") does not survive the
+accounting: the pre-fix 0/40 was a real refusal-loss (the mixed
+posture); the post-fix 23/40 is a REAL-LOOKING RACE — serving-loop
+progress at assert time, not loss. What lands is served and delivered;
+it just hadn't all landed yet.
+
+## 5. Fix
+
+At the seam the accounting names: the harness's served-topology settle
+needs the server-drain step the OFF arm already has. The
+client-observable equivalent of `server.idle()` is speculation.md §4
+step 2: an event's overlay intent entry retires exactly when its
+terminal consequence has ARRIVED back at the firing client (carrier:
+the tracked stream entry's own `consequenced`/`status`/`error` fields,
+backstopped by `eventWatermark` coverage). The runtime already
+maintains the outstanding set
+(`overlay-destination.ts` `trackIntent`/`#checkIntents`) and exposes
+its size (`Runtime.speculationOverlay.pendingIntentCount`).
+
+The fix (test infrastructure only, no product semantics touched):
+
+- `multi-runtime-worker.ts` gains an `eventQuiescence` RPC — poll the
+  runtime's outstanding-intent count to 0, bounded by a caller-supplied
+  budget. The OFF arm has no overlay (`speculationOverlay` undefined)
+  and resolves immediately.
+- `MultiRuntimeHarness.settle`, in the no-in-process-server arm only,
+  inserts the quiescence wait between the sessions' idle and the
+  barrier — one shared budget (10 s) per `settle()` call across all
+  rounds, so a genuinely wedged consequence degrades to today's
+  behavior (the assert speaks) instead of hanging the harness. The OFF
+  arm's settle is byte-identical.
+
+Ordering argument: after step 1's idle every fired echo is sealed and
+every append is discharging; the quiescence wait then ends only when
+every event's terminal consequence has arrived at ITS writer, which
+requires the server to have committed it; the following barrier
+(`pullOpenSpacesToHead`) is an ordered-after round trip, so the
+observer's replica reaches a head ≥ every consequence commit; step 4's
+idle re-derives. The observer's schema-read demand for newly-linked
+element docs resolves across the remaining rounds (the storm step runs
+20).
+
+This restores settle PARITY between the arms — the ON settle now means
+what the OFF settle always meant ("the server has drained what I
+sent") — and does not weaken the step's assertion: the step still
+asserts full 40/40 reader convergence on a session that never wrote.
+
+Red-first: the step (skip lifted) is the red test — red twice locally
+pre-fix (landed=22, 23), green 5/5 post-fix (see §6).
+
+FLAG, recorded not decided (adjacent, out of this fix's scope): under
+ON, a client that does `await send(); await runtime.idle()` has no
+guarantee its OWN send's consequence is visible — OFF's idle implies
+it (the handler ran in-process). The harness now closes that gap for
+TESTS; whether the PRODUCT's idle/settle vocabulary should carry an
+intent-quiescence barrier is a spec question adjacent to OW47's
+pending-commit-barrier seat (S-F covers binding writes), not
+something this fix decides.
+
+## 6. Verification
+
+(pending — filled after the fix runs)

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5144,15 +5144,35 @@ supply; OW29/OW32/OW34 closed):
     surfaces where the wish UI belongs. Trigger: rides the
     OW48/OW49 fix arc (detectability; not itself the lift condition).
   - **OW51 — the default-app `splitDefinitions` undefined-read (the
-    ON read-semantics seam).** A note.tsx lift callback's input
-    arrives `undefined` under ON where the OFF arm always supplies it
-    — `TypeError: Cannot read properties of undefined (reading
-    'split')` at `notes/reference-block.ts:62`, caught by the
-    integration console gate (the same console error W4 §6.2 recorded
-    on the note workload's rc=1, here fatal). Owed: root-cause which
-    ON read shape reaches the lift undefined (served value vintage,
-    schema default not applied, or arrival ordering) and fix at the
-    producer or the lift contract. Trigger: lifts the
+    ON read-semantics seam): ROOT-CAUSED (2026-08-21, the
+    optimize-phase loss triage) — ARRIVAL ORDERING; the fix fork is
+    FLAGGED for the owner.** The undefined read is a scheduler lift
+    on a freshly SERVED-instantiated note (default-app's menuNewNote
+    runs authoritatively in the wave; the client's speculative child
+    is refused at piece-start commit and carries different
+    handler-frame ids per speculation.md §4 W2.1) evaluated while its
+    input's link chain — through the piece's result/process doc to
+    the schema-default-only `pendingEdit` cell — is still
+    materializing in the reading runtime's replica view: the
+    mid-chain resolution yields `undefined` and the leaf schema's
+    `default: null` is never consulted (every leaf default site is
+    null-safe; the undefined enters above the leaf). NOT client-only:
+    the toolshed's own serving runtime hits the identical TypeError
+    in its pull-settle loop (no overlay, no runtime-client protocol
+    in that stack), amid `event-view-lag` replica-view warnings.
+    Racy, load-sensitive (1/6 local browser runs; W4's loaded bench
+    2-for-2 at n=20); single-creation headless flows never hit it.
+    Not served-value vintage; "schema default not applied" only as
+    the symptom of the chain dying early. Owed: the OWNER's call on
+    the fix fork — (1) defer-on-unresolved-chain in the runner
+    (speculation.md §2's client-side PENDING sentence arguably
+    already states it; the serving-runtime equivalent is UNSTATED —
+    new spec wording + scheduler-semantics blast radius), vs (2)
+    "lifts tolerate undefined during arrival" (a pattern-contract
+    change: under OFF a schema-defaulted input never reads
+    undefined) — then the fix red-first on the ruled arm. Evidence:
+    docs/history/plans/server-execution-v2/optimize/
+    ow51-undefined-read-report.md. Trigger: lifts the
     `integration/default-app.test.ts` ON skip.
   - **OW52 — the convergence-storm ON loss (landed 23/40): CLOSED
     (2026-08-21, the optimize-phase loss triage) — NOT a loss.** The

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5154,17 +5154,36 @@ supply; OW29/OW32/OW34 closed):
     schema default not applied, or arrival ordering) and fix at the
     producer or the lift contract. Trigger: lifts the
     `integration/default-app.test.ts` ON skip.
-  - **OW52 — the convergence-storm ON loss (landed 23/40).** Under
-    the TRUE ON topology the storm step (2×20 pipelined `post` events,
-    `idle:false`, per writer) leaves the non-writing observer at
-    landed=23/40 — a REAL loss (the pre-fix mixed posture refused all
-    40, masking it); the file's 3 element-schema tests are green.
-    WHERE the 17 die — append admission, queue, dispatch, or
-    consequence commit under pipelined contention — is UNTRIAGED; the
-    (α) exactly-once invariants say nothing about append-side loss
-    under storm depth. Owed: the triage and the fix. Trigger: lifts
-    the `integration/convergence-storm.test.ts` step entry (green
-    5/5).
+  - **OW52 — the convergence-storm ON loss (landed 23/40): CLOSED
+    (2026-08-21, the optimize-phase loss triage) — NOT a loss.** The
+    full 40-event accounting (serving-loop counters + the space's
+    sqlite commit log) cleared every candidate seam: append admission
+    40/40 (`events.appended`), drain/dispatch 40/40
+    (`events.processed`, `skippedIdempotent` 0, purge/orphan counters
+    0), consequences EXACTLY-ONCE (all 40 eventIds across 10 derived
+    commits, zero duplicates — the (α) invariant held at storm depth),
+    all 40 array appends durable, and the observer CONVERGES to 40/40
+    (~2–3 s of serving drain; 16 waves, 9 deadline-cut — the honest
+    flush deadline's routine shape, serving-loop.md §3). Per-wave
+    coalescing (`coalescedPerWaveMax` 11) collapses wave boundaries
+    only, never handler runs — no coalescing-by-design ambiguity. The
+    red was the HARNESS: the served-topology `settle()` had no
+    server-drain step (the OFF arm's `server.idle()`), so a fixed
+    round count of idle/barrier hops raced the drain and the assert
+    read a mid-drain head. Fixed in the harness (test infrastructure,
+    no product semantics): `MultiRuntimeHarness.settle`'s
+    toolshed-backed arm waits, bounded, for each session's
+    outstanding-intent set to empty — speculation.md §4 step 2's
+    arrived-terminal-consequence retirement,
+    `Runtime.speculationOverlay.pendingIntentCount` — before the
+    barrier, restoring settle parity between the arms. Step green ON
+    5/5 + file 4/4 ON and OFF; the step entry LIFTED. Evidence:
+    docs/history/plans/server-execution-v2/optimize/
+    ow52-storm-loss-report.md. Recorded, not decided (adjacent):
+    whether the PRODUCT's idle vocabulary should carry an
+    intent-quiescence barrier under ON (OFF's idle implies own-send
+    consequence visibility; ON's does not) — a spec question beside
+    OW47's pending-commit-barrier seat, surfaced in the report.
   - **OW53 — the sqlite multi-runtime identity pair under ON.** Two
     semantic asserts under the TRUE ON topology: db-owner — a SECOND
     user's runtime re-mints itself as the sqlite db handle owner

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5145,7 +5145,10 @@ supply; OW29/OW32/OW34 closed):
     OW48/OW49 fix arc (detectability; not itself the lift condition).
   - **OW51 — the default-app `splitDefinitions` undefined-read (the
     ON read-semantics seam): ROOT-CAUSED (2026-08-21, the
-    optimize-phase loss triage) — ARRIVAL ORDERING; the fix fork is
+    optimize-phase loss triage) — ARRIVAL ORDERING (mechanism CLASS,
+    established by elimination; the exact failing hop is inferred,
+    not traced — the report's evidence-status block draws the line);
+    the fix fork is
     FLAGGED for the owner.** The undefined read is a scheduler lift
     on a freshly SERVED-instantiated note (default-app's menuNewNote
     runs authoritatively in the wave; the client's speculative child
@@ -5196,7 +5199,11 @@ supply; OW29/OW32/OW34 closed):
     outstanding-intent set to empty — speculation.md §4 step 2's
     arrived-terminal-consequence retirement,
     `Runtime.speculationOverlay.pendingIntentCount` — before the
-    barrier, restoring settle parity between the arms. Step green ON
+    barrier, restoring the arms' settle agreement for FIRST-ORDER
+    consequences (server-side cascade children are no session's
+    intent and ride the barrier rounds — the storm has none; budget
+    exhaustion warns loudly so a slow-box mid-drain red
+    self-identifies instead of re-opening this row). Step green ON
     5/5 + file 4/4 ON and OFF; the step entry LIFTED. Evidence:
     docs/history/plans/server-execution-v2/optimize/
     ow52-storm-loss-report.md. Recorded, not decided (adjacent):

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -470,28 +470,61 @@ export class MultiRuntimeHarness {
    * the drain (the OW52 shape: a 40-event pipelined storm needs ~2–3 s of
    * server time while 20 rounds complete in well under a second, so the
    * assert read a mid-drain head). Step 2's replacement is the
-   * client-observable equivalent of `server.idle()`: wait until every event
+   * client-observable stand-in for `server.idle()`: wait until every event
    * each session fired has its terminal consequence ARRIVED back at that
    * session (speculation.md §4 step 2 — the overlay's outstanding-intent set
-   * empties exactly then). The wait shares ONE budget across the whole
-   * `settle()` call, so a genuinely wedged consequence degrades to the old
-   * behavior (the caller's assert speaks) instead of hanging the harness;
-   * the barrier then pulls each replica to a head ≥ every consequence
-   * commit. Instant on an OFF-posture toolshed run (no overlay, no
-   * outstanding intents).
+   * empties exactly then). CAVEAT (#6158 review F2): this covers
+   * FIRST-ORDER consequences only — a server-side cascade child (an event a
+   * served handler itself emits) is no session's intent and commits in a
+   * LATER wave, outside the wait; cascades ride the ordinary barrier rounds,
+   * so a test asserting on cascade results still needs enough rounds (or a
+   * `waitFor`). The wait shares ONE budget across the whole `settle()`
+   * call, so a genuinely wedged consequence degrades to the old behavior
+   * (the caller's assert speaks) instead of hanging the harness — LOUDLY:
+   * exhausting the budget with intents still outstanding warns once, so a
+   * red assert after it self-identifies as budget exhaustion (a slow
+   * serving drain) rather than re-opening the OW52 loss triage. The
+   * barrier then pulls each replica to a head ≥ every first-order
+   * consequence commit. Instant on an OFF-posture toolshed run (no
+   * overlay, no outstanding intents).
    */
   async settle(rounds = 2): Promise<void> {
     const quiescenceDeadline = this.#server === undefined
       ? Date.now() + SERVED_SETTLE_QUIESCENCE_BUDGET_MS
       : undefined;
+    let quiescenceWarned = false;
     for (let i = 0; i < rounds; i++) {
       await Promise.all(this.sessions.map((session) => session.idle()));
       await this.#server?.idle();
       if (quiescenceDeadline !== undefined) {
         const budget = Math.max(0, quiescenceDeadline - Date.now());
-        await Promise.all(
+        const outcomes = await Promise.all(
           this.sessions.map((session) => session.eventQuiescence(budget)),
         );
+        // #6158 review F1: the worker returns pending > 0 ONLY at its
+        // deadline, so any nonzero here means the shared budget ran out
+        // with consequences still outstanding — the reads that follow may
+        // see a MID-DRAIN head. Say so once, so the resulting red names
+        // itself instead of presenting as the OW52 "loss" shape.
+        if (!quiescenceWarned && outcomes.some((o) => o.pending > 0)) {
+          quiescenceWarned = true;
+          const detail = outcomes
+            .map((outcome, index) =>
+              outcome.pending > 0
+                ? `${this.sessions[index].label}: ${outcome.pending}`
+                : undefined
+            )
+            .filter((entry) => entry !== undefined)
+            .join(", ");
+          console.warn(
+            `[multi-runtime-harness] settle: event-consequence quiescence ` +
+              `budget (${SERVED_SETTLE_QUIESCENCE_BUDGET_MS} ms) exhausted ` +
+              `with intents still outstanding (${detail}) — subsequent ` +
+              `reads may see a mid-drain head. A red assert after this ` +
+              `line is BUDGET EXHAUSTION (a slow serving drain or a wedged ` +
+              `consequence), not the OW52 loss shape.`,
+          );
+        }
       }
       await Promise.all(this.sessions.map((session) => session.barrier()));
       await Promise.all(this.sessions.map((session) => session.idle()));

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -96,6 +96,11 @@ export interface MultiRuntimeHarnessOptions {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const RPC_TIMEOUT_MS = 120_000;
+/** Total event-consequence quiescence budget per `settle()` call on a
+ * toolshed-backed harness (see `settle`): generous against the measured
+ * ~2–3 s serving drain of a 40-event pipelined storm, small against the
+ * suite timeouts a wedged consequence would otherwise eat. */
+const SERVED_SETTLE_QUIESCENCE_BUDGET_MS = 10_000;
 
 class WorkerClient {
   #worker: Worker;
@@ -284,6 +289,19 @@ export class MultiRuntimeSession {
   }
 
   /**
+   * Wait, bounded by `timeoutMs`, until every event this session fired has
+   * its terminal consequence ARRIVED back here (speculation.md §4 step 2 —
+   * the overlay's outstanding-intent set is empty). Resolves with the
+   * still-outstanding count when the budget elapses first. Instant on the
+   * OFF arm (no overlay). See `MultiRuntimeHarness.settle`.
+   */
+  async eventQuiescence(timeoutMs?: number): Promise<{ pending: number }> {
+    return await this.#client.call("eventQuiescence", { timeoutMs }) as {
+      pending: number;
+    };
+  }
+
+  /**
    * Force an ordered-after round trip on this runtime's open space connections,
    * so any subscription fan-out the server has already sent has landed here.
    * See `MultiRuntimeHarness.settle`.
@@ -445,14 +463,36 @@ export class MultiRuntimeHarness {
    * 4. Every runtime settles again, so a foreign write that just arrived and
    *    re-derives local cells has its recompute run before this round ends.
    *
-   * With a running toolshed (when `apiUrl` was passed) there is no in-process
-   * server handle for step 2; the barrier in step 3 still pulls in whatever the
-   * toolshed has sent, and successive rounds converge.
+   * With a running toolshed (when `apiUrl` was passed, or the ON posture
+   * resolved one) there is no in-process server handle for step 2, and under
+   * the ON posture the toolshed's serving loop processes this harness's event
+   * appends ASYNCHRONOUSLY — a fixed round count of idle/barrier hops races
+   * the drain (the OW52 shape: a 40-event pipelined storm needs ~2–3 s of
+   * server time while 20 rounds complete in well under a second, so the
+   * assert read a mid-drain head). Step 2's replacement is the
+   * client-observable equivalent of `server.idle()`: wait until every event
+   * each session fired has its terminal consequence ARRIVED back at that
+   * session (speculation.md §4 step 2 — the overlay's outstanding-intent set
+   * empties exactly then). The wait shares ONE budget across the whole
+   * `settle()` call, so a genuinely wedged consequence degrades to the old
+   * behavior (the caller's assert speaks) instead of hanging the harness;
+   * the barrier then pulls each replica to a head ≥ every consequence
+   * commit. Instant on an OFF-posture toolshed run (no overlay, no
+   * outstanding intents).
    */
   async settle(rounds = 2): Promise<void> {
+    const quiescenceDeadline = this.#server === undefined
+      ? Date.now() + SERVED_SETTLE_QUIESCENCE_BUDGET_MS
+      : undefined;
     for (let i = 0; i < rounds; i++) {
       await Promise.all(this.sessions.map((session) => session.idle()));
       await this.#server?.idle();
+      if (quiescenceDeadline !== undefined) {
+        const budget = Math.max(0, quiescenceDeadline - Date.now());
+        await Promise.all(
+          this.sessions.map((session) => session.eventQuiescence(budget)),
+        );
+      }
       await Promise.all(this.sessions.map((session) => session.barrier()));
       await Promise.all(this.sessions.map((session) => session.idle()));
     }

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -449,6 +449,33 @@ const handlers: Record<
     return {};
   },
 
+  // Wait until this runtime has NO outstanding event intents: every event it
+  // fired has reached a terminal consequence (consequenced, errored, dropped,
+  // or refused) AND that consequence has arrived back here — speculation.md
+  // §4 step 2's retirement, whose outstanding set the overlay maintains
+  // (`Runtime.speculationOverlay.pendingIntentCount`). Under the served (ON)
+  // topology this is the client-observable "the server has drained my sends"
+  // signal the harness settle uses in place of the in-process server's
+  // `idle()` (see MultiRuntimeHarness.settle). Resolves `{ pending: 0 }` on
+  // quiescence, or with the still-outstanding count once `timeoutMs`
+  // elapses — the caller's settle round proceeds and the test's own assert
+  // speaks, so a wedged consequence degrades loudly instead of hanging the
+  // harness. The OFF arm has no overlay and resolves immediately.
+  async eventQuiescence({ timeoutMs }) {
+    const runtime = controller().runtime;
+    const budget = typeof timeoutMs === "number" ? timeoutMs : 10_000;
+    const deadline = Date.now() + budget;
+    for (;;) {
+      const pending = runtime.speculationOverlay?.pendingIntentCount ?? 0;
+      if (pending === 0) return { pending: 0 };
+      if (Date.now() >= deadline) return { pending };
+      // Plain timer wait: consequence pushes arrive on the WebSocket and the
+      // overlay's intent listener runs in a microtask on the replica
+      // notification, so nothing here needs nudging — just time.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  },
+
   // Force an ordered-after round trip on every open space connection, so any
   // subscription fan-out the server has already sent has been received and
   // applied by this runtime before returning. The harness's cross-runtime

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -142,6 +142,10 @@ export class ExecutorHost {
     }
     return {
       ...this.#stats,
+      // Own copy: the live Record mutates under bumpDerivedCommits and
+      // the top-level spread shares its reference (the same reason as
+      // NIT-1's settle-series copy below).
+      derivedCommitsBySpace: { ...this.#stats.derivedCommitsBySpace },
       events: { ...this.#stats.events },
       demand: { ...this.#stats.demand },
       settle: {

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -103,7 +103,7 @@ import {
 } from "./wave.ts";
 import { EngineWaveCommitSink } from "./engine-wave-sink.ts";
 import { readWatermarkSeq, watermarkDocLink } from "./watermark.ts";
-import type { ServingLoopStats } from "./stats.ts";
+import { bumpDerivedCommits, type ServingLoopStats } from "./stats.ts";
 import { type SealedEffectBatch, SpaceOutbox } from "./outbox.ts";
 import { effectCompletionKeyOf } from "./effect-completion.ts";
 import { markRendererTrustedEvent } from "../cfc/ui-contract.ts";
@@ -1782,7 +1782,7 @@ export class SpaceServer implements TransactionSealDestination {
           .then(() => replica.whenApplied!(localSeq)),
       );
     }
-    this.#options.stats.derivedCommits += 1;
+    bumpDerivedCommits(this.#options.stats, String(this.#options.space));
     // In-process dirtiness + push (the §4 injection): report like a
     // wave commit — subscribers get the derived rows, the feed carries
     // the record, and the loop skips its own echo by class + holder.
@@ -3518,7 +3518,7 @@ export class SpaceServer implements TransactionSealDestination {
       return;
     }
     if (outcome.seq !== undefined) {
-      stats.derivedCommits += 1;
+      bumpDerivedCommits(stats, String(this.#options.space));
       this.#wavesCommitted += 1;
       this.#options.onWaveCommitted?.();
       // (d′): a derived commit after a growth wake is the

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -39,6 +39,24 @@ export type ServingLoopStats = {
   authoredSeen: number;
   effectAcks: number;
   derivedCommits: number;
+  /** `derivedCommits`, attributed per space (the space DID as the key).
+   * The process-wide total cannot scope a delta to the space under test
+   * on a shared host — another space's serving activity in the window
+   * (a drain-settle quiescence advance from an earlier test's space, a
+   * parked space reactivating) is indistinguishable from the watched
+   * space's waves — which is what the sx2-events coalescing observation
+   * and OW52-style loss accounting both need. Bounded like
+   * `settle.series`: at most {@link DERIVED_COMMITS_BY_SPACE_MAX}
+   * spaces tracked; a commit for a NEW space beyond the cap evicts the
+   * oldest-tracked row, folding its count into
+   * `derivedCommitsBySpaceDropped` so the total stays conserved
+   * (tracked rows + the fold = `derivedCommits`). Bump through
+   * {@link bumpDerivedCommits} only, which keeps total and row in
+   * lockstep. */
+  derivedCommitsBySpace: Record<string, number>;
+  /** Counts folded out of `derivedCommitsBySpace` by the cap eviction
+   * (never a lost commit — the process-wide total keeps them). */
+  derivedCommitsBySpaceDropped: number;
   /** Demanded-structure loads that THREW (serving-loop.md §1: a value
    * the server cannot serve is counted AND surfaced here, not just
    * logged). Counted per attempt; the loop retries the root on each
@@ -331,6 +349,8 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
   authoredSeen: 0,
   effectAcks: 0,
   derivedCommits: 0,
+  derivedCommitsBySpace: {},
+  derivedCommitsBySpaceDropped: 0,
   structureLoadFailures: 0,
   structureLoadDeferred: 0,
   structureLoadTerminal: 0,
@@ -377,6 +397,37 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
   outbox: { queued: 0, completed: 0, failed: 0, budgetDeferrals: 0 },
   lease: { held: 0, lost: 0 },
 });
+
+/** The `derivedCommitsBySpace` cap (the settle.series bounding
+ * discipline, applied to a keyed map: oldest-inserted row evicted). A
+ * long-lived host serves many short-lived spaces; the map must not grow
+ * with them. */
+export const DERIVED_COMMITS_BY_SPACE_MAX = 256;
+
+/** The ONE way to count a derived commit: bumps the process-wide total
+ * and the space's row together (a site that bumped one but not the
+ * other would silently break the conservation the per-space block
+ * promises — tracked rows + dropped fold = total). Evicts the
+ * oldest-tracked space's row into `derivedCommitsBySpaceDropped` when a
+ * NEW space arrives past {@link DERIVED_COMMITS_BY_SPACE_MAX}. */
+export const bumpDerivedCommits = (
+  stats: ServingLoopStats,
+  space: string,
+): void => {
+  stats.derivedCommits += 1;
+  const bySpace = stats.derivedCommitsBySpace;
+  if (bySpace[space] === undefined) {
+    const keys = Object.keys(bySpace);
+    if (keys.length >= DERIVED_COMMITS_BY_SPACE_MAX) {
+      // Insertion order is the eviction order (string keys preserve it).
+      const oldest = keys[0];
+      stats.derivedCommitsBySpaceDropped += bySpace[oldest];
+      delete bySpace[oldest];
+    }
+    bySpace[space] = 0;
+  }
+  bySpace[space] += 1;
+};
 
 // One provider per process (the ExecutorHost registers itself); the
 // health route reads through this seam so toolshed needs no reference to

--- a/packages/runner/test/executor-stats.test.ts
+++ b/packages/runner/test/executor-stats.test.ts
@@ -1,0 +1,72 @@
+// The serving loop's per-space derived-commit accounting
+// (`derivedCommitsBySpace` — serving-loop.md §7's counter block). The
+// process-wide `derivedCommits` total cannot attribute a delta to the
+// space under test on a shared host (another space's serving activity —
+// e.g. a drain-settle quiescence advance from a PREVIOUS test's space —
+// is indistinguishable from the watched space's waves), which is what
+// the sx2-events coalescing observation and the OW52-style loss
+// accounting both need. The helper keeps the total and the per-space
+// row in lockstep and bounds the map like settle.series: at most
+// DERIVED_COMMITS_BY_SPACE_MAX spaces tracked, oldest row evicted into
+// the dropped fold.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  bumpDerivedCommits,
+  DERIVED_COMMITS_BY_SPACE_MAX,
+  emptyServingLoopStats,
+} from "../src/executor/stats.ts";
+
+describe("bumpDerivedCommits (per-space derived-commit accounting)", () => {
+  it("keeps the total and the per-space row in lockstep", () => {
+    const stats = emptyServingLoopStats();
+    bumpDerivedCommits(stats, "did:key:zSpaceA");
+    bumpDerivedCommits(stats, "did:key:zSpaceA");
+    bumpDerivedCommits(stats, "did:key:zSpaceB");
+    expect(stats.derivedCommits).toBe(3);
+    expect(stats.derivedCommitsBySpace["did:key:zSpaceA"]).toBe(2);
+    expect(stats.derivedCommitsBySpace["did:key:zSpaceB"]).toBe(1);
+    expect(stats.derivedCommitsBySpaceDropped).toBe(0);
+  });
+
+  it("bounds the map: a new space beyond the cap evicts the OLDEST row into the dropped fold, and the total never loses a count", () => {
+    const stats = emptyServingLoopStats();
+    for (let i = 0; i < DERIVED_COMMITS_BY_SPACE_MAX; i++) {
+      bumpDerivedCommits(stats, `did:key:z${i}`);
+      bumpDerivedCommits(stats, `did:key:z${i}`);
+    }
+    expect(Object.keys(stats.derivedCommitsBySpace).length).toBe(
+      DERIVED_COMMITS_BY_SPACE_MAX,
+    );
+    // One over the cap: the oldest (z0, count 2) folds into dropped.
+    bumpDerivedCommits(stats, "did:key:zOverflow");
+    expect(Object.keys(stats.derivedCommitsBySpace).length).toBe(
+      DERIVED_COMMITS_BY_SPACE_MAX,
+    );
+    expect(stats.derivedCommitsBySpace["did:key:z0"]).toBeUndefined();
+    expect(stats.derivedCommitsBySpace["did:key:zOverflow"]).toBe(1);
+    expect(stats.derivedCommitsBySpaceDropped).toBe(2);
+    // The process-wide total is conserved: tracked rows + dropped fold.
+    const tracked = Object.values(stats.derivedCommitsBySpace)
+      .reduce((a, b) => a + b, 0);
+    expect(tracked + stats.derivedCommitsBySpaceDropped).toBe(
+      stats.derivedCommits,
+    );
+  });
+
+  it("an evicted space that speaks again re-enters as a fresh row (its history stays in the fold)", () => {
+    const stats = emptyServingLoopStats();
+    for (let i = 0; i < DERIVED_COMMITS_BY_SPACE_MAX + 1; i++) {
+      bumpDerivedCommits(stats, `did:key:z${i}`);
+    }
+    // z0 was evicted by the overflow above; it speaks again.
+    bumpDerivedCommits(stats, "did:key:z0");
+    expect(stats.derivedCommitsBySpace["did:key:z0"]).toBe(1);
+    const tracked = Object.values(stats.derivedCommitsBySpace)
+      .reduce((a, b) => a + b, 0);
+    expect(tracked + stats.derivedCommitsBySpaceDropped).toBe(
+      stats.derivedCommits,
+    );
+  });
+});

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -136,7 +136,7 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): six file entries (default-app, cfc-group-chat-demo, profile-embed, home-profile-reload-durability, the sqlite identity pair) and two STEP entries (cellset-lww's own-write race, convergence-storm's storm step) — every gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): six file entries (default-app, cfc-group-chat-demo, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ONE STEP entry (cellset-lww's own-write race; convergence-storm's storm step LIFTED by OW52's close — the red was the harness settle racing the serving drain, not a loss) — every gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // File-level entries only in the --ignore flag (step entries never drop
@@ -176,9 +176,15 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     report,
     /patterns: SKIP-STEP integration\/cellset-lww\.test\.ts :: end-to-end: a typed name survives the own-write race through save \(until phase-7; the rest of the file runs\)/,
   );
-  assertMatch(
-    report,
-    /patterns: SKIP-STEP integration\/convergence-storm\.test\.ts :: a non-writing session sees every concurrently-posted message \(until phase-7; the rest of the file runs\)/,
+  // The convergence-storm storm-step entry was LIFTED (OW52 CLOSED,
+  // 2026-08-21: the 23/40 red was the harness's served-topology settle
+  // racing the serving drain — no loss at any seam; the settle now waits
+  // for event-consequence quiescence and the step is green ON 5/5). The
+  // file's in-file guard remains and resolves to NO entry, so the step
+  // RUNS on the ON arm — pinned here so a re-skip is a deliberate edit.
+  assert(
+    !report.includes("integration/convergence-storm.test.ts"),
+    "convergence-storm must carry NO skip entry (OW52 closed; the storm step runs ON)",
   );
   // The two-browser gates RUN in the ON arm: cfc-group-chat-two-browsers
   // (fan-out stage B) and lunch-poll-vote (W3.1's S1 + the 6/6 lift).
@@ -216,7 +222,7 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   const gateEntries = SERVER_EXECUTION_ON_SKIPS.patterns.filter((skip) =>
     skip.file !== "integration/topics-navigation.test.ts"
   );
-  assertEquals(gateEntries.length, 8);
+  assertEquals(gateEntries.length, 7);
   for (const entry of gateEntries) {
     assertEquals(entry.phase, "phase-7");
     assertMatch(entry.reason, /First ON-lane CI gate \(2026-08-21/);
@@ -225,13 +231,13 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     assertMatch(entry.reason, /(NOT|NEITHER) a demand hole/i);
     assertMatch(entry.reason, /flip PR needs this list EMPTY/);
   }
-  // The two STEP entries are BOUND: the guard lookup the files call
-  // resolves exactly these entries (the validator additionally checks the
-  // files name the steps and call the guard).
+  // The STEP entry is BOUND: the guard lookup the file calls resolves
+  // exactly this entry (the validator additionally checks the file names
+  // the step and calls the guard). convergence-storm's guard resolves to
+  // NO entry since the OW52 lift — its step runs.
   const steps = gateEntries.filter((skip) => skip.step !== undefined);
   assertEquals(steps.map((skip) => skip.file), [
     "integration/cellset-lww.test.ts",
-    "integration/convergence-storm.test.ts",
   ]);
   for (const entry of steps) {
     assertEquals(
@@ -249,7 +255,7 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     "./integration/convergence-storm.test.ts",
   ]);
   assertEquals(skipped, []);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 9);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 8);
   assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
 });
 

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -345,24 +345,6 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "on-render-stall-rootcause.md §2b). Lifts when OW47 closes and " +
         "the step greens ON; the flip PR needs this list EMPTY.",
     },
-    {
-      file: "integration/convergence-storm.test.ts",
-      step: "a non-writing session sees every concurrently-posted message",
-      phase: "phase-7",
-      reason: "First ON-lane CI gate (2026-08-21; skip-and-land — gates " +
-        "the FLIP, not the land): under the TRUE ON topology the 3 " +
-        "element-schema tests are green; this storm step is red with a " +
-        "REAL ON loss — 2×20 pipelined posts (idle:false), observer " +
-        "landed=23/40 (was 0/40 under the pre-fix mixed posture, which " +
-        "refused every append): a write-path loss at storm depth; WHERE " +
-        "the 17 die (append admission, queue, dispatch, or consequence " +
-        "commit under pipelined contention) is UNTRIAGED " +
-        "(verification-coverage.md OW52). NOT a demand hole — what lands " +
-        "is served and delivered to the non-writing observer. Evidence: " +
-        "docs/history/plans/server-execution-v2/" +
-        "stage-c/first-on-ci-gate.md. Lifts when OW52 closes and the " +
-        "step greens ON 5/5; the flip PR needs this list EMPTY.",
-    },
   ],
   runner: [
     {

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -208,18 +208,29 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
       phase: "phase-7",
       reason: "First ON-lane CI gate (2026-08-21, run 32447348664; " +
         "skip-and-land — gates the FLIP, not the land): the browser " +
-        "console gate (integration/shell-utils.ts afterEach) trips on a " +
-        "deterministic `TypeError: Cannot read properties of undefined " +
-        "(reading 'split')` at `splitDefinitions` " +
+        "console gate (integration/shell-utils.ts afterEach) trips on " +
+        "`TypeError: Cannot read properties of undefined (reading " +
+        "'split')` at `splitDefinitions` " +
         "(api/patterns/notes/reference-block.ts:62) inside note.tsx lift " +
-        "callbacks — an ON READ-SEMANTICS seam: under the ON posture the " +
-        "lift's input arrives undefined where the OFF arm always supplies " +
-        "it (the same console error W4 §6.2 recorded on the note workload; " +
-        "fatal here because the console gate fails the test). Reproduced " +
-        "locally ON; OFF green. NOT a demand hole. Evidence: " +
-        "docs/history/plans/server-execution-v2/stage-c/first-on-ci-gate.md. " +
-        "Lifts when verification-coverage.md OW51 closes and the file " +
-        "greens ON; the flip PR needs this list EMPTY.",
+        "callbacks. ROOT-CAUSED by the optimize-phase triage " +
+        "(2026-08-21): ARRIVAL ORDERING — a scheduler lift on a freshly " +
+        "SERVED-instantiated note runs while its input's link chain " +
+        "(through the piece's result/process doc to the " +
+        "schema-default-only pendingEdit cell) is still materializing in " +
+        "the reading runtime's replica view; the mid-chain resolution " +
+        "yields undefined and the leaf default:null is never consulted. " +
+        "NOT client-only (the toolshed's serving runtime hits the same " +
+        "TypeError in its pull-settle loop); racy and load-sensitive " +
+        "(W4's loaded bench 2-for-2 at n=20; quiet-box browser runs " +
+        "mostly green); OFF green by construction (instantiate-and-read " +
+        "in one runtime). The fix fork is FLAGGED for the owner " +
+        "(defer-on-unresolved-chain in the runner vs lifts tolerating " +
+        "undefined during arrival — both change a stated/relied-upon " +
+        "semantic). Evidence: docs/history/plans/server-execution-v2/" +
+        "optimize/ow51-undefined-read-report.md (and " +
+        "stage-c/first-on-ci-gate.md). Lifts when verification-" +
+        "coverage.md OW51 closes and the file greens ON; the flip PR " +
+        "needs this list EMPTY.",
     },
     {
       file: "integration/cfc-group-chat-demo.test.ts",

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -219,7 +219,9 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "schema-default-only pendingEdit cell) is still materializing in " +
         "the reading runtime's replica view; the mid-chain resolution " +
         "yields undefined and the leaf default:null is never consulted. " +
-        "NOT client-only (the toolshed's serving runtime hits the same " +
+        "NOT a demand hole (the gate's classification stands — the value " +
+        "is served and lands; the read races its arrival), and NOT " +
+        "client-only (the toolshed's serving runtime hits the same " +
         "TypeError in its pull-settle loop); racy and load-sensitive " +
         "(W4's loaded bench 2-for-2 at n=20; quiet-box browser runs " +
         "mostly green); OFF green by construction (instantiate-and-read " +


### PR DESCRIPTION
## Why

The optimize-on-main phase's loss-triage queue held two untriaged first-ON-CI-gate surfaces, plus a coordinator-routed rider on the same machinery:

1. **OW52 (data-loss class, triaged first)** — the convergence-storm ON red (observer landed=23/40) was registered as a REAL 17-message loss. The full 40-event accounting (serving-loop counters + the space's sqlite commit log) shows **nothing is lost anywhere**: append admission 40/40, drain/dispatch 40/40, consequences exactly-once (all 40 eventIds across 10 derived commits, zero duplicates), all 40 array appends durable, observer converges to 40/40 in ~2–3 s. The red is the HARNESS: the toolshed-backed (ON) `MultiRuntimeHarness.settle` has no equivalent of the OFF arm's `server.idle()` drain step, so a fixed round count of idle/barrier hops races the serving loop's asynchronous drain and the assert reads a mid-drain head.
2. **OW51** — the default-app `splitDefinitions` undefined-read is ROOT-CAUSED as **arrival ordering**: a scheduler lift on a freshly served-instantiated note runs while its input's link chain (through the piece's result/process doc to the schema-default-only `pendingEdit` cell) is still materializing in the reading runtime's replica view; the mid-chain resolution yields `undefined` and the leaf schema's `default: null` is never consulted. Decisively NOT client-only: the toolshed's own serving runtime hits the identical TypeError in its pull-settle loop. The honest fix is a contract fork, so per flag-don't-fill it is **FLAGGED for the owner**, not made: defer-on-unresolved-chain in the runner (speculation.md §2's client PENDING sentence arguably states it; the serving-runtime equivalent is unstated) vs lifts tolerating undefined during arrival (a pattern-contract change). The `default-app.test.ts` ON skip stays.
3. **The sx2-events coalescing-gate flake** (danfuzz-side writeup, coordinator-routed): both read claims VERIFIED — the append queue serializes one entry per commit round trip so the `derivedDelta < N` assert measures a load ratio the test cannot control (my idle box logged exactly 7, the CI-passing value), and `derivedCommits` is host-global with open cross-space pollution paths (an S1 quiescence advance from an earlier test's space was directly observed landing after its test exited). Per-space scoping landed as honest observability; it does NOT fix the flake. Three gate dispositions evaluated with a RECOMMENDATION (constructed-queue-depth pin in the runner suite via the existing `syncGate` drain-park lever + demote the sx2 ratio assert to its logged line) — the testing.md §5 criterion change is an owner ruling, not shipped here.

## What Changed

- `packages/patterns/integration/multi-runtime-worker.ts` / `multi-runtime-harness.ts`: `eventQuiescence` RPC (bounded wait until the runtime's outstanding-intent set is empty — speculation.md §4 step 2's arrived-terminal-consequence retirement, `pendingIntentCount`); `settle()`'s toolshed-backed arm waits on it between idle and barrier with ONE shared 10 s budget per `settle()` call (a wedged consequence degrades to the old racy behavior instead of hanging). OFF arm byte-identical.
- `tasks/server-execution-on-skips.ts`: the convergence-storm STEP entry LIFTED (the step runs ON again); the default-app entry's reason updated with the OW51 root cause + report pointer (skip itself unchanged).
- `packages/runner/src/executor/stats.ts` / `space-server.ts` / `host.ts`: `derivedCommitsBySpace` + `derivedCommitsBySpaceDropped` (bounded like `settle.series`, 256 spaces, oldest-evicted-into-fold, conservation kept), bumped at both increment sites through one `bumpDerivedCommits` helper; deep-copied in the host's stats snapshot.
- `docs/specs/server-side-execution/verification-coverage.md`: OW52 row CLOSED with the accounting; OW51 row updated with the root cause + the flagged fork (stays owed).
- `docs/history/plans/server-execution-v2/optimize/`: `ow52-storm-loss-report.md` (the 40-event accounting), `ow51-undefined-read-report.md` (the arrival-ordering root cause, server-side stacks, negative results), `ow-sx2-coalescing-gate.md` (verified claims, dispositions, recommendation).

## Test plan

- **OW52 red-first**: the storm step red twice locally ON pre-fix (landed=22, 23 — the exact CI shape), green **5/5** post-fix; `convergence-storm.test.ts` 4/4 ON and 4/4 OFF. Every harness-family file under the settle change ran locally: `cfc-group-chat-demo-multi-runtime` 7/7 ON + OFF, `cellset-lww` 3 green + OW47 step skipped ON / 4/4 OFF, `data-file-multi-runtime` and `cellset-lww-lost-update` 2/2 ON + OFF, the sqlite pair green OFF (still file-skipped ON).
- **Stats red-first**: `packages/runner/test/executor-stats.test.ts` (lockstep, cap eviction + conservation, evicted-space re-entry) failed before the helper existed, green after; `executor-space-server`, `executor-settle-advance`, `executor-outbox-budget`, `executor-events-down` (18 steps), `executor-serving-loop` (24 steps) all green. Live-verified: `/api/health/stats` serves the block; an sx2-events ON run attributes its derived commits to its one space.
- Skips validator self-run exit 0; `deno check`, `deno fmt --check`, `deno lint` clean on every touched file; every deno invocation `--no-lock`; worktree clean (no lockfile churn).
- OW51: docs + skip-reason text only — no behavior change to verify beyond the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

