### PR TITLE
feat(cli): piece inspect says which result fields are cached

### DIFF
--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -82,6 +82,12 @@ deno task cf piece step --piece ID ...  # Runs scheduling step, triggers recompu
 deno task cf get --piece ID totalSpent ...  # Now correct
 ```
 
+`piece inspect` says which values those are. Its `--- Cached Result Fields ---`
+section names the result fields that come from a computed cell, and the commit
+each was last derived at, beside the commit the argument document stands at.
+Result fields the section does not name read live state, so they never go
+stale.
+
 ## Inspect Transformed Output
 
 When the question is "what did the compiler emit?", use `cf check` with

--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -83,10 +83,13 @@ deno task cf get --piece ID totalSpent ...  # Now correct
 ```
 
 `piece inspect` says which values those are. Its `--- Cached Result Fields ---`
-section names the result fields that come from a computed cell, and the commit
-each was last derived at, beside the commit the argument document stands at.
-Result fields the section does not name read live state, so they never go
-stale.
+section names every result field whose resolution crosses a computed cell. It
+prints each computed cell's last-derived commit beside the commit the argument
+document stands at. A computed cell which points on to live state still counts,
+because the cached choice of which live state to follow can itself be stale.
+Commit numbers only order within one space; the output names both spaces and
+refuses the comparison when they differ. Result fields the section does not
+name resolve entirely through live state.
 
 ## Inspect Transformed Output
 

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -412,15 +412,16 @@ export function renderCachedResultFields(
     "Each field below reads a computed cell, which holds the value its last",
     "committed derivation produced. Reading it does not re-derive it.",
   );
-  if (sourceCommit !== undefined) {
-    lines.push(`Source (Inputs) stands at commit ${sourceCommit}.`);
-  }
   for (const field of cached) {
     lines.push(
       `  - ${field.name}: ${
         field.derivedAtCommit === undefined
           ? "the local replica holds no commit for it"
           : `last derived at commit ${field.derivedAtCommit}`
+      }${
+        sourceCommit === undefined
+          ? ""
+          : `; Source (Inputs) stands at commit ${sourceCommit}`
       }`,
     );
   }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -70,6 +70,7 @@ import {
   stepPiece,
 } from "../lib/piece.ts";
 import type {
+  CachedResultField,
   ExecutedPieceCallable,
   PieceCallablesListing,
 } from "../lib/piece.ts";
@@ -385,6 +386,45 @@ export function pieceDescribeJson(
     ...(inputs !== undefined ? { inputs } : {}),
     ...verbListingJson(listingPart, all),
   };
+}
+
+/**
+ * The `--- Cached Result Fields ---` section of `cf piece inspect`, without
+ * the blank line that separates it from the section above.
+ *
+ * The `--- Result ---` block prints a live value and a cached one the same
+ * way, so this section names which of the two each field is, and says what
+ * instant a cached one answers for. `sourceCommit` is the commit the argument
+ * document behind `--- Source (Inputs) ---` stands at. It comes from the same
+ * per-space sequence as a field's own commit, so the two order against each
+ * other.
+ */
+export function renderCachedResultFields(
+  cached: readonly CachedResultField[],
+  sourceCommit: number | undefined,
+): string {
+  const lines = ["--- Cached Result Fields ---"];
+  if (cached.length === 0) {
+    lines.push("  (none)");
+    return lines.join("\n");
+  }
+  lines.push(
+    "Each field below reads a computed cell, which holds the value its last",
+    "committed derivation produced. Reading it does not re-derive it.",
+  );
+  if (sourceCommit !== undefined) {
+    lines.push(`Source (Inputs) stands at commit ${sourceCommit}.`);
+  }
+  for (const field of cached) {
+    lines.push(
+      `  - ${field.name}: ${
+        field.derivedAtCommit === undefined
+          ? "the local replica holds no commit for it"
+          : `last derived at commit ${field.derivedAtCommit}`
+      }`,
+    );
+  }
+  return lines.join("\n");
 }
 
 export function renderPieceSummaries(
@@ -2181,6 +2221,13 @@ Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
     } else {
       output += "\n<no result data>";
     }
+
+    output += `\n\n${
+      renderCachedResultFields(
+        pieceData.cachedResultFields,
+        pieceData.sourceCommit,
+      )
+    }`;
 
     output += "\n\n--- Reading From ---";
     if (pieceData.readingFrom.length > 0) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -73,6 +73,7 @@ import type {
   CachedResultField,
   ExecutedPieceCallable,
   PieceCallablesListing,
+  PieceInspection,
 } from "../lib/piece.ts";
 import { render, safeStringify } from "../lib/render.ts";
 import { newSessionId } from "../lib/session.ts";
@@ -445,6 +446,85 @@ export function renderCachedResultFields(
     );
   }
   return lines.join("\n");
+}
+
+/** The human-readable output for `cf piece inspect`. */
+export function renderPieceInspection(
+  pieceData: PieceInspection,
+  summary: boolean,
+): string {
+  const displayData = summary
+    ? {
+      ...pieceData,
+      source: summarizeForDisplay(pieceData.source),
+      result: summarizeForDisplay(pieceData.result),
+    }
+    : pieceData;
+
+  let output = `
+=== Piece: ${pieceData.id} ===
+Name: ${pieceData.name || "<no name>"}
+Pattern: ${formatPatternRef(pieceData.patternRef)}
+Pattern Ref: ${formatPatternIdentity(pieceData.patternRef)}
+Source Ref: ${pieceData.patternRef?.source.ref ?? "<unknown>"}
+Repository: ${pieceData.patternRef?.source.repository ?? "<unknown>"}
+Source Entry: ${pieceData.patternRef?.source.entry ?? "<unknown>"}
+Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
+
+--- Source (Inputs) ---`;
+
+  if (displayData.source) {
+    output += `\n${safeStringify(displayData.source)}`;
+  } else {
+    output += "\n<no source data>";
+  }
+
+  output += "\n\n--- Result ---";
+  if (displayData.result !== null && displayData.result !== undefined) {
+    const isPlainObject = typeof displayData.result === "object" &&
+      !Array.isArray(displayData.result);
+    if (!summary && isPlainObject) {
+      const filteredResult = {
+        ...(displayData.result as Record<string | symbol, unknown>),
+      };
+      if (UI in filteredResult && typeof filteredResult[UI] === "object") {
+        filteredResult[UI] = "<large UI object - use --json to see full UI>";
+      }
+      output += `\n${safeStringify(filteredResult)}`;
+    } else {
+      output += `\n${safeStringify(displayData.result)}`;
+    }
+  } else {
+    output += "\n<no result data>";
+  }
+
+  output += `\n\n${
+    renderCachedResultFields(
+      pieceData.cachedResultFields,
+      pieceData.sourceCommit,
+      pieceData.sourceSpace,
+    )
+  }`;
+
+  output += "\n\n--- Reading From ---";
+  if (pieceData.readingFrom.length > 0) {
+    pieceData.readingFrom.forEach((ref) => {
+      output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
+    });
+  } else {
+    output += "\n  (none)";
+  }
+
+  output += "\n\n--- Read By ---";
+  if (pieceData.readBy.length > 0) {
+    pieceData.readBy.forEach((ref) => {
+      output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
+    });
+  } else {
+    output += "\n  (none)";
+  }
+
+  return output;
 }
 
 export function renderPieceSummaries(
@@ -2203,72 +2283,7 @@ export const piece = targetOptions(
       return;
     }
 
-    // Build formatted output as template
-    let output = `
-=== Piece: ${pieceData.id} ===
-Name: ${pieceData.name || "<no name>"}
-Pattern: ${formatPatternRef(pieceData.patternRef)}
-Pattern Ref: ${formatPatternIdentity(pieceData.patternRef)}
-Source Ref: ${pieceData.patternRef?.source.ref ?? "<unknown>"}
-Repository: ${pieceData.patternRef?.source.repository ?? "<unknown>"}
-Source Entry: ${pieceData.patternRef?.source.entry ?? "<unknown>"}
-Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
-
---- Source (Inputs) ---`;
-
-    if (displayData.source) {
-      output += `\n${safeStringify(displayData.source)}`;
-    } else {
-      output += "\n<no source data>";
-    }
-
-    output += "\n\n--- Result ---";
-    if (displayData.result !== null && displayData.result !== undefined) {
-      const isPlainObject = typeof displayData.result === "object" &&
-        !Array.isArray(displayData.result);
-      if (!options.summary && isPlainObject) {
-        // Filter out large UI objects that clutter the non-summary output
-        const filteredResult = {
-          ...(displayData.result as Record<string | symbol, unknown>),
-        };
-        if (UI in filteredResult && typeof filteredResult[UI] === "object") {
-          filteredResult[UI] = "<large UI object - use --json to see full UI>";
-        }
-        output += `\n${safeStringify(filteredResult)}`;
-      } else {
-        output += `\n${safeStringify(displayData.result)}`;
-      }
-    } else {
-      output += "\n<no result data>";
-    }
-
-    output += `\n\n${
-      renderCachedResultFields(
-        pieceData.cachedResultFields,
-        pieceData.sourceCommit,
-        pieceData.sourceSpace,
-      )
-    }`;
-
-    output += "\n\n--- Reading From ---";
-    if (pieceData.readingFrom.length > 0) {
-      pieceData.readingFrom.forEach((ref) => {
-        output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
-      });
-    } else {
-      output += "\n  (none)";
-    }
-
-    output += "\n\n--- Read By ---";
-    if (pieceData.readBy.length > 0) {
-      pieceData.readBy.forEach((ref) => {
-        output += `\n  - ${ref.id}${ref.name ? ` (${ref.name})` : ""}`;
-      });
-    } else {
-      output += "\n  (none)";
-    }
-
-    render(output);
+    render(renderPieceInspection(pieceData, options.summary === true));
   })
   /* piece view */
   .command("view", "Display the rendered view for a piece")

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -395,13 +395,14 @@ export function pieceDescribeJson(
  * The `--- Result ---` block prints a live value and a cached one the same
  * way, so this section names which of the two each field is, and says what
  * instant a cached one answers for. `sourceCommit` is the commit the argument
- * document behind `--- Source (Inputs) ---` stands at. It comes from the same
- * per-space sequence as a field's own commit, so the two order against each
- * other.
+ * document behind `--- Source (Inputs) ---` stands at. Commit numbers order
+ * only when the computed cell and source document share `sourceSpace`; the
+ * section identifies and refuses cross-space comparisons.
  */
 export function renderCachedResultFields(
   cached: readonly CachedResultField[],
   sourceCommit: number | undefined,
+  sourceSpace: string | undefined,
 ): string {
   const lines = ["--- Cached Result Fields ---"];
   if (cached.length === 0) {
@@ -409,19 +410,37 @@ export function renderCachedResultFields(
     return lines.join("\n");
   }
   lines.push(
-    "Each field below reads a computed cell, which holds the value its last",
-    "committed derivation produced. Reading it does not re-derive it.",
+    "Each field below crosses computed state holding what its last committed",
+    "derivation produced. Reading the field does not re-derive that state.",
   );
   for (const field of cached) {
+    const spaces = new Set<string>(field.cells.map((cell) => cell.space));
+    if (sourceSpace !== undefined) spaces.add(sourceSpace);
+    const crossesSpaces = spaces.size > 1;
+    const cellDescriptions = field.cells.map((cell) => {
+      const commit = cell.derivedAtCommit === undefined
+        ? "the local replica holds no commit for it"
+        : `last derived at commit ${cell.derivedAtCommit}`;
+      return crossesSpaces ? `${commit} in space ${cell.space}` : commit;
+    });
+    const cachedDescription = cellDescriptions.length === 1
+      ? cellDescriptions[0]
+      : `${cellDescriptions.length} computed cells: ${
+        cellDescriptions.join("; ")
+      }`;
     lines.push(
-      `  - ${field.name}: ${
-        field.derivedAtCommit === undefined
-          ? "the local replica holds no commit for it"
-          : `last derived at commit ${field.derivedAtCommit}`
-      }${
+      `  - ${field.name}: ${cachedDescription}${
         sourceCommit === undefined
           ? ""
-          : `; Source (Inputs) stands at commit ${sourceCommit}`
+          : `; Source (Inputs) stands at commit ${sourceCommit}${
+            crossesSpaces && sourceSpace !== undefined
+              ? ` in space ${sourceSpace}`
+              : ""
+          }`
+      }${
+        crossesSpaces
+          ? "; commits from different spaces cannot be compared"
+          : ""
       }`,
     );
   }
@@ -2227,6 +2246,7 @@ Source Origin: ${pieceData.patternRef?.source.origin ?? "<unknown>"}
       renderCachedResultFields(
         pieceData.cachedResultFields,
         pieceData.sourceCommit,
+        pieceData.sourceSpace,
       )
     }`;
 

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -3701,7 +3701,8 @@ function commitOfDocument(
 }
 
 /**
- * Which of `names` a read of `resultCell` resolves through a computed cell.
+ * Which fields of `result` resolve through a computed cell when read from
+ * `resultCell`.
  *
  * The runtime's own link resolution supplies every dereference. A computed
  * document counts even when its cached value is another link and the terminal
@@ -3712,12 +3713,13 @@ function commitOfDocument(
  */
 export function cachedResultFields(
   resultCell: Cell<unknown>,
-  names: readonly string[],
+  result: Readonly<unknown>,
 ): CachedResultField[] {
+  if (!isObjectNotArray(result)) return [];
   const runtime = resultCell.runtime;
   const tx = runtime.readTx();
   const cached: CachedResultField[] = [];
-  for (const name of names) {
+  for (const name of Object.keys(result)) {
     const start = resultCell.key(name).getAsNormalizedFullLink();
     const { link: resolved, traces } = resolveLinkTracingDereferences(
       runtime,
@@ -3752,7 +3754,7 @@ export interface PieceInspection {
   name?: string;
   patternRef?: PiecePatternRef;
   source?: Readonly<unknown>;
-  result: Readonly<unknown>;
+  result: Readonly<unknown> | null | undefined;
   /**
    * The commit the argument document behind `source` last stood at. It can be
    * ordered against a {@link CachedResultCell} commit only when both have the
@@ -3817,9 +3819,7 @@ export async function inspectPiece(
     inputCell.getAsNormalizedFullLink(),
   );
   const sourceCommit = commitOfDocument(runtime, sourceLink);
-  const cached = isObjectNotArray(result)
-    ? cachedResultFields(resultCell, Object.keys(result))
-    : [];
+  const cached = cachedResultFields(resultCell, result);
 
   return {
     id,
@@ -3866,9 +3866,7 @@ async function inspectSlugTargetCell(
     name,
     patternRef,
     result,
-    cachedResultFields: isObjectNotArray(result)
-      ? cachedResultFields(target, Object.keys(result))
-      : [],
+    cachedResultFields: cachedResultFields(target, result),
     readingFrom: [],
     readBy: [],
   };

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -48,6 +48,7 @@ import {
   NAME,
   type NormalizedFullLink,
   resolveLink,
+  resolveLinkTracingDereferences,
   Runtime,
   runtimePresets,
   RuntimeProgram,
@@ -3656,16 +3657,26 @@ export async function generateSpaceMap(
 }
 
 /**
- * A result field whose value the runtime read out of a computed cell. Such a
- * cell holds what its last committed derivation produced, and nothing
- * re-derives it when a reader reads it, so its value can name an earlier
- * instant than the argument the derivation ran over.
+ * A result field whose resolution crosses computed state. Each computed cell
+ * holds what its last committed derivation produced, and reading the field
+ * does not re-derive it, so either a terminal value or a cached choice of link
+ * can describe an earlier instant than the current argument.
  */
 export interface CachedResultField {
   /** The field's name on the piece's result. */
   name: string;
-  /** The computed entity the field's value was read from. */
+  /** The computed documents crossed while resolving the field's value. */
+  cells: CachedResultCell[];
+}
+
+/** One computed document crossed while resolving a result field. */
+export interface CachedResultCell {
+  /** The computed entity's id. */
   id: string;
+  /** The space whose commit sequence contains `derivedAtCommit`. */
+  space: MemorySpace;
+  /** The computed entity's memory scope. */
+  scope: CellScope;
   /**
    * The commit the entity's document last stood at. Absent when the local
    * replica holds no confirmed version of that document.
@@ -3680,20 +3691,22 @@ export interface CachedResultField {
  */
 function commitOfDocument(
   runtime: Runtime,
-  link: NormalizedFullLink,
+  link: { id: string; space: MemorySpace; scope: CellScope },
 ): number | undefined {
   const provider = runtime.storageManager.open(link.space);
-  return provider.replica.get({ id: link.id, scope: link.scope })?.since;
+  return provider.replica.get({
+    id: link.id as NormalizedFullLink["id"],
+    scope: link.scope,
+  })?.since;
 }
 
 /**
- * Which of `names` a read of `resultCell` answers from a computed cell.
+ * Which of `names` a read of `resultCell` resolves through a computed cell.
  *
- * The runtime's own link resolution decides this, so the entity named is the
- * one the value came out of rather than the first link the field stores. A
- * field whose stored link crosses a computed cell on the way to live state —
- * a derived list of links into the argument, say — reads live state and is
- * left out. Every id that is not a computed one counts as live, unknown URI
+ * The runtime's own link resolution supplies every dereference. A computed
+ * document counts even when its cached value is another link and the terminal
+ * entity is live: choosing that link was itself a derivation which can be
+ * stale. Every id that is not a computed one counts as live, unknown URI
  * schemes included, which is the strict reading `entityKindOfIdString`
  * requires of its callers.
  */
@@ -3705,18 +3718,30 @@ export function cachedResultFields(
   const tx = runtime.readTx();
   const cached: CachedResultField[] = [];
   for (const name of names) {
-    const resolved = resolveLink(
+    const start = resultCell.key(name).getAsNormalizedFullLink();
+    const { link: resolved, traces } = resolveLinkTracingDereferences(
       runtime,
       tx,
-      resultCell.key(name).getAsNormalizedFullLink(),
+      start,
     );
-    if (entityKindOfIdString(resolved.id) !== "computed") continue;
-    const derivedAtCommit = commitOfDocument(runtime, resolved);
-    cached.push({
-      name,
-      id: resolved.id,
-      ...(derivedAtCommit !== undefined && { derivedAtCommit }),
-    });
+    const documents = [start, ...traces.map(({ target }) => target), resolved];
+    const cells = new Map<string, CachedResultCell>();
+    for (const document of documents) {
+      if (entityKindOfIdString(document.id) !== "computed") continue;
+      const key =
+        `${document.space}\u0000${document.scope}\u0000${document.id}`;
+      if (cells.has(key)) continue;
+      const derivedAtCommit = commitOfDocument(runtime, document);
+      cells.set(key, {
+        id: document.id,
+        space: document.space,
+        scope: document.scope,
+        ...(derivedAtCommit !== undefined && { derivedAtCommit }),
+      });
+    }
+    if (cells.size > 0) {
+      cached.push({ name, cells: [...cells.values()] });
+    }
   }
   return cached;
 }
@@ -3729,12 +3754,14 @@ export interface PieceInspection {
   source?: Readonly<unknown>;
   result: Readonly<unknown>;
   /**
-   * The commit the argument document behind `source` last stood at. It comes
-   * from the same per-space sequence as a {@link CachedResultField}'s own
-   * commit, so the two order against each other.
+   * The commit the argument document behind `source` last stood at. It can be
+   * ordered against a {@link CachedResultCell} commit only when both have the
+   * same `space`.
    */
   sourceCommit?: number;
-  /** The fields of `result` a read answers from a computed cell's cache. */
+  /** The space whose commit sequence contains `sourceCommit`. */
+  sourceSpace?: MemorySpace;
+  /** The fields of `result` whose resolution crosses a computed-cell cache. */
   cachedResultFields: CachedResultField[];
   readingFrom: Array<{ id: string; name?: string }>;
   readBy: Array<{ id: string; name?: string }>;
@@ -3784,14 +3811,12 @@ export async function inspectPiece(
   const resultCell = await piece.result.getCell();
   const inputCell = await piece.input.getCell();
   const runtime = resultCell.runtime;
-  const sourceCommit = commitOfDocument(
+  const sourceLink = resolveLink(
     runtime,
-    resolveLink(
-      runtime,
-      runtime.readTx(),
-      inputCell.getAsNormalizedFullLink(),
-    ),
+    runtime.readTx(),
+    inputCell.getAsNormalizedFullLink(),
   );
+  const sourceCommit = commitOfDocument(runtime, sourceLink);
   const cached = isObjectNotArray(result)
     ? cachedResultFields(resultCell, Object.keys(result))
     : [];
@@ -3802,6 +3827,7 @@ export async function inspectPiece(
     patternRef,
     source,
     ...(sourceCommit !== undefined && { sourceCommit }),
+    sourceSpace: sourceLink.space,
     result,
     cachedResultFields: cached,
     readingFrom,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -46,6 +46,8 @@ import {
   isSlugAddress,
   type MemorySpace,
   NAME,
+  type NormalizedFullLink,
+  resolveLink,
   Runtime,
   runtimePresets,
   RuntimeProgram,
@@ -65,6 +67,7 @@ import {
   resolveCfcSchemaRefs,
   validateSchemaValue,
 } from "@commonfabric/runner/cfc";
+import { entityKindOfIdString } from "@commonfabric/runner/entity-kind";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import {
@@ -3652,18 +3655,95 @@ export async function generateSpaceMap(
   return formatSpaceMap(connections, format);
 }
 
-export async function inspectPiece(
-  config: PieceConfig,
-  deps: PieceOperationDependencies = {},
-): Promise<{
+/**
+ * A result field whose value the runtime read out of a computed cell. Such a
+ * cell holds what its last committed derivation produced, and nothing
+ * re-derives it when a reader reads it, so its value can name an earlier
+ * instant than the argument the derivation ran over.
+ */
+export interface CachedResultField {
+  /** The field's name on the piece's result. */
+  name: string;
+  /** The computed entity the field's value was read from. */
+  id: string;
+  /**
+   * The commit the entity's document last stood at. Absent when the local
+   * replica holds no confirmed version of that document.
+   */
+  derivedAtCommit?: number;
+}
+
+/**
+ * The commit `link`'s document last stood at, read from the space's local
+ * replica. Commit sequences are assigned per space, so two documents read from
+ * one replica can be ordered against each other.
+ */
+function commitOfDocument(
+  runtime: Runtime,
+  link: NormalizedFullLink,
+): number | undefined {
+  const provider = runtime.storageManager.open(link.space);
+  return provider.replica.get({ id: link.id, scope: link.scope })?.since;
+}
+
+/**
+ * Which of `names` a read of `resultCell` answers from a computed cell.
+ *
+ * The runtime's own link resolution decides this, so the entity named is the
+ * one the value came out of rather than the first link the field stores. A
+ * field whose stored link crosses a computed cell on the way to live state —
+ * a derived list of links into the argument, say — reads live state and is
+ * left out. Every id that is not a computed one counts as live, unknown URI
+ * schemes included, which is the strict reading `entityKindOfIdString`
+ * requires of its callers.
+ */
+export function cachedResultFields(
+  resultCell: Cell<unknown>,
+  names: readonly string[],
+): CachedResultField[] {
+  const runtime = resultCell.runtime;
+  const tx = runtime.readTx();
+  const cached: CachedResultField[] = [];
+  for (const name of names) {
+    const resolved = resolveLink(
+      runtime,
+      tx,
+      resultCell.key(name).getAsNormalizedFullLink(),
+    );
+    if (entityKindOfIdString(resolved.id) !== "computed") continue;
+    const derivedAtCommit = commitOfDocument(runtime, resolved);
+    cached.push({
+      name,
+      id: resolved.id,
+      ...(derivedAtCommit !== undefined && { derivedAtCommit }),
+    });
+  }
+  return cached;
+}
+
+/** What {@link inspectPiece} reports about one piece. */
+export interface PieceInspection {
   id: string;
   name?: string;
   patternRef?: PiecePatternRef;
   source?: Readonly<unknown>;
   result: Readonly<unknown>;
+  /**
+   * The commit the argument document behind `source` last stood at. It comes
+   * from the same per-space sequence as a {@link CachedResultField}'s own
+   * commit, so the two order against each other.
+   */
+  sourceCommit?: number;
+  /** The fields of `result` a read answers from a computed cell's cache. */
+  cachedResultFields: CachedResultField[];
   readingFrom: Array<{ id: string; name?: string }>;
   readBy: Array<{ id: string; name?: string }>;
-}> {
+}
+
+export async function inspectPiece(
+  config: PieceConfig,
+  deps: PieceOperationDependencies = {},
+): Promise<PieceInspection> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   let resolvedConfig: PieceConfig;
   try {
@@ -3701,13 +3781,29 @@ export async function inspectPiece(
     id: piece.id,
     name: piece.name(),
   }));
+  const resultCell = await piece.result.getCell();
+  const inputCell = await piece.input.getCell();
+  const runtime = resultCell.runtime;
+  const sourceCommit = commitOfDocument(
+    runtime,
+    resolveLink(
+      runtime,
+      runtime.readTx(),
+      inputCell.getAsNormalizedFullLink(),
+    ),
+  );
+  const cached = isObjectNotArray(result)
+    ? cachedResultFields(resultCell, Object.keys(result))
+    : [];
 
   return {
     id,
     name,
     patternRef,
     source,
+    ...(sourceCommit !== undefined && { sourceCommit }),
     result,
+    cachedResultFields: cached,
     readingFrom,
     readBy,
   };
@@ -3716,15 +3812,7 @@ export async function inspectPiece(
 async function inspectSlugTargetCell(
   pieces: PiecesController,
   slug: string,
-): Promise<{
-  id: string;
-  name?: string;
-  patternRef?: PiecePatternRef;
-  source?: Readonly<unknown>;
-  result: Readonly<unknown>;
-  readingFrom: Array<{ id: string; name?: string }>;
-  readBy: Array<{ id: string; name?: string }>;
-}> {
+): Promise<PieceInspection> {
   const target = await resolveSlugTargetCell(pieces, slug);
   await target.pull();
   const result = target.get() as Readonly<unknown>;
@@ -3752,6 +3840,9 @@ async function inspectSlugTargetCell(
     name,
     patternRef,
     result,
+    cachedResultFields: isObjectNotArray(result)
+      ? cachedResultFields(target, Object.keys(result))
+      : [],
     readingFrom: [],
     readBy: [],
   };

--- a/packages/cli/test/piece-cached-result-fields.test.ts
+++ b/packages/cli/test/piece-cached-result-fields.test.ts
@@ -14,9 +14,9 @@ import { type CachedResultField, cachedResultFields } from "../lib/piece.ts";
  * `title` hands the argument's own cell back, so a read of it lands in the
  * argument document. `shout` is derived from it, so the runtime materializes a
  * computed cell and a read of it lands there. `loud` is derived too, and its
- * result field stores a link to a computed cell — but that cell holds a link
- * on to the map's output, which is an ordinary entity, so a read of `loud`
- * lands in live state and the field is not cached.
+ * result field stores a link to a computed cell which holds a link on to the
+ * map's ordinary output entity. Resolving `loud` therefore crosses cached
+ * state even though it ends in live state.
  */
 const PROGRAM = {
   main: "/main.tsx",
@@ -104,35 +104,61 @@ describe("piece-cached-result-fields", () => {
     });
 
     it("returns the derived field and not the one linked into the argument", () => {
-      expect(report.cached.map((field) => field.name)).toEqual(["shout"]);
-      expect(report.cached[0].id.startsWith("computed:")).toBe(true);
+      expect(report.cached.map((field) => field.name)).toEqual([
+        "shout",
+        "loud",
+      ]);
+      expect(report.cached[0].cells[0].id.startsWith("computed:")).toBe(true);
     });
 
     it("returns the commit the derived field's own document last stood at", () => {
-      expect(typeof report.cached[0].derivedAtCommit).toBe("number");
+      expect(typeof report.cached[0].cells[0].derivedAtCommit).toBe("number");
     });
 
-    it("returns nothing for a field whose computed cell links on to live state", () => {
-      // The distinction this pins is between the link a field stores and the
-      // entity its value comes out of. `loud` stores a computed link and reads
-      // live state, so classifying on the stored link alone would list it.
+    it("returns a computed hop which links on to live state", () => {
       expect(report.firstHop.loud.startsWith("computed:")).toBe(true);
-      expect(report.cached.map((field) => field.name)).not.toContain("loud");
+      expect(report.cached.find((field) => field.name === "loud")?.cells)
+        .toEqual([
+          expect.objectContaining({
+            id: report.firstHop.loud,
+            derivedAtCommit: expect.any(Number),
+          }),
+        ]);
     });
   });
 
   describe("renderCachedResultFields()", () => {
     it("returns each field's own commit beside the argument's", () => {
-      const section = renderCachedResultFields([
-        { name: "adminName", id: "computed:fid1:one", derivedAtCommit: 182802 },
-        { name: "todayDate", id: "computed:fid1:two", derivedAtCommit: 182785 },
-      ], 253299);
+      const section = renderCachedResultFields(
+        [
+          {
+            name: "adminName",
+            cells: [{
+              id: "computed:fid1:one",
+              space: "did:key:source",
+              scope: "space",
+              derivedAtCommit: 182802,
+            }],
+          },
+          {
+            name: "todayDate",
+            cells: [{
+              id: "computed:fid1:two",
+              space: "did:key:source",
+              scope: "space",
+              derivedAtCommit: 182785,
+            }],
+          },
+        ],
+        253299,
+        "did:key:source",
+      );
 
       expect(section).toBe(
         [
           "--- Cached Result Fields ---",
-          "Each field below reads a computed cell, which holds the value its last",
-          "committed derivation produced. Reading it does not re-derive it.",
+          "Each field below crosses computed state holding what its last committed",
+          "derivation produced. Reading the field does not re-derive that state.",
           "  - adminName: last derived at commit 182802; Source (Inputs) stands at commit 253299",
           "  - todayDate: last derived at commit 182785; Source (Inputs) stands at commit 253299",
         ].join("\n"),
@@ -140,21 +166,55 @@ describe("piece-cached-result-fields", () => {
     });
 
     it("returns `(none)` when every result field reads live state", () => {
-      expect(renderCachedResultFields([], 253299)).toBe(
+      expect(renderCachedResultFields([], 253299, "did:key:source")).toBe(
         "--- Cached Result Fields ---\n  (none)",
       );
     });
 
     it("returns a field with no commit as one the replica holds none for", () => {
       const section = renderCachedResultFields(
-        [{ name: "myName", id: "computed:fid1:three" }],
+        [{
+          name: "myName",
+          cells: [{
+            id: "computed:fid1:three",
+            space: "did:key:source",
+            scope: "space",
+          }],
+        }],
         undefined,
+        "did:key:source",
       );
 
       expect(section).toContain(
         "- myName: the local replica holds no commit for it",
       );
       expect(section).not.toContain("Source (Inputs)");
+    });
+
+    it("does not compare commits from different spaces", () => {
+      const section = renderCachedResultFields(
+        [{
+          name: "profileName",
+          cells: [{
+            id: "computed:fid1:remote",
+            space: "did:key:remote",
+            scope: "space",
+            derivedAtCommit: 12,
+          }],
+        }],
+        900,
+        "did:key:source",
+      );
+
+      expect(section).toContain(
+        "last derived at commit 12 in space did:key:remote",
+      );
+      expect(section).toContain(
+        "Source (Inputs) stands at commit 900 in space did:key:source",
+      );
+      expect(section).toContain(
+        "commits from different spaces cannot be compared",
+      );
     });
   });
 });

--- a/packages/cli/test/piece-cached-result-fields.test.ts
+++ b/packages/cli/test/piece-cached-result-fields.test.ts
@@ -1,10 +1,13 @@
 import { beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { parseLink, Runtime } from "@commonfabric/runner";
+import { parseLink, Runtime, UI } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
-import { renderCachedResultFields } from "../commands/piece.ts";
+import {
+  renderCachedResultFields,
+  renderPieceInspection,
+} from "../commands/piece.ts";
 import { type CachedResultField, cachedResultFields } from "../lib/piece.ts";
 
 /**
@@ -46,6 +49,7 @@ const FIELDS = ["title", "shout", "loud"];
 /** What one run of {@link PROGRAM} says about its own result fields. */
 interface LivePieceReport {
   cached: CachedResultField[];
+  primitive: CachedResultField[];
   /** The entity each field's own stored link names, before any is followed. */
   firstHop: Record<string, string>;
 }
@@ -88,7 +92,11 @@ async function runLivePiece(): Promise<LivePieceReport> {
     for (const name of FIELDS) {
       firstHop[name] = parseLink(stored[name] as never, base)?.id ?? base.id;
     }
-    return { cached: cachedResultFields(result, FIELDS), firstHop };
+    return {
+      cached: cachedResultFields(result, stored),
+      primitive: cachedResultFields(result, "not an object result"),
+      firstHop,
+    };
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -104,15 +112,21 @@ describe("piece-cached-result-fields", () => {
     });
 
     it("returns the derived field and not the one linked into the argument", () => {
-      expect(report.cached.map((field) => field.name)).toEqual([
-        "shout",
+      expect(report.cached.map((field) => field.name).sort()).toEqual([
         "loud",
+        "shout",
       ]);
-      expect(report.cached[0].cells[0].id.startsWith("computed:")).toBe(true);
+      expect(
+        report.cached.find((field) => field.name === "shout")?.cells[0].id
+          .startsWith("computed:"),
+      ).toBe(true);
     });
 
     it("returns the commit the derived field's own document last stood at", () => {
-      expect(typeof report.cached[0].cells[0].derivedAtCommit).toBe("number");
+      expect(
+        typeof report.cached.find((field) => field.name === "shout")?.cells[0]
+          .derivedAtCommit,
+      ).toBe("number");
     });
 
     it("returns a computed hop which links on to live state", () => {
@@ -124,6 +138,10 @@ describe("piece-cached-result-fields", () => {
             derivedAtCommit: expect.any(Number),
           }),
         ]);
+    });
+
+    it("returns no cached fields for a scalar result", () => {
+      expect(report.primitive).toEqual([]);
     });
   });
 
@@ -215,6 +233,72 @@ describe("piece-cached-result-fields", () => {
       expect(section).toContain(
         "commits from different spaces cannot be compared",
       );
+    });
+  });
+
+  describe("renderPieceInspection()", () => {
+    it("places the cached-field section between the result and references", () => {
+      const output = renderPieceInspection({
+        id: "piece-one",
+        name: "Example",
+        patternRef: {
+          identity: "A".repeat(43),
+          symbol: "default",
+          source: {
+            ref: `cf:pattern:${"A".repeat(43)}`,
+            repository: "https://github.com/example/repo",
+            entry: "/pattern.tsx",
+            origin: "https://example.com/pattern.tsx",
+          },
+        },
+        source: { title: "Input" },
+        result: { title: "Result", [UI]: { tag: "div" } },
+        sourceCommit: 20,
+        sourceSpace: "did:key:source",
+        cachedResultFields: [{
+          name: "title",
+          cells: [{
+            id: "computed:fid1:title",
+            space: "did:key:source",
+            scope: "space",
+            derivedAtCommit: 10,
+          }],
+        }],
+        readingFrom: [{ id: "source", name: "Source" }, { id: "bare" }],
+        readBy: [{ id: "reader", name: "Reader" }, { id: "anonymous" }],
+      }, false);
+
+      expect(output.indexOf("--- Result ---")).toBeLessThan(
+        output.indexOf("--- Cached Result Fields ---"),
+      );
+      expect(output.indexOf("--- Cached Result Fields ---")).toBeLessThan(
+        output.indexOf("--- Reading From ---"),
+      );
+      expect(output).toContain(
+        '"$UI": "<large UI object - use --json to see full UI>"',
+      );
+      expect(output).toContain(
+        "title: last derived at commit 10; Source (Inputs) stands at commit 20",
+      );
+      expect(output).toContain("  - source (Source)\n  - bare");
+      expect(output).toContain("  - reader (Reader)\n  - anonymous");
+    });
+
+    it("summarizes data and renders absent values and references", () => {
+      const output = renderPieceInspection({
+        id: "piece-two",
+        result: null,
+        cachedResultFields: [],
+        readingFrom: [],
+        readBy: [],
+      }, true);
+
+      expect(output).toContain("Name: <no name>");
+      expect(output).toContain("<no source data>");
+      expect(output).toContain("<no result data>");
+      expect(output).toContain("--- Cached Result Fields ---\n  (none)");
+      expect(output).toContain("--- Reading From ---\n  (none)");
+      expect(output).toContain("--- Read By ---\n  (none)");
     });
   });
 });

--- a/packages/cli/test/piece-cached-result-fields.test.ts
+++ b/packages/cli/test/piece-cached-result-fields.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { parseLink, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
+import { renderCachedResultFields } from "../commands/piece.ts";
+import { type CachedResultField, cachedResultFields } from "../lib/piece.ts";
+
+/**
+ * A pattern whose result carries each shape the classification has to tell
+ * apart.
+ *
+ * `title` hands the argument's own cell back, so a read of it lands in the
+ * argument document. `shout` is derived from it, so the runtime materializes a
+ * computed cell and a read of it lands there. `loud` is derived too, and its
+ * result field stores a link to a computed cell — but that cell holds a link
+ * on to the map's output, which is an ordinary entity, so a read of `loud`
+ * lands in live state and the field is not cached.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { computed, pattern } from "commonfabric";',
+      "",
+      "interface In { title: string; items: string[]; }",
+      "interface Out {",
+      "  title: string;",
+      "  shout: string;",
+      "  loud: string[];",
+      "}",
+      "",
+      "export default pattern<In, Out>(({ title, items }) => ({",
+      "  title,",
+      "  shout: computed(() => title.toUpperCase()),",
+      "  loud: items.map((item) => item.toUpperCase()),",
+      "}));",
+    ].join("\n"),
+  }],
+};
+
+const FIELDS = ["title", "shout", "loud"];
+
+/** What one run of {@link PROGRAM} says about its own result fields. */
+interface LivePieceReport {
+  cached: CachedResultField[];
+  /** The entity each field's own stored link names, before any is followed. */
+  firstHop: Record<string, string>;
+}
+
+/** Builds a piece from {@link PROGRAM}, runs it, and reports on its result. */
+async function runLivePiece(): Promise<LivePieceReport> {
+  const signer = await Identity.fromPassphrase("piece cached result fields");
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  try {
+    const space = signer.did();
+    const compiled = await runtime.patternManager.compilePattern(
+      PROGRAM as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const rootCell = runtime.getCell(space, "cached-fields", undefined, tx);
+    const root = runtime.run(
+      tx,
+      compiled,
+      { title: "cruller", items: ["jam", "glaze"] },
+      rootCell,
+    );
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await runtime.idle();
+    await storageManager.synced();
+    await root.pull();
+
+    const result = getResultCellWithSourceSchema(root);
+    const base = result.getAsNormalizedFullLink();
+    const stored = result.getRaw({ lastNode: "top" }) as Record<
+      string,
+      unknown
+    >;
+    const firstHop: Record<string, string> = {};
+    for (const name of FIELDS) {
+      firstHop[name] = parseLink(stored[name] as never, base)?.id ?? base.id;
+    }
+    return { cached: cachedResultFields(result, FIELDS), firstHop };
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+}
+
+describe("piece-cached-result-fields", () => {
+  describe("cachedResultFields()", () => {
+    let report: LivePieceReport;
+
+    beforeAll(async () => {
+      report = await runLivePiece();
+    });
+
+    it("returns the derived field and not the one linked into the argument", () => {
+      expect(report.cached.map((field) => field.name)).toEqual(["shout"]);
+      expect(report.cached[0].id.startsWith("computed:")).toBe(true);
+    });
+
+    it("returns the commit the derived field's own document last stood at", () => {
+      expect(typeof report.cached[0].derivedAtCommit).toBe("number");
+    });
+
+    it("returns nothing for a field whose computed cell links on to live state", () => {
+      // The distinction this pins is between the link a field stores and the
+      // entity its value comes out of. `loud` stores a computed link and reads
+      // live state, so classifying on the stored link alone would list it.
+      expect(report.firstHop.loud.startsWith("computed:")).toBe(true);
+      expect(report.cached.map((field) => field.name)).not.toContain("loud");
+    });
+  });
+
+  describe("renderCachedResultFields()", () => {
+    it("returns each field's own commit beside the argument's", () => {
+      const section = renderCachedResultFields([
+        { name: "adminName", id: "computed:fid1:one", derivedAtCommit: 182802 },
+        { name: "todayDate", id: "computed:fid1:two", derivedAtCommit: 182785 },
+      ], 253299);
+
+      expect(section).toContain("--- Cached Result Fields ---");
+      expect(section).toContain("Source (Inputs) stands at commit 253299.");
+      expect(section).toContain("- adminName: last derived at commit 182802");
+      expect(section).toContain("- todayDate: last derived at commit 182785");
+    });
+
+    it("returns `(none)` when every result field reads live state", () => {
+      expect(renderCachedResultFields([], 253299)).toBe(
+        "--- Cached Result Fields ---\n  (none)",
+      );
+    });
+
+    it("returns a field with no commit as one the replica holds none for", () => {
+      const section = renderCachedResultFields(
+        [{ name: "myName", id: "computed:fid1:three" }],
+        undefined,
+      );
+
+      expect(section).toContain(
+        "- myName: the local replica holds no commit for it",
+      );
+      expect(section).not.toContain("Source (Inputs)");
+    });
+  });
+});

--- a/packages/cli/test/piece-cached-result-fields.test.ts
+++ b/packages/cli/test/piece-cached-result-fields.test.ts
@@ -128,10 +128,15 @@ describe("piece-cached-result-fields", () => {
         { name: "todayDate", id: "computed:fid1:two", derivedAtCommit: 182785 },
       ], 253299);
 
-      expect(section).toContain("--- Cached Result Fields ---");
-      expect(section).toContain("Source (Inputs) stands at commit 253299.");
-      expect(section).toContain("- adminName: last derived at commit 182802");
-      expect(section).toContain("- todayDate: last derived at commit 182785");
+      expect(section).toBe(
+        [
+          "--- Cached Result Fields ---",
+          "Each field below reads a computed cell, which holds the value its last",
+          "committed derivation produced. Reading it does not re-derive it.",
+          "  - adminName: last derived at commit 182802; Source (Inputs) stands at commit 253299",
+          "  - todayDate: last derived at commit 182785; Source (Inputs) stands at commit 253299",
+        ].join("\n"),
+      );
     });
 
     it("returns `(none)` when every result field reads live state", () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -3927,6 +3927,7 @@ describe("cli piece parsing", () => {
       expect(inspected.id).toBe(PIECE);
       expect(inspected.cachedResultFields).toEqual([]);
       expect(inspected.sourceCommit).toBeUndefined();
+      expect(inspected.sourceSpace).toBe(space);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -3887,28 +3887,48 @@ describe("cli piece parsing", () => {
       symbol: "default",
       source: { ref: `cf:pattern:${"B".repeat(43)}` },
     };
-    const inspected = await inspectPiece(
-      { apiUrl: API_URL, space: SPACE, identity: ID, piece: "notes" },
-      {
-        resolvePieceAddress: () => Promise.resolve(PIECE),
-        loadPieces: () =>
-          Promise.resolve({
-            get: () =>
-              Promise.resolve({
-                id: PIECE,
-                name: () => "Notes",
-                getPatternRef: () => Promise.resolve(patternRef),
-                input: { get: () => Promise.resolve({ title: "Input" }) },
-                result: { get: () => Promise.resolve({ title: "Result" }) },
-                readingFrom: () => Promise.resolve([]),
-                readBy: () => Promise.resolve([]),
-              }),
-          } as any),
-      },
-    );
+    const signer = await Identity.fromPassphrase("cf piece inspect provenance");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+    try {
+      const space = signer.did();
+      const inspected = await inspectPiece(
+        { apiUrl: API_URL, space: SPACE, identity: ID, piece: "notes" },
+        {
+          resolvePieceAddress: () => Promise.resolve(PIECE),
+          loadPieces: () =>
+            Promise.resolve({
+              get: () =>
+                Promise.resolve({
+                  id: PIECE,
+                  name: () => "Notes",
+                  getPatternRef: () => Promise.resolve(patternRef),
+                  input: {
+                    get: () => Promise.resolve({ title: "Input" }),
+                    getCell: () =>
+                      Promise.resolve(runtime.getCell(space, "argument")),
+                  },
+                  result: {
+                    get: () => Promise.resolve({ title: "Result" }),
+                    getCell: () =>
+                      Promise.resolve(runtime.getCell(space, "result")),
+                  },
+                  readingFrom: () => Promise.resolve([]),
+                  readBy: () => Promise.resolve([]),
+                }),
+            } as any),
+        },
+      );
 
-    expect(inspected.patternRef).toEqual(patternRef);
-    expect(inspected.id).toBe(PIECE);
+      expect(inspected.patternRef).toEqual(patternRef);
+      expect(inspected.id).toBe(PIECE);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
   });
 
   it("forwards repository metadata when deploying a home pattern", async () => {

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -3925,6 +3925,8 @@ describe("cli piece parsing", () => {
 
       expect(inspected.patternRef).toEqual(patternRef);
       expect(inspected.id).toBe(PIECE);
+      expect(inspected.cachedResultFields).toEqual([]);
+      expect(inspected.sourceCommit).toBeUndefined();
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -116,7 +116,10 @@ export {
   setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "./storage/reactivity-log.ts";
-export { resolveLink } from "./link-resolution.ts";
+export {
+  resolveLink,
+  resolveLinkTracingDereferences,
+} from "./link-resolution.ts";
 export {
   areLinksSame,
   getMetaLink,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -28,6 +28,7 @@ import {
   type MemorySpace,
   type QueryError as IQueryError,
   type Result,
+  type Revision,
   type Signer,
   type State,
   type The as MediaType,
@@ -2162,9 +2163,11 @@ export type EventAppendDeliveryOutcome =
 export interface ISpaceReplica extends ISpace {
   /**
    * Return a state for the requested entry or returns `undefined` if replica
-   * does not have it.
+   * does not have it. The state carries `since`, the commit sequence the
+   * entry's document last stood at in this space, so two entries read from
+   * one replica can be ordered against each other.
    */
-  get(entry: BaseMemoryAddress): State | undefined;
+  get(entry: BaseMemoryAddress): Revision<State> | undefined;
 
   /**
    * The doc's visible document (confirmed + this replica's pending

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -13,6 +13,7 @@ import {
   type ConnectionError as IConnectionError,
   type MemorySpace,
   type MIME,
+  type Revision,
   type Signer,
   type TransactionError,
   type URI,
@@ -2753,7 +2754,7 @@ class SpaceReplica implements ISpaceReplica {
     this.#replacementRead = replacementRead;
   }
 
-  get(entry: IMemoryAddress): State | undefined {
+  get(entry: IMemoryAddress): Revision<State> | undefined {
     return this.getState(
       entry.id as URI,
       entry.scope,
@@ -3361,7 +3362,7 @@ class SpaceReplica implements ISpaceReplica {
       .map(([address]) =>
         this.getState(address.id, address.scope, undefined, address.scopeKey)
       )
-      .filter((state): state is State => state !== undefined);
+      .filter((state): state is Revision<State> => state !== undefined);
     this.#subscription.next({
       type: "load",
       space: this.#space,
@@ -6187,7 +6188,7 @@ class SpaceReplica implements ISpaceReplica {
     scope?: CellScope,
     identity?: ScopeKeyIdentity,
     explicit?: ScopeKey,
-  ): State | undefined {
+  ): Revision<State> | undefined {
     const visible = this.visibleVersion(id, scope, identity, explicit);
     if (!visible) {
       return undefined;
@@ -6206,7 +6207,7 @@ class SpaceReplica implements ISpaceReplica {
       // own-identity read's state is byte-identical to before.
       ...(explicit !== undefined ? { scopeKey: explicit } : {}),
       since: visible.record.confirmed.seq,
-    } as State;
+    } as Revision<State>;
   }
 
   private visibleDocument(

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -420,13 +420,15 @@ deno task cf piece step --piece ID ...  # Required!
 deno task cf piece inspect --piece ID ...
 ```
 
-`piece inspect` prints a `--- Cached Result Fields ---` section naming the
-result fields whose values come out of a computed cell, with the commit each was
-last derived at. The commit the argument document stands at is printed beside
-them, drawn from the same per-space sequence, so a field that has not been
-re-derived since the argument moved reads as behind it. Result fields the
-section does not name read live state. `--json` carries the same information as
-`cachedResultFields` and `sourceCommit`.
+`piece inspect` prints a `--- Cached Result Fields ---` section naming every
+result field whose resolution crosses a computed cell, with each computed cell's
+last-derived commit. The commit the argument document stands at is printed
+beside the field. A computed cell which links on to live state is still named:
+the cached choice of link can be stale. Commit numbers from different spaces do
+not order, and the output identifies that case instead of comparing them. Result
+fields the section does not name resolve entirely through live state. `--json`
+carries the same information as `cachedResultFields`, `sourceCommit`, and
+`sourceSpace`.
 
 **Handler testing workflow** (automated test → deploy → call → step → inspect):
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -420,6 +420,14 @@ deno task cf piece step --piece ID ...  # Required!
 deno task cf piece inspect --piece ID ...
 ```
 
+`piece inspect` prints a `--- Cached Result Fields ---` section naming the
+result fields whose values come out of a computed cell, with the commit each was
+last derived at. The commit the argument document stands at is printed beside
+them, drawn from the same per-space sequence, so a field that has not been
+re-derived since the argument moved reads as behind it. Result fields the
+section does not name read live state. `--json` carries the same information as
+`cachedResultFields` and `sourceCommit`.
+
 **Handler testing workflow** (automated test → deploy → call → step → inspect):
 
 ```bash


### PR DESCRIPTION
`cf piece inspect` printed a piece's stored argument under `--- Source (Inputs) ---` and its result under `--- Result ---`, formatted identically. The two blocks can describe different instants, and nothing in the output said so.

A piece's result surface mixes two kinds of field. A field backed by an `of:` address is a live link, usually straight into the argument document, and is always current. A field backed by a `computed:` address is a cached derivation: the stored contents are what the last committed derivation produced, and nothing re-derives them on read. Reading the output there was no way to tell which class a field was in, so two adjacent values could be weeks apart and look equally authoritative. One deployed poll shows the shape: `adminName` printed "Gideon W" under Source and "Mike" under Result, while `todayDate` read a date nine days behind the votes the argument held.

The command now prints a `--- Cached Result Fields ---` section naming only the fields a read answers from a computed cell, so a mostly-live result stays quiet. Each named field carries the commit its document last stood at, which is a fact the reader can read rather than a caveat they have to evaluate, and the commit the argument document stands at is printed beside them. Both come from the space's own commit sequence, so a field that has not been re-derived since the argument moved reads as behind it. On the poll above the section names `adminName` at commit 182802 and `todayDate` at 182785, with the argument standing at 253299.

Which class a field is in is decided by the runtime's own link resolution, against the entity the value comes out of rather than the first link the field stores. The two differ: a `.map()` result stores a link to a computed cell, and that cell holds a link on to the map's output, which is an ordinary entity — so the value read is live and the field is left out. Every id that is not a computed one counts as live, unknown URI schemes included, which is the strict reading `entityKindOfIdString` requires of its callers.

The commit an entity last stood at was already on the state the replica hands back, as the `since` field `getState` fills in, but `ISpaceReplica.get` declared a return type without it. That declaration now says `Revision<State>`, which is what the one implementation has always returned.

`--json` carries the same facts, as `cachedResultFields` and `sourceCommit`.

This is the presentation alone. A derived value is still allowed to diverge from its inputs indefinitely with nothing re-deriving it on read, and a programmatic reader inside the runtime still has no way to know that what it received is a cache.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

