### PR TITLE
docs(plans): bulk piece operations — retarget, repair, and rollback on one spine

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -49,6 +49,10 @@ a record: archive it to `docs/history/plans/` following the procedure in
   confidentiality. Gated on a CFC review that has not happened.
 - [CFC runner implementation](runner_cfc_implementation.md) defines the
   commit-boundary enforcement workstreams and rollout.
+- [Bulk piece operations](piece-bulk-operations.md) designs retargeting,
+  repairing, and rolling back many pieces as one reviewable, resumable
+  operation over a shared plan — with batching as an execution strategy
+  underneath rather than the subject.
 - [Topics migration rehearsal](topics-migration-rehearsal.md) is the concrete,
   unexecuted script for `setsrc`-ing the Estuary Topics board against a clone
   and then live.

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -307,14 +307,32 @@ run, which is the point at which resetting the copy stops being an option.
 Enough to start on, and no more than that.
 
 **The core is library code; the entry point is thin.** Enumerating, reading
-each piece's identity, emitting a plan, and consuming one are ordinary
-functions with no opinion about how they are invoked. They belong beside the
-other piece operations, where they can be tested without a command surface at
-all. Only a small wrapper on top has to decide whether this is spelled as a
-subcommand of an existing group, a group of its own, or something else — so
-that decision is genuinely deferred rather than quietly made, and the first
-increment does not wait on it. A decision made when the first *write*
-operation needs a home is made with more information than one made now.
+each piece's identity, emitting a plan, consuming one, applying a row, and
+restoring a retained revision are ordinary functions with no opinion about
+how they are invoked. They live in `packages/piece/src/ops/`, beside the
+piece and pieces controllers they call — the layer that owns piece
+operations, and one from which the runner's local-program resolution is
+importable, so turning a row's source into a program belongs there too.
+There they are tested on the package's own runtime fixtures, with no command
+surface at all. Only a small wrapper in the CLI has to decide whether this is
+spelled as a subcommand of an existing group, a group of its own, or
+something else — so that decision is genuinely deferred rather than quietly
+made, and the first increment does not wait on it. A decision made when the
+first *write* operation needs a home is made with more information than one
+made now.
+
+**Two selectors to start, and the collection one carries the order.** A
+selector is a value handed to the survey. `{kind: "collection", holder,
+path}` names a holder piece and the path to its collection, and emits the
+members followed by the holder as the last row — children first, parent last
+is a property of the selector, not a step the operator performs.
+`{kind: "list", pieces}` names pieces outright: the orphan the containment
+check found, or any other hand-picked set. A space-wide "every piece on
+identity X" is not a live selector — live, it could only come from the
+registry or from running every piece, and both are ruled out above — so it
+exists only as the third enumeration, offline, where a rehearsal clone's
+store can be read. Selectors that take a fixer or a validator arrive with
+their stages.
 
 **The plan is line-oriented JSON.** One header object, then one object per
 piece, and **line order is execution order** — the simplest encoding of a
@@ -323,8 +341,8 @@ running anything.
 
 ```text
 {"kind":"piece-plan","v":1,"space":"did:key:…","takenAt":"…","enumerated":{"collection":113,"registry":7,"registeredOutside":0}}
-{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…","retained":true},"op":{"kind":"retarget","source":"topic.tsx","rev":"…","patternIdentity":"Xk3Lp…"}}
-{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…","retained":true,"revisionId":"rev-bbb…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…","patternIdentity":"Nq8Hw…"}}
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…","retained":true},"op":{"kind":"retarget","source":{"main":"topic.tsx"},"rev":"…","patternIdentity":"Xk3Lp…","allowIncompatible":true}}
+{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…","retained":true,"revisionId":"rev-bbb…"},"op":{"kind":"retarget","source":{"main":"main.tsx"},"rev":"…","patternIdentity":"Nq8Hw…","allowIncompatible":true}}
 ```
 
 and the rollback row derived from the first of those:
@@ -333,7 +351,7 @@ and the rollback row derived from the first of those:
 {"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"Xk3Lp…"},"op":{"kind":"restore","patternIdentity":"PB0Gum…"}}
 ```
 
-Five things this buys, each of them a claim made earlier in this document
+What the encoding buys — most of it a claim made earlier in this document
 that would otherwise have no mechanism:
 
 - **`expect` and `op` together are enough to derive the rollback.** A retarget
@@ -368,6 +386,22 @@ that would otherwise have no mechanism:
   recording the collection count, the registry count, and how many registered
   in-scope pieces the collection lacks is what makes the check reviewable
   afterwards rather than only at run time.
+- **The identity is the pin; `rev` is a label.** A row's `source` names a
+  main file and, when the program has them, its root, tests, and data files,
+  and the apply resolves it through the runner's local-program resolution so
+  nothing attached is dropped. Before writing, the apply recomputes the
+  identity of the source it actually resolved and refuses the row if that
+  differs from `op.patternIdentity` — a different checkout or an uncommitted
+  edit cannot slip through, because the hash catches it. `rev` is recorded
+  for readers and for diffing two plans, and is never enforced: enforcing it
+  would add a second refusal for a condition the identity already proves,
+  and would tie the plan to a git checkout.
+- **The compatibility override is a field on the row, stamped at plan
+  time.** `op.allowIncompatible` is what the apply honors, and nothing else;
+  a flag on the plan command stamps it onto every row, or onto the rows a
+  selector picks. One operator decision, as a per-run flag would be — but
+  the plan shows exactly which rows ran with the gate open, a reviewer can
+  strip it from rows that should not, and the record afterwards is per row.
 - **`phase` labels rows; it does not sort them.** Order is already the line
   order. A phase is for grouping a report and for stopping between groups,
   which keeps one concept from doing two jobs.
@@ -381,6 +415,13 @@ emits complete rows. A survey given none emits rows with `expect` alone,
 which is the pre-state record the after-survey is compared against and a
 valid input to a later pass that adds the `op`. The two are one command with
 one optional argument, not two tools.
+
+**The validator is a schema.** A supplied validator is a JSON schema; the
+survey reads each piece under it and names the ones that fail, which is the
+question a broken holder read cannot answer. The canonical validator is the
+holder's own demanded schema, so the common case supplies no code at all.
+Code-shaped checking waits for the fixer, which is the same question asked
+of a transform.
 
 **The identity read returns the identity and nothing else.** One piece in,
 `{piece, patternIdentity, symbol}` out, no input document, no result, no link
@@ -424,6 +465,13 @@ not merely take a per-piece startup cost across a board-sized set — it fails
 outright well before finishing, which turns a survey into a partial answer
 that looks like a complete one.
 
+**Delivers:** the identity read; the survey, with its plan file, tally,
+containment result, and `retained` column — run against the live board on
+day one, it answers which pieces sit on which identity and whether anything
+registered sits outside the holder; the survey-diff, which compares a survey
+against a plan or an earlier survey and is the verification every later
+stage uses; and the drill skeleton.
+
 - [ ] Enumeration comes from the holder's collection, and the registry is
       compared against it by containment: a registered in-scope piece the
       collection lacks stops the run and is named. A silent subset is the
@@ -442,16 +490,23 @@ that looks like a complete one.
       planning later.
 - [ ] A tally accompanies it, so "do these pieces all agree?" is answered
       without reading every row.
-- [ ] A supplied validator selects the pieces that fail it, naming each one.
-      A collection whose read fails as a whole is diagnosable by this and by
-      nothing else in bulk.
+- [ ] A supplied validator — a JSON schema the survey reads each piece
+      under — selects the pieces that fail it, naming each one. A collection
+      whose read fails as a whole is diagnosable by this and by nothing else
+      in bulk.
+- [ ] The survey-diff: a survey compared against a plan or an earlier
+      survey, reporting per piece moved as planned, still outstanding, or
+      moved to something the plan did not ask for.
 
 ### 2. Repair, by a supplied fixer
 
 The caller supplies a **fixer** — a pure transform from a piece's stored
 document to the document it should hold — and the spine iterates it over the
 selected pieces. The tooling owns selection, ordering, the write, the stop,
-and resume; the fixer owns only what the change is.
+and resume; the fixer owns only what the change is. A fixer is a TypeScript
+module the run imports: typed against the document shape, unit-testable
+without a space, and checkable for the purity it has to have. Writing one is
+a repository-local task, which is the trade that buys those three.
 
 A vocabulary of built-in repairs is the wrong shape here. Every defect worth
 a bulk repair is particular, so a fixed vocabulary is permanently one defect
@@ -488,6 +543,11 @@ much later. A fixer either round-trips them untouched or the run refuses the
 document, and this is the constraint most likely to be discovered the
 expensive way.
 
+**Delivers:** the fixer runner; the dry-run per-piece document diff, which
+stands alone as a read-only "what would change" report; and the
+complete-document and links-intact refusals as library checks, which the
+Topics restore script hand-rolls today and should import instead.
+
 - [ ] A fixer is supplied by the caller, and adding a new kind of repair
       requires no change to the tooling.
 - [ ] Selection, resume, and verification all derive from the fixer being a
@@ -514,8 +574,19 @@ from, is the report of what the run did. What this stage adds is the
 requirement that applying never implies it — an apply that exits zero is not
 a verdict, and the two stay separate invocations.
 
+**Delivers:** the identity computed from a source, exposed where the plan
+command can call it and a person can check which identity current `main`
+produces; the plan consumer with grouped sessions; the stop report; per-piece
+timing, where the number from the first rehearsal run decides whether
+siblings may run concurrently and whether stage 5 is worth building; and the
+retarget drill. This is also the stage at which the entry point gets its
+spelling (decision 1).
+
 - [ ] A retarget of a seeded board runs to completion from a checked-in plan.
 - [ ] Preconditions are proved for every row before the first write.
+- [ ] The identity of each row's resolved source is recomputed before the
+      write and must equal `op.patternIdentity`; `rev` is never enforced.
+- [ ] The compatibility override is honored from the row field alone.
 - [ ] Every retarget row carries the identity its source produces, computed
       without compiling, and the precondition check classifies each piece as
       outstanding, landed, or moved elsewhere against that row alone.
@@ -543,6 +614,10 @@ a verdict, and the two stay separate invocations.
 The plan derived in the other direction — each row returning its piece to the
 revision the plan recorded it at, through the runtime's own restore of a
 retained revision rather than through a second retarget.
+
+**Delivers:** the restore seam — the first command in front of the runtime's
+retained-revision restore, useful on its own for any single piece; the
+rollback-plan derivation; and the rollback drill.
 
 - [ ] A completed retarget is fully reversed from its own plan, with no
       second artifact needed: each rollback row's precondition is the identity
@@ -573,6 +648,8 @@ sessions are stage 3's floor; this stage is only the step from a group to the
 whole run. Last, because it is an optimization over a spine that must exist
 first, and because it is the only stage gated on measurement.
 
+**Delivers:** a measurement, and nothing else unless the measurement says so.
+
 - [ ] Revisited only after the client's execution responsibilities settle.
       This stage optimizes work that may not stay here; see the scope section.
 - [ ] Measured at the piece count a real board carries, not a sample of it —
@@ -601,17 +678,25 @@ left to production: stopping a run midway and completing it by re-invocation
 is the property most likely to rot silently, because nothing else exercises
 it.
 
+The seeded board is a checked-in fixture pair — a trimmed "prior generation"
+pattern and a "current" one — deployed and then retargeted, not the Topics
+pattern at two revisions. That keeps the drill fast and stable, and it means
+the drill reds when bulk operations break and not when Topics changes; the
+Topics rehearsal remains the place where the real pattern is exercised.
+
 ## Open decisions
 
 Each is named with the stage that forces it, so none of them has to be
 settled before work starts.
 
-1. **How bulk is spelled** — *stage 1*. Whether the existing per-piece
-   commands grow a repeatable target, or bulk operations get their own verb,
+1. **How bulk is spelled** — *stage 3*. Whether the existing per-piece
+   commands grow a plan-file target, or bulk operations get their own group,
    decides whether the word for "one piece" stays consistent across the
    command surface. This interacts with
-   [CLI surface shape](cli-surface-shape.md), and it is the first decision
-   because every later stage inherits it.
+   [CLI surface shape](cli-surface-shape.md). It is deferred on purpose: the
+   core is library code, so nothing in stage 1 waits on it, and it is settled
+   when the first write operation needs a home. Until then the survey and
+   the identity read surface wherever the thin wrapper finds cheapest.
 2. ~~**Where preconditions are evaluated.**~~ **Resolved: over the API, and
    stage 1 builds the read.** A piece's pattern identity is readable from a
    live deployment without running the piece — the piece inspection path
@@ -621,11 +706,13 @@ settled before work starts.
    snapshot endpoint the offline path depends on refuses to mount in a
    production environment, so there is no offline option there to weigh.
    What does not yet exist is a read of the right *shape*: see stage 1.
-3. **Scope of a compatibility override** — *stage 1*. An override that lets
-   one refused piece through is a per-piece decision today. Applied to a
-   plan, one flag covering every row turns many decisions into one, which is
-   a different risk from the same flag used many times. Per-row or per-run is
-   a real choice, not a detail.
+3. ~~**Scope of a compatibility override.**~~ **Resolved: a field on the
+   row, stamped by a flag at plan time.** An override that lets one refused
+   piece through is a per-piece decision today; applied to a plan, one flag
+   covering every row turns many decisions into one, which is a different
+   risk from the same flag used many times. The row field keeps the record
+   per row and the plan-time flag keeps the decision single; the apply reads
+   only the row. See the plan encoding above.
 4. **Whether repair gets a narrow write** — *stage 2*. Two writes reach a
    piece's stored input today. One replaces the whole document and re-runs
    the piece against it. The other writes at a path inside the document, but
@@ -637,13 +724,14 @@ settled before work starts.
    freezing a stale schema into a live board. Either repair gets a path write
    that can be told to skip that validation, or the design accepts the wide
    one and says why.
-5. **How a fixer is supplied** — *stage 2*. A module the run imports and
-   calls can be type-checked against the document shape and can be tested
-   without a space; a program the run pipes a document through is
-   language-agnostic and matches how the surrounding operational scripts
-   already work. The choice decides whether writing a fixer is a
-   repository-local task or something an operator can do from anywhere, and
-   whether the purity a fixer has to have is enforced or merely asked for.
+5. ~~**How a fixer is supplied.**~~ **Resolved: a validator is a JSON
+   schema; a fixer is a TypeScript module the run imports.** A module can be
+   type-checked against the document shape, tested without a space, and
+   checked for the purity a fixer has to have; a program piped a document is
+   language-agnostic but can only be asked for those. The validator needs no
+   code at all, because the canonical one is the holder's demanded schema.
+   Writing a fixer is therefore a repository-local task, which is the trade
+   the choice makes.
 6. **Whether siblings may be applied concurrently** — *stage 3, and open
    until the first pass is measured.* Serial ordering exists because a parent
    recomputing over changing children is what storms, but the children of one

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -14,7 +14,7 @@ stopped — with three different apply steps hanging off the end.
 
 Building any one of them alone produces a tool that cannot become the other
 two. Retarget is one source across many pieces; rollback is many pieces each
-returning to a different recorded source; repair does not go through the
+returning to its own recorded revision; repair does not go through the
 source path at all. A design that starts from "apply one source to a list of
 pieces" has already excluded two thirds of the subject.
 
@@ -69,7 +69,7 @@ what changes is the deployment they name.
 | --- | --- | --- | --- |
 | **Retarget** | pieces on a given pattern, or an explicit list | one source package to every selected piece | rollback |
 | **Repair** | pieces a supplied fixer would change | that fixer's output, as each piece's whole document | a second fixer, or restore from a content export |
-| **Rollback** | pieces a plan previously moved | each piece's own recorded prior source | a second retarget |
+| **Rollback** | pieces a plan previously moved | each piece's own retained prior revision | a second retarget |
 | **Survey** | any enumerated set | nothing — it reads and reports | n/a; it writes nothing |
 
 They are one subject because the risky parts are identical: deciding what is
@@ -118,17 +118,29 @@ subset, reports success over that subset, and leaves the rest untouched with
 nothing in the output to say so.
 
 That failure is invisible by construction, so the design does not merely
-prefer the collection — it requires **two enumerations to be compared, and a
-disagreement to stop the run**. A count that matches is worth little on its
-own; a count that differs is the strongest signal available that the
-selection is wrong, and it is worth more than any amount of care taken after
-the set is chosen.
+prefer the collection — it requires **a second enumeration, compared by
+containment, with a disagreement stopping the run**. The registry is the
+cheap second source and is expected to be the smaller, so equality is the
+wrong test; the test is that every registered piece on an in-scope identity
+is also in the collection. One that is not is either a member the collection
+read dropped or a piece of the same kind living outside the holder, and
+either way the plan does not account for it — so the run stops, names it,
+and the operator regenerates the plan with it named or excluded by name.
+Where an offline copy of the store is available, as it is on a rehearsal
+clone, a third enumeration — every piece in the space on an in-scope
+identity — is the strongest check of all, and a rehearsal that fails it does
+not proceed to the live run. Both counts and the containment result go into
+the plan's header, so the check is reviewable after the fact and not only at
+run time.
 
 **Plan** freezes the selection into an artifact. See below.
 
-**Check preconditions** proves, before touching anything, that every piece is
-in the state the plan recorded. A piece that is not is reported and the run
-does not start.
+**Check preconditions** classifies every row, before touching anything, from
+one read of its piece: still in the state the plan recorded, and so
+outstanding; already in the state the operation produces, and so landed; or
+in neither, which means something other than this plan moved it. The third is
+reported by name and the run does not start. The first two are what make
+resume a re-invocation rather than a separate mode.
 
 **Apply serially**, in plan order, stopping at the first failure. Serial is
 not a limitation to be optimized away — a parent recomputing over children
@@ -138,8 +150,9 @@ mid-change is the failure this ordering exists to prevent.
 exits zero is not a verdict: the source-update path reports success for a
 piece whose source committed but whose running instance failed to refresh.
 
-**Resume** re-derives what is outstanding on every invocation, so a stopped
-run is continued by re-running the same command.
+**Resume** is the precondition check again: re-running the same command
+re-derives what is outstanding, skips what landed, and stops on what moved
+elsewhere.
 
 ## The plan is the artifact
 
@@ -155,10 +168,11 @@ of:fid1:ccc…  document-hash=9f2c…        repair=<fixer>
 
 Four properties follow from making this a file rather than a command line:
 
-- **Rollback is the same plan with two columns swapped.** The precondition
-  becomes what the retarget produced; the operation becomes each piece's own
-  recorded prior source. This is the property a one-source-many-pieces
-  interface cannot have.
+- **Rollback is derived from the plan, row by row.** The precondition becomes
+  the state the retarget produced; the operation becomes a return to the
+  revision each row recorded its piece at. Nothing has to be re-surveyed or
+  re-supplied, which is the property a one-source-many-pieces interface cannot
+  have.
 - **It is reviewable before it runs, and diffable before it runs again.** A
   plan generated against a clone and a plan generated against production
   should differ only in ways someone can explain.
@@ -174,24 +188,30 @@ re-derived differently each time.
 
 ## Resume is decided from recorded pre-state
 
-A piece is outstanding when it still satisfies its recorded precondition.
-Not when it differs from some target.
+A piece is outstanding when it still satisfies its recorded precondition, and
+landed when it is in the state its operation produces. Both are decided from
+the plan and one read of the piece; neither compiles anything.
 
-This distinction is what makes resume cheap and correct. "Does this piece
-already run the source I am about to apply?" requires compiling the candidate
-and still does not see the source transition, revision history, or repository
-metadata the update path owns — so it cannot be answered honestly. "Has this
-piece left the state the plan recorded for it?" is answerable by reading the
-store, needs no compile and no candidate, and is exactly the question resume
-has to answer.
+The second half is cheap because a pattern identity is a function of authored
+source, not of a compile: the runtime computes the identity a source closure
+will be stored under without compiling it, and a plan carries that value on
+every retarget row beside the source it names. So "is this piece already on
+the identity this row produces?" is answered the same way as "is it still on
+the identity this row recorded?" — by comparing one identity read against a
+value already in the plan. What neither question asks is "does this piece
+already run the source I am about to apply?", which would need a compile and
+still would not see the source transition, revision history, or repository
+metadata the update path owns. Resume never needs that question.
 
 The consequence is that resume costs one read per piece and is decided before
 any write, which is why re-invoking a stopped run is safe and nearly free on
-the pieces that already landed.
+the pieces that already landed — and why a piece on neither identity is a
+stop rather than a skip: nothing in the plan accounts for where it is.
 
-It also bounds what resume can claim. A piece that left its recorded state is
-known to have moved; it is *not* thereby known to be healthy. Verification is
-the separate pass for that, and no amount of pre-state checking substitutes.
+It also bounds what resume can claim. A piece on the identity its row
+produces is known to have moved as planned; it is *not* thereby known to be
+healthy. Verification is the separate pass for that, and no amount of
+pre-state checking substitutes.
 
 ## What a stop leaves behind
 
@@ -213,7 +233,7 @@ store is a known outcome, and the design assumes it.
 ## Where batching lives
 
 Batching is an execution strategy under the apply step, not an operation and
-not the subject. Three strategies exist, and only the first two words of that
+not the subject. Four strategies exist, and only the first two words of that
 sentence are about speed:
 
 - **A process per piece.** Simple and isolated, and it does not work. Across
@@ -270,8 +290,8 @@ much has to exist before it is safe to run:
   against a resettable copy; a live run also needs rollback, which is not an
   improvement on that path but the only reversal available there, and which
   has to be exercised on a copy before it is relied on.
-- **Stage 5 is under all of them.** Session reuse only makes an existing
-  operation faster.
+- **Stage 5 is under all of them.** A whole-run session only makes an
+  existing operation faster.
 
 **The first useful increment is stages 1 and 3.** A rehearsal-only retarget —
 survey the board, apply the source across it, resume when it stops — needs
@@ -302,27 +322,55 @@ constraint that has to survive review, and one a reader can check without
 running anything.
 
 ```text
-{"kind":"piece-plan","v":1,"space":"did:key:…","takenAt":"…","enumerated":{"collection":113,"registry":7}}
-{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…"},"op":{"kind":"retarget","source":"topic.tsx","rev":"…"}}
-{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…"}}
+{"kind":"piece-plan","v":1,"space":"did:key:…","takenAt":"…","enumerated":{"collection":113,"registry":7,"registeredOutside":0}}
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…","revisionId":"rev-aaa…"},"op":{"kind":"retarget","source":"topic.tsx","rev":"…","patternIdentity":"Xk3Lp…"}}
+{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…","revisionId":"rev-bbb…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…","patternIdentity":"Nq8Hw…"}}
 ```
 
-Four things this buys, each of them a claim made earlier in this document
+and the rollback row derived from the first of those:
+
+```text
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"Xk3Lp…"},"op":{"kind":"restore","revisionId":"rev-aaa…"}}
+```
+
+Five things this buys, each of them a claim made earlier in this document
 that would otherwise have no mechanism:
 
-- **`expect` and `op` are the two columns rollback swaps.** For a retarget,
-  `expect` holds where the piece is and `op` says where it goes; a rollback
-  plan is the same rows with those exchanged. The property is mechanical
-  rather than aspirational.
-- **The header records both enumerations.** Selection disagreement is the
-  failure this design most wants to catch, and recording both counts is what
-  makes it reviewable afterwards rather than only at run time.
+- **`expect` and `op` together are enough to derive the rollback.** A retarget
+  row's `expect` holds the identity the piece is on and the revision it is at;
+  its `op` holds the source to apply and the identity that source produces,
+  computed from the source without compiling it (a source that mounts other
+  patterns over fabric imports is the exception, and a compile gives the same
+  value). The rollback row's `expect` is that produced identity, and its `op`
+  is a return to the recorded revision. The property is mechanical because
+  each row carries both ends of the move.
+- **A return to a recorded revision is the runtime's own operation, not a
+  second retarget.** Every source update appends a revision to the piece that
+  retains the exact source closure it ran, and the runtime can restore a piece
+  to one of those revisions by its identifier without being handed the source
+  again ([piece source lifecycle](../specs/piece-source-lifecycle.md)). That
+  is what `restore` names. A rollback that instead re-applied an old checkout
+  of the source would re-derive, by hand and from outside the space, what the
+  piece already retains — and would have nothing to apply for a row whose
+  prior source no checkout still matches.
+- **The header records both enumerations and the containment check.**
+  Selection error is the failure this design most wants to catch, and
+  recording the collection count, the registry count, and how many registered
+  in-scope pieces the collection lacks is what makes the check reviewable
+  afterwards rather than only at run time.
 - **`phase` labels rows; it does not sort them.** Order is already the line
   order. A phase is for grouping a report and for stopping between groups,
   which keeps one concept from doing two jobs.
 - **A structured encoding avoids inventing a small language.** Preconditions
   and operations have fields, and a delimited format would need escaping
   rules that grow into a parser nobody chose to write.
+
+**`op` is filled by naming an operation; `expect` is filled by reading.** A
+survey given an operation — a source to retarget to, a fixer to apply —
+emits complete rows. A survey given none emits rows with `expect` alone,
+which is the pre-state record the after-survey is compared against and a
+valid input to a later pass that adds the `op`. The two are one command with
+one optional argument, not two tools.
 
 **The identity read returns the identity and nothing else.** One piece in,
 `{piece, patternIdentity, symbol}` out, no input document, no result, no link
@@ -334,7 +382,8 @@ board affordable.
 ### 1. Survey: enumeration, and the plan
 
 A read-only pass that enumerates a set of pieces, reports what each one
-currently holds, and writes the result as a plan. No writes, and therefore
+currently holds, and writes the result as plan rows — `expect` filled from
+the read, `op` filled when an operation was named. No writes, and therefore
 nothing to undo — which is why it is first, and why it can be run against a
 live deployment before anything else has been built.
 
@@ -343,8 +392,9 @@ has been wrong:
 
 **It enumerates from the holder's collection and cross-checks.** Per the
 spine above, the piece registry is not a list of what exists, and a tool that
-enumerates from it operates on a subset while reporting success. Two
-enumerations, compared, with a disagreement stopping the run.
+enumerates from it operates on a subset while reporting success. The registry
+is compared against the collection by containment, and a registered in-scope
+piece the collection lacks stops the run.
 
 **It reads the identity alone, cheaply, and live.** A piece's pattern
 identity is reachable without running the piece, but the paths that reach it
@@ -364,14 +414,19 @@ not merely take a per-piece startup cost across a board-sized set — it fails
 outright well before finishing, which turns a survey into a partial answer
 that looks like a complete one.
 
-- [ ] Enumeration comes from the holder's collection, and a second
-      enumeration is compared against it.
-- [ ] A disagreement between the two stops the run and reports both counts.
-      A silent subset is the failure this exists to prevent.
+- [ ] Enumeration comes from the holder's collection, and the registry is
+      compared against it by containment: a registered in-scope piece the
+      collection lacks stops the run and is named. A silent subset is the
+      failure this exists to prevent.
+- [ ] Both counts and the containment result are recorded in the plan's
+      header.
 - [ ] One process handles a board-sized set, start to finish.
 - [ ] The read reports live state on every invocation, and a test proves it:
       a read taken after a change reflects the change.
-- [ ] The output is a plan — the same artifact the later stages consume.
+- [ ] The output is a plan — the same artifact the later stages consume —
+      with `expect` filled, and `op` filled when the survey was given an
+      operation. Op-less rows are the pre-state record and a valid input to
+      planning later.
 - [ ] A tally accompanies it, so "do these pieces all agree?" is answered
       without reading every row.
 - [ ] A supplied validator selects the pieces that fail it, naming each one.
@@ -405,11 +460,13 @@ from what the fixer actually does, because they *are* what the fixer does.
 This is why a fixer must be a pure function of the document: a fixer that
 reads a clock or a random source makes all three questions unanswerable.
 
-**A fixer returns the whole document.** The write available for stored data
+**A fixer returns the whole document.** The write a repair goes through
 replaces a piece's input document entirely, so a fixer that returns a
-fragment silently zeroes every field it omitted. The tooling has to hold that
-line rather than trusting it — a document that lost fields the fixer never
-mentioned is a defect, not an intent, and the run should refuse it.
+fragment silently drops every omitted field that has no schema default and
+resets to its default every omitted field that has one. The tooling has to
+hold that line rather than trusting it — a document that lost fields the
+fixer never mentioned is a defect, not an intent, and the run should refuse
+it.
 
 **A fixer must not treat a link as data.** A stored document contains
 references as well as values. Rewriting a reference as a plain value corrupts
@@ -446,8 +503,13 @@ a verdict, and the two stay separate invocations.
 
 - [ ] A retarget of a seeded board runs to completion from a checked-in plan.
 - [ ] Preconditions are proved for every row before the first write.
+- [ ] Every retarget row carries the identity its source produces, computed
+      without compiling, and the precondition check classifies each piece as
+      outstanding, landed, or moved elsewhere against that row alone.
 - [ ] A run interrupted partway is completed by re-invoking the same command,
-      and the pieces that landed are not rewritten.
+      and the pieces that landed are not rewritten. A piece on neither of its
+      row's identities stops the run by name rather than being skipped or
+      rewritten.
 - [ ] A stopped run names every unattempted piece, not a count of them.
 - [ ] The after-survey distinguishes "moved as planned", "still outstanding",
       and "moved to something the plan did not ask for" — the third being
@@ -465,25 +527,34 @@ a verdict, and the two stay separate invocations.
 
 ### 4. Rollback
 
-The same plan read in the other direction — each row returning its piece to
-the source the plan recorded for it.
+The plan derived in the other direction — each row returning its piece to the
+revision the plan recorded it at, through the runtime's own restore of a
+retained revision rather than through a second retarget.
 
 - [ ] A completed retarget is fully reversed from its own plan, with no
-      second artifact needed.
+      second artifact needed: each rollback row's precondition is the identity
+      the retarget row produced, and its operation names the recorded
+      revision.
+- [ ] The restore of a retained revision is reachable from the same entry
+      point as the other operations. Today it is a runtime operation with no
+      command in front of it, so this stage is where one appears.
 - [ ] Rollback checks preconditions the same way, so a piece changed by
       something else since the retarget stops the reversal rather than being
-      overwritten.
+      overwritten — and a piece already back on its recorded identity is
+      landed, which is what makes a rollback resumable.
 - [ ] A rollback is itself resumable.
 - [ ] The reversal is exercised against a copy, in the drill, before any live
       run is allowed to depend on it. A rollback path first attempted during
       the incident it exists for is not a rollback path.
 
-### 5. Session reuse
+### 5. A session across the whole run
 
-An execution strategy under the apply step: one session serving many pieces,
-so session start-up, replica warm-up, and source resolution are paid once.
-Last, because it is an optimization over a spine that must exist first, and
-because it is the only stage gated on measurement.
+The widest execution strategy under the apply step: one session serving every
+piece in the run rather than a bounded group of them, so session start-up,
+replica warm-up, and source resolution are paid once in total. Grouped
+sessions are stage 3's floor; this stage is only the step from a group to the
+whole run. Last, because it is an optimization over a spine that must exist
+first, and because it is the only stage gated on measurement.
 
 - [ ] Revisited only after the client's execution responsibilities settle.
       This stage optimizes work that may not stay here; see the scope section.
@@ -538,12 +609,17 @@ settled before work starts.
    plan, one flag covering every row turns many decisions into one, which is
    a different risk from the same flag used many times. Per-row or per-run is
    a real choice, not a detail.
-4. **Whether repair gets a narrow write** — *stage 2*. Today the only write
-   for stored data replaces a piece's whole input document, so "change one
-   property" is a whole-document read-modify-write per piece. That is a large
-   blast radius for a small change, and it is the same path that has been
-   observed freezing a stale schema into a live board. Either repair gets a
-   narrower primitive, or the design accepts the wide one and says why.
+4. **Whether repair gets a narrow write** — *stage 2*. Two writes reach a
+   piece's stored input today. One replaces the whole document and re-runs
+   the piece against it. The other writes at a path inside the document, but
+   validates the document it lands in against the piece's schema before
+   committing — which is exactly what a document in need of repair fails, so
+   it refuses the pieces a repair exists for. That leaves "change one
+   property" as a whole-document read-modify-write per piece: a large blast
+   radius for a small change, and the same path that has been observed
+   freezing a stale schema into a live board. Either repair gets a path write
+   that can be told to skip that validation, or the design accepts the wide
+   one and says why.
 5. **How a fixer is supplied** — *stage 2*. A module the run imports and
    calls can be type-checked against the document shape and can be tested
    without a space; a program the run pipes a document through is
@@ -598,14 +674,17 @@ computation happens. The strategies are not. So the execution strategy stays
 behind a seam and the widest of them stays unbuilt: it is the part most
 likely to be answered rather than optimized.
 
-**What durable state answers "has this piece been migrated?"** The pre-state
-check above answers "has it moved", which is enough for resume and rollback
-and is deliberately all this design relies on. A stronger claim — that a
-piece has been migrated, by a particular plan, to a particular source — would
-need durable per-piece state that does not exist today, or an idempotence
-property on the source-update path. Both are questions about piece semantics
-rather than about tooling, and belong with whoever owns the piece source
-transition rather than being settled here.
+**What durable state answers "has this piece been migrated?"** The
+precondition check above answers "is it on the identity this row recorded, or
+on the one this row produces", which is enough for resume and rollback and is
+deliberately all this design relies on. A piece does keep a durable record of
+its own source transitions — the append-only revision log that rollback
+restores from — but that log says what the piece ran and when, not which plan
+moved it or why. A stronger claim, that a piece has been migrated by a
+particular plan, would need that attribution recorded somewhere, and whether
+a revision should carry it is a question about piece semantics rather than
+about tooling. It belongs with whoever owns the piece source transition rather
+than being settled here.
 
 ## Related
 
@@ -616,4 +695,6 @@ transition rather than being settled here.
   instance of the retarget operation, with a manifest, an ordering, and a
   rollback record.
 - [CLI surface shape](cli-surface-shape.md) governs the command vocabulary
-  that decision 4 above would change.
+  that decision 1 above would change.
+- [Piece source lifecycle](../specs/piece-source-lifecycle.md) specifies the
+  revision log a piece keeps and the restore operation rollback is built on.

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -282,6 +282,55 @@ than a detour from it: every part of it is a part of the finished thing.
 Rollback is not skipped, it is sequenced — it returns before the first live
 run, which is the point at which resetting the copy stops being an option.
 
+### The shape of the first increment
+
+Enough to start on, and no more than that.
+
+**The core is library code; the entry point is thin.** Enumerating, reading
+each piece's identity, emitting a plan, and consuming one are ordinary
+functions with no opinion about how they are invoked. They belong beside the
+other piece operations, where they can be tested without a command surface at
+all. Only a small wrapper on top has to decide whether this is spelled as a
+subcommand of an existing group, a group of its own, or something else — so
+that decision is genuinely deferred rather than quietly made, and the first
+increment does not wait on it. A decision made when the first *write*
+operation needs a home is made with more information than one made now.
+
+**The plan is line-oriented JSON.** One header object, then one object per
+piece, and **line order is execution order** — the simplest encoding of a
+constraint that has to survive review, and one a reader can check without
+running anything.
+
+```text
+{"kind":"piece-plan","v":1,"space":"did:key:…","takenAt":"…","enumerated":{"collection":113,"registry":7}}
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…"},"op":{"kind":"retarget","source":"topic.tsx","rev":"…"}}
+{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…"}}
+```
+
+Four things this buys, each of them a claim made earlier in this document
+that would otherwise have no mechanism:
+
+- **`expect` and `op` are the two columns rollback swaps.** For a retarget,
+  `expect` holds where the piece is and `op` says where it goes; a rollback
+  plan is the same rows with those exchanged. The property is mechanical
+  rather than aspirational.
+- **The header records both enumerations.** Selection disagreement is the
+  failure this design most wants to catch, and recording both counts is what
+  makes it reviewable afterwards rather than only at run time.
+- **`phase` labels rows; it does not sort them.** Order is already the line
+  order. A phase is for grouping a report and for stopping between groups,
+  which keeps one concept from doing two jobs.
+- **A structured encoding avoids inventing a small language.** Preconditions
+  and operations have fields, and a delimited format would need escaping
+  rules that grow into a parser nobody chose to write.
+
+**The identity read returns the identity and nothing else.** One piece in,
+`{piece, patternIdentity, symbol}` out, no input document, no result, no link
+graph. Whether it surfaces as a flag on the existing per-piece inspection or
+as its own thing resolves with the entry-point question above; the function
+underneath is the same either way, and it is what makes a survey over a large
+board affordable.
+
 ### 1. Survey: enumeration, and the plan
 
 A read-only pass that enumerates a set of pieces, reports what each one
@@ -436,6 +485,8 @@ so session start-up, replica warm-up, and source resolution are paid once.
 Last, because it is an optimization over a spine that must exist first, and
 because it is the only stage gated on measurement.
 
+- [ ] Revisited only after the client's execution responsibilities settle.
+      This stage optimizes work that may not stay here; see the scope section.
 - [ ] Measured at the piece count a real board carries, not a sample of it —
       wall-clock, peak memory, and whether every piece completes.
 - [ ] The spine is unchanged by the strategy: same plan, same preconditions,
@@ -514,7 +565,38 @@ settled before work starts.
    is the floor precisely so that this stays a question rather than a
    prerequisite.
 
-## Out of scope, and where it goes
+## Scope, and what sits next to it
+
+**This is the shape half of a larger division.**
+[Verb evolution](verb-evolution.md) already splits the problem three ways —
+migration handles the shape, versioned interfaces handle the callers, and a
+per-piece upgrade policy handles the rollout. This document is the first of
+those and none of the others. It says how to change many pieces safely; it
+says nothing about which pieces *should* change, when, or on whose authority,
+and a reader who arrives here looking for that should go there instead. The
+division is worth stating because both documents are live and neither is
+legible as a part without it.
+
+**Many pieces in one space, not many spaces.** Every operation here is scoped
+to a single space, because that is what the consumer needs and because the
+alternative is not a free generalization. A run across many spaces changes
+things this design currently settles by assuming one: a plan would need to
+name a space per row rather than once in its header, selection would have to
+enumerate spaces before enumerating pieces, a session strategy would group by
+space before grouping by piece, and a stop would leave a remainder spanning
+spaces rather than a list within one. None of that is precluded — the spine
+survives it — but it is a second design and not a flag.
+
+**How much to invest in a shared session is gated on more than measurement.**
+The execution strategies above are arithmetic about work the client does:
+warming a replica, swapping a source, letting a piece settle. Where that work
+runs is itself moving — [server-primary execution](server-execution-v2.md) is
+sequencing a change to which responsibilities remain client-side. The spine
+is indifferent to the outcome, since selection, preconditions, ordering,
+stopping, and resumption are about operator control rather than about where a
+computation happens. The strategies are not. So the execution strategy stays
+behind a seam and the widest of them stays unbuilt: it is the part most
+likely to be answered rather than optimized.
 
 **What durable state answers "has this piece been migrated?"** The pre-state
 check above answers "has it moved", which is enough for resume and rollback

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -221,19 +221,32 @@ sentence are about speed:
   well before the end, so the cost is not the per-piece startup — it is a
   partial result that looks like a complete one. This strategy is ruled out
   rather than deprecated.
-- **One process, a session per piece.** The floor, and what every stage here
-  assumes. It removes the spawn entirely while keeping each piece's session
-  independent, so nothing accumulates across the run.
-- **One process, one session across many pieces.** Amortizes the rest: the
-  source package is resolved and pinned once, and the linked-document warm-up
-  is paid once because later pieces meet an already-warm replica.
+- **One process, a session per piece.** The bare floor. It removes the spawn
+  entirely while keeping each piece's session independent, so nothing
+  accumulates across the run — and it recovers almost nothing, because
+  process and session start-up are a small part of what a piece costs.
+- **One process, one session per bounded group.** The working strategy. A
+  session serves a fixed number of pieces and is then replaced, so the
+  expensive warm-up is paid once per group rather than once per piece, while
+  the number of pieces ever live at once stays bounded by the group size
+  rather than by the length of the run.
+- **One process, one session across the whole run.** Maximum amortization,
+  and the only one whose risk grows with the work: every updated piece stays
+  running for the rest of the run, so memory and cross-piece interference
+  scale with the total. Unmeasured at the sizes that motivate it.
 
-The third is worth having and is bounded by a question the second does not
-raise: an updated piece stays running in the shared session for the rest of
-the run, so memory and cross-piece interference scale with the batch, and
-neither has been measured at the sizes that motivate it. A strategy that has
-not been measured at its intended scale is not yet a strategy — which is why
-the floor is the second and not the third.
+The grouped strategy is the floor for anything board-sized, and the reason is
+arithmetic rather than caution. The warm-up dominates the per-piece cost, so
+paying it once per group of twenty recovers most of what the whole-run
+session would, while the thing that has never been measured — many pieces
+live in one process — is held to twenty instead of hundreds. A group boundary
+is also a natural resume point, so the strategy that bounds the risk is the
+same one that bounds what a failure costs.
+
+What no strategy recovers is the swap itself. Replacing a piece's source,
+re-staging its argument, and letting it settle is the actual work, it is paid
+once per piece, and it sets the floor on any run. Amortization changes what
+surrounds that; it does not change that.
 
 Whichever strategy applies, order stays serial and the spine above is
 unchanged. That is the point of putting batching underneath it: the plan,
@@ -259,6 +272,15 @@ much has to exist before it is safe to run:
   has to be exercised on a copy before it is relied on.
 - **Stage 5 is under all of them.** Session reuse only makes an existing
   operation faster.
+
+**The first useful increment is stages 1 and 3.** A rehearsal-only retarget —
+survey the board, apply the source across it, resume when it stops — needs
+neither repair nor rollback, because a rehearsal's reversal is resetting the
+copy. That increment is worth naming because it is what an upgrade waiting on
+this tooling actually needs, and because it is a prefix of the design rather
+than a detour from it: every part of it is a part of the finished thing.
+Rollback is not skipped, it is sequenced — it returns before the first live
+run, which is the point at which resetting the copy stops being an option.
 
 ### 1. Survey: enumeration, and the plan
 
@@ -383,6 +405,14 @@ a verdict, and the two stay separate invocations.
       what an upgrade that half-converged looks like.
 - [ ] It composes with the existing space-level checks rather than replacing
       them; those remain the acceptance gate.
+- [ ] Sessions are grouped rather than per-piece or per-run, and the group
+      size is a knob rather than a constant in the code.
+- [ ] A group boundary is a resume point: a run that dies inside a group
+      resumes from the start of that group, having lost at most a group's
+      worth of warm-up.
+- [ ] Per-piece timing is reported as the run proceeds. A run whose cost per
+      piece is unknown cannot be improved, and the number is the input to
+      every decision below about whether to go faster.
 
 ### 4. Rollback
 
@@ -470,8 +500,19 @@ settled before work starts.
    already work. The choice decides whether writing a fixer is a
    repository-local task or something an operator can do from anywhere, and
    whether the purity a fixer has to have is enforced or merely asked for.
-6. **Whether one session is viable at the sizes that motivate it** —
-   *stage 5*, and open until measured.
+6. **Whether siblings may be applied concurrently** — *stage 3, and open
+   until the first pass is measured.* Serial ordering exists because a parent
+   recomputing over changing children is what storms, but the children of one
+   parent are independent of each other, so bounded concurrency across them
+   with the parent last is the largest speed lever available. It is also the
+   one that contradicts the operating procedure, which says to migrate
+   serially. The honest sequence is to run serially once while watching the
+   churn the procedure already teaches how to read, and let that decide —
+   rather than to reason about the storm from either direction.
+7. **Whether one session across a whole run is viable at the sizes that
+   motivate it** — *stage 5*, and open until measured. The grouped strategy
+   is the floor precisely so that this stays a question rather than a
+   prerequisite.
 
 ## Out of scope, and where it goes
 

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -63,20 +63,36 @@ A rehearsal that used different tooling from the live run would rehearse
 something else. Both runs use the same commands and the same plan format;
 what changes is the deployment they name.
 
-## The three operations
+## The operations
 
 | | selects | applies | reverses with |
 | --- | --- | --- | --- |
 | **Retarget** | pieces on a given pattern, or an explicit list | one source package to every selected piece | rollback |
 | **Repair** | pieces a supplied fixer would change | that fixer's output, as each piece's whole document | a second fixer, or restore from a content export |
 | **Rollback** | pieces a plan previously moved | each piece's own recorded prior source | a second retarget |
+| **Survey** | any enumerated set | nothing — it reads and reports | n/a; it writes nothing |
 
 They are one subject because the risky parts are identical: deciding what is
 in scope, proving each piece is in the state you think it is, not losing your
 place when the run stops, and telling afterwards whether it worked. They are
-three operations because the write paths, the preconditions, and the
+separate operations because the write paths, the preconditions, and the
 reversibility differ, and a tool that conflates them will get one of those
-three wrong for two of the operations.
+wrong for the others.
+
+**Survey is the one that writes nothing, and it is not a lesser member.** It
+answers "what does each of these pieces currently look like?" and "which of
+them fails this test?" — the second being the same insight as a fixer being
+its own predicate, with a validator in place of a transform. It earns its
+place because those questions are otherwise unanswerable in bulk: when a
+holder demands something one stored member cannot satisfy, the read fails for
+the whole collection at once and names neither the offending member nor its
+position, so finding the one bad piece among a hundred has no better method
+than bisection by hand. A survey answers it in one pass.
+
+Survey is also how the other three are judged. A survey taken before a run is
+the pre-state record the plan needs; the same survey taken afterwards is the
+verification; and the difference between them is the report of what the run
+actually did. One artifact, three uses — which is why it is built first.
 
 ## The spine
 
@@ -85,11 +101,28 @@ select → plan → check preconditions → apply serially → verify → resume
 ```
 
 **Select** names the set. The selector is not assumed to be pattern identity:
-it may be a pattern, a parent's membership array, an explicit list, or — for
-a repair — the supplied fixer itself, since the pieces it would change are
+it may be a pattern, a holder's own collection, an explicit list, or — for a
+repair — the supplied fixer itself, since the pieces it would change are
 exactly the pieces that need it. Identity is one selector among several, and
 treating it as the axis is what makes a tool board-shaped or upgrade-shaped
 instead of general.
+
+**Selection reads the holder's collection, not the space's piece registry.**
+The registry records pieces that were explicitly registered, which is
+something a piece-creation command does and a pattern's own handler has no
+reason to do. So a board's collection and the registry listing describe
+different sets, and the registry is the smaller and less truthful of the two
+— on a board whose members are created through its own handler, most members
+are absent from it. A tool that enumerates by registry silently operates on a
+subset, reports success over that subset, and leaves the rest untouched with
+nothing in the output to say so.
+
+That failure is invisible by construction, so the design does not merely
+prefer the collection — it requires **two enumerations to be compared, and a
+disagreement to stop the run**. A count that matches is worth little on its
+own; a count that differs is the strongest signal available that the
+selection is wrong, and it is worth more than any amount of care taken after
+the set is chosen.
 
 **Plan** freezes the selection into an artifact. See below.
 
@@ -180,19 +213,27 @@ store is a known outcome, and the design assumes it.
 ## Where batching lives
 
 Batching is an execution strategy under the apply step, not an operation and
-not the subject. Two strategies exist:
+not the subject. Three strategies exist, and only the first two words of that
+sentence are about speed:
 
-- **A process per piece.** Simple, isolated, and pays session start-up,
-  replica warm-up, and source resolution once per piece.
-- **One session for many pieces.** Amortizes all of that. The source package
-  is resolved and pinned once, and the linked-document warm-up is paid once
-  because subsequent pieces meet an already-warm replica.
+- **A process per piece.** Simple and isolated, and it does not work. Across
+  a board-sized set a loop that spawns a command per piece fails outright
+  well before the end, so the cost is not the per-piece startup — it is a
+  partial result that looks like a complete one. This strategy is ruled out
+  rather than deprecated.
+- **One process, a session per piece.** The floor, and what every stage here
+  assumes. It removes the spawn entirely while keeping each piece's session
+  independent, so nothing accumulates across the run.
+- **One process, one session across many pieces.** Amortizes the rest: the
+  source package is resolved and pinned once, and the linked-document warm-up
+  is paid once because later pieces meet an already-warm replica.
 
-The second is worth having and is bounded by questions the first does not
-raise: every updated piece stays running in the shared session for the rest
-of the run, so memory and cross-piece interference scale with the batch, and
+The third is worth having and is bounded by a question the second does not
+raise: an updated piece stays running in the shared session for the rest of
+the run, so memory and cross-piece interference scale with the batch, and
 neither has been measured at the sizes that motivate it. A strategy that has
-not been measured at its intended scale is not yet a strategy.
+not been measured at its intended scale is not yet a strategy — which is why
+the floor is the second and not the third.
 
 Whichever strategy applies, order stays serial and the spine above is
 unchanged. That is the point of putting batching underneath it: the plan,
@@ -201,60 +242,70 @@ the execution strategy does.
 
 ## Building it
 
-Stage 1 is the spine, and everything else is a track over it. The two tracks
-are independent after that, because they have different reversals and so
-different floors:
+Stage 1 writes nothing and everything else stands on it. After that the order
+follows what each operation can be undone by, since that is what decides how
+much has to exist before it is safe to run:
 
-- **Stage 1 is shared and comes first.** A plan, preconditions, a serial
-  apply, and resume. Nothing else is buildable without it and both tracks
-  need all of it.
-- **The repair track is stage 2**, and its floor is stage 1 alone. A repair's
-  reversal is a restore from a content export, which already exists and is
-  already drilled, so repair does not wait on rollback the way retarget does.
-- **The retarget track is stages 3 and 4.** Verification is enough to
-  rehearse against a resettable copy; a live run also needs rollback, which
-  is not an improvement on that path but the only reversal available there,
-  and which has to be exercised on a copy before it is relied on.
-- **Stage 5 is under both.** Session reuse only makes an existing operation
-  faster.
+- **Stage 1 is read-only, shared, and immediately useful on its own.** It is
+  the answer to "what do these pieces currently look like, and which of them
+  is wrong?" — a question that is asked during every upgrade and that has no
+  bulk answer today.
+- **Stage 2 is repair**, whose reversal is a restore from a content export
+  that already exists and is already drilled. So it needs stage 1 and nothing
+  else.
+- **Stages 3 and 4 are the retarget track.** The apply is enough to rehearse
+  against a resettable copy; a live run also needs rollback, which is not an
+  improvement on that path but the only reversal available there, and which
+  has to be exercised on a copy before it is relied on.
+- **Stage 5 is under all of them.** Session reuse only makes an existing
+  operation faster.
 
-Repair is ordered ahead of the retarget track because a supplied fixer is
-useful the moment the spine exists, and because the defect it answers is
-usually found — as this one was — while doing something else.
+### 1. Survey: enumeration, and the plan
 
-### 1. The plan, and retarget
+A read-only pass that enumerates a set of pieces, reports what each one
+currently holds, and writes the result as a plan. No writes, and therefore
+nothing to undo — which is why it is first, and why it can be run against a
+live deployment before anything else has been built.
 
-A command that produces a plan from a selector, and a driver that consumes
-one: checks every row's precondition before writing, applies serially in plan
-order, stops at the first failure naming the remainder by piece, and
-recomputes what is outstanding on each invocation.
+Three things it has to get right, and each of them is a way a bulk operation
+has been wrong:
 
-It also needs a read that does not exist yet in the right shape. A piece's
-pattern identity is reachable live and without running the piece, but only
-through paths that carry far more than the identity: per-piece inspection
-also pulls the whole input document, the whole result, and the link graph in
-both directions, and the space-wide listing runs every piece it lists. Both
-are diagnostics. A plan over a large board needs the identity alone, one
-cheap read per piece, and that is a small addition to machinery that already
-exists rather than new capability.
+**It enumerates from the holder's collection and cross-checks.** Per the
+spine above, the piece registry is not a list of what exists, and a tool that
+enumerates from it operates on a subset while reporting success. Two
+enumerations, compared, with a disagreement stopping the run.
 
-The snapshot-download path is not the answer here, and stage 1 should not
-reach for it. It caches the downloaded store indefinitely with no expiry, and
-the flag that re-downloads is on the pull command rather than on the reads —
-so a second read after a run would be served the pre-run snapshot and report
-that nothing had moved. A resume check backed by that is not slow or
-approximate, it is confidently wrong, which is the one failure mode a resume
-check must not have.
+**It reads the identity alone, cheaply, and live.** A piece's pattern
+identity is reachable without running the piece, but the paths that reach it
+today are diagnostics: per-piece inspection also pulls the whole input, the
+whole result, and the link graph both ways, and the space-wide listing runs
+every piece it lists. A survey over a large board needs one small read per
+piece. The snapshot-download path is not an alternative — it caches
+indefinitely with no expiry and its re-download flag is on the pull command
+rather than the reads, so a survey taken after a run would be served the
+pre-run snapshot and report that nothing had changed. It is also unavailable
+where it would matter most: the endpoint behind it refuses to mount in a
+production environment and its routes answer as though they do not exist.
 
-- [ ] A plan is generated from a selector and checked in as an artifact.
-- [ ] Preconditions are proved for every row before the first write.
-- [ ] A retarget of a seeded board runs to completion from a checked-in plan.
-- [ ] A run interrupted partway is completed by re-invoking the same command,
-      and the pieces that landed are not rewritten.
-- [ ] A stopped run names every unattempted piece, not a count of them.
-- [ ] The precondition read reports live state on every invocation, and a
-      test proves it: a read taken after a change reflects the change. A
-      cached answer here would make resume confidently wrong.
+**It runs as one process over N pieces.** This is a correctness constraint
+rather than a performance one. A shell loop spawning a command per piece does
+not merely take a per-piece startup cost across a board-sized set — it fails
+outright well before finishing, which turns a survey into a partial answer
+that looks like a complete one.
+
+- [ ] Enumeration comes from the holder's collection, and a second
+      enumeration is compared against it.
+- [ ] A disagreement between the two stops the run and reports both counts.
+      A silent subset is the failure this exists to prevent.
+- [ ] One process handles a board-sized set, start to finish.
+- [ ] The read reports live state on every invocation, and a test proves it:
+      a read taken after a change reflects the change.
+- [ ] The output is a plan — the same artifact the later stages consume.
+- [ ] A tally accompanies it, so "do these pieces all agree?" is answered
+      without reading every row.
+- [ ] A supplied validator selects the pieces that fail it, naming each one.
+      A collection whose read fails as a whole is diagnosable by this and by
+      nothing else in bulk.
 
 ### 2. Repair, by a supplied fixer
 
@@ -309,16 +360,27 @@ expensive way.
       that would rewrite one as a value is refused.
 - [ ] Re-running a completed repair writes nothing.
 
-### 3. Verification as its own pass
+### 3. Retarget
 
-A pass that reads every row's current state and reports it against what the
-plan expected, exiting nonzero while anything is outstanding. It reports; it
-does not repair.
+The upgrade apply: one source package across the pieces a plan names, serial,
+in plan order, checking each row's precondition before writing it, stopping
+at the first failure with the remainder named, and recomputing what is
+outstanding on every invocation.
 
-- [ ] Verification is a separate invocation from application, and applying
-      never implies it.
-- [ ] The pass distinguishes "moved as planned", "still outstanding", and
-      "moved to something the plan did not ask for".
+Verification is not a stage of its own, because stage 1 already is it: a
+survey taken after a run, compared against the survey the plan was built
+from, is the report of what the run did. What this stage adds is the
+requirement that applying never implies it — an apply that exits zero is not
+a verdict, and the two stay separate invocations.
+
+- [ ] A retarget of a seeded board runs to completion from a checked-in plan.
+- [ ] Preconditions are proved for every row before the first write.
+- [ ] A run interrupted partway is completed by re-invoking the same command,
+      and the pieces that landed are not rewritten.
+- [ ] A stopped run names every unattempted piece, not a count of them.
+- [ ] The after-survey distinguishes "moved as planned", "still outstanding",
+      and "moved to something the plan did not ask for" — the third being
+      what an upgrade that half-converged looks like.
 - [ ] It composes with the existing space-level checks rather than replacing
       them; those remain the acceptance gate.
 
@@ -386,8 +448,10 @@ settled before work starts.
    live deployment without running the piece — the piece inspection path
    loads the cell with execution off and reports the identity ref — so the
    same check serves a rehearsal and a live run, and neither is verified by
-   a mechanism the other does not use. What does not yet exist is a read of
-   the right *shape*: see below.
+   a mechanism the other does not use. The alternative decided itself: the
+   snapshot endpoint the offline path depends on refuses to mount in a
+   production environment, so there is no offline option there to weigh.
+   What does not yet exist is a read of the right *shape*: see stage 1.
 3. **Scope of a compatibility override** — *stage 1*. An override that lets
    one refused piece through is a per-piece decision today. Applied to a
    plan, one flag covering every row turns many decisions into one, which is

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,0 +1,200 @@
+# Bulk piece operations
+
+**Status:** proposed, unbuilt. The design for changing many pieces in one
+space as one reviewable, resumable operation.
+
+## The short version
+
+**Three operations over many pieces share one spine and differ only in what
+they apply.** Retargeting a piece's source, repairing its stored data, and
+rolling either back are the same problem — select a set, record what each
+piece looks like now, apply serially, verify, and resume from wherever it
+stopped — with three different apply steps hanging off the end.
+
+Building any one of them alone produces a tool that cannot become the other
+two. Retarget is one source across many pieces; rollback is many pieces each
+returning to a different recorded source; repair does not go through the
+source path at all. A design that starts from "apply one source to a list of
+pieces" has already excluded two thirds of the subject.
+
+## The three operations
+
+| | selects | applies | reverses with |
+| --- | --- | --- | --- |
+| **Retarget** | pieces on a given pattern, or an explicit list | one source package to every selected piece | rollback |
+| **Repair** | pieces whose stored data matches a predicate | a change to each piece's own stored data | a second repair, or restore from an export |
+| **Rollback** | pieces a plan previously moved | each piece's own recorded prior source | a second retarget |
+
+They are one subject because the risky parts are identical: deciding what is
+in scope, proving each piece is in the state you think it is, not losing your
+place when the run stops, and telling afterwards whether it worked. They are
+three operations because the write paths, the preconditions, and the
+reversibility differ, and a tool that conflates them will get one of those
+three wrong for two of the operations.
+
+## The spine
+
+```text
+select → plan → check preconditions → apply serially → verify → resume
+```
+
+**Select** names the set. The selector is not assumed to be pattern identity:
+it may be a pattern, a parent's membership array, a stored-data predicate, or
+an explicit list. Identity is one selector among several, and treating it as
+the axis is what makes a tool topic-shaped or migration-shaped instead of
+general.
+
+**Plan** freezes the selection into an artifact. See below.
+
+**Check preconditions** proves, before touching anything, that every piece is
+in the state the plan recorded. A piece that is not is reported and the run
+does not start.
+
+**Apply serially**, in plan order, stopping at the first failure. Serial is
+not a limitation to be optimized away — a parent recomputing over children
+mid-change is the failure this ordering exists to prevent.
+
+**Verify** is a separate pass, never a side effect of applying. An apply that
+exits zero is not a verdict: the source-update path reports success for a
+piece whose source committed but whose running instance failed to refresh.
+
+**Resume** re-derives what is outstanding on every invocation, so a stopped
+run is continued by re-running the same command.
+
+## The plan is the artifact
+
+A plan is a list of rows, each naming a piece, the state it must be in, and
+what to do to it:
+
+```text
+piece                          precondition                     operation
+of:fid1:aaa…  pattern-identity=PB0Gum…   retarget=topic.tsx@<rev>
+of:fid1:bbb…  pattern-identity=PB0Gum…   retarget=topic.tsx@<rev>
+of:fid1:ccc…  stored.schema=true         repair=drop-property:schema
+```
+
+Four properties follow from making this a file rather than a command line:
+
+- **Rollback is the same plan with two columns swapped.** The precondition
+  becomes what the retarget produced; the operation becomes each piece's own
+  recorded prior source. This is the property a one-source-many-pieces
+  interface cannot have.
+- **It is reviewable before it runs, and diffable before it runs again.** A
+  plan generated against a clone and a plan generated against production
+  should differ only in ways someone can explain.
+- **It carries order.** Children before parents is a correctness constraint,
+  not a preference, and it belongs in the artifact rather than in the
+  operator's shell history where nothing can check it.
+- **It is the record of what the pieces looked like beforehand**, which is
+  what makes both resume and rollback possible.
+
+The plan is produced by a command, not by a pipeline transcribed from a
+runbook. A plan that has to be re-derived by hand for each operation is
+re-derived differently each time.
+
+## Resume is decided from recorded pre-state
+
+A piece is outstanding when it still satisfies its recorded precondition.
+Not when it differs from some target.
+
+This distinction is what makes resume cheap and correct. "Does this piece
+already run the source I am about to apply?" requires compiling the candidate
+and still does not see the source transition, revision history, or repository
+metadata the update path owns — so it cannot be answered honestly. "Has this
+piece left the state the plan recorded for it?" is answerable by reading the
+store, needs no compile and no candidate, and is exactly the question resume
+has to answer.
+
+The consequence is that resume costs one read per piece and is decided before
+any write, which is why re-invoking a stopped run is safe and nearly free on
+the pieces that already landed.
+
+It also bounds what resume can claim. A piece that left its recorded state is
+known to have moved; it is *not* thereby known to be healthy. Verification is
+the separate pass for that, and no amount of pre-state checking substitutes.
+
+## What a stop leaves behind
+
+A run that stops has produced a partially changed space, and there is no
+transaction to hide behind. So the stop is designed rather than incidental:
+
+- Every piece that landed keeps its change.
+- The pieces not attempted are written out **by name**, not counted, so the
+  remainder is addressable without reconstructing it by hand.
+- The failure is classified — a refusal about one piece, or the server having
+  gone away — by a state check made *after* the failure. Never by a
+  wall-clock probe before it: a healthy server here has been measured taking
+  over a minute to answer while still completing writes, so a timeout would
+  abort working runs.
+
+Mid-run failure is expected, not exceptional. Resource exhaustion on a large
+store is a known outcome, and the design assumes it.
+
+## Where batching lives
+
+Batching is an execution strategy under the apply step, not an operation and
+not the subject. Two strategies exist:
+
+- **A process per piece.** Simple, isolated, and pays session start-up,
+  replica warm-up, and source resolution once per piece.
+- **One session for many pieces.** Amortizes all of that. The source package
+  is resolved and pinned once, and the linked-document warm-up is paid once
+  because subsequent pieces meet an already-warm replica.
+
+The second is worth having and is bounded by questions the first does not
+raise: every updated piece stays running in the shared session for the rest
+of the run, so memory and cross-piece interference scale with the batch, and
+neither has been measured at the sizes that motivate it. A strategy that has
+not been measured at its intended scale is not yet a strategy.
+
+Whichever strategy applies, order stays serial and the spine above is
+unchanged. That is the point of putting batching underneath it: the plan,
+the preconditions, the stop behavior, and the verification do not change when
+the execution strategy does.
+
+## Open decisions
+
+1. **Where preconditions are evaluated.** Reading a piece's current state
+   from a store file is cheap and offline, but requires filesystem access to
+   the space. The same question has to be answerable over the API for a space
+   reached only that way. Whether both are supported, or one is canonical,
+   is undecided.
+2. **Whether repair gets a narrow write.** Today the only write for stored
+   data replaces a piece's whole input document, so "change one property"
+   is a whole-document read-modify-write per piece. That is a large blast
+   radius for a small change, and it is the same path that has been observed
+   freezing a stale schema into a live board. Either repair gets a narrower
+   primitive, or the design accepts the wide one and says why.
+3. **Scope of a compatibility override.** An override that lets one refused
+   piece through is a per-piece decision today. Applied to a plan, one flag
+   covering every row turns many decisions into one, which is a different
+   risk from the same flag used many times. Per-row or per-run is a real
+   choice, not a detail.
+4. **How bulk is spelled.** Whether the existing per-piece commands grow a
+   repeatable target, or bulk operations get their own verb, decides whether
+   the word for "one piece" stays consistent across the command surface.
+   This interacts with [CLI surface shape](cli-surface-shape.md).
+5. **Whether one session is viable at the sizes that motivate it.** Open
+   until measured; see above.
+
+## Out of scope, and where it goes
+
+**What durable state answers "has this piece been migrated?"** The pre-state
+check above answers "has it moved", which is enough for resume and rollback
+and is deliberately all this design relies on. A stronger claim — that a
+piece has been migrated, by a particular plan, to a particular source — would
+need durable per-piece state that does not exist today, or an idempotence
+property on the source-update path. Both are questions about piece semantics
+rather than about tooling, and belong with whoever owns the piece source
+transition rather than being settled here.
+
+## Related
+
+- [The space-clone rehearsal procedure](../development/space-clone-rehearsal.md)
+  is the operating loop a bulk operation runs inside: clone, serve, verify,
+  reset.
+- [Topics board migration](topics-migration-rehearsal.md) is a worked
+  instance of the retarget operation, with a manifest, an ordering, and a
+  rollback record.
+- [CLI surface shape](cli-surface-shape.md) governs the command vocabulary
+  that decision 4 above would change.

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -33,6 +33,30 @@ operations exist, but that they are **known to work before anyone needs
 them** — which is what the drill below is for, and why it is a success
 criterion rather than a nicety.
 
+### An upgrade is two runs, not one
+
+Every upgrade is rehearsed against a scratch deployment holding a copy of the
+board, and only then run against the deployment holding the live one. The two
+runs are the same operation against different stakes, and the differences are
+what the tooling has to respect:
+
+- **The rehearsal can be reset; the live run cannot.** There is no space
+  reset for a production deployment, so the only reversal available there is
+  a rollback through this tooling, from a record captured before the run
+  started. That makes rollback a prerequisite of the first live run rather
+  than a later convenience.
+- **The plan is the thing compared across the two.** A plan generated against
+  the copy and a plan generated against the live board should differ only in
+  ways someone can explain, and that comparison is the last check before the
+  live attempt. It is only possible because the plan is a file.
+- **The live run happens inside a quiet window**, against data that is being
+  written to right up until it starts. Its plan is therefore generated at the
+  start of that window, not inherited from the rehearsal.
+
+A rehearsal that used different tooling from the live run would rehearse
+something else. Both runs use the same commands and the same plan format;
+what changes is the deployment they name.
+
 ## The three operations
 
 | | selects | applies | reverses with |
@@ -171,8 +195,18 @@ the execution strategy does.
 ## Building it
 
 Five stages. Each one leaves something usable on its own, and the order is
-chosen so that the next Topics upgrade is unblocked by the first two rather
-than by all five.
+chosen around what each kind of run needs:
+
+- **Stages 1–2 are enough to rehearse.** A run against a resettable copy
+  needs a plan, preconditions, a resumable apply, and a way to judge the
+  result. If it goes wrong, the copy is reset and the pass is repeated.
+- **Stages 1–3 are the floor for a live run.** Rollback is not an
+  improvement on the live path, it is the only reversal available there, and
+  it has to be exercised on the copy before it is relied on against the real
+  board.
+- **Stages 4–5 are independent of both.** Repair answers a different need
+  than an upgrade, and session reuse only makes an existing operation
+  faster.
 
 ### 1. The plan, and retarget
 
@@ -212,6 +246,9 @@ the source the plan recorded for it.
       something else since the retarget stops the reversal rather than being
       overwritten.
 - [ ] A rollback is itself resumable.
+- [ ] The reversal is exercised against a copy, in the drill, before any live
+      run is allowed to depend on it. A rollback path first attempted during
+      the incident it exists for is not a rollback path.
 
 ### 4. Repair
 
@@ -269,11 +306,14 @@ settled before work starts.
    command surface. This interacts with
    [CLI surface shape](cli-surface-shape.md), and it is the first decision
    because every later stage inherits it.
-2. **Where preconditions are evaluated** — *stage 1*. Reading a piece's
-   current state from a store file is cheap and offline, but requires
-   filesystem access to the space. The same question has to be answerable
-   over the API for a space reached only that way. Whether both are
-   supported, or one is canonical, is undecided.
+2. **Where preconditions are evaluated** — *stage 1*, and forced rather than
+   deferrable. Reading a piece's current state from a store file is cheap
+   and offline, and it is how a rehearsal against a local copy would
+   naturally do it. A live deployment may offer no such access, and a
+   precondition check that only works against a copy would leave the live
+   run — the one that cannot be reset — as the least verified of the two.
+   Either the check works over the API as well, or the rehearsal is
+   measuring a mechanism the live run does not use.
 3. **Scope of a compatibility override** — *stage 1*. An override that lets
    one refused piece through is a per-piece decision today. Applied to a
    plan, one flag covering every row turns many decisions into one, which is

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,7 +1,8 @@
 # Bulk piece operations
 
-**Status:** proposed, unbuilt. The design for changing many pieces in one
-space as one reviewable, resumable operation.
+**Status:** proposed, unbuilt. The design and build sequence for changing
+many pieces in one space as one reviewable, resumable operation. Driven by
+recurring Topics board upgrades.
 
 ## The short version
 
@@ -16,6 +17,21 @@ two. Retarget is one source across many pieces; rollback is many pieces each
 returning to a different recorded source; repair does not go through the
 source path at all. A design that starts from "apply one source to a list of
 pieces" has already excluded two thirds of the subject.
+
+## The consumer
+
+The Topics board is upgraded on a recurring basis, and every upgrade is a
+bulk operation: a retarget of every topic piece plus the board that holds
+them, ordered children-first. Around it sit the other two — a repair when an
+upgrade exposes stored data that no current write path would produce, and a
+rollback when one goes wrong under a quiet window.
+
+That recurrence is the requirement. Tooling that is built when an upgrade is
+already looming is tooling that gets its first real exercise during the
+operation it is supposed to make safe. So the goal is not only that these
+operations exist, but that they are **known to work before anyone needs
+them** — which is what the drill below is for, and why it is a success
+criterion rather than a nicety.
 
 ## The three operations
 
@@ -152,30 +168,125 @@ unchanged. That is the point of putting batching underneath it: the plan,
 the preconditions, the stop behavior, and the verification do not change when
 the execution strategy does.
 
+## Building it
+
+Five stages. Each one leaves something usable on its own, and the order is
+chosen so that the next Topics upgrade is unblocked by the first two rather
+than by all five.
+
+### 1. The plan, and retarget
+
+A command that produces a plan from a selector, and a driver that consumes
+one: checks every row's precondition before writing, applies serially in plan
+order, stops at the first failure naming the remainder by piece, and
+recomputes what is outstanding on each invocation.
+
+- [ ] A plan is generated from a selector and checked in as an artifact.
+- [ ] Preconditions are proved for every row before the first write.
+- [ ] A retarget of a seeded board runs to completion from a checked-in plan.
+- [ ] A run interrupted partway is completed by re-invoking the same command,
+      and the pieces that landed are not rewritten.
+- [ ] A stopped run names every unattempted piece, not a count of them.
+
+### 2. Verification as its own pass
+
+A pass that reads every row's current state and reports it against what the
+plan expected, exiting nonzero while anything is outstanding. It reports; it
+does not repair.
+
+- [ ] Verification is a separate invocation from application, and applying
+      never implies it.
+- [ ] The pass distinguishes "moved as planned", "still outstanding", and
+      "moved to something the plan did not ask for".
+- [ ] It composes with the existing space-level checks rather than replacing
+      them; those remain the acceptance gate.
+
+### 3. Rollback
+
+The same plan read in the other direction — each row returning its piece to
+the source the plan recorded for it.
+
+- [ ] A completed retarget is fully reversed from its own plan, with no
+      second artifact needed.
+- [ ] Rollback checks preconditions the same way, so a piece changed by
+      something else since the retarget stops the reversal rather than being
+      overwritten.
+- [ ] A rollback is itself resumable.
+
+### 4. Repair
+
+A predicate selector and an in-place data operation, which forces the
+narrow-write decision below. The first case is data that no current write
+path would produce, found on the oldest pieces of a board.
+
+- [ ] A predicate selects pieces by stored data, not only by pattern.
+- [ ] A repair changes what it names and demonstrably leaves the rest of each
+      piece's stored document unchanged.
+- [ ] Re-running a completed repair is a no-op, decided by the same
+      precondition check.
+
+### 5. Session reuse
+
+An execution strategy under the apply step: one session serving many pieces,
+so session start-up, replica warm-up, and source resolution are paid once.
+Last, because it is an optimization over a spine that must exist first, and
+because it is the only stage gated on measurement.
+
+- [ ] Measured at the piece count a real board carries, not a sample of it —
+      wall-clock, peak memory, and whether every piece completes.
+- [ ] The spine is unchanged by the strategy: same plan, same preconditions,
+      same stop behavior, same verification.
+- [ ] A failure under the shared session degrades to the same stop report,
+      with the same remainder named.
+
+## The drill
+
+Every stage above is finished by a drill that runs in continuous integration
+against a seeded space, in the manner of the content-safety drill that
+already guards export and restore: deploy a board, seed it, take the store
+snapshot, run the operation, and assert the outcome.
+
+The drill is what converts this design from documentation into a standing
+guarantee. Its subject is the real pattern, so a change that breaks bulk
+operations should break the drill, and the answer to "does the migration
+tooling still work?" is a CI result rather than an expedition. Without it,
+each upgrade re-discovers the tooling's condition at the moment it is least
+affordable to.
+
+An interrupted run is part of what the drill exercises, not an edge case
+left to production: stopping a run midway and completing it by re-invocation
+is the property most likely to rot silently, because nothing else exercises
+it.
+
 ## Open decisions
 
-1. **Where preconditions are evaluated.** Reading a piece's current state
-   from a store file is cheap and offline, but requires filesystem access to
-   the space. The same question has to be answerable over the API for a space
-   reached only that way. Whether both are supported, or one is canonical,
-   is undecided.
-2. **Whether repair gets a narrow write.** Today the only write for stored
-   data replaces a piece's whole input document, so "change one property"
-   is a whole-document read-modify-write per piece. That is a large blast
-   radius for a small change, and it is the same path that has been observed
-   freezing a stale schema into a live board. Either repair gets a narrower
-   primitive, or the design accepts the wide one and says why.
-3. **Scope of a compatibility override.** An override that lets one refused
-   piece through is a per-piece decision today. Applied to a plan, one flag
-   covering every row turns many decisions into one, which is a different
-   risk from the same flag used many times. Per-row or per-run is a real
-   choice, not a detail.
-4. **How bulk is spelled.** Whether the existing per-piece commands grow a
-   repeatable target, or bulk operations get their own verb, decides whether
-   the word for "one piece" stays consistent across the command surface.
-   This interacts with [CLI surface shape](cli-surface-shape.md).
-5. **Whether one session is viable at the sizes that motivate it.** Open
-   until measured; see above.
+Each is named with the stage that forces it, so none of them has to be
+settled before work starts.
+
+1. **How bulk is spelled** — *stage 1*. Whether the existing per-piece
+   commands grow a repeatable target, or bulk operations get their own verb,
+   decides whether the word for "one piece" stays consistent across the
+   command surface. This interacts with
+   [CLI surface shape](cli-surface-shape.md), and it is the first decision
+   because every later stage inherits it.
+2. **Where preconditions are evaluated** — *stage 1*. Reading a piece's
+   current state from a store file is cheap and offline, but requires
+   filesystem access to the space. The same question has to be answerable
+   over the API for a space reached only that way. Whether both are
+   supported, or one is canonical, is undecided.
+3. **Scope of a compatibility override** — *stage 1*. An override that lets
+   one refused piece through is a per-piece decision today. Applied to a
+   plan, one flag covering every row turns many decisions into one, which is
+   a different risk from the same flag used many times. Per-row or per-run is
+   a real choice, not a detail.
+4. **Whether repair gets a narrow write** — *stage 4*. Today the only write
+   for stored data replaces a piece's whole input document, so "change one
+   property" is a whole-document read-modify-write per piece. That is a large
+   blast radius for a small change, and it is the same path that has been
+   observed freezing a stale schema into a live board. Either repair gets a
+   narrower primitive, or the design accepts the wide one and says why.
+5. **Whether one session is viable at the sizes that motivate it** —
+   *stage 5*, and open until measured.
 
 ## Out of scope, and where it goes
 

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -215,12 +215,32 @@ one: checks every row's precondition before writing, applies serially in plan
 order, stops at the first failure naming the remainder by piece, and
 recomputes what is outstanding on each invocation.
 
+It also needs a read that does not exist yet in the right shape. A piece's
+pattern identity is reachable live and without running the piece, but only
+through paths that carry far more than the identity: per-piece inspection
+also pulls the whole input document, the whole result, and the link graph in
+both directions, and the space-wide listing runs every piece it lists. Both
+are diagnostics. A plan over a large board needs the identity alone, one
+cheap read per piece, and that is a small addition to machinery that already
+exists rather than new capability.
+
+The snapshot-download path is not the answer here, and stage 1 should not
+reach for it. It caches the downloaded store indefinitely with no expiry, and
+the flag that re-downloads is on the pull command rather than on the reads —
+so a second read after a run would be served the pre-run snapshot and report
+that nothing had moved. A resume check backed by that is not slow or
+approximate, it is confidently wrong, which is the one failure mode a resume
+check must not have.
+
 - [ ] A plan is generated from a selector and checked in as an artifact.
 - [ ] Preconditions are proved for every row before the first write.
 - [ ] A retarget of a seeded board runs to completion from a checked-in plan.
 - [ ] A run interrupted partway is completed by re-invoking the same command,
       and the pieces that landed are not rewritten.
 - [ ] A stopped run names every unattempted piece, not a count of them.
+- [ ] The precondition read reports live state on every invocation, and a
+      test proves it: a read taken after a change reflects the change. A
+      cached answer here would make resume confidently wrong.
 
 ### 2. Verification as its own pass
 
@@ -306,14 +326,13 @@ settled before work starts.
    command surface. This interacts with
    [CLI surface shape](cli-surface-shape.md), and it is the first decision
    because every later stage inherits it.
-2. **Where preconditions are evaluated** — *stage 1*, and forced rather than
-   deferrable. Reading a piece's current state from a store file is cheap
-   and offline, and it is how a rehearsal against a local copy would
-   naturally do it. A live deployment may offer no such access, and a
-   precondition check that only works against a copy would leave the live
-   run — the one that cannot be reset — as the least verified of the two.
-   Either the check works over the API as well, or the rehearsal is
-   measuring a mechanism the live run does not use.
+2. ~~**Where preconditions are evaluated.**~~ **Resolved: over the API, and
+   stage 1 builds the read.** A piece's pattern identity is readable from a
+   live deployment without running the piece — the piece inspection path
+   loads the cell with execution off and reports the identity ref — so the
+   same check serves a rehearsal and a live run, and neither is verified by
+   a mechanism the other does not use. What does not yet exist is a read of
+   the right *shape*: see below.
 3. **Scope of a compatibility override** — *stage 1*. An override that lets
    one refused piece through is a per-piece decision today. Applied to a
    plan, one flag covering every row turns many decisions into one, which is

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -170,9 +170,9 @@ Four properties follow from making this a file rather than a command line:
 
 - **Rollback is derived from the plan, row by row.** The precondition becomes
   the state the retarget produced; the operation becomes a return to the
-  revision each row recorded its piece at. Nothing has to be re-surveyed or
-  re-supplied, which is the property a one-source-many-pieces interface cannot
-  have.
+  retained revision carrying the identity each row recorded. Nothing has to
+  be re-surveyed or re-supplied, which is the property a one-source-many-pieces
+  interface cannot have.
 - **It is reviewable before it runs, and diffable before it runs again.** A
   plan generated against a clone and a plan generated against production
   should differ only in ways someone can explain.
@@ -323,36 +323,46 @@ running anything.
 
 ```text
 {"kind":"piece-plan","v":1,"space":"did:key:…","takenAt":"…","enumerated":{"collection":113,"registry":7,"registeredOutside":0}}
-{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…","revisionId":"rev-aaa…"},"op":{"kind":"retarget","source":"topic.tsx","rev":"…","patternIdentity":"Xk3Lp…"}}
-{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…","revisionId":"rev-bbb…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…","patternIdentity":"Nq8Hw…"}}
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"PB0Gum…","retained":true},"op":{"kind":"retarget","source":"topic.tsx","rev":"…","patternIdentity":"Xk3Lp…"}}
+{"piece":"of:fid1:bbb…","phase":"board","expect":{"patternIdentity":"WpIRvA…","retained":true,"revisionId":"rev-bbb…"},"op":{"kind":"retarget","source":"main.tsx","rev":"…","patternIdentity":"Nq8Hw…"}}
 ```
 
 and the rollback row derived from the first of those:
 
 ```text
-{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"Xk3Lp…"},"op":{"kind":"restore","revisionId":"rev-aaa…"}}
+{"piece":"of:fid1:aaa…","phase":"topics","expect":{"patternIdentity":"Xk3Lp…"},"op":{"kind":"restore","patternIdentity":"PB0Gum…"}}
 ```
 
 Five things this buys, each of them a claim made earlier in this document
 that would otherwise have no mechanism:
 
 - **`expect` and `op` together are enough to derive the rollback.** A retarget
-  row's `expect` holds the identity the piece is on and the revision it is at;
-  its `op` holds the source to apply and the identity that source produces,
-  computed from the source without compiling it (a source that mounts other
-  patterns over fabric imports is the exception, and a compile gives the same
-  value). The rollback row's `expect` is that produced identity, and its `op`
-  is a return to the recorded revision. The property is mechanical because
-  each row carries both ends of the move.
+  row's `expect` holds the identity the piece is on, whether the source behind
+  that identity is still retained in the space, and — for a piece that already
+  keeps a revision log — the revision it is at; its `op` holds the source to
+  apply and the identity that source produces, computed from the source
+  without compiling it (a source that mounts other patterns over fabric
+  imports is the exception, and a compile gives the same value). The rollback
+  row's `expect` is that produced identity, and its `op` restores the retained
+  revision carrying the recorded one. The property is mechanical because each
+  row carries both ends of the move.
 - **A return to a recorded revision is the runtime's own operation, not a
   second retarget.** Every source update appends a revision to the piece that
   retains the exact source closure it ran, and the runtime can restore a piece
-  to one of those revisions by its identifier without being handed the source
-  again ([piece source lifecycle](../specs/piece-source-lifecycle.md)). That
-  is what `restore` names. A rollback that instead re-applied an old checkout
-  of the source would re-derive, by hand and from outside the space, what the
-  piece already retains — and would have nothing to apply for a row whose
-  prior source no checkout still matches.
+  to one of those revisions without being handed the source again
+  ([piece source lifecycle](../specs/piece-source-lifecycle.md)). That is what
+  `restore` names. A piece with no revision log yet gets one from the retarget
+  itself: the transition first appends a baseline revision retaining the
+  source the piece was on, provided that source is still retained in the
+  space — so for most pieces the rollback target exists only after the
+  retarget, which is why the rollback row names the recorded identity rather
+  than a revision the survey could not have read. A piece whose prior source
+  is no longer retained has no restore target, and the survey says so up
+  front (`retained`), because the read that answers it is available before
+  the run. A rollback that instead re-applied an old checkout of the source
+  would re-derive, by hand and from outside the space, what the piece
+  already retains — and is exactly, and only, what the unretained rows need
+  an operator to supply before a live run.
 - **The header records both enumerations and the containment check.**
   Selection error is the failure this design most wants to catch, and
   recording the collection count, the registry count, and how many registered
@@ -420,6 +430,9 @@ that looks like a complete one.
       failure this exists to prevent.
 - [ ] Both counts and the containment result are recorded in the plan's
       header.
+- [ ] Each row records whether the source behind its recorded identity is
+      still retained in the space, so a row with no rollback target is known
+      before the run rather than during the incident.
 - [ ] One process handles a board-sized set, start to finish.
 - [ ] The read reports live state on every invocation, and a test proves it:
       a read taken after a change reflects the change.
@@ -533,8 +546,12 @@ retained revision rather than through a second retarget.
 
 - [ ] A completed retarget is fully reversed from its own plan, with no
       second artifact needed: each rollback row's precondition is the identity
-      the retarget row produced, and its operation names the recorded
-      revision.
+      the retarget row produced, and its operation restores the retained
+      revision carrying the recorded identity.
+- [ ] A row whose prior source was not retained is refused by rollback with
+      the reason named, never silently skipped — and a live run is not
+      started with such rows unless the operator has supplied the legacy
+      source for them or accepted, by name, that they cannot be rolled back.
 - [ ] The restore of a retained revision is reachable from the same entry
       point as the other operations. Today it is a runtime operation with no
       command in front of it, so this stage is where one appears.

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -18,6 +18,12 @@ returning to a different recorded source; repair does not go through the
 source path at all. A design that starts from "apply one source to a list of
 pieces" has already excluded two thirds of the subject.
 
+What the caller supplies differs by operation, and that is the whole of the
+difference: a source package for a retarget, a **fixer** for a repair, and
+nothing at all for a rollback, which reads what the plan already recorded.
+Everything else — selection, ordering, the pre-state record, the serial
+apply, the stop, resume, and verification — is the same machinery.
+
 ## The consumer
 
 The Topics board is upgraded on a recurring basis, and every upgrade is a
@@ -62,7 +68,7 @@ what changes is the deployment they name.
 | | selects | applies | reverses with |
 | --- | --- | --- | --- |
 | **Retarget** | pieces on a given pattern, or an explicit list | one source package to every selected piece | rollback |
-| **Repair** | pieces whose stored data matches a predicate | a change to each piece's own stored data | a second repair, or restore from an export |
+| **Repair** | pieces a supplied fixer would change | that fixer's output, as each piece's whole document | a second fixer, or restore from a content export |
 | **Rollback** | pieces a plan previously moved | each piece's own recorded prior source | a second retarget |
 
 They are one subject because the risky parts are identical: deciding what is
@@ -79,10 +85,11 @@ select → plan → check preconditions → apply serially → verify → resume
 ```
 
 **Select** names the set. The selector is not assumed to be pattern identity:
-it may be a pattern, a parent's membership array, a stored-data predicate, or
-an explicit list. Identity is one selector among several, and treating it as
-the axis is what makes a tool topic-shaped or migration-shaped instead of
-general.
+it may be a pattern, a parent's membership array, an explicit list, or — for
+a repair — the supplied fixer itself, since the pieces it would change are
+exactly the pieces that need it. Identity is one selector among several, and
+treating it as the axis is what makes a tool board-shaped or upgrade-shaped
+instead of general.
 
 **Plan** freezes the selection into an artifact. See below.
 
@@ -107,10 +114,10 @@ A plan is a list of rows, each naming a piece, the state it must be in, and
 what to do to it:
 
 ```text
-piece                          precondition                     operation
+piece         precondition               operation
 of:fid1:aaa…  pattern-identity=PB0Gum…   retarget=topic.tsx@<rev>
 of:fid1:bbb…  pattern-identity=PB0Gum…   retarget=topic.tsx@<rev>
-of:fid1:ccc…  stored.schema=true         repair=drop-property:schema
+of:fid1:ccc…  document-hash=9f2c…        repair=<fixer>
 ```
 
 Four properties follow from making this a file rather than a command line:
@@ -194,19 +201,26 @@ the execution strategy does.
 
 ## Building it
 
-Five stages. Each one leaves something usable on its own, and the order is
-chosen around what each kind of run needs:
+Stage 1 is the spine, and everything else is a track over it. The two tracks
+are independent after that, because they have different reversals and so
+different floors:
 
-- **Stages 1–2 are enough to rehearse.** A run against a resettable copy
-  needs a plan, preconditions, a resumable apply, and a way to judge the
-  result. If it goes wrong, the copy is reset and the pass is repeated.
-- **Stages 1–3 are the floor for a live run.** Rollback is not an
-  improvement on the live path, it is the only reversal available there, and
-  it has to be exercised on the copy before it is relied on against the real
-  board.
-- **Stages 4–5 are independent of both.** Repair answers a different need
-  than an upgrade, and session reuse only makes an existing operation
+- **Stage 1 is shared and comes first.** A plan, preconditions, a serial
+  apply, and resume. Nothing else is buildable without it and both tracks
+  need all of it.
+- **The repair track is stage 2**, and its floor is stage 1 alone. A repair's
+  reversal is a restore from a content export, which already exists and is
+  already drilled, so repair does not wait on rollback the way retarget does.
+- **The retarget track is stages 3 and 4.** Verification is enough to
+  rehearse against a resettable copy; a live run also needs rollback, which
+  is not an improvement on that path but the only reversal available there,
+  and which has to be exercised on a copy before it is relied on.
+- **Stage 5 is under both.** Session reuse only makes an existing operation
   faster.
+
+Repair is ordered ahead of the retarget track because a supplied fixer is
+useful the moment the spine exists, and because the defect it answers is
+usually found — as this one was — while doing something else.
 
 ### 1. The plan, and retarget
 
@@ -242,7 +256,60 @@ check must not have.
       test proves it: a read taken after a change reflects the change. A
       cached answer here would make resume confidently wrong.
 
-### 2. Verification as its own pass
+### 2. Repair, by a supplied fixer
+
+The caller supplies a **fixer** — a pure transform from a piece's stored
+document to the document it should hold — and the spine iterates it over the
+selected pieces. The tooling owns selection, ordering, the write, the stop,
+and resume; the fixer owns only what the change is.
+
+A vocabulary of built-in repairs is the wrong shape here. Every defect worth
+a bulk repair is particular, so a fixed vocabulary is permanently one defect
+behind, and each new one becomes a change to the tool rather than an input to
+it.
+
+**The fixer is its own predicate.** A fixer that returns a document unchanged
+means that piece needs nothing, which collapses selection, resumption, and
+verification into one mechanism:
+
+- Selection is "run the fixer, keep the pieces it would change".
+- Resume is the same question asked again — a piece already repaired is one
+  the fixer no longer changes.
+- Verification is the same question asked afterwards — a repair succeeded
+  when re-running the fixer over the stored result is a no-op.
+
+None of those needs a separate predicate language, and none of them can drift
+from what the fixer actually does, because they *are* what the fixer does.
+This is why a fixer must be a pure function of the document: a fixer that
+reads a clock or a random source makes all three questions unanswerable.
+
+**A fixer returns the whole document.** The write available for stored data
+replaces a piece's input document entirely, so a fixer that returns a
+fragment silently zeroes every field it omitted. The tooling has to hold that
+line rather than trusting it — a document that lost fields the fixer never
+mentioned is a defect, not an intent, and the run should refuse it.
+
+**A fixer must not treat a link as data.** A stored document contains
+references as well as values. Rewriting a reference as a plain value corrupts
+it and dropping one destroys it, and neither is visible in the result until
+much later. A fixer either round-trips them untouched or the run refuses the
+document, and this is the constraint most likely to be discovered the
+expensive way.
+
+- [ ] A fixer is supplied by the caller, and adding a new kind of repair
+      requires no change to the tooling.
+- [ ] Selection, resume, and verification all derive from the fixer being a
+      no-op, with no separately maintained predicate.
+- [ ] A dry run reports the exact per-piece document diff, and writes
+      nothing. For a whole-document write this is a requirement, not a
+      convenience.
+- [ ] A fixer that returns an incomplete document is refused rather than
+      applied, and a test proves the refusal.
+- [ ] References survive a repair that does not mention them, and a fixer
+      that would rewrite one as a value is refused.
+- [ ] Re-running a completed repair writes nothing.
+
+### 3. Verification as its own pass
 
 A pass that reads every row's current state and reports it against what the
 plan expected, exiting nonzero while anything is outstanding. It reports; it
@@ -255,7 +322,7 @@ does not repair.
 - [ ] It composes with the existing space-level checks rather than replacing
       them; those remain the acceptance gate.
 
-### 3. Rollback
+### 4. Rollback
 
 The same plan read in the other direction — each row returning its piece to
 the source the plan recorded for it.
@@ -269,18 +336,6 @@ the source the plan recorded for it.
 - [ ] The reversal is exercised against a copy, in the drill, before any live
       run is allowed to depend on it. A rollback path first attempted during
       the incident it exists for is not a rollback path.
-
-### 4. Repair
-
-A predicate selector and an in-place data operation, which forces the
-narrow-write decision below. The first case is data that no current write
-path would produce, found on the oldest pieces of a board.
-
-- [ ] A predicate selects pieces by stored data, not only by pattern.
-- [ ] A repair changes what it names and demonstrably leaves the rest of each
-      piece's stored document unchanged.
-- [ ] Re-running a completed repair is a no-op, decided by the same
-      precondition check.
 
 ### 5. Session reuse
 
@@ -338,13 +393,20 @@ settled before work starts.
    plan, one flag covering every row turns many decisions into one, which is
    a different risk from the same flag used many times. Per-row or per-run is
    a real choice, not a detail.
-4. **Whether repair gets a narrow write** — *stage 4*. Today the only write
+4. **Whether repair gets a narrow write** — *stage 2*. Today the only write
    for stored data replaces a piece's whole input document, so "change one
    property" is a whole-document read-modify-write per piece. That is a large
    blast radius for a small change, and it is the same path that has been
    observed freezing a stale schema into a live board. Either repair gets a
    narrower primitive, or the design accepts the wide one and says why.
-5. **Whether one session is viable at the sizes that motivate it** —
+5. **How a fixer is supplied** — *stage 2*. A module the run imports and
+   calls can be type-checked against the document shape and can be tested
+   without a space; a program the run pipes a document through is
+   language-agnostic and matches how the surrounding operational scripts
+   already work. The choice decides whether writing a fixer is a
+   repository-local task or something an operator can do from anywhere, and
+   whether the purity a fixer has to have is enforced or merely asked for.
+6. **Whether one session is viable at the sizes that motivate it** —
    *stage 5*, and open until measured.
 
 ## Out of scope, and where it goes

--- a/docs/plans/topics-migration-rehearsal.md
+++ b/docs/plans/topics-migration-rehearsal.md
@@ -76,8 +76,9 @@ grep -E 'PB0GumS5vkDPyKAWciwh-4UtypoJwKFUXcDj3SsspHY|-85Wmyd9iwUjbpwnTYR2YolxkMU
 The count check is the point: the space holds 319 pieces across 150 identities,
 so "did I migrate the right 74?" is a question the manifest answers and a
 hand-copied list does not. It is also the rollback record — the second column is
-the source id to `setsrc` back to, which the Going-live section requires be
-captured before starting.
+the identity each piece has to be returned to, and the Going-live section says
+what can take a piece back there and what else must be captured before
+starting.
 
 **Upgrading to:** `packages/patterns/topics/{topic,main}.tsx` at current `main`
 (#4997's legacy-safety fixes plus #4991's body-at-create and thrown
@@ -353,14 +354,23 @@ piece — a pass whose midpoint is unknown is not one of the two clean passes.
 ## Going live
 
 Only after two clean passes, and with a rollback manifest written down first:
-the pristine snapshot path, the exact reset command, the prior source ids
-for every piece (`cf inspect piece <space> <fid>` records the current pattern
-identity — capture all 74 before starting), and a **fresh content export**
+the pristine snapshot path, the exact reset command, the prior pattern
+identity of every piece (`cf inspect piece <space> <fid>` records it — capture
+all 74 before starting) together with the source checkout that produced each
+of those identities, pinned by git rev, and a **fresh content export**
 taken from a snapshot of production at the start of the quiet window, so the
 per-topic restore has current data rather than rehearsal-age data.
 
-There is no `cf space reset` for production. The rollback is a `setsrc` back to
-the recorded source ids, which is why capturing them beforehand is not optional.
+There is no `cf space reset` for production. The rollback returns each piece
+to its recorded identity, and `setsrc` cannot be pointed at an identity — it
+takes a source path — so a rollback by `setsrc` re-applies the legacy source
+checked out at the rev that produced the identity, which is why that rev is
+captured beside the manifest and not reconstructed afterwards. The runtime
+also retains, on the piece, a revision for the source it was on before the
+migration — when that source is still present in the space — which is what
+[bulk piece operations](piece-bulk-operations.md) builds rollback on; no
+command fronts that restore yet, so until one does, the recorded-rev `setsrc`
+is the rollback.
 Above it sit two content tiers: `topics-restore.ts` repairs an individual
 damaged topic in place from the export, and the last resort is the operator
 swapping the store file back to the snapshot — which loses everything written


### PR DESCRIPTION
## Why

Upgrading the Topics board is a recurring operation, it is slow enough to be
disruptive (~1.5 min/piece × 113 topics ≈ 2.8 hours), and the last run did not
converge. There is no tooling for it: the procedure is a runbook that says
"run `setsrc` once per piece" and a set of hand-assembled shell loops. This
adds `docs/plans/piece-bulk-operations.md`, the design and build sequence for
doing it as one reviewable, resumable operation — and, deliberately, for doing
the two neighbouring operations (repairing stored data, rolling back) on the
same spine rather than as three unrelated tools.

The immediate need is a fast, resumable `setsrc` across the full topic list.
The design names that as stages 1 and 3, so it is a **prefix of the finished
thing rather than a detour** — nothing built for the urgent path gets unwound.

This supersedes the approach in #6027, which was withdrawn for being too
narrow (see *Ruled out* below).

## What's here

One document, plus a rollback correction to
`docs/plans/topics-migration-rehearsal.md`. No code. `docs/plans/README.md`
gains its index entry.

The design in one paragraph: three write operations — **retarget** a piece's
source, **repair** its stored data, **roll back** either — plus a read-only
**survey**, all share one spine (*select → plan → check preconditions → apply
serially → verify → resume*) and differ only in what the caller supplies. A
plan is a file of `(piece, precondition, operation)` rows, each row carrying
both ends of its move, so rollback is derived from it row by row — the
property a one-source-many-pieces interface structurally cannot have. Resume
classifies each piece from one identity read against the plan alone:
outstanding, landed, or moved by something else.

## Current state of the world (2026-08-21)

Facts a pickup agent should not have to rediscover, and which deliberately do
**not** live in the doc because they will be stale in a month:

- The Estuary board holds **113 topics**. Earlier figures of 73 and 106 in
  other documents are out of date.
- **The last migration did not converge.** At least three distinct pattern
  identities remain, interleaved rather than contiguous. Re-checked after it
  was reported finished, so this is current.
- **`cf piece ls` sees 7 of the 113.** `getRegisteredPieces()` reads the piece
  *registry*, and its own doc comment says "not every stored piece root."
  Registration happens through the default pattern's `addPiece` stream, which
  `cf piece new` calls and a pattern's own handler does not — so topics made
  via `addTopic` are absent. This is the leading hypothesis for why the
  migration missed pieces.
- The enumeration that returns all 113:
  `cf get --piece <board> --space <did> topics --input --select '@'` — and it
  works **because it returns addresses without reading through the elements**.
  On this board today, reading through the collection returns nothing
  (`--select title` yields 0 while `--select '@'` yields 113), though each
  topic read directly by its own address is fine. So the survey's two-step
  shape — addresses from the collection, then one direct read per piece — is
  not merely the cheaper design, it is the only one that works here right now.
  Measurements in #6143.
- **`cf inspect pull --remote` 404s against Estuary by design.** The dump
  route "hard-refuses to mount under `ENV=production`" and its routes "404 as
  if they never existed." The offline-store path is closed for production;
  live reads are the only option there.
- **A shell loop spawning one `deno task cf` per piece dies at 8–11
  iterations** on macOS. One process for N pieces is a correctness floor, not
  a performance preference.
- **A pattern identity is computable from source without compiling.**
  `computeEntryIdentity(main, files)` in
  `packages/runner/src/harness/entry-identity.ts` returns the value the engine
  stores as `patternIdentity.identity`, as a pure function of the authored
  closure (not for sources with `cf:` fabric imports; topics has none). So a
  retarget row carries its post-identity, and the precondition check tells
  *landed* from *moved elsewhere* with no compile.
- **The runtime already keeps a per-piece source revision log and can restore
  a retained revision.** Every `setPattern` appends a `PieceSourceRevision`
  (`packages/runner/src/runner.ts`) retaining the exact source closure;
  `PieceController.changeSource({kind:"restore", revisionId})`
  (`packages/piece/src/ops/piece-controller.ts`) reloads it. Spec:
  `docs/specs/piece-source-lifecycle.md`. A piece with no revision log gets
  a baseline revision retaining its pre-state source appended by its first
  transition *iff* that source is still retained in the space
  (`preparePieceSourceTransitionBaseline` / `applyPieceSourceTransition`,
  `packages/runner/src/runner.ts`; `setPattern` allows an unavailable
  baseline only for a legacy detached piece) — so the survey cannot read a
  revision id for a legacy piece, and an unretained prior source has no
  restore target; the survey flags those rows (`retained`). Nothing on the
  CLI fronts restore — `cf piece setsrc` takes only a local path — so
  rollback is a `restore` behind a new seam, not a second `setsrc` of an old
  checkout. (`docs/plans/topics-migration-rehearsal.md` said rollback is "a
  `setsrc` back to the recorded source ids"; no such command exists — fixed
  in `8995ae510`.)
- **Two input writes exist, not one.** `cf piece apply` replaces the whole
  document (schema defaults merged, setup re-run). `cf piece set --input`
  writes at a path but validates the destination document against the
  piece's schema first — which is what a document in need of repair fails.
  Decision 4 in the doc.
- **`setsrc` reports success when the source committed but the refresh
  failed** — a `console.warn` and `return` in `PieceController.setPattern`;
  the CLI prints "Updated source" regardless. This is why verify is its own
  pass.

## The urgent path — where to start

1. **Survey** (stage 1). Read-only: enumerate from the board's collection,
   one cheap identity read per piece, one process, emit a plan plus a tally.
   Zero risk, runs against Estuary today, and it answers the open question of
   which topics are on which identity. Start here.
2. **Retarget** (stage 3). Consume the plan; grouped sessions (~20 pieces per
   session); serial; precondition checked per row and three-state —
   outstanding / landed / moved elsewhere, the third stopping the run by
   name; stop naming the remainder; resume by re-running. Each row carries
   the identity its source produces (above). **Must emit per-piece timing.**
3. **Measure, then decide.** Per-piece timing under grouped sessions is the
   irreducible cost. It decides whether concurrency across siblings is needed
   and whether a wider session is worth its risk.

The doc's *shape of the first increment* section specifies what stage 1 emits
and stage 3 consumes — the plan encoding, the core/entry-point split, and the
identity read — so this is buildable without further design decisions.

Repair (stage 2) and rollback (stage 4) are sequenced after, per the doc.
Rollback must exist before the first live Estuary run — production has no
space reset, so it is the only reversal available there. It is a `restore`
of each row's recorded revision, and it needs the CLI/library seam onto
`changeSource(restore)` that does not exist today.

**Expect a conditional outcome on speed.** The profiled decomposition is
~0.4s CLI start, ~1s session, ~20–27s neighbourhood sync, ~1s cached compile,
~14s swap + re-stage + settle. Only the swap is irreducible. If it really is
~14s, grouping gets 2.8 hours to roughly 30 minutes. If it is closer to 60s,
grouping barely helps and concurrency becomes the only lever. Step 2's timing
output settles which world this is; do not promise 6× before it does.

## Ruled out, and why

- **Repeatable `--piece` on `setsrc`** (#6027). One source across N pieces,
  no enumeration, no plan, no resume. Cannot express rollback, which is N
  pieces each returning to a different source. Its ~40-line one-session apply
  loop is worth reusing as an internal mechanism of stage 3; its interface is
  not. Do not revive the PR.
- **A vocabulary of built-in repairs** (`drop-property:schema` and friends).
  Every defect worth a bulk repair is particular, so a fixed vocabulary is
  permanently one defect behind. The caller supplies a fixer instead.
- **Enumerating from the piece registry.** See above — it silently yields a
  subset and reports success over it.
- **The snapshot-download path for pre-state.** Caches indefinitely with no
  expiry, and its re-download flag is on `pull` rather than on the reads, so a
  post-run read is served the pre-run snapshot and reports that nothing moved.
  Unavailable in production regardless.
- **A process per piece.** Fails outright before finishing a board-sized set,
  yielding a partial result that reads as complete.
- **`scripts/topics-migrate.ts`** (parked on `park/piece-migrate-draft`). Its
  planning and resume logic are sound; its execution model is process-per-piece
  and is therefore ruled out. Treat it as a source of ideas, not starting code.

## Open questions

Seven are listed in the doc, each tagged with the stage that forces it. Three
are resolved (2: preconditions read live over the API; 3: the compatibility
override is a per-row field stamped by a plan-time flag; 5: a validator is a
JSON schema, a fixer a TypeScript module). **How bulk is spelled** (1) is
deferred to stage 3 on purpose — the core is library code, so nothing in
stage 1 waits on it — and it is Mike's call, since `cli-surface-shape.md` is
his. 4 waits on stage 2; 6 and 7 wait on the per-piece timing stage 3 emits.

The question for @mathpirate is answered in the thread: serial `setsrc`
across many pieces has held, each `cf` invocation being its own session; many
pieces *inside one* session remains unmeasured, which is what grouping at ~20
is for.

## What this is not

The doc's *scope* section states three limits rather than leaving them to be
assumed. It is the **shape** half of the division `docs/plans/verb-evolution.md`
already draws — versioned interfaces handle the callers, a per-piece upgrade
policy handles the rollout — so it says how to change many pieces safely and
nothing about which should change or when. It is **one space, not many**, with
the four things a multi-space run would change named. And its execution
strategies are arithmetic about work whose home is moving: server-primary
execution is sequencing a change to what stays client-side, so the spine is
indifferent but the strategies are not, and the widest one stays unbuilt.

## Related open work

- **#6143** (draft) is the live read regression on this board and carries the
  measurements above. It removes the failure class by narrowing the board's
  demand; stage 1's supplied-validator criterion is the general diagnostic for
  the next instance of it. Complementary, not overlapping — but a survey built
  before it lands must use the two-step read described above.
- **#5423** (held) specifies a persistent `cf` daemon, whose stated motivation
  is the same per-process cost this design amortizes with grouped sessions —
  process startup, connection setup, runtime construction, replica sync. It is
  held pending the server transition. Worth keeping the two coherent: grouped
  sessions are the in-process form of what a daemon would do across processes.
- **#6027** is the withdrawn narrow approach. See *Ruled out*.

## Revised 2026-08-21, after a review against the tree

`b7b6991e9`, `8995ae510`, and `e9c2ac62a` (cf-review via Claude Fable 5, on
Mike's behalf). Three
contradictions in the spine — two resting on premises the code refutes —
plus the two cubic comments:

- **Resume vs the precondition gate.** "Every piece must be in its recorded
  state or the run does not start" refused every resume, and resume could not
  tell *landed* from *moved by something else*. The check is now three-state
  per row and resume is that check re-run — possible because the
  post-identity is computable without a compile, so each retarget row carries
  it.
- **Rollback by "swapping two columns"** (cubic P2). The encoding did not
  support it: prior state was an identity, the op a source, the swap not a
  valid op. Rows now record the identity the piece was found on and whether
  its source is still retained (a revision id only when the piece already
  keeps a log); the rollback op restores the retained revision carrying that
  identity; the rollback plan is derived row by row. Stage 4 gains the seam
  that fronts `changeSource(restore)` and refuses unretained rows by name.
  `8995ae510` also fixes `topics-migration-rehearsal.md`, which said rollback
  is "a `setsrc` back to the recorded source ids" (`setsrc` takes a path; the
  rev that produced each legacy identity is now captured beside the manifest,
  and the doc points at this plan's restore).
- **`e9c2ac62a` — the day-one implementation questions, answered with Mike.**
  Library home `packages/piece/src/ops/`; selectors = a holder's collection
  (emits children then the holder) + an explicit list; the identity is the
  pin and `rev` a label — the apply recomputes the resolved source's identity
  and refuses a row on mismatch; `op.allowIncompatible` per row, stamped by a
  plan-time flag (decision 3 closed); validator = JSON schema, fixer =
  TypeScript module (decision 5 closed); decision 1 retagged to stage 3; the
  drill seeds a checked-in old/new fixture pair. Every stage carries a
  **Delivers:** line naming the artifacts it leaves behind that stand alone.
- **"Two enumerations, a disagreement stops the run."** Unsatisfiable on the
  board it is for (registry 7, collection 113 — a known subset). The check is
  containment: a registered in-scope piece the collection lacks stops the run;
  both counts and the result go in the header; a third, space-wide
  enumeration is named for rehearsal clones, where the offline store exists.
- Smaller: the survey says what fills `op`; stage 5 is the *whole-run*
  session, so it no longer overlaps stage 3's grouped sessions; decision 4
  names the
  path-scoped write and why it does not serve; the scope section no longer
  says no durable per-piece source state exists; Related points at decision 1
  (cubic P3) and at the source-lifecycle spec.

## Test plan

`deno task check-docs` passes (560 blocks). All relative links resolve. Prose
wrapped at 80 columns except tables and the JSON example lines. `docs/` is
excluded from `deno fmt`, so widths were checked by script.

The document is unbuilt. It has had one review pass against the tree; see
*Revised* above.

