### PR TITLE
fix(shell): the serialized app state carries a DID, not a key

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -410,8 +410,8 @@ a `//` block; see [Section markers](#section-markers) above.
 - Every exported symbol: variable, function, class, type.
 - Every class and every public member of one, including the constructor,
   whether or not the class is exported.
-- Every member of a `type` or `interface` declaration, whether or not the
-  declaration is exported.
+- Every `type` and `interface` declaration and every member of one, whether or
+  not the declaration is exported.
 - Every non-trivial internal function.
 
 Anything else may have one, and the bar is low. Err toward writing one for all

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -410,6 +410,8 @@ a `//` block; see [Section markers](#section-markers) above.
 - Every exported symbol: variable, function, class, type.
 - Every class and every public member of one, including the constructor,
   whether or not the class is exported.
+- Every member of a `type` or `interface` declaration, whether or not the
+  declaration is exported.
 - Every non-trivial internal function.
 
 Anything else may have one, and the bar is low. Err toward writing one for all

--- a/packages/integration/shell-page-probe.ts
+++ b/packages/integration/shell-page-probe.ts
@@ -35,8 +35,8 @@ export interface ShellPageProbe {
   view?: unknown;
   /** Why that state could not be read, when `app` is set and reading it threw. */
   viewError?: string;
-  /** Whether that state carries an identity. */
-  identity?: boolean;
+  /** The DID of the identity that state carries, where it carries one. */
+  identityDid?: string;
   /** The start of the document's rendered text. */
   text: string;
   /**
@@ -51,7 +51,7 @@ export interface ShellPageProbe {
 export async function readShellPageProbe(page: Page): Promise<ShellPageProbe> {
   return await page.evaluate((textLimit: number, tailLimit: number) => {
     const scope = globalThis as typeof globalThis & {
-      app?: { serialize?: () => { view?: unknown; identity?: unknown } };
+      app?: { serialize?: () => { view?: unknown; identityDid?: string } };
       __cfConsoleTail?: Array<{ t: number; method: string; text: string }>;
     };
 
@@ -65,12 +65,12 @@ export async function readShellPageProbe(page: Page): Promise<ShellPageProbe> {
     const app = typeof scope.app?.serialize === "function";
     let view: unknown;
     let viewError: string | undefined;
-    let identity: boolean | undefined;
+    let identityDid: string | undefined;
     if (app) {
       try {
         const state = scope.app!.serialize!();
         view = state.view;
-        identity = !!state.identity;
+        identityDid = state.identityDid;
       } catch (error) {
         viewError = String(error);
       }
@@ -93,7 +93,7 @@ export async function readShellPageProbe(page: Page): Promise<ShellPageProbe> {
       app,
       view,
       viewError,
-      identity,
+      identityDid,
       text,
       consoleTail,
     };
@@ -124,7 +124,7 @@ export function describeShellPage(probe: ShellPageProbe): string {
   } else if (probe.app) {
     lines.push(
       `  globalThis.app: present, holding view ${JSON.stringify(probe.view)}` +
-        ` and ${probe.identity ? "an identity" : "no identity"}`,
+        ` and ${probe.identityDid ?? "no identity"}`,
     );
   } else {
     lines.push("  globalThis.app: absent");

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -20,7 +20,7 @@ import {
   appViewToUrlPath,
   isAppViewEqual,
 } from "@commonfabric/navigation";
-import { AppState, deserialize } from "@commonfabric/shell/app-state";
+import { AppStateSerialized } from "@commonfabric/shell/app-state";
 
 import { describeThrown } from "./describe-thrown.ts";
 import {
@@ -168,12 +168,12 @@ async function loginToPublishedApp(
   );
 }
 
-// How an `AppState` reads in a failure message. The identity is named by its
-// DID, which the serialized state a page probe reads does not carry.
-function describeAppState(state: AppState | undefined): string {
+// How a serialized `AppState` reads in a failure message.
+function describeAppState(state: AppStateSerialized | undefined): string {
   if (!state) return "none (the page never yielded a state)";
-  const identity = state.identity ? state.identity.did() : "none";
-  return `view ${JSON.stringify(state.view)}, identity ${identity}`;
+  return `view ${JSON.stringify(state.view)}, identity ${
+    state.identityDid ?? "none"
+  }`;
 }
 
 /**
@@ -181,15 +181,15 @@ function describeAppState(state: AppState | undefined): string {
  * reports: what the wait was for, the last state it managed to read, and what
  * `page` holds now.
  *
- * The two states answer different questions. `lastState` is what the wait saw,
- * decoded in the test process, so it names the identity by DID. The page probe
- * is read at failure time and covers the case the wait itself cannot describe:
- * a document that is not the shell, where no state was ever there to read.
+ * The two states answer different questions. `lastState` is what the wait saw.
+ * The page probe is read at failure time and covers the case the wait itself
+ * cannot describe: a document that is not the shell, where no state was ever
+ * there to read.
  */
 export async function describeStateWaitFailure(
   page: Page,
   params: { view: AppView; identity?: Identity },
-  lastState: AppState | undefined,
+  lastState: AppStateSerialized | undefined,
 ): Promise<string> {
   const lines = [`  awaited view: ${JSON.stringify(params.view)}`];
   if (params.identity) {
@@ -281,13 +281,12 @@ export class ShellIntegration {
     return page;
   }
 
-  async state(): Promise<AppState | undefined> {
+  async state(): Promise<AppStateSerialized | undefined> {
     this.checkIsOk();
     const page = this.page();
-    const state = await page.evaluate(() => {
+    return await page.evaluate(() => {
       return globalThis.app ? globalThis.app.serialize() : undefined;
     });
-    return state ? deserialize(state) : undefined;
   }
 
   // Login to the initialized app with provided identity.
@@ -310,17 +309,15 @@ export class ShellIntegration {
       view: AppView;
       identity?: Identity;
     },
-  ): Promise<AppState> {
+  ): Promise<AppStateSerialized> {
     function stateMatches(
-      state: AppState | undefined,
+      state: AppStateSerialized | undefined,
       params: Parameters<typeof ShellIntegration.prototype.waitForState>[0],
     ): boolean {
       return !!(
         state &&
         isAppViewEqual(state.view, params.view) &&
-        (params.identity
-          ? state.identity?.did() === params.identity.did()
-          : true)
+        (params.identity ? state.identityDid === params.identity.did() : true)
       );
     }
 
@@ -329,7 +326,7 @@ export class ShellIntegration {
     // The last state the poll below managed to read. A failure reports it, so
     // the message says what the wait actually saw rather than only that it
     // never saw what it wanted.
-    let lastState: AppState | undefined;
+    let lastState: AppStateSerialized | undefined;
     try {
       await waitFor(async () => {
         lastState = await this.state();

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -168,7 +168,7 @@ async function loginToPublishedApp(
   );
 }
 
-// How a serialized `AppState` reads in a failure message.
+/** How a serialized `AppState` reads in a failure message. */
 function describeAppState(state: AppStateSerialized | undefined): string {
   if (!state) return "none (the page never yielded a state)";
   return `view ${JSON.stringify(state.view)}, identity ${

--- a/packages/integration/test/shell-failure-reports.test.ts
+++ b/packages/integration/test/shell-failure-reports.test.ts
@@ -29,7 +29,7 @@ const SHELL_DOCUMENT = `<!DOCTYPE html>
 <body><x-root-view></x-root-view></body></html>`;
 
 // The same document with the shell already booted far enough to have published
-// itself, holding the home view and an identity.
+// itself, holding the home view and an identity named by its DID.
 const BOOTED_SHELL_DOCUMENT = `<!DOCTYPE html>
 <html><head><title>Common Fabric</title></head>
 <body><x-root-view></x-root-view>
@@ -37,7 +37,7 @@ const BOOTED_SHELL_DOCUMENT = `<!DOCTYPE html>
   globalThis.app = {
     serialize: () => ({
       view: { builtin: "home" },
-      identity: { privateKey: [1, 2, 3] },
+      identityDid: "did:key:zBootedShellFixture",
     }),
   };
 </script>
@@ -51,7 +51,7 @@ const REFUSING_SHELL_DOCUMENT = `<!DOCTYPE html>
 <script>
   globalThis.app = {
     state: () => ({}),
-    serialize: () => ({ view: { builtin: "home" }, identity: undefined }),
+    serialize: () => ({ view: { builtin: "home" }, identityDid: undefined }),
     setIdentity: () => { throw new Error("the key store is not open"); },
   };
 </script>
@@ -149,7 +149,7 @@ describe("shell-failure-reports", () => {
       const probe = await readShellPageProbe(page);
       expect(probe.app).toBe(true);
       expect(probe.view).toEqual({ builtin: "home" });
-      expect(probe.identity).toBe(true);
+      expect(probe.identityDid).toBe("did:key:zBootedShellFixture");
     });
 
     it("returns the console messages the page retained", async () => {
@@ -221,7 +221,8 @@ describe("shell-failure-reports", () => {
 
       const described = describeShellPage(await readShellPageProbe(page));
       expect(described).toContain(
-        'globalThis.app: present, holding view {"builtin":"home"} and an identity',
+        'globalThis.app: present, holding view {"builtin":"home"} and ' +
+          "did:key:zBootedShellFixture",
       );
       expect(described).toContain("x-root-view: present");
     });
@@ -262,8 +263,8 @@ describe("shell-failure-reports", () => {
         { view: { builtin: "home" }, identity: awaited },
         {
           view: { builtin: "home" },
-          identity: held,
-          apiUrl: new URL(origin),
+          identityDid: held.did(),
+          apiUrl: origin,
           config: {},
         },
       );

--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -98,7 +98,7 @@ describe("shell login tests", () => {
     await shell.login(identity);
 
     const state = await shell.state();
-    assertEquals(state?.identity?.did(), identity.did());
+    assertEquals(state?.identityDid, identity.did());
   });
 
   it("can create a new user via passphrase", async () => {

--- a/packages/shell/src/lib/app-state.ts
+++ b/packages/shell/src/lib/app-state.ts
@@ -2,7 +2,6 @@ import {
   deserializeKeyPairRaw,
   DID,
   Identity,
-  serializeKeyPairRaw,
   TransferrableInsecureCryptoKeyPair,
 } from "@commonfabric/identity";
 import { AppView } from "@commonfabric/navigation";
@@ -41,8 +40,15 @@ export function isAppStateConfigKey(
   return false;
 }
 
+// The application state as it crosses the integration-test page boundary,
+// which carries only what JSON can express.
+//
+// An identity appears as its DID rather than as itself. That is what a reader
+// on the far side wants -- it is what names an identity in a comparison and in
+// a message -- and it is a public string, where the identity's key material is
+// a secret that a key pair holding `CryptoKey` handles cannot produce at all.
 export type AppStateSerialized = Omit<AppState, "identity" | "apiUrl"> & {
-  identity?: TransferrableInsecureCryptoKeyPair | null;
+  identityDid?: DID;
   apiUrl: string;
 };
 
@@ -107,25 +113,7 @@ export function serialize(
 ): AppStateSerialized {
   const { identity, apiUrl, ...other } = state;
   const out = other as unknown as AppStateSerialized;
-  // Identity key serialization uses array buffers and webcrypto references
-  // for JavaScript contexts. When serializing state here, its in service
-  // of transferring to astral, JSONish boundaries. Convert the key to
-  // buffers of `Array<number>`.
-  out.identity = identity
-    ? serializeKeyPairRaw(identity.serialize())
-    : undefined;
+  out.identityDid = identity?.did();
   out.apiUrl = apiUrl.toString();
-  return out;
-}
-
-export async function deserialize(
-  state: AppStateSerialized,
-): Promise<AppState> {
-  const { identity, apiUrl, ...other } = state;
-  const out = other as unknown as AppState;
-  out.identity = identity
-    ? await Identity.fromRaw(deserializeKeyPairRaw(identity).privateKey)
-    : undefined;
-  out.apiUrl = new URL(apiUrl);
   return out;
 }

--- a/packages/shell/src/lib/app-state.ts
+++ b/packages/shell/src/lib/app-state.ts
@@ -40,15 +40,23 @@ export function isAppStateConfigKey(
   return false;
 }
 
-// The application state as it crosses the integration-test page boundary,
-// which carries only what JSON can express.
-//
-// An identity appears as its DID rather than as itself. That is what a reader
-// on the far side wants -- it is what names an identity in a comparison and in
-// a message -- and it is a public string, where the identity's key material is
-// a secret that a key pair holding `CryptoKey` handles cannot produce at all.
+/**
+ * The application state as it crosses the integration-test page boundary,
+ * which carries only what JSON can express.
+ */
 export type AppStateSerialized = Omit<AppState, "identity" | "apiUrl"> & {
+  /**
+   * The DID of the identity the state holds, where it holds one.
+   *
+   * An identity appears here as its DID rather than as itself. That is what a
+   * reader on the far side wants -- it is what names an identity in a
+   * comparison and in a message -- and it is a public string, where the
+   * identity's key material is a secret that a key pair holding `CryptoKey`
+   * handles cannot produce at all.
+   */
   identityDid?: DID;
+
+  /** The API URL, as a string, `URL` being no more JSON than an identity is. */
   apiUrl: string;
 };
 

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -4,11 +4,9 @@ import { describe, it } from "@std/testing/bdd";
 import { Identity, serializeKeyPairRaw } from "@commonfabric/identity";
 import {
   AppState,
-  AppStateSerialized,
   assertIdentityChangeAllowed,
   clone,
   createAppState,
-  deserialize,
   isAppStateConfigKey,
   resolveIdentity,
   serialize,
@@ -101,53 +99,24 @@ describe("AppState", () => {
     let serialized = serialize(state);
     assert(serialized.apiUrl === API_URL);
     assert((serialized.view as { spaceName: string }).spaceName === SPACE_NAME);
-    assert(
-      serialized.identity === undefined,
+    assertEquals(
+      serialized.identityDid,
+      undefined,
       "Identity not provided (undefined).",
     );
 
-    state.identity = await Identity.generate({ implementation: "webcrypto" }),
+    // Both implementations, because a DID is the one thing either state of a
+    // key pair can produce: the "webcrypto" arm holds `CryptoKey` handles,
+    // whose material is unreachable, and a serialized state carries none.
+    for (const implementation of ["webcrypto", "noble"] as const) {
+      state.identity = await Identity.generate({ implementation });
       serialized = serialize(state);
-    assert(serialized.apiUrl === API_URL);
-    assert((serialized.view as { spaceName: string }).spaceName === SPACE_NAME);
-    assert(
-      serialized.identity === null,
-      "WebCrypto keys cannot be serialized (null).",
-    );
-
-    state.identity = await Identity.generate({ implementation: "noble" });
-    serialized = serialize(state);
-    assert(serialized.apiUrl === API_URL);
-    assert((serialized.view as { spaceName: string }).spaceName === SPACE_NAME);
-    assert(serialized.identity);
-    assert(
-      (await Identity.fromRaw(Uint8Array.from(serialized.identity.privateKey)))
-        .did() ===
+      assert(serialized.apiUrl === API_URL);
+      assertEquals(
+        serialized.identityDid,
         state.identity.did(),
-      "Insecure keys are serializable.",
-    );
-  });
-
-  it("deserialize", async () => {
-    const identity = await Identity.generate({ implementation: "noble" });
-    const identityRaw = serializeKeyPairRaw(identity.serialize());
-    assert(identityRaw, "Deserialized, transferrable identity.");
-
-    const serialized: AppStateSerialized = {
-      apiUrl: API_URL,
-      view: { spaceName: SPACE_NAME },
-      config: {},
-    };
-
-    let state = await deserialize(serialized);
-    assert(state.apiUrl.toString() === API_URL.toString());
-    assert((state.view as { spaceName: string }).spaceName === SPACE_NAME);
-    assert(state.identity === undefined);
-
-    serialized.identity = identityRaw;
-    state = await deserialize(serialized);
-    assert(state.apiUrl.toString() === API_URL.toString());
-    assert((state.view as { spaceName: string }).spaceName === SPACE_NAME);
-    assert(state.identity?.did() === identity.did(), "deserializes identity.");
+        implementation,
+      );
+    }
   });
 });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

**Land this before #6174.** It is a prep PR in the strict sense: it changes no
production path, and it makes #6174 smaller — see "What this does to #6174"
below.

## The bug

`ShellIntegration.state()` read `globalThis.app.serialize()` and ran it through
`deserialize()`, which rebuilt an `Identity` from the transported key material.
Two consumers then asked that `Identity` for its DID: `describeAppState()` for
a failure message, and — the part that matters — `stateMatches()` inside
`waitForState()`, which compares it against the identity a caller is waiting
for.

A key pair holding `CryptoKey` handles cannot be written down, so `serialize()`
answered `null` for one and `deserialize()` turned that into `undefined`. On a
platform where the shell page mints a native identity, that comparison is never
true and **`waitForState({ identity })` runs to its timeout**, reporting
`identity: none`. Not a diagnostic — a hang.

It is latent, and what it waits on is a browser flag. I ran the shell
integration suite against Astral's Chrome: it passes today, including
`piece.test.ts`'s two `waitForState({ identity })` calls — so the page's key
pair holds material there, Chrome keeping ed25519 in Web Crypto behind
"Experimental Web Features" (note [1] on `isNativeEd25519Supported`). When that
flips, `resolveIdentity()` starts minting native identities in the page and
four waits begin timing out: `shell/integration/piece.test.ts` ×2,
`patterns/integration/default-app.test.ts`, `cfc-group-chat-demo.test.ts`.

The shape is worth naming: a secret was being transported so that a public fact
could be derived from it at the far side. That worked for exactly as long as
the secret happened to be transportable.

## The fix

A DID is what both consumers want, both states of a key pair have one, and it
is public. `AppStateSerialized` carries `identityDid`; the harness compares and
prints that string; `shell-page-probe` reports it in place of a bare "has an
identity" boolean, which is strictly more useful in a failure block.

`deserialize()` goes with it. Rebuilding an `Identity` was only ever in service
of reading a DID out of it — its single consumer was `shell-utils.ts:288`, the
shell never reads its own serialized form, and `resolveIdentity()` covers the
login direction unchanged. `topics-navigation-helpers.ts` reads only `view`.

Nothing branched on `waitForState()`'s return value, so widening it to the
serialized shape is free; `default-app.test.ts` already `JSON.stringify`s
`shell.state()`, which reads better this way.

## What this does to #6174

#6174 currently retypes `AppStateSerialized.identity`, adds a
`serializeIdentity()` whose handles arm answers `null`, threads that through
`serialize()`, and changes `deserialize()`. With this landed, all of that stops
existing: the outward direction carries no identity at all, and what remains
there is the login direction alone. It also removes the `null` branch cubic
raised against that PR, rather than defending it.

## Verification

- `deno task check` (41 groups), `fmt --check`, `lint`, `check-docs`,
  `check-skill-facts`, `check-no-waitfor`, `check-package-cycles`,
  `check-unused-deps`, `check-conflict-markers`: green.
- Workspace `deno task test`: all packages passing, 409s.
- `shell` integration against a shell built from this branch and served on its
  own port: 8 of 9, including `login` (which now asserts `state?.identityDid`)
  and `piece` (whose waits pass an identity). The ninth, `blob-upload`, fails
  identically on a `main`-built shell in the same split-origin setup — page and
  API on different ports, which CI does not have.
- The `serialize` test now runs both implementations, since the DID is the one
  thing either state can produce. **Ablated against the bug itself**: restoring
  the old asymmetry — a DID only where the key could be written down — fails it
  on the `webcrypto` arm and no other.

## Not covered

No test drives the handles arm through the *real* harness, because Astral's
Chrome will not mint one. The unit test is the whole of the evidence for that
arm, which is why it exercises both implementations explicitly rather than
whatever the platform defaults to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HFv1TWsCHmd525KCRJ2m8


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


