### PR TITLE
perf: prepare the perf skill and the server for the serverExecution ON arm

### DIFF
--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -93,7 +93,9 @@ matches the capture:
   parent's total is its own span rather than the sum of its children's. Run the
   process under `--inspect` and the marks and timestamps land on the DevTools
   timeline beside the samples, so zooming to the phase is a drag rather than
-  arithmetic.   Deno has no `--cpu-prof`: V8 rejects the flag, which is Node's rather than
+  arithmetic.
+
+  Deno has no `--cpu-prof`: V8 rejects the flag, which is Node's rather than
   V8's. To get a `.cpuprofile` out of the `cf test` process, drive V8's profiler
   from inside it with `node:inspector`, which Deno implements — connect a
   `Session`, `Profiler.enable`, `Profiler.start` around the phase, and
@@ -300,7 +302,75 @@ has often stopped early.
 
 ## The server side
 
-Not covered here yet. A toolshed is a Deno process, so `--inspect` and the
-DevTools profiler reach it, and OTEL spans exist behind `OTEL_ENABLED` with a
-collector to receive them. Whoever profiles the server first should write the
-concrete steps into this document, the way the steps above are written.
+A toolshed carries the same timing machinery as everything above, and reports it
+over HTTP. Start there; a CPU profile of the server is step 3 here as much as it
+is above.
+
+### Which arm is this?
+
+Under the `serverExecution` ON arm the server runs the derivations, so where you
+point the instruments changes. Two probes settle it, and both belong in the
+record beside any number:
+
+```bash
+curl -s "$API_URL/api/health/stats" | jq 'has("servingLoop")'
+```
+
+```bash
+curl -s "$API_URL/api/meta" | jq .shellServerExecutionDefine
+```
+
+The first is true exactly when that process is serving. The second says what the
+browser shell was *built* with — the define is baked at build time, so a
+source-run toolshed serves the OFF-arm shell whatever its own environment says.
+Clients declare their own posture from their own environment too: `cf` and the
+integration harnesses announce `serverExecution=false` unless
+`EXPERIMENTAL_SERVER_EXECUTION=true` is set for them as well, and a client on
+the other arm from its server measures neither.
+
+### Read `/api/health/stats`
+
+One request, no harness, and it answers most of step 0 and step 1 for the server
+process:
+
+- `timingStats` — the process's logger timing statistics, keyed exactly as the
+  `cf test` rows are and carrying `count`, `totalTime`, `min`/`max`, `p50` and
+  `p95`. A serving toolshed runs the runtime, so `scheduler/run/action`,
+  `traverse` and `runner/start/*` appear here meaning the *server's* work.
+- `logCounts` — the same per-logger counts, which is how a warning storm shows
+  up as a number rather than as a log to grep.
+- `slowQueries` — the last hundred query or watch operations over 100 ms, with
+  the space and the root and watch counts.
+- `servingLoop` — the serving loop's counters
+  ([`serving-loop.md` §7](../../specs/server-side-execution/serving-loop.md)),
+  present only when this process serves. `settle.series` is a ready-made
+  per-authored-input latency series: admission to watermark coverage, with the
+  wave and cycle counts behind each entry.
+
+Two things to know before quoting any of it. Everything accumulates for the
+process's whole life, across every space it has served, so capture before and
+after a phase and diff rather than reading an absolute. And each timing row
+carries a full CDF, which makes the response hundreds of kilobytes after even a
+single deploy — sample it at phase boundaries; polling it is its own load.
+
+The serving loop's own phases are wrapped as `executor/wave/cycle`, `/drain` and
+`/settle`. Read them against `wavesBudgetExhausted`, which is a censored
+measurement: a wave that overruns the flush deadline reports that deadline
+however far past it the wave ran, so the counter says how often and the
+span says by how much. `memory/frame/queue` against `memory/frame/handle` splits
+a connection's frame time into waiting behind earlier frames and doing its own
+work, and `memory/flush/queue` against `memory/flush/refresh` does the same for
+the push side. In each pair, only the second is the frame's own cost — a queue
+time far above every handle time is head-of-line blocking, and the fix is at the
+frame in front.
+
+### Profile the process
+
+A toolshed is a Deno process, so the recipes in step 2 apply to it: run it under
+`--inspect` and attach DevTools, or drive V8's profiler from inside it with
+`node:inspector`. Take the profile over a bracketed phase — the marks have to be
+in this process, which for a server means the health-stats capture either side
+rather than a mark in the test that provoked it.
+
+OTEL spans exist behind `OTEL_ENABLED` with a collector to receive them, and are
+the right instrument for a deployed server rather than a local investigation.

--- a/docs/development/debugging/profiling.md
+++ b/docs/development/debugging/profiling.md
@@ -325,8 +325,17 @@ browser shell was *built* with — the define is baked at build time, so a
 source-run toolshed serves the OFF-arm shell whatever its own environment says.
 Clients declare their own posture from their own environment too: `cf` and the
 integration harnesses announce `serverExecution=false` unless
-`EXPERIMENTAL_SERVER_EXECUTION=true` is set for them as well, and a client on
-the other arm from its server measures neither.
+`EXPERIMENTAL_SERVER_EXECUTION=true` is set for them as well.
+
+A client on the other arm from its server is worth naming precisely, because it
+is more dangerous than a broken instrument. Every probe keeps reporting
+faithfully — the server's timing statistics and its serving-loop counters are
+true readings of what that server did. What they are readings *of* is a
+configuration that ships in neither arm: an OFF-declared client still commits
+its own derivations while the serving loop derives them too, so wave counts, the
+settle series and the amplification ratio all describe a system nobody runs. The
+numbers look fine. Check both ends before the run rather than trying to discount
+them afterwards.
 
 ### Read `/api/health/stats`
 
@@ -347,22 +356,43 @@ process:
   per-authored-input latency series: admission to watermark coverage, with the
   wave and cycle counts behind each entry.
 
-Two things to know before quoting any of it. Everything accumulates for the
-process's whole life, across every space it has served, so capture before and
-after a phase and diff rather than reading an absolute. And each timing row
-carries a full CDF, which makes the response hundreds of kilobytes after even a
-single deploy — sample it at phase boundaries; polling it is its own load.
+Everything here accumulates for the process's whole life, across every space it
+has served, so a phase is a difference between two captures rather than any
+single one — and **only `count` and `totalTime` subtract**. `min`, `max`, `p50`,
+`p95` and the CDF describe the whole lifetime; differencing them yields a number
+that looks like a phase percentile and is not one. What a diff of the two
+additive fields does give you honestly is the phase's call count and its mean.
+
+For a phase *distribution*, the process has to have seen only the phase, so
+start a fresh toolshed and capture once at the end. The logger does carry a
+delta reservoir (`resetAllTimingBaselines()`, surfaced on `globalThis` and read
+back as the `*SinceBaseline` fields and `cdfSinceBaseline`), but nothing on the
+health route sets it, so it is reachable in a browser console and not in a
+server you are talking to over HTTP.
+
+Whichever way you capture, capture sparingly: each timing row carries its whole
+CDF, which puts the response into the hundreds of kilobytes after even a single
+deploy. Read it at phase boundaries — polling it is its own load.
 
 The serving loop's own phases are wrapped as `executor/wave/cycle`, `/drain` and
 `/settle`. Read them against `wavesBudgetExhausted`, which is a censored
 measurement: a wave that overruns the flush deadline reports that deadline
-however far past it the wave ran, so the counter says how often and the
-span says by how much. `memory/frame/queue` against `memory/frame/handle` splits
-a connection's frame time into waiting behind earlier frames and doing its own
-work, and `memory/flush/queue` against `memory/flush/refresh` does the same for
-the push side. In each pair, only the second is the frame's own cost — a queue
-time far above every handle time is head-of-line blocking, and the fix is at the
-frame in front.
+however far past it the wave ran, so the counter says how often and the span
+says by how much.
+
+`memory/frame/queue` against `memory/frame/handle` splits an inbound frame's
+time into waiting behind the frames already in flight on its connection and
+doing its own work. Only the second is that frame's cost, so a queue time far
+above every handle time is head-of-line blocking, and the fix is at the frame in
+front rather than at the one that reported it.
+
+`memory/flush/queue` against `memory/flush/refresh` is the same split one level
+coarser, on the push side: a flush **pass**, never a frame. `refresh` covers
+every dirty space the pass selected and every frame those sessions were owed, so
+a large batched fan-out and one expensive send are the same number here and
+dividing it to recover a per-frame cost is unsound. Read it as a bound instead —
+a client's push waits at least the refresh delay plus these two — and reach for
+`servingLoop.push` when the question is which sessions a batch served.
 
 ### Profile the process
 

--- a/packages/memory/test/v2-frame-timing.test.ts
+++ b/packages/memory/test/v2-frame-timing.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { getLogger } from "@commonfabric/utils/logger";
+
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+
+// A connection handles its frames one at a time, so what a frame costs
+// splits in two: how long it waited behind the frames already in flight,
+// and how long it took once it started. The server records the halves
+// under separate keys, `/api/health/stats` reports them as its
+// `timingStats.memory` block, and both
+// `docs/development/debugging/profiling.md` and
+// `skills/perf-investigation/SKILL.md` name them as the way to tell
+// head-of-line blocking from expensive work.
+//
+// That makes the KEY NAMES load-bearing documentation with no other gate
+// behind them: nothing else in the repository fails when a rename leaves
+// those two documents pointing at rows that no longer exist. These tests
+// are that gate, so they assert the names and the split — never a
+// duration, which is a property of the machine.
+
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+/** Statistics accumulate per logger for the process's life, so a count is
+ * only readable as a delta against what earlier tests left behind. */
+const frameCounts = (): { queue: number; handle: number } => {
+  const timing = getLogger("memory");
+  return {
+    queue: timing.getTimeStats("memory", "frame", "queue")?.count ?? 0,
+    handle: timing.getTimeStats("memory", "frame", "handle")?.count ?? 0,
+  };
+};
+
+describe("v2 server frame timing", () => {
+  it("records a waiting half and a working half for each frame received", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-records"),
+    });
+    try {
+      const before = frameCounts();
+      const connection = server.connect(() => {});
+      await connection.receive(encodeMemoryBoundary(HELLO));
+
+      const after = frameCounts();
+      expect(after.queue - before.queue).toBe(1);
+      expect(after.handle - before.handle).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("records one of each half per frame when frames arrive faster than they are handled", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-queues"),
+    });
+    try {
+      const connection = server.connect(() => {});
+      await connection.receive(encodeMemoryBoundary(HELLO));
+
+      const before = frameCounts();
+      // Handed over without awaiting the first, which is how a socket
+      // delivers: the second frame waits in the ordered chain. Both halves
+      // are counted per FRAME, so an instrument that measured the chain's
+      // turn instead of the frame would come up short here and pass above.
+      const frame = encodeMemoryBoundary({
+        type: "session.watch.set",
+        requestId: "watch",
+        space: "did:key:z6Mk-frame-timing-queues",
+        sessionId: "never-opened",
+        watches: [],
+      });
+      await Promise.all([
+        connection.receive(frame),
+        connection.receive(frame),
+        connection.receive(frame),
+      ]);
+
+      const after = frameCounts();
+      expect(after.queue - before.queue).toBe(3);
+      expect(after.handle - before.handle).toBe(3);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/memory/test/v2-frame-timing.test.ts
+++ b/packages/memory/test/v2-frame-timing.test.ts
@@ -41,6 +41,14 @@ const frameCounts = (): { queue: number; handle: number } => {
   };
 };
 
+const flushCounts = (): { queue: number; refresh: number } => {
+  const timing = getLogger("memory");
+  return {
+    queue: timing.getTimeStats("memory", "flush", "queue")?.count ?? 0,
+    refresh: timing.getTimeStats("memory", "flush", "refresh")?.count ?? 0,
+  };
+};
+
 describe("v2 server frame timing", () => {
   it("records a waiting half and a working half for each frame received", async () => {
     const server = new Server({
@@ -90,6 +98,38 @@ describe("v2 server frame timing", () => {
       const after = frameCounts();
       expect(after.queue - before.queue).toBe(3);
       expect(after.handle - before.handle).toBe(3);
+    } finally {
+      await server.close();
+    }
+  });
+  it("times a flush as one pass over every dirty space, not once per frame", async () => {
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://frame-timing-flush"),
+      subscriptionRefreshDelayMs: "manual",
+    });
+    try {
+      const before = flushCounts();
+      // Two spaces dirtied before a single flush. The pass fans out to
+      // both, so a pair of counts that tracked SENDS would read two here.
+      // Reading one is the property the walkthrough and the skill both
+      // lean on: `memory/flush/refresh` is a batch cost, and dividing it
+      // to recover what one frame cost is unsound.
+      await server.writeDocument(
+        "did:key:z6Mk-frame-timing-flush-a",
+        "of:doc:a",
+        { flushed: true },
+      );
+      await server.writeDocument(
+        "did:key:z6Mk-frame-timing-flush-b",
+        "of:doc:b",
+        { flushed: true },
+      );
+      await server.flushSessions();
+
+      const after = flushCounts();
+      expect(after.queue - before.queue).toBe(1);
+      expect(after.refresh - before.refresh).toBe(1);
     } finally {
       await server.close();
     }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -5060,12 +5060,15 @@ export class Server {
 
   async flushSessions(spaces?: Iterable<string>): Promise<void> {
     this.cancelScheduledRefresh();
-    // The push side's half of the frame accounting the connection's receive
-    // keeps for the pull side: `memory/flush/queue` is how long this pass
-    // waited for the flush in front of it, `memory/flush/refresh` how long
-    // its own evaluation-and-send took. A client's push latency is the sum
-    // of the two plus the refresh delay, and which of them dominates says
-    // whether the server is flushing too often or evaluating too much.
+    // The same waiting-against-working split the connection's receive keeps,
+    // one level coarser: a flush PASS, not a frame. `memory/flush/queue` is
+    // how long this pass waited for the flush in front of it,
+    // `memory/flush/refresh` how long its own evaluation and sending took —
+    // across every dirty space the pass selected and every frame those
+    // sessions were owed, so it is a batch cost and dividing it by anything
+    // to recover a per-frame one is unsound. What it does bound is how long
+    // a client's push can sit behind the server's own fan-out: push latency
+    // is at least the refresh delay plus these two.
     const requestedAt = performance.now();
     const run = async () => {
       const refreshStart = Date.now();

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2,6 +2,7 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 
 import type { FabricPlainObject } from "@commonfabric/api";
+import { getLogger } from "@commonfabric/utils/logger";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { SpanStatusCode, trace } from "@opentelemetry/api";
 
@@ -137,6 +138,15 @@ export { SessionRegistry } from "./session-registry.ts";
 // OTLP SDK installed. Spans created here are purely additive observability and
 // do not affect write/fan-out behavior.
 const tracer = trace.getTracer("memory-server", "1.0.0");
+
+/**
+ * Timing-only logger. It never logs — the statistics behind `time()` are
+ * recorded whether or not a logger is enabled, and `/api/health/stats`
+ * reports them as the `timingStats.memory` block — so the frames a
+ * connection handles are measurable on a deployed server without turning
+ * anything on.
+ */
+const timing = getLogger("memory", { enabled: false });
 
 const SUBSCRIPTION_REFRESH_DELAY_MS = 5;
 const MIN_REFRESH_QUEUE_DRAIN_WAIT_MS = 500;
@@ -594,11 +604,25 @@ class Connection {
 
   async receive(payload: string): Promise<void> {
     this.#pendingReceives += 1;
+    // A connection handles its frames one at a time, so a frame's cost has
+    // two halves that are fixed at opposite ends of the stack: how long it
+    // WAITED behind the frames already in flight (`memory/frame/queue`), and
+    // how long it took once it started (`memory/frame/handle`). Only the
+    // second is the frame's own work — a queue time that tracks the handle
+    // time of whatever precedes it is head-of-line blocking, and the fix is
+    // to make that other frame cheaper rather than this one.
+    const arrivedAt = performance.now();
     try {
       const previous = this.#receiving;
-      const current = previous.catch(() => undefined).then(() =>
-        this.receiveOrdered(payload)
-      );
+      const current = previous.catch(() => undefined).then(async () => {
+        const startedAt = performance.now();
+        timing.time(arrivedAt, startedAt, "memory", "frame", "queue");
+        try {
+          await this.receiveOrdered(payload);
+        } finally {
+          timing.time(startedAt, "memory", "frame", "handle");
+        }
+      });
       this.#receiving = current.then(() => undefined, () => undefined);
       return await current;
     } finally {
@@ -5036,13 +5060,23 @@ export class Server {
 
   async flushSessions(spaces?: Iterable<string>): Promise<void> {
     this.cancelScheduledRefresh();
+    // The push side's half of the frame accounting the connection's receive
+    // keeps for the pull side: `memory/flush/queue` is how long this pass
+    // waited for the flush in front of it, `memory/flush/refresh` how long
+    // its own evaluation-and-send took. A client's push latency is the sum
+    // of the two plus the refresh delay, and which of them dominates says
+    // whether the server is flushing too often or evaluating too much.
+    const requestedAt = performance.now();
     const run = async () => {
       const refreshStart = Date.now();
+      const startedAt = performance.now();
+      timing.time(requestedAt, startedAt, "memory", "flush", "queue");
       try {
         await this.refreshLoop(
           spaces === undefined ? undefined : new Set(spaces),
         );
       } finally {
+        timing.time(startedAt, "memory", "flush", "refresh");
         this.#lastRefreshDurationMs = Math.max(
           0,
           Date.now() - refreshStart,

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -1928,12 +1928,15 @@ export class SpaceServer implements TransactionSealDestination {
         // of magnitude over. This span carries the distribution the
         // counter censors, and pairs with it rather than replacing it —
         // the count says how often, the p95 says by how much.
+        //
+        // Recorded on the way out rather than from a `finally`, so a cycle
+        // that THREW contributes nothing: that path parks the space, which
+        // the counters and the loop-failed log already carry, and its
+        // duration is the time to a failure rather than the time to serve
+        // a wave. Averaging the two would be worse than missing one.
         const cycleStart = performance.now();
-        try {
-          await this.#waveCycle();
-        } finally {
-          timing.time(cycleStart, "executor", "wave", "cycle");
-        }
+        await this.#waveCycle();
+        timing.time(cycleStart, "executor", "wave", "cycle");
         if (!this.#active || this.#parkRequested) break;
         if (!this.#hasWork()) {
           const idleParkMs = this.#options.policy?.idleParkMs ??
@@ -3294,9 +3297,12 @@ export class SpaceServer implements TransactionSealDestination {
         }
       }
     } finally {
-      timing.time(settleStart, "executor", "wave", "settle");
       if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
     }
+    // After the timer is cleared and outside the `finally`, for the reason
+    // the cycle span is: a settle that threw is a failed wave, not a slow
+    // one, and folding its duration in would blunt the measurement.
+    timing.time(settleStart, "executor", "wave", "settle");
 
     // Promote settle-gated re-armed roots (stage P2-F): a TRUE settle
     // proved every frame ≤ batchHead applied — the re-arming commit's

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -121,6 +121,16 @@ import type { PostCommitSideEffect } from "../cfc/types.ts";
 
 const logger = getLogger("space-server", { enabled: true, level: "warn" });
 
+/**
+ * Timing-only logger for the wave's phases. The §7 counters say how many
+ * waves ran and how many hit the deadline; these say how long they took and
+ * where inside one the time went. Recorded whether or not a logger is
+ * enabled, and reported by `/api/health/stats` as `timingStats.executor` —
+ * so a serving toolshed answers "how long is a wave" over HTTP, with
+ * nothing switched on.
+ */
+const timing = getLogger("executor", { enabled: false });
+
 /** Consecutive not-yet-loadable deferrals of ONE demanded root after
  * which the root counts as STUCK (`stats.structureLoadStuck`, once per
  * crossing) and the loop WARNS (`structure-load-stuck`, again at each
@@ -1911,7 +1921,19 @@ export class SpaceServer implements TransactionSealDestination {
     this.#loopRunning = true;
     try {
       while (this.#active && !this.#parkRequested) {
-        await this.#waveCycle();
+        // `wavesBudgetExhausted` says a cycle reached the flush deadline
+        // and nothing more: every overrunning wave reports that same
+        // deadline however far past it the wave ran, so the counter alone
+        // cannot separate a loop barely over its budget from one an order
+        // of magnitude over. This span carries the distribution the
+        // counter censors, and pairs with it rather than replacing it —
+        // the count says how often, the p95 says by how much.
+        const cycleStart = performance.now();
+        try {
+          await this.#waveCycle();
+        } finally {
+          timing.time(cycleStart, "executor", "wave", "cycle");
+        }
         if (!this.#active || this.#parkRequested) break;
         if (!this.#hasWork()) {
           const idleParkMs = this.#options.policy?.idleParkMs ??
@@ -3163,8 +3185,12 @@ export class SpaceServer implements TransactionSealDestination {
     // that under the deadline race below): dispatch auto-loads a
     // handler's piece itself (ensurePieceRunning), and a genuinely
     // cold view defers on the input/backstop cadence — the
-    // creation-race arm the deferral budget was sized for.
+    // creation-race arm the deferral budget was sized for. Being ahead of
+    // the race and fully awaited is also why the drain is timed: it is
+    // wave duration that no deadline bounds and no counter reports.
+    const drainStart = performance.now();
     const drainedEvents = await this.#drainStreamEvents(runtime);
+    timing.time(drainStart, "executor", "wave", "drain");
     this.#retireAckedEffects(runtime);
 
     // Settle to quiescence under the flush deadline: idle() is the wave
@@ -3211,6 +3237,11 @@ export class SpaceServer implements TransactionSealDestination {
         this.#feedArrived?.resolve();
       });
     let exhausted = false;
+    // The segment the deadline actually cuts. Read against
+    // `executor/wave/cycle`: a settle at the deadline inside a much longer
+    // cycle means the wave's cost is the seal and the commit, not the
+    // derivations, and the two are fixed in different places.
+    const settleStart = performance.now();
     try {
       while (true) {
         // RACE the deadline (serving-loop.md §3's second exhaustion
@@ -3263,6 +3294,7 @@ export class SpaceServer implements TransactionSealDestination {
         }
       }
     } finally {
+      timing.time(settleStart, "executor", "wave", "settle");
       if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
     }
 

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -46,6 +46,7 @@ import {
 } from "../src/executor/watermark.ts";
 import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 import { getArtifactEntryRef } from "../src/builder/pattern-metadata.ts";
+import { getLogger } from "@commonfabric/utils/logger";
 
 class SharedServerStorageManager extends EmulatedStorageManager {
   // Delegate to the base connectTo (shared-harness extraction, CT-1962):
@@ -380,6 +381,61 @@ describe("stage F serving loop", () => {
     expect(
       watermarkCell(servingRuntime!, space).get()?.seq,
     ).toBeGreaterThanOrEqual(authored2);
+  });
+
+  it("records a wave's duration and its phases as timing spans, which the §7 counters cannot carry", async () => {
+    // `wavesBudgetExhausted` is a censored measurement: a wave that
+    // overruns the flush deadline reports that deadline however far past
+    // it the wave ran, so the counter alone cannot tell a loop barely
+    // over its budget from one an order of magnitude over. These spans
+    // carry the distribution, `/api/health/stats` reports them as its
+    // `timingStats.executor` block, and both
+    // `docs/development/debugging/profiling.md` and
+    // `skills/perf-investigation/SKILL.md` name the keys as the way to
+    // read a wave's cost. Nothing else fails when a rename leaves those
+    // documents pointing at rows that no longer exist, so the assertion
+    // here is on the KEY NAMES — never on a duration, which belongs to
+    // the machine.
+    const timing = getLogger("executor");
+    const cycles = () =>
+      timing.getTimeStats("executor", "wave", "cycle")?.count ?? 0;
+    const drains = () =>
+      timing.getTimeStats("executor", "wave", "drain")?.count ?? 0;
+    const settles = () =>
+      timing.getTimeStats("executor", "wave", "settle")?.count ?? 0;
+    const before = { cycle: cycles(), drain: drains(), settle: settles() };
+
+    host = newHost({ flushDeadlineMs: 5_000, idleParkMs: 600_000 });
+    openClient();
+    const engine = await server.engineForSpace(space);
+
+    const clientArg = clientRuntime.getCell<{ n: number }>(
+      space,
+      "wave-timing-arg",
+      undefined,
+    );
+    await clientArg.sync();
+    const tx = clientRuntime.edit();
+    clientArg.withTx(tx).set({ n: 7 });
+    expect((await tx.commit()).error).toBeUndefined();
+    const authoredSeq = Engine.serverSeq(engine);
+    await waitForSettled(clientRuntime, space, authoredSeq, {
+      timeoutMs: 10_000,
+    });
+
+    // Read with the loop stopped. A running loop records a cycle's drain
+    // before the cycle that encloses it, so the counts differ by one at an
+    // arbitrary observation point and only agree at rest.
+    await host.close();
+
+    // Every cycle runs its drain and its settle, so at rest the three
+    // counts agree — a phase recorded on only some paths through the cycle
+    // shows up here as a shortfall rather than as a silently partial
+    // picture of where a wave's time went.
+    const served = cycles() - before.cycle;
+    expect(served).toBeGreaterThanOrEqual(1);
+    expect(drains() - before.drain).toBe(served);
+    expect(settles() - before.settle).toBe(served);
   });
 
   it("retries a demanded root the loader could not start YET: demand precedes the instantiation commit (the creation race), the deferred ensure re-attempts on a later cycle, and the piece serves", async () => {

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -94,6 +94,82 @@ measurement: it is shared, its timings carry whatever else is happening to it,
 and its client sits idle for most of a read, so it settles whether a cost is
 real long before it says how large.
 
+**The server's own stats.** `/api/health/stats` on whichever toolshed the rungs
+above are talking to reports that process's timing statistics, log counts and
+slow queries, and — when it is serving — the serving loop's counters. One
+request, no harness, and under the `serverExecution` ON arm it reaches where
+most of the work now is. "The server side" in
+`docs/development/debugging/profiling.md` has the requests and the fields; the
+next section here is what to know before making them.
+
+## Which process is doing the work
+
+`serverExecution` decides where a derivation runs, and a measurement taken
+without knowing which arm it was on describes neither. Under the ON arm servers
+do the compute that is stored, clients commit only intent, and a client's own
+derivation runs divert into a process-local speculation overlay — an echo. The
+registry entry in `docs/development/EXPERIMENTAL_OPTIONS.md` defines both arms;
+`docs/specs/server-side-execution/testing.md` binds how they are measured. What
+follows is what to have in mind before pointing an instrument anywhere, the
+walkthrough's server section being where the requests and their fields live.
+
+**The posture is a fact you check, not one you set.** Which arm a server is on,
+and which arm the browser shell was _built_ for, are both one request away — and
+a client declares its own posture from its own environment, so a `cf` or a
+harness left at its default against a serving toolshed is a mixed posture that
+measures neither arm. Probe both ends before the run and record what they said
+beside the number, the way a board size is recorded.
+
+**Read the server's instruments before adding any.** The health route already
+reports the serving process's own logger statistics, under the same key names
+the pattern-test rung prints and the same ones the client records. So
+`scheduler/run/action` and `traverse` exist in both processes and mean different
+halves of one interaction, and which process a row came from is the only thing
+that distinguishes them. Say which, in every number you report.
+
+**A counter says how often; only a span says by how much.** A counter that fires
+when something hits a deadline is a censored measurement: every wave that
+overruns the flush budget reports that same budget, however far past it the wave
+ran, so the count cannot separate a loop barely over from one an order of
+magnitude over. The wave's phases are timed alongside the counters for that
+reason, and reading them together is what shows a deadline enforced by a timer
+failing to cut synchronous work. Neither replaces the other — the count for
+frequency, the span for width.
+
+**Frames are the sync point.** `waitForSettled` in
+`packages/runner/src/executor/watermark.ts` resolves when the space's watermark
+covers a given commit, riding the ordinary subscription, so it waits on a frame
+rather than polling for a rendered consequence. It is what "the server is done"
+means under ON, and `runtime.idle()` is not: a flag-ON client goes idle over its
+own echo while the durable result is still a wave away, so a harness that timed
+a write by awaiting idle is timing the speculation. Every such harness needs
+re-reading against the ON arm before its numbers mean anything.
+
+Frames are also a queue, with the two costs any queue has — waiting behind what
+is already in flight, and the work itself — and the memory server times them
+apart on both directions of the socket. Only the second is a frame's own cost. A
+queue time that dwarfs every handle time is head-of-line blocking, and it is
+fixed at the frame in front rather than at the one that reported it.
+
+That watermark helper wants a `Runtime`, so it is the Deno-side test process's
+instrument rather than the browser's. On the browser rung the equivalent is
+already in `collectBrowserLoadSummary`, whose flag-ON rows account for the echo:
+how many overlay entries were dropped late, and how many retired on the
+watermark backstop rather than on their own consequence mark. The backstop is
+the later of the two signals by construction, so its share is a read on how long
+the client held a value it had already been told about — which is the half of an
+interaction's latency that no server-side counter can see.
+
+**The workload stays uninstrumented.**
+`docs/specs/server-side-execution/testing.md` §1 makes this binding for v2
+measurement, and it is the one rule here that cuts against the rest of this
+skill: probes added to the measured path warm it and understate its cost, which
+is how v1 measured itself faster than it was. Under ON the reach is longer than
+it looks, because the server runs the same pattern code — a probe added for the
+client arm is now also running inside the wave it is timing. Instrument the
+runtime and the serving loop, which every arm shares; leave the workload
+byte-identical across arms and read the difference from outside.
+
 ## The logger names it; the profiler weighs it
 
 Use both, because neither is sufficient and the failure is asymmetric.
@@ -322,6 +398,13 @@ inferring per-operation cost by dividing the time to build one — building is a
 different curve, and the number you want for a regression is what one more costs
 at a given size.
 
+Under the `serverExecution` ON arm the pair becomes a triple, because the write
+no longer completes where it was issued: the writer's own settle is over its
+echo, the durable result lands a wave later on the server, and the render
+follows that. Split the measurement at each handover — write to echo, echo to
+watermark coverage, coverage to painted — or the one number hides which of the
+three moved.
+
 ## What your harness holds live
 
 A harness that holds more live than its subject does measures itself. This is
@@ -349,6 +432,14 @@ read turned out to be what the `cf` CLI does against the real board, at sixteen
 times the scale — which is why the deployed rung exists above. A rig that
 exaggerates a real cost and a rig that invents one look identical from inside
 the rig.
+
+Under the ON arm the stakes rise, because demand is what makes the server run
+anything at all: what a client holds live decides which derivations a wave has
+to make current before it can commit. So an over-wide sink no longer costs its
+own process alone — it enlarges every wave in that space, for every client. The
+`servingLoop.demand` counters are the server's account of it, and
+`demandedInstancesMax` against what the product would actually demand is the
+same question this section asks, answered from the other side.
 
 ## Measuring honestly
 

--- a/skills/perf-investigation/SKILL.md
+++ b/skills/perf-investigation/SKILL.md
@@ -116,9 +116,11 @@ walkthrough's server section being where the requests and their fields live.
 **The posture is a fact you check, not one you set.** Which arm a server is on,
 and which arm the browser shell was _built_ for, are both one request away — and
 a client declares its own posture from its own environment, so a `cf` or a
-harness left at its default against a serving toolshed is a mixed posture that
-measures neither arm. Probe both ends before the run and record what they said
-beside the number, the way a board size is recorded.
+harness left at its default against a serving toolshed is a mixed posture. That
+one is worth recognizing because nothing about it looks wrong: every instrument
+keeps reporting faithfully, and what it reports is a configuration that ships in
+neither arm, with both ends deriving. Probe both ends before the run and record
+what they said beside the number, the way a board size is recorded.
 
 **Read the server's instruments before adding any.** The health route already
 reports the serving process's own logger statistics, under the same key names
@@ -147,9 +149,11 @@ re-reading against the ON arm before its numbers mean anything.
 
 Frames are also a queue, with the two costs any queue has — waiting behind what
 is already in flight, and the work itself — and the memory server times them
-apart on both directions of the socket. Only the second is a frame's own cost. A
-queue time that dwarfs every handle time is head-of-line blocking, and it is
-fixed at the frame in front rather than at the one that reported it.
+apart. Only the second is a frame's own cost, so a queue time that dwarfs every
+handle time is head-of-line blocking, and it is fixed at the frame in front
+rather than at the one that reported it. The same split exists on the push side
+one level coarser, over a flush pass rather than a frame, which makes it a bound
+on push latency and not a per-frame cost to divide down.
 
 That watermark helper wants a `Runtime`, so it is the Deno-side test process's
 instrument rather than the browser's. On the browser rung the equivalent is


### PR DESCRIPTION
Server execution moves the compute that is stored to the server. This gets the performance instruments and the perf skill ready for that, and closes two gaps found by running a serving toolshed and measuring it.

## What the server already reported, and what it did not

`/api/health/stats` already returns the whole serving process's logger timing statistics — the same `n`/`total`/`p50`/`p95` rows the `cf test` rung prints, under the same key names, from the other side of the socket. Nobody had to build that, and nothing said so.

What it did not report was the serving loop itself. `packages/runner/src/executor/` carried no timing spans across 8,800 lines, and neither did the memory server, so every timing key on a serving toolshed was a client-runtime key that happened to be running server-side.

Two additions close that, both through the logger's existing statistics, so they land in `timingStats` for free and add no mechanism to explain:

- **`executor/wave/cycle`, `/drain`, `/settle`.** `wavesBudgetExhausted` is a censored measurement: every wave that overruns the flush deadline reports that same deadline, however far past it the wave ran. On one local deploy the counter said 5 of 15 waves exhausted while `cycle` max was 1,022 ms against a 100 ms deadline — the deadline is a `Promise.race` against a timer, so it cannot cut synchronous work, and a wave holding a compile is indistinguishable from one barely over budget until the span says otherwise.
- **`memory/frame/queue` vs `memory/frame/handle`**, and `memory/flush/queue` vs `/refresh`. `Connection.receive` chains onto `#receiving`, so a connection's frames serialize; `#pendingReceives` counted the depth of that queue and nothing timed residency in it. `performance.now()` at arrival and at dequeue splits waiting from working on both directions of the socket. Measured on the same deploy: frame queue max 197 ms against handle max 62 ms — head-of-line blocking, which is fixed at the frame in front rather than at the one that reported it.

## The skill, and how it divides with the walkthrough

The skill gains a section on what changes about the *question* under the ON arm. The load-bearing part is that `runtime.idle()` stops meaning "done": a flag-ON client settles over its speculation overlay while the durable result is still a wave away, so `waitForSettled` on the watermark is the sync point, and every harness that timed a write by awaiting idle is timing the echo. `packages/patterns/integration/topic-create-onscreen.test.ts` is one of them.

`docs/development/debugging/profiling.md` had a section reading "The server side: Not covered here yet… Whoever profiles the server first should write the concrete steps into this document." Those are now the steps.

The two stay split the way the skill's own preamble already declares: the walkthrough carries the requests, the fields and the traps in reading them, read while measuring; the skill carries the judgment, which has to be in mind before a rig exists, and points at the walkthrough rather than restating it. A skill is loaded into context whole, where every sentence competes with the task.

## Two things worth knowing

**The mixed-posture trap is easy to hit.** `cf` against a serving toolshed prints `serverExecution=false` — clients declare their own posture from their own environment. A run in that state measures neither arm and nothing warns you. Both probes (`servingLoop` present, `/api/meta`'s `shellServerExecutionDefine`) are now written down.

**`testing.md` §1's "workloads are uninstrumented" cuts against the rest of the skill**, so it is carried with its reason — v1's own probes warmed the measured path — and with the ON-specific sharpening: the server runs the same pattern code, so a probe added for the client arm now also runs inside the wave it is timing.

## Tests

Two files' worth, asserting the key names and the phase split — never a duration. The docs now cite these keys as the way to answer a question, and nothing else fails when a rename leaves them pointing at rows that no longer exist. Both were mutation-tested: removing either record fails its test.

The wave-timing test reads with the loop stopped. A running loop records a cycle's drain before the cycle enclosing it, so the counts differ by one at an arbitrary observation point and only agree at rest; it ran green three times over the full file.

## Verification

`deno task check` · `check-docs` (564 blocks) · `check-skill-facts` · `check-no-waitfor` · `check-conflict-markers` · `deno fmt --check` · `deno lint` · `packages/memory` 553 passed · `packages/runner` 1268 passed (7246 steps) · all `executor-*` 194 steps.

Every number quoted above came from a toolshed run with `EXPERIMENTAL_SERVER_EXECUTION=true` on an M3 Max, one `cf piece new` of `packages/patterns/counter/counter.tsx` against it — a single local deploy, not an investigation, and quoted for shape rather than as a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

