### PR TITLE
docs: name cubic, and how to read a PR's review comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,9 +206,14 @@ Before committing, squashing, or otherwise getting a branch ready to be reviewed
 or landed: Execute repo-wide `deno fmt --check` and `deno lint` checks, and run
 all relevant tests.
 
-When babysitting a PR through CI, look for codex review comments in addition to
-failed CI jobs. When facing difficulties getting coverage checks to pass,
-consider the information in `docs/development/COVERAGE.md`.
+When babysitting a PR through CI, look for review comments in addition to failed
+CI jobs. Cubic reviews nearly every PR here, and its review lands a few minutes
+after each push, so wait for it before concluding a PR has none. Read its
+findings with `gh api repos/commontoolsinc/labs/pulls/<n>/comments`; they are
+inline review comments, which `gh pr view` does not return.
+`docs/development/pr-review-comments.md` covers the rest. When facing
+difficulties getting coverage checks to pass, consider the information in
+`docs/development/COVERAGE.md`.
 
 ### Automated gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,8 +209,8 @@ all relevant tests.
 When babysitting a PR through CI, look for review comments in addition to failed
 CI jobs. Cubic reviews nearly every PR here, and its review lands a few minutes
 after each push, so wait for it before concluding a PR has none. Read its
-findings with `gh api repos/commontoolsinc/labs/pulls/<n>/comments`; they are
-inline review comments, which `gh pr view` does not return.
+findings with `gh api --paginate repos/commontoolsinc/labs/pulls/<n>/comments`;
+they are inline review comments, which `gh pr view` does not return.
 `docs/development/pr-review-comments.md` covers the rest. When facing
 difficulties getting coverage checks to pass, consider the information in
 `docs/development/COVERAGE.md`.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -61,6 +61,10 @@ mapped in [`../README.md`](../README.md).
 
 ## Continuous integration, deployment, and measurement
 
+- [`pr-review-comments.md`](pr-review-comments.md) — reading the review
+  comments on a pull request: the commands that list a reviewer's findings and
+  tell you which threads are still open, which automated reviewers post here,
+  and why `gh pr view` returns none of it
 - [`deploying.md`](deploying.md) — how a commit reaches a host: which jobs
   deploy where, and the contract the bastion's deploy wrapper enforces on what
   they pass it. Read this before editing a deploy step, because that wrapper

--- a/docs/development/pr-review-comments.md
+++ b/docs/development/pr-review-comments.md
@@ -1,0 +1,75 @@
+# Reading review comments on a pull request
+
+An automated reviewer posts its findings as inline review comments: each one is
+attached to a file and a line of the diff. This document names the commands
+that list those findings, and at the end the command that looks as though it
+would and does not.
+
+## Listing the findings
+
+This returns every inline review comment on a pull request, with the file and
+line each is attached to:
+
+```bash
+gh api repos/commontoolsinc/labs/pulls/<n>/comments
+```
+
+A finding whose line has since changed comes back with `line` set to null. The
+`path` still identifies the file.
+
+## Checking whether a thread is still open
+
+This reports, for each thread, whether it is resolved and whether it is
+outdated because the code beneath it moved:
+
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:100){
+        nodes{ isResolved isOutdated path line comments(first:10){ nodes{ author{login} body } } }
+      }
+    }
+  }
+}' -f owner=commontoolsinc -f repo=labs -F number=<n>
+```
+
+An unresolved thread is one still waiting on you. An outdated thread may still
+be waiting on you: the code moved, which is not the same as the finding being
+answered.
+
+## Waiting for the review
+
+Cubic reviews nearly every pull request in this repository. It is configured by
+[`cubic.yaml`](../../cubic.yaml) at the repository root, which points it at the
+same guidance the `/cf-review` skill and human reviewers use, and it posts as
+`cubic-dev-ai[bot]`. The Codex connector reviews a minority of pull requests
+and posts as `chatgpt-codex-connector[bot]`.
+
+Cubic's review arrives a few minutes after a push, so it can be absent simply
+because it has not run yet. Wait for it before concluding a pull request has no
+findings. A push that adds commits starts a fresh review, so the wait applies
+again each time.
+
+Take the feedback into account and leave a comment if you disagree, as
+[the contributing section of the root `README.md`](../../README.md#contributing)
+requires.
+
+## Why `gh pr view` shows nothing
+
+Neither of these returns inline review comments:
+
+```bash
+gh pr view <n> --json comments,reviews
+gh pr view <n> --comments
+```
+
+`comments` holds the issue-comment timeline, which is the conversation at the
+bottom of the pull request. Inline findings are not in it, so it is frequently
+an empty list on a pull request that has several. `reviews` holds one entry per
+submitted review, carrying that review's summary body and not the individual
+comments it contains. A summary body is a claim about the findings rather than
+the findings themselves, and cubic's says every issue was addressed once its
+threads are resolved, so reading it in place of the findings can turn an open
+one into a clean bill of health.

--- a/docs/development/pr-review-comments.md
+++ b/docs/development/pr-review-comments.md
@@ -41,10 +41,10 @@ query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
 }' -f owner=commontoolsinc -f repo=labs -F number=<n>
 ```
 
-An unresolved thread still needs inspection. It may be waiting on you, or on
-the reviewer after a reply; `isResolved` alone does not assign the next action.
-An outdated thread also needs inspection: the code moved, which is not the same
-as the finding being answered.
+An unresolved thread still needs inspection, even when it is outdated: the code
+moving is not the same as the finding being answered. It may be waiting on you,
+or on the reviewer after a reply; `isResolved` alone does not assign the next
+action.
 
 ## Waiting for the review
 

--- a/docs/development/pr-review-comments.md
+++ b/docs/development/pr-review-comments.md
@@ -1,21 +1,26 @@
 # Reading review comments on a pull request
 
-An automated reviewer posts its findings as inline review comments: each one is
-attached to a file and a line of the diff. This document names the commands
-that list those findings, and at the end the command that looks as though it
-would and does not.
+An automated reviewer posts its findings as inline review comments. Each one is
+attached to a file, and a line comment is also attached to a line of the diff.
+This document names the commands that list those findings, and at the end the
+command that looks as though it would and does not.
 
 ## Listing the findings
 
 This returns every inline review comment on a pull request, with the file and
-line each is attached to:
+any line it is attached to:
 
 ```bash
 gh api --paginate repos/commontoolsinc/labs/pulls/<n>/comments
 ```
 
-A finding whose line has since changed comes back with `line` set to null. The
-`path` still identifies the file.
+Line comments have `subject_type` set to `line`. When the line has since
+changed, `line` comes back as null. File-level comments have `subject_type` set
+to `file` and no line. In both cases, `path` identifies the file.
+
+A comment with no `in_reply_to_id` starts a thread and carries that thread's
+finding. A comment with `in_reply_to_id` is a reply in an existing thread. The
+endpoint returns both kinds.
 
 ## Checking whether a thread is still open
 
@@ -36,9 +41,10 @@ query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
 }' -f owner=commontoolsinc -f repo=labs -F number=<n>
 ```
 
-An unresolved thread is one still waiting on you. An outdated thread may still
-be waiting on you: the code moved, which is not the same as the finding being
-answered.
+An unresolved thread still needs inspection. It may be waiting on you, or on
+the reviewer after a reply; `isResolved` alone does not assign the next action.
+An outdated thread also needs inspection: the code moved, which is not the same
+as the finding being answered.
 
 ## Waiting for the review
 

--- a/docs/development/pr-review-comments.md
+++ b/docs/development/pr-review-comments.md
@@ -11,7 +11,7 @@ This returns every inline review comment on a pull request, with the file and
 line each is attached to:
 
 ```bash
-gh api repos/commontoolsinc/labs/pulls/<n>/comments
+gh api --paginate repos/commontoolsinc/labs/pulls/<n>/comments
 ```
 
 A finding whose line has since changed comes back with `line` set to null. The
@@ -23,12 +23,13 @@ This reports, for each thread, whether it is resolved and whether it is
 outdated because the code beneath it moved:
 
 ```bash
-gh api graphql -f query='
-query($owner:String!,$repo:String!,$number:Int!){
+gh api graphql --paginate -f query='
+query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
   repository(owner:$owner,name:$repo){
     pullRequest(number:$number){
-      reviewThreads(first:100){
-        nodes{ isResolved isOutdated path line comments(first:10){ nodes{ author{login} body } } }
+      reviewThreads(first:100,after:$endCursor){
+        nodes{ isResolved isOutdated path line comments(first:1){ nodes{ author{login} body } } }
+        pageInfo{ hasNextPage endCursor }
       }
     }
   }


### PR DESCRIPTION
The instruction for babysitting a PR through CI told agents to look for codex review comments. Codex is not the reviewer that comments here most often. Across the last thirty merged pull requests, cubic left inline findings on seventeen and the Codex connector on three. Cubic is also the reviewer this repository configures, through cubic.yaml, and the one the contributing section of the root README tells contributors to always take into account. An agent following the old line looked for the rarer reviewer, and could report a pull request as unreviewed while a cubic finding sat open on it.

Underneath that is a mechanical trap that makes the miss easy even when you know which reviewer to expect. Both reviewers post their findings as inline review comments, attached to a file and a line of the diff, and neither `gh pr view <n> --json comments,reviews` nor `gh pr view <n> --comments` returns that kind of comment. The `comments` field holds the issue-comment timeline, which does not contain them and so is often an empty list on a pull request carrying several. The `reviews` field holds one entry per submitted review, carrying only that review's summary body; cubic's summary says every issue was addressed once its threads are resolved, so reading the summary in place of the findings can turn an open finding into a clean bill of health. Checked against a pull request with seven inline findings, both commands report none of them.

The commands that do return them are `gh api
repos/commontoolsinc/labs/pulls/<n>/comments` for the findings themselves, and a GraphQL query for the pull request's review threads when you need to know whether a thread is resolved or has gone outdated because the code beneath it moved.

AGENTS.md is loaded in full at the start of every session, so it keeps only the part an agent must not get wrong: wait for cubic's review before concluding a pull request has no findings, read the findings with the command that returns them, and do not trust `gh pr view` to show them. The rest goes in a new document,
docs/development/pr-review-comments.md, indexed from the development README under continuous integration. That document leads with the commands that work and explains the ones that do not at the end, because a reader who stops early should still leave with something they can run; the explanation is worth keeping because the failure is silent, and an empty list is indistinguishable from an unreviewed pull request to anyone who does not know why it is empty.

A path-scoped rule under .claude/rules/ was the other candidate home and does not fit: those load when a matching file is read, and babysitting a pull request is not triggered by opening any file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

