### PR TITLE
test-records: add optional identity variants

### DIFF
--- a/.github/actions/test-records-ship/action.yml
+++ b/.github/actions/test-records-ship/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Shard label like "3/8" when the job is sharded.
     required: false
     default: ""
+  variant:
+    description: Stable name of a non-default test configuration.
+    required: false
+    default: ""
   junit:
     description: >-
       Newline-separated JUnit ingestion specifications, each
@@ -34,11 +38,15 @@ runs:
       env:
         SHIP_JOB: ${{ inputs.job }}
         SHIP_SHARD: ${{ inputs.shard }}
+        SHIP_VARIANT: ${{ inputs.variant }}
         SHIP_JUNIT: ${{ inputs.junit }}
       run: |
         args=(--out test-records-artifact --job "$SHIP_JOB")
         if [ -n "$SHIP_SHARD" ]; then
           args+=(--shard "$SHIP_SHARD")
+        fi
+        if [ -n "$SHIP_VARIANT" ]; then
+          args+=(--variant "$SHIP_VARIANT")
         fi
         while IFS= read -r spec; do
           if [ -n "$spec" ]; then

--- a/docs/development/test-records-adoption.md
+++ b/docs/development/test-records-adoption.md
@@ -15,11 +15,11 @@ and leans on everything shared.
   repository.
 - **The record schema and library**:
   `@commonfabric/test-support/records` in this repository — the identity
-  triple, the NDJSON line codecs with untrusted-input validation, the
-  spool lifecycle with kernel-released locks, the JUnit ingester, the
-  create-only store client, and the validating reader. Vendor or import it
-  rather than reimplementing; the schema version (`v1` in object paths) is
-  shared across repositories.
+  with three required parts and an optional variant, the NDJSON line codecs
+  with untrusted-input validation, the spool lifecycle with kernel-released
+  locks, the JUnit ingester, the create-only store client, and the validating
+  reader. Vendor or import it rather than reimplementing; the schema version
+  (`v1` in object paths) is shared across repositories.
 - **Personal keys**: scoped to people, not repositories. A key minted once
   through this repository's minting workflow writes
   `<repo>/test-records/submissions/local/<username>/` in every adopted
@@ -52,10 +52,12 @@ and leans on everything shared.
    deterministic names. Copy `.github/workflows/test-records-relay.yml`
    and `tasks/test-records-relay.ts`; the only repository-specific parts
    are the constants and the watched workflow names.
-4. **An identity table.** For each test surface: its kind, its scope, and
-   what its runner reports as the name. Hold the line on the rules that
-   keep identities durable — names from the runner, shard labels never in
-   identity, file paths only where the file genuinely is the test.
+4. **An identity table.** For each test surface: its kind, its scope, what
+   its runner reports as the name, and any non-default configuration that
+   needs a separate variant. Keep the default configuration unmarked. Hold
+   the line on the rules that keep identities durable — names from the
+   runner, shard labels never in identity, file paths only where the file
+   genuinely is the test.
 5. **Producers.** Three classes cover every surface:
    - Jobs that already write JUnit XML: add the ship step with a
      `--junit kind=...,scope=...,prefix=...,glob=...` specification and
@@ -65,7 +67,13 @@ and leans on everything shared.
    - Command-level checks: wrap with a `run-recorded`-style task that
      spools one record from the exit code.
    Each job points `CF_TEST_RECORDS_DIR` at a workspace spool and ends
-   with the credential-free gather-and-upload step, `if: always()`.
+   with the credential-free gather-and-upload step, `if: always()`. Set the
+   step's `variant` input only for a stable non-default configuration whose
+   history must remain separate.
+   The relay checks out its parser from the default branch. Land support for
+   a new optional record field before a later change starts emitting it from
+   test workflows. An older relay drops an unknown field before writing the
+   create-only store object.
 6. **Local ownership.** The task entry points that people actually run
    stamp a spool when `CF_TEST_RECORDS_KEY_FILE` is present, ship it at
    the end, and sweep the spool root for orphans; see

--- a/docs/development/test-records.md
+++ b/docs/development/test-records.md
@@ -14,11 +14,18 @@ how to opt a workstation in, and how to read the data.
 
 ## What a record is
 
-A test's identity is the triple of **kind** (`unit`, `browser`, `pattern`,
-`integration`, `typecheck`, `lint`, `format`, `gate`), **scope** (the owning
-workspace member, or `repo`), and **name** (whatever the test's own runner
-reports — a bdd describe chain, a pattern file path, a task name, a script
-step). One record is one JSON line; one uploaded object is a run's
+A test's identity has three required parts: **kind** (`unit`, `browser`,
+`pattern`, `integration`, `typecheck`, `lint`, `format`, `gate`), **scope**
+(the owning workspace member, or `repo`), and **name** (whatever the test's
+own runner reports — a bdd describe chain, a pattern file path, a task name,
+a script step). An optional **variant** separates the same test running
+in a non-default configuration. The default configuration is unmarked. The
+server-execution ON jobs use `server-execution` after variant-aware relay
+support is on the default branch. When server execution becomes the default,
+remove that marker from the ON jobs and mark the surviving explicit OFF jobs
+as `server-execution-off`. New default runs then continue the history of
+today's unmarked default jobs. One record is one JSON line; one uploaded
+object is a run's
 context line followed by its record lines. The schema, the line codecs, and
 their validators live in `packages/test-support/src/records/`.
 
@@ -34,7 +41,8 @@ Renaming a test renames its identity and splits its history. When the
 continuity matters, append a line to `tasks/test-identity-aliases.jsonl`
 mapping the old identity (or a whole scope, for a package rename) to the
 new one with the date; `deno task check-test-aliases` holds that file to
-append-only, no-double-mapping, acyclic rules.
+append-only, no-double-mapping, acyclic rules. The same rename applies to
+every variant.
 
 ## The environment surface
 
@@ -213,6 +221,16 @@ members' personal-fork pull requests report while the store accepts
 nothing authored by anyone else; other fork runs still run their tests
 normally and simply ship no records. Re-running the relay, or
 dispatching it with a run id, re-ships idempotently.
+
+The shared `test-records-ship` action accepts an optional `variant` input.
+It applies the value to every spooled and JUnit-derived record in that job.
+Leave it unset for the default configuration.
+
+The relay runs its parser from the default branch. Land parser, relay, reader,
+and action support for a new optional record field before any test workflow
+starts emitting it. Enabling a field in the same change makes the old relay
+drop it from that change's pull-request artifacts before writing them to the
+create-only store.
 
 ## Reading the data
 

--- a/docs/specs/test-records.md
+++ b/docs/specs/test-records.md
@@ -13,7 +13,7 @@ reasoning that shaped what follows. The shared implementation is
 
 ## Identity
 
-A test's identity is the triple, scoped within a repository:
+A test's identity has three required parts, scoped within a repository:
 
 - **kind** — the class of check: `unit`, `browser`, `pattern`,
   `integration`, `typecheck`, `lint`, `format`, `gate`.
@@ -25,17 +25,26 @@ A test's identity is the triple, scoped within a repository:
   script's own name (`acl.sh`), a script step (`integration.sh
   piece-values`), or a task-plus-item pair (`cfcheck <file>`,
   `pattern-compat <key>`, `pattern-vintage <testKey> <tier> <stamp>`).
+- **variant**, when present — a stable name for a non-default configuration
+  that runs the same test. The default configuration has no variant. The
+  server-execution ON jobs use `server-execution` after variant-aware relay
+  support is on the default branch. When server execution becomes the
+  default, the ON jobs omit that marker, so new runs continue the history of
+  today's unmarked default jobs. The surviving explicit OFF jobs use
+  `server-execution-off` so their history remains separate.
 
 Identity survives moving a test between files, splitting or renaming test
 files, reformatting, editing bodies, and resharding — shard and slice
 labels, and the section that dispatched a script step, are run context and
-never identity. Identity does not survive a change to the reported name; a
+never identity. A configuration is a variant only when its results need a
+separate history. Identity does not survive a change to the reported name; a
 rename splits history, and a line appended to
 `tasks/test-identity-aliases.jsonl` bridges a split worth bridging. That
 file is append-only, maps any identity at most once, must stay acyclic, and
 each line carries the rename's date; readers resolve aliases transitively
 and apply one only to records older than its date
-(`deno task check-test-aliases` enforces the file's shape).
+(`deno task check-test-aliases` enforces the file's shape). Alias lines name
+the three required identity parts and apply the rename to every variant.
 
 A task-level record may coexist with the per-item records of the same run
 (`pattern-compat` beside `pattern-compat <key>`, `integration.sh` beside
@@ -59,6 +68,11 @@ compaction.
 ```json
 { "line": "record", "test": { "k": "unit", "s": "bakery", "n": "glaze > thickens when heated" }, "outcome": "pass", "durationMs": 12 }
 ```
+
+The compact identity fields are `k`, `s`, `n`, and optional `v`. Omitting
+`v` means the default configuration. Readers retain the existing
+`[k,s,n]` grouping key for unmarked records and append `v` as a fourth part
+only when it is present.
 
 A record carries `outcome` (`pass`, `fail`, or `skip`), `durationMs` from
 the runner's own measurement (never a clock inside the test process, which
@@ -187,8 +201,20 @@ zero records or not — and `job.json`; an artifact without a readable
 than ship a context-only object that would read as a run with no tests. The attempt lives in the artifact name because artifacts
 are scoped to the run: a re-run's relay re-ships an earlier attempt's
 artifacts into collisions and ships the re-run jobs' new artifacts as new
-objects, so re-runs neither drop nor double-count records. The relay
-workflow follows the completion of every workflow that runs tests —
+objects, so re-runs neither drop nor double-count records.
+
+The shared shipping action's optional `variant` input stamps every spooled
+and JUnit-derived record gathered by that job. Jobs omit it for the default
+configuration.
+
+The relay checks out its implementation from the default branch, not from
+the triggering test run. A new optional record field therefore rolls out in
+two changes. Its parser, relay, readers, and shipping-action support land
+first. Test workflows start emitting the field only after that support is on
+the default branch. Otherwise the old relay drops the field before writing a
+create-only object that cannot be repaired in place.
+
+The relay workflow follows the completion of every workflow that runs tests —
 success, failure, cancellation, and timeout alike. It ships a
 same-repository run unconditionally, since only write access creates
 one, and a fork run only when the run's actor — read from the trusted

--- a/packages/dashboard/test-records-history.test.ts
+++ b/packages/dashboard/test-records-history.test.ts
@@ -72,6 +72,30 @@ Deno.test("collectDay aggregates runs, failures, and durations per identity", as
   assertEquals(isDayAggregate(aggregates[0]), true);
 });
 
+Deno.test("collectDay separates variant records from default history", async () => {
+  const variant = JSON.stringify({
+    line: "record",
+    test: {
+      k: "unit",
+      s: "bakery",
+      n: "glaze",
+      v: "wood-fired",
+    },
+    outcome: "pass",
+    durationMs: 200,
+  });
+  const aggregates = await collectDay("2026/08/16", {
+    fetchImpl: storeFetch([PASS, variant]),
+  });
+  assertEquals(aggregates.map(({ key, runs }) => ({ key, runs })), [{
+    key: '["unit","bakery","glaze","wood-fired"]',
+    runs: 1,
+  }, {
+    key: '["unit","bakery","glaze"]',
+    runs: 1,
+  }]);
+});
+
 // A body holding two reports, the second fork-authored: its records must
 // not reach the decision-feeding aggregates.
 Deno.test("collectDay excludes fork-authored reports", async () => {
@@ -147,12 +171,23 @@ Deno.test("isDayAggregate rejects inconsistent aggregates", () => {
     maxDurationMs: 300,
   };
   assertEquals(isDayAggregate(sound), true);
+  assertEquals(
+    isDayAggregate({
+      ...sound,
+      key: '["unit","bakery","glaze","server-execution"]',
+    }),
+    true,
+  );
   assertEquals(isDayAggregate({ ...sound, failures: 2, skips: 1 }), false);
   assertEquals(isDayAggregate({ ...sound, runs: 1.5 }), false);
   assertEquals(isDayAggregate({ ...sound, totalDurationMs: NaN }), false);
   assertEquals(isDayAggregate({ ...sound, maxDurationMs: -1 }), false);
   assertEquals(isDayAggregate({ ...sound, key: "not a triple" }), false);
   assertEquals(isDayAggregate({ ...sound, key: '["unit","bakery"]' }), false);
+  assertEquals(
+    isDayAggregate({ ...sound, key: '["unit","bakery","glaze",""]' }),
+    false,
+  );
 });
 
 Deno.test("the store refreshes missing days, persists, and reloads", async () => {

--- a/packages/dashboard/test-records-history.test.ts
+++ b/packages/dashboard/test-records-history.test.ts
@@ -174,7 +174,7 @@ Deno.test("isDayAggregate rejects inconsistent aggregates", () => {
   assertEquals(
     isDayAggregate({
       ...sound,
-      key: '["unit","bakery","glaze","server-execution"]',
+      key: '["unit","bakery","glaze","wood-fired"]',
     }),
     true,
   );

--- a/packages/dashboard/test-records-history.ts
+++ b/packages/dashboard/test-records-history.ts
@@ -17,6 +17,7 @@ import {
   listObjects,
   loadAliasResolver,
   readObject,
+  testIdentityKey,
 } from "@commonfabric/test-support/records";
 import { dashboardCacheFile } from "./history-files.ts";
 
@@ -34,7 +35,7 @@ export const TEST_RECORDS_REFRESH_TAIL_DAYS = 3;
 
 /** One test's aggregate for one day. */
 export interface DayAggregate {
-  /** JSON-array identity key, ["kind","scope","name"]. */
+  /** JSON-array identity key, with an optional fourth variant part. */
   key: string;
   /** "yyyy/mm/dd". */
   day: string;
@@ -66,10 +67,11 @@ export function isDayAggregate(value: unknown): value is DayAggregate {
   ) {
     return false;
   }
-  // The key is the JSON form of the [kind, scope, name] identity triple.
+  // The key has three required identity parts and an optional variant.
   try {
     const identity = JSON.parse(aggregate.key);
-    return Array.isArray(identity) && identity.length === 3 &&
+    return Array.isArray(identity) &&
+      (identity.length === 3 || identity.length === 4) &&
       identity.every((part) => typeof part === "string" && part.length > 0);
   } catch {
     return false;
@@ -113,7 +115,7 @@ export async function collectDay(
         const test = options.aliases !== undefined
           ? options.aliases.resolve(record.test, day)
           : record.test;
-        const key = JSON.stringify([test.k, test.s, test.n]);
+        const key = testIdentityKey(test);
         let entry = byKey.get(key);
         if (entry === undefined) {
           entry = {

--- a/packages/test-support/src/records/aliases.test.ts
+++ b/packages/test-support/src/records/aliases.test.ts
@@ -58,7 +58,7 @@ describe("aliases", () => {
     it("returns an error for a variant-scoped alias", () => {
       const line = JSON.stringify({
         ...FULL,
-        from: { ...FULL.from, v: "server-execution" },
+        from: { ...FULL.from, v: "wood-fired" },
       });
       expect(parseAliasLine(line)).toBe("has a malformed `from`");
     });
@@ -173,14 +173,14 @@ describe("aliases", () => {
           k: "unit",
           s: "bakery",
           n: "glaze > sets",
-          v: "server-execution",
+          v: "wood-fired",
         },
         "2026/08/10",
       )).toEqual({
         k: "unit",
         s: "patisserie",
         n: "glaze > cures",
-        v: "server-execution",
+        v: "wood-fired",
       });
     });
 

--- a/packages/test-support/src/records/aliases.test.ts
+++ b/packages/test-support/src/records/aliases.test.ts
@@ -54,6 +54,14 @@ describe("aliases", () => {
       });
       expect(typeof parseAliasLine(line)).toBe("string");
     });
+
+    it("returns an error for a variant-scoped alias", () => {
+      const line = JSON.stringify({
+        ...FULL,
+        from: { ...FULL.from, v: "server-execution" },
+      });
+      expect(parseAliasLine(line)).toBe("has a malformed `from`");
+    });
   });
 
   describe("aliasGraphProblems()", () => {
@@ -156,6 +164,24 @@ describe("aliases", () => {
         { k: "unit", s: "bakery", n: "anything" },
         "2026/08/10",
       )).toEqual({ k: "unit", s: "patisserie", n: "anything" });
+    });
+
+    it("keeps the variant while resolving aliases", () => {
+      const resolver = new AliasResolver([FULL, SCOPE]);
+      expect(resolver.resolve(
+        {
+          k: "unit",
+          s: "bakery",
+          n: "glaze > sets",
+          v: "server-execution",
+        },
+        "2026/08/10",
+      )).toEqual({
+        k: "unit",
+        s: "patisserie",
+        n: "glaze > cures",
+        v: "server-execution",
+      });
     });
 
     it("prefers a full-identity mapping over the scope's", () => {

--- a/packages/test-support/src/records/aliases.ts
+++ b/packages/test-support/src/records/aliases.ts
@@ -27,6 +27,10 @@ export interface AliasLine {
 function isIdentityPart(value: unknown, wholeScope: boolean): boolean {
   if (typeof value !== "object" || value === null) return false;
   const part = value as Record<string, unknown>;
+  const expectedKeys = wholeScope ? ["k", "s"] : ["k", "n", "s"];
+  if (Object.keys(part).sort().join(",") !== expectedKeys.join(",")) {
+    return false;
+  }
   if (typeof part.k !== "string" || part.k.length === 0) return false;
   if (typeof part.s !== "string" || part.s.length === 0) return false;
   if (wholeScope) return part.n === undefined;
@@ -155,6 +159,7 @@ export class AliasResolver {
       const exact = this.#byIdentity.get(aliasKeyOf(current));
       if (exact !== undefined && day < exact.date) {
         current = {
+          ...current,
           k: exact.to.k,
           s: exact.to.s,
           n: exact.to.n ?? current.n,
@@ -165,7 +170,11 @@ export class AliasResolver {
         aliasKeyOf({ k: current.k, s: current.s }),
       );
       if (scope !== undefined && day < scope.date) {
-        current = { k: scope.to.k, s: scope.to.s, n: current.n };
+        current = {
+          ...current,
+          k: scope.to.k,
+          s: scope.to.s,
+        };
         continue;
       }
       return current;

--- a/packages/test-support/src/records/mod.ts
+++ b/packages/test-support/src/records/mod.ts
@@ -9,6 +9,7 @@ export {
   RECORD_SCHEMA_VERSION,
   serializeContextLine,
   serializeRecordLine,
+  testIdentityKey,
 } from "./schema.ts";
 export type {
   CiContext,

--- a/packages/test-support/src/records/schema.test.ts
+++ b/packages/test-support/src/records/schema.test.ts
@@ -62,7 +62,7 @@ describe("schema", () => {
     it("keeps a non-default test variant", () => {
       const record: TestRecord = {
         ...RECORD,
-        test: { ...RECORD.test, v: "server-execution" },
+        test: { ...RECORD.test, v: "wood-fired" },
       };
       expect(parseRecordLine(serializeRecordLine(record).trim()))
         .toEqual(record);
@@ -112,9 +112,9 @@ describe("schema", () => {
     });
 
     it("adds the non-default variant as a fourth part", () => {
-      expect(testIdentityKey({ ...RECORD.test, v: "server-execution" }))
+      expect(testIdentityKey({ ...RECORD.test, v: "wood-fired" }))
         .toBe(
-          '["unit","bakery","glaze > thickens when heated","server-execution"]',
+          '["unit","bakery","glaze > thickens when heated","wood-fired"]',
         );
     });
   });

--- a/packages/test-support/src/records/schema.test.ts
+++ b/packages/test-support/src/records/schema.test.ts
@@ -12,6 +12,7 @@ import {
   type RunContext,
   serializeContextLine,
   serializeRecordLine,
+  testIdentityKey,
   type TestRecord,
 } from "./schema.ts";
 
@@ -58,6 +59,15 @@ describe("schema", () => {
         .toEqual(record);
     });
 
+    it("keeps a non-default test variant", () => {
+      const record: TestRecord = {
+        ...RECORD,
+        test: { ...RECORD.test, v: "server-execution" },
+      };
+      expect(parseRecordLine(serializeRecordLine(record).trim()))
+        .toEqual(record);
+    });
+
     it("returns undefined for malformed JSON", () => {
       expect(parseRecordLine("{nope")).toBeUndefined();
     });
@@ -83,6 +93,29 @@ describe("schema", () => {
         test: { k: "unit", s: "", n: "x" },
       });
       expect(parseRecordLine(line)).toBeUndefined();
+    });
+
+    it("returns undefined for an empty test variant", () => {
+      const line = JSON.stringify({
+        ...RECORD,
+        test: { ...RECORD.test, v: "" },
+      });
+      expect(parseRecordLine(line)).toBeUndefined();
+    });
+  });
+
+  describe("testIdentityKey()", () => {
+    it("keeps the existing key for the default configuration", () => {
+      expect(testIdentityKey(RECORD.test)).toBe(
+        '["unit","bakery","glaze > thickens when heated"]',
+      );
+    });
+
+    it("adds the non-default variant as a fourth part", () => {
+      expect(testIdentityKey({ ...RECORD.test, v: "server-execution" }))
+        .toBe(
+          '["unit","bakery","glaze > thickens when heated","server-execution"]',
+        );
     });
   });
 

--- a/packages/test-support/src/records/schema.ts
+++ b/packages/test-support/src/records/schema.ts
@@ -10,8 +10,9 @@ export const RECORD_SCHEMA_VERSION = 1;
 
 /**
  * Durable name of a test: the kind of check, the workspace member that owns
- * it (or "repo" for repository-level checks), and the full name the test's
- * own runner reports.
+ * it (or "repo" for repository-level checks), the full name the test's own
+ * runner reports, and a non-default configuration when one needs separate
+ * history.
  */
 export interface TestIdentity {
   /** Class of check: "unit", "browser", "pattern", "integration",
@@ -21,6 +22,17 @@ export interface TestIdentity {
   s: string;
   /** Name as reported by the test's own runner. */
   n: string;
+  /** Non-default configuration under which the test ran. */
+  v?: string;
+}
+
+/** Stable JSON-array key for grouping records by test identity. */
+export function testIdentityKey(test: TestIdentity): string {
+  return JSON.stringify(
+    test.v === undefined
+      ? [test.k, test.s, test.n]
+      : [test.k, test.s, test.n, test.v],
+  );
 }
 
 /** One line stating that one test executed once in one run. */
@@ -127,6 +139,7 @@ export function parseRecordLine(line: string): TestRecord | undefined {
   ) {
     return undefined;
   }
+  if (test.v !== undefined && !isNonEmptyString(test.v)) return undefined;
   if (!OUTCOMES.has(record.outcome as string)) return undefined;
   if (
     typeof record.durationMs !== "number" ||
@@ -141,6 +154,7 @@ export function parseRecordLine(line: string): TestRecord | undefined {
     outcome: record.outcome as TestRecord["outcome"],
     durationMs: record.durationMs,
   };
+  if (test.v !== undefined) result.test.v = test.v;
   if (record.file !== undefined) result.file = record.file as string;
   return result;
 }

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -618,7 +618,7 @@ Deno.test("every test-records artifact name is store-safe and unique", async () 
   assert(shipSteps >= 14, `only ${shipSteps} ship steps found`);
 });
 
-Deno.test("every deno.yml job that writes a JUnit file spools and ships test records (the ON lanes' observability gap: 25 pattern-ON flakes had to be censused from raw Actions logs because the two server-execution ON jobs set no CF_TEST_RECORDS_DIR and had no ship step — records the dashboard never saw)", async () => {
+Deno.test("every deno.yml JUnit job spools and ships test records", async () => {
   const contents = withoutComments(await workflow("deno.yml"));
   const missing: string[] = [];
   let junitJobs = 0;
@@ -630,6 +630,14 @@ Deno.test("every deno.yml job that writes a JUnit file spools and ships test rec
       missing.push(
         `${jobId}: writes a JUnit file but has no test-records-ship step`,
       );
+    } else {
+      const ship = stepBlock(job, "📤 Ship test records");
+      if (!ship.includes("if: always()")) {
+        missing.push(`${jobId}: does not ship test records after a failure`);
+      }
+      if (!ship.includes("junit:")) {
+        missing.push(`${jobId}: does not gather its JUnit file`);
+      }
     }
     if (!job.includes("CF_TEST_RECORDS_DIR:")) {
       missing.push(
@@ -642,4 +650,60 @@ Deno.test("every deno.yml job that writes a JUnit file spools and ships test rec
   // Pin the search itself: zero junit jobs would mean the extraction
   // broke, not that the repository stopped writing JUnit files.
   assert(junitJobs >= 7, `only ${junitJobs} JUnit-writing jobs found`);
+});
+
+Deno.test("test-records-ship forwards its optional variant input", async () => {
+  const action = await Deno.readTextFile(
+    new URL(
+      "../.github/actions/test-records-ship/action.yml",
+      import.meta.url,
+    ),
+  );
+  assertStringIncludes(action, "  variant:\n");
+  assertStringIncludes(action, "SHIP_VARIANT: ${{ inputs.variant }}");
+  assertStringIncludes(action, 'args+=(--variant "$SHIP_VARIANT")');
+});
+
+Deno.test("server-execution variant rollout waits for relay support", async () => {
+  const contents = withoutComments(await workflow("deno.yml"));
+  const packageJob = jobBlock(
+    contents,
+    "package-integration-test-server-execution-on",
+  );
+  const patternJob = jobBlock(
+    contents,
+    "pattern-integration-test-server-execution-on",
+  );
+  assertStringIncludes(
+    packageJob,
+    "--junit-path=../../test-results/${JUNIT_NAME}.xml",
+  );
+  assertStringIncludes(packageJob, "JUNIT_NAME: ${{ matrix.junit_name }}");
+  assertStringIncludes(
+    stepBlock(packageJob, "📤 Ship test records"),
+    "glob=test-results/${{ matrix.junit_name }}.xml",
+  );
+  assertStringIncludes(
+    patternJob,
+    "--junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml",
+  );
+  assertStringIncludes(
+    stepBlock(patternJob, "📤 Ship test records"),
+    "glob=test-results/patterns-server-execution-on-${{ matrix.shard }}.xml",
+  );
+
+  for (
+    const jobId of [
+      "package-integration-test",
+      "pattern-integration-test",
+      "package-integration-test-server-execution-on",
+      "pattern-integration-test-server-execution-on",
+    ]
+  ) {
+    const ship = stepBlock(jobBlock(contents, jobId), "📤 Ship test records");
+    assert(
+      !ship.includes("variant:"),
+      `${jobId}: variants start only after relay support reaches main`,
+    );
+  }
 });

--- a/tasks/test-records-gather.test.ts
+++ b/tasks/test-records-gather.test.ts
@@ -104,6 +104,7 @@ describe("test-records-gather", () => {
         out,
         job: "Test (3/8)",
         shard: "3/8",
+        variant: "server-execution",
         junit: [{
           kind: "unit",
           scope: "cli",
@@ -125,9 +126,15 @@ describe("test-records-gather", () => {
       expect(lines.length).toBe(2);
       const records = lines.map((line) => parseRecordLine(line));
       expect(records[0]?.test.n).toBe("check-docs");
+      expect(records[0]?.test.v).toBe("server-execution");
       expect(records[1]).toEqual({
         line: "record",
-        test: { k: "unit", s: "cli", n: "alpha" },
+        test: {
+          k: "unit",
+          s: "cli",
+          n: "alpha",
+          v: "server-execution",
+        },
         outcome: "pass",
         durationMs: 250,
         file: "packages/cli/test/alpha.test.ts",
@@ -194,12 +201,15 @@ describe("test-records-gather", () => {
         "Test (3/8)",
         "--shard",
         "3/8",
+        "--variant",
+        "server-execution",
         "--junit",
         "kind=unit,scope=cli,glob=*.xml",
       ]);
       expect(options?.out).toBe("artifact");
       expect(options?.job).toBe("Test (3/8)");
       expect(options?.shard).toBe("3/8");
+      expect(options?.variant).toBe("server-execution");
       expect(options?.junit.length).toBe(1);
     });
 
@@ -221,6 +231,16 @@ describe("test-records-gather", () => {
       expect(parseGatherArgs(["--out"])).toBeUndefined();
       expect(parseGatherArgs(["--mystery", "x"])).toBeUndefined();
       expect(parseGatherArgs(["--out", "artifact"])).toBeUndefined();
+      expect(
+        parseGatherArgs([
+          "--out",
+          "artifact",
+          "--job",
+          "Check",
+          "--variant",
+          "",
+        ]),
+      ).toBeUndefined();
     });
   });
 });

--- a/tasks/test-records-gather.test.ts
+++ b/tasks/test-records-gather.test.ts
@@ -104,7 +104,7 @@ describe("test-records-gather", () => {
         out,
         job: "Test (3/8)",
         shard: "3/8",
-        variant: "server-execution",
+        variant: "wood-fired",
         junit: [{
           kind: "unit",
           scope: "cli",
@@ -126,14 +126,14 @@ describe("test-records-gather", () => {
       expect(lines.length).toBe(2);
       const records = lines.map((line) => parseRecordLine(line));
       expect(records[0]?.test.n).toBe("check-docs");
-      expect(records[0]?.test.v).toBe("server-execution");
+      expect(records[0]?.test.v).toBe("wood-fired");
       expect(records[1]).toEqual({
         line: "record",
         test: {
           k: "unit",
           s: "cli",
           n: "alpha",
-          v: "server-execution",
+          v: "wood-fired",
         },
         outcome: "pass",
         durationMs: 250,
@@ -208,14 +208,14 @@ describe("test-records-gather", () => {
         "--shard",
         "3/8",
         "--variant",
-        "server-execution",
+        "wood-fired",
         "--junit",
         "kind=unit,scope=cli,glob=*.xml",
       ]);
       expect(options?.out).toBe("artifact");
       expect(options?.job).toBe("Test (3/8)");
       expect(options?.shard).toBe("3/8");
-      expect(options?.variant).toBe("server-execution");
+      expect(options?.variant).toBe("wood-fired");
       expect(options?.junit.length).toBe(1);
     });
 

--- a/tasks/test-records-gather.test.ts
+++ b/tasks/test-records-gather.test.ts
@@ -151,6 +151,12 @@ describe("test-records-gather", () => {
       expect(facts.job).toBe("Check");
     });
 
+    it("rejects an empty variant from a direct caller", async () => {
+      await expect(
+        gather({ out: join(dir, "out"), job: "Check", variant: "", junit: [] }),
+      ).rejects.toThrow("--variant must not be empty");
+    });
+
     it("records the commit, branch, and pull request head from the environment", async () => {
       const out = join(dir, "out");
       const eventPath = join(dir, "event.json");

--- a/tasks/test-records-gather.ts
+++ b/tasks/test-records-gather.ts
@@ -6,6 +6,7 @@
  *
  *   deno run -A tasks/test-records-gather.ts --out <dir> --job <name>
  *     [--shard <label>]
+ *     [--variant <name>]
  *     [--junit kind=<kind>,scope=<scope>[,prefix=<repo path>],glob=<glob>]...
  *
  * The output directory holds records.ndjson (one record line per test) and
@@ -83,6 +84,7 @@ export interface GatherOptions {
   out: string;
   job: string;
   shard?: string;
+  variant?: string;
   junit: JUnitSpec[];
   spoolDir?: string;
   env?: Environment;
@@ -90,6 +92,9 @@ export interface GatherOptions {
 
 /** Gathers the spool and JUnit files into the artifact directory. */
 export async function gather(options: GatherOptions): Promise<void> {
+  if (options.variant !== undefined && options.variant.length === 0) {
+    throw new Error("--variant must not be empty");
+  }
   const records: TestRecord[] = [];
   if (options.spoolDir !== undefined) {
     const spooled = await readSpool(options.spoolDir);
@@ -126,6 +131,10 @@ export async function gather(options: GatherOptions): Promise<void> {
     if (matched === 0) {
       console.warn(`test records: no JUnit files matched ${spec.glob}`);
     }
+  }
+
+  if (options.variant !== undefined) {
+    for (const record of records) record.test.v = options.variant;
   }
 
   const env = options.env ?? Deno.env.get;
@@ -171,7 +180,7 @@ export async function gather(options: GatherOptions): Promise<void> {
 function usage(): never {
   console.error(
     "usage: test-records-gather.ts --out <dir> --job <name> " +
-      "[--shard <label>] [--junit <spec>]...",
+      "[--shard <label>] [--variant <name>] [--junit <spec>]...",
   );
   Deno.exit(2);
 }
@@ -188,6 +197,7 @@ export function parseGatherArgs(
   let out: string | undefined;
   let job: string | undefined;
   let shard: string | undefined;
+  let variant: string | undefined;
   const junit: JUnitSpec[] = [];
   const args = [...argsIn];
   while (args.length > 0) {
@@ -204,6 +214,10 @@ export function parseGatherArgs(
       case "--shard":
         shard = value;
         break;
+      case "--variant":
+        if (value.length === 0) return undefined;
+        variant = value;
+        break;
       case "--junit":
         try {
           junit.push(parseJUnitSpec(value));
@@ -218,6 +232,7 @@ export function parseGatherArgs(
   if (out === undefined || job === undefined) return undefined;
   const options: GatherOptions = { out, job, junit };
   if (shard !== undefined) options.shard = shard;
+  if (variant !== undefined) options.variant = variant;
   return options;
 }
 

--- a/tasks/test-records-report.test.ts
+++ b/tasks/test-records-report.test.ts
@@ -5,6 +5,7 @@ import {
   aggregate,
   churnFamilies,
   collisions,
+  formatIdentity,
   identityKey,
   overSixtySeconds,
   parseReportArgs,
@@ -95,6 +96,22 @@ describe("test-records-report", () => {
       }));
       expect(entry?.runs).toBe(2);
       expect(byIdentity.size).toBe(1);
+    });
+
+    it("separates a non-default variant from the default history", () => {
+      const unmarked = record("glaze", "pass", 10);
+      const marked: TestRecord = {
+        ...unmarked,
+        test: { ...unmarked.test, v: "server-execution" },
+      };
+      const byIdentity = aggregate([report("a", [unmarked, marked])]);
+      expect([...byIdentity.keys()]).toEqual([
+        '["unit","bakery","glaze"]',
+        '["unit","bakery","glaze","server-execution"]',
+      ]);
+      expect(formatIdentity([...byIdentity.keys()][1]!)).toBe(
+        "[unit] bakery: glaze (variant: server-execution)",
+      );
     });
   });
 

--- a/tasks/test-records-report.test.ts
+++ b/tasks/test-records-report.test.ts
@@ -102,15 +102,15 @@ describe("test-records-report", () => {
       const unmarked = record("glaze", "pass", 10);
       const marked: TestRecord = {
         ...unmarked,
-        test: { ...unmarked.test, v: "server-execution" },
+        test: { ...unmarked.test, v: "wood-fired" },
       };
       const byIdentity = aggregate([report("a", [unmarked, marked])]);
       expect([...byIdentity.keys()]).toEqual([
         '["unit","bakery","glaze"]',
-        '["unit","bakery","glaze","server-execution"]',
+        '["unit","bakery","glaze","wood-fired"]',
       ]);
       expect(formatIdentity([...byIdentity.keys()][1]!)).toBe(
-        "[unit] bakery: glaze (variant: server-execution)",
+        "[unit] bakery: glaze (variant: wood-fired)",
       );
     });
   });

--- a/tasks/test-records-report.ts
+++ b/tasks/test-records-report.ts
@@ -20,6 +20,8 @@ import {
   loadAliasResolver,
   readObject,
   type StoredReport,
+  type TestIdentity,
+  testIdentityKey,
 } from "@commonfabric/test-support/records";
 import { ciSubmissionsPrefix, storeBucket } from "./test-records-config.ts";
 
@@ -32,15 +34,19 @@ export interface IdentityAggregate {
   maxDurationMs: number;
 }
 
-export function identityKey(test: { k: string; s: string; n: string }): string {
-  // A JSON array: unambiguous however many spaces the name contains, and
-  // printable everywhere the key surfaces.
-  return JSON.stringify([test.k, test.s, test.n]);
+export function identityKey(test: TestIdentity): string {
+  return testIdentityKey(test);
 }
 
 export function formatIdentity(key: string): string {
-  const [k, s, n] = JSON.parse(key) as [string, string, string];
-  return `[${k}] ${s}: ${n}`;
+  const [k, s, n, variant] = JSON.parse(key) as [
+    string,
+    string,
+    string,
+    string?,
+  ];
+  const suffix = variant === undefined ? "" : ` (variant: ${variant})`;
+  return `[${k}] ${s}: ${n}${suffix}`;
 }
 
 /**


### PR DESCRIPTION
Tests that run under default and non-default configurations currently share the same kind, scope, and name identity. Their results therefore collapse into one history even when the configurations behave differently.

Add an optional variant identity part while retaining the exact existing three-part key for unmarked default records. Preserve variants across test aliases, keep alias declarations variant-agnostic, and teach the report and dashboard history collector to aggregate four-part keys separately.

Let the shared shipping action pass a variant to the gatherer, which stamps both spooled and JUnit-derived records. Document the two-change rollout required because the privileged relay runs its parser from the default branch. Producer workflows remain unmarked until this support has landed.

Keep the dashboard cache at version 1 because unmarked keys are unchanged and no variant producer existed for an older reader to collapse.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

