### PR TITLE
ci: ON lanes spool + ship test records (census gap); census follow-up docs

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -854,6 +854,8 @@ jobs:
     name: "Package Integration Tests / server-execution ON (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
+    env:
+      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     needs: ["build-toolshed-on"]
     strategy:
       fail-fast: false
@@ -969,6 +971,17 @@ jobs:
           path: test-results/${{ matrix.junit_name }}.xml
           retention-days: 90
           if-no-files-found: ignore
+
+      - name: 📤 Ship test records
+        if: always()
+        uses: ./.github/actions/test-records-ship
+        with:
+          artifact: package-integration-server-execution-on-${{ matrix.suite_name }}
+          job: >-
+            Package Integration Tests / server-execution ON
+            (${{ matrix.suite_name }})
+          junit: >-
+            kind=integration,scope=${{ matrix.suite_name }},prefix=${{ matrix.package_dir }},glob=test-results/${{ matrix.junit_name }}.xml
 
   cli-integration-test:
     name: "CLI Integration Tests (${{ matrix.suite_name }})"
@@ -1339,6 +1352,8 @@ jobs:
     name: "Pattern Integration Tests / server-execution ON (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     timeout-minutes: *job-timeout
+    env:
+      CF_TEST_RECORDS_DIR: ${{ github.workspace }}/test-records-spool
     needs: ["build-toolshed-on"]
     strategy:
       fail-fast: false
@@ -1454,6 +1469,18 @@ jobs:
           path: test-results/
           retention-days: 90
           if-no-files-found: ignore
+
+      - name: 📤 Ship test records
+        if: always()
+        uses: ./.github/actions/test-records-ship
+        with:
+          artifact: pattern-integration-server-execution-on-${{ matrix.shard }}
+          job: >-
+            Pattern Integration Tests / server-execution ON
+            (${{ matrix.shard }}/${{ matrix.total }})
+          shard: ${{ matrix.shard }}/${{ matrix.total }}
+          junit: >-
+            kind=integration,scope=patterns,prefix=packages/patterns,glob=test-results/patterns-server-execution-on-${{ matrix.shard }}.xml
 
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"

--- a/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow-sx2-coalescing-gate.md
@@ -14,7 +14,11 @@ sx2-events.test.ts`, assert `derivedDelta < N` ("rapid-fire coalescing:
 10 derived commits for 10 events must stay well under N"),
 intermittently red on the ON pattern lane on unrelated PRs; re-run
 clears it. Their measurements: CI passing runs log exactly 7, the
-failing run 10; locally 4–5 over ~20 runs.
+failing run 10; locally 4–5 over ~20 runs. Additional evidence (the
+owner's ON-flake census, 2026-08-21 — 123 runs, 25 ON failures, its
+item 4): one more CI occurrence at 15:25Z on #6136 with the
+same-commit rerun green — the load-ratio shape exactly as analyzed
+below; the disposition (owner ruling on the gate) is unchanged.
 
 Relation to OW52, stated first because the two were plausibly one
 question: they are NOT. The OW52 storm accounting

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -228,3 +228,32 @@ skip-entry status: the `integration/convergence-storm.test.ts` step
 entry LIFTED. The in-file guard wiring stays (designed binding for any
 future entry; a guard without an entry is a no-op and the validator
 only checks the other direction).
+
+## 7. Post-merge addendum: the census's group-chat waitFor flakes (items 1+3)
+
+The owner's ON-flake census (2026-08-21; 123 runs, 25 ON failures, all
+pattern-ON) counted 10 shard-7 failures of
+`cfc-group-chat-demo-multi-runtime.test.ts` "admin lockdown gates room
+creation but never message sending" (`Timed out waiting for: bob's
+post-lockdown message arrives at alice`, `MultiRuntimeHarness.waitFor`)
+plus one of "admins can grant admin to another user by name" — every
+observed failure PRE-dating #6158's merge.
+
+Coverage verdict: **this fix covers them.** The failing primitive is
+`waitFor`, whose every poll calls `settle(1)` — and since #6158 each
+such poll blocks (bounded) until the polling sessions' fired events
+have their terminal consequences ARRIVED, then barriers to head. Bob's
+message send is exactly such an intent and the awaited message is its
+first-order consequence, so the former poll race (fast no-op polls
+burning the 30 s window while a loaded runner's serving loop drained)
+is now an event-driven wait at the settle layer; the `waitFor` timeout
+remains only the failure bound, per
+docs/development/waiting-in-tests.md. No timeout was changed.
+
+Empirical verification (quiet dev box, dev toolshed ON, fresh stores):
+the full file — both census tests included, 7 steps per run —
+**12/12 green at 1907e050e** (this fix's squash, pre-#6156) and
+**12/12 green at 9d989c0c1** (main tip with OW31's identity build),
+6–17 s per run, zero quiescence-budget warnings. The census's
+load-dependence caveat applies to any local bench; the mechanism
+coverage above is the primary argument, the 24/24 the corroboration.

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -562,3 +562,29 @@ Deno.test("every test-records artifact name is store-safe and unique", async () 
   // extraction broke, not that the repository stopped shipping records.
   assert(shipSteps >= 14, `only ${shipSteps} ship steps found`);
 });
+
+Deno.test("every deno.yml job that writes a JUnit file spools and ships test records (the ON lanes' observability gap: 25 pattern-ON flakes had to be censused from raw Actions logs because the two server-execution ON jobs set no CF_TEST_RECORDS_DIR and had no ship step — records the dashboard never saw)", async () => {
+  const contents = withoutComments(await workflow("deno.yml"));
+  const missing: string[] = [];
+  let junitJobs = 0;
+  for (const jobId of jobIds(contents)) {
+    const job = jobBlock(contents, jobId);
+    if (!job.includes("--junit-path=")) continue;
+    junitJobs++;
+    if (!job.includes("uses: ./.github/actions/test-records-ship")) {
+      missing.push(
+        `${jobId}: writes a JUnit file but has no test-records-ship step`,
+      );
+    }
+    if (!job.includes("CF_TEST_RECORDS_DIR:")) {
+      missing.push(
+        `${jobId}: runs tests without CF_TEST_RECORDS_DIR — the spool ` +
+          "half of the records is never written",
+      );
+    }
+  }
+  assertEquals(missing, []);
+  // Pin the search itself: zero junit jobs would mean the extraction
+  // broke, not that the repository stopped writing JUnit files.
+  assert(junitJobs >= 7, `only ${junitJobs} JUnit-writing jobs found`);
+});


### PR DESCRIPTION
## Why

The owner's ON-flake census (2026-08-21: 123 runs, 25 ON failures, all in the pattern-ON lane; package-ON 378/378) had to be reconstructed from raw Actions logs: the two server-execution ON jobs in `deno.yml` were the only test jobs with **no `CF_TEST_RECORDS_DIR` and no test-records-ship step**, so ON flakes were invisible to `tasks/test-records-report.ts` and the dashboard. This closes the observability gap by mirroring the sibling jobs' wiring exactly, and pins the invariant so the gap class cannot silently recur.

A second, docs-only commit records the census's other two items for this train: the coverage verdict for the `cfc-group-chat-demo-multi-runtime` waitFor flakes (census items 1+3 — verified COVERED by #6158's settle-quiescence fix: the failing primitive's own `settle(1)` poll now blocks on consequence arrival; **12/12 green at 1907e050e and 12/12 at 9d989c0c1**, both census tests every run, no timeout touched), and the census citation on the sx2 coalescing-gate report (item 4 — one more CI occurrence at 15:25Z on #6136, same-commit rerun green; disposition unchanged, owner ruling still pending).

## What Changed

- `.github/workflows/deno.yml`: `CF_TEST_RECORDS_DIR` env + a `Ship test records` step on `pattern-integration-test-server-execution-on` (artifact `pattern-integration-server-execution-on-<shard>`, the ON junit glob `test-results/patterns-server-execution-on-<shard>.xml`, shard label) and on `package-integration-test-server-execution-on` (artifact `package-integration-server-execution-on-<suite>`, the ON junit glob) — inputs mirroring the OFF siblings.
- `tasks/ci-workflow.test.ts`: new invariant pin — every `deno.yml` job that writes a JUnit file must set `CF_TEST_RECORDS_DIR` and carry a test-records-ship step.
- `docs/…/optimize/ow52-storm-loss-report.md` §7 + `ow-sx2-coalescing-gate.md`: the census follow-ups above.

## Test plan

Red-first: the invariant test FAILS against origin/main's `deno.yml` (names both ON jobs, both missing halves) and passes with the edits. Full `ci-workflow.test.ts` 12/12 green — the pre-existing store-safe/unique artifact-name pin covers the two new ship steps (shipSteps 14 → 16). YAML parses (`@std/yaml`). The workflow change itself is exercised by this PR's own CI run: the two ON lanes should now upload `test-records-*` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

