### PR TITLE
feat(cf-harness): the API gateway is opt-in, like the Codex subscription

### DIFF
--- a/docs/plans/cf-harness-codex-subscription-auth.md
+++ b/docs/plans/cf-harness-codex-subscription-auth.md
@@ -126,8 +126,10 @@ incompatible or too costly to maintain; it is not the selected path here.
 
 1. Add a separate `openai-codex` provider. Do not reinterpret
    `gatewayAuthMode: "bearer"` as subscription auth.
-2. Preserve the existing OpenAI-compatible gateway as the default. Existing
-   CLI flags, library callers, run artifacts, and tests remain compatible.
+2. Keep the OpenAI-compatible gateway a first-class provider, selected the same
+   explicit way `openai-codex` is. Neither provider is a default: a run that
+   names none is refused rather than routed to a billing route it never chose.
+   Existing CLI flags, library callers, and run artifacts keep their shapes.
 3. Keep `cf-harness` in charge of every model turn and every harness tool call.
    Subscription auth changes provider transport and credentials, not CFC
    authority.
@@ -447,7 +449,8 @@ Expected files:
 
 - [x] Replace combinations that can represent invalid states with a provider
   union: current OpenAI-compatible gateway config or `openai-codex` config.
-- [x] Keep the gateway provider and its current defaults unchanged.
+- [x] Keep the gateway provider's URL and auth defaults unchanged; selecting
+  the provider itself is explicit.
 - [x] Add `--model-provider openai-codex` and
   `CF_HARNESS_MODEL_PROVIDER=openai-codex` as explicit opt-ins.
 - [x] Reject gateway URL/auth flags when `openai-codex` is selected instead of
@@ -623,7 +626,7 @@ Expected files:
 - Importing credentials from Codex CLI or other harnesses.
 - A native Codex app-server runtime mode.
 - Managed Business/Enterprise automation through Codex access tokens.
-- Changing the package's default model or provider.
+- Changing the package's default model.
 - Using subscription credentials for non-Codex OpenAI APIs.
 
 [opencode-codex]: https://github.com/anomalyco/opencode/blob/411eff73f026d4950c07947c4d983788cb615baa/packages/opencode/src/plugin/openai/codex.ts

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -205,12 +205,18 @@ From [packages/cf-harness](.):
 
 ## CLI Example
 
+Every run selects a provider, and there is no default. The examples in this
+section pass `--model-provider` for one run; `CF_HARNESS_MODEL_PROVIDER` selects
+one for a shell and `config set` selects one for a machine, and the later
+examples in this document assume a provider selected one of those two ways.
+
 Standard bearer-auth mode:
 
 ```bash
 cd packages/cf-harness
 CF_HARNESS_API_KEY=... deno task run -- \
   --workspace ../.. \
+  --model-provider openai-compatible-gateway \
   --prompt "Summarize the cf-harness package structure." \
   --print-transcript
 ```
@@ -221,6 +227,7 @@ No-auth gateway mode:
 cd packages/cf-harness
 deno task run -- \
   --workspace ../.. \
+  --model-provider openai-compatible-gateway \
   --gateway-auth-mode none \
   --prompt "Summarize the cf-harness package structure." \
   --print-transcript
@@ -232,6 +239,7 @@ GPT-5.6 cache experiment:
 cd packages/cf-harness
 CF_HARNESS_API_KEY=... deno task run -- \
   --workspace ../.. \
+  --model-provider openai-compatible-gateway \
   --model gpt-5.6-terra \
   --reasoning-effort low \
   --prompt-cache-mode explicit \
@@ -297,14 +305,17 @@ ancestors concurrently. `cf-harness` never imports or shares
 `~/.codex/auth.json`. A failed refresh does not fall back to `OPENAI_API_KEY`,
 the Common Tools gateway, or unauthenticated mode.
 
-Direct runs resolve a provider from explicit CLI, environment, persistent
-preference, then the historical gateway default. Provider resolution does not
-resolve or rewrite model aliases. Resume retains the recorded provider and
-ignores the persistent preference; an explicit conflicting provider is a
-`provider-mismatch` failure. Structured config and auth commands use versioned
-JSON result envelopes. Login emits a versioned NDJSON authorization event before
-its terminal result. These responses expose connection health but no tokens,
-full account identifiers, expiries, or raw provider errors.
+Direct runs resolve a provider from explicit CLI, environment, then persistent
+preference. Every provider is opt-in: a run that names none through
+`--model-provider`, `CF_HARNESS_MODEL_PROVIDER`, or `config set` fails with
+`provider-configuration-required` rather than billing a route it never chose.
+Provider resolution does not resolve or rewrite model aliases. Resume retains
+the recorded provider and ignores the persistent preference; an explicit
+conflicting provider is a `provider-mismatch` failure. Structured config and
+auth commands use versioned JSON result envelopes. Login emits a versioned
+NDJSON authorization event before its terminal result. These responses expose
+connection health but no tokens, full account identifiers, expiries, or raw
+provider errors.
 
 Resume a root run with `--resume-run <run-root-or-run-state.json>`. Codex resume
 keeps the recorded provider, model, exact credential owner, and encrypted
@@ -342,8 +353,9 @@ CF_HARNESS_HOME=/canonical/private/home \
 ```
 
 The entrypoint serves both execution shapes. It rejects missing or invalid
-provider configuration instead of applying the historical gateway default. Codex
-preflight reads bounded connection health without refreshing; an expired
+provider configuration, and reads only the persisted preference from that
+home—the environment and CLI selections direct runs accept are not consulted.
+Codex preflight reads bounded connection health without refreshing; an expired
 credential refreshes only in the serialized resolver immediately before model
 traffic. Disconnected and reconnect-required Codex configurations return
 `provider-auth-required` without contacting Codex or the gateway. Resumed runs

--- a/packages/cf-harness/src/auth/provider-settings.ts
+++ b/packages/cf-harness/src/auth/provider-settings.ts
@@ -21,7 +21,7 @@ export type HarnessProviderSettingsState =
 
 export interface HarnessProviderResolution {
   provider: HarnessModelProviderId;
-  source: "explicit" | "environment" | "persistent" | "default";
+  source: "explicit" | "environment" | "persistent";
 }
 
 const detailOf = (error: unknown): string =>
@@ -364,12 +364,16 @@ const stateError = (
       : "Provider settings are invalid",
   );
 
-/** Resolves the provider with manual CLI precedence. */
+/**
+ * Resolves the provider a run bills against, from an explicit request, the
+ * environment, then the persistent preference. Neither provider is a default:
+ * a harness that configured none resolves to none, so a run is refused rather
+ * than routed to a billing route nobody named.
+ */
 export const resolveHarnessModelProviderPreference = async (options: {
   store: Pick<FileHarnessProviderSettingsStore, "inspect">;
   explicit?: HarnessModelProviderId;
   environment?: HarnessModelProviderId;
-  strict?: boolean;
 }): Promise<HarnessProviderResolution> => {
   if (options.explicit !== undefined) {
     return { provider: options.explicit, source: "explicit" };
@@ -381,13 +385,11 @@ export const resolveHarnessModelProviderPreference = async (options: {
   if (state.state === "configured") {
     return { provider: state.settings.modelProvider, source: "persistent" };
   }
-  if (state.state === "missing" && options.strict !== true) {
-    return { provider: "openai-compatible-gateway", source: "default" };
-  }
   if (state.state === "missing") {
     throw new HarnessControlError(
       "provider-configuration-required",
-      "A persistent model provider must be configured",
+      "No model provider is selected; choose one with --model-provider, " +
+        "CF_HARNESS_MODEL_PROVIDER, or `config set`",
     );
   }
   throw stateError(state);

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -489,6 +489,8 @@ Options:
   --no-skill-catalog            Disable automatic skill catalog disclosure
   --model <name>                Model name (default: ${DEFAULT_MODEL})
   --model-provider <provider>   openai-compatible-gateway | openai-codex
+                                (no default; select one here, through
+                                CF_HARNESS_MODEL_PROVIDER, or with config set)
   --reasoning-effort <effort>   Provider reasoning effort (for example low, medium, high)
   --compact-threshold <n>       Token threshold for server-side compaction
                                 (default: 75% of the model input budget; 0 disables)
@@ -2537,11 +2539,7 @@ const runCfHarnessConfigCommand = async (
     if (action === "inspect") {
       const state = await store.inspect();
       let effectiveProvider: HarnessModelProviderId | undefined;
-      let effectiveSource:
-        | "environment"
-        | "persistent"
-        | "default"
-        | undefined;
+      let effectiveSource: "environment" | "persistent" | undefined;
       const rawEnvironment = nonEmptyEnvValue(
         deps.env?.CF_HARNESS_MODEL_PROVIDER ??
           (deps.env === undefined
@@ -2558,16 +2556,9 @@ const runCfHarnessConfigCommand = async (
       if (environment !== undefined) {
         effectiveProvider = environment;
         effectiveSource = "environment";
-      } else if (
-        state.state === "configured" || state.state === "missing"
-      ) {
-        if (state.state === "configured") {
-          effectiveProvider = state.settings.modelProvider;
-          effectiveSource = "persistent";
-        } else {
-          effectiveProvider = "openai-compatible-gateway";
-          effectiveSource = "default";
-        }
+      } else if (state.state === "configured") {
+        effectiveProvider = state.settings.modelProvider;
+        effectiveSource = "persistent";
       }
       const result = {
         state: state.state,

--- a/packages/cf-harness/src/loom-local-host.ts
+++ b/packages/cf-harness/src/loom-local-host.ts
@@ -370,7 +370,6 @@ export const createLoomLocalCfHarnessHost = async (
   const configuredProvider = async (): Promise<HarnessModelProviderId> =>
     (await resolveHarnessModelProviderPreference({
       store: providerStore,
-      strict: true,
     })).provider;
 
   const preflightCodex = async (): Promise<OpenAICodexCredentialResolver> => {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2381,6 +2381,10 @@ Deno.test("runCfHarnessCli reads CF_HARNESS_COMPACT_THRESHOLD from the process e
   for (const name of projected) Deno.env.delete(name);
   Deno.env.set("CF_HARNESS_API_KEY", "test-key");
   Deno.env.set("CF_HARNESS_COMPACT_THRESHOLD", "9000");
+  // The projection is what this test is about, and provider selection reads it
+  // too: without a projected selection the run is refused before the threshold
+  // is ever consulted, on any machine whose harness home configured none.
+  Deno.env.set("CF_HARNESS_MODEL_PROVIDER", "openai-compatible-gateway");
   try {
     const { io } = createIoBuffers();
     let createdOptions: Record<string, unknown> | undefined;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -3819,27 +3819,31 @@ Deno.test("runCfHarnessCli refuses a run that selected no model provider", async
   // No store is injected, so the run reads the harness home the CLI resolves
   // for itself — the one place an operator's persisted selection would be.
   const home = await Deno.makeTempDir({ prefix: "cf-harness-no-provider-" });
-  const { io, stdout, stderr } = createIoBuffers();
-  const exitCode = await runCfHarnessCli(
-    ["--prompt", "hello"],
-    {
-      io,
-      env: {
-        CF_HARNESS_HOME: home,
-        CF_HARNESS_API_KEY: "key-for-a-gateway-nobody-asked-for",
+  try {
+    const { io, stdout, stderr } = createIoBuffers();
+    const exitCode = await runCfHarnessCli(
+      ["--prompt", "hello"],
+      {
+        io,
+        env: {
+          CF_HARNESS_HOME: home,
+          CF_HARNESS_API_KEY: "key-for-a-gateway-nobody-asked-for",
+        },
+        createModelClient: () => {
+          throw new Error("unselected provider must not reach a model client");
+        },
       },
-      createModelClient: () => {
-        throw new Error("unselected provider must not reach a model client");
-      },
-    },
-  );
+    );
 
-  assertEquals(exitCode, 1);
-  assertEquals(stdout, []);
-  assertEquals(stderr, [
-    "No model provider is selected; choose one with --model-provider, " +
-    "CF_HARNESS_MODEL_PROVIDER, or `config set`\n",
-  ]);
+    assertEquals(exitCode, 1);
+    assertEquals(stdout, []);
+    assertEquals(stderr, [
+      "No model provider is selected; choose one with --model-provider, " +
+      "CF_HARNESS_MODEL_PROVIDER, or `config set`\n",
+    ]);
+  } finally {
+    await Deno.remove(home, { recursive: true });
+  }
 });
 
 Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", async () => {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -1945,7 +1945,14 @@ Deno.test("runCfHarnessCli registers and disposes signal handlers around a run",
   let registeredSignals: readonly string[] = [];
   let disposed = false;
   const exitCode = await runCfHarnessCli(
-    ["--prompt", "hello", "--gateway-auth-mode", "none"],
+    [
+      "--model-provider",
+      "openai-compatible-gateway",
+      "--prompt",
+      "hello",
+      "--gateway-auth-mode",
+      "none",
+    ],
     {
       io,
       env: {},
@@ -2017,6 +2024,8 @@ Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata",
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--focus-root",
@@ -2139,6 +2148,8 @@ Deno.test("runCfHarnessCli announces well-known grants to the model and the oper
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       workspace,
       "--prompt",
@@ -2225,6 +2236,8 @@ Deno.test("runCfHarnessCli says so when the well-known grants cannot be establis
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2291,6 +2304,8 @@ Deno.test("runCfHarnessCli forwards --compact-threshold to a fresh run", async (
   let createdOptions: Record<string, unknown> | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--focus-root",
@@ -2437,6 +2452,8 @@ Deno.test("runCfHarnessCli passes image attachments to the prompt loop", async (
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       workspace,
       "--image",
@@ -2540,6 +2557,8 @@ Deno.test("runCfHarnessCli passes tool and subagent profile allowlists", async (
     let createdOptions: Record<string, unknown> | undefined;
     const exitCode = await runCfHarnessCli(
       [
+        "--model-provider",
+        "openai-compatible-gateway",
         "--workspace",
         "/tmp/project",
         "--prompt",
@@ -2607,6 +2626,8 @@ Deno.test("runCfHarnessCli passes Browser Access leases to the prompt loop", asy
   let createdOptions: Record<string, unknown> | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2675,6 +2696,8 @@ Deno.test("runCfHarnessCli can override the prompt-slot role for testing", async
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2748,6 +2771,8 @@ Deno.test("runCfHarnessCli passes a Loom run manifest and its prompt slot", asyn
   } as const;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2812,6 +2837,8 @@ Deno.test("runCfHarnessCli can stream transcript events as they happen", async (
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2917,6 +2944,8 @@ Deno.test("runCfHarnessCli uses plain stdout and no operator guidance in batch m
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -2978,6 +3007,8 @@ Deno.test("runCfHarnessCli writes a structured batch result sidecar when request
   const writes: Array<{ path: string; text: string }> = [];
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -3087,6 +3118,8 @@ Deno.test("runCfHarnessCli validates a top-level structured result sidecar", asy
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -3186,6 +3219,8 @@ Deno.test("runCfHarnessCli exits nonzero when top-level structured result is inv
   const writes: Array<{ path: string; text: string }> = [];
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -3296,6 +3331,8 @@ Deno.test({
 
       const exitCode = await runCfHarnessCli(
         [
+          "--model-provider",
+          "openai-compatible-gateway",
           "--workspace",
           workspace,
           "--prompt",
@@ -3416,6 +3453,8 @@ Deno.test({
       let engine: CfHarnessEngine | undefined;
       const exitCode = await runCfHarnessCli(
         [
+          "--model-provider",
+          "openai-compatible-gateway",
           "--workspace",
           workspace,
           "--prompt",
@@ -3761,7 +3800,7 @@ Deno.test("runCfHarnessCli reports argument errors to stderr", async () => {
 Deno.test("runCfHarnessCli fails early when no API key is configured", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(
-    ["--prompt", "hello"],
+    ["--model-provider", "openai-compatible-gateway", "--prompt", "hello"],
     { io, env: {} },
   );
 
@@ -3772,11 +3811,45 @@ Deno.test("runCfHarnessCli fails early when no API key is configured", async () 
   ]);
 });
 
+Deno.test("runCfHarnessCli refuses a run that selected no model provider", async () => {
+  const providerSettingsStore = {
+    inspect: () => Promise.resolve({ state: "missing" as const }),
+    initialize: () => Promise.reject(new Error("unused")),
+    set: () => Promise.reject(new Error("unused")),
+  };
+  const { io, stdout, stderr } = createIoBuffers();
+  const exitCode = await runCfHarnessCli(
+    ["--prompt", "hello"],
+    {
+      io,
+      env: { CF_HARNESS_API_KEY: "key-for-a-gateway-nobody-asked-for" },
+      providerSettingsStore,
+      createModelClient: () => {
+        throw new Error("unselected provider must not reach a model client");
+      },
+    },
+  );
+
+  assertEquals(exitCode, 1);
+  assertEquals(stdout, []);
+  assertEquals(stderr, [
+    "No model provider is selected; choose one with --model-provider, " +
+    "CF_HARNESS_MODEL_PROVIDER, or `config set`\n",
+  ]);
+});
+
 Deno.test("runCfHarnessCli allows no-auth gateway mode without an API key", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   let createdOptions: Record<string, unknown> | undefined;
   const exitCode = await runCfHarnessCli(
-    ["--prompt", "hello", "--gateway-auth-mode", "none"],
+    [
+      "--model-provider",
+      "openai-compatible-gateway",
+      "--prompt",
+      "hello",
+      "--gateway-auth-mode",
+      "none",
+    ],
     {
       io,
       env: {},
@@ -4458,6 +4531,8 @@ Deno.test("runCfHarnessCli threads fabric-mount into engine additionalMounts", a
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -4527,6 +4602,8 @@ Deno.test("runCfHarnessCli threads host-mount into engine additionalMounts", asy
   let runPromptOptions: RunHarnessPromptOptions | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       workspace,
       "--prompt",
@@ -4598,6 +4675,8 @@ Deno.test("runCfHarnessCli threads sandbox-image into engine sandbox config", as
   let createdOptions: Record<string, unknown> | undefined;
   const exitCode = await runCfHarnessCli(
     [
+      "--model-provider",
+      "openai-compatible-gateway",
       "--workspace",
       "/tmp/project",
       "--prompt",
@@ -4948,11 +5027,7 @@ Deno.test("structured config commands expose stable success and failure envelope
     version: 1,
     ok: true,
     command: "config.inspect",
-    result: {
-      state: "missing",
-      effectiveProvider: "openai-compatible-gateway",
-      effectiveSource: "default",
-    },
+    result: { state: "missing" },
   });
 
   const initialized = createIoBuffers();

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -3816,18 +3816,18 @@ Deno.test("runCfHarnessCli fails early when no API key is configured", async () 
 });
 
 Deno.test("runCfHarnessCli refuses a run that selected no model provider", async () => {
-  const providerSettingsStore = {
-    inspect: () => Promise.resolve({ state: "missing" as const }),
-    initialize: () => Promise.reject(new Error("unused")),
-    set: () => Promise.reject(new Error("unused")),
-  };
+  // No store is injected, so the run reads the harness home the CLI resolves
+  // for itself — the one place an operator's persisted selection would be.
+  const home = await Deno.makeTempDir({ prefix: "cf-harness-no-provider-" });
   const { io, stdout, stderr } = createIoBuffers();
   const exitCode = await runCfHarnessCli(
     ["--prompt", "hello"],
     {
       io,
-      env: { CF_HARNESS_API_KEY: "key-for-a-gateway-nobody-asked-for" },
-      providerSettingsStore,
+      env: {
+        CF_HARNESS_HOME: home,
+        CF_HARNESS_API_KEY: "key-for-a-gateway-nobody-asked-for",
+      },
       createModelClient: () => {
         throw new Error("unselected provider must not reach a model client");
       },

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -5056,6 +5056,21 @@ Deno.test("structured config commands expose stable success and failure envelope
     );
   }
 
+  const persisted = createIoBuffers();
+  assertEquals(
+    await runCfHarnessCli(["config", "inspect", "--json"], {
+      io: persisted.io,
+      env,
+    }),
+    0,
+  );
+  assertEquals(JSON.parse(persisted.stdout[0]).result, {
+    state: "configured",
+    configuredProvider: "openai-compatible-gateway",
+    effectiveProvider: "openai-compatible-gateway",
+    effectiveSource: "persistent",
+  });
+
   await Deno.writeTextFile(join(home, "config.json"), "{secret-corruption", {
     mode: 0o600,
   });

--- a/packages/cf-harness/test/provider-settings.test.ts
+++ b/packages/cf-harness/test/provider-settings.test.ts
@@ -219,7 +219,7 @@ file.close();`,
   });
 
   describe("resolveHarnessModelProviderPreference()", () => {
-    it("applies explicit, environment, persistent, and default precedence", async () => {
+    it("applies explicit, environment, and persistent precedence", async () => {
       const configured = {
         inspect: () =>
           Promise.resolve({
@@ -251,24 +251,34 @@ file.close();`,
       });
       expect(await resolveHarnessModelProviderPreference({ store: configured }))
         .toEqual({ provider: "openai-codex", source: "persistent" });
+    });
+
+    it("selects no provider when none was requested or configured", async () => {
+      const missing = {
+        inspect: () => Promise.resolve({ state: "missing" as const }),
+      };
+      await expect(resolveHarnessModelProviderPreference({ store: missing }))
+        .rejects.toMatchObject({
+          code: "provider-configuration-required",
+        });
       expect(
         await resolveHarnessModelProviderPreference({
-          store: { inspect: () => Promise.resolve({ state: "missing" }) },
+          store: missing,
+          explicit: "openai-compatible-gateway",
         }),
       ).toEqual({
         provider: "openai-compatible-gateway",
-        source: "default",
+        source: "explicit",
       });
+      expect(
+        await resolveHarnessModelProviderPreference({
+          store: missing,
+          environment: "openai-codex",
+        }),
+      ).toEqual({ provider: "openai-codex", source: "environment" });
     });
 
-    it("requires persistent configuration in strict mode", async () => {
-      const resolution = resolveHarnessModelProviderPreference({
-        store: { inspect: () => Promise.resolve({ state: "missing" }) },
-        strict: true,
-      });
-      await expect(resolution).rejects.toMatchObject({
-        code: "provider-configuration-required",
-      });
+    it("rejects unusable provider settings", async () => {
       await expect(
         resolveHarnessModelProviderPreference({
           store: {


### PR DESCRIPTION
A direct run resolved its provider from an explicit CLI selection, the environment, then the persistent preference — and, failing all three, fell through to the OpenAI-compatible gateway. That last step billed a route nobody named.

It is gone. A run that selects no provider fails with `provider-configuration-required` before a model client is constructed, and both providers are now reached the same three ways:

| selection | scope |
| --- | --- |
| `--model-provider openai-compatible-gateway` | one run |
| `CF_HARNESS_MODEL_PROVIDER=openai-codex` | one shell |
| `cf-harness config set openai-codex` | one machine, persisted in `CF_HARNESS_HOME/config.json` |

A Loom run manifest's `modelProvider` still selects one too. The Codex path is unchanged — it was already opt-in, and the environment variable was never Codex-specific; it names either provider.

### Also in this change

- `config inspect` on an unconfigured home reports `{"state": "missing"}` with no `effectiveProvider`/`effectiveSource`, and `"default"` leaves `HarnessProviderResolution["source"]`.
- `strict` leaves the resolver. Strict is the only behavior, so `createLoomLocalCfHarnessHost()` no longer opts into what it already required.
- Help text, the README's provider-resolution prose and CLI examples, and the live Codex-subscription plan's "preserve the gateway as the default" decision.

### Two fallbacks deliberately kept

Neither is a user choosing nothing, and removing either goes past this change:

1. `resolveHarnessConfig()` still defaults for a library caller that constructs an engine without a provider. Requiring it there is a breaking API change across every `new CfHarnessEngine(...)` call site, Loom's adapter included. The CLI and the Loom host both pass a resolved provider, so no user-facing path reaches it.
2. A resumed run whose state predates the recorded `modelProvider` field still reads as the gateway — which is what it ran on. Dropping this would make those runs unresumable.

### Verification

748 tests pass in `packages/cf-harness`; repo-wide `deno fmt --check`, `deno lint`, `deno task check-docs`, and `deno task check-skill-facts` pass. Restoring the old fallback under mutation fails both new tests — the unit test in `provider-settings.test.ts` and a CLI test that also asserts no model client is constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

