### PR TITLE
fix(test-records): revoke a person's old key before minting the new one

### DIFF
--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -123,10 +123,13 @@ accounts of people with no pull-request activity for a month and
 re-enables them when they return — the same key file simply starts
 working again.
 
-You hold one live key: minting revokes the previous ones, so
-`deno task test-records-key setup --rotate` is how a lost or leaked key
-is rotated, and a second machine gets the existing key file copied to it
-rather than a fresh mint that would kill the first machine's.
+You hold one live key: minting revokes the previous ones before it
+creates the new one, so `deno task test-records-key setup --rotate` is
+how a lost or leaked key is rotated, and a second machine gets the
+existing key file copied to it rather than a fresh mint that would kill
+the first machine's. A mint that fails after the revocation leaves you
+with no key rather than two; the next run says so, and running setup
+again mints one.
 
 ## How records move
 

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -144,8 +144,9 @@ service accounts (`test-records-gh-<username>`, the login lowercased)
 with create on their own `submissions/local/<username>/` folders, minted
 by a dispatch-gated workflow and delivered sealed to a
 requester-generated X25519 identity. Minting revokes the account's
-previous keys once the new one exists — a person holds one live key, and
-re-requesting is how a lost or compromised key is rotated — and a daily
+previous keys before the new one exists — a person holds one live key,
+never two, and re-requesting is how a lost or compromised key is
+rotated — and a daily
 janitor disables accounts after a month without pull-request activity
 and re-enables them on return. The **compactor**, when provisioned,
 holds create on `aggregated/` and rewrites each closed day of raw

--- a/tasks/test-records-mint.test.ts
+++ b/tasks/test-records-mint.test.ts
@@ -296,7 +296,7 @@ describe("test-records-mint", () => {
       expect(log[0]?.url).toContain("keyTypes=USER_MANAGED");
     });
 
-    it("revokes every key the account held before", async () => {
+    it("revokes every key the account held before minting one", async () => {
       const log: { method: string; url: string; body?: string }[] = [];
       await mintKey(
         {
@@ -311,9 +311,9 @@ describe("test-records-mint", () => {
                 ],
               },
             },
+            { status: 200, json: {} },
+            { status: 200, json: {} },
             { status: 200, json: { privateKeyData: keyData } },
-            { status: 200, json: {} },
-            { status: 200, json: {} },
           ], log),
         },
         "sa@x",
@@ -323,9 +323,18 @@ describe("test-records-mint", () => {
       expect(deletes.length).toBe(2);
       expect(deletes[0]?.url).toContain("/keys/old1");
       expect(deletes[1]?.url).toContain("/keys/old2");
+      // The account never holds two live keys, so the new one is created
+      // only once the old ones are gone.
+      expect(log.map((entry) => entry.method)).toEqual([
+        "GET",
+        "DELETE",
+        "DELETE",
+        "POST",
+      ]);
     });
 
-    it("throws when a superseded key cannot be revoked", async () => {
+    it("throws before minting when a key cannot be revoked", async () => {
+      const log: { method: string; url: string; body?: string }[] = [];
       await expect(mintKey(
         {
           token: "t",
@@ -336,13 +345,33 @@ describe("test-records-mint", () => {
                 keys: [{ name: "projects/p/serviceAccounts/sa@x/keys/old" }],
               },
             },
-            { status: 200, json: { privateKeyData: keyData } },
+            { status: 500 },
+          ], log),
+        },
+        "sa@x",
+        "octocat",
+      )).rejects.toThrow("revoking");
+      // Nothing was created, so no key is left that nobody holds.
+      expect(log.some((entry) => entry.method === "POST")).toBe(false);
+    });
+
+    it("names the permission a refused revocation needs", async () => {
+      await expect(mintKey(
+        {
+          token: "t",
+          fetchImpl: sequenceFetch([
+            {
+              status: 200,
+              json: {
+                keys: [{ name: "projects/p/serviceAccounts/sa@x/keys/old" }],
+              },
+            },
             { status: 403 },
           ], []),
         },
         "sa@x",
         "octocat",
-      )).rejects.toThrow("revoking");
+      )).rejects.toThrow("iam.serviceAccountKeys.delete");
     });
   });
 

--- a/tasks/test-records-mint.ts
+++ b/tasks/test-records-mint.ts
@@ -254,10 +254,18 @@ export function isAccountNotVisible(
 
 /**
  * Mints one key and returns the key file JSON with cf_username added.
- * Every user-managed key the account held before is deleted once the new
- * one exists: a person holds one live key, so re-requesting rotates —
- * a lost or compromised key stops working the moment its replacement is
- * minted — and the account can never creep toward the key limit.
+ * Every user-managed key the account held is revoked before the new one
+ * is created: a person holds one live key, so re-requesting rotates, and
+ * a lost or compromised key stops working as early as it can rather than
+ * as late as it can.
+ *
+ * Revoking first is also what makes a failure part way through leave
+ * nothing behind. A mint that fails after creating a key would leave one
+ * nobody holds, live, counting against the ten a service account may
+ * have and visible to no one. A revoke that fails leaves the person with
+ * the key they already had, and a mint that fails after revoking leaves
+ * them with none — which their next test run tells them, and which
+ * running the setup command again fixes.
  */
 export async function mintKey(
   client: GcpClient,
@@ -280,6 +288,20 @@ export async function mintKey(
     .map((key) => key.name)
     .filter((name): name is string => typeof name === "string");
 
+  for (const name of superseded) {
+    const deleted = await gcp(client, "DELETE", `${IAM}/${name}`);
+    if (deleted.status !== 200) {
+      throw new Error(
+        `revoking the superseded key ${name} failed: HTTP ${deleted.status}` +
+          (deleted.status === 403
+            ? "; the broker's role is missing " +
+              "iam.serviceAccountKeys.delete, without which no key can be " +
+              "rotated (infra: tofu/test-records)"
+            : ""),
+      );
+    }
+  }
+
   const minted = await gcp(client, "POST", `${account}/keys`, {});
   if (minted.status !== 200) {
     throw new Error(
@@ -291,15 +313,6 @@ export async function mintKey(
   const keyData = (minted.json as { privateKeyData?: string }).privateKeyData;
   if (keyData === undefined) {
     throw new Error("the key response carried no privateKeyData");
-  }
-
-  for (const name of superseded) {
-    const deleted = await gcp(client, "DELETE", `${IAM}/${name}`);
-    if (deleted.status !== 200) {
-      throw new Error(
-        `revoking the superseded key ${name} failed: HTTP ${deleted.status}`,
-      );
-    }
   }
 
   const decoded = atob(keyData);


### PR DESCRIPTION
Minting for someone who already held a key failed, and failed after creating one: the run got HTTP 403 deleting the key it was replacing, having already minted its replacement. The key it made was never sealed or published, so nobody holds it, and it is live on the account — counting against the ten a service account may have, visible to no one, and impossible for that same broker to clean up, since deleting is the permission it turned out not to have.

Revoking now happens before minting. The account never holds two live keys, and a failure part way through leaves nothing behind rather than something nobody can see: a revocation that fails leaves the person the key they already had, and a mint that fails after revoking leaves them with none, which their next test run reports and which running setup again fixes. Being left without a key is a state that announces itself; an extra live key is not.

A refused revocation now also says what would let it through, since the answer is a permission in another repository and not anything in this one.

The broker cannot delete keys at all today, so rotation has never worked — the first mint for a person succeeds because there is nothing to revoke, and every mint after it fails. That is a change to the custom role in the infra repository's tofu/test-records root, without which this reordering only moves where the same failure lands.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

