### PR TITLE
refactor(data-model): a codec's `encode()` is handed the live environment

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2097,12 +2097,11 @@ Key contracts:
 
 /**
  * The minimal interface that codec `encode()` and `decode()` implementations
- * may depend on. In practice this is provided by the `Runtime` class from
- * `packages/runner/src/runtime.ts`, but defining it as an interface here
- * avoids a circular dependency between the fabric protocol and the runner.
- *
- * Implementors of `encode()` and `decode()` should depend on this interface,
- * not on the concrete `Runtime` class.
+ * may depend on: what a codec needs of the live system around it, and
+ * nothing more. This package names what it requires rather than the classes
+ * that happen to supply it, so a client brings its own.
+ * `BaseLiveEnvironment` is the base to build one on, and
+ * `NullLiveEnvironment` covers a caller that expects to need no cell.
  */
 export interface LiveEnvironment {
   /**
@@ -2131,14 +2130,12 @@ export interface LiveEnvironment {
 }
 ```
 
-> **Why an interface, not the concrete `Runtime`?** The fabric protocol is
-> intended to live in a foundational package (`packages/data-model/`).
-> If codec `decode()` implementations depended on the full `Runtime` type
-> from `packages/runner/`, it would create a circular dependency. The
-> `LiveEnvironment` interface captures the minimal surface needed for
-> decoding. The `Runtime` class satisfies this interface. Future
-> fabric types may extend `LiveEnvironment` if they need additional
-> capabilities beyond `getCell` and `shouldDeepFreeze`.
+> **Why an interface rather than a named class?** `packages/data-model/` is a
+> standalone low-level package, and a requirement it states as an interface is
+> one any client can satisfy. It has several already -- `memory` builds one,
+> as do tests in `data-model` and `runner` -- and more are expected. Future
+> fabric types may extend `LiveEnvironment` if they need capabilities beyond
+> `getCell` and `shouldDeepFreeze`.
 
 ### 2.6 Brand Detection
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -578,7 +578,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   // slots + bag; `wrappedValue` / `toNativeFrozen()` / `toNativeThawed()`
   // build the native `Error` projection on demand. `deepClone(frozen)`
   // round-trips through the codec: `codec.decode(tag,
-  // codec.encode(this), env)`. Bodies omitted for brevity.)
+  // codec.encode(this, env), env)`. Bodies omitted for brevity.)
 
   static #codec = Object.freeze(
     new (class FabricErrorCodec extends BaseNonterminalCodec {
@@ -592,7 +592,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
        * case) to avoid redundancy; `decode()` interprets `null` as "same
        * as `type`."
        */
-      encode(value: FabricError): FabricValue {
+      encode(value: FabricError, _env: LiveEnvironment): FabricValue {
         const state: Record<string, FabricValue> = {
           type: value.type,
           name: value.name === value.type ? null : value.name,
@@ -702,7 +702,7 @@ export class FabricMap
 
       /** Entry pairs as an array of two-element arrays; insertion order
        *  is preserved. */
-      encode(value: FabricMap): FabricValue {
+      encode(value: FabricMap, _env: LiveEnvironment): FabricValue {
         return [...value.map.entries()] as FabricValue;
       }
 
@@ -756,7 +756,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
       }
 
       /** Elements as an array; iteration order is preserved. */
-      encode(value: FabricSet): FabricValue {
+      encode(value: FabricSet, _env: LiveEnvironment): FabricValue {
         return [...value.set] as FabricValue;
       }
 
@@ -1936,8 +1936,11 @@ export interface FabricCodec<Encoded> {
    * ever called after `canEncode()` has confirmed that `value` is
    * encodable by this instance. The result is expected to be a _shallow_
    * encoding. The codec system handles recursion as necessary.
+   *
+   * `env` is what a codec reaches the running system through, the same one
+   * `decode()` is handed.
    */
-  encode(value: FabricValue): Encoded;
+  encode(value: FabricValue, env: LiveEnvironment): Encoded;
 }
 
 /**
@@ -2093,13 +2096,13 @@ Key contracts:
 // file: packages/data-model/codec-interface/interface.ts
 
 /**
- * The minimal interface that codec `decode()` implementations may depend
- * on. In practice this is provided by the `Runtime` class from
+ * The minimal interface that codec `encode()` and `decode()` implementations
+ * may depend on. In practice this is provided by the `Runtime` class from
  * `packages/runner/src/runtime.ts`, but defining it as an interface here
  * avoids a circular dependency between the fabric protocol and the runner.
  *
- * Implementors of `decode()` should depend on this interface, not on
- * the concrete `Runtime` class.
+ * Implementors of `encode()` and `decode()` should depend on this interface,
+ * not on the concrete `Runtime` class.
  */
 export interface LiveEnvironment {
   /**
@@ -2225,7 +2228,10 @@ class Temperature extends BaseFabricInstance {
       }
 
       /** Extract essential state (shallow). */
-      encode(value: Temperature): TemperatureState {
+      encode(
+        value: Temperature,
+        _env: LiveEnvironment,
+      ): TemperatureState {
         return { value: value.value, unit: value.unit };
       }
 
@@ -2266,7 +2272,7 @@ flatten it into `{ value: 100, unit: "C" }`. With the protocol, the
 codec system:
 
 1. Finds the class's codec (via the registry; Section 4.5) and calls
-   `codec.encode(value)` to extract the essential state.
+   `codec.encode(value, env)` to extract the essential state.
 2. Encodes that state (recursively handling any nested `FabricValue`s)
    and wraps it with the tag from `codec.tagForValue(value)`.
 3. On decoding, routes the tag back to the codec, asks
@@ -2454,7 +2460,7 @@ export class UnknownValue extends BaseFabricInstance {
       }
 
       /** The preserved bare state -- NOT an envelope. */
-      encode(value: UnknownValue): FabricValue {
+      encode(value: UnknownValue, _env: LiveEnvironment): FabricValue {
         return value.state;
       }
 
@@ -2577,7 +2583,10 @@ export class ProblematicValue extends BaseFabricInstance {
       }
 
       /** All three preserved facts; the tag is data here, not structure. */
-      encode(value: ProblematicValue): FabricValue {
+      encode(
+        value: ProblematicValue,
+        _env: LiveEnvironment,
+      ): FabricValue {
         return {
           tag: value.wireTypeTag,
           state: value.state,

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -2,7 +2,10 @@ import { ensureDir } from "@std/fs";
 import { dirname, join } from "@std/path";
 
 import type { CellScope, JSONSchema } from "@commonfabric/api";
-import { codecOf } from "@commonfabric/data-model/codec-common";
+import {
+  codecOf,
+  NULL_LIVE_ENVIRONMENT,
+} from "@commonfabric/data-model/codec-common";
 import {
   FabricPrimitive,
   FabricSpecialObject,
@@ -1146,7 +1149,9 @@ async function searchTextMatches(
         // contributes nothing here. For anything else, a missing codec is a
         // real fault and `codecOf()` throws, which the `catch` reports.
         if (!(current instanceof FabricPrimitive)) {
-          representations.push({ value: codecOf(current).encode(current) });
+          representations.push({
+            value: codecOf(current).encode(current, NULL_LIVE_ENVIRONMENT),
+          });
         }
       } catch (error) {
         reportReadError?.(error);

--- a/packages/data-model/src/codec-common/BaseEncodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseEncodeAct.ts
@@ -167,8 +167,10 @@ export abstract class BaseEncodeAct<Encoded, SerializedForm = Encoded>
     try {
       tag = matched.tagForValue(value);
       state = (matched instanceof BaseTerminalCodec)
-        ? (matched as TerminalCodec<Encoded>).encode(value)
-        : this.encodeValue((matched as NonterminalCodec).encode(value));
+        ? (matched as TerminalCodec<Encoded>).encode(value, this.env)
+        : this.encodeValue(
+          (matched as NonterminalCodec).encode(value, this.env),
+        );
     } finally {
       // Left in a `finally` because `tagForValue()` and a codec's `encode()`
       // can both throw. The act outlives a throw -- it belongs to the call,

--- a/packages/data-model/src/codec-common/ProblematicValue.ts
+++ b/packages/data-model/src/codec-common/ProblematicValue.ts
@@ -162,7 +162,10 @@ export class ProblematicValue extends BaseFabricInstance {
       }
 
       /** @inheritDoc */
-      encode(value: ProblematicValue): ProblematicValueState {
+      encode(
+        value: ProblematicValue,
+        _env: LiveEnvironment,
+      ): ProblematicValueState {
         return {
           tag: value.wireTypeTag,
           state: value.state,

--- a/packages/data-model/src/codec-common/SymbolCodec.ts
+++ b/packages/data-model/src/codec-common/SymbolCodec.ts
@@ -75,7 +75,7 @@ export class SymbolCodec<Encoded>
   }
 
   /** @inheritDoc */
-  encode(value: symbol): Encoded & string {
+  encode(value: symbol, _env: LiveEnvironment): Encoded & string {
     // `canEncode()` already verified the symbol has a registry key.
     return this.#keyAsEncoded(Symbol.keyFor(value)!);
   }

--- a/packages/data-model/src/codec-common/UnknownValue.ts
+++ b/packages/data-model/src/codec-common/UnknownValue.ts
@@ -116,7 +116,7 @@ export class UnknownValue extends BaseFabricInstance {
       }
 
       /** @inheritDoc */
-      encode(value: UnknownValue): FabricValue {
+      encode(value: UnknownValue, _env: LiveEnvironment): FabricValue {
         return value.state;
       }
 

--- a/packages/data-model/src/codec-interface/BaseFabricCodec.ts
+++ b/packages/data-model/src/codec-interface/BaseFabricCodec.ts
@@ -79,7 +79,7 @@ export abstract class BaseFabricCodec<Encoded, State extends Encoded = Encoded>
    * What this codec emits is what it takes back: `State` is the same type
    * {@link #canDecode} narrows to and {@link #decode} is handed.
    */
-  abstract encode(value: FabricValue): State;
+  abstract encode(value: FabricValue, env: LiveEnvironment): State;
 
   //
   // Instance members

--- a/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
+++ b/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
@@ -1,8 +1,8 @@
 /**
  * Null `LiveEnvironment`: a singleton whose `getCell()` always throws.
- * Useful as a default for decode paths that aren't expected to encounter
- * `Cell` references (e.g. storage-boundary reads of values known to be
- * structurally flat).
+ * Useful as a default for encode and decode paths that aren't expected to
+ * encounter `Cell` references (e.g. storage-boundary reads of values known to
+ * be structurally flat).
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
@@ -42,10 +42,9 @@ export class NullLiveEnvironment extends BaseLiveEnvironment {
 
 /**
  * Shared `NullLiveEnvironment` instance with `.shouldDeepFreeze ===
- * true` and whose `getCell()` always throws. Pass this when a decoder wants a
- * live environment but isn't expected to need cell decoding; if a cell ref
- * does turn up, the throw makes the unexpected decode obvious instead
- * of silent.
+ * true` and whose `getCell()` always throws. Pass this when a codec wants a
+ * live environment but isn't expected to need a cell; if a cell ref does turn
+ * up, the throw makes the unexpected lookup obvious instead of silent.
  */
 export const NULL_LIVE_ENVIRONMENT: LiveEnvironment = Object
   .freeze(new NullLiveEnvironment(true));

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -172,8 +172,11 @@ export interface FabricCodec<Encoded> {
    * called after {@link #canEncode} has confirmed that `value` is encodable by
    * this instance. The result is expected to be a _shallow_ encoding; the
    * codec system handles recursion as necessary.
+   *
+   * `env` is what a codec reaches the running system through, the same one
+   * {@link #decode} is handed.
    */
-  encode(value: FabricValue): Encoded;
+  encode(value: FabricValue, env: LiveEnvironment): Encoded;
 }
 
 /**
@@ -268,10 +271,10 @@ export interface FabricClassWithNonterminalCodec {
 }
 
 /**
- * The minimal interface that codec `decode()` implementations may depend on.
- * Provided by the `Runtime` in practice, but defined as an interface here to
- * avoid a circular dependency between the fabric protocol and the runner.
- * See Section 2.5 of the formal spec.
+ * The minimal interface that codec `encode()` and `decode()` implementations
+ * may depend on. Provided by the `Runtime` in practice, but defined as an
+ * interface here to avoid a circular dependency between the fabric protocol
+ * and the runner. See Section 2.5 of the formal spec.
  */
 export interface LiveEnvironment {
   /**

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -272,9 +272,11 @@ export interface FabricClassWithNonterminalCodec {
 
 /**
  * The minimal interface that codec `encode()` and `decode()` implementations
- * may depend on. Provided by the `Runtime` in practice, but defined as an
- * interface here to avoid a circular dependency between the fabric protocol
- * and the runner. See Section 2.5 of the formal spec.
+ * may depend on: what a codec needs of the live system around it, and nothing
+ * more. This package names what it requires rather than the classes that
+ * happen to supply it, so a client brings its own. `BaseLiveEnvironment` is
+ * the base to build one on, and `NullLiveEnvironment` covers a caller that
+ * expects to need no cell. See Section 2.5 of the formal spec.
  */
 export interface LiveEnvironment {
   /**

--- a/packages/data-model/src/codec-json/BigIntCodec.ts
+++ b/packages/data-model/src/codec-json/BigIntCodec.ts
@@ -36,7 +36,7 @@ export class BigIntCodec extends BaseTerminalCodec<JsonCodecValue, string> {
   }
 
   /** @inheritDoc */
-  encode(value: bigint): string {
+  encode(value: bigint, _env: LiveEnvironment): string {
     return bigintToUnpaddedBase64url(value);
   }
 

--- a/packages/data-model/src/codec-json/SpecialNumberCodec.ts
+++ b/packages/data-model/src/codec-json/SpecialNumberCodec.ts
@@ -49,7 +49,7 @@ export class SpecialNumberCodec
   }
 
   /** @inheritDoc */
-  encode(value: number): SpecialNumberState {
+  encode(value: number, _env: LiveEnvironment): SpecialNumberState {
     if (Number.isNaN(value)) return "NaN";
     if (value === Infinity) return "+Infinity";
     if (value === -Infinity) return "-Infinity";

--- a/packages/data-model/src/codec-json/UndefinedCodec.ts
+++ b/packages/data-model/src/codec-json/UndefinedCodec.ts
@@ -21,7 +21,7 @@ export class UndefinedCodec extends BaseTerminalCodec<JsonCodecValue, null> {
   }
 
   /** @inheritDoc */
-  encode(_value: FabricValue): null {
+  encode(_value: FabricValue, _env: LiveEnvironment): null {
     return null;
   }
 

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -389,7 +389,7 @@ export class FabricError extends FabricNativeWrapper<Error>
     );
     return codec.decode(
       CODEC_TYPE_TAGS.Error,
-      codec.encode(this),
+      codec.encode(this, liveEnvironment),
       liveEnvironment,
     ) as FabricError;
   }
@@ -435,7 +435,7 @@ export class FabricError extends FabricNativeWrapper<Error>
       }
 
       /** @inheritDoc */
-      encode(value: FabricError): FabricPlainObject {
+      encode(value: FabricError, _env: LiveEnvironment): FabricPlainObject {
         const state: Record<string, FabricValue> = {
           type: value.type,
           name: value.name === value.type ? null : value.name,

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -118,7 +118,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
       }
 
       /** @inheritDoc */
-      encode(value: FabricLink): FabricPlainObject {
+      encode(value: FabricLink, _env: LiveEnvironment): FabricPlainObject {
         // The payload IS the encoded state; its nested values are recursively
         // encoded by the engine.
         return value.#payload;

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -87,7 +87,7 @@ export class FabricMap
        *
        * Stub -- throws until `Map` support is implemented.
        */
-      encode(_value: FabricMap): FabricValue {
+      encode(_value: FabricMap, _env: LiveEnvironment): FabricValue {
         throw new Error("`FabricMap`: not yet implemented");
       }
 

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -86,7 +86,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
        *
        * Stub -- throws until `Set` support is implemented.
        */
-      encode(_value: FabricSet): FabricValue {
+      encode(_value: FabricSet, _env: LiveEnvironment): FabricValue {
         throw new Error("`FabricSet`: not yet implemented");
       }
 

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -153,7 +153,7 @@ export class FabricBytes extends BaseFabricPrimitive {
       }
 
       /** @inheritDoc */
-      encode(value: FabricBytes): string {
+      encode(value: FabricBytes, _env: LiveEnvironment): string {
         return toUnpaddedBase64url(value.#bytes);
       }
     })(),
@@ -176,7 +176,7 @@ export class FabricBytes extends BaseFabricPrimitive {
        * mutating the encoded tree before it crosses cannot reach into this
        * instance.
        */
-      encode(value: FabricBytes): RealmCodecValue {
+      encode(value: FabricBytes, _env: LiveEnvironment): RealmCodecValue {
         return value.sliceBuffer();
       }
 

--- a/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
@@ -55,7 +55,7 @@ export class FabricEpochDay extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricEpochDay): string {
+      encode(value: FabricEpochDay, _env: LiveEnvironment): string {
         return bigintToUnpaddedBase64url(value.#value);
       }
 
@@ -91,7 +91,7 @@ export class FabricEpochDay extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricEpochDay): RealmCodecValue {
+      encode(value: FabricEpochDay, _env: LiveEnvironment): RealmCodecValue {
         return value.#value;
       }
 

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -62,7 +62,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricEpochNsec): string {
+      encode(value: FabricEpochNsec, _env: LiveEnvironment): string {
         return bigintToUnpaddedBase64url(value.#value);
       }
 
@@ -98,7 +98,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricEpochNsec): RealmCodecValue {
+      encode(value: FabricEpochNsec, _env: LiveEnvironment): RealmCodecValue {
         return value.#value;
       }
 

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -140,7 +140,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
       }
 
       /** @inheritDoc */
-      encode(value: FabricHash): FabricHashState {
+      encode(value: FabricHash, _env: LiveEnvironment): FabricHashState {
         return { tag: value.tag, hash: value.hashString };
       }
 
@@ -186,7 +186,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
        * the value would cede bytes that are not part of it, and one shared
        * with this instance would leave a transferred value hollow.
        */
-      encode(value: FabricHash): RealmCodecValue {
+      encode(value: FabricHash, _env: LiveEnvironment): RealmCodecValue {
         return { tag: value.tag, hash: value.#hash.buffer.slice(0) };
       }
 

--- a/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
+++ b/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
@@ -238,7 +238,10 @@ export class FabricKeyPair extends BaseFabricPrimitive {
        * @throws If `value` holds handles, that state having no representation
        *   in this format.
        */
-      encode(value: FabricKeyPair): FabricKeyPairMaterialState {
+      encode(
+        value: FabricKeyPair,
+        _env: LiveEnvironment,
+      ): FabricKeyPairMaterialState {
         if (!value.hasMaterial) {
           throw new Error(
             "Cannot encode a key pair that holds handles: a `CryptoKey` has " +
@@ -299,7 +302,7 @@ export class FabricKeyPair extends BaseFabricPrimitive {
        * Each state names its arm by shape: a `CryptoKey` in the key slots for
        * handles, an `ArrayBuffer` and an algorithm for material.
        */
-      encode(value: FabricKeyPair): RealmCodecValue {
+      encode(value: FabricKeyPair, _env: LiveEnvironment): RealmCodecValue {
         if (!value.hasMaterial) {
           return {
             publicKey: value.#publicKey as CryptoKey,

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -157,7 +157,7 @@ export class FabricRegExp extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricRegExp): FabricRegExpState {
+      encode(value: FabricRegExp, _env: LiveEnvironment): FabricRegExpState {
         return {
           source: value.#source,
           flags: value.#flags,
@@ -236,7 +236,7 @@ export class FabricRegExp extends BaseFabricPrimitive
       }
 
       /** @inheritDoc */
-      encode(value: FabricRegExp): RealmCodecValue {
+      encode(value: FabricRegExp, _env: LiveEnvironment): RealmCodecValue {
         return {
           source: value.#source,
           flags: value.#flags,

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -22,7 +22,7 @@ import { isDeepFrozen } from "./deep-freeze.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { BaseFabricInstance } from "@/fabric-bases/BaseFabricInstance.ts";
-import { codecOf } from "@/codec-common/index.ts";
+import { codecOf, NULL_LIVE_ENVIRONMENT } from "@/codec-common/index.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { FabricKeyPair } from "@/fabric-primitives/FabricKeyPair.ts";
@@ -316,7 +316,7 @@ function feedObjectValue(
       hasher.update(TAG_INSTANCE_BYTES);
       const codec = codecOf(fabInst);
       hasher.update(getStringRep(codec.tagForValue(fabInst)));
-      const state = codec.encode(fabInst);
+      const state = codec.encode(fabInst, NULL_LIVE_ENVIRONMENT);
       feedValue(hasher, state);
       return;
     }

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -189,11 +189,12 @@ describe("ProblematicValue", () => {
         it("returns the tag, state, and error together", () => {
           const pv = new ProblematicValue("Weird@7", { x: 1 }, "oops");
 
-          expect(ProblematicValue[CODEC].encode(pv)).toEqual({
-            tag: "Weird@7",
-            state: { x: 1 },
-            error: "oops",
-          });
+          expect(ProblematicValue[CODEC].encode(pv, NULL_LIVE_ENVIRONMENT))
+            .toEqual({
+              tag: "Weird@7",
+              state: { x: 1 },
+              error: "oops",
+            });
         });
       });
 

--- a/packages/data-model/test/codec-common/SymbolCodec.test.ts
+++ b/packages/data-model/test/codec-common/SymbolCodec.test.ts
@@ -60,11 +60,11 @@ describe("SymbolCodec", () => {
 
     describe("encode()", () => {
       it('encodes `Symbol.for("foo")` to its registry key', () => {
-        expect(codec.encode(Symbol.for("foo"))).toBe("foo");
+        expect(codec.encode(Symbol.for("foo"), env)).toBe("foo");
       });
 
       it('encodes `Symbol.for("")` (empty key)', () => {
-        expect(codec.encode(Symbol.for(""))).toBe("");
+        expect(codec.encode(Symbol.for(""), env)).toBe("");
       });
     });
 
@@ -82,7 +82,7 @@ describe("SymbolCodec", () => {
       it("round-trips an interned symbol to the same registry instance", () => {
         const result = codec.decode(
           expectedTag,
-          codec.encode(Symbol.for("hello")),
+          codec.encode(Symbol.for("hello"), env),
           env,
         );
         expect(typeof result).toBe("symbol");
@@ -93,7 +93,7 @@ describe("SymbolCodec", () => {
         const key = "café-☕-\u{1F600}";
         const result = codec.decode(
           expectedTag,
-          codec.encode(Symbol.for(key)),
+          codec.encode(Symbol.for(key), env),
           env,
         );
         expect(result).toBe(Symbol.for(key));

--- a/packages/data-model/test/codec-common/UnknownValue.test.ts
+++ b/packages/data-model/test/codec-common/UnknownValue.test.ts
@@ -17,6 +17,7 @@ import {
   IS_DEEP_FROZEN,
 } from "@/fabric-bases/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-interface/interface.ts";
+import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts";
 import { ProblematicStateError } from "@/codec-common/ProblematicStateError.ts";
 import { UnknownValue } from "@/codec-common/UnknownValue.ts";
 import { deepFreeze, isValidDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -115,7 +116,9 @@ describe("UnknownValue", () => {
       describe("encode()", () => {
         it("returns the bare `state` (the tag is carried separately)", () => {
           const uv = new UnknownValue("Weird@7", { data: [1, 2, 3] });
-          expect(UnknownValue[CODEC].encode(uv)).toEqual({ data: [1, 2, 3] });
+          expect(UnknownValue[CODEC].encode(uv, NULL_LIVE_ENVIRONMENT)).toEqual(
+            { data: [1, 2, 3] },
+          );
         });
       });
 

--- a/packages/data-model/test/codec-json/BigIntCodec.test.ts
+++ b/packages/data-model/test/codec-json/BigIntCodec.test.ts
@@ -44,32 +44,32 @@ describe("BigIntCodec", () => {
     describe("encode()", () => {
       it("encodes `42n` to base64url of two's complement bytes", () => {
         // 42n -> [0x2a] -> base64 "Kg"
-        expect(codec.encode(42n)).toBe("Kg");
+        expect(codec.encode(42n, env)).toBe("Kg");
       });
 
       it('encodes `0n` to base64 `"AA"`', () => {
         // 0n -> [0x00] -> base64 "AA"
-        expect(codec.encode(0n)).toBe("AA");
+        expect(codec.encode(0n, env)).toBe("AA");
       });
 
       it('encodes `-1n` to base64url `"_w"`', () => {
         // -1n -> [0xFF] -> base64url "_w"
-        expect(codec.encode(-1n)).toBe("_w");
+        expect(codec.encode(-1n, env)).toBe("_w");
       });
 
       it('encodes `1n` to base64 `"AQ"`', () => {
         // 1n -> [0x01] -> base64 "AQ"
-        expect(codec.encode(1n)).toBe("AQ");
+        expect(codec.encode(1n, env)).toBe("AQ");
       });
 
       it("encodes `128n` with sign-extension byte", () => {
         // 128n -> [0x00, 0x80] -> base64 "AIA"
-        expect(codec.encode(128n)).toBe("AIA");
+        expect(codec.encode(128n, env)).toBe("AIA");
       });
 
       it("produces unpadded base64 output (no trailing `=`)", () => {
         // 42n produces 1 byte -> 2 base64 chars (would be "Kg==" with padding)
-        const b64 = codec.encode(42n) as string;
+        const b64 = codec.encode(42n, env) as string;
         expect(b64).toBe("Kg");
         expect(b64).not.toContain("=");
       });
@@ -117,59 +117,71 @@ describe("BigIntCodec", () => {
 
     describe("round trip encode-decode", () => {
       it("round-trips at top level", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(42n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(42n, env), env);
         expect(decoded).toBe(42n);
       });
 
       it("round-trips a negative `bigint`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(-999n), env);
+        const decoded = codec.decode(
+          expectedTag,
+          codec.encode(-999n, env),
+          env,
+        );
         expect(decoded).toBe(-999n);
       });
 
       it("round-trips a zero `bigint`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(0n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(0n, env), env);
         expect(decoded).toBe(0n);
       });
 
       it("round-trips `1n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(1n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(1n, env), env);
         expect(decoded).toBe(1n);
       });
 
       it("round-trips `-1n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(-1n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(-1n, env), env);
         expect(decoded).toBe(-1n);
       });
 
       it("round-trips a large `bigint`", () => {
         const big = 2n ** 64n;
-        const decoded = codec.decode(expectedTag, codec.encode(big), env);
+        const decoded = codec.decode(expectedTag, codec.encode(big, env), env);
         expect(decoded).toBe(big);
       });
 
       it("round-trips a large negative `bigint`", () => {
         const big = -(2n ** 64n);
-        const decoded = codec.decode(expectedTag, codec.encode(big), env);
+        const decoded = codec.decode(expectedTag, codec.encode(big, env), env);
         expect(decoded).toBe(big);
       });
 
       it("round-trips boundary value `127n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(127n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(127n, env), env);
         expect(decoded).toBe(127n);
       });
 
       it("round-trips boundary value `128n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(128n), env);
+        const decoded = codec.decode(expectedTag, codec.encode(128n, env), env);
         expect(decoded).toBe(128n);
       });
 
       it("round-trips boundary value `-128n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(-128n), env);
+        const decoded = codec.decode(
+          expectedTag,
+          codec.encode(-128n, env),
+          env,
+        );
         expect(decoded).toBe(-128n);
       });
 
       it("round-trips boundary value `-129n`", () => {
-        const decoded = codec.decode(expectedTag, codec.encode(-129n), env);
+        const decoded = codec.decode(
+          expectedTag,
+          codec.encode(-129n, env),
+          env,
+        );
         expect(decoded).toBe(-129n);
       });
     });

--- a/packages/data-model/test/codec-json/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/codec-json/SpecialNumberCodec.test.ts
@@ -45,19 +45,19 @@ describe("SpecialNumberCodec", () => {
 
     describe("encode()", () => {
       it('encodes `-0` to the literal `"-0"`', () => {
-        expect(codec.encode(-0)).toBe("-0");
+        expect(codec.encode(-0, env)).toBe("-0");
       });
 
       it('encodes `NaN` to the literal `"NaN"`', () => {
-        expect(codec.encode(NaN)).toBe("NaN");
+        expect(codec.encode(NaN, env)).toBe("NaN");
       });
 
       it('encodes `+Infinity` to the literal `"+Infinity"`', () => {
-        expect(codec.encode(Infinity)).toBe("+Infinity");
+        expect(codec.encode(Infinity, env)).toBe("+Infinity");
       });
 
       it('encodes `-Infinity` to the literal `"-Infinity"`', () => {
-        expect(codec.encode(-Infinity)).toBe("-Infinity");
+        expect(codec.encode(-Infinity, env)).toBe("-Infinity");
       });
 
       it('any `NaN` bit pattern encodes as the literal `"NaN"`', () => {
@@ -65,7 +65,7 @@ describe("SpecialNumberCodec", () => {
         view.setBigUint64(0, 0x7ff8000000000001n, false);
         const nonCanonicalNaN = view.getFloat64(0, false);
         expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
-        expect(codec.encode(nonCanonicalNaN)).toBe("NaN");
+        expect(codec.encode(nonCanonicalNaN, env)).toBe("NaN");
       });
     });
 
@@ -88,19 +88,19 @@ describe("SpecialNumberCodec", () => {
 
     describe("round trip encode-decode", () => {
       it("round-trips `-0` (preserves sign of zero)", () => {
-        const result = codec.decode(expectedTag, codec.encode(-0), env);
+        const result = codec.decode(expectedTag, codec.encode(-0, env), env);
         expect(Object.is(result, -0)).toBe(true);
       });
 
       it("round-trips `NaN`", () => {
-        const result = codec.decode(expectedTag, codec.encode(NaN), env);
+        const result = codec.decode(expectedTag, codec.encode(NaN, env), env);
         expect(Number.isNaN(result)).toBe(true);
       });
 
       it("round-trips `+Infinity`", () => {
         const result = codec.decode(
           expectedTag,
-          codec.encode(Infinity),
+          codec.encode(Infinity, env),
           env,
         );
         expect(result).toBe(Infinity);
@@ -109,7 +109,7 @@ describe("SpecialNumberCodec", () => {
       it("round-trips `-Infinity`", () => {
         const result = codec.decode(
           expectedTag,
-          codec.encode(-Infinity),
+          codec.encode(-Infinity, env),
           env,
         );
         expect(result).toBe(-Infinity);

--- a/packages/data-model/test/codec-json/UndefinedCodec.test.ts
+++ b/packages/data-model/test/codec-json/UndefinedCodec.test.ts
@@ -39,7 +39,7 @@ describe("UndefinedCodec", () => {
 
     describe("encode()", () => {
       it("encodes `undefined` to `null` state", () => {
-        expect(codec.encode(undefined)).toBe(null);
+        expect(codec.encode(undefined, env)).toBe(null);
       });
     });
 
@@ -64,7 +64,7 @@ describe("UndefinedCodec", () => {
       it("round-trips `undefined` via encode -> decode", () => {
         const decoded = codec.decode(
           expectedTag,
-          codec.encode(undefined),
+          codec.encode(undefined, env),
           env,
         );
         expect(decoded).toBe(undefined);

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -118,9 +118,11 @@ describe("FabricError", () => {
     });
 
     describe("`[CODEC]` `encode()` state", () => {
+      const env = NULL_LIVE_ENVIRONMENT;
+
       it("returns `type`, `name=null` (common case), `message`, `stack`", () => {
         const se = FabricError.fromNativeError(new Error("hello"));
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -132,7 +134,7 @@ describe("FabricError", () => {
 
       it("sets `name` to `null` when `type === name` (`TypeError`)", () => {
         const se = FabricError.fromNativeError(new TypeError("bad"));
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -144,7 +146,7 @@ describe("FabricError", () => {
         const err = new TypeError("bad");
         err.name = "CustomName";
         const se = FabricError.fromNativeError(err);
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -157,7 +159,7 @@ describe("FabricError", () => {
         const outer = FabricError.fromNativeError(
           new Error("outer", { cause: inner }),
         );
-        const state = FabricError[CODEC].encode(outer) as Record<
+        const state = FabricError[CODEC].encode(outer, env) as Record<
           string,
           FabricValue
         >;
@@ -169,7 +171,7 @@ describe("FabricError", () => {
         (err as unknown as Record<string, unknown>).code = 42;
         (err as unknown as Record<string, unknown>).detail = "more info";
         const se = FabricError.fromNativeError(err);
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -184,7 +186,7 @@ describe("FabricError", () => {
           enumerable: true,
         });
         const se = FabricError.fromNativeError(err);
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -200,7 +202,7 @@ describe("FabricError", () => {
         });
         (err as unknown as Record<string, unknown>).name = "Error";
         const se = FabricError.fromNativeError(err);
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -211,7 +213,7 @@ describe("FabricError", () => {
         const err = new Error("no stack");
         err.stack = undefined;
         const se = FabricError.fromNativeError(err);
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -224,7 +226,7 @@ describe("FabricError", () => {
         (original as unknown as Record<string, unknown>).code = 42;
         const se = FabricError.fromNativeError(original);
 
-        const state = FabricError[CODEC].encode(se);
+        const state = FabricError[CODEC].encode(se, env);
         const restored = FabricError[CODEC].decode(
           CODEC_TYPE_TAGS.Error,
           state,
@@ -241,7 +243,7 @@ describe("FabricError", () => {
         original.name = "SpecialType";
         const se = FabricError.fromNativeError(original);
 
-        const state = FabricError[CODEC].encode(se) as Record<
+        const state = FabricError[CODEC].encode(se, env) as Record<
           string,
           FabricValue
         >;
@@ -566,7 +568,7 @@ describe("FabricError", () => {
       describe("encode()", () => {
         it("encodes a basic `FabricError` to its `{ type, name, message }` state", () => {
           const se = FabricError.fromNativeError(new Error("test"));
-          const state = codec.encode(se) as Record<string, unknown>;
+          const state = codec.encode(se, env) as Record<string, unknown>;
           expect(state.type).toBe("Error");
           expect(state.name).toBe(null); // null = same as type (common case)
           expect(state.message).toBe("test");
@@ -575,7 +577,7 @@ describe("FabricError", () => {
         it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
           // TypeError: name === constructor.name === "TypeError".
           const se = FabricError.fromNativeError(new TypeError("type check"));
-          const state = codec.encode(se) as Record<string, unknown>;
+          const state = codec.encode(se, env) as Record<string, unknown>;
           expect(state.type).toBe("TypeError");
           expect(state.name).toBe(null); // null = same as type
           expect(state.message).toBe("type check");
@@ -585,7 +587,7 @@ describe("FabricError", () => {
           const err = new Error("custom");
           err.name = "MyCustomError";
           const se = FabricError.fromNativeError(err);
-          const state = codec.encode(se) as Record<string, unknown>;
+          const state = codec.encode(se, env) as Record<string, unknown>;
           expect(state.type).toBe("Error");
           expect(state.name).toBe("MyCustomError");
           expect(state.message).toBe("custom");
@@ -723,7 +725,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(new Error("hello"));
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded).toBeInstanceOf(FabricError);
@@ -736,7 +738,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(new TypeError("bad type"));
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded).toBeInstanceOf(FabricError);
@@ -751,7 +753,7 @@ describe("FabricError", () => {
           );
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded).toBeInstanceOf(FabricError);
@@ -766,7 +768,7 @@ describe("FabricError", () => {
           );
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(outer),
+            codec.encode(outer, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.message).toBe("outer");
@@ -786,7 +788,7 @@ describe("FabricError", () => {
           const outerSe = FabricError.fromNativeError(outerErr);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(outerSe),
+            codec.encode(outerSe, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.message).toBe("outer");
@@ -801,7 +803,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.message).toBe("oops");
@@ -819,7 +821,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.name).toBe("MyCustomError");
@@ -830,7 +832,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(new TypeError("rt"));
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
@@ -847,7 +849,7 @@ describe("FabricError", () => {
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(se),
+            codec.encode(se, env),
             env,
           ) as unknown as FabricError;
           expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -201,7 +201,7 @@ describe("FabricLink", () => {
       describe("encode()", () => {
         it("encodes to the payload object", () => {
           const link = new FabricLink({ id: "fid1:abc", path: ["a", "b"] });
-          expect(codec.encode(link)).toEqual({
+          expect(codec.encode(link, env)).toEqual({
             id: "fid1:abc",
             path: ["a", "b"],
           });
@@ -239,7 +239,7 @@ describe("FabricLink", () => {
           });
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(link),
+            codec.encode(link, env),
             env,
           ) as FabricLink;
           expect(decoded).toBeInstanceOf(FabricLink);

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -144,7 +144,7 @@ describe("FabricMap", () => {
 
       describe("encode()", () => {
         it("throws (stub)", () => {
-          expect(() => codec.encode(new FabricMap(new Map()))).toThrow(
+          expect(() => codec.encode(new FabricMap(new Map()), env)).toThrow(
             "not yet implemented",
           );
         });

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -128,7 +128,7 @@ describe("FabricSet", () => {
 
       describe("encode()", () => {
         it("throws (stub)", () => {
-          expect(() => codec.encode(new FabricSet(new Set()))).toThrow(
+          expect(() => codec.encode(new FabricSet(new Set()), env)).toThrow(
             "not yet implemented",
           );
         });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -229,12 +229,12 @@ describe("FabricBytes", () => {
         it("encodes to an unpadded base64url string", () => {
           // [1, 2, 3] -> base64url "AQID".
           const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
-          expect(codec.encode(fb)).toBe("AQID");
+          expect(codec.encode(fb, env)).toBe("AQID");
         });
 
         it("encodes empty bytes to the empty string", () => {
           const fb = new FabricBytes(new Uint8Array());
-          expect(codec.encode(fb)).toBe("");
+          expect(codec.encode(fb, env)).toBe("");
         });
       });
 
@@ -264,7 +264,7 @@ describe("FabricBytes", () => {
           const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(fb),
+            codec.encode(fb, env),
             env,
           ) as unknown as FabricBytes;
           expect(decoded).toBeInstanceOf(FabricBytes);
@@ -275,7 +275,7 @@ describe("FabricBytes", () => {
           const fb = new FabricBytes(new Uint8Array());
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(fb),
+            codec.encode(fb, env),
             env,
           ) as unknown as FabricBytes;
           expect(decoded).toBeInstanceOf(FabricBytes);

--- a/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
@@ -84,7 +84,7 @@ describe("FabricEpochDay", () => {
         it("encodes to a flat base64 string (epoch zero)", () => {
           const sd = new FabricEpochDay(0n);
           // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-          expect(codec.encode(sd)).toBe("AA");
+          expect(codec.encode(sd, env)).toBe("AA");
         });
       });
 
@@ -124,7 +124,7 @@ describe("FabricEpochDay", () => {
           const sd = new FabricEpochDay(0n);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sd),
+            codec.encode(sd, env),
             env,
           ) as unknown as FabricEpochDay;
           expect(decoded).toBeInstanceOf(FabricEpochDay);
@@ -136,7 +136,7 @@ describe("FabricEpochDay", () => {
           const sd = new FabricEpochDay(days);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sd),
+            codec.encode(sd, env),
             env,
           ) as unknown as FabricEpochDay;
           expect(decoded).toBeInstanceOf(FabricEpochDay);
@@ -148,7 +148,7 @@ describe("FabricEpochDay", () => {
           const sd = new FabricEpochDay(days);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sd),
+            codec.encode(sd, env),
             env,
           ) as unknown as FabricEpochDay;
           expect(decoded).toBeInstanceOf(FabricEpochDay);

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -90,7 +90,7 @@ describe("FabricEpochNsec", () => {
         it("encodes to a flat base64 string (epoch zero)", () => {
           const sn = new FabricEpochNsec(0n);
           // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-          expect(codec.encode(sn)).toBe("AA");
+          expect(codec.encode(sn, env)).toBe("AA");
         });
       });
 
@@ -130,7 +130,7 @@ describe("FabricEpochNsec", () => {
           const sn = new FabricEpochNsec(0n);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sn),
+            codec.encode(sn, env),
             env,
           ) as unknown as FabricEpochNsec;
           expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -144,7 +144,7 @@ describe("FabricEpochNsec", () => {
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sn),
+            codec.encode(sn, env),
             env,
           ) as unknown as FabricEpochNsec;
           expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -156,7 +156,7 @@ describe("FabricEpochNsec", () => {
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sn),
+            codec.encode(sn, env),
             env,
           ) as unknown as FabricEpochNsec;
           expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -169,7 +169,7 @@ describe("FabricEpochNsec", () => {
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(sn),
+            codec.encode(sn, env),
             env,
           ) as unknown as FabricEpochNsec;
           expect(decoded.value).toBe(nsec);

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -221,7 +221,7 @@ describe("FabricHash", () => {
       describe("encode()", () => {
         it("encodes to a `{ tag, hash }` object", () => {
           const cid = new FabricHash(SAMPLE_HASH, "fid1");
-          expect(codec.encode(cid)).toEqual({
+          expect(codec.encode(cid, env)).toEqual({
             tag: "fid1",
             hash: cid.hashString,
           });
@@ -275,7 +275,7 @@ describe("FabricHash", () => {
           const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(cid),
+            codec.encode(cid, env),
             env,
           );
           expect(decoded).toBeInstanceOf(FabricHash);

--- a/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
@@ -272,7 +272,7 @@ describe("FabricKeyPair", () => {
 
       describe("encode()", () => {
         it("encodes material to an `{ algorithm, publicKey, privateKey }` object", () => {
-          expect(codec.encode(materialPair())).toEqual({
+          expect(codec.encode(materialPair(), env)).toEqual({
             algorithm: "ExampleAlgorithm",
             publicKey: "AQID",
             privateKey: "-vv8_Q",
@@ -282,7 +282,9 @@ describe("FabricKeyPair", () => {
         it("throws for an instance holding handles", async () => {
           const pair = new FabricKeyPair(await generatePair());
 
-          expect(() => codec.encode(pair)).toThrow(/no JSON representation/);
+          expect(() => codec.encode(pair, env)).toThrow(
+            /no JSON representation/,
+          );
         });
       });
 
@@ -342,7 +344,7 @@ describe("FabricKeyPair", () => {
         it("round-trips an instance holding material", () => {
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(materialPair()),
+            codec.encode(materialPair(), env),
             env,
           ) as FabricKeyPair;
 
@@ -361,7 +363,7 @@ describe("FabricKeyPair", () => {
 
       describe("encode()", () => {
         it("encodes material to transferable `ArrayBuffer`s", () => {
-          const state = codec.encode(materialPair()) as {
+          const state = codec.encode(materialPair(), env) as {
             algorithm: string;
             publicKey: ArrayBuffer;
             privateKey: ArrayBuffer;
@@ -381,7 +383,7 @@ describe("FabricKeyPair", () => {
 
         it("encodes handles to the `CryptoKey`s themselves", async () => {
           const source = await generatePair();
-          const state = codec.encode(new FabricKeyPair(source)) as {
+          const state = codec.encode(new FabricKeyPair(source), env) as {
             algorithm?: string;
             publicKey: CryptoKey;
             privateKey: CryptoKey;
@@ -397,11 +399,14 @@ describe("FabricKeyPair", () => {
 
       describe("canDecode()", () => {
         it("returns `true` for a material state", () => {
-          expect(codec.canDecode(codec.encode(materialPair()))).toBe(true);
+          expect(codec.canDecode(codec.encode(materialPair(), env))).toBe(true);
         });
 
         it("returns `true` for a handle state", async () => {
-          const state = codec.encode(new FabricKeyPair(await generatePair()));
+          const state = codec.encode(
+            new FabricKeyPair(await generatePair()),
+            env,
+          );
 
           expect(codec.canDecode(state)).toBe(true);
         });
@@ -450,7 +455,7 @@ describe("FabricKeyPair", () => {
 
       describe("decode()", () => {
         it("throws given a state whose buffers are already spent", () => {
-          const state = codec.encode(materialPair());
+          const state = codec.encode(materialPair(), env);
 
           codec.decode(expectedTag, state as never, env);
 
@@ -463,7 +468,7 @@ describe("FabricKeyPair", () => {
         it("round-trips an instance holding material", () => {
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(materialPair()) as never,
+            codec.encode(materialPair(), env) as never,
             env,
           ) as FabricKeyPair;
 
@@ -478,7 +483,7 @@ describe("FabricKeyPair", () => {
           const source = await generatePair();
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(new FabricKeyPair(source)) as never,
+            codec.encode(new FabricKeyPair(source), env) as never,
             env,
           ) as FabricKeyPair;
 

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -162,7 +162,7 @@ describe("FabricRegExp", () => {
       describe("encode()", () => {
         it("encodes to a `{ source, flags, flavor }` object", () => {
           const re = new FabricRegExp(/ab+c/gi);
-          expect(codec.encode(re)).toEqual({
+          expect(codec.encode(re, env)).toEqual({
             flags: "gi",
             flavor: "es2025",
             source: "ab+c",
@@ -262,7 +262,7 @@ describe("FabricRegExp", () => {
           const re = new FabricRegExp(/ab+c/gi);
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(re),
+            codec.encode(re, env),
             env,
           ) as unknown as FabricRegExp;
           expect(decoded).toBeInstanceOf(FabricRegExp);
@@ -275,7 +275,7 @@ describe("FabricRegExp", () => {
           const re = new FabricRegExp("es2025", "^x*$", "");
           const decoded = codec.decode(
             expectedTag,
-            codec.encode(re),
+            codec.encode(re, env),
             env,
           ) as unknown as FabricRegExp;
           expect(decoded).toBeInstanceOf(FabricRegExp);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## What

`FabricCodec.decode()` takes a `LiveEnvironment`. `encode()` did not, so a
codec had no way to reach the running system while encoding — however many
entry points accepted an environment, it stopped at the walk.

The act was holding one the whole time. `BaseCodecAct` stores the `env` the
engine minted the act with and exposes `get env()`; `BaseDecodeAct` passes it
to `decode()`; `BaseEncodeAct` just did not pass it to `encode()`.

This runs the parameter the rest of the way:

- `FabricCodec.encode(value, env)` in `codec-interface/interface.ts`, and the
  `abstract` that mirrors it on `BaseFabricCodec`.
- `BaseEncodeAct.#encodeTagged()` passes `this.env` to both codec kinds, the
  terminal and the nonterminal.
- The 22 implementations take it as `_env`.

The entry points are unchanged: `realmFromFabricValue()` and
`jsonFromFabricValue()` both already accepted an optional `env` and
substituted `NULL_LIVE_ENVIRONMENT`.

## Callers outside the walk

Three places call a codec's `encode()` directly, and each now names an
environment rather than being given one:

- `FabricError`'s `[DEEP_CLONE_CORE]` already built a `NullLiveEnvironment`
  for the `decode()` half of its round trip, and now passes that same one to
  `encode()`.
- `value-hash.ts` hashes a `FabricInstance` through its codec's state, and
  passes `NULL_LIVE_ENVIRONMENT` — a hash has no cell to resolve, and the
  throw says so if one ever turns up.
- `cli/lib/piece.ts` builds searchable text representations, same reasoning.

## What this deliberately does not do

`LiveEnvironment`'s members are untouched. `getCell()` resolves a reference
*into* an instance, which is a decode-side question; the encode-side
counterpart is real and wanted, and is a separate change. So every one of the
22 implementations ignores the parameter today. That is the point of landing
it now: the plumbing is what the next change needs and is mechanical, and
adding an interface member is not.

`docs/specs/space-model/1-data-model.md` mirrors the old signature and is left
alone; `space-model-formal-spec/` is the authoritative series and is updated
here.

## Verification

Run locally at `75de39935`:

- `deno task check` — `Type check complete.`, all 41 groups
- `deno lint` — `Checked 4887 files`, exit 0
- `deno fmt --check` — `Checked 4978 files`, exit 0
- `deno task check-docs` — `All 564 checked code block(s) passed.`
- `packages/data-model` `deno task test` — `ok | 57 passed (2689 steps) | 0 failed`
- `packages/cli` `deno task test` — `ok | 175 passed | 0 failed`, exit 0

The type checker found every call site rather than a grep: `deno task check`
went from 91 errors across `data-model`, `cli` and `scripts` down to zero, and
each one is a place the argument had to be supplied.


## Second commit: the `LiveEnvironment` doc comment

`f62a05f4d`. The doc named a circular dependency with `runner` as the reason
the requirement is stated as an interface, and named `Runtime` as what supplies
one in practice. Neither holds.

`data-model` is a standalone low-level package, and stating a requirement as an
interface is what lets any client satisfy it — which is not a fact about
`runner`. It already has several clients: `memory` builds a `LiveEnvironment`
(`v2.ts:1350`), and tests in `data-model` and `runner` build their own. More are
expected.

And the `Runtime` claim is false, not merely the wrong rationale. Type-level
probe on this branch:

```
TS2741: Property 'shouldDeepFreeze' is missing in type 'Runtime'
        but required in type 'LiveEnvironment'.
```

Nothing under `packages/runner/src` names `LiveEnvironment` at all. Every
implementation that exists today is either `NullLiveEnvironment` or a test
subclass of `BaseLiveEnvironment`, so the doc now points at those two as what a
client actually builds on.

Both the doc comment and Section 2.5 of the formal spec are updated. Gates
re-run at `f62a05f4d`: `check` `Type check complete.`, `lint` 0, `fmt --check`
0, `check-docs` 564 blocks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


