### PR TITLE
fix(test-records): one record identity per test

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -134,6 +134,12 @@ record on their own. Two consequences worth knowing while writing one:
   interpolated identifiers, which mint a new identity every time they
   shift; renames split history unless bridged in
   `tasks/test-identity-aliases.jsonl`.
+- The name has to be unique within its scope — the whole describe chain
+  plus the `it()` description, or the bare `Deno.test` name, across every
+  test file of the package. Two tests under one name are one identity, so
+  their outcomes and durations merge and neither can be tracked on its
+  own. A loop that generates names is the case to check twice: a
+  hand-written test beside it can land on one of them.
 - Every test must finish within sixty seconds in CI, not counting setup.
 
 A new test *surface* (a new CI job, script, or harness) does need wiring —

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -1,8 +1,10 @@
 # Test-run records
 
-Every execution of every test in this repository produces one record — its
-identity, outcome, and duration — shipped with the run's context to a public
-store. [The spec](../specs/test-records.md) is the contract (identity
+Every top-level test run with recording enabled produces one record per test —
+its identity, outcome, and duration — shipped with the run's context to a
+public store. A repository test that drives a harness as a library over fixture
+files produces its own record, not records for the fixture runs.
+[The spec](../specs/test-records.md) is the contract (identity
 rules, line formats, store guarantees, trust boundaries), and the
 reasoning that produced it is in [the archived
 plan](../history/plans/test-run-telemetry.md). This document is how the

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -1,9 +1,10 @@
 # Test-run records
 
-Every top-level test run with recording enabled produces one record per test —
-its identity, outcome, and duration — shipped with the run's context to a
-public store. A repository test that drives a harness as a library over fixture
-files produces its own record, not records for the fixture runs.
+When recording is enabled, a top-level test run produces one record per test.
+Each record contains the test's identity, outcome, and duration. The run ships
+those records with its context to a public store. A repository test that drives
+a harness as a library over fixture files produces its own record, not records
+for the fixture runs.
 [The spec](../specs/test-records.md) is the contract (identity
 rules, line formats, store guarantees, trust boundaries), and the
 reasoning that produced it is in [the archived

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -15,7 +15,7 @@ A test's identity is the triple of **kind** (`unit`, `browser`, `pattern`,
 `integration`, `typecheck`, `lint`, `format`, `gate`), **scope** (the owning
 workspace member, or `repo`), and **name** (whatever the test's own runner
 reports — a bdd describe chain, a pattern file path, a task name, a script
-section). One record is one JSON line; one uploaded object is a run's
+step). One record is one JSON line; one uploaded object is a run's
 context line followed by its record lines. The schema, the line codecs, and
 their validators live in `packages/test-support/src/records/`.
 
@@ -263,6 +263,22 @@ Anything else wraps its command:
 ```
 deno task run-recorded <kind> <scope> <name> -- <command...>
 ```
+
+A harness that is also a library — one this repository's own tests drive
+over fixture files — takes the decision to record from its caller, not
+from the environment alone. Its entry point asks for records; a test
+driving the same function does not, since the files it hands over are that
+test's fixtures. `recordsSpooledBy` from
+`@commonfabric/test-support/records` pins both halves of that: it points
+recording at a fresh spool, runs the function, and hands back every record
+the function left there.
+
+A harness a test drives as a child process takes it the other way round,
+since the child reads its own environment: the test hands the child an
+empty `CF_TEST_RECORDS_DIR`, which is recording off. `tasks/integration.ts`
+does that for the `cf` children whose files it times itself, and
+`packages/deno-web-test/test/utils.ts` for the fixture projects it runs the
+browser harness over.
 
 Every test must finish within sixty seconds in CI, not counting setup; a
 check that cannot is a container to split, and the report's over-60s list

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -38,8 +38,13 @@ and apply one only to records older than its date
 (`deno task check-test-aliases` enforces the file's shape).
 
 A task-level record may coexist with the per-item records of the same run
-(`pattern-compat` beside `pattern-compat <key>`); the item records carry
-the task name as a prefix, and the two are distinct identities.
+(`pattern-compat` beside `pattern-compat <key>`, `integration.sh` beside
+`integration.sh <step>`); the item records carry the task name as a
+prefix, and the two are distinct identities. The task name is the task's
+own, never the label of the slice or section CI dispatched — a task-level
+record that took its name from the dispatch would both rename itself
+whenever the work is re-sliced and, where a section and an item share a
+label, report under that item's identity.
 
 ## Records and contexts
 
@@ -90,10 +95,22 @@ every read boundary (`parseRecordLine`, `parseContextLine`).
 
 Producers append record lines to their own ULID-named fragment file inside
 the directory named by `CF_TEST_RECORDS_DIR`; an unset variable disables
-recording everywhere, and that is the entire opt-out. Producers append
-line by line as results arrive, never share files, create the directory if
-it does not exist, and on any write failure warn once and stop; recording
-never fails a run.
+recording everywhere, and that is the entire opt-out.
+
+Producers append line by line as results arrive, never share files, create
+the directory if it does not exist, and on any write failure warn once and
+stop; recording never fails a run.
+
+A producer records the run it was asked for. Several are also libraries
+that this repository's own tests drive — the pattern runner behind
+`cf test`, the type-check task, the vintage gate's replay — and each takes
+the decision to record from its caller rather than from the environment
+alone. The entry point asks for records; a test driving the same function
+does not, because the files it hands over are that test's fixtures, and a
+fixture is data rather than a test of this repository. A test that drives
+such a harness as a child process hands it an empty
+`CF_TEST_RECORDS_DIR`, since the child reads its own environment; an
+empty value is recording off, the same as an unset one.
 
 A run's owner — locally `deno task test`, `deno task integration`, or
 `deno task run-recorded` when a personal key is present — creates the

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -20,7 +20,7 @@ import { inspect } from "./inspect.ts";
 import { invocationSession } from "./invocation-session.ts";
 import { piece, pieceDataCommand } from "./piece.ts";
 import { space } from "./space.ts";
-import { test } from "./test-command.ts";
+import { createTestCommand } from "./test-command.ts";
 import { view } from "./view.ts";
 import { wish } from "./wish.ts";
 
@@ -181,7 +181,7 @@ export const main = new Command()
   .command("id", identity)
   .command("init", init)
   .command("invocation-session", invocationSession)
-  .command("test", test)
+  .command("test", createTestCommand({ recordResults: true }))
   .command("wish", wish)
   // The top-level spellings of the piece data commands: the same builders
   // the `piece` chain mounts under the same names, so `cf get` and

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -6,177 +6,185 @@ import { Command } from "@cliffy/command";
 import { cliText } from "../lib/cli-name.ts";
 import { discoverTestFiles, runTests } from "../lib/test-runner.ts";
 
-export const test = new Command()
-  .name("test")
-  .description("Run pattern tests (.test.tsx files).")
-  .example(
-    cliText("cf test ./counter.test.tsx"),
-    "Run a single test pattern file.",
-  )
-  .example(
-    cliText("cf test ./patterns/"),
-    "Run all .test.tsx files in a directory (recursive).",
-  )
-  .example(
-    cliText("cf test './*.test.tsx'"),
-    "Run all test files matching a glob pattern.",
-  )
-  .example(
-    cliText("cf test ./counter.test.tsx --timeout 10000"),
-    "Run with custom timeout (10 seconds).",
-  )
-  .example(
-    cliText(
-      "cf test ./battleship/pass-and-play/main.test.tsx --root ./battleship",
-    ),
-    "Run with custom root for resolving imports from sibling directories.",
-  )
-  .option(
-    "--timeout <ms:number>",
-    "Timeout per test action in milliseconds.",
-    { default: 5000 },
-  )
-  .option(
-    "--verbose",
-    "Show detailed execution logs.",
-  )
-  .option(
-    "--root <dir:string>",
-    "Root directory for resolving imports. Defaults to the nearest ancestor whose deno.json(c) declares a package name, else the test file's directory.",
-  )
-  .option(
-    "--datafile <path:string>",
-    "Attach a data file the pattern under test cannot name. Repeatable.",
-    { collect: true },
-  )
-  .option(
-    "--stats-threshold <ms:number>",
-    "Print logger stats for steps slower than this (ms). 0 = every step. Requires --verbose.",
-    { default: 5000 },
-  )
-  .option(
-    "--stats-include <prefixes:string>",
-    "Comma-separated timing categories to always print in verbose stats output (exact or prefix match).",
-  )
-  .option(
-    "--stats-action-limit <count:number>",
-    "Number of per-step scheduler action deltas to print in verbose mode.",
-    { default: 10 },
-  )
-  .option(
-    "--storage-stats",
-    "Print storage-related logger timings and counts after each test file.",
-  )
-  .option(
-    "--storage-stats-limit <count:number>",
-    "Maximum number of storage timing/count entries to print with --storage-stats.",
-    { default: 16 },
-  )
-  .option(
-    "--pattern-coverage-dir <dir:string>",
-    "Write pattern runtime coverage LCOV artifacts to this directory.",
-  )
-  .option(
-    "--timing-measures-out <file:string>",
-    "Emit a performance.measure per logger time span and write them here as " +
-      "JSON. Aggregate with skills/perf-investigation/scripts/" +
-      "aggregate-measures.ts.",
-  )
-  .arguments("<paths...:string>")
-  .action(async (options, ...paths) => {
-    const testFiles: string[] = [];
+export interface TestCommandOptions {
+  recordResults?: boolean;
+}
 
-    for (const path of paths) {
-      const fullPath = resolve(Deno.cwd(), path);
+export function createTestCommand(
+  { recordResults = false }: TestCommandOptions = {},
+) {
+  return new Command()
+    .name("test")
+    .description("Run pattern tests (.test.tsx files).")
+    .example(
+      cliText("cf test ./counter.test.tsx"),
+      "Run a single test pattern file.",
+    )
+    .example(
+      cliText("cf test ./patterns/"),
+      "Run all .test.tsx files in a directory (recursive).",
+    )
+    .example(
+      cliText("cf test './*.test.tsx'"),
+      "Run all test files matching a glob pattern.",
+    )
+    .example(
+      cliText("cf test ./counter.test.tsx --timeout 10000"),
+      "Run with custom timeout (10 seconds).",
+    )
+    .example(
+      cliText(
+        "cf test ./battleship/pass-and-play/main.test.tsx --root ./battleship",
+      ),
+      "Run with custom root for resolving imports from sibling directories.",
+    )
+    .option(
+      "--timeout <ms:number>",
+      "Timeout per test action in milliseconds.",
+      { default: 5000 },
+    )
+    .option(
+      "--verbose",
+      "Show detailed execution logs.",
+    )
+    .option(
+      "--root <dir:string>",
+      "Root directory for resolving imports. Defaults to the nearest ancestor whose deno.json(c) declares a package name, else the test file's directory.",
+    )
+    .option(
+      "--datafile <path:string>",
+      "Attach a data file the pattern under test cannot name. Repeatable.",
+      { collect: true },
+    )
+    .option(
+      "--stats-threshold <ms:number>",
+      "Print logger stats for steps slower than this (ms). 0 = every step. Requires --verbose.",
+      { default: 5000 },
+    )
+    .option(
+      "--stats-include <prefixes:string>",
+      "Comma-separated timing categories to always print in verbose stats output (exact or prefix match).",
+    )
+    .option(
+      "--stats-action-limit <count:number>",
+      "Number of per-step scheduler action deltas to print in verbose mode.",
+      { default: 10 },
+    )
+    .option(
+      "--storage-stats",
+      "Print storage-related logger timings and counts after each test file.",
+    )
+    .option(
+      "--storage-stats-limit <count:number>",
+      "Maximum number of storage timing/count entries to print with --storage-stats.",
+      { default: 16 },
+    )
+    .option(
+      "--pattern-coverage-dir <dir:string>",
+      "Write pattern runtime coverage LCOV artifacts to this directory.",
+    )
+    .option(
+      "--timing-measures-out <file:string>",
+      "Emit a performance.measure per logger time span and write them here as " +
+        "JSON. Aggregate with skills/perf-investigation/scripts/" +
+        "aggregate-measures.ts.",
+    )
+    .arguments("<paths...:string>")
+    .action(async (options, ...paths) => {
+      const testFiles: string[] = [];
 
-      // Check if it's a glob pattern
-      if (path.includes("*")) {
-        // Expand glob pattern
-        for await (const entry of expandGlob(fullPath)) {
-          if (entry.isFile && entry.name.endsWith(".test.tsx")) {
-            testFiles.push(entry.path);
-          }
-        }
-      } else {
-        // Check if path exists
-        let stat: Deno.FileInfo;
-        try {
-          stat = await Deno.stat(fullPath);
-        } catch (error) {
-          if (error instanceof Deno.errors.NotFound) {
-            console.error(`Error: Path not found: ${fullPath}`);
-          } else {
-            console.error(`Error accessing path ${fullPath}:`, error);
-          }
-          Deno.exit(1);
-        }
+      for (const path of paths) {
+        const fullPath = resolve(Deno.cwd(), path);
 
-        if (stat.isDirectory) {
-          // Discover test files in directory
-          const discovered = await discoverTestFiles(fullPath);
-          testFiles.push(...discovered);
-        } else if (stat.isFile) {
-          // Single file - warn but allow non-.test.tsx for flexibility
-          if (!path.endsWith(".test.tsx")) {
-            console.warn(`Warning: ${path} does not end with .test.tsx`);
+        // Check if it's a glob pattern
+        if (path.includes("*")) {
+          // Expand glob pattern
+          for await (const entry of expandGlob(fullPath)) {
+            if (entry.isFile && entry.name.endsWith(".test.tsx")) {
+              testFiles.push(entry.path);
+            }
           }
-          testFiles.push(fullPath);
         } else {
-          console.error(`Error: ${fullPath} is not a file or directory`);
-          Deno.exit(1);
+          // Check if path exists
+          let stat: Deno.FileInfo;
+          try {
+            stat = await Deno.stat(fullPath);
+          } catch (error) {
+            if (error instanceof Deno.errors.NotFound) {
+              console.error(`Error: Path not found: ${fullPath}`);
+            } else {
+              console.error(`Error accessing path ${fullPath}:`, error);
+            }
+            Deno.exit(1);
+          }
+
+          if (stat.isDirectory) {
+            // Discover test files in directory
+            const discovered = await discoverTestFiles(fullPath);
+            testFiles.push(...discovered);
+          } else if (stat.isFile) {
+            // Single file - warn but allow non-.test.tsx for flexibility
+            if (!path.endsWith(".test.tsx")) {
+              console.warn(`Warning: ${path} does not end with .test.tsx`);
+            }
+            testFiles.push(fullPath);
+          } else {
+            console.error(`Error: ${fullPath} is not a file or directory`);
+            Deno.exit(1);
+          }
         }
       }
-    }
 
-    // Deduplicate test files (in case of overlapping paths like ./patterns/ and ./patterns/counter.test.tsx)
-    const uniqueTestFiles = [...new Set(testFiles)];
+      // Deduplicate test files (in case of overlapping paths like ./patterns/ and ./patterns/counter.test.tsx)
+      const uniqueTestFiles = [...new Set(testFiles)];
 
-    if (uniqueTestFiles.length === 0) {
-      console.error(`Error: No test files found`);
-      Deno.exit(1);
-    }
+      if (uniqueTestFiles.length === 0) {
+        console.error(`Error: No test files found`);
+        Deno.exit(1);
+      }
 
-    console.log(`Found ${uniqueTestFiles.length} test file(s)`);
+      console.log(`Found ${uniqueTestFiles.length} test file(s)`);
 
-    // Resolve root path if provided
-    const root = options.root ? resolve(Deno.cwd(), options.root) : undefined;
-    const patternCoverageDir = options.patternCoverageDir
-      ? resolve(Deno.cwd(), options.patternCoverageDir)
-      : Deno.env.get("CF_PATTERN_COVERAGE_DIR")
-      ? resolve(Deno.cwd(), Deno.env.get("CF_PATTERN_COVERAGE_DIR")!)
-      : undefined;
-    const statsInclude = options.statsInclude
-      ? String(options.statsInclude)
-        .split(",")
-        .map((part) => part.trim())
-        .filter(Boolean)
-      : undefined;
+      // Resolve root path if provided
+      const root = options.root ? resolve(Deno.cwd(), options.root) : undefined;
+      const patternCoverageDir = options.patternCoverageDir
+        ? resolve(Deno.cwd(), options.patternCoverageDir)
+        : Deno.env.get("CF_PATTERN_COVERAGE_DIR")
+        ? resolve(Deno.cwd(), Deno.env.get("CF_PATTERN_COVERAGE_DIR")!)
+        : undefined;
+      const statsInclude = options.statsInclude
+        ? String(options.statsInclude)
+          .split(",")
+          .map((part) => part.trim())
+          .filter(Boolean)
+        : undefined;
 
-    // Run tests
-    const { failed } = await runTests(uniqueTestFiles, {
-      timeout: options.timeout,
-      verbose: options.verbose,
-      root,
-      dataFilePaths: options.datafile?.map((path: string) =>
-        resolve(Deno.cwd(), path)
-      ),
-      statsThreshold: options.statsThreshold,
-      statsInclude,
-      statsActionLimit: options.statsActionLimit,
-      storageStats: options.storageStats,
-      storageStatsLimit: options.storageStatsLimit,
-      timingMeasuresOut: options.timingMeasuresOut
-        ? resolve(Deno.cwd(), options.timingMeasuresOut)
-        : undefined,
-      patternCoverageDir,
-      continuousUI: Deno.env.get("CF_TEST_CONTINUOUS_UI") === "1",
-      // The files this command was pointed at are a run of tests, so they
-      // are the run's records. Recording still needs CF_TEST_RECORDS_DIR.
-      recordResults: true,
+      // Run tests
+      const { failed } = await runTests(uniqueTestFiles, {
+        timeout: options.timeout,
+        verbose: options.verbose,
+        root,
+        dataFilePaths: options.datafile?.map((path: string) =>
+          resolve(Deno.cwd(), path)
+        ),
+        statsThreshold: options.statsThreshold,
+        statsInclude,
+        statsActionLimit: options.statsActionLimit,
+        storageStats: options.storageStats,
+        storageStatsLimit: options.storageStatsLimit,
+        timingMeasuresOut: options.timingMeasuresOut
+          ? resolve(Deno.cwd(), options.timingMeasuresOut)
+          : undefined,
+        patternCoverageDir,
+        continuousUI: Deno.env.get("CF_TEST_CONTINUOUS_UI") === "1",
+        recordResults,
+      });
+
+      // Exit with error code if any tests failed
+      if (failed > 0) {
+        Deno.exit(1);
+      }
     });
+}
 
-    // Exit with error code if any tests failed
-    if (failed > 0) {
-      Deno.exit(1);
-    }
-  });
+export const test = createTestCommand();

--- a/packages/cli/commands/test-command.ts
+++ b/packages/cli/commands/test-command.ts
@@ -170,6 +170,9 @@ export const test = new Command()
         : undefined,
       patternCoverageDir,
       continuousUI: Deno.env.get("CF_TEST_CONTINUOUS_UI") === "1",
+      // The files this command was pointed at are a run of tests, so they
+      // are the run's records. Recording still needs CF_TEST_RECORDS_DIR.
+      recordResults: true,
     });
 
     // Exit with error code if any tests failed

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -65,11 +65,13 @@ SCHEMA_INCOMPATIBLE_PATTERN_SRC="$SCRIPT_DIR/pattern/schema-incompatible.tsx"
 CUSTOM_EXPORT="customPatternExport" # for testing this feature
 SECTION="${CF_CLI_INTEGRATION_SECTION:-${1:-all}}"
 
-# The dispatched section is the recorded test: one record per run, named
-# "integration.sh <section>", written from the EXIT trap with the script's
-# status and duration.
+# The script records as one test named "integration.sh", written from the EXIT
+# trap with its status and duration; each step below records as its own test
+# named "integration.sh <step>". Neither name carries the dispatched section:
+# which section scheduled a step is run context, and the same script and the
+# same step join across a CI section leg and a local `all` run.
 source "$SCRIPT_DIR/test-records.sh"
-cf_test_record_script "integration.sh $SECTION"
+cf_test_record_script "integration.sh"
 
 # A fresh invocation id. uuidgen is not present on every runner image, so this
 # falls back to Python, which the timing helper above already requires.
@@ -1294,10 +1296,9 @@ run_piece_data_files() {
   echo "Successfully ran CLI data-file integration tests for ${API_URL}."
 }
 
-# Each step of a section records as its own test, named
-# "integration.sh <section> <step>"; the begin markers close the previous
-# step's record and the exit trap closes the last one, so a failing step is
-# recorded with the failure.
+# Each step records as its own test, named "integration.sh <step>"; the begin
+# markers close the previous step's record and the exit trap closes the last
+# one, so a failing step is recorded with the failure.
 case "$SECTION" in
   all)
     cf_test_step_begin piece-values

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -354,6 +354,16 @@ export interface TestRunnerOptions {
   /** Keep the test descriptor's `$UI` demanded for the full test run. */
   continuousUI?: boolean;
   /**
+   * Spool one test record per file run, named by the file's
+   * repository-relative path.
+   *
+   * The `cf test` command sets this: the files it was pointed at are the
+   * tests of a run. A caller inside another test leaves it unset, because
+   * the files it hands over are that test's fixtures, and a fixture is data
+   * rather than a test of this repository.
+   */
+  recordResults?: boolean;
+  /**
    * Emit a `performance.measure` per logger time span and write them here.
    *
    * The statistics a run prints are aggregates: they say a key was reached
@@ -2027,10 +2037,13 @@ export async function runTests(
 
   // One record per file, spooled with the file's final verdict — the one
   // that includes the runtime-error, console, and idempotence checks below,
-  // not just the assertion results. Inert unless CF_TEST_RECORDS_DIR is
-  // set; the integration orchestrator clears that variable for its cf
-  // children and records from its own clock instead.
-  const recordsFragment = FragmentWriter.openForRun();
+  // not just the assertion results. Written only for a caller that asked
+  // for records, and inert unless CF_TEST_RECORDS_DIR is set; the
+  // integration orchestrator clears that variable for its cf children and
+  // records from its own clock instead.
+  const recordsFragment = options.recordResults === true
+    ? FragmentWriter.openForRun()
+    : undefined;
   const recordFile = (testPath: string, failed: boolean, durationMs: number) =>
     recordsFragment?.append({
       line: "record",

--- a/packages/cli/test/run-tests.ts
+++ b/packages/cli/test/run-tests.ts
@@ -53,6 +53,7 @@ const SERIAL_TESTS = [
   "test/runtime-creation.test.ts",
   "test/test-runner-compile-byte-cache.test.ts",
   "test/test-runner-pattern-coverage.test.ts",
+  "test/test-runner-records.test.ts",
   "test/view-commitmsg-01.test.ts",
   "test/view-commitmsg-02.test.ts",
   "test/view-commitmsg-03.test.ts",

--- a/packages/cli/test/test-runner-records.test.ts
+++ b/packages/cli/test/test-runner-records.test.ts
@@ -11,11 +11,54 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { join, resolve } from "@std/path";
 import { recordsSpooledBy } from "@commonfabric/test-support/records";
+import {
+  createTestCommand,
+  test as testCommand,
+} from "../commands/test-command.ts";
 import { runTests } from "../lib/test-runner.ts";
 
 const FIXTURES = resolve(import.meta.dirname!, "fixtures/data-files");
 const FIXTURE = join(FIXTURES, "single.test.tsx");
 const DATA_FILE = join(FIXTURES, "data", "cities.json");
+
+async function runTestCommand(
+  command: ReturnType<typeof createTestCommand>,
+): Promise<void> {
+  const previousLog = console.log;
+  console.log = () => {};
+  try {
+    await command.parse([
+      FIXTURE,
+      "--root",
+      FIXTURES,
+      "--datafile",
+      DATA_FILE,
+    ]);
+  } finally {
+    console.log = previousLog;
+  }
+}
+
+async function runRootTestCommand(): Promise<void> {
+  // deno-lint-ignore cf-imports/no-inline-module-import -- The query creates an independent command instance.
+  const { main } = await import(
+    "../commands/main.ts?test-runner-records"
+  );
+  const previousLog = console.log;
+  console.log = () => {};
+  try {
+    await main.parse([
+      "test",
+      FIXTURE,
+      "--root",
+      FIXTURES,
+      "--datafile",
+      DATA_FILE,
+    ]);
+  } finally {
+    console.log = previousLog;
+  }
+}
 
 describe("pattern test recording", () => {
   it("spools nothing for a caller that did not ask for records", async () => {
@@ -25,14 +68,13 @@ describe("pattern test recording", () => {
     expect(spooled).toEqual([]);
   });
 
-  it("spools one record per file for a caller that asked", async () => {
-    const spooled = await recordsSpooledBy(() =>
-      runTests(FIXTURE, {
-        root: FIXTURES,
-        dataFilePaths: [DATA_FILE],
-        recordResults: true,
-      })
-    );
+  it("spools nothing for an in-process command", async () => {
+    const spooled = await recordsSpooledBy(() => runTestCommand(testCommand));
+    expect(spooled).toEqual([]);
+  });
+
+  it("spools one record per file for the top-level command", async () => {
+    const spooled = await recordsSpooledBy(runRootTestCommand);
     expect(spooled).toHaveLength(1);
     expect(spooled[0].test.k).toBe("pattern");
     expect(spooled[0].test.s).toBe("patterns");

--- a/packages/cli/test/test-runner-records.test.ts
+++ b/packages/cli/test/test-runner-records.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Who the pattern runner records for.
+ *
+ * `runTests` is both the body of `cf test` and a library the tests in this
+ * package drive over fixture files. A record names a test of this repository,
+ * so only the first of those two callers asks for one; a fixture run by a test
+ * is that test's data.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import { recordsSpooledBy } from "@commonfabric/test-support/records";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/data-files");
+const FIXTURE = join(FIXTURES, "single.test.tsx");
+const DATA_FILE = join(FIXTURES, "data", "cities.json");
+
+describe("pattern test recording", () => {
+  it("spools nothing for a caller that did not ask for records", async () => {
+    const spooled = await recordsSpooledBy(() =>
+      runTests(FIXTURE, { root: FIXTURES, dataFilePaths: [DATA_FILE] })
+    );
+    expect(spooled).toEqual([]);
+  });
+
+  it("spools one record per file for a caller that asked", async () => {
+    const spooled = await recordsSpooledBy(() =>
+      runTests(FIXTURE, {
+        root: FIXTURES,
+        dataFilePaths: [DATA_FILE],
+        recordResults: true,
+      })
+    );
+    expect(spooled).toHaveLength(1);
+    expect(spooled[0].test.k).toBe("pattern");
+    expect(spooled[0].test.s).toBe("patterns");
+    expect(spooled[0].test.n).toBe(
+      "packages/cli/test/fixtures/data-files/single.test.tsx",
+    );
+    expect(spooled[0].outcome).toBe("pass");
+  });
+});

--- a/packages/deno-web-test/test/utils.ts
+++ b/packages/deno-web-test/test/utils.ts
@@ -3,6 +3,7 @@ import { AssertionError } from "@std/assert";
 import { copy } from "@std/fs";
 import { parse as parseJsonc } from "@std/jsonc";
 import { decode } from "@commonfabric/utils/encoding";
+import { RECORDS_DIR_VARIABLE } from "@commonfabric/test-support/records";
 
 const dirname = import.meta.dirname as string;
 const CLI_PATH = path.join(dirname, "..", "cli.ts");
@@ -232,6 +233,11 @@ export const runDenoWebTest = async (
     cwd: tmpProjectPath,
     env: {
       [STDERR_BOUNDARY_ENV]: stderrBoundary,
+      // The harness inside the child records one browser-kind record per
+      // test it runs. These projects are fixtures of the tests in this
+      // directory rather than tests of this repository, so the child is
+      // given no spool to write them to.
+      [RECORDS_DIR_VARIABLE]: "",
     },
   }).output().then((output) =>
     new HarnessRun(

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -264,7 +264,7 @@ describe("link-utils", () => {
       });
     });
 
-    it("should parse sigil links to normalized links", () => {
+    it("should drop a redundant overwrite this when parsing sigil links", () => {
       const sigilLink = {
         "/": {
           [LINK_V1_TAG]: {
@@ -286,7 +286,7 @@ describe("link-utils", () => {
       });
     });
 
-    it("should parse sigil links with overwrite this to normalized links", () => {
+    it("should parse sigil links with overwrite redirect to normalized links", () => {
       const sigilLink = {
         "/": {
           [LINK_V1_TAG]: {

--- a/packages/runner/test/schema-defaults.test.ts
+++ b/packages/runner/test/schema-defaults.test.ts
@@ -812,7 +812,7 @@ describe("Schema - Default Values", () => {
       expect(value.name.get()).toBe("Updated Name");
     });
 
-    it("should make immutable cells if they provide the default value", () => {
+    it("should make immutable cells if a $ref target provides the default value", () => {
       const schema = {
         $defs: {
           NameEntry: {
@@ -830,7 +830,7 @@ describe("Schema - Default Values", () => {
 
       const c = runtime.getCell<any>(
         space,
-        "should make immutable cells if they provide the default value 1",
+        "should make immutable cells if a $ref target provides the default value 1",
         undefined,
         tx,
       );

--- a/packages/runner/test/schema-ref-default.test.ts
+++ b/packages/runner/test/schema-ref-default.test.ts
@@ -71,7 +71,7 @@ describe("$ref with default support", () => {
       expect(resolved).toHaveProperty("default", "outermost");
     });
 
-    it("should handle chained refs with defaults at each level (outermost wins)", () => {
+    it("should handle chained refs with defaults at each level and none at the ref site (outermost $defs level wins)", () => {
       const schema: JSONSchema = {
         $defs: {
           Level3: { type: "string", default: "level3" },

--- a/packages/test-support/deno.jsonc
+++ b/packages/test-support/deno.jsonc
@@ -16,7 +16,7 @@
     // which is a different binary whenever the shell's Deno is not the pinned
     // one. A task line runs the Deno running the task, so asking that Deno for
     // its own path allows exactly the one binary the tests start.
-    "test": "deno test --frozen=true --allow-env=CF_COMPILE_CACHE_FILE --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") src/*.test.ts src/records/*.test.ts",
+    "test": "deno test --frozen=true --allow-env=CF_COMPILE_CACHE_FILE,CF_TEST_RECORDS_DIR --allow-read --allow-write --allow-run=$(deno eval \"console.log(Deno.execPath())\") src/*.test.ts src/records/*.test.ts test/records/*.test.ts",
     "check": "deno check src/**/*.ts test/clock-preload.ts",
     "fmt": "deno fmt src/ test/",
     "lint": "deno lint src/ test/"

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -81,3 +81,4 @@ export {
 export type { CreateObjectOptions, CreateObjectResult } from "./store.ts";
 export { listObjects, parseReportGroups, readObject } from "./store-reader.ts";
 export type { StoredReport, StoredReportGroup } from "./store-reader.ts";
+export { recordsSpooledBy } from "./testing.ts";

--- a/packages/test-support/src/records/testing.ts
+++ b/packages/test-support/src/records/testing.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers for testing the producer side of recording. Test use only: the
+ * spool they point at is a temporary directory, and the environment variable
+ * that names it is restored when the body returns.
+ */
+
+import { join } from "@std/path";
+import { parseRecordLine, type TestRecord } from "./schema.ts";
+import { RECORDS_DIR_VARIABLE } from "./paths.ts";
+
+/**
+ * Runs `body` with recording pointed at a fresh spool, and returns every
+ * record it left there.
+ *
+ * This is how a producer's opt-in is pinned: a caller that did not ask for
+ * records gets an empty array back even though recording was on for the
+ * whole body.
+ *
+ * The variable it sets is the whole process's, so a test file calling this
+ * runs alone. Under a runner that puts several test files on threads of one
+ * process — `deno test --parallel`, which `packages/cli/test/run-tests.ts`
+ * uses — the file belongs on that runner's serial list.
+ */
+export async function recordsSpooledBy(
+  body: () => Promise<unknown>,
+): Promise<TestRecord[]> {
+  const dir = await Deno.makeTempDir({ prefix: "test-records-spooled-" });
+  const before = Deno.env.get(RECORDS_DIR_VARIABLE);
+  Deno.env.set(RECORDS_DIR_VARIABLE, dir);
+  try {
+    await body();
+    const records: TestRecord[] = [];
+    for await (const entry of Deno.readDir(dir)) {
+      if (!entry.isFile) continue;
+      const text = await Deno.readTextFile(join(dir, entry.name));
+      for (const line of text.split("\n")) {
+        const record = parseRecordLine(line);
+        if (record !== undefined) records.push(record);
+      }
+    }
+    return records;
+  } finally {
+    if (before === undefined) {
+      Deno.env.delete(RECORDS_DIR_VARIABLE);
+    } else {
+      Deno.env.set(RECORDS_DIR_VARIABLE, before);
+    }
+    await Deno.remove(dir, { recursive: true });
+  }
+}

--- a/packages/test-support/test/records/testing.test.ts
+++ b/packages/test-support/test/records/testing.test.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+
+import {
+  FragmentWriter,
+  RECORDS_DIR_VARIABLE,
+  recordsSpooledBy,
+  type TestRecord,
+} from "@commonfabric/test-support/records";
+
+const RECORD: TestRecord = {
+  line: "record",
+  test: { k: "unit", s: "bakery", n: "glaze > sets" },
+  outcome: "pass",
+  durationMs: 5,
+};
+
+describe("recordsSpooledBy()", () => {
+  it("returns records and skips other spool contents", async () => {
+    const records = await recordsSpooledBy(async () => {
+      const dir = Deno.env.get(RECORDS_DIR_VARIABLE);
+      expect(dir).toBeDefined();
+      await Deno.mkdir(join(dir!, "nested"));
+      await Deno.writeTextFile(join(dir!, "empty.ndjson"), "\n");
+
+      const writer = FragmentWriter.openForRun();
+      expect(writer).toBeDefined();
+      writer!.append(RECORD);
+      writer!.close();
+    });
+
+    expect(records).toEqual([RECORD]);
+  });
+
+  it("restores an existing spool variable", async () => {
+    const before = Deno.env.get(RECORDS_DIR_VARIABLE);
+    Deno.env.set(RECORDS_DIR_VARIABLE, "outer-spool");
+    try {
+      await recordsSpooledBy(() => {
+        expect(Deno.env.get(RECORDS_DIR_VARIABLE)).not.toBe("outer-spool");
+        return Promise.resolve();
+      });
+      expect(Deno.env.get(RECORDS_DIR_VARIABLE)).toBe("outer-spool");
+    } finally {
+      if (before === undefined) {
+        Deno.env.delete(RECORDS_DIR_VARIABLE);
+      } else {
+        Deno.env.set(RECORDS_DIR_VARIABLE, before);
+      }
+    }
+  });
+
+  it("leaves the spool variable unset when it began unset", async () => {
+    const before = Deno.env.get(RECORDS_DIR_VARIABLE);
+    Deno.env.delete(RECORDS_DIR_VARIABLE);
+    try {
+      await recordsSpooledBy(() => {
+        expect(Deno.env.get(RECORDS_DIR_VARIABLE)).toBeDefined();
+        return Promise.resolve();
+      });
+      expect(Deno.env.get(RECORDS_DIR_VARIABLE)).toBeUndefined();
+    } finally {
+      if (before !== undefined) {
+        Deno.env.set(RECORDS_DIR_VARIABLE, before);
+      }
+    }
+  });
+});

--- a/packages/ts-transformers/test/reactive/dataflow.test.ts
+++ b/packages/ts-transformers/test/reactive/dataflow.test.ts
@@ -142,7 +142,7 @@ declare const collection: {
     assertEquals(classifyArrayMethodResultSinkCall(call, checker), undefined);
   });
 
-  it("recognizes fetchJson as a reactive origin call", () => {
+  it("recognizes a fetchJson call carrying a result argument as a reactive origin call", () => {
     const { call, checker } = getCallExpression(
       'fetchJson({ url: "https://example.com", result: [] })',
       {

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -1839,7 +1839,7 @@ Deno.test("Pattern Context Validation - Safe Wrappers", async (t) => {
     },
   );
 
-  await t.step("allows reading opaques inside computed()", async () => {
+  await t.step("allows reading a Cell inside computed()", async () => {
     const source =
       `      import { pattern, computed, Cell, h } from "commonfabric";
 
@@ -1857,7 +1857,7 @@ Deno.test("Pattern Context Validation - Safe Wrappers", async (t) => {
     assertEquals(
       errors.length,
       0,
-      "Reading opaques inside computed() should be allowed",
+      "Reading a Cell inside computed() should be allowed",
     );
   });
 

--- a/tasks/check-local-program.test.ts
+++ b/tasks/check-local-program.test.ts
@@ -217,21 +217,24 @@ Deno.test("scan tolerates a tracked file deleted from the working tree", async (
   }
 });
 
-Deno.test("main reports success and returns 0 on a clean tree", async () => {
-  const root = await fixtureRepo({
-    "packages/foo/build.ts": "export const x = 1;\n",
-  });
-  try {
-    let code = -1;
-    const { out } = await captureConsole(async () => {
-      code = await main(root);
+Deno.test(
+  "check-local-program main reports success and returns 0 on a clean tree",
+  async () => {
+    const root = await fixtureRepo({
+      "packages/foo/build.ts": "export const x = 1;\n",
     });
-    assertEquals(code, 0);
-    assert(out.includes("Local programs are built through one operation"));
-  } finally {
-    await Deno.remove(root, { recursive: true });
-  }
-});
+    try {
+      let code = -1;
+      const { out } = await captureConsole(async () => {
+        code = await main(root);
+      });
+      assertEquals(code, 0);
+      assert(out.includes("Local programs are built through one operation"));
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
 
 Deno.test("main reports the offender and the route to take instead", async () => {
   const root = await fixtureRepo({

--- a/tasks/check-no-waitfor.test.ts
+++ b/tasks/check-no-waitfor.test.ts
@@ -339,7 +339,7 @@ Deno.test("no un-allowlisted polling waitFor in integration tests", async () => 
   );
 });
 
-Deno.test("ALLOWLIST has no stale entries", async () => {
+Deno.test("the polling-waitFor ALLOWLIST has no stale entries", async () => {
   const { allowlisted } = await scan();
   const seen = new Set(allowlisted);
   const stale = [...ALLOWLIST].filter((path) => !seen.has(path)).sort();
@@ -354,22 +354,25 @@ Deno.test("ALLOWLIST has no stale entries", async () => {
 // The next two tests drive the command entry point over a temp fixture tree, so
 // they cover the clean and violation paths without depending on the real tree.
 
-Deno.test("main reports success and returns 0 on a clean tree", async () => {
-  const root = await fixtureTree(
-    "ok.test.ts",
-    'import { env } from "@commonfabric/integration";\n',
-  );
-  try {
-    let code = -1;
-    const { out } = await captureConsole(async () => {
-      code = await main(root);
-    });
-    assertEquals(code, 0);
-    assert(out.includes("No new polling waitFor"));
-  } finally {
-    await Deno.remove(root, { recursive: true });
-  }
-});
+Deno.test(
+  "check-no-waitfor main reports success and returns 0 on a clean tree",
+  async () => {
+    const root = await fixtureTree(
+      "ok.test.ts",
+      'import { env } from "@commonfabric/integration";\n',
+    );
+    try {
+      let code = -1;
+      const { out } = await captureConsole(async () => {
+        code = await main(root);
+      });
+      assertEquals(code, 0);
+      assert(out.includes("No new polling waitFor"));
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
 
 Deno.test("main reports the offender and returns 1 on a violation", async () => {
   const root = await fixtureTree(

--- a/tasks/check-unused-deps.test.ts
+++ b/tasks/check-unused-deps.test.ts
@@ -250,7 +250,7 @@ Deno.test("no unused import map entries in the repository", async () => {
   );
 });
 
-Deno.test("ALLOWLIST has no stale entries", async () => {
+Deno.test("the unused-import-map ALLOWLIST has no stale entries", async () => {
   const { allowlisted } = await scan();
   const live = new Set(
     allowlisted.map((entry) => `${entry.config}\t${entry.alias}`),

--- a/tasks/pattern-vintage-run.test.ts
+++ b/tasks/pattern-vintage-run.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { exists } from "@std/fs";
 import { Identity } from "@commonfabric/identity";
+import { recordsSpooledBy } from "@commonfabric/test-support/records";
 import {
   AUTO,
   AUTO_GENERATIONS_KEPT,
@@ -607,6 +608,38 @@ describe("the vintage gate, end to end", () => {
 
     expect(replayed).toBe(1);
     expect(failures).toEqual([]);
+  });
+
+  it("spools no records for a caller that did not ask for them", async () => {
+    await captureMissing(
+      roots,
+      [TEST_KEY],
+      new Date("2026-07-29T12:00:00.000Z"),
+    );
+
+    const spooled = await recordsSpooledBy(() => replayAll(roots));
+
+    expect(spooled).toEqual([]);
+  });
+
+  it("spools one record per fixture for a caller that asked", async () => {
+    await captureMissing(
+      roots,
+      [TEST_KEY],
+      new Date("2026-07-29T12:00:00.000Z"),
+    );
+
+    const spooled = await recordsSpooledBy(() =>
+      replayAll(roots, { recordResults: true })
+    );
+
+    expect(spooled).toHaveLength(1);
+    expect(spooled[0].test.k).toBe("gate");
+    expect(spooled[0].test.s).toBe("repo");
+    expect(spooled[0].test.n).toBe(
+      `pattern-vintage ${TEST_KEY} ${PINNED} 2026-07-29T12-00-00.000Z`,
+    );
+    expect(spooled[0].outcome).toBe("pass");
   });
 
   it("FAILS when today's pattern requires an unbound new input", async () => {

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -895,6 +895,19 @@ export async function replayVintage(
   });
 }
 
+/** How `replayAll` reports what it walked. */
+export interface ReplayAllOptions {
+  /**
+   * Spool one gate record per fixture replayed.
+   *
+   * The task's entry point sets this: the fixtures under the repository's
+   * vintage root are the gate's tests. A caller inside another test leaves
+   * it unset, because the fixtures it points the roots at are that test's
+   * own, and a fixture is data rather than a test of this repository.
+   */
+  recordResults?: boolean;
+}
+
 /**
  * Replay every fixture under `vintagesRoot`.
  *
@@ -905,6 +918,7 @@ export async function replayVintage(
  */
 export async function replayAll(
   roots: GateRoots,
+  options: ReplayAllOptions = {},
 ): Promise<
   {
     vintages: VintageRef[];
@@ -977,7 +991,9 @@ export async function replayAll(
   // covers several patterns, and anything finer would be a redesign. The
   // stamp is part of the name because each captured generation is its own
   // test; a new capture is a new test, not a rename.
-  const recordsFragment = FragmentWriter.openForRun();
+  const recordsFragment = options.recordResults === true
+    ? FragmentWriter.openForRun()
+    : undefined;
   for (const vintage of vintages) {
     const replayStarted = performance.now();
     const report = await replayVintage(roots, vintage);

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -267,7 +267,7 @@ async function main() {
     ));
   }
 
-  const replay = await replayAll(roots);
+  const replay = await replayAll(roots, { recordResults: true });
 
   if (Deno.args.includes("--capture-changed")) {
     emit(describeCaptureOutcome(

--- a/tasks/select-generated-pattern-files.test.ts
+++ b/tasks/select-generated-pattern-files.test.ts
@@ -1,27 +1,10 @@
 import { assertEquals } from "@std/assert";
 import {
   listGeneratedPatternTests,
-  parseShard,
   selectGeneratedPatternFiles,
 } from "./select-generated-pattern-files.ts";
 
 const TOTAL_SHARDS = 2;
-
-Deno.test("parseShard parses shard notation", () => {
-  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
-});
-
-Deno.test("parseShard rejects invalid shard notation", () => {
-  try {
-    parseShard("5/4");
-    throw new Error("expected parseShard to throw");
-  } catch (error) {
-    assertEquals(
-      (error as Error).message,
-      "Shard index 5 exceeds total shard count 4",
-    );
-  }
-});
 
 Deno.test("selectGeneratedPatternFiles round-robins sorted names", () => {
   const files = [

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -9,7 +9,6 @@ import {
   PATTERN_INTEGRATION_TEST_WEIGHTS,
   selectPatternIntegrationFiles,
 } from "./select-pattern-integration-files.ts";
-import { parseShard } from "./shard-utils.ts";
 import {
   parsePatternIntegrationShard,
   selectPatternIntegrationShard,
@@ -19,40 +18,6 @@ const TOTAL_SHARDS = PATTERN_INTEGRATION_SHARD_COUNT;
 const INTERNALLY_SHARDED_FILE_NAMES = new Set<string>(
   INTERNALLY_SHARDED_PATTERN_INTEGRATION_FILES,
 );
-
-Deno.test("parseShard parses shard notation", () => {
-  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
-  assertEquals(parseShard("9007199254740991/9007199254740991"), {
-    index: Number.MAX_SAFE_INTEGER,
-    total: Number.MAX_SAFE_INTEGER,
-  });
-});
-
-Deno.test("parseShard rejects invalid shard notation", () => {
-  try {
-    parseShard("5/4");
-    throw new Error("expected parseShard to throw");
-  } catch (error) {
-    assertEquals(
-      (error as Error).message,
-      "Shard index 5 exceeds total shard count 4",
-    );
-  }
-});
-
-Deno.test("parseShard rejects unsafe integer values", () => {
-  const enormous = "9".repeat(400);
-  for (
-    const raw of [
-      "1/9007199254740992",
-      "9007199254740992/9007199254740992",
-      "9007199254740993/9007199254740992",
-      `${enormous}/${enormous}`,
-    ]
-  ) {
-    assertThrows(() => parseShard(raw), Error, "safe integers");
-  }
-});
 
 Deno.test("pattern integration shard defaults local runs to every item", () => {
   const shard = parsePatternIntegrationShard(undefined);

--- a/tasks/select-runner-test-files.test.ts
+++ b/tasks/select-runner-test-files.test.ts
@@ -3,26 +3,9 @@ import {
   listRunnerTests,
   selectRunnerTestFiles,
 } from "./select-runner-test-files.ts";
-import { parseShard } from "./shard-utils.ts";
 import { RUNNER_TEST_WEIGHTS } from "./test-timing-weights.ts";
 
 const TOTAL_SHARDS = 8;
-
-Deno.test("parseShard parses shard notation", () => {
-  assertEquals(parseShard("2/5"), { index: 2, total: 5 });
-});
-
-Deno.test("parseShard rejects invalid shard notation", () => {
-  try {
-    parseShard("6/5");
-    throw new Error("expected parseShard to throw");
-  } catch (error) {
-    assertEquals(
-      (error as Error).message,
-      "Shard index 6 exceeds total shard count 5",
-    );
-  }
-});
 
 Deno.test("runner test weighting spreads expensive files across shards", () => {
   const files = ["a", "b", "c", "d", "e", "f"].map((name) => ({

--- a/tasks/shard-utils.test.ts
+++ b/tasks/shard-utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { parseShard } from "./shard-utils.ts";
+
+describe("shard-utils", () => {
+  describe("parseShard()", () => {
+    it("returns the index and total of shard notation", () => {
+      expect(parseShard("2/5")).toEqual({ index: 2, total: 5 });
+      expect(parseShard("9007199254740991/9007199254740991")).toEqual({
+        index: Number.MAX_SAFE_INTEGER,
+        total: Number.MAX_SAFE_INTEGER,
+      });
+    });
+
+    it("throws given notation that is not two positive integers", () => {
+      for (const raw of ["", "1", "1/", "/4", "0/4", "1/0", "a/b", "1.5/4"]) {
+        expect(() => parseShard(raw)).toThrow("Expected shard argument");
+      }
+    });
+
+    it("throws given an index past the total", () => {
+      expect(() => parseShard("6/5")).toThrow(
+        "Shard index 6 exceeds total shard count 5",
+      );
+    });
+
+    it("throws given an index or total that is not a safe integer", () => {
+      const enormous = "9".repeat(400);
+      for (
+        const raw of [
+          "1/9007199254740992",
+          "9007199254740992/9007199254740992",
+          "9007199254740993/9007199254740992",
+          `${enormous}/${enormous}`,
+        ]
+      ) {
+        expect(() => parseShard(raw)).toThrow("safe integers");
+      }
+    });
+  });
+});

--- a/tasks/test-identity-aliases.jsonl
+++ b/tasks/test-identity-aliases.jsonl
@@ -1,0 +1,2 @@
+{"date":"2026-08-20","from":{"k":"unit","s":"runner","n":"link-utils > parseLink > should parse sigil links with overwrite this to normalized links"},"to":{"k":"unit","s":"runner","n":"link-utils > parseLink > should parse sigil links with overwrite redirect to normalized links"}}
+{"date":"2026-08-20","from":{"k":"unit","s":"tasks","n":"parseShard rejects unsafe integer values"},"to":{"k":"unit","s":"tasks","n":"shard-utils > parseShard() > throws given an index or total that is not a safe integer"}}

--- a/tasks/typecheck.test.ts
+++ b/tasks/typecheck.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { dirname, fromFileUrl, join } from "@std/path";
 
+import { recordsSpooledBy } from "@commonfabric/test-support/records";
+
 import {
   checkGroup,
   collectPathsByScope,
@@ -134,6 +136,31 @@ describe("typecheck", () => {
 
     it("fails an empty path collection outright", async () => {
       expect(await runTypecheck(new Map())).toBe(false);
+    });
+
+    it("spools no records for a caller that did not ask for them", async () => {
+      const spooled = await recordsSpooledBy(() =>
+        runTypecheck(new Map([["alpha", ["a.ts"]]]), { check: stub({}, []) })
+      );
+      expect(spooled).toEqual([]);
+    });
+
+    it("spools one record per scope for a caller that asked", async () => {
+      const spooled = await recordsSpooledBy(() =>
+        runTypecheck(
+          new Map([["alpha", ["a.ts"]], ["beta", ["b.ts"]]]),
+          { check: stub({ beta: false }, []), recordResults: true },
+        )
+      );
+      expect(
+        spooled.map((record) => [record.test.s, record.outcome]).sort(),
+      ).toEqual([["alpha", "pass"], ["beta", "fail"]]);
+      expect(spooled.every((record) => record.test.k === "typecheck")).toBe(
+        true,
+      );
+      expect(spooled.every((record) => record.test.n === "deno-check")).toBe(
+        true,
+      );
     });
   });
 });

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -225,6 +225,15 @@ export interface TypecheckOptions {
   list?: boolean;
   reload?: boolean;
   check?: typeof checkGroup;
+  /**
+   * Spool one typecheck record per scope.
+   *
+   * The task's entry point sets this: the scopes it collected are the
+   * repository's packages. A caller inside another test leaves it unset,
+   * because the scopes it hands over are that test's fixtures, and a
+   * fixture is data rather than a check of this repository.
+   */
+  recordResults?: boolean;
 }
 
 /**
@@ -262,7 +271,9 @@ export async function runTypecheck(
     `Type checking ${total} paths in ${byScope.size} package groups...`,
   );
 
-  const recordsFragment = FragmentWriter.openForRun();
+  const recordsFragment = options.recordResults === true
+    ? FragmentWriter.openForRun()
+    : undefined;
   const scopes = [...byScope.keys()];
   const results: GroupResult[] = [];
   let next = 0;
@@ -312,6 +323,7 @@ export async function main(): Promise<void> {
   const passed = await runTypecheck(await collectPathsByScope(), {
     list: Deno.args.includes("--list"),
     reload: (Deno.env.get("DENO_CHECK_RELOAD") ?? "") !== "",
+    recordResults: true,
   });
   if (!passed) Deno.exit(1);
 }


### PR DESCRIPTION
The test-run record store reported thirty test identities appearing more than once inside a single uploaded object, which is one job recording the same identity twice. A collision makes two distinct executions indistinguishable in history: their outcomes and durations merge, and neither can be tracked on its own. Every CI run reproduced all thirty. They have three causes, and each wants a different remedy.

Nineteen come from a function that records being called as a library by this repository's own tests. The pattern runner behind `cf test`, the type-check task, and the vintage gate's replay each opened a record fragment whenever CF_TEST_RECORDS_DIR was set, and inside a `deno test` process it always is. So the fixtures those tests hand the function entered the store as tests of this repository. Around twenty unit tests in packages/cli drive the pattern runner over files under packages/cli/test/fixtures, and several share a fixture, which is the collision: `pattern-coverage/single.test.tsx` reported four times in one job. The outcomes were worse than the duplication. Fixtures that exist to be rejected, such as `assert-diagnostics/failing.test.tsx`, recorded hundreds of failures a week under names that read like broken tests, and `data-files/single.test.tsx` recorded a pass and a failure under one identity in one job because one unit test attaches the data file and another deliberately does not. The vintage gate's own tests replay throwaway trees, which put twenty-nine records under `pattern-vintage vintage-gate-subject.test.tsx pinned 2026-07-29T12-00-00.000Z` in one shard. The type-check task's tests pass stub scopes named alpha, beta, and gamma.

Recording is now the caller's decision rather than the environment's. Each of the three takes a `recordResults` option, default off: the entry point that was asked to run tests sets it, and a test driving the same function leaves it alone. The environment variable still gates everything, so asking for records outside a spooled run still writes none. Beyond the nineteen collisions this removes sixty-five fixture identities carrying 15,372 records, 6,603 of them failures, from a seven-day window.

Three come from a batch record wearing an item's name. The CLI integration script recorded itself as `integration.sh $SECTION`, and every section CI dispatches shares its name with one of its own steps, so all three CLI integration jobs wrote two records under one name. The piece-call leg reported `integration.sh piece-call` at 317 seconds, which is the whole section rather than the step, and that container sat in the over-sixty-second list looking like a test. The script now records under its own name, `integration.sh`, beside the per-step `integration.sh <step>` records — the batch-and-item shape the spec already describes for `pattern-compat`, and one that keeps the CI section label out of an identity where the spec says run context belongs.

Eight come from two different tests sharing a name, and running the whole `tasks` package locally found a ninth the store had not shown, since its two files usually land in different jobs. Each is renamed after what it actually exercises. Two `it()` duplicates in the runner's schema tests differ by where the default comes from. A `link-utils` pair needed the name held by a third test that was itself mislabeled, carrying `overwrite: "redirect"` under a name saying "this". A hand-written `fetchJson` case in ts-transformers collided with a name a neighboring loop generates. In the `tasks` scope the collisions crossed files: `parseShard` lives in shard-utils.ts and had no test file, so three selection-task test files each carried a near-identical copy of its tests, and those now live in tasks/shard-utils.test.ts beside the function they exercise.

The browser harness had the same disease in its subprocess form, without producing a collision. Its tests copy fixture projects to temporary directories and run them through `deno task test`, and that child inherited CF_TEST_RECORDS_DIR, so four fixture projects reported as browser tests of this repository — 656 records, of which the `timeout-project` fixture whose job is to hang contributed 109 failures. The child is now handed an empty CF_TEST_RECORDS_DIR, which reads as recording off, the way the integration orchestrator already treats its own `cf` children.

Two renames are bridged in tasks/test-identity-aliases.jsonl, and only two. An alias maps one old identity to one new one, so it fits a test that changed its name and nothing else: the `link-utils` rename, and the `parseShard` unsafe-integer case moving into its own file. It fits none of the rest, where either the old name still belongs to a test that kept it, or the history under the old name is two tests' runs mixed together and attaching that to one survivor would be a fiction.

`recordsSpooledBy` is added to @commonfabric/test-support/records for testing the two halves of an opt-in: it points recording at a fresh spool, runs a function, and returns every record the function left there. All three in-process producers gain a pair of tests built on it. The helper sets a process-wide variable, so the CLI package's new test file joins the list of files its runner keeps off the parallel threads.

The spec and the operating guide gain the rule in both its forms, the in-process option and the child-process environment. The rule for writing tests gains the constraint these violated: a name has to be unique within its scope, and a loop that generates names is the case to check twice, since a hand-written test beside it can land on one of them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

