### PR TITLE
feat(cli): isolate malformed JSON Lines records

### DIFF
--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -5,8 +5,9 @@ recognized shebang use plain text, while filename-free transformed compiler
 output keeps its TypeScript default. Piped source can select a language directly
 or through a virtual filename. Declarative metadata can now describe extensions,
 exact names, compound patterns, explicit aliases, and direct interpreter
-shebangs. JSON Lines and NDJSON names use the JSON tokenizer. Python files with
-recognized extensions now have syntax highlighting.
+shebangs. JSON Lines and NDJSON use the JSON tokenizer with independent lexical
+state for each record. Python files with recognized extensions now have syntax
+highlighting.
 Automatic container detection is limited to structurally identified raw unified
 diffs and standard Git commit output. Recognized shebangs and transformed
 compiler headers remain explicit source selectors. Binary is a supported,
@@ -261,7 +262,7 @@ contains 40 path-change events on current JSON Lines paths since February 18,
 grammar work.
 
 - [x] Reuse the JSON tokenizer for `.jsonl` and `.ndjson`.
-- [ ] Isolate malformed lines so one line cannot affect the next.
+- [x] Isolate malformed lines so one line cannot affect the next.
 - [ ] Recognize `.webmanifest`, `.tldr`, Deno lock files, JSON-shaped `.cfg`
   files, VS Code workspace files, and Swift `Package.resolved`.
 - [ ] Add Jupyter notebook container recognition for `.ipynb`.

--- a/docs/plans/cf-view-language-coverage.md
+++ b/docs/plans/cf-view-language-coverage.md
@@ -1,13 +1,15 @@
 # `cf view` language and syntax coverage plan
 
-Status: In progress. Unknown named files and filename-free source without a
-recognized shebang use plain text, while filename-free transformed compiler
-output keeps its TypeScript default. Piped source can select a language directly
-or through a virtual filename. Declarative metadata can now describe extensions,
-exact names, compound patterns, explicit aliases, and direct interpreter
-shebangs. JSON Lines and NDJSON use the JSON tokenizer with independent lexical
-state for each record. Python files with recognized extensions now have syntax
-highlighting.
+Status: In progress.
+
+Unknown named files and filename-free source without a recognized shebang use
+plain text, while filename-free transformed compiler output keeps its TypeScript
+default. Piped source can select a language directly or through a virtual
+filename. Declarative metadata can now describe extensions, exact names,
+compound patterns, explicit aliases, and direct interpreter shebangs. JSON Lines
+and NDJSON use the JSON tokenizer with independent lexical state for each record.
+Python files with recognized extensions now have syntax highlighting.
+
 Automatic container detection is limited to structurally identified raw unified
 diffs and standard Git commit output. Recognized shebangs and transformed
 compiler headers remain explicit source selectors. Binary is a supported,
@@ -17,6 +19,7 @@ decoding. Interactive binary views use a bounded preview, while redirected
 output streams the complete dump. Text saves use the encoder paired with the
 decoded source, including preservation of a UTF-8 byte order mark. Binary files
 remain outside diff editing and semantic source loading.
+
 Parser-backed Python, Go, shell, and HTML implementations use Tree-sitter
 through a shared, language-neutral adapter and official grammar packages.
 The order is provisional because recent activity was measured in six of the 26

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -6,11 +6,13 @@
  * TypeScript parse that would misread a bare top-level `{…}` as a block and
  * shred it.
  *
- * The tokenizer is lenient: it never throws on malformed input (an unterminated
- * string or comment simply runs to end of file) so the pager keeps coloring a
- * file the user is midway through editing. JSONC line and block comments and
- * trailing commas are colored, not rejected. Object keys in a single top-level
- * value become a navigation tree, so `wasd`/Tab step through its structure.
+ * The tokenizer is lenient: it never throws on malformed input, so the pager
+ * keeps coloring a file the user is midway through editing. An unterminated
+ * string or comment runs to the end of an ordinary JSON source. JSON Lines
+ * ends it at the record boundary so the next record starts with fresh lexical
+ * state. JSONC line and block comments and trailing commas are colored, not
+ * rejected. Object keys in a single top-level value become a navigation tree,
+ * so `wasd`/Tab step through its structure.
  */
 
 import type {
@@ -37,42 +39,58 @@ interface Token {
 
 const WS = new Set([" ", "\t", "\n", "\r"]);
 
-/** Tokenise `text` into a gapless run of tokens covering every character. */
-function tokenize(text: string): Token[] {
+/** Tokenize `text` into a gapless run of tokens covering every character. */
+function tokenize(text: string, isolateLines = false): Token[] {
+  if (!isolateLines) return tokenizeRange(text, 0, text.length);
+
   const toks: Token[] = [];
-  const n = text.length;
-  let i = 0;
+  let start = 0;
+  while (start < text.length) {
+    const newline = text.indexOf("\n", start);
+    const end = newline < 0 ? text.length : newline;
+    for (const token of tokenizeRange(text, start, end)) toks.push(token);
+    if (newline < 0) break;
+    toks.push({ start: newline, end: newline + 1, cls: "whitespace" });
+    start = newline + 1;
+  }
+  return toks;
+}
+
+/** Tokenize the half-open range from `start` to `end`. */
+function tokenizeRange(text: string, start: number, end: number): Token[] {
+  const toks: Token[] = [];
+  let i = start;
   let depth = 0;
-  while (i < n) {
+  while (i < end) {
     const c = text[i];
     if (WS.has(c)) {
       let j = i + 1;
-      while (j < n && WS.has(text[j])) j++;
+      while (j < end && WS.has(text[j])) j++;
       toks.push({ start: i, end: j, cls: "whitespace" });
       i = j;
     } else if (c === "/" && text[i + 1] === "/") {
       let j = i + 2;
-      while (j < n && text[j] !== "\n") j++;
+      while (j < end && text[j] !== "\n") j++;
       toks.push({ start: i, end: j, cls: "comment" });
       i = j;
     } else if (c === "/" && text[i + 1] === "*") {
       let j = i + 2;
-      while (j < n && !(text[j] === "*" && text[j + 1] === "/")) j++;
-      j = Math.min(n, j + 2); // include the closing `*/` when present
+      while (j < end && !(text[j] === "*" && text[j + 1] === "/")) j++;
+      j = Math.min(end, j + 2); // include the closing `*/` when present
       toks.push({ start: i, end: j, cls: "comment" });
       i = j;
     } else if (c === '"') {
-      const end = scanString(text, i);
+      const stringEnd = scanString(text, i, end);
       // A string immediately followed (past trivia) by `:` is an object key.
-      const cls: TokenClass = nextSignificantIs(text, end, ":")
+      const cls: TokenClass = nextSignificantIs(text, stringEnd, end, ":")
         ? "propertyName"
         : "string";
-      toks.push({ start: i, end, cls });
-      i = end;
+      toks.push({ start: i, end: stringEnd, cls });
+      i = stringEnd;
     } else if (c === "-" || (c >= "0" && c <= "9")) {
-      const end = scanNumber(text, i);
-      toks.push({ start: i, end, cls: "number" });
-      i = end;
+      const numberEnd = scanNumber(text, i, end);
+      toks.push({ start: i, end: numberEnd, cls: "number" });
+      i = numberEnd;
     } else if (c === "{" || c === "[") {
       toks.push({ start: i, end: i + 1, cls: "bracket", depth });
       depth++;
@@ -86,7 +104,7 @@ function tokenize(text: string): Token[] {
       i++;
     } else if (isWordChar(c)) {
       let j = i + 1;
-      while (j < n && isWordChar(text[j])) j++;
+      while (j < end && isWordChar(text[j])) j++;
       const word = text.slice(i, j);
       const cls: TokenClass = word === "true" || word === "false"
         ? "boolean"
@@ -108,49 +126,53 @@ function tokenize(text: string): Token[] {
   return toks;
 }
 
-/** End offset of the string literal starting at `start` (past the close quote,
- * or end of text when unterminated). Backslash escapes the next character. */
-function scanString(text: string, start: number): number {
-  const n = text.length;
+/**
+ * Return the end offset of the string literal starting at `start`.
+ * Backslash escapes the next character.
+ */
+function scanString(text: string, start: number, end: number): number {
   let j = start + 1;
-  while (j < n && text[j] !== '"') {
+  while (j < end && text[j] !== '"') {
     if (text[j] === "\\") j++;
     j++;
   }
-  return Math.min(n, j + 1);
+  return Math.min(end, j + 1);
 }
 
 /** End offset of the number literal starting at `start`. */
-function scanNumber(text: string, start: number): number {
-  const n = text.length;
+function scanNumber(text: string, start: number, end: number): number {
   let j = start;
   if (text[j] === "-") j++;
-  while (j < n && isDigit(text[j])) j++;
+  while (j < end && isDigit(text[j])) j++;
   if (text[j] === ".") {
     j++;
-    while (j < n && isDigit(text[j])) j++;
+    while (j < end && isDigit(text[j])) j++;
   }
   if (text[j] === "e" || text[j] === "E") {
     j++;
     if (text[j] === "+" || text[j] === "-") j++;
-    while (j < n && isDigit(text[j])) j++;
+    while (j < end && isDigit(text[j])) j++;
   }
   return j;
 }
 
 /** Whether the next significant (non-trivia) character from `from` is `ch`. */
-function nextSignificantIs(text: string, from: number, ch: string): boolean {
-  const n = text.length;
+function nextSignificantIs(
+  text: string,
+  from: number,
+  end: number,
+  ch: string,
+): boolean {
   let i = from;
-  while (i < n) {
+  while (i < end) {
     const c = text[i];
     if (WS.has(c)) {
       i++;
     } else if (c === "/" && text[i + 1] === "/") {
-      while (i < n && text[i] !== "\n") i++;
+      while (i < end && text[i] !== "\n") i++;
     } else if (c === "/" && text[i + 1] === "*") {
       i += 2;
-      while (i < n && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      while (i < end && !(text[i] === "*" && text[i + 1] === "/")) i++;
       i += 2;
     } else {
       return c === ch;
@@ -167,14 +189,13 @@ function isWordChar(c: string): boolean {
   return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z");
 }
 
-/** Color `text` into rendered lines by splitting each token across the line
- * boundaries it spans (a block comment is the only token that crosses one). */
-export function jsonHighlightLines(text: string): Line[] {
+/** Color `text` into rendered lines from the selected token stream. */
+function highlightLines(text: string, isolateLines: boolean): Line[] {
   const lineStarts = computeLineStarts(text);
   const rawLines = text.split("\n");
   const spans: Span[][] = rawLines.map(() => []);
   const col = rawLines.map(() => 0);
-  for (const tok of tokenize(text)) {
+  for (const tok of tokenize(text, isolateLines)) {
     let pos = tok.start;
     let li = lineIndexOf(lineStarts, pos);
     while (pos < tok.end && li < rawLines.length) {
@@ -207,16 +228,41 @@ export function jsonHighlightLines(text: string): Line[] {
   return rawLines.map((t, i) => ({ text: t, spans: spans[i] }));
 }
 
-/** A whole-document JSON highlighter. JSON is cheap enough to recolor whole on
- * every keystroke, so no incremental state is needed. */
+/** Color a JSON or JSONC source into rendered lines. */
+export function jsonHighlightLines(text: string): Line[] {
+  return highlightLines(text, false);
+}
+
+/** Color JSON Lines source with independent lexical state for every record. */
+export function jsonLinesHighlightLines(text: string): Line[] {
+  return highlightLines(text, true);
+}
+
+/**
+ * Build a whole-document JSON highlighter. JSON is cheap enough to recolor
+ * whole on every keystroke, so no incremental state is needed.
+ */
 export function createJsonHighlighter(initial: string): Highlighter {
-  let lines: Line[] = jsonHighlightLines(initial);
+  return createHighlighter(initial, jsonHighlightLines);
+}
+
+/** A whole-document JSON Lines highlighter with independent record state. */
+export function createJsonLinesHighlighter(initial: string): Highlighter {
+  return createHighlighter(initial, jsonLinesHighlightLines);
+}
+
+/** Build a highlighter from a whole-source coloring function. */
+function createHighlighter(
+  initial: string,
+  highlight: (text: string) => Line[],
+): Highlighter {
+  let lines: Line[] = highlight(initial);
   return {
     get lines() {
       return lines;
     },
     update(next: string): readonly Line[] {
-      lines = jsonHighlightLines(next);
+      lines = highlight(next);
       return lines;
     },
   };
@@ -241,6 +287,23 @@ export function jsonDocument(text: string): Document {
     structure,
     flatStructure: flattenStructure(structure),
     definitions,
+  };
+}
+
+/** Build a JSON Lines document with structure only for one-record input. */
+export function jsonLinesDocument(text: string): Document {
+  const lines = jsonLinesHighlightLines(text);
+  const recordCount =
+    text.split("\n").filter((line) => line.trim().length > 0).length;
+  if (recordCount === 1) {
+    return { ...jsonDocument(text), lines };
+  }
+  return {
+    text,
+    lines,
+    structure: [],
+    flatStructure: [],
+    definitions: new Map(),
   };
 }
 

--- a/packages/cli/lib/view/languages/json/language.ts
+++ b/packages/cli/lib/view/languages/json/language.ts
@@ -1,12 +1,15 @@
 /**
- * The JSON, JSONC, and JSON Lines language for the pager. Coloring and
+ * The JSON, JSONC, and JSON Lines languages for the pager. Coloring and
  * structure live in {@link ./json.ts}; this module adapts them to the
- * {@link Language} contract.
+ * {@link Language} contract. JSON Lines uses the same tokenizer with fresh
+ * lexical state for each record.
  *
  * JSON has no semantic layer (no types or cross-file definitions to resolve),
- * so it omits `createSemantics`/`createDiffSemantics`. A single top-level
- * value contributes a node tree of object keys. Its diff-hunk navigation
- * reuses the generic {@link remapStructure} the TypeScript language also uses.
+ * so it omits `createSemantics`/`createDiffSemantics`. A single JSON or JSONC
+ * value contributes a node tree of object keys. One-record JSON Lines input
+ * can contribute the same structure, while multi-record input has no
+ * cross-record structure. Diff-hunk navigation reuses the generic
+ * {@link remapStructure} the TypeScript language also uses.
  */
 
 import type { Language } from "../language.ts";
@@ -14,8 +17,11 @@ import { utf8Decoder } from "../decoder.ts";
 import { remapStructure } from "../../diffremap.ts";
 import {
   createJsonHighlighter,
+  createJsonLinesHighlighter,
   jsonDocument,
   jsonHighlightLines,
+  jsonLinesDocument,
+  jsonLinesHighlightLines,
 } from "./json.ts";
 
 export const jsonLanguage: Language = {
@@ -24,10 +30,10 @@ export const jsonLanguage: Language = {
   input: { kind: "text", decoder: utf8Decoder },
 
   metadata: {
-    extensions: [".json", ".jsonc", ".jsonl", ".ndjson"],
+    extensions: [".json", ".jsonc"],
     filenames: [],
     filenamePatterns: [/\.jsonc?\.example$/i],
-    aliases: ["jsonc", "jsonl", "ndjson"],
+    aliases: ["jsonc"],
     interpreters: [],
   },
 
@@ -38,6 +44,29 @@ export const jsonLanguage: Language = {
   highlightFullFileOnDiffEdit: true,
 
   createHighlighter: (text) => createJsonHighlighter(text),
+
+  hunkStructure: (ctx) => remapStructure(ctx),
+};
+
+/** JSON Lines and NDJSON with lexical state isolated to each record. */
+export const jsonLinesLanguage: Language = {
+  id: "json-lines",
+
+  input: { kind: "text", decoder: utf8Decoder },
+
+  metadata: {
+    extensions: [".jsonl", ".ndjson"],
+    filenames: [],
+    filenamePatterns: [],
+    aliases: ["jsonl", "ndjson"],
+    interpreters: [],
+  },
+
+  parseDocument: (text) => jsonLinesDocument(text),
+
+  highlightLines: (text) => jsonLinesHighlightLines(text),
+
+  createHighlighter: (text) => createJsonLinesHighlighter(text),
 
   hunkStructure: (ctx) => remapStructure(ctx),
 };

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -29,7 +29,7 @@ import type { DecodedLanguageSource, LanguageDecoder } from "./decoder.ts";
 import { utf8Decoder } from "./decoder.ts";
 import { typeScriptLanguage } from "./typescript/language.ts";
 import { markdownLanguage } from "./markdown/language.ts";
-import { jsonLanguage } from "./json/language.ts";
+import { jsonLanguage, jsonLinesLanguage } from "./json/language.ts";
 import { yamlLanguage } from "./yaml/language.ts";
 import { pythonLanguage } from "./python/language.ts";
 import { binaryLanguage } from "./binary/language.ts";
@@ -186,8 +186,10 @@ export interface LanguageMetadata {
  * language's metadata once per source; all later work is method dispatch.
  */
 export interface Language {
-  /** Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`,
-   * `"yaml"`, `"python"`, `"binary"`, or `"plain-text"`. */
+  /**
+   * Stable identifier, such as `"typescript"`, `"markdown"`, `"json"`,
+   * `"json-lines"`, `"yaml"`, `"python"`, `"binary"`, or `"plain-text"`.
+   */
   readonly id: string;
 
   /** Decoding and, for byte languages, incremental rendering behavior. */
@@ -367,6 +369,7 @@ function allLanguages(): readonly Language[] {
     typeScriptLanguage,
     markdownLanguage,
     jsonLanguage,
+    jsonLinesLanguage,
     yamlLanguage,
     pythonLanguage,
     binaryLanguage,

--- a/packages/cli/test/fixtures/view-language/corpus.ts
+++ b/packages/cli/test/fixtures/view-language/corpus.ts
@@ -24,6 +24,8 @@ export interface SelectionCases {
  */
 export interface ViewLanguageFixture {
   readonly languageId: string;
+  /** Other adapters that deliberately share this fixture's token evidence. */
+  readonly highlightingPeers?: readonly string[];
   readonly surveyRepository: string;
   readonly surveyCommit: string;
   readonly surveyPath: string;
@@ -99,6 +101,7 @@ export const VIEW_LANGUAGE_FIXTURES: readonly ViewLanguageFixture[] = [
   },
   {
     languageId: "json",
+    highlightingPeers: ["json-lines"],
     surveyRepository: "labs",
     surveyCommit: "a09656c3342bf3e34b68c5f754c25473acb0afef",
     surveyPath: "deno.jsonc",
@@ -110,14 +113,34 @@ export const VIEW_LANGUAGE_FIXTURES: readonly ViewLanguageFixture[] = [
         "deno.jsonc",
         "package.json",
         "settings.jsonc.example",
-        "tasks/test-identity-aliases.jsonl",
-        "tests/fixtures/location.point.sample.ndjson",
       ],
-      aliases: ["json", "jsonc", "jsonl", "ndjson"],
+      aliases: ["json", "jsonc"],
     },
     beforeEvidence: { text: '"tasks"', className: "propertyName" },
     afterEvidence: { text: '"tasks"', className: "propertyName" },
     incompleteEvidence: { text: '"workspace"', className: "propertyName" },
+  },
+  {
+    languageId: "json-lines",
+    surveyRepository: "labs",
+    surveyCommit: "69fcd7efa983a143d1fbe0bc8167b0a6a9be6835",
+    surveyPath: "tasks/test-identity-aliases.jsonl",
+    before: new URL("./json-lines/before.jsonl", import.meta.url),
+    after: new URL("./json-lines/after.jsonl", import.meta.url),
+    incomplete: new URL(
+      "./json-lines/incomplete.fixture",
+      import.meta.url,
+    ),
+    selection: {
+      filenames: [
+        "tasks/test-identity-aliases.jsonl",
+        "tests/fixtures/location.point.sample.ndjson",
+      ],
+      aliases: ["json-lines", "jsonl", "ndjson"],
+    },
+    beforeEvidence: { text: '"queued"', className: "propertyName" },
+    afterEvidence: { text: '"processed"', className: "propertyName" },
+    incompleteEvidence: { text: '"editing"', className: "propertyName" },
   },
   {
     languageId: "yaml",

--- a/packages/cli/test/fixtures/view-language/json-lines/after.jsonl
+++ b/packages/cli/test/fixtures/view-language/json-lines/after.jsonl
@@ -1,0 +1,2 @@
+{"testId":"old","note":"unterminated
+{"processed":true,"canonicalId":"current"}

--- a/packages/cli/test/fixtures/view-language/json-lines/before.jsonl
+++ b/packages/cli/test/fixtures/view-language/json-lines/before.jsonl
@@ -1,0 +1,2 @@
+{"testId":"old","note":"unterminated
+{"queued":true,"canonicalId":"new"}

--- a/packages/cli/test/fixtures/view-language/json-lines/incomplete.fixture
+++ b/packages/cli/test/fixtures/view-language/json-lines/incomplete.fixture
@@ -1,0 +1,2 @@
+{"testId":"editing","note":"unterminated
+{"editing":true,"canonicalId":"pending"}

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -36,9 +36,9 @@ function classesOf(lines: readonly Line[], token: string): Set<TokenClass> {
 Deno.test("json: language metadata selects JSON filenames", () => {
   assertEquals(languageForFile("deno.json").id, "json");
   assertEquals(languageForFile("/a/b/tsconfig.jsonc").id, "json");
-  assertEquals(languageForFile("records.jsonl").id, "json");
-  assertEquals(languageForFile("events.ndjson").id, "json");
-  assertEquals(languageForFile("EVENTS.NDJSON").id, "json");
+  assertEquals(languageForFile("records.jsonl").id, "json-lines");
+  assertEquals(languageForFile("events.ndjson").id, "json-lines");
+  assertEquals(languageForFile("EVENTS.NDJSON").id, "json-lines");
   assertEquals(languageForFile("UPPER.JSON").id, "json");
   assertEquals(languageForFile("config.json.example").id, "json");
   assertEquals(languageForFile("main.ts").id, "typescript");
@@ -57,6 +57,48 @@ Deno.test("json: line-oriented files use JSON token classes", () => {
   assertEquals(classesOf(lines, '"testId"'), new Set(["propertyName"]));
   assertEquals(classesOf(lines, '"old"'), new Set(["string"]));
   assertEquals(classesOf(lines, '"current"'), new Set(["string"]));
+  assertEquals(verbatim(lines), src);
+});
+
+Deno.test("json: malformed records leave following records highlighted", () => {
+  for (
+    const malformed of [
+      '{"broken":"unterminated',
+      '{"broken":/* unterminated',
+      '{"broken":[',
+    ]
+  ) {
+    const src = `${malformed}\n{"next":true}`;
+    const lines = languageForFile("events.jsonl").highlightLines(
+      src,
+      "events.jsonl",
+    );
+    const brackets = lines[1].spans.filter((span) => span.cls === "bracket");
+
+    assertEquals(
+      classesOf(lines.slice(1), '"next"'),
+      new Set([
+        "propertyName",
+      ]),
+    );
+    assertEquals(classesOf(lines.slice(1), "true"), new Set(["boolean"]));
+    assertEquals(brackets.map((span) => span.bracketDepth), [0, 0]);
+    assertEquals(verbatim(lines), src);
+  }
+});
+
+Deno.test("json: large line-oriented records highlight without throwing", () => {
+  const properties = Array.from(
+    { length: 40_000 },
+    (_, index) => `"key${index}":${index}`,
+  );
+  const src = `{${properties.join(",")}}`;
+  const lines = languageForFile("large.jsonl").highlightLines(
+    src,
+    "large.jsonl",
+  );
+
+  assertEquals(classesOf(lines, '"key39999"'), new Set(["propertyName"]));
   assertEquals(verbatim(lines), src);
 });
 
@@ -89,6 +131,19 @@ Deno.test("json: line-oriented documents expose no partial structure", () => {
 
   assertEquals(doc.structure, []);
   assertEquals(doc.definitions.size, 0);
+});
+
+Deno.test("json: one line-oriented record exposes its structure", () => {
+  const language = languageForFile("event.jsonl");
+  const source = '{"event":"created","sequence":1}\n';
+  const doc = language.parseDocument(source, "event.jsonl");
+
+  assertEquals(doc.structure.map((node) => node.label), [
+    "event",
+    "sequence",
+  ]);
+  assert(doc.definitions.has("event"));
+  assert(doc.definitions.has("sequence"));
 });
 
 Deno.test("json: keys, values, and literals get distinct classes", () => {

--- a/packages/cli/test/view-json.test.ts
+++ b/packages/cli/test/view-json.test.ts
@@ -102,7 +102,7 @@ Deno.test("json: large line-oriented records highlight without throwing", () => 
   assertEquals(verbatim(lines), src);
 });
 
-Deno.test("json: line-oriented live edits reuse JSON token classes", () => {
+Deno.test("json: line-oriented live edits preserve record isolation", () => {
   const before = '{"event":"created","sequence":1}\n';
   const after = [
     '{"event":"created","sequence":1}',
@@ -119,6 +119,23 @@ Deno.test("json: line-oriented live edits reuse JSON token classes", () => {
   assertEquals(classesOf(lines, '"updated"'), new Set(["string"]));
   assertEquals(classesOf(lines, "2"), new Set(["number"]));
   assertEquals(verbatim(lines), after);
+
+  const malformed = [
+    '{"event":"unterminated',
+    '{"event":"recovered","sequence":3}',
+  ].join("\n");
+  const recoveredLines = highlighter.update(malformed);
+
+  assertEquals(
+    classesOf(recoveredLines.slice(1), '"event"'),
+    new Set(["propertyName"]),
+  );
+  assertEquals(
+    classesOf(recoveredLines.slice(1), '"recovered"'),
+    new Set(["string"]),
+  );
+  assertEquals(classesOf(recoveredLines.slice(1), "3"), new Set(["number"]));
+  assertEquals(verbatim(recoveredLines), malformed);
 });
 
 Deno.test("json: line-oriented documents expose no partial structure", () => {

--- a/packages/cli/test/view-language-fixtures.test.ts
+++ b/packages/cli/test/view-language-fixtures.test.ts
@@ -57,9 +57,12 @@ function expectLanguageSpecificEvidence(
   fileName: string,
   languageId: string,
   evidence: HighlightEvidence,
+  highlightingPeers: readonly string[] = [],
 ): void {
   for (const otherId of languageIds()) {
-    if (otherId === languageId) continue;
+    if (otherId === languageId || highlightingPeers.includes(otherId)) {
+      continue;
+    }
     const other = languageForName(otherId);
     if (other?.input.kind !== "text") continue;
     const lines = other.highlightLines(source, fileName);
@@ -170,18 +173,21 @@ describe("view language fixture corpus", () => {
           fixture.surveyPath,
           fixture.languageId,
           fixture.beforeEvidence,
+          fixture.highlightingPeers,
         );
         expectLanguageSpecificEvidence(
           after,
           fixture.surveyPath,
           fixture.languageId,
           fixture.afterEvidence,
+          fixture.highlightingPeers,
         );
         expectLanguageSpecificEvidence(
           incomplete,
           fixture.surveyPath,
           fixture.languageId,
           fixture.incompleteEvidence,
+          fixture.highlightingPeers,
         );
       });
 

--- a/packages/cli/test/view-language.test.ts
+++ b/packages/cli/test/view-language.test.ts
@@ -29,7 +29,10 @@ import {
 import { type LanguageDecoder } from "../lib/view/languages/decoder.ts";
 import { typeScriptLanguage } from "../lib/view/languages/typescript/language.ts";
 import { markdownLanguage } from "../lib/view/languages/markdown/language.ts";
-import { jsonLanguage } from "../lib/view/languages/json/language.ts";
+import {
+  jsonLanguage,
+  jsonLinesLanguage,
+} from "../lib/view/languages/json/language.ts";
 import { yamlLanguage } from "../lib/view/languages/yaml/language.ts";
 import { pythonLanguage } from "../lib/view/languages/python/language.ts";
 import { binaryLanguage } from "../lib/view/languages/binary/language.ts";
@@ -93,8 +96,9 @@ Deno.test("languageForName: identifiers and aliases resolve explicit overrides",
   assertEquals(languageForName("md"), markdownLanguage);
   assertEquals(languageForName("json"), jsonLanguage);
   assertEquals(languageForName("jsonc"), jsonLanguage);
-  assertEquals(languageForName("jsonl"), jsonLanguage);
-  assertEquals(languageForName("ndjson"), jsonLanguage);
+  assertEquals(languageForName("json-lines"), jsonLinesLanguage);
+  assertEquals(languageForName("jsonl"), jsonLinesLanguage);
+  assertEquals(languageForName("ndjson"), jsonLinesLanguage);
   assertEquals(languageForName("yaml"), yamlLanguage);
   assertEquals(languageForName("yml"), yamlLanguage);
   assertEquals(languageForName("python"), pythonLanguage);
@@ -109,6 +113,7 @@ Deno.test("languageForName: identifiers and aliases resolve explicit overrides",
     "typescript",
     "markdown",
     "json",
+    "json-lines",
     "yaml",
     "python",
     "binary",
@@ -123,6 +128,7 @@ Deno.test("languageForName: identifiers and aliases resolve explicit overrides",
     "md",
     "json",
     "jsonc",
+    "json-lines",
     "jsonl",
     "ndjson",
     "yaml",
@@ -453,6 +459,7 @@ Deno.test("distinctLanguages: dedupes in first-seen order", () => {
     "b.ts",
     "c.md",
     "d.json",
+    "events.jsonl",
     "e.yaml",
     "f.py",
     "image.png",
@@ -464,6 +471,7 @@ Deno.test("distinctLanguages: dedupes in first-seen order", () => {
       "typescript",
       "markdown",
       "json",
+      "json-lines",
       "yaml",
       "python",
       "binary",
@@ -588,6 +596,7 @@ Deno.test("diffSemanticsFor: TypeScript answers over its own files in the diff",
         [
           markdownLanguage,
           jsonLanguage,
+          jsonLinesLanguage,
           yamlLanguage,
           pythonLanguage,
           plainTextLanguage,


### PR DESCRIPTION
JSON Lines files shared the whole-document JSON tokenizer, so an unterminated string or block comment and unmatched brackets changed the highlighting of every later record.

Register a distinct JSON Lines language strategy that shares the JSON scanner while tokenizing each record with fresh lexical state. Keep ordinary JSON and JSONC on whole-document tokenization. Preserve navigation and definitions for one-record files while suppressing cross-record structure, and append tokens without argument spreading so large generated records do not exceed the JavaScript argument limit.

Add direct, live-edit, diff, explicit-alias, large-record, structure, and shared-corpus coverage. Mark the completed work item in the live language coverage plan.

Verified with the focused JSON, language-selection, and shared fixture suites; the complete CLI suite, where 1,705 tests passed and the two unchanged terminal-color assertions failed; repository-wide formatting and linting; the documentation code-block checker; and the full workspace type check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

