### PR TITLE
fix(test-records): report command termination signals

### DIFF
--- a/tasks/run-recorded.test.ts
+++ b/tasks/run-recorded.test.ts
@@ -76,6 +76,28 @@ describe("run-recorded", () => {
     expect(spool.records[0]?.outcome).toBe("fail");
   });
 
+  it({
+    name: "reports the signal that terminated the command",
+    ignore: Deno.build.os === "windows",
+    async fn() {
+      const output = await runRecorded(spoolDir, [
+        "gate",
+        "repo",
+        "probe-signal",
+        "--",
+        "/bin/sh",
+        "-c",
+        "kill -TERM $$",
+      ]);
+      expect(output.code).toBe(143);
+      expect(new TextDecoder().decode(output.stderr)).toContain(
+        "run-recorded: `/bin/sh` terminated by `SIGTERM`.",
+      );
+      const spool = await readSpool(spoolDir);
+      expect(spool.records[0]?.outcome).toBe("fail");
+    },
+  });
+
   it("records a fail with code 127 for an unrunnable command", async () => {
     const output = await runRecorded(spoolDir, [
       "gate",

--- a/tasks/run-recorded.ts
+++ b/tasks/run-recorded.ts
@@ -70,7 +70,13 @@ async function main(): Promise<void> {
       stdout: "inherit",
       stderr: "inherit",
     }).spawn();
-    code = (await child.status).code;
+    const status = await child.status;
+    code = status.code;
+    if (status.signal !== null) {
+      console.error(
+        `run-recorded: \`${args[0]}\` terminated by \`${status.signal}\`.`,
+      );
+    }
   } catch (error) {
     console.error(`run-recorded: cannot run ${args[0]}: ${error}`);
     code = 127;


### PR DESCRIPTION
Commands terminated by a signal left run-recorded consumers with only a numeric exit code. That loses the distinction between an ordinary exit and signal termination when the wrapper exits with the same numeric value.

Read the child's complete command status and report its executable and signal when termination was signal-driven. Preserve the child exit code and the existing failure record.

Cover the behavior with a deterministic Unix-only child process that terminates on SIGTERM. The test verifies the numeric exit code, diagnostic, and recorded failure, and skips Windows where `/bin/sh` is unavailable.

The focused run-recorded suite, repository format check, and repository lint check pass.

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

