### PR TITLE
fix(background-piece-service): keep the service's key material out of the JS context

### DIFF
--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -20,20 +20,21 @@ export function isValidPieceId(id: string): boolean {
   return !!id && id.length === 59;
 }
 
-// Derives the identity configured for this service,
-// receiving an `IDENTITY` and `OPERATOR_PASS` from the environment.
-//
-// First, uses the key path to load a key.
-// If not set, falls back to operator pass to
-// use an insecure passphrase.
-// This fallback should be removed once fully migrated
-// over to using keyfiles.
-//
-// The ed25519 implementation is left to the platform, which on a supporting
-// one means Web Crypto: the seed each form below starts from is imported into
-// a non-extractable `CryptoKey` and then dropped, so what this service holds
-// afterwards -- and what it hands a worker realm, structured cloning carrying
-// a `CryptoKey` whole -- is a key handle.
+/**
+ * Derives the identity configured for this service, from an `IDENTITY` and an
+ * `OPERATOR_PASS` taken from the environment. A key path loads a key; absent
+ * one, the operator pass stands in as an insecure passphrase identity. That
+ * fallback should be removed once fully migrated over to using keyfiles.
+ *
+ * The ed25519 implementation is left to the platform, which on a supporting
+ * one means Web Crypto: the seed each form starts from is imported into a
+ * non-extractable `CryptoKey` and then dropped, so what this service holds
+ * afterwards -- and what it hands a worker realm, structured cloning carrying
+ * a `CryptoKey` whole -- is a key handle.
+ *
+ * @throws If the key path names something unreadable, or if neither variable
+ *   is set.
+ */
 export async function getIdentity(
   identityPath?: string,
   operatorPass?: string,

--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -30,9 +30,10 @@ export function isValidPieceId(id: string): boolean {
 // over to using keyfiles.
 //
 // The ed25519 implementation is left to the platform, which on a supporting
-// one means Web Crypto: the private key is then a non-extractable `CryptoKey`
-// and its material never enters the JS context. A worker realm receives that
-// key as itself, structured cloning carrying a `CryptoKey` whole.
+// one means Web Crypto: the seed each form below starts from is imported into
+// a non-extractable `CryptoKey` and then dropped, so what this service holds
+// afterwards -- and what it hands a worker realm, structured cloning carrying
+// a `CryptoKey` whole -- is a key handle.
 export async function getIdentity(
   identityPath?: string,
   operatorPass?: string,

--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -30,10 +30,13 @@ export function isValidPieceId(id: string): boolean {
  * one means Web Crypto: the seed each form starts from is imported into a
  * non-extractable `CryptoKey` and then dropped, so what this service holds
  * afterwards -- and what it hands a worker realm, structured cloning carrying
- * a `CryptoKey` whole -- is a key handle.
+ * a `CryptoKey` whole -- is a key handle. For the keyfile form that is the
+ * whole of it; the passphrase form leaves `OPERATOR_PASS` in the environment,
+ * from which the key can be derived again, which is part of what makes it the
+ * insecure one.
  *
- * @throws If the key path names something unreadable, or if neither variable
- *   is set.
+ * @throws If the key path names something unreadable or unusable, or if
+ *   neither variable is set.
  */
 export async function getIdentity(
   identityPath?: string,
@@ -51,7 +54,7 @@ export async function getIdentity(
     console.warn("Using insecure passphrase identity.");
     return await Identity.fromPassphrase(operatorPass);
   }
-  throw new Error("No IDENTITY or OPERATOR_PASS environemnt set.");
+  throw new Error("No IDENTITY or OPERATOR_PASS environment set.");
 }
 
 export async function setBGPiece({

--- a/packages/background-piece-service/src/utils.ts
+++ b/packages/background-piece-service/src/utils.ts
@@ -4,7 +4,7 @@ import {
   type MemorySpace,
   type Runtime,
 } from "@commonfabric/runner";
-import { Identity, type IdentityCreateConfig } from "@commonfabric/identity";
+import { Identity } from "@commonfabric/identity";
 import {
   BG_CELL_CAUSE,
   BG_SYSTEM_SPACE_ID,
@@ -28,30 +28,26 @@ export function isValidPieceId(id: string): boolean {
 // use an insecure passphrase.
 // This fallback should be removed once fully migrated
 // over to using keyfiles.
+//
+// The ed25519 implementation is left to the platform, which on a supporting
+// one means Web Crypto: the private key is then a non-extractable `CryptoKey`
+// and its material never enters the JS context. A worker realm receives that
+// key as itself, structured cloning carrying a `CryptoKey` whole.
 export async function getIdentity(
   identityPath?: string,
   operatorPass?: string,
 ): Promise<Identity> {
-  // Deno does not support serializing `CryptoKey`, safely
-  // passing keys to workers. Explicitly use the fallback implementation,
-  // which makes key material available to the JS context, in order
-  // to transfer key material to workers.
-  // https://github.com/denoland/deno/issues/12067#issuecomment-1975001079
-  const keyConfig: IdentityCreateConfig = {
-    implementation: "noble",
-  };
-
   if (identityPath) {
     console.log(`Using identity at ${identityPath}`);
     try {
       const pkcs8Key = await Deno.readFile(identityPath);
-      return await Identity.fromPkcs8(pkcs8Key, keyConfig);
+      return await Identity.fromPkcs8(pkcs8Key);
     } catch (_e) {
       throw new Error(`Could not read key at ${identityPath}.`);
     }
   } else if (operatorPass) {
     console.warn("Using insecure passphrase identity.");
-    return await Identity.fromPassphrase(operatorPass, keyConfig);
+    return await Identity.fromPassphrase(operatorPass);
   }
   throw new Error("No IDENTITY or OPERATOR_PASS environemnt set.");
 }

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -410,7 +410,7 @@ describe("background piece utility functions", () => {
     await assertRejects(
       () => getIdentity(),
       Error,
-      "No IDENTITY or OPERATOR_PASS environemnt set.",
+      "No IDENTITY or OPERATOR_PASS environment set.",
     );
     await Deno.remove(dir, { recursive: true });
   });

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -393,6 +393,15 @@ describe("background piece utility functions", () => {
     const fromPassphrase = await getIdentity(undefined, "operator");
     assertEquals(fromPassphrase.did().startsWith("did:key:"), true);
 
+    // Both hold key handles rather than material, which is the point of
+    // leaving the implementation to the platform: the service's private key
+    // never enters the JS context. Asserted rather than guarded on support --
+    // this service runs on Deno, which has ed25519 in Web Crypto, and a build
+    // that quietly lost it would have this service holding its own signing
+    // secret again.
+    assertEquals(fromFile.keyPair.hasMaterial, false);
+    assertEquals(fromPassphrase.keyPair.hasMaterial, false);
+
     await assertRejects(
       () => getIdentity(`${dir}/missing.pem`),
       Error,
@@ -841,7 +850,11 @@ describe("SpaceManager", () => {
 describe("background worker", () => {
   it("handles ready, invalid requests, initialization, run errors, and cleanup", async () => {
     await withRealWorker(async (worker, nextMessage) => {
-      const identity = await Identity.generate({ implementation: "noble" });
+      // The platform's own implementation, as `getIdentity()` leaves it, so
+      // this exercises the key pair the service actually sends: one holding
+      // `CryptoKey` handles, which only the realm encoding can carry.
+      const identity = await Identity.generate();
+      assertEquals(identity.keyPair.hasMaterial, false);
       const ready = await nextMessage((message) => message.type === "ready");
       assertEquals(ready.msgId, -1);
 

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -394,11 +394,11 @@ describe("background piece utility functions", () => {
     assertEquals(fromPassphrase.did().startsWith("did:key:"), true);
 
     // Both hold key handles rather than material, which is the point of
-    // leaving the implementation to the platform: the service's private key
-    // never enters the JS context. Asserted rather than guarded on support --
-    // this service runs on Deno, which has ed25519 in Web Crypto, and a build
-    // that quietly lost it would have this service holding its own signing
-    // secret again.
+    // leaving the implementation to the platform: what the service keeps, and
+    // what it hands a worker, is a handle. Asserted rather than guarded on
+    // support -- this service runs on Deno, which has ed25519 in Web Crypto,
+    // and a build that quietly lost it would have this service holding its own
+    // signing secret again.
     assertEquals(fromFile.keyPair.hasMaterial, false);
     assertEquals(fromPassphrase.keyPair.hasMaterial, false);
 

--- a/packages/identity/src/ed25519/utils.ts
+++ b/packages/identity/src/ed25519/utils.ts
@@ -140,10 +140,10 @@ export class AuthorizationError extends Error {
 //   https://caniuse.com/mdn-api_subtlecrypto_generatekey_ed25519
 // * [2] Firefox supports ed25519 keys, though cannot be serialized (stored in IndexedDB)
 //   until v136 https://bugzilla.mozilla.org/show_bug.cgi?id=1939993.
-// * [3] While Deno serializes `CryptoKey`s without throwing, they cannot be rehydrated
-//   after cloning. We do not test that here, as we prefer the WebCrypto implementation
-//   in Deno, but in scenarios where a clone is necessary, a fallback implementation
-//   can be requested.
+// * [3] Deno carries a `CryptoKey` through structured cloning whole -- the clone
+//   is a `CryptoKey` with its extractability and algorithm intact, and it signs
+//   -- both within a realm and across a worker boundary. So the cloneability
+//   this checks is about Firefox, per [2], and not about Deno.
 //   https://github.com/denoland/deno/issues/12067#issuecomment-1975001079
 // * [4] Safari/Webkit generates randomized signatures as per `draft-irtf-cfrg-det-sigs-with-noise`
 //   https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/

--- a/packages/identity/src/ed25519/utils.ts
+++ b/packages/identity/src/ed25519/utils.ts
@@ -140,10 +140,13 @@ export class AuthorizationError extends Error {
 //   https://caniuse.com/mdn-api_subtlecrypto_generatekey_ed25519
 // * [2] Firefox supports ed25519 keys, though cannot be serialized (stored in IndexedDB)
 //   until v136 https://bugzilla.mozilla.org/show_bug.cgi?id=1939993.
-// * [3] Deno carries a `CryptoKey` through structured cloning whole -- the clone
-//   is a `CryptoKey` with its extractability and algorithm intact, and it signs
-//   -- both within a realm and across a worker boundary. So the cloneability
-//   this checks is about Firefox, per [2], and not about Deno.
+// * [3] Deno carries a `CryptoKey` across one worker boundary whole: the clone
+//   is a `CryptoKey` with its extractability and algorithm intact, and it
+//   signs. A key that itself arrived that way does not survive a further
+//   crossing -- it degrades to a plain object -- so a relay through two workers
+//   loses what a single hop keeps. Cloning within a realm has no such limit,
+//   which is the cloning this function checks, and that check is about Firefox
+//   per [2].
 //   https://github.com/denoland/deno/issues/12067#issuecomment-1975001079
 // * [4] Safari/Webkit generates randomized signatures as per `draft-irtf-cfrg-det-sigs-with-noise`
 //   https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

#6174 has landed, so this now targets `main` and its diff is its own: three
files, three commits. The one line that needed the stack — the test assertion
reading `identity.keyPair.hasMaterial` — is vocabulary `main` now carries.

## The claim being removed

`getIdentity()` forced `implementation: "noble"` on this comment:

> Deno does not support serializing `CryptoKey`, safely passing keys to
> workers. Explicitly use the fallback implementation, which makes key
> material available to the JS context, in order to transfer key material to
> workers. https://github.com/denoland/deno/issues/12067#issuecomment-1975001079

That is not so on the Deno `mise.toml` pins (2.9.4). I measured it two
ways rather than reading it:

- **Across a worker boundary.** A non-extractable Ed25519 pair generated in the
  parent, `postMessage`d to a module worker: the worker receives
  `privateKey instanceof CryptoKey === true`, `extractable === false`,
  `algorithm.name === "Ed25519"`, signs a payload with it, and the parent
  verifies that signature against its own public key.
- **Within a realm.** The same pair through `structuredClone()`: same three
  properties, signs, verifies.

So the forcing bought nothing, and it cost the service its private key —
"noble" holds the signing secret as bytes for the process's whole life and
sends a copy to every worker, which is exactly what the comment says it was
choosing.

**Corrected after review, because the first version of this overclaimed.** Both
forms `getIdentity()` builds start from a seed — PKCS8 decoded, or a passphrase
hashed — and that seed does pass through the JS context on its way into
`importKey()`. What the native arm buys is that the seed is imported into a
non-extractable `CryptoKey` and then dropped: what the service holds afterwards,
and what it hands a worker realm, is a handle. The comment and the test now say
that rather than "never enters the JS context".

## The same claim elsewhere

`identity`'s note [3] on `isNativeEd25519Supported` cites the same issue for
"While Deno serializes `CryptoKey`s without throwing, they cannot be rehydrated
after cloning" — falsified by both probes above, under either reading of
"rehydrated". Corrected to what Deno does. It changes no behavior: that check
does not test rehydration, and the cloneability it does test is about Firefox,
per note [2]. **Called out separately because it is the one hunk outside
`background-piece-service`, and it is prose** — easy to drop if you would
rather word it yourself.

## Grip

Nothing checked which implementation the service ends up with, so two tests
move onto the arm this puts into production:

- `getIdentity()` now asserts that both identities it can build hold key
  handles rather than material. Asserted rather than guarded on platform
  support: this service runs on Deno, and a build that quietly lost ed25519 in
  Web Crypto would have it holding its own signing secret again, which is the
  thing worth failing over.
- The real-worker initialize test built its identity as "noble". It now uses
  the platform's own implementation and asserts the pair holds handles, so the
  end-to-end `initialize()` path exercises what the service actually sends —
  a pair only the realm encoding can carry.

Ablated: restoring `{ implementation: "noble" }` on the key-file path fails the
first assertion. The real-worker test passes with the native pair, so the
crossing, `Identity.fromKeyPair()`, `NativeEd25519Signer` and the session it
opens all work on handles end to end.

## How it got here

#6174 was squash-merged, so merging `main` into this branch produced five
conflicts in *#6174's* files — files this change does not touch — because the
branch carries those commits individually and `main` carries them as one. The
three commits here were replayed onto `main` instead. Verified rather than
assumed: all three files are byte-identical to what the pre-replay tip held.

## Verification

`deno task check` (all 41 groups), `fmt --check`, `lint`, `check-docs`,
`check-skill-facts`, `check-no-waitfor`, `check-package-cycles`,
`check-unused-deps`: green. Workspace `deno task test`: all packages passing,
421s.

## Not measured

Whether the service's identity path is reached anywhere that needs `toRaw()`
or `toPkcs8()`, which only "noble" can answer — grepped rather than run, and
`background-piece-service` calls neither on this identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HFv1TWsCHmd525KCRJ2m8


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




