### PR TITLE
docs(data-model): write down the encoding path's input contract

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2331,6 +2331,38 @@ aligns with the reactive system's assumption that values don't mutate in place.
 > (effectively-immutable wrappers) for collection types, preserving the
 > immutability guarantee even after unwrapping.
 
+### 2.10 Encode Input Contract
+
+Encoding is specified only for a **valid `FabricValue`** — one that has
+passed, or would pass, `isValidFabricValue()` (Section 1). Given such a value,
+an engine's `encode()` produces its format's serialized form or throws for a
+reason the format names: a `FabricSpecialObject` whose class no codec in the
+registry claims, or a cycle.
+
+Given anything else, **all error checking is best-effort.** The binding part
+of that is what it forbids rather than what it permits: no check on this path
+may cost correct input anything. A non-member may therefore encode, may encode
+to something wrong, or may throw, and which of those happens is not specified
+and may differ between formats.
+
+Two consequences follow, and neither is a defect:
+
+- An engine may share a subtree with the value it was given when nothing in
+  that subtree needed encoding. Vetting what is shared would cost the walk the
+  sharing exists to avoid, and would charge it to input that is correct.
+- A codec's `canEncode()` and `encode()` may take a valid `FabricValue` as
+  given, and `encode()` may further take as given that this same codec's
+  `canEncode()` has already returned `true` for it. Re-checking either is work
+  spent on input that is correct by contract.
+
+**Decoding is governed the opposite way.** A serialized form is untrusted
+input in its own right — it arrives from another writer, another version, or
+another realm — so a form that is not this format's, or a payload that will
+not parse, is refused rather than handled best-effort, and `lenient` decides
+only whether the caller sees a throw or a `ProblematicValue` (Section 4.5).
+The asymmetry is deliberate: an encoder is handed a value by its own caller,
+and a decoder is handed one by a stranger.
+
 ---
 
 ## 3. Unknown Types

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -161,9 +161,19 @@ export abstract class BaseCodecEngine<
    * `NULL_LIVE_ENVIRONMENT`, so a codec asking such an environment for a
    * cell fails by name rather than on `undefined`.
    *
+   * **The input contract.** `value` must be a valid `FabricValue`, which is
+   * the question `isValidFabricValue()` answers. Given one, this works.
+   * Given anything else, what checking happens is best-effort: nothing on
+   * this path spends time on correct input in order to catch incorrect
+   * input, so a non-member may encode, may encode to something wrong, or may
+   * throw, and which of those it does is not promised. The same licence
+   * reaches a codec's `canEncode()` and `encode()`, both of which may take a
+   * valid `FabricValue` as given.
+   *
    * @throws If `value` holds something the format cannot carry: a
-   *   `FabricSpecialObject` whose class no codec in the registry claims, a
-   *   cycle, or an object that is no kind of `FabricValue` at all.
+   *   `FabricSpecialObject` whose class no codec in the registry claims, or a
+   *   cycle. A value that is no `FabricValue` at all falls under the input
+   *   contract above rather than here.
    */
   encode(
     value: FabricValue,

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -107,7 +107,12 @@ export interface FabricCodec<Encoded> {
    */
   get recognizedTypeTag(): string | undefined;
 
-  /** Returns `true` if this handler can encode the state of the given value. */
+  /**
+   * Returns `true` if this handler can encode the state of the given value.
+   *
+   * May take `value` as a valid `FabricValue`; see `BaseCodecEngine.encode()`
+   * for the input contract that makes that safe to assume.
+   */
   canEncode(value: FabricValue): boolean;
 
   /**
@@ -172,6 +177,11 @@ export interface FabricCodec<Encoded> {
    * called after {@link #canEncode} has confirmed that `value` is encodable by
    * this instance. The result is expected to be a _shallow_ encoding; the
    * codec system handles recursion as necessary.
+   *
+   * Two things an implementation may take as given: that `value` is a valid
+   * `FabricValue`, and that this instance's own {@link #canEncode} has
+   * returned `true` for it. Re-checking either is work spent on input that is
+   * correct by contract; see `BaseCodecEngine.encode()`.
    *
    * `env` is what a codec reaches the running system through, the same one
    * {@link #decode} is handed.

--- a/packages/data-model/src/codecs.ts
+++ b/packages/data-model/src/codecs.ts
@@ -79,6 +79,9 @@ const jsonCodecEngine = newDefaultJsonCodecEngine();
  * JSON-embedded encoding, prefixed with the format-identifying tag `fvj1:`.
  * If no live environment is given, {@link NULL_LIVE_ENVIRONMENT} is
  * substituted, which throws if anything asks it for a cell.
+ *
+ * `value` must be a valid `FabricValue`; handing this anything else is
+ * best-effort, per the input contract on `BaseCodecEngine.encode()`.
  */
 export function jsonFromFabricValue(
   value: FabricValue,
@@ -169,6 +172,12 @@ const realmCodecEngine = newDefaultRealmCodecEngine();
  *
  * If no live environment is given, {@link NULL_LIVE_ENVIRONMENT} is
  * substituted, which throws if anything asks it for a cell.
+ *
+ * `value` must be a valid `FabricValue`; handing this anything else is
+ * best-effort, per the input contract on `BaseCodecEngine.encode()`. That
+ * contract is what lets a subtree needing no encoding be shared with `value`
+ * rather than copied: vetting one would cost the walk the sharing exists to
+ * avoid, and would charge it to correct input.
  *
  * Named for the `<target>From<Source>Value` family that
  * `fabricFromNativeValue()` and `nativeFromFabricValue()` establish. Both

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -116,6 +116,11 @@ export function isValidFabricValueLayer(
  * Contrast the shallow, single-level sibling `isValidFabricValueLayer()` and
  * `isValidFabricConvertibleValue()` (which additionally accepts native values
  * *convertible* to fabric form).
+ *
+ * This is the admission test the encoding path's input contract is written
+ * against: a value this accepts encodes, and one it does not gets whatever
+ * best-effort handling costs correct input nothing. See
+ * `BaseCodecEngine.encode()`.
  */
 export function isValidFabricValue(value: unknown): value is FabricValue {
   // Fast leaf paths first, so a function or a primitive returns without


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## What

The contract was real and unwritten. Written down now, once:

> Pass a valid `FabricValue` — one that has passed or would pass
> `isValidFabricValue()` — and encoding works. Pass anything else and all error
> checking is best-effort, meaning nothing that makes correct input run
> inefficiently; it might or might not work, and it might or might not throw.

The binding half is what it **forbids**, not what it permits: no check on the
encoding path may cost correct input anything.

Stated on `BaseCodecEngine.encode()`, which already carried the neighbouring
`@throws`, and referred to — not restated — from `jsonFromFabricValue()`,
`realmFromFabricValue()`, `FabricCodec.canEncode()`, `FabricCodec.encode()`, and
`isValidFabricValue()`. One account, four pointers, so there is nothing to
drift.

## What it settles

Two behaviors that read as defects and are not:

- **The realm encoder shares a subtree with the value it was given** when
  nothing in that subtree needed encoding, un-vetted. Vetting it would cost the
  walk the sharing exists to avoid, and charge that walk to correct input —
  which the contract forbids. So the copy-on-write pass-through is not in
  tension with the contract; it is the contract expressed as code.
- **Both encoders accept a non-member.** Measured on `main`: given a plain
  object with an own accessor-backed property, `isValidFabricValue()` returns
  `false` and `fabricFromNativeValue()` refuses, while `realmFromFabricValue()`
  accepts and passes it through with the getter intact, *and*
  `jsonFromFabricValue()` accepts and silently flattens it to
  `fvj1:{"a":{"n":1},"plain":7}`. Both are within contract, and that they differ
  is also within contract.

And it grants a codec author two assumptions, both now written on the
interface: that the value is a valid `FabricValue`, and that this same codec's
`canEncode()` has already returned `true` for it.

## A false claim corrected on the way

`encode()`'s `@throws` promised a throw for "an object that is no kind of
`FabricValue` at all". It throws for some — a `Map` does — and not for others;
the accessor-backed plain object above encodes cleanly. A doc promising what
the code does not do is worse than silence, so that case now falls under the
input contract, where no outcome is promised, rather than under a `@throws`
that cannot keep its word. The two cases the throw *can* promise —
a `FabricSpecialObject` no codec claims, and a cycle — stay.

## The spec

New Section 2.10, "Encode Input Contract", which has room for the thing the
jsdoc does not: **decoding is governed the opposite way.** A serialized form is
untrusted input in its own right — another writer, another version, another
realm — so a form that is not the format's, or a payload that will not parse,
is *refused*, and `lenient` decides only whether the caller sees a throw or a
`ProblematicValue`. An encoder is handed a value by its own caller; a decoder is
handed one by a stranger.

Appended as 2.10 rather than inserted as a new 2.9, deliberately: inserting
would renumber "Decode Guarantees", which `3-json-encoding.md:369` cites by
number. Reading order suffers slightly; a live cross-reference does not.

## Verification

Run locally at `93f5e3d92`:

- `deno task check` — `Type check complete.`, all 41 groups
- `deno lint` — `Checked 4895 files`, exit 0
- `deno fmt --check` — `Checked 4986 files`, exit 0
- `deno task check-docs` — `All 564 checked code block(s) passed.`
- `packages/data-model` `deno task test` — `ok | 57 passed (2689 steps) | 0 failed`

Documentation only; no executable line changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

