### PR TITLE
feat(test-records): record what agents run, and take the key back off

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -139,6 +139,11 @@ record on their own. Two consequences worth knowing while writing one:
 A new test *surface* (a new CI job, script, or harness) does need wiring —
 `docs/development/test-records.md` under "Covering a new test surface".
 
+Your own runs are recorded too, and are marked as an agent's: with
+`CF_TEST_AGENT` unset, the run context carries the name of the harness
+you are running under. Nothing to set, and nothing to work around —
+a run of yours is data about the tests, the same as anyone's.
+
 When running tests for a team member — someone with commit access —
 whose environment has no `CF_TEST_RECORDS_KEY_FILE`, it is worth
 mentioning once, not per run, that `deno task test-records-key setup`

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -40,15 +40,28 @@ append-only, no-double-mapping, acyclic rules.
   everywhere. CI jobs set it to a workspace directory; local entry points
   set it themselves when they own a run. Never point two concurrent runs
   at one directory by hand — each run owns its own spool.
-- `CF_TEST_RECORDS_KEY_FILE` — a personal reporting key
-  (see below), exported from the login shell's profile by
-  `deno task test-records-key setup`. Its presence is the local opt-in:
-  with it, `deno task test`, `deno task integration`, and `deno task
-  run-recorded` stamp a spool, ship it when the run ends, and sweep any
-  orphaned spools a killed run left behind.
+- `CF_TEST_RECORDS_KEY_FILE` — a personal reporting key (see below), put in
+  the shell's profile and in each agent harness's configuration by `deno
+  task test-records-key setup`. Its presence is the local opt-in: with it,
+  `deno task test`, `deno task integration`, and `deno task run-recorded`
+  stamp a spool, ship it when the run ends, and sweep any orphaned spools a
+  killed run left behind. It has to reach shells nobody is typing into,
+  since that is what an agent's run is, so the export goes in `.zshenv`
+  rather than `.zshrc`. A harness that runs its commands through no shell at
+  all is covered by its own configuration instead, which the setup command
+  writes; the harnesses it knows are listed in
+  `tasks/test-records-agent-config.ts`, and one whose directory is not
+  there is left alone. Anything else — a bash workstation whose agents run
+  non-interactive shells, a harness nothing here knows — puts the variable
+  in whatever starts the agent.
 - `CF_TEST_AGENT` — an opaque label for the operating agent, recorded
-  verbatim in the run context. Set it to tell an agent fleet's runs apart
-  from a person's; it is never required.
+  verbatim in the run context. Set it to tell one agent from another, or
+  one checkout of a fleet from the next; it is never required. Left
+  unset, a run started by an agent is still labeled, by the harness that
+  started it — `claude-code`, `cursor`, `codex`, or `agent` for anything
+  that announces itself only as one. A person's own terminal carries
+  none of those, so their runs stay unlabeled, and a consumer that wants
+  human runs alone reads the ones with no `agent` field.
 - `CF_TEST_RECORDS_SPOOL_ROOT` — overrides the per-user spool root, which
   is otherwise under the user cache directory
   (`~/.cache/common-fabric/test-records`). The root is deliberately not in
@@ -76,8 +89,12 @@ deno task test-records-key setup
 
 generates a delivery identity, dispatches the minting workflow, watches
 until the run delivers, installs the key file with owner-only
-permissions, and exports `CF_TEST_RECORDS_KEY_FILE` from the login
-shell's profile — every shell opened after that records. A profile that
+permissions, and puts `CF_TEST_RECORDS_KEY_FILE` where the things that
+run tests will find it: the shell's profile, and the configuration of
+every agent harness installed here, since an agent that runs its
+commands without a shell is reached only by telling its harness to
+carry the variable. Every shell opened after that records, and so does
+every agent. A profile that
 already sets the variable is reported and left alone, whether it points
 somewhere else or sets it without exporting it, and so is a login
 profile that does not exist yet, since creating one is what stops a
@@ -130,6 +147,26 @@ existing key file copied to it rather than a fresh mint that would kill
 the first machine's. A mint that fails after the revocation leaves you
 with no key rather than two; the next run says so, and running setup
 again mints one.
+
+## Taking it off a workstation
+
+```
+deno task test-records-key uninstall
+```
+
+removes what setup put there — the key file, the delivery identity, the
+export it added, and the entry in each harness's configuration —
+leaving any line or value a person set themselves alone.
+Records that were spooled and never shipped stay where they are, since a
+later key ships them; the command says where they sit and what removing
+them would throw away.
+
+Two things it deliberately does not do. The service account and its key
+still exist, so a key that has leaked is made useless by minting a
+replacement, from this machine or any other, and not by uninstalling.
+And records already in the store stay there: they carry no personal
+material, and no key this tool installs can change or remove anything
+that is already stored.
 
 ## How records move
 

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -157,6 +157,17 @@ deno task test-records-key uninstall
 removes what setup put there — the key file, the delivery identity, the
 export it added, and the entry in each harness's configuration —
 leaving any line or value a person set themselves alone.
+
+Both commands write a profile the way a profile should be written. A
+profile that is a symbolic link, which is what a dotfiles repository
+leaves behind, is followed: the link stays a link and the file it points
+at is what changes. A file's permissions carry over, so one kept
+readable only by its owner comes back that way, and a file either of
+them creates is readable only by its owner. Each replacement happens in
+one step, because a shell startup file left half written is a shell that
+will not start. And a file whose state cannot be read — permissions
+withdrawn, a directory closed off — is reported and left alone rather
+than guessed at.
 Records that were spooled and never shipped stay where they are, since a
 later key ships them; the command says where they sit and what removing
 them would throw away.

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -148,6 +148,14 @@ the first machine's. A mint that fails after the revocation leaves you
 with no key rather than two; the next run says so, and running setup
 again mints one.
 
+A key file on disk is not the same thing as a key that works, so setup
+asks whether the one installed here is still accepted before it stands
+down. A key that has been revoked — by a rotation from another machine,
+or by a mint that failed after revoking the key it was replacing — is
+replaced rather than mistaken for a working one, and no flag is needed
+to recover. Where the question cannot be put at all, setup says so and
+leaves the key alone.
+
 ## Taking it off a workstation
 
 ```

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -110,7 +110,9 @@ watching for the run that click starts. The wait has no bound, since a
 run takes as long as it takes; Ctrl-C stops watching and running the
 command again picks up where it left off. Run it on a workstation that
 already holds a key and it re-checks the shell profile rather than
-minting a second one.
+minting a second one — unless a run is already minting for you, which it
+takes up, because the key that run delivers is the one replacing what is
+installed.
 
 `request` and `collect` are the same path in two invocations, for
 somewhere a watching command is unwanted — a shell without a terminal to

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -68,7 +68,9 @@ name (a constant owned by the repository's tooling, never derived from git
 remotes), the `commit` the tests ran against, a `dirty` flag, an optional
 `branch`, `env` (`ci` or `local`), the machine facts (`os`, `arch`,
 `denoVersion`), an ISO 8601 `startedAt` from the run's start, an optional
-opaque `agent` label from `CF_TEST_AGENT`, and for CI runs a `ci` block:
+opaque `agent` label — `CF_TEST_AGENT`, or the name of the harness the
+run was started under when that variable is unset — and for CI runs a
+`ci` block:
 `workflowRunId`, `runAttempt` (the attempt that produced the records),
 `workflow`, `job` (display name with matrix leg), optional `shard`,
 optional `headCommit` (the pull request's head; `commit` is the ephemeral

--- a/packages/test-support/src/records/paths.test.ts
+++ b/packages/test-support/src/records/paths.test.ts
@@ -94,5 +94,38 @@ describe("paths", () => {
       expect(agentLabel(() => "probe")).toBe("probe");
       expect(agentLabel(() => "")).toBeUndefined();
     });
+
+    it("names the harness an agent runs under", () => {
+      expect(agentLabel((name) => name === "CLAUDECODE" ? "1" : undefined))
+        .toBe("claude-code");
+      expect(agentLabel((name) => name === "CURSOR_AGENT" ? "1" : undefined))
+        .toBe("cursor");
+      expect(
+        agentLabel((name) => name === "CODEX_SANDBOX" ? "seatbelt" : undefined),
+      )
+        .toBe("codex");
+      expect(
+        agentLabel((name) =>
+          name === "AI_AGENT" ? "claude-code_2-1-237_agent" : undefined
+        ),
+      ).toBe("agent");
+    });
+
+    it("keeps the deliberate label over the harness it runs under", () => {
+      expect(
+        agentLabel((name) =>
+          name === "CF_TEST_AGENT"
+            ? "labs-B"
+            : name === "CLAUDECODE"
+            ? "1"
+            : undefined
+        ),
+      ).toBe("labs-B");
+    });
+
+    it("returns undefined for a shell with no agent in it", () => {
+      expect(agentLabel((name) => name === "HOME" ? "/h" : undefined))
+        .toBeUndefined();
+    });
   });
 });

--- a/packages/test-support/src/records/paths.ts
+++ b/packages/test-support/src/records/paths.ts
@@ -113,10 +113,37 @@ export function defaultSpoolRoot(
   return undefined;
 }
 
-/** The opaque agent label, when one is set. */
+/**
+ * Harnesses that drive an agent, and the name each is recorded under.
+ * A harness announces itself in the environment it hands the commands
+ * it runs, and the first of these that is present names the run's
+ * operator. The names are stable strings rather than anything the
+ * harness reports about itself, so a version bump does not split an
+ * agent's history in two.
+ */
+const AGENT_MARKERS: readonly { variable: string; label: string }[] = [
+  { variable: "CLAUDECODE", label: "claude-code" },
+  { variable: "CURSOR_AGENT", label: "cursor" },
+  { variable: "CODEX_SANDBOX", label: "codex" },
+  { variable: "AI_AGENT", label: "agent" },
+];
+
+/**
+ * The opaque agent label. CF_TEST_AGENT is what a person or a fleet
+ * sets deliberately, and nothing else overrides it. Without one, a run
+ * an agent started is labeled by the harness that started it, so an
+ * agent's runs are told apart from a person's without a variable having
+ * to be set in every checkout a fleet works in. A person's own terminal
+ * carries none of these and their runs stay unlabeled.
+ */
 export function agentLabel(
   env: Environment = Deno.env.get,
 ): string | undefined {
   const agent = readEnv(AGENT_VARIABLE, env);
-  return agent !== undefined && agent.length > 0 ? agent : undefined;
+  if (agent !== undefined && agent.length > 0) return agent;
+  for (const marker of AGENT_MARKERS) {
+    const value = readEnv(marker.variable, env);
+    if (value !== undefined && value.length > 0) return marker.label;
+  }
+  return undefined;
 }

--- a/packages/test-support/src/records/schema.ts
+++ b/packages/test-support/src/records/schema.ts
@@ -72,7 +72,10 @@ export interface RunContext {
   branch?: string;
   env: "ci" | "local";
   ci?: CiContext;
-  /** Opaque label for the operating agent, from CF_TEST_AGENT. */
+  /**
+   * Opaque label for the operating agent: CF_TEST_AGENT, or the
+   * harness a run was started under when that variable is unset.
+   */
   agent?: string;
   os: string;
   arch: string;

--- a/tasks/test-records-agent-config.test.ts
+++ b/tasks/test-records-agent-config.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import type { Environment } from "@commonfabric/test-support/records";
+
+import {
+  type AgentHarness,
+  exportFromAgentConfigs,
+  installedHarnesses,
+  unexportFromAgentConfigs,
+} from "./test-records-agent-config.ts";
+
+const VARIABLE = "CF_TEST_RECORDS_KEY_FILE";
+const KEY = "/h/.config/common-fabric/test-records-key.json";
+
+describe("test-records-agent-config", () => {
+  let home: string;
+  let harnesses: readonly AgentHarness[];
+  let env: Environment;
+  let config: string;
+
+  beforeEach(async () => {
+    home = await Deno.makeTempDir({ prefix: "test-records-agent-" });
+    harnesses = [{
+      name: "Test Harness",
+      home: (root) => join(root, ".harness"),
+      config: (root) => join(root, ".harness", "settings.json"),
+    }];
+    env = (name) => name === "HOME" ? home : undefined;
+    config = join(home, ".harness", "settings.json");
+  });
+
+  afterEach(async () => {
+    await Deno.remove(home, { recursive: true }).catch(() => {});
+  });
+
+  /** A harness whose directory is there, as an installed one's is. */
+  async function install(): Promise<void> {
+    await Deno.mkdir(join(home, ".harness"), { recursive: true });
+  }
+
+  describe("installedHarnesses()", () => {
+    it("returns the harnesses whose directory is there", async () => {
+      await install();
+      expect(await installedHarnesses(env, harnesses)).toEqual([
+        { harness: harnesses[0]!, config },
+      ]);
+    });
+
+    it("returns nothing for a harness that is not installed", async () => {
+      expect(await installedHarnesses(env, harnesses)).toEqual([]);
+      expect(await installedHarnesses(() => undefined, harnesses)).toEqual([]);
+    });
+  });
+
+  describe("exportFromAgentConfigs()", () => {
+    it("writes the variable into a configuration that has none", async () => {
+      await install();
+      await Deno.writeTextFile(config, '{\n  "theme": "auto"\n}\n');
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates).toEqual([
+        { harness: "Test Harness", path: config, outcome: "added" },
+      ]);
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        theme: "auto",
+        env: { [VARIABLE]: KEY },
+      });
+    });
+
+    it("keeps everything else in the env block", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { DEBUG: "true" } }),
+      );
+
+      await exportFromAgentConfigs(VARIABLE, KEY, env, harnesses);
+
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { DEBUG: "true", [VARIABLE]: KEY },
+      });
+    });
+
+    it("creates the configuration when the harness has none yet", async () => {
+      await install();
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("added");
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { [VARIABLE]: KEY },
+      });
+    });
+
+    it("reports a value already there and writes nothing", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { [VARIABLE]: KEY } }),
+      );
+      const before = await Deno.readTextFile(config);
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("present");
+      expect(await Deno.readTextFile(config)).toBe(before);
+    });
+
+    it("reports another value as a conflict and writes nothing", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { [VARIABLE]: "/elsewhere.json" } }),
+      );
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates).toEqual([{
+        harness: "Test Harness",
+        path: config,
+        outcome: "conflict",
+        existing: "/elsewhere.json",
+      }]);
+    });
+
+    it("writes into a configuration file that is empty", async () => {
+      await install();
+      await Deno.writeTextFile(config, "");
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("added");
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { [VARIABLE]: KEY },
+      });
+    });
+
+    it("leaves no temporary file beside the one it wrote", async () => {
+      await install();
+
+      await exportFromAgentConfigs(VARIABLE, KEY, env, harnesses);
+
+      const names: string[] = [];
+      for await (const entry of Deno.readDir(join(home, ".harness"))) {
+        names.push(entry.name);
+      }
+      expect(names).toEqual(["settings.json"]);
+    });
+
+    it("refuses a configuration that does not parse", async () => {
+      await install();
+      await Deno.writeTextFile(config, "{ not json");
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("unreadable");
+      // The file a harness reads is left exactly as it was.
+      expect(await Deno.readTextFile(config)).toBe("{ not json");
+    });
+
+    it("refuses a configuration that cannot be read at all", async () => {
+      await install();
+      await Deno.mkdir(config);
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("unreadable");
+    });
+
+    it("refuses a configuration whose env is not a block", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ env: "nonsense" }));
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates[0]?.outcome).toBe("unreadable");
+    });
+
+    it("leaves a harness that is not installed alone", async () => {
+      expect(await exportFromAgentConfigs(VARIABLE, KEY, env, harnesses))
+        .toEqual([]);
+      await expect(Deno.stat(config)).rejects.toThrow();
+    });
+  });
+
+  describe("unexportFromAgentConfigs()", () => {
+    it("takes the variable out and the empty env block with it", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ theme: "auto" }));
+      await exportFromAgentConfigs(VARIABLE, KEY, env, harnesses);
+
+      const removals = await unexportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(removals).toEqual([
+        { harness: "Test Harness", path: config, outcome: "removed" },
+      ]);
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        theme: "auto",
+      });
+    });
+
+    it("keeps the rest of the env block", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { DEBUG: "true", [VARIABLE]: KEY } }),
+      );
+
+      await unexportFromAgentConfigs(VARIABLE, KEY, env, harnesses);
+
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { DEBUG: "true" },
+      });
+    });
+
+    it("keeps a value this tool did not write", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { [VARIABLE]: "/elsewhere.json" } }),
+      );
+
+      const removals = await unexportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(removals).toEqual([{
+        harness: "Test Harness",
+        path: config,
+        outcome: "kept",
+        existing: "/elsewhere.json",
+      }]);
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { [VARIABLE]: "/elsewhere.json" },
+      });
+    });
+
+    it("returns nothing for a configuration that never carried it", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ theme: "auto" }));
+
+      expect(await unexportFromAgentConfigs(VARIABLE, KEY, env, harnesses))
+        .toEqual([]);
+    });
+
+    it("reports a configuration that does not parse", async () => {
+      await install();
+      await Deno.writeTextFile(config, "{ not json");
+
+      const removals = await unexportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(removals[0]?.outcome).toBe("unreadable");
+      expect(await Deno.readTextFile(config)).toBe("{ not json");
+    });
+
+    it("returns nothing when there is no configuration at all", async () => {
+      await install();
+      expect(await unexportFromAgentConfigs(VARIABLE, KEY, env, harnesses))
+        .toEqual([]);
+    });
+  });
+});

--- a/tasks/test-records-agent-config.test.ts
+++ b/tasks/test-records-agent-config.test.ts
@@ -8,7 +8,11 @@ import {
   exportFromAgentConfigs,
   installedHarnesses,
   unexportFromAgentConfigs,
+  writeConfig,
 } from "./test-records-agent-config.ts";
+
+/** A writer that declines, as it does when the file moved under it. */
+const declines = () => Promise.resolve(false);
 
 const VARIABLE = "CF_TEST_RECORDS_KEY_FILE";
 const KEY = "/h/.config/common-fabric/test-records-key.json";
@@ -190,6 +194,71 @@ describe("test-records-agent-config", () => {
       expect(await Deno.readTextFile(config)).toBe("{ not json");
     });
 
+    it("reports a value of any other type as a conflict", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { [VARIABLE]: null } }),
+      );
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+      );
+
+      expect(updates).toEqual([{
+        harness: "Test Harness",
+        path: config,
+        outcome: "conflict",
+        existing: "null",
+      }]);
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        env: { [VARIABLE]: null },
+      });
+    });
+
+    it("keeps the permissions the configuration already had", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ theme: "auto" }));
+      await Deno.chmod(config, 0o600);
+
+      await exportFromAgentConfigs(VARIABLE, KEY, env, harnesses);
+
+      expect((await Deno.stat(config)).mode! & 0o777).toBe(0o600);
+    });
+
+    it("stands down when the configuration changed under it", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ theme: "dark" }));
+
+      // The text the configuration was read from no longer describes the
+      // file, which is what a harness writing its own settings looks
+      // like from here.
+      const wrote = await writeConfig(config, { theme: "auto" }, "{}");
+
+      expect(wrote).toBe(false);
+      expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
+        theme: "dark",
+      });
+    });
+
+    it("reports a write that stood down as changed", async () => {
+      await install();
+      await Deno.writeTextFile(config, JSON.stringify({ theme: "auto" }));
+
+      const updates = await exportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+        declines,
+      );
+
+      expect(updates[0]?.outcome).toBe("changed");
+    });
+
     it("refuses a configuration that cannot be read at all", async () => {
       await install();
       await Deno.mkdir(config);
@@ -283,6 +352,24 @@ describe("test-records-agent-config", () => {
       expect(JSON.parse(await Deno.readTextFile(config))).toEqual({
         env: { [VARIABLE]: "/elsewhere.json" },
       });
+    });
+
+    it("reports a removal that stood down as changed", async () => {
+      await install();
+      await Deno.writeTextFile(
+        config,
+        JSON.stringify({ env: { [VARIABLE]: KEY } }),
+      );
+
+      const removals = await unexportFromAgentConfigs(
+        VARIABLE,
+        KEY,
+        env,
+        harnesses,
+        declines,
+      );
+
+      expect(removals[0]?.outcome).toBe("changed");
     });
 
     it("returns nothing for a configuration that never carried it", async () => {

--- a/tasks/test-records-agent-config.ts
+++ b/tasks/test-records-agent-config.ts
@@ -14,6 +14,7 @@
  */
 
 import { dirname, join } from "@std/path";
+import { replaceFile } from "./test-records-atomic-write.ts";
 import { type Environment, readEnv } from "@commonfabric/test-support/records";
 
 /** A harness whose configuration can carry the variable. */
@@ -140,54 +141,43 @@ async function readConfig(path: string): Promise<ConfigRead> {
 }
 
 /**
- * Writes configuration through a temporary file in the same directory,
- * so what a harness reads is never a half-written file. The file's own
- * permissions carry over: a configuration somebody keeps readable only
- * by themselves stays that way, rather than taking whatever a fresh
- * file gets from the umask.
+ * Writes a configuration, in one step or not at all: the replacement
+ * itself is `replaceFile`, which keeps the file's permissions and any
+ * link leading to it.
  *
- * The text the configuration was read from is checked again before the
- * rename. A harness writing its own settings between the two is rare
- * and losing what it wrote would be silent, so the write stands down
- * and says so instead.
+ * The text the configuration was read from is checked again first. A
+ * harness writing its own settings in between is rare, and losing what
+ * it wrote would be silent, so the write stands down and says so.
+ * Between that check and the rename there is a moment this cannot
+ * account for, and no portable way to close it; what it buys is that
+ * the ordinary case of a harness writing while a person runs setup
+ * does not quietly lose a setting.
  */
 export async function writeConfig(
   path: string,
   config: Record<string, unknown>,
   before: string | undefined,
 ): Promise<boolean> {
-  const temporary = `${path}.${crypto.randomUUID()}.tmp`;
+  if (!await unchanged(path, before)) return false;
   await Deno.mkdir(dirname(path), { recursive: true });
-  try {
-    await Deno.writeTextFile(temporary, JSON.stringify(config, null, 2) + "\n");
-    const mode = await fileMode(path);
-    if (mode !== undefined) await Deno.chmod(temporary, mode).catch(() => {});
-    if (await readText(path) !== before) return false;
-    await Deno.rename(temporary, path);
-    return true;
-  } finally {
-    // The rename takes the temporary file's name away, so this removes
-    // one only when the write or the rename did not get that far.
-    await Deno.remove(temporary).catch(() => {});
-  }
+  await replaceFile(path, JSON.stringify(config, null, 2) + "\n");
+  return true;
 }
 
-/** The permission bits of a file that is already there. */
-async function fileMode(path: string): Promise<number | undefined> {
+/**
+ * Whether a file still holds the text it was read from. A file that
+ * cannot be read now is not a file this can say that about, so it
+ * answers no: standing down loses nothing, and writing anyway would
+ * lose whatever put it out of reach.
+ */
+async function unchanged(
+  path: string,
+  before: string | undefined,
+): Promise<boolean> {
   try {
-    const mode = (await Deno.stat(path)).mode;
-    return mode === null || mode === undefined ? undefined : mode & 0o7777;
-  } catch {
-    return undefined;
-  }
-}
-
-/** A file's text, or undefined where there is no file. */
-async function readText(path: string): Promise<string | undefined> {
-  try {
-    return await Deno.readTextFile(path);
-  } catch {
-    return undefined;
+    return await Deno.readTextFile(path) === before;
+  } catch (error) {
+    return error instanceof Deno.errors.NotFound && before === undefined;
   }
 }
 

--- a/tasks/test-records-agent-config.ts
+++ b/tasks/test-records-agent-config.ts
@@ -39,6 +39,17 @@ export const AGENT_HARNESSES: readonly AgentHarness[] = [
   },
 ];
 
+/**
+ * Replaces a configuration file, answering false where it declined to
+ * because the file is no longer the one that was read. Injectable so a
+ * test can have it decline.
+ */
+export type ConfigWriter = (
+  path: string,
+  config: Record<string, unknown>,
+  before: string | undefined,
+) => Promise<boolean>;
+
 /** What one harness configuration's update did. */
 export type AgentConfigOutcome =
   /** The variable was written into the configuration. */
@@ -48,7 +59,9 @@ export type AgentConfigOutcome =
   /** It carries the variable with another value; nothing was written. */
   | "conflict"
   /** The file does not parse, so nothing was written. */
-  | "unreadable";
+  | "unreadable"
+  /** The file changed while this was writing, so nothing was written. */
+  | "changed";
 
 export interface AgentConfigUpdate {
   harness: string;
@@ -62,9 +75,14 @@ export interface AgentConfigUpdate {
 export type AgentConfigRemoval = {
   harness: string;
   path: string;
-  outcome: "removed" | "kept" | "unreadable";
+  outcome: "removed" | "kept" | "unreadable" | "changed";
   existing?: string;
 };
+
+/** A configuration value as a person should see it quoted back. */
+function describe(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value) ?? "nothing";
+}
 
 function homeDirectory(env: Environment): string | undefined {
   return readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
@@ -91,46 +109,85 @@ export async function installedHarnesses(
   return installed;
 }
 
-/** The configuration a file holds, or undefined when it holds none. */
-async function readConfig(
-  path: string,
-): Promise<Record<string, unknown> | undefined | "unreadable"> {
+/** What a configuration file holds, and the text it was read from. */
+type ConfigRead =
+  | { kind: "missing" }
+  | { kind: "unreadable" }
+  | {
+    kind: "config";
+    config: Record<string, unknown>;
+    text: string;
+  };
+
+async function readConfig(path: string): Promise<ConfigRead> {
   let text: string;
   try {
     text = await Deno.readTextFile(path);
   } catch (error) {
-    if (error instanceof Deno.errors.NotFound) return undefined;
-    return "unreadable";
+    if (error instanceof Deno.errors.NotFound) return { kind: "missing" };
+    return { kind: "unreadable" };
   }
-  if (text.trim().length === 0) return {};
+  if (text.trim().length === 0) return { kind: "config", config: {}, text };
   try {
     const parsed = JSON.parse(text);
     return typeof parsed === "object" && parsed !== null &&
         !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : "unreadable";
+      ? { kind: "config", config: parsed as Record<string, unknown>, text }
+      : { kind: "unreadable" };
   } catch {
-    return "unreadable";
+    return { kind: "unreadable" };
   }
 }
 
 /**
  * Writes configuration through a temporary file in the same directory,
- * so what a harness reads is never a half-written file.
+ * so what a harness reads is never a half-written file. The file's own
+ * permissions carry over: a configuration somebody keeps readable only
+ * by themselves stays that way, rather than taking whatever a fresh
+ * file gets from the umask.
+ *
+ * The text the configuration was read from is checked again before the
+ * rename. A harness writing its own settings between the two is rare
+ * and losing what it wrote would be silent, so the write stands down
+ * and says so instead.
  */
-async function writeConfig(
+export async function writeConfig(
   path: string,
   config: Record<string, unknown>,
-): Promise<void> {
+  before: string | undefined,
+): Promise<boolean> {
   const temporary = `${path}.${crypto.randomUUID()}.tmp`;
   await Deno.mkdir(dirname(path), { recursive: true });
   try {
     await Deno.writeTextFile(temporary, JSON.stringify(config, null, 2) + "\n");
+    const mode = await fileMode(path);
+    if (mode !== undefined) await Deno.chmod(temporary, mode).catch(() => {});
+    if (await readText(path) !== before) return false;
     await Deno.rename(temporary, path);
+    return true;
   } finally {
     // The rename takes the temporary file's name away, so this removes
     // one only when the write or the rename did not get that far.
     await Deno.remove(temporary).catch(() => {});
+  }
+}
+
+/** The permission bits of a file that is already there. */
+async function fileMode(path: string): Promise<number | undefined> {
+  try {
+    const mode = (await Deno.stat(path)).mode;
+    return mode === null || mode === undefined ? undefined : mode & 0o7777;
+  } catch {
+    return undefined;
+  }
+}
+
+/** A file's text, or undefined where there is no file. */
+async function readText(path: string): Promise<string | undefined> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch {
+    return undefined;
   }
 }
 
@@ -154,6 +211,7 @@ export async function exportFromAgentConfigs(
   value: string,
   env: Environment = Deno.env.get,
   harnesses: readonly AgentHarness[] = AGENT_HARNESSES,
+  write: ConfigWriter = writeConfig,
 ): Promise<AgentConfigUpdate[]> {
   const updates: AgentConfigUpdate[] = [];
   for (
@@ -162,48 +220,68 @@ export async function exportFromAgentConfigs(
       harnesses,
     )
   ) {
-    const config = await readConfig(path);
-    if (config === "unreadable") {
+    const read = await readConfig(path);
+    if (read.kind === "unreadable") {
       updates.push({ harness: harness.name, path, outcome: "unreadable" });
       continue;
     }
-    const held = config ?? {};
+    const held = read.kind === "config" ? read.config : {};
+    const before = read.kind === "config" ? read.text : undefined;
     const block = envBlock(held);
     if (block === undefined) {
       updates.push({ harness: harness.name, path, outcome: "unreadable" });
       continue;
     }
     const existing = block[name];
-    if (typeof existing === "string" && existing !== value) {
-      updates.push({
-        harness: harness.name,
-        path,
-        outcome: "conflict",
-        existing,
-      });
-      continue;
-    }
     if (existing === value) {
       updates.push({ harness: harness.name, path, outcome: "present" });
       continue;
     }
-    await writeConfig(path, { ...held, env: { ...block, [name]: value } });
-    updates.push({ harness: harness.name, path, outcome: "added" });
+    if (existing !== undefined) {
+      // Whatever it is — another path, a null, a number — it is not what
+      // this tool wrote, and writing over it would take away something
+      // nothing here can put back.
+      updates.push({
+        harness: harness.name,
+        path,
+        outcome: "conflict",
+        existing: describe(existing),
+      });
+      continue;
+    }
+    const wrote = await write(
+      path,
+      { ...held, env: { ...block, [name]: value } },
+      before,
+    );
+    updates.push({
+      harness: harness.name,
+      path,
+      outcome: wrote ? "added" : "changed",
+    });
   }
   return updates;
 }
 
 /**
  * Takes one variable back out of every installed harness's
- * configuration, leaving a value this tool did not write in place. An
- * env block with nothing left in it goes too, so the file returns to
- * the shape it had.
+ * configuration, leaving a value naming anything else in place. An env
+ * block with nothing left in it goes too, so the file returns to the
+ * shape it had.
+ *
+ * What comes out is decided by the value, not by a record of who wrote
+ * it: an entry naming the key file is removed whether this tool put it
+ * there or a person did. That is the same answer either way, because
+ * the key file is being deleted in the same breath, and an entry naming
+ * a file that is gone would hand every command the harness runs a
+ * variable pointing at nothing.
  */
 export async function unexportFromAgentConfigs(
   name: string,
   value: string,
   env: Environment = Deno.env.get,
   harnesses: readonly AgentHarness[] = AGENT_HARNESSES,
+  write: ConfigWriter = writeConfig,
 ): Promise<AgentConfigRemoval[]> {
   const removals: AgentConfigRemoval[] = [];
   for (
@@ -212,12 +290,13 @@ export async function unexportFromAgentConfigs(
       harnesses,
     )
   ) {
-    const config = await readConfig(path);
-    if (config === undefined) continue;
-    if (config === "unreadable") {
+    const read = await readConfig(path);
+    if (read.kind === "missing") continue;
+    if (read.kind === "unreadable") {
       removals.push({ harness: harness.name, path, outcome: "unreadable" });
       continue;
     }
+    const config = read.config;
     const block = envBlock(config);
     if (block === undefined || !(name in block)) continue;
     const existing = block[name];
@@ -226,7 +305,7 @@ export async function unexportFromAgentConfigs(
         harness: harness.name,
         path,
         outcome: "kept",
-        ...(typeof existing === "string" ? { existing } : {}),
+        existing: describe(existing),
       });
       continue;
     }
@@ -237,8 +316,12 @@ export async function unexportFromAgentConfigs(
     } else {
       written.env = rest;
     }
-    await writeConfig(path, written);
-    removals.push({ harness: harness.name, path, outcome: "removed" });
+    const wrote = await write(path, written, read.text);
+    removals.push({
+      harness: harness.name,
+      path,
+      outcome: wrote ? "removed" : "changed",
+    });
   }
   return removals;
 }

--- a/tasks/test-records-agent-config.ts
+++ b/tasks/test-records-agent-config.ts
@@ -1,0 +1,244 @@
+/**
+ * Putting an environment variable into the configuration of the
+ * harnesses that run agents. A shell profile reaches an agent whose
+ * commands go through that shell; an agent that runs commands some
+ * other way is reached only by telling its harness to carry the
+ * variable, which is what this does.
+ *
+ * These are other programs' files. Nothing here writes one that does
+ * not parse, writes one whose variable is already set to something
+ * else, or writes a file in place: the new text goes to a temporary
+ * file beside it and is renamed over it, so an interrupted write leaves
+ * the configuration a harness reads either exactly as it was or exactly
+ * as it should be, and never half of each.
+ */
+
+import { dirname, join } from "@std/path";
+import { type Environment, readEnv } from "@commonfabric/test-support/records";
+
+/** A harness whose configuration can carry the variable. */
+export interface AgentHarness {
+  /** What the harness is called, for what the tool prints. */
+  name: string;
+  /** The directory whose presence means the harness is installed. */
+  home: (home: string) => string;
+  /** The configuration file, which need not exist yet. */
+  config: (home: string) => string;
+}
+
+/**
+ * The harnesses this knows how to configure. A harness is left alone
+ * unless its own directory is there, so nothing creates configuration
+ * for a program the person does not run.
+ */
+export const AGENT_HARNESSES: readonly AgentHarness[] = [
+  {
+    name: "Claude Code",
+    home: (home) => join(home, ".claude"),
+    config: (home) => join(home, ".claude", "settings.json"),
+  },
+];
+
+/** What one harness configuration's update did. */
+export type AgentConfigOutcome =
+  /** The variable was written into the configuration. */
+  | "added"
+  /** The configuration already carries the variable with this value. */
+  | "present"
+  /** It carries the variable with another value; nothing was written. */
+  | "conflict"
+  /** The file does not parse, so nothing was written. */
+  | "unreadable";
+
+export interface AgentConfigUpdate {
+  harness: string;
+  path: string;
+  outcome: AgentConfigOutcome;
+  /** The value already there, for a conflict. */
+  existing?: string;
+}
+
+/** What one harness configuration's removal did. */
+export type AgentConfigRemoval = {
+  harness: string;
+  path: string;
+  outcome: "removed" | "kept" | "unreadable";
+  existing?: string;
+};
+
+function homeDirectory(env: Environment): string | undefined {
+  return readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
+}
+
+/** The harnesses installed for this person. */
+export async function installedHarnesses(
+  env: Environment = Deno.env.get,
+  harnesses: readonly AgentHarness[] = AGENT_HARNESSES,
+): Promise<{ harness: AgentHarness; config: string }[]> {
+  const home = homeDirectory(env);
+  if (home === undefined || home.length === 0) return [];
+  const installed: { harness: AgentHarness; config: string }[] = [];
+  for (const harness of harnesses) {
+    try {
+      const stat = await Deno.stat(harness.home(home));
+      if (stat.isDirectory) {
+        installed.push({ harness, config: harness.config(home) });
+      }
+    } catch {
+      // A harness that is not installed has nothing to configure.
+    }
+  }
+  return installed;
+}
+
+/** The configuration a file holds, or undefined when it holds none. */
+async function readConfig(
+  path: string,
+): Promise<Record<string, unknown> | undefined | "unreadable"> {
+  let text: string;
+  try {
+    text = await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return undefined;
+    return "unreadable";
+  }
+  if (text.trim().length === 0) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return typeof parsed === "object" && parsed !== null &&
+        !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : "unreadable";
+  } catch {
+    return "unreadable";
+  }
+}
+
+/**
+ * Writes configuration through a temporary file in the same directory,
+ * so what a harness reads is never a half-written file.
+ */
+async function writeConfig(
+  path: string,
+  config: Record<string, unknown>,
+): Promise<void> {
+  const temporary = `${path}.${crypto.randomUUID()}.tmp`;
+  await Deno.mkdir(dirname(path), { recursive: true });
+  try {
+    await Deno.writeTextFile(temporary, JSON.stringify(config, null, 2) + "\n");
+    await Deno.rename(temporary, path);
+  } finally {
+    // The rename takes the temporary file's name away, so this removes
+    // one only when the write or the rename did not get that far.
+    await Deno.remove(temporary).catch(() => {});
+  }
+}
+
+/** The env block a configuration carries, when it carries a usable one. */
+function envBlock(
+  config: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const env = config.env;
+  if (env === undefined) return {};
+  return typeof env === "object" && env !== null && !Array.isArray(env)
+    ? env as Record<string, unknown>
+    : undefined;
+}
+
+/**
+ * Carries one variable into every installed harness's configuration,
+ * returning what each one's update did.
+ */
+export async function exportFromAgentConfigs(
+  name: string,
+  value: string,
+  env: Environment = Deno.env.get,
+  harnesses: readonly AgentHarness[] = AGENT_HARNESSES,
+): Promise<AgentConfigUpdate[]> {
+  const updates: AgentConfigUpdate[] = [];
+  for (
+    const { harness, config: path } of await installedHarnesses(
+      env,
+      harnesses,
+    )
+  ) {
+    const config = await readConfig(path);
+    if (config === "unreadable") {
+      updates.push({ harness: harness.name, path, outcome: "unreadable" });
+      continue;
+    }
+    const held = config ?? {};
+    const block = envBlock(held);
+    if (block === undefined) {
+      updates.push({ harness: harness.name, path, outcome: "unreadable" });
+      continue;
+    }
+    const existing = block[name];
+    if (typeof existing === "string" && existing !== value) {
+      updates.push({
+        harness: harness.name,
+        path,
+        outcome: "conflict",
+        existing,
+      });
+      continue;
+    }
+    if (existing === value) {
+      updates.push({ harness: harness.name, path, outcome: "present" });
+      continue;
+    }
+    await writeConfig(path, { ...held, env: { ...block, [name]: value } });
+    updates.push({ harness: harness.name, path, outcome: "added" });
+  }
+  return updates;
+}
+
+/**
+ * Takes one variable back out of every installed harness's
+ * configuration, leaving a value this tool did not write in place. An
+ * env block with nothing left in it goes too, so the file returns to
+ * the shape it had.
+ */
+export async function unexportFromAgentConfigs(
+  name: string,
+  value: string,
+  env: Environment = Deno.env.get,
+  harnesses: readonly AgentHarness[] = AGENT_HARNESSES,
+): Promise<AgentConfigRemoval[]> {
+  const removals: AgentConfigRemoval[] = [];
+  for (
+    const { harness, config: path } of await installedHarnesses(
+      env,
+      harnesses,
+    )
+  ) {
+    const config = await readConfig(path);
+    if (config === undefined) continue;
+    if (config === "unreadable") {
+      removals.push({ harness: harness.name, path, outcome: "unreadable" });
+      continue;
+    }
+    const block = envBlock(config);
+    if (block === undefined || !(name in block)) continue;
+    const existing = block[name];
+    if (existing !== value) {
+      removals.push({
+        harness: harness.name,
+        path,
+        outcome: "kept",
+        ...(typeof existing === "string" ? { existing } : {}),
+      });
+      continue;
+    }
+    const { [name]: _removed, ...rest } = block;
+    const written = { ...config };
+    if (Object.keys(rest).length === 0) {
+      delete written.env;
+    } else {
+      written.env = rest;
+    }
+    await writeConfig(path, written);
+    removals.push({ harness: harness.name, path, outcome: "removed" });
+  }
+  return removals;
+}

--- a/tasks/test-records-atomic-write.test.ts
+++ b/tasks/test-records-atomic-write.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+
+import { replaceFile } from "./test-records-atomic-write.ts";
+
+describe("test-records-atomic-write", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await Deno.makeTempDir({ prefix: "test-records-atomic-" });
+  });
+
+  afterEach(async () => {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  });
+
+  describe("replaceFile()", () => {
+    it("writes a file that is not there yet", async () => {
+      const path = join(dir, "fresh.txt");
+
+      await replaceFile(path, "hello\n");
+
+      expect(await Deno.readTextFile(path)).toBe("hello\n");
+    });
+
+    it("replaces what a file held", async () => {
+      const path = join(dir, "held.txt");
+      await Deno.writeTextFile(path, "before\n");
+
+      await replaceFile(path, "after\n");
+
+      expect(await Deno.readTextFile(path)).toBe("after\n");
+    });
+
+    it("keeps the permissions a file already had", async () => {
+      const path = join(dir, "private.txt");
+      await Deno.writeTextFile(path, "before\n");
+      await Deno.chmod(path, 0o600);
+
+      await replaceFile(path, "after\n");
+
+      expect((await Deno.stat(path)).mode! & 0o777).toBe(0o600);
+    });
+
+    it("writes through a link rather than over it", async () => {
+      const real = join(dir, "real.txt");
+      const link = join(dir, "link.txt");
+      await Deno.writeTextFile(real, "before\n");
+      await Deno.symlink(real, link);
+
+      await replaceFile(link, "after\n");
+
+      // The link is still a link, and what it points at is what changed.
+      expect((await Deno.lstat(link)).isSymlink).toBe(true);
+      expect(await Deno.readTextFile(real)).toBe("after\n");
+    });
+
+    it("leaves nothing beside the file it wrote", async () => {
+      const path = join(dir, "tidy.txt");
+
+      await replaceFile(path, "hello\n");
+
+      const names: string[] = [];
+      for await (const entry of Deno.readDir(dir)) names.push(entry.name);
+      expect(names).toEqual(["tidy.txt"]);
+    });
+
+    it("leaves the file alone when the replacement cannot be written", async () => {
+      const path = join(dir, "kept.txt");
+      await Deno.writeTextFile(path, "before\n");
+      await Deno.chmod(dir, 0o500);
+
+      try {
+        await expect(replaceFile(path, "after\n")).rejects.toThrow();
+        expect(await Deno.readTextFile(path)).toBe("before\n");
+      } finally {
+        await Deno.chmod(dir, 0o700);
+      }
+    });
+  });
+});

--- a/tasks/test-records-atomic-write.test.ts
+++ b/tasks/test-records-atomic-write.test.ts
@@ -56,6 +56,40 @@ describe("test-records-atomic-write", () => {
       expect(await Deno.readTextFile(real)).toBe("after\n");
     });
 
+    it("writes what a link with nothing at the end of it names", async () => {
+      const missing = join(dir, "missing.txt");
+      const link = join(dir, "dangling.txt");
+      await Deno.symlink(missing, link);
+
+      await replaceFile(link, "after\n");
+
+      expect((await Deno.lstat(link)).isSymlink).toBe(true);
+      expect(await Deno.readTextFile(missing)).toBe("after\n");
+    });
+
+    it("creates a file only its owner can read", async () => {
+      const path = join(dir, "new.txt");
+
+      await replaceFile(path, "hello\n");
+
+      expect((await Deno.stat(path)).mode! & 0o777).toBe(0o600);
+    });
+
+    it("refuses a path it cannot read the state of", async () => {
+      const closed = join(dir, "closed");
+      await Deno.mkdir(closed);
+      await Deno.chmod(closed, 0o000);
+
+      try {
+        // Not "there is no file": there is no answer, and writing would
+        // be a guess about a file somebody has closed off.
+        await expect(replaceFile(join(closed, "f.txt"), "x\n")).rejects
+          .toThrow();
+      } finally {
+        await Deno.chmod(closed, 0o700);
+      }
+    });
+
     it("leaves nothing beside the file it wrote", async () => {
       const path = join(dir, "tidy.txt");
 

--- a/tasks/test-records-atomic-write.ts
+++ b/tasks/test-records-atomic-write.ts
@@ -10,48 +10,71 @@
  *
  * Two properties of the file being replaced are carried over. Its
  * permissions, so a file kept readable only by its owner does not come
- * back readable by everyone; a mode that cannot be reproduced stops the
- * replacement rather than widening it. And a symbolic link, resolved
- * before anything is written, so a profile linked into somebody's
- * dotfiles repository stays a link and the file it points at is what
- * changes.
+ * back readable by everyone; the temporary file is private from the
+ * moment it exists and takes the target's mode before the rename,
+ * because what it holds is a copy of the target, and a profile can hold
+ * anything a person has put in it. And a symbolic link, resolved before
+ * anything is written, so a profile linked into somebody's dotfiles
+ * repository stays a link and the file it points at is what changes.
+ *
+ * A file this cannot read the state of is a file it does not replace.
+ * Only a path with nothing at it counts as absent; every other failure
+ * stops the replacement, because the alternative is guessing, and the
+ * guess that goes wrong is the one that widens access.
  */
 
-import { dirname, join } from "@std/path";
+import { dirname, isAbsolute, join } from "@std/path";
 
-/** Where a path leads once every link on it is followed. */
-async function target(path: string): Promise<string> {
+/**
+ * Asks the filesystem something, answering undefined only where there
+ * is no file to answer about. Every other failure is raised: a file
+ * this cannot read the state of is a file it does not replace, because
+ * the alternative is guessing, and the guess that goes wrong is the one
+ * that widens access.
+ */
+async function ifPresent<T>(ask: () => Promise<T>): Promise<T | undefined> {
   try {
-    return await Deno.realPath(path);
-  } catch {
-    // Nothing there to follow: the path names the file to create.
-    return path;
+    return await ask();
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return undefined;
+    throw error;
   }
 }
 
-/** The permission bits of a file that is already there. */
+/**
+ * Where a path leads once every link on it is followed. A link that
+ * points at nothing leads to what it names, so writing follows the link
+ * rather than replacing it.
+ */
+async function target(path: string): Promise<string> {
+  const real = await ifPresent(() => Deno.realPath(path));
+  if (real !== undefined) return real;
+  const itself = await ifPresent(() => Deno.lstat(path));
+  if (itself === undefined) return path;
+  // Something is there that realPath would not follow: a link with
+  // nothing at the end of it, which still says where the file goes.
+  const named = await Deno.readLink(path);
+  return isAbsolute(named) ? named : join(dirname(path), named);
+}
+
+/** The permission bits of the file at a path, or undefined for no file. */
 async function permissions(path: string): Promise<number | undefined> {
-  try {
-    const mode = (await Deno.stat(path)).mode;
-    return mode === null || mode === undefined ? undefined : mode & 0o7777;
-  } catch {
-    return undefined;
-  }
+  const mode = (await ifPresent(() => Deno.stat(path)))?.mode;
+  return mode === null || mode === undefined ? undefined : mode & 0o7777;
 }
 
 /**
  * Writes text over a file in one step. The file's own permissions and
  * any link leading to it survive; a failure leaves the file as it was.
+ * A file this creates is readable only by its owner, which is the safe
+ * end of the choice for something a person's environment is read from.
  */
 export async function replaceFile(path: string, text: string): Promise<void> {
   const real = await target(path);
-  const temporary = join(
-    dirname(real),
-    `.${crypto.randomUUID()}.tmp`,
-  );
+  const mode = await permissions(real);
+  const temporary = join(dirname(real), `.${crypto.randomUUID()}.tmp`);
   try {
-    await Deno.writeTextFile(temporary, text);
-    const mode = await permissions(real);
+    await Deno.writeTextFile(temporary, text, { mode: 0o600, createNew: true });
     // A mode that cannot be put on the replacement is not a detail to
     // shrug off: renaming anyway is what would widen access to a file
     // somebody keeps to themselves.

--- a/tasks/test-records-atomic-write.ts
+++ b/tasks/test-records-atomic-write.ts
@@ -1,0 +1,65 @@
+/**
+ * Replacing a file somebody else owns, in one step or not at all.
+ *
+ * The files this writes — shell profiles, an agent harness's settings —
+ * belong to other programs and to the person, and a half-written one is
+ * worse than an unwritten one: a shell startup file cut off in the
+ * middle is a shell that will not start. So the new text goes to a
+ * temporary file beside the target and is renamed over it, which the
+ * kernel does in one step.
+ *
+ * Two properties of the file being replaced are carried over. Its
+ * permissions, so a file kept readable only by its owner does not come
+ * back readable by everyone; a mode that cannot be reproduced stops the
+ * replacement rather than widening it. And a symbolic link, resolved
+ * before anything is written, so a profile linked into somebody's
+ * dotfiles repository stays a link and the file it points at is what
+ * changes.
+ */
+
+import { dirname, join } from "@std/path";
+
+/** Where a path leads once every link on it is followed. */
+async function target(path: string): Promise<string> {
+  try {
+    return await Deno.realPath(path);
+  } catch {
+    // Nothing there to follow: the path names the file to create.
+    return path;
+  }
+}
+
+/** The permission bits of a file that is already there. */
+async function permissions(path: string): Promise<number | undefined> {
+  try {
+    const mode = (await Deno.stat(path)).mode;
+    return mode === null || mode === undefined ? undefined : mode & 0o7777;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Writes text over a file in one step. The file's own permissions and
+ * any link leading to it survive; a failure leaves the file as it was.
+ */
+export async function replaceFile(path: string, text: string): Promise<void> {
+  const real = await target(path);
+  const temporary = join(
+    dirname(real),
+    `.${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    await Deno.writeTextFile(temporary, text);
+    const mode = await permissions(real);
+    // A mode that cannot be put on the replacement is not a detail to
+    // shrug off: renaming anyway is what would widen access to a file
+    // somebody keeps to themselves.
+    if (mode !== undefined) await Deno.chmod(temporary, mode);
+    await Deno.rename(temporary, real);
+  } finally {
+    // The rename takes the temporary file's name away, so this removes
+    // one only where the write or the rename did not get that far.
+    await Deno.remove(temporary).catch(() => {});
+  }
+}

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -16,10 +16,6 @@ import {
   uninstallCommand,
 } from "./test-records-key.ts";
 import {
-  AGENT_HARNESSES,
-  type AgentHarness,
-} from "./test-records-agent-config.ts";
-import {
   generateIdentity,
   type KeyDeliveryIdentity,
   recipientFingerprint,

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -1313,6 +1313,28 @@ describe("test-records-key", () => {
       expect(await uninstallCommand(deps)).toBe(0);
     });
 
+    it("does not claim recording stopped when a line was kept", async () => {
+      await installed();
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.writeTextFile(
+        join(home, ".zshenv"),
+        `export CF_TEST_RECORDS_KEY_FILE="/elsewhere.json"\n`,
+      );
+      const said: string[] = [];
+      const log = console.log;
+      console.log = (line: string) => said.push(line);
+      try {
+        expect(await uninstallCommand(deps)).toBe(0);
+      } finally {
+        console.log = log;
+      }
+
+      const report = said.join("\n");
+      expect(report).toContain("What this tool put here is gone.");
+      expect(report).not.toContain("Every new shell records nothing.");
+    });
+
     it("keeps an export the tool did not write", async () => {
       withStub({});
       const inner = deps.env;

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -51,6 +51,7 @@ async function signingKey(): Promise<string> {
 }
 
 const KEY_TEXT = await signingKey();
+const OTHER_KEY_TEXT = await signingKey();
 
 function u16le(value: number): number[] {
   return [value & 0xff, (value >> 8) & 0xff];
@@ -994,10 +995,39 @@ describe("test-records-key", () => {
       expect(await Deno.readTextFile(profile)).toContain(
         "CF_TEST_RECORDS_KEY_FILE",
       );
-      // It asks whether the key still works, and nothing else: no run is
-      // dispatched and no delivery is looked for.
-      expect(urls.every((line) => line.includes("oauth2.googleapis.com")))
+      // It asks what is going and whether the key still works, and
+      // starts nothing.
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
+      expect(urls.some((line) => line.includes("oauth2.googleapis.com")))
         .toBe(true);
+    });
+
+    it("takes up a run already going even with a key installed", async () => {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      const published = await delivery(identity, OTHER_KEY_TEXT);
+      const going = mintRun(identity.recipient, {
+        id: 11,
+        status: "in_progress",
+        conclusion: undefined,
+      });
+      withStub({
+        runPages: [[going], [mintRun(identity.recipient, { id: 11 })]],
+        ...published,
+      });
+
+      // The run was dispatched to replace this key, so standing down on
+      // the installed one is how a person ends up holding a dead key.
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(OTHER_KEY_TEXT);
     });
 
     it("mints a replacement for a key that is no longer accepted", async () => {

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -3,6 +3,8 @@ import { expect } from "@std/expect";
 import { join } from "@std/path";
 
 import {
+  agentConfigReport,
+  agentRemovalReport,
   collectCommand,
   defaultDeps,
   defaultGithubToken,
@@ -13,6 +15,10 @@ import {
   setupCommand,
   uninstallCommand,
 } from "./test-records-key.ts";
+import {
+  AGENT_HARNESSES,
+  type AgentHarness,
+} from "./test-records-agent-config.ts";
 import {
   generateIdentity,
   type KeyDeliveryIdentity,
@@ -1296,6 +1302,23 @@ describe("test-records-key", () => {
       ).toBe("{}");
     });
 
+    it("keeps the key when the profile cannot be taken apart", async () => {
+      await installed();
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      // A profile that cannot be replaced: the removal fails, and the
+      // key it names must still be there afterwards.
+      await Deno.remove(join(home, ".zshenv"));
+      await Deno.mkdir(join(home, ".zshenv", "inside"), { recursive: true });
+
+      await expect(uninstallCommand(deps)).rejects.toThrow();
+
+      expect(
+        (await Deno.stat(join(home, "common-fabric", "test-records-key.json")))
+          .isFile,
+      ).toBe(true);
+    });
+
     it("says which file it could not remove", async () => {
       withStub({});
       // A directory where the key file goes is not something a delete
@@ -1331,7 +1354,7 @@ describe("test-records-key", () => {
       }
 
       const report = said.join("\n");
-      expect(report).toContain("What this tool put here is gone.");
+      expect(report).toContain("What this tool could take back is gone.");
       expect(report).not.toContain("Every new shell records nothing.");
     });
 
@@ -1360,6 +1383,81 @@ describe("test-records-key", () => {
 
       expect(await uninstallCommand(deps)).toBe(0);
       expect((await Deno.stat(join(spools, "run-1"))).isDirectory).toBe(true);
+    });
+  });
+
+  describe("agentConfigReport()", () => {
+    const update = (
+      outcome: "added" | "present" | "conflict" | "changed" | "unreadable",
+      existing?: string,
+    ) => ({
+      harness: "Claude Code",
+      path: "/h/.claude/settings.json",
+      outcome,
+      ...(existing !== undefined ? { existing } : {}),
+    });
+
+    it("says the harness carries the key file", () => {
+      expect(agentConfigReport(update("added"), "/k.json")).toContain(
+        "Claude Code passes CF_TEST_RECORDS_KEY_FILE",
+      );
+      expect(agentConfigReport(update("present"), "/k.json")).toContain(
+        "already passes the key file on",
+      );
+    });
+
+    it("quotes back a value it would not write over", () => {
+      const report = agentConfigReport(update("conflict", "/other"), "/k.json");
+      expect(report).toContain("/other");
+      expect(report).toContain("Left alone.");
+    });
+
+    it("says nothing was written when the file moved under it", () => {
+      expect(agentConfigReport(update("changed"), "/k.json")).toContain(
+        "changed while this was writing",
+      );
+    });
+
+    it("hands back the line to add when the file does not parse", () => {
+      expect(agentConfigReport(update("unreadable"), "/k.json")).toContain(
+        '"CF_TEST_RECORDS_KEY_FILE": "/k.json"',
+      );
+    });
+  });
+
+  describe("agentRemovalReport()", () => {
+    const removal = (
+      outcome: "removed" | "kept" | "changed" | "unreadable",
+      existing?: string,
+    ) => ({
+      harness: "Claude Code",
+      path: "/h/.claude/settings.json",
+      outcome,
+      ...(existing !== undefined ? { existing } : {}),
+    });
+
+    it("says the harness has stopped carrying the key file", () => {
+      expect(agentRemovalReport(removal("removed"))).toContain(
+        "no longer passes CF_TEST_RECORDS_KEY_FILE on",
+      );
+    });
+
+    it("says why a value stayed", () => {
+      const report = agentRemovalReport(removal("kept", "/other"));
+      expect(report).toContain("/other");
+      expect(report).toContain("not the key this tool installed");
+    });
+
+    it("says nothing was written when the file moved under it", () => {
+      expect(agentRemovalReport(removal("changed"))).toContain(
+        "changed while this was writing",
+      );
+    });
+
+    it("says what to do by hand when the file does not parse", () => {
+      expect(agentRemovalReport(removal("unreadable"))).toContain(
+        'out of its "env" by hand',
+      );
     });
   });
 

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -11,6 +11,7 @@ import {
   requestCommand,
   runCli,
   setupCommand,
+  uninstallCommand,
 } from "./test-records-key.ts";
 import {
   generateIdentity,
@@ -477,14 +478,14 @@ describe("test-records-key", () => {
         return inner(name);
       };
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         'export CF_TEST_RECORDS_KEY_FILE="/somewhere/else.json"\n',
       );
 
       expect(await collectCommand(deps)).toBe(0);
 
       // The profile is a person's file: the line that disagrees stays.
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(
         'export CF_TEST_RECORDS_KEY_FILE="/somewhere/else.json"\n',
       );
     });
@@ -501,10 +502,10 @@ describe("test-records-key", () => {
       };
       const line = `export CF_TEST_RECORDS_KEY_FILE="$HOME/common-fabric/` +
         `test-records-key.json"\n`;
-      await Deno.writeTextFile(join(home, ".zshrc"), line);
+      await Deno.writeTextFile(join(home, ".zshenv"), line);
 
       expect(await collectCommand(deps)).toBe(0);
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(line);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(line);
     });
 
     it("keeps the key beside the identity under a plain home", async () => {
@@ -540,10 +541,10 @@ describe("test-records-key", () => {
       };
       const line = `CF_TEST_RECORDS_KEY_FILE="$HOME/common-fabric/` +
         `test-records-key.json"\n`;
-      await Deno.writeTextFile(join(home, ".zshrc"), line);
+      await Deno.writeTextFile(join(home, ".zshenv"), line);
 
       expect(await collectCommand(deps)).toBe(0);
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(line);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(line);
     });
 
     it("reports the login profile a shell reads and does not have", async () => {
@@ -571,6 +572,76 @@ describe("test-records-key", () => {
       await expect(collectCommand(deps)).rejects.toThrow(
         "Neither XDG_CONFIG_HOME nor HOME is set.",
       );
+    });
+
+    /** A workstation with an agent harness, holding this settings text. */
+    async function withHarness(settings?: string): Promise<string> {
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.mkdir(join(home, ".claude"), { recursive: true });
+      const path = join(home, ".claude", "settings.json");
+      if (settings !== undefined) await Deno.writeTextFile(path, settings);
+      return path;
+    }
+
+    /** Where the key lands for these tests. */
+    function keyPath(): string {
+      return join(home, "common-fabric", "test-records-key.json");
+    }
+
+    it("passes the key file to an agent harness installed here", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.mkdir(join(home, ".claude"), { recursive: true });
+
+      expect(await collectCommand(deps)).toBe(0);
+
+      const settings = JSON.parse(
+        await Deno.readTextFile(join(home, ".claude", "settings.json")),
+      );
+      expect(settings.env.CF_TEST_RECORDS_KEY_FILE).toBe(
+        join(home, "common-fabric", "test-records-key.json"),
+      );
+    });
+
+    it("says a harness already passes the key file on", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const settings = await withHarness(
+        JSON.stringify({ env: { CF_TEST_RECORDS_KEY_FILE: keyPath() } }),
+      );
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(JSON.parse(await Deno.readTextFile(settings))).toEqual({
+        env: { CF_TEST_RECORDS_KEY_FILE: keyPath() },
+      });
+    });
+
+    it("leaves a harness pointed at another key alone", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const text = JSON.stringify({
+        env: { CF_TEST_RECORDS_KEY_FILE: "/elsewhere.json" },
+      });
+      const settings = await withHarness(text);
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(settings)).toBe(text);
+    });
+
+    it("leaves a harness configuration that does not parse alone", async () => {
+      const identity = await storeIdentity();
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const settings = await withHarness("{ not json");
+
+      expect(await collectCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(settings)).toBe("{ not json");
     });
 
     it("throws when the token cannot read the collector's login", async () => {
@@ -679,7 +750,7 @@ describe("test-records-key", () => {
         if (name === "SHELL") return "/bin/zsh";
         return inner(name);
       };
-      return join(home, ".zshrc");
+      return join(home, ".zshenv");
     }
 
     it("dispatches, waits for the run, installs, and exports the key", async () => {
@@ -1115,6 +1186,161 @@ describe("test-records-key", () => {
     });
   });
 
+  describe("uninstallCommand()", () => {
+    /** A workstation that setup has been through. */
+    async function installed(): Promise<string> {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      await Deno.writeTextFile(join(home, ".zshenv"), "alias l=ls\n");
+      await collectCommand(deps);
+      return join(home, ".zshenv");
+    }
+
+    it("removes the key, the identity, and the export", async () => {
+      const profile = await installed();
+
+      expect(await uninstallCommand(deps)).toBe(0);
+
+      await expect(
+        Deno.stat(join(home, "common-fabric", "test-records-key.json")),
+      ).rejects.toThrow();
+      await expect(
+        Deno.stat(join(home, "common-fabric", "test-records-identity.json")),
+      ).rejects.toThrow();
+      expect(await Deno.readTextFile(profile)).toBe("alias l=ls\n");
+    });
+
+    it("stops an agent harness passing the key file on", async () => {
+      await installed();
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.mkdir(join(home, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(home, ".claude", "settings.json"),
+        JSON.stringify({
+          theme: "auto",
+          env: {
+            CF_TEST_RECORDS_KEY_FILE: join(
+              home,
+              "common-fabric",
+              "test-records-key.json",
+            ),
+          },
+        }),
+      );
+
+      expect(await uninstallCommand(deps)).toBe(0);
+
+      expect(
+        JSON.parse(
+          await Deno.readTextFile(join(home, ".claude", "settings.json")),
+        ),
+      ).toEqual({ theme: "auto" });
+    });
+
+    it("keeps a harness pointed at a key this tool did not install", async () => {
+      await installed();
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.mkdir(join(home, ".claude"), { recursive: true });
+      const text = JSON.stringify({
+        env: { CF_TEST_RECORDS_KEY_FILE: "/elsewhere.json" },
+      });
+      await Deno.writeTextFile(join(home, ".claude", "settings.json"), text);
+
+      expect(await uninstallCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(join(home, ".claude", "settings.json")),
+      ).toBe(text);
+    });
+
+    it("reports a harness configuration it cannot read", async () => {
+      await installed();
+      const inner = deps.env;
+      deps.env = (name) => name === "HOME" ? home : inner(name);
+      await Deno.mkdir(join(home, ".claude"), { recursive: true });
+      await Deno.writeTextFile(
+        join(home, ".claude", "settings.json"),
+        "{ not json",
+      );
+
+      expect(await uninstallCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(join(home, ".claude", "settings.json")),
+      ).toBe("{ not json");
+    });
+
+    it("leaves the directory when something else is in it", async () => {
+      await installed();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "something-else.json"),
+        "{}",
+      );
+
+      expect(await uninstallCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "something-else.json"),
+        ),
+      ).toBe("{}");
+    });
+
+    it("says which file it could not remove", async () => {
+      withStub({});
+      // A directory where the key file goes is not something a delete
+      // of the key file can take away.
+      await Deno.mkdir(
+        join(home, "common-fabric", "test-records-key.json", "inside"),
+        { recursive: true },
+      );
+
+      await expect(uninstallCommand(deps)).rejects.toThrow("Cannot remove");
+    });
+
+    it("says so when there was nothing to remove", async () => {
+      withStub({});
+      expect(await uninstallCommand(deps)).toBe(0);
+    });
+
+    it("keeps an export the tool did not write", async () => {
+      withStub({});
+      const inner = deps.env;
+      deps.env = (name) => {
+        if (name === "HOME") return home;
+        if (name === "SHELL") return "/bin/zsh";
+        return inner(name);
+      };
+      const line = `export CF_TEST_RECORDS_KEY_FILE="/elsewhere.json"\n`;
+      await Deno.writeTextFile(join(home, ".zshenv"), line);
+
+      expect(await uninstallCommand(deps)).toBe(0);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(line);
+    });
+
+    it("leaves spools of records that were never shipped", async () => {
+      await installed();
+      const spools = join(home, "spools");
+      await Deno.mkdir(join(spools, "run-1"), { recursive: true });
+      const inner = deps.env;
+      deps.env = (name) =>
+        name === "CF_TEST_RECORDS_SPOOL_ROOT" ? spools : inner(name);
+
+      expect(await uninstallCommand(deps)).toBe(0);
+      expect((await Deno.stat(join(spools, "run-1"))).isDirectory).toBe(true);
+    });
+  });
+
   describe("runCli()", () => {
     it("returns 2 and prints usage for a command it does not have", async () => {
       withStub({});
@@ -1127,6 +1353,12 @@ describe("test-records-key", () => {
       expect(await runCli(["setup", "--wat"], deps)).toBe(2);
       expect(await runCli(["request", "--wat"], deps)).toBe(2);
       expect(await runCli(["collect", "--wat"], deps)).toBe(2);
+      expect(await runCli(["uninstall", "--wat"], deps)).toBe(2);
+    });
+
+    it("runs uninstall", async () => {
+      withStub({});
+      expect(await runCli(["uninstall"], deps)).toBe(0);
     });
 
     it("returns 1 and reports a failure a person can hit", async () => {

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -22,12 +22,35 @@ import {
   seal,
 } from "./test-records-crypto.ts";
 
-const KEY_TEXT = JSON.stringify({
-  client_email: "test-records-gh-octocat@p.iam.gserviceaccount.com",
-  private_key: "pem",
-  token_uri: "https://oauth2.googleapis.com/token",
-  cf_username: "octocat",
-});
+/** A key file whose private key can actually sign, as a real one does. */
+async function signingKey(): Promise<string> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    await crypto.subtle.exportKey("pkcs8", pair.privateKey),
+  );
+  const base64 = btoa(String.fromCharCode(...pkcs8)).replace(
+    /(.{64})/g,
+    "$1\n",
+  );
+  return JSON.stringify({
+    client_email: "test-records-gh-octocat@p.iam.gserviceaccount.com",
+    private_key:
+      `-----BEGIN PRIVATE KEY-----\n${base64}\n-----END PRIVATE KEY-----\n`,
+    token_uri: "https://oauth2.googleapis.com/token",
+    cf_username: "octocat",
+  });
+}
+
+const KEY_TEXT = await signingKey();
 
 function u16le(value: number): number[] {
   return [value & 0xff, (value >> 8) & 0xff];
@@ -140,6 +163,8 @@ function mintRun(
 interface StubOptions {
   login?: string;
   loginStatus?: number;
+  /** What the token endpoint says about the installed key. */
+  keyStatus?: number;
   /** One page of runs per listing call; the last repeats. */
   runPages?: Record<string, unknown>[][];
   runsStatus?: number;
@@ -175,6 +200,13 @@ describe("test-records-key", () => {
     withFetch(
       ((input: URL | RequestInfo) => {
         const url = String(input);
+        if (url.includes("oauth2.googleapis.com/token")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ access_token: "t" }), {
+              status: options.keyStatus ?? 200,
+            }),
+          );
+        }
         if (url.endsWith("/user")) {
           return Promise.resolve(
             new Response(
@@ -962,7 +994,92 @@ describe("test-records-key", () => {
       expect(await Deno.readTextFile(profile)).toContain(
         "CF_TEST_RECORDS_KEY_FILE",
       );
-      expect(urls).toEqual([]);
+      // It asks whether the key still works, and nothing else: no run is
+      // dispatched and no delivery is looked for.
+      expect(urls.every((line) => line.includes("oauth2.googleapis.com")))
+        .toBe(true);
+    });
+
+    it("mints a replacement for a key that is no longer accepted", async () => {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      const published = await delivery(identity);
+      withStub({
+        keyStatus: 400,
+        runPages: [[mintRun(identity.recipient)]],
+        ...published,
+      });
+
+      // A mint that failed after revoking leaves a file naming a key
+      // nothing accepts; setup must not take it for a working one.
+      expect(await setupCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+      expect(urls.some((line) => line.includes("oauth2.googleapis.com"))).toBe(
+        true,
+      );
+    });
+
+    it("replaces a key file that cannot sign", async () => {
+      const identity = await storeIdentity();
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        JSON.stringify({
+          client_email: "test-records-gh-octocat@p.iam.gserviceaccount.com",
+          private_key: "not a key",
+          token_uri: "https://oauth2.googleapis.com/token",
+          cf_username: "octocat",
+        }),
+      );
+      const published = await delivery(identity);
+      withStub({ runPages: [[mintRun(identity.recipient)]], ...published });
+
+      // Nothing will accept it, so there is no asking to be done.
+      expect(await setupCommand(deps)).toBe(0);
+      expect(
+        await Deno.readTextFile(
+          join(home, "common-fabric", "test-records-key.json"),
+        ),
+      ).toBe(KEY_TEXT);
+      expect(urls.some((line) => line.includes("oauth2.googleapis.com")))
+        .toBe(false);
+    });
+
+    it("keeps a key the endpoint could not be asked about", async () => {
+      await Deno.mkdir(join(home, "common-fabric"), { recursive: true });
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      withStub({});
+      const inner = deps.fetchImpl;
+      deps.fetchImpl = ((input: URL | RequestInfo, init?: RequestInit) => {
+        if (String(input).includes("oauth2.googleapis.com")) {
+          return Promise.reject(new TypeError("connection refused"));
+        }
+        return inner(input, init);
+      }) as typeof fetch;
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
+    });
+
+    it("keeps a key it could not ask about", async () => {
+      await Deno.mkdir(join(home, "common-fabric"), { recursive: true });
+      await Deno.writeTextFile(
+        join(home, "common-fabric", "test-records-key.json"),
+        KEY_TEXT,
+      );
+      withStub({ keyStatus: 503 });
+
+      expect(await setupCommand(deps)).toBe(0);
+      expect(urls.some((line) => line.includes("/dispatches"))).toBe(false);
     });
 
     it("mints a replacement when asked to rotate", async () => {

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -1039,6 +1039,10 @@ alone. Take ${RECORDS_KEY_FILE_VARIABLE} out of its "env" by hand.`);
     console.log("Nothing to remove; this workstation was not recording.");
     return 0;
   }
+  // What somebody else set stays, and so does whatever it points at, so
+  // saying recording has stopped would be saying something untrue.
+  const kept = removals.some((removal) => removal.outcome !== "removed") ||
+    configs.some((config) => config.outcome !== "removed");
 
   const root = defaultSpoolRoot(deps.env);
   const spools = root === undefined ? undefined : await spoolCount(root);
@@ -1053,7 +1057,11 @@ A later key ships them; remove that directory to throw them away.`);
   }
 
   console.log(`
-Every new shell records nothing. Two things this does not do.
+${
+    kept
+      ? "What this tool put here is gone."
+      : "Every new shell records nothing."
+  } Two things this does not do.
 
 The key still exists. This stops the machine using it, and the service
 account and the key itself are untouched; a key that has leaked stops

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -18,6 +18,10 @@
  *   deno task test-records-key collect
  *     The second half alone: install the delivery of a finished run.
  *
+ *   deno task test-records-key uninstall
+ *     Takes back everything setup put on the workstation: the key, the
+ *     delivery identity, and the export it added to the profiles.
+ *
  * Keys are a team-member workflow, and every part is self-service. A
  * person contributing without commit access needs no key: local tests run
  * identically without one, and CI records their pull requests' runs on
@@ -26,6 +30,7 @@
 
 import { join } from "@std/path";
 import {
+  defaultSpoolRoot,
   type Environment,
   readEnv,
   RECORDS_KEY_FILE_VARIABLE,
@@ -44,11 +49,17 @@ import {
 } from "./test-records-config.ts";
 import { readZip } from "./test-records-zip.ts";
 import {
+  type AgentConfigUpdate,
+  exportFromAgentConfigs,
+  unexportFromAgentConfigs,
+} from "./test-records-agent-config.ts";
+import {
   exportFromProfiles,
   exportLine,
   type ProfileUpdate,
   reloadHint,
   shellKind,
+  unexportFromProfiles,
 } from "./test-records-shell-config.ts";
 
 const API = "https://api.github.com";
@@ -607,6 +618,47 @@ Every new shell records its test runs. For the one you are in:
 
     ${reloadHint(added[0]!.path, kind)}`);
   }
+  await exportAgentConfigs(deps, path);
+  return updates;
+}
+
+/**
+ * Carries the key file into the configuration of every agent harness
+ * installed here. A shell profile covers an agent whose commands go
+ * through that shell; this covers the rest.
+ */
+async function exportAgentConfigs(
+  deps: KeyToolDeps,
+  path: string,
+): Promise<AgentConfigUpdate[]> {
+  const updates = await exportFromAgentConfigs(
+    RECORDS_KEY_FILE_VARIABLE,
+    path,
+    deps.env,
+  );
+  for (const update of updates) {
+    if (update.outcome === "added") {
+      console.log(
+        `${update.harness} passes ${RECORDS_KEY_FILE_VARIABLE} to what it ` +
+          `runs (${update.path})`,
+      );
+    } else if (update.outcome === "present") {
+      console.log(`${update.harness} already passes the key file on.`);
+    } else if (update.outcome === "conflict") {
+      console.log(`
+${update.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${update.harness} as
+
+    ${update.existing}
+
+Left alone. Point it at ${path} to record from this key.`);
+    } else {
+      console.log(`
+${update.path} does not parse as JSON, so ${update.harness} was left
+alone. Add this to its "env" once the file is readable again:
+
+    "${RECORDS_KEY_FILE_VARIABLE}": "${path}"`);
+    }
+  }
   return updates;
 }
 
@@ -893,9 +945,132 @@ export async function collectCommand(
   return 0;
 }
 
+/** Deletes a file, saying whether there was one. */
+async function removeFile(path: string): Promise<boolean> {
+  try {
+    await Deno.remove(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw new KeyToolError(`Cannot remove ${path}: ${reason(error)}`);
+  }
+}
+
+/** The spools waiting under a root, of which there may be none. */
+async function spoolCount(root: string): Promise<number | undefined> {
+  try {
+    let count = 0;
+    for await (const entry of Deno.readDir(root)) {
+      if (entry.isDirectory) count += 1;
+    }
+    return count;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Takes this workstation back to where it was before `setup`: the key,
+ * the delivery identity, and the export are removed, and the recording
+ * every task entry point does turns itself off with them.
+ */
+export async function uninstallCommand(
+  deps: KeyToolDeps = defaultDeps(),
+): Promise<number> {
+  const key = keyFilePath(deps.env);
+  const identity = identityPath(deps.env);
+  const removedKey = await removeFile(key);
+  if (removedKey) console.log(`Removed ${key}`);
+  const removedIdentity = await removeFile(identity);
+  if (removedIdentity) console.log(`Removed ${identity}`);
+  // The directory goes only when this tool leaves it empty; anything
+  // else in there belongs to something other than test records.
+  await Deno.remove(configDir(deps.env)).catch(() => {});
+
+  const removals = await unexportFromProfiles(
+    RECORDS_KEY_FILE_VARIABLE,
+    deps.env,
+  );
+  for (const removal of removals) {
+    if (removal.outcome === "removed") {
+      console.log(
+        `${RECORDS_KEY_FILE_VARIABLE} no longer exported from ${removal.path}`,
+      );
+    } else {
+      console.log(`
+${removal.path} sets ${RECORDS_KEY_FILE_VARIABLE} in a line this tool did
+not write:
+
+    ${removal.existing}
+
+Left alone. Recording continues from whatever key that names.`);
+    }
+  }
+
+  const configs = await unexportFromAgentConfigs(
+    RECORDS_KEY_FILE_VARIABLE,
+    key,
+    deps.env,
+  );
+  for (const config of configs) {
+    if (config.outcome === "removed") {
+      console.log(
+        `${config.harness} no longer passes ${RECORDS_KEY_FILE_VARIABLE} on ` +
+          `(${config.path})`,
+      );
+    } else if (config.outcome === "kept") {
+      console.log(`
+${config.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${config.harness} as
+
+    ${config.existing}
+
+Left alone. It is not the key this tool installed.`);
+    } else {
+      console.log(`
+${config.path} does not parse as JSON, so ${config.harness} was left
+alone. Take ${RECORDS_KEY_FILE_VARIABLE} out of its "env" by hand.`);
+    }
+  }
+
+  const removed = removedKey || removedIdentity ||
+    removals.some((removal) => removal.outcome === "removed") ||
+    configs.some((config) => config.outcome === "removed");
+  if (!removed) {
+    console.log("Nothing to remove; this workstation was not recording.");
+    return 0;
+  }
+
+  const root = defaultSpoolRoot(deps.env);
+  const spools = root === undefined ? undefined : await spoolCount(root);
+  if (spools !== undefined && spools > 0) {
+    const runs = spools === 1 ? "One run's" : `${spools} runs'`;
+    console.log(`
+${runs} records were never shipped, and are still spooled in
+
+    ${root}
+
+A later key ships them; remove that directory to throw them away.`);
+  }
+
+  console.log(`
+Every new shell records nothing. Two things this does not do.
+
+The key still exists. This stops the machine using it, and the service
+account and the key itself are untouched; a key that has leaked stops
+working only when a new one replaces it, which any machine can do with
+
+    deno task test-records-key setup --rotate
+
+Records already shipped stay in the store. They carry no personal
+material, and nothing there can be changed or removed by any key this
+tool installs.`);
+  return 0;
+}
+
 function usage(): number {
   console.error(
-    "usage: deno task test-records-key <setup [--rotate]|request|collect>",
+    "usage: deno task test-records-key " +
+      "<setup [--rotate]|request|collect|uninstall>",
   );
   return 2;
 }
@@ -956,6 +1131,10 @@ export async function runCli(
     if (command === "collect") {
       if (rest.length > 0) return usage();
       return await collectCommand(deps);
+    }
+    if (command === "uninstall") {
+      if (rest.length > 0) return usage();
+      return await uninstallCommand(deps);
     }
     return usage();
   } catch (error) {

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -49,6 +49,7 @@ import {
 } from "./test-records-config.ts";
 import { readZip } from "./test-records-zip.ts";
 import {
+  type AgentConfigRemoval,
   type AgentConfigUpdate,
   exportFromAgentConfigs,
   unexportFromAgentConfigs,
@@ -578,6 +579,9 @@ async function exportKeyFile(
 No shell profile to update. Export the key file yourself:
 
     ${RECORDS_KEY_FILE_VARIABLE}=${path}`);
+    // A workstation with no profile to write can still be running an
+    // agent, whose harness carries the variable instead.
+    await exportAgentConfigs(deps, path);
     return updates;
   }
   const kind = shellKind(deps.env);
@@ -622,6 +626,61 @@ Every new shell records its test runs. For the one you are in:
   return updates;
 }
 
+/** What one harness configuration's update says to a person. */
+export function agentConfigReport(
+  update: AgentConfigUpdate,
+  path: string,
+): string {
+  switch (update.outcome) {
+    case "added":
+      return `${update.harness} passes ${RECORDS_KEY_FILE_VARIABLE} to what ` +
+        `it runs (${update.path})`;
+    case "present":
+      return `${update.harness} already passes the key file on.`;
+    case "conflict":
+      return `
+${update.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${update.harness} as
+
+    ${update.existing}
+
+Left alone. Point it at ${path} to record from this key.`;
+    case "changed":
+      return `
+${update.path} changed while this was writing, so ${update.harness} was
+left as it stands. Run the command again.`;
+    case "unreadable":
+      return `
+${update.path} does not parse as JSON, so ${update.harness} was left
+alone. Add this to its "env" once the file is readable again:
+
+    "${RECORDS_KEY_FILE_VARIABLE}": "${path}"`;
+  }
+}
+
+/** What one harness configuration's removal says to a person. */
+export function agentRemovalReport(removal: AgentConfigRemoval): string {
+  switch (removal.outcome) {
+    case "removed":
+      return `${removal.harness} no longer passes ` +
+        `${RECORDS_KEY_FILE_VARIABLE} on (${removal.path})`;
+    case "kept":
+      return `
+${removal.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${removal.harness} as
+
+    ${removal.existing}
+
+Left alone. It is not the key this tool installed.`;
+    case "changed":
+      return `
+${removal.path} changed while this was writing, so ${removal.harness} was
+left as it stands. Run the command again.`;
+    case "unreadable":
+      return `
+${removal.path} does not parse as JSON, so ${removal.harness} was left
+alone. Take ${RECORDS_KEY_FILE_VARIABLE} out of its "env" by hand.`;
+  }
+}
+
 /**
  * Carries the key file into the configuration of every agent harness
  * installed here. A shell profile covers an agent whose commands go
@@ -636,29 +695,7 @@ async function exportAgentConfigs(
     path,
     deps.env,
   );
-  for (const update of updates) {
-    if (update.outcome === "added") {
-      console.log(
-        `${update.harness} passes ${RECORDS_KEY_FILE_VARIABLE} to what it ` +
-          `runs (${update.path})`,
-      );
-    } else if (update.outcome === "present") {
-      console.log(`${update.harness} already passes the key file on.`);
-    } else if (update.outcome === "conflict") {
-      console.log(`
-${update.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${update.harness} as
-
-    ${update.existing}
-
-Left alone. Point it at ${path} to record from this key.`);
-    } else {
-      console.log(`
-${update.path} does not parse as JSON, so ${update.harness} was left
-alone. Add this to its "env" once the file is readable again:
-
-    "${RECORDS_KEY_FILE_VARIABLE}": "${path}"`);
-    }
-  }
+  for (const update of updates) console.log(agentConfigReport(update, path));
   return updates;
 }
 
@@ -979,16 +1016,13 @@ export async function uninstallCommand(
 ): Promise<number> {
   const key = keyFilePath(deps.env);
   const identity = identityPath(deps.env);
-  const removedKey = await removeFile(key);
-  if (removedKey) console.log(`Removed ${key}`);
-  const removedIdentity = await removeFile(identity);
-  if (removedIdentity) console.log(`Removed ${identity}`);
-  // The directory goes only when this tool leaves it empty; anything
-  // else in there belongs to something other than test records.
-  await Deno.remove(configDir(deps.env)).catch(() => {});
 
+  // What names the key comes apart before the key itself. A removal
+  // that fails part way then leaves a workstation that still records,
+  // rather than one pointing every shell at a file that is gone.
   const removals = await unexportFromProfiles(
     RECORDS_KEY_FILE_VARIABLE,
+    key,
     deps.env,
   );
   for (const removal of removals) {
@@ -1012,25 +1046,15 @@ Left alone. Recording continues from whatever key that names.`);
     key,
     deps.env,
   );
-  for (const config of configs) {
-    if (config.outcome === "removed") {
-      console.log(
-        `${config.harness} no longer passes ${RECORDS_KEY_FILE_VARIABLE} on ` +
-          `(${config.path})`,
-      );
-    } else if (config.outcome === "kept") {
-      console.log(`
-${config.path} gives ${RECORDS_KEY_FILE_VARIABLE} to ${config.harness} as
+  for (const config of configs) console.log(agentRemovalReport(config));
 
-    ${config.existing}
-
-Left alone. It is not the key this tool installed.`);
-    } else {
-      console.log(`
-${config.path} does not parse as JSON, so ${config.harness} was left
-alone. Take ${RECORDS_KEY_FILE_VARIABLE} out of its "env" by hand.`);
-    }
-  }
+  const removedKey = await removeFile(key);
+  if (removedKey) console.log(`Removed ${key}`);
+  const removedIdentity = await removeFile(identity);
+  if (removedIdentity) console.log(`Removed ${identity}`);
+  // The directory goes only when this tool leaves it empty; anything
+  // else in there belongs to something other than test records.
+  await Deno.remove(configDir(deps.env)).catch(() => {});
 
   const removed = removedKey || removedIdentity ||
     removals.some((removal) => removal.outcome === "removed") ||
@@ -1059,7 +1083,7 @@ A later key ships them; remove that directory to throw them away.`);
   console.log(`
 ${
     kept
-      ? "What this tool put here is gone."
+      ? "What this tool could take back is gone."
       : "Every new shell records nothing."
   } Two things this does not do.
 

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -34,6 +34,8 @@ import {
   type Environment,
   readEnv,
   RECORDS_KEY_FILE_VARIABLE,
+  saAssertion,
+  STORE_WRITE_SCOPE,
 } from "@commonfabric/test-support/records";
 import {
   generateIdentity,
@@ -45,6 +47,7 @@ import {
 import {
   MINT_WORKFLOW_FILE,
   parsePersonalKeyFile,
+  type PersonalKeyFile,
   REPO,
 } from "./test-records-config.ts";
 import { readZip } from "./test-records-zip.ts";
@@ -702,7 +705,7 @@ async function exportAgentConfigs(
 /** The key already installed on this workstation, when there is one. */
 async function installedKey(
   env: Environment,
-): Promise<{ path: string; username: string } | undefined> {
+): Promise<{ path: string; key: PersonalKeyFile } | undefined> {
   const path = keyFilePath(env);
   let text: string;
   try {
@@ -711,8 +714,56 @@ async function installedKey(
     return undefined;
   }
   const parsed = parsePersonalKeyFile(text);
-  if (parsed === undefined) return undefined;
-  return { path, username: parsed.cf_username };
+  return parsed === undefined ? undefined : { path, key: parsed };
+}
+
+/**
+ * Whether Google still accepts the installed key, as far as asking can
+ * tell: true where it does, false where it is refused, and undefined
+ * where the question could not be put.
+ *
+ * A key file on disk is not the same thing as a key that works. Minting
+ * revokes the person's previous keys before it creates the new one, so a
+ * mint that fails in between leaves this workstation holding a file that
+ * names a key nothing will accept — and every later test run would ship
+ * nothing while saying so only in a warning nobody reads.
+ */
+async function keyStillWorks(
+  deps: KeyToolDeps,
+  key: PersonalKeyFile,
+): Promise<boolean | undefined> {
+  let assertion: string;
+  try {
+    assertion = await saAssertion(
+      key,
+      Math.floor(Date.now() / 1000),
+      STORE_WRITE_SCOPE,
+    );
+  } catch {
+    // A key that cannot sign is a key nothing will accept, whatever the
+    // endpoint would have said about it.
+    return false;
+  }
+  let response: Response;
+  try {
+    response = await deps.fetchImpl(key.token_uri, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      }),
+    });
+  } catch {
+    // The endpoint could not be reached, which says nothing about the
+    // key; a workstation offline enough for this cannot mint either.
+    return undefined;
+  }
+  await response.text();
+  if (response.ok) return true;
+  // A key that has been revoked, or an account that has been disabled,
+  // is refused; anything else is the endpoint having a bad day.
+  return response.status === 400 || response.status === 401 ? false : undefined;
 }
 
 export async function requestCommand(
@@ -824,18 +875,32 @@ export async function setupCommand(
 ): Promise<number> {
   const existing = await installedKey(deps.env);
   if (existing !== undefined && options.rotate !== true) {
-    console.log(
-      `A reporting key for ${existing.username} is installed at ` +
-        `${existing.path}`,
-    );
-    await exportKeyFile(deps, existing.path);
-    console.log(`
+    const works = await keyStillWorks(deps, existing.key);
+    if (works === false) {
+      console.log(`
+The key installed at ${existing.path} is no longer accepted, which is
+what a mint that failed after revoking the key it was replacing leaves
+behind. Minting a replacement; there is nothing live to revoke.`);
+    } else {
+      console.log(
+        `A reporting key for ${existing.key.cf_username} is installed at ` +
+          `${existing.path}`,
+      );
+      if (works === undefined) {
+        console.log(
+          "Whether the token endpoint still accepts it could not be asked " +
+            "just now.",
+        );
+      }
+      await exportKeyFile(deps, existing.path);
+      console.log(`
 Minting another key revokes this one, on every machine holding a copy.
 To rotate deliberately:
 
     deno task test-records-key setup --rotate
 `);
-    return 0;
+      return 0;
+    }
   }
 
   const token = await deps.githubToken();

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -873,8 +873,41 @@ export async function setupCommand(
   deps: KeyToolDeps = defaultDeps(),
   options: { rotate?: boolean } = {},
 ): Promise<number> {
+  const token = await deps.githubToken();
+  const login = token === undefined
+    ? undefined
+    : await githubLogin(deps, token);
+  const stored = await loadIdentity(deps.env);
+
+  // What this recipient already has going, asked before anything else,
+  // because a run still minting is this person's own earlier attempt —
+  // a watch they stopped, or a dispatch from a browser — and taking it
+  // up is what rerunning the command is for. Rotating deliberately is
+  // the one case that wants a new run whatever is already going.
+  let search: RunSearch | undefined;
+  let found: RunMatch | undefined;
+  if (
+    options.rotate !== true && token !== undefined && login !== undefined &&
+    stored !== undefined
+  ) {
+    search = {
+      token,
+      recipient: stored.recipient,
+      artifactName: await deliveryName(stored.recipient),
+      login,
+    };
+    found = (await findMintRun(deps, search)).match;
+  }
+  const running = found !== undefined && found.artifact === undefined &&
+    found.run.status !== "completed";
+
+  // A key installed here settles the matter only when nothing is being
+  // minted to replace it. The key that run delivers is the one this
+  // workstation is going to need, and the mint revokes this one to make
+  // it, so standing down now is how a person ends up holding a key that
+  // has been revoked.
   const existing = await installedKey(deps.env);
-  if (existing !== undefined && options.rotate !== true) {
+  if (existing !== undefined && options.rotate !== true && !running) {
     const works = await keyStillWorks(deps, existing.key);
     if (works === false) {
       console.log(`
@@ -903,14 +936,12 @@ To rotate deliberately:
     }
   }
 
-  const token = await deps.githubToken();
   if (token === undefined) {
     throw new KeyToolError(
       "A GitHub token is needed to mint and collect a key; set GH_TOKEN " +
         "or sign in with `gh auth login`",
     );
   }
-  const login = await githubLogin(deps, token);
   if (login === undefined) {
     throw new KeyToolError(
       "Cannot read your GitHub login; use a token that can GET /user.",
@@ -919,37 +950,26 @@ To rotate deliberately:
 
   const identity = await ensureIdentity(deps);
   console.log(`Recipient: ${identity.recipient}`);
-  const search: RunSearch = {
+  const watching: RunSearch = search ?? {
     token,
     recipient: identity.recipient,
     artifactName: await deliveryName(identity.recipient),
     login,
   };
 
-  // A run already minting for this recipient is this person's own
-  // earlier attempt — a watch they stopped, or a browser dispatch — and
-  // taking it up is what makes rerunning resume rather than start
-  // again. Minting a second time would revoke the key the first is
-  // about to deliver. Rotating deliberately is the one case that wants
-  // a new run whatever is already going.
-  const inFlight = options.rotate === true
-    ? undefined
-    : (await findMintRun(deps, search)).match;
   let artifact: number;
-  if (inFlight?.artifact !== undefined) {
-    console.log(
-      `An earlier run has the key waiting: ${runUrl(inFlight.run)}`,
-    );
-    artifact = inFlight.artifact;
+  if (found?.artifact !== undefined) {
+    console.log(`An earlier run has the key waiting: ${runUrl(found.run)}`);
+    artifact = found.artifact;
   } else {
-    if (inFlight !== undefined && inFlight.run.status !== "completed") {
+    if (running && found !== undefined) {
       console.log(
         `A minting run for this recipient is already going: ${
-          runUrl(inFlight.run)
+          runUrl(found.run)
         }`,
       );
-      const created = Date.parse(inFlight.run.created_at ?? "");
-      if (!Number.isNaN(created)) search.notBefore = created;
+      const created = Date.parse(found.run.created_at ?? "");
+      if (!Number.isNaN(created)) watching.notBefore = created;
     } else {
       const dispatch = await dispatchMint(
         deps,
@@ -966,9 +986,9 @@ Waiting for that run — this command collects the key on its own once it
 finishes. Ctrl-C stops watching; rerunning picks up where it left off.
 `);
       }
-      if (dispatch.at !== undefined) search.notBefore = dispatch.at;
+      if (dispatch.at !== undefined) watching.notBefore = dispatch.at;
     }
-    artifact = await awaitDelivery(deps, search);
+    artifact = await awaitDelivery(deps, watching);
   }
   const path = await installDelivery(deps, token, identity, login, artifact);
   console.log(`Key installed: ${path}`);

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -13,7 +13,6 @@ import {
   profileCandidates,
   profilesToInspect,
   reloadHint,
-  replaceFile,
   shellKind,
   stripMarkedBlock,
   unexportFromProfiles,
@@ -582,27 +581,6 @@ describe("test-records-shell-config", () => {
       expect(removals).toEqual([
         { path: join(home, ".zshrc"), outcome: "removed" },
       ]);
-    });
-  });
-
-  describe("replaceFile()", () => {
-    it("writes a file that is not there yet", async () => {
-      const path = join(home, "fresh.txt");
-
-      await replaceFile(path, "hello\n");
-
-      expect(await Deno.readTextFile(path)).toBe("hello\n");
-    });
-
-    it("keeps the permissions a file already had", async () => {
-      const path = join(home, "kept.txt");
-      await Deno.writeTextFile(path, "before\n");
-      await Deno.chmod(path, 0o600);
-
-      await replaceFile(path, "after\n");
-
-      expect(await Deno.readTextFile(path)).toBe("after\n");
-      expect((await Deno.stat(path)).mode! & 0o777).toBe(0o600);
     });
   });
 

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -11,8 +11,11 @@ import {
   MARKER,
   parseSetting,
   profileCandidates,
+  profilesToInspect,
   reloadHint,
   shellKind,
+  stripMarkedBlock,
+  unexportFromProfiles,
 } from "./test-records-shell-config.ts";
 
 const VARIABLE = "CF_TEST_RECORDS_KEY_FILE";
@@ -47,19 +50,19 @@ describe("test-records-shell-config", () => {
   });
 
   describe("profileCandidates()", () => {
-    it("returns the zsh profile under ZDOTDIR when one is set", () => {
+    it("returns the zsh profile every shell reads, under ZDOTDIR", () => {
       expect(
         profileCandidates(
           environment({ SHELL: "/bin/zsh", HOME: "/h", ZDOTDIR: "/z" }),
           "linux",
         ),
-      ).toEqual(["/z/.zshrc"]);
+      ).toEqual(["/z/.zshenv"]);
     });
 
     it("returns the home zsh profile without ZDOTDIR", () => {
       expect(
         profileCandidates(environment({ SHELL: "/bin/zsh", HOME: "/h" })),
-      ).toEqual(["/h/.zshrc"]);
+      ).toEqual(["/h/.zshenv"]);
     });
 
     it("orders the bash profiles by the ones the platform reads first", () => {
@@ -97,6 +100,19 @@ describe("test-records-shell-config", () => {
 
     it("returns nothing without a home directory", () => {
       expect(profileCandidates(environment({ SHELL: "/bin/zsh" }))).toEqual([]);
+    });
+  });
+
+  describe("profilesToInspect()", () => {
+    it("returns the zsh profile read after the one written", () => {
+      expect(profilesToInspect(environment({ SHELL: "/bin/zsh", HOME: "/h" })))
+        .toEqual(["/h/.zshrc"]);
+    });
+
+    it("returns nothing for a shell with one profile", () => {
+      expect(profilesToInspect(environment({ SHELL: "/bin/bash", HOME: "/h" })))
+        .toEqual([]);
+      expect(profilesToInspect(environment({ HOME: "/h" }))).toEqual([]);
     });
   });
 
@@ -253,25 +269,45 @@ describe("test-records-shell-config", () => {
       return environment({ SHELL: "/bin/zsh", HOME: home });
     }
 
+    it("reports a conflicting line in the profile read after it", async () => {
+      const key = join(home, ".config", "k.json");
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `export ${VARIABLE}="/somewhere/else.json"\n`,
+      );
+
+      const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
+
+      // .zshrc is read after .zshenv, so what it says would win.
+      expect(updates).toEqual([
+        {
+          path: join(home, ".zshrc"),
+          outcome: "conflict",
+          existing: `export ${VARIABLE}="/somewhere/else.json"`,
+        },
+        { path: join(home, ".zshenv"), outcome: "added" },
+      ]);
+    });
+
     it("appends the marked line to the profile", async () => {
       const key = join(home, ".config", "k.json");
       const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
       expect(updates).toEqual([
-        { path: join(home, ".zshrc"), outcome: "added" },
+        { path: join(home, ".zshenv"), outcome: "added" },
       ]);
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(
         `${MARKER}\nexport ${VARIABLE}="$HOME/.config/k.json"\n`,
       );
     });
 
     it("keeps an existing profile's contents and its trailing newline", async () => {
-      await Deno.writeTextFile(join(home, ".zshrc"), "alias l=ls");
+      await Deno.writeTextFile(join(home, ".zshenv"), "alias l=ls");
       const key = join(home, ".config", "k.json");
 
       await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(
         `alias l=ls\n\n${MARKER}\nexport ${VARIABLE}="$HOME/.config/k.json"\n`,
       );
     });
@@ -279,20 +315,20 @@ describe("test-records-shell-config", () => {
     it("reports the same value as already present and writes nothing", async () => {
       const key = join(home, ".config", "k.json");
       await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
-      const before = await Deno.readTextFile(join(home, ".zshrc"));
+      const before = await Deno.readTextFile(join(home, ".zshenv"));
 
       const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
       expect(updates).toEqual([
-        { path: join(home, ".zshrc"), outcome: "present" },
+        { path: join(home, ".zshenv"), outcome: "present" },
       ]);
-      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(before);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(before);
     });
 
     it("reports a value that only starts the same as a conflict", async () => {
       const key = join(home, ".config", "k.json");
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         `export ${VARIABLE}="${key}.backup"\n`,
       );
 
@@ -304,7 +340,7 @@ describe("test-records-shell-config", () => {
     it("accepts an export that carries a comment after it", async () => {
       const key = join(home, ".config", "k.json");
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         `export ${VARIABLE}="$HOME/.config/k.json" # the reporting key\n`,
       );
 
@@ -316,7 +352,7 @@ describe("test-records-shell-config", () => {
     it("reports a single-quoted $HOME as the other value it is", async () => {
       const key = join(home, ".config", "k.json");
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         `export ${VARIABLE}='$HOME/.config/k.json'\n`,
       );
 
@@ -330,14 +366,14 @@ describe("test-records-shell-config", () => {
     it("reports an assignment that is never exported", async () => {
       const key = join(home, ".config", "k.json");
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         `${VARIABLE}="$HOME/.config/k.json"\n`,
       );
 
       const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
       expect(updates).toEqual([{
-        path: join(home, ".zshrc"),
+        path: join(home, ".zshenv"),
         outcome: "unexported",
         existing: `${VARIABLE}="$HOME/.config/k.json"`,
       }]);
@@ -364,7 +400,7 @@ describe("test-records-shell-config", () => {
 
     it("reports a line pointing elsewhere as a conflict", async () => {
       await Deno.writeTextFile(
-        join(home, ".zshrc"),
+        join(home, ".zshenv"),
         `export ${VARIABLE}="/somewhere/else.json"\n`,
       );
       const key = join(home, ".config", "k.json");
@@ -372,7 +408,7 @@ describe("test-records-shell-config", () => {
       const updates = await exportFromProfiles(VARIABLE, key, zsh(), "darwin");
 
       expect(updates).toEqual([{
-        path: join(home, ".zshrc"),
+        path: join(home, ".zshenv"),
         outcome: "conflict",
         existing: `export ${VARIABLE}="/somewhere/else.json"`,
       }]);
@@ -414,10 +450,119 @@ describe("test-records-shell-config", () => {
       );
     });
 
+    it("raises a profile that cannot be read", async () => {
+      await Deno.mkdir(join(home, ".zshenv"));
+
+      await expect(
+        exportFromProfiles(VARIABLE, join(home, "k.json"), zsh(), "darwin"),
+      ).rejects.toThrow();
+    });
+
     it("returns nothing when there is no home directory to write in", async () => {
       expect(
         await exportFromProfiles(VARIABLE, "/k.json", environment({})),
       ).toEqual([]);
+    });
+  });
+
+  describe("stripMarkedBlock()", () => {
+    it("takes out the marker, its line, and the blank line before it", () => {
+      const text = `alias l=ls\n\n${MARKER}\nexport ${VARIABLE}="/k.json"\n`;
+      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+        text: "alias l=ls\n",
+        removed: true,
+      });
+    });
+
+    it("leaves a marker that introduces something else", () => {
+      const text = `${MARKER}\necho hello\n`;
+      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+        text,
+        removed: false,
+      });
+    });
+
+    it("leaves a line the tool did not write", () => {
+      const text = `export ${VARIABLE}="/k.json"\n`;
+      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+        text,
+        removed: false,
+      });
+    });
+  });
+
+  describe("unexportFromProfiles()", () => {
+    function zshEnv(): Environment {
+      return environment({ SHELL: "/bin/zsh", HOME: home });
+    }
+
+    it("removes what it wrote and leaves the rest of the file", async () => {
+      await Deno.writeTextFile(join(home, ".zshrc"), "alias l=ls\n");
+      await exportFromProfiles(
+        VARIABLE,
+        join(home, "k.json"),
+        zshEnv(),
+        "darwin",
+      );
+
+      const removals = await unexportFromProfiles(
+        VARIABLE,
+        zshEnv(),
+        "darwin",
+      );
+
+      expect(removals).toEqual([
+        { path: join(home, ".zshenv"), outcome: "removed" },
+      ]);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe("");
+      expect(await Deno.readTextFile(join(home, ".zshrc"))).toBe(
+        "alias l=ls\n",
+      );
+    });
+
+    it("keeps a line the tool did not write", async () => {
+      await Deno.writeTextFile(
+        join(home, ".zshenv"),
+        `export ${VARIABLE}="/elsewhere.json"\n`,
+      );
+
+      const removals = await unexportFromProfiles(
+        VARIABLE,
+        zshEnv(),
+        "darwin",
+      );
+
+      expect(removals).toEqual([{
+        path: join(home, ".zshenv"),
+        outcome: "kept",
+        existing: `export ${VARIABLE}="/elsewhere.json"`,
+      }]);
+      expect(await Deno.readTextFile(join(home, ".zshenv"))).toBe(
+        `export ${VARIABLE}="/elsewhere.json"\n`,
+      );
+    });
+
+    it("returns nothing when no profile mentions it", async () => {
+      await Deno.writeTextFile(join(home, ".zshenv"), "alias l=ls\n");
+      expect(await unexportFromProfiles(VARIABLE, zshEnv(), "darwin"))
+        .toEqual([]);
+    });
+
+    it("removes from a profile it only reads as well", async () => {
+      await Deno.writeTextFile(
+        join(home, ".zshrc"),
+        `${MARKER}\nexport ${VARIABLE}="/k.json"\n`,
+      );
+
+      const removals = await unexportFromProfiles(
+        VARIABLE,
+        zshEnv(),
+        "darwin",
+      );
+
+      expect(removals).toEqual([
+        { path: join(home, ".zshrc"), outcome: "removed" },
+      ]);
     });
   });
 

--- a/tasks/test-records-shell-config.test.ts
+++ b/tasks/test-records-shell-config.test.ts
@@ -13,6 +13,7 @@ import {
   profileCandidates,
   profilesToInspect,
   reloadHint,
+  replaceFile,
   shellKind,
   stripMarkedBlock,
   unexportFromProfiles,
@@ -26,9 +27,11 @@ function environment(values: Record<string, string>): Environment {
 
 describe("test-records-shell-config", () => {
   let home: string;
+  let KEY_PATH: string;
 
   beforeEach(async () => {
     home = await Deno.makeTempDir({ prefix: "test-records-profile-" });
+    KEY_PATH = join(home, "k.json");
   });
 
   afterEach(async () => {
@@ -104,9 +107,9 @@ describe("test-records-shell-config", () => {
   });
 
   describe("profilesToInspect()", () => {
-    it("returns the zsh profile read after the one written", () => {
+    it("returns every zsh profile read after the one written", () => {
       expect(profilesToInspect(environment({ SHELL: "/bin/zsh", HOME: "/h" })))
-        .toEqual(["/h/.zshrc"]);
+        .toEqual(["/h/.zprofile", "/h/.zshrc", "/h/.zlogin"]);
     });
 
     it("returns nothing for a shell with one profile", () => {
@@ -208,6 +211,14 @@ describe("test-records-shell-config", () => {
     it("reports an assignment that is never exported", () => {
       expect(parseSetting(`${VARIABLE}=/k.json\n`, VARIABLE)).toEqual({
         line: `${VARIABLE}=/k.json`,
+        exported: false,
+        value: "/k.json",
+      });
+    });
+
+    it("reads a fish set with no flags as not exported", () => {
+      expect(parseSetting(`set ${VARIABLE} "/k.json"\n`, VARIABLE)).toEqual({
+        line: `set ${VARIABLE} "/k.json"`,
         exported: false,
         value: "/k.json",
       });
@@ -466,9 +477,11 @@ describe("test-records-shell-config", () => {
   });
 
   describe("stripMarkedBlock()", () => {
+    const WRITTEN = `export ${VARIABLE}="/k.json"`;
+
     it("takes out the marker, its line, and the blank line before it", () => {
-      const text = `alias l=ls\n\n${MARKER}\nexport ${VARIABLE}="/k.json"\n`;
-      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+      const text = `alias l=ls\n\n${MARKER}\n${WRITTEN}\n`;
+      expect(stripMarkedBlock(text, WRITTEN)).toEqual({
         text: "alias l=ls\n",
         removed: true,
       });
@@ -476,15 +489,23 @@ describe("test-records-shell-config", () => {
 
     it("leaves a marker that introduces something else", () => {
       const text = `${MARKER}\necho hello\n`;
-      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+      expect(stripMarkedBlock(text, WRITTEN)).toEqual({
+        text,
+        removed: false,
+      });
+    });
+
+    it("leaves a marked line a person has since edited", () => {
+      const text = `${MARKER}\nexport ${VARIABLE}="/somewhere/else.json"\n`;
+      expect(stripMarkedBlock(text, WRITTEN)).toEqual({
         text,
         removed: false,
       });
     });
 
     it("leaves a line the tool did not write", () => {
-      const text = `export ${VARIABLE}="/k.json"\n`;
-      expect(stripMarkedBlock(text, VARIABLE)).toEqual({
+      const text = `${WRITTEN}\n`;
+      expect(stripMarkedBlock(text, WRITTEN)).toEqual({
         text,
         removed: false,
       });
@@ -498,15 +519,11 @@ describe("test-records-shell-config", () => {
 
     it("removes what it wrote and leaves the rest of the file", async () => {
       await Deno.writeTextFile(join(home, ".zshrc"), "alias l=ls\n");
-      await exportFromProfiles(
-        VARIABLE,
-        join(home, "k.json"),
-        zshEnv(),
-        "darwin",
-      );
+      await exportFromProfiles(VARIABLE, KEY_PATH, zshEnv(), "darwin");
 
       const removals = await unexportFromProfiles(
         VARIABLE,
+        KEY_PATH,
         zshEnv(),
         "darwin",
       );
@@ -528,6 +545,7 @@ describe("test-records-shell-config", () => {
 
       const removals = await unexportFromProfiles(
         VARIABLE,
+        KEY_PATH,
         zshEnv(),
         "darwin",
       );
@@ -544,18 +562,19 @@ describe("test-records-shell-config", () => {
 
     it("returns nothing when no profile mentions it", async () => {
       await Deno.writeTextFile(join(home, ".zshenv"), "alias l=ls\n");
-      expect(await unexportFromProfiles(VARIABLE, zshEnv(), "darwin"))
+      expect(await unexportFromProfiles(VARIABLE, KEY_PATH, zshEnv(), "darwin"))
         .toEqual([]);
     });
 
     it("removes from a profile it only reads as well", async () => {
       await Deno.writeTextFile(
         join(home, ".zshrc"),
-        `${MARKER}\nexport ${VARIABLE}="/k.json"\n`,
+        `${MARKER}\nexport ${VARIABLE}="$HOME/k.json"\n`,
       );
 
       const removals = await unexportFromProfiles(
         VARIABLE,
+        KEY_PATH,
         zshEnv(),
         "darwin",
       );
@@ -563,6 +582,27 @@ describe("test-records-shell-config", () => {
       expect(removals).toEqual([
         { path: join(home, ".zshrc"), outcome: "removed" },
       ]);
+    });
+  });
+
+  describe("replaceFile()", () => {
+    it("writes a file that is not there yet", async () => {
+      const path = join(home, "fresh.txt");
+
+      await replaceFile(path, "hello\n");
+
+      expect(await Deno.readTextFile(path)).toBe("hello\n");
+    });
+
+    it("keeps the permissions a file already had", async () => {
+      const path = join(home, "kept.txt");
+      await Deno.writeTextFile(path, "before\n");
+      await Deno.chmod(path, 0o600);
+
+      await replaceFile(path, "after\n");
+
+      expect(await Deno.readTextFile(path)).toBe("after\n");
+      expect((await Deno.stat(path)).mode! & 0o777).toBe(0o600);
     });
   });
 

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -74,6 +74,12 @@ export function shellKind(env: Environment = Deno.env.get): ShellKind {
  * bash splits its startup between two files differently on macOS than on
  * Linux and a person whose terminal reads only one of them would
  * otherwise get a line that never runs.
+ *
+ * For zsh this is .zshenv rather than .zshrc. A test run started by
+ * something other than a person typing — an agent's shell, a script, an
+ * editor's task runner — is not an interactive shell, and .zshrc is
+ * only read by interactive ones. Recording has to survive that, so the
+ * export goes in the file every zsh reads.
  */
 export function profileCandidates(
   env: Environment = Deno.env.get,
@@ -82,11 +88,8 @@ export function profileCandidates(
   const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
   if (home === undefined || home.length === 0) return [];
   switch (shellKind(env)) {
-    case "zsh": {
-      const zdotdir = readEnv("ZDOTDIR", env);
-      const dir = zdotdir !== undefined && zdotdir.length > 0 ? zdotdir : home;
-      return [join(dir, ".zshrc")];
-    }
+    case "zsh":
+      return [join(zshDir(env, home), ".zshenv")];
     case "bash":
       return os === "darwin"
         ? [join(home, ".bash_profile"), join(home, ".bashrc")]
@@ -101,6 +104,24 @@ export function profileCandidates(
     case "posix":
       return [join(home, ".profile")];
   }
+}
+
+function zshDir(env: Environment, home: string): string {
+  const zdotdir = readEnv("ZDOTDIR", env);
+  return zdotdir !== undefined && zdotdir.length > 0 ? zdotdir : home;
+}
+
+/**
+ * Profiles that are not written but are read for a setting already
+ * there, because a shell reads them after the one written and what they
+ * say would win. A zsh reads .zshrc after .zshenv.
+ */
+export function profilesToInspect(
+  env: Environment = Deno.env.get,
+): string[] {
+  const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
+  if (home === undefined || home.length === 0) return [];
+  return shellKind(env) === "zsh" ? [join(zshDir(env, home), ".zshrc")] : [];
 }
 
 /** A path split at the home directory, when it sits under one. */
@@ -289,6 +310,20 @@ async function readIfPresent(path: string): Promise<string | undefined> {
   }
 }
 
+/** What a profile that already sets the variable amounts to. */
+function verdict(
+  path: string,
+  existing: ProfileSetting,
+  value: string,
+): ProfileUpdate {
+  if (existing.value !== value) {
+    return { path, outcome: "conflict", existing: existing.line };
+  }
+  return existing.exported
+    ? { path, outcome: "present" }
+    : { path, outcome: "unexported", existing: existing.line };
+}
+
 async function updateOne(
   path: string,
   name: string,
@@ -300,14 +335,7 @@ async function updateOne(
   const text = await readIfPresent(path);
   if (text === undefined && !create) return undefined;
   const existing = parseSetting(text ?? "", name, home);
-  if (existing !== undefined) {
-    if (existing.value !== value) {
-      return { path, outcome: "conflict", existing: existing.line };
-    }
-    return existing.exported
-      ? { path, outcome: "present" }
-      : { path, outcome: "unexported", existing: existing.line };
-  }
+  if (existing !== undefined) return verdict(path, existing, value);
   const separator = text === undefined || text.length === 0
     ? ""
     : text.endsWith("\n")
@@ -339,11 +367,18 @@ export async function exportFromProfiles(
   const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
   const line = exportLine(shellKind(env), name, value, home);
   const updates: ProfileUpdate[] = [];
+  for (const path of profilesToInspect(env)) {
+    const text = await readIfPresent(path);
+    if (text === undefined) continue;
+    const existing = parseSetting(text, name, home);
+    if (existing === undefined) continue;
+    updates.push(verdict(path, existing, value));
+  }
   for (const path of candidates) {
     const update = await updateOne(path, name, line, value, home, false);
     if (update !== undefined) updates.push(update);
   }
-  if (updates.length === 0) {
+  if (!updates.some((update) => candidates.includes(update.path))) {
     const created = await updateOne(
       candidates[0]!,
       name,
@@ -360,6 +395,79 @@ export async function exportFromProfiles(
     updates.unshift({ path: first, outcome: "absent" });
   }
   return updates;
+}
+
+/** What one profile file's removal did. */
+export type RemovalOutcome =
+  /** The line this tool wrote was taken out. */
+  | "removed"
+  /** The variable is set by a line this tool did not write. */
+  | "kept";
+
+export interface ProfileRemoval {
+  path: string;
+  outcome: RemovalOutcome;
+  /** The line left in place, for one this tool did not write. */
+  existing?: string;
+}
+
+/**
+ * Takes the marked block out of a profile's text. The blank line this
+ * tool put in front of the marker goes with it, so removing what was
+ * added leaves the file as it stood.
+ */
+export function stripMarkedBlock(
+  text: string,
+  name: string,
+): { text: string; removed: boolean } {
+  const lines = text.split("\n");
+  const kept: string[] = [];
+  let removed = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    const next = lines[index + 1];
+    if (
+      line.trim() === MARKER && next !== undefined &&
+      parseSetting(next, name) !== undefined
+    ) {
+      if (kept.length > 0 && kept[kept.length - 1]!.trim() === "") kept.pop();
+      index += 1;
+      removed = true;
+      continue;
+    }
+    kept.push(line);
+  }
+  return { text: kept.join("\n"), removed };
+}
+
+/**
+ * Takes this tool's export back out of every profile it writes or
+ * reads, returning what each file's removal did. A line setting the
+ * variable that this tool did not write is reported and left alone: it
+ * is a person's own, whatever it says.
+ */
+export async function unexportFromProfiles(
+  name: string,
+  env: Environment = Deno.env.get,
+  os: string = Deno.build.os,
+): Promise<ProfileRemoval[]> {
+  const removals: ProfileRemoval[] = [];
+  const paths = [...profileCandidates(env, os), ...profilesToInspect(env)];
+  for (const path of paths) {
+    const text = await readIfPresent(path);
+    if (text === undefined) continue;
+    const stripped = stripMarkedBlock(text, name);
+    if (stripped.removed) {
+      await Deno.writeTextFile(path, stripped.text);
+      removals.push({ path, outcome: "removed" });
+      continue;
+    }
+    const existing = parseSetting(text, name);
+    if (existing !== undefined) {
+      removals.push({ path, outcome: "kept", existing: existing.line });
+    }
+  }
+  return removals;
 }
 
 /** The command that loads a profile into the shell already running. */

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -114,14 +114,17 @@ function zshDir(env: Environment, home: string): string {
 /**
  * Profiles that are not written but are read for a setting already
  * there, because a shell reads them after the one written and what they
- * say would win. A zsh reads .zshrc after .zshenv.
+ * say would win. A zsh reads .zshenv first and then, depending on how
+ * the shell was started, .zprofile, .zshrc, and .zlogin.
  */
 export function profilesToInspect(
   env: Environment = Deno.env.get,
 ): string[] {
   const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
   if (home === undefined || home.length === 0) return [];
-  return shellKind(env) === "zsh" ? [join(zshDir(env, home), ".zshrc")] : [];
+  if (shellKind(env) !== "zsh") return [];
+  const dir = zshDir(env, home);
+  return [".zprofile", ".zshrc", ".zlogin"].map((name) => join(dir, name));
 }
 
 /** A path split at the home directory, when it sits under one. */
@@ -412,13 +415,16 @@ export interface ProfileRemoval {
 }
 
 /**
- * Takes the marked block out of a profile's text. The blank line this
- * tool put in front of the marker goes with it, so removing what was
- * added leaves the file as it stood.
+ * Takes the marked block out of a profile's text. Only a block whose
+ * line is word for word the one this tool writes comes out: a marker
+ * over something a person has since edited names their line now,
+ * whatever the comment above it says. The blank line this tool put in
+ * front of the marker goes with it, so removing what was added leaves
+ * the file as it stood.
  */
 export function stripMarkedBlock(
   text: string,
-  name: string,
+  written: string,
 ): { text: string; removed: boolean } {
   const lines = text.split("\n");
   const kept: string[] = [];
@@ -427,8 +433,7 @@ export function stripMarkedBlock(
     const line = lines[index]!;
     const next = lines[index + 1];
     if (
-      line.trim() === MARKER && next !== undefined &&
-      parseSetting(next, name) !== undefined
+      line.trim() === MARKER && next !== undefined && next.trim() === written
     ) {
       if (kept.length > 0 && kept[kept.length - 1]!.trim() === "") kept.pop();
       index += 1;
@@ -441,6 +446,33 @@ export function stripMarkedBlock(
 }
 
 /**
+ * Replaces a profile's whole text through a temporary file in the same
+ * directory, keeping the file's own permissions. A shell startup file
+ * left half written is a shell that fails to start, so the replacement
+ * is never partial.
+ */
+export async function replaceFile(
+  path: string,
+  text: string,
+): Promise<void> {
+  const temporary = `${path}.${crypto.randomUUID()}.tmp`;
+  try {
+    await Deno.writeTextFile(temporary, text);
+    try {
+      const mode = (await Deno.stat(path)).mode;
+      if (mode !== null && mode !== undefined) {
+        await Deno.chmod(temporary, mode & 0o7777).catch(() => {});
+      }
+    } catch {
+      // No file to take permissions from; the new one keeps its own.
+    }
+    await Deno.rename(temporary, path);
+  } finally {
+    await Deno.remove(temporary).catch(() => {});
+  }
+}
+
+/**
  * Takes this tool's export back out of every profile it writes or
  * reads, returning what each file's removal did. A line setting the
  * variable that this tool did not write is reported and left alone: it
@@ -448,17 +480,20 @@ export function stripMarkedBlock(
  */
 export async function unexportFromProfiles(
   name: string,
+  value: string,
   env: Environment = Deno.env.get,
   os: string = Deno.build.os,
 ): Promise<ProfileRemoval[]> {
   const removals: ProfileRemoval[] = [];
+  const home = readEnv("HOME", env) ?? readEnv("USERPROFILE", env);
+  const written = exportLine(shellKind(env), name, value, home);
   const paths = [...profileCandidates(env, os), ...profilesToInspect(env)];
   for (const path of paths) {
     const text = await readIfPresent(path);
     if (text === undefined) continue;
-    const stripped = stripMarkedBlock(text, name);
+    const stripped = stripMarkedBlock(text, written);
     if (stripped.removed) {
-      await Deno.writeTextFile(path, stripped.text);
+      await replaceFile(path, stripped.text);
       removals.push({ path, outcome: "removed" });
       continue;
     }

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -13,6 +13,7 @@
  */
 
 import { dirname, join } from "@std/path";
+import { replaceFile } from "./test-records-atomic-write.ts";
 import { type Environment, readEnv } from "@commonfabric/test-support/records";
 
 /** The comment that marks the lines this tool wrote. */
@@ -443,33 +444,6 @@ export function stripMarkedBlock(
     kept.push(line);
   }
   return { text: kept.join("\n"), removed };
-}
-
-/**
- * Replaces a profile's whole text through a temporary file in the same
- * directory, keeping the file's own permissions. A shell startup file
- * left half written is a shell that fails to start, so the replacement
- * is never partial.
- */
-export async function replaceFile(
-  path: string,
-  text: string,
-): Promise<void> {
-  const temporary = `${path}.${crypto.randomUUID()}.tmp`;
-  try {
-    await Deno.writeTextFile(temporary, text);
-    try {
-      const mode = (await Deno.stat(path)).mode;
-      if (mode !== null && mode !== undefined) {
-        await Deno.chmod(temporary, mode & 0o7777).catch(() => {});
-      }
-    } catch {
-      // No file to take permissions from; the new one keeps its own.
-    }
-    await Deno.rename(temporary, path);
-  } finally {
-    await Deno.remove(temporary).catch(() => {});
-  }
 }
 
 /**


### PR DESCRIPTION
Three things stood between an agent's test runs and the history they belong in, and one thing stood between a person and undoing any of it.

The export went into a profile an agent never reads. For zsh, setup wrote .zshrc, which only interactive shells read — and a run an agent starts is the definition of a shell nobody is typing into. It now goes in .zshenv, which every zsh reads however it was started, and .zshrc is read but not written, so a line there that would win over the one just written is reported rather than silently overridden. An agent whose harness runs commands through no shell at all is reached by its harness's own configuration, which setup now writes: the harnesses it knows sit in a table with room for the next, and one whose directory is absent is left alone, so nothing creates configuration for a program this machine does not run. Those are other programs' files, so the rules are stricter than for a profile. A configuration that does not parse is reported and left exactly as it was, since rewriting it would discard everything it holds; one already carrying the variable with another value is left alone the same way; everything else in the file survives the edit; and the new text goes to a temporary file beside the real one and is renamed over it, so what a harness reads is either what it was or what it should be and never half of each.

The run context could not tell an agent's run from a person's unless somebody set CF_TEST_AGENT in every checkout the agents work in, which for a fleet spread over dozens of them is a variable nobody will keep up to date. The harnesses already announce themselves in the environment they hand the commands they run, so with CF_TEST_AGENT unset the label is the harness's name — claude-code, cursor, codex, or agent for one that says only that much. The names are fixed strings rather than anything the harness reports about itself, so an upgrade does not split an agent's history in two. CF_TEST_AGENT still overrides it, and a person's terminal carries none of those variables, so their runs stay unlabeled and a consumer wanting human runs alone reads the records with no agent field.

Undoing all of that by hand meant knowing the key file, the delivery identity, the profile, and each harness's configuration, and knowing which line in the profile was the tool's. `uninstall` does it: both files go, the directory goes with them when nothing else is in it, the marked block comes out of every profile — along with the blank line it put in front of it, so the file reads as it did before — and the entry comes out of each harness's configuration, taking an emptied env block with it. A line or value somebody else set is reported and left, because it is theirs whatever it says. Records that were spooled and never shipped stay where they are: they are the one thing here that cannot be recreated, a later key ships them, and the command says where they sit rather than deciding on someone's behalf. It also says the two things it does not do — the service account and its key still exist, so a leaked key is made useless by minting a replacement and not by uninstalling, and records already in the store stay there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

