### PR TITLE
fix(runner): the α3 sibling hold arms from the handler

### DIFF
--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -61,8 +61,9 @@ import { newSharedServer } from "./memory-v2-test-utils.ts";
  * test). `settleGateWhen` scopes the hold: the serving loop runs a
  * settle in EVERY cycle (empty ones included), so an unconditional gate
  * would catch some idle cycle already in flight and starve the drain
- * the test needs — the predicate lets exactly the cycle that SEALED the
- * watched state hang. Undefined everywhere else.
+ * the test needs. The predicate must become true before the intended
+ * cycle reaches the barrier; a flag set by the handler gives that cycle
+ * a causal name. Undefined everywhere else.
  *
  * The second seam, the drain's SYNC gate (`syncGate` / `syncGateWhen`,
  * the seal→outcome-window pin): the serving drain awaits the sidecar
@@ -2444,12 +2445,9 @@ describe("Phase 3 events-down (serving side)", () => {
 
       // Hold the wave open for the cycle that RUNS the copy: the handler
       // arms the gate as its first act, and that assignment is sequenced
-      // before the cycle's settle reaches its barrier — the hold catches
-      // the sealing cycle structurally, where a polled overlay read raced
-      // it (the settle could cross the barrier before either seal was
-      // visible, flush the wave, and a later, empty cycle hung instead —
-      // CT-2060). An idle settle already in flight still passes: nothing
-      // arms until the copy actually runs.
+      // before the cycle's settle reaches its barrier, so the hold catches
+      // the sealing cycle structurally. An idle settle already in flight
+      // still passes: nothing arms until the copy actually runs.
       servingManager!.settleGate = gate.promise;
       servingManager!.settleGateWhen = () => holdArmed;
       let released = false;

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -2404,11 +2404,18 @@ describe("Phase 3 events-down (serving side)", () => {
     try {
       const servingSeen = w.servingC;
       // The s2 handler records every tag; for the derivation's "ping" it
-      // ALSO commits the sibling tx inline (the intent half).
+      // ALSO commits the sibling tx inline (the intent half) — and ARMS
+      // the settle gate as its first act, so the arming is sequenced
+      // before this cycle's settle reaches its barrier (see the gate
+      // installation below).
+      let holdArmed = false;
       cancels.push(w.serving.scheduler.addEventHandler(
         (tx: IExtendedStorageTransaction, event: unknown) => {
           const tag = (event as { tag?: string })?.tag ?? "?";
-          if (tag === "ping") stampSibling(w.serving, tx, sideServing);
+          if (tag === "ping") {
+            holdArmed = true;
+            stampSibling(w.serving, tx, sideServing);
+          }
           const current = servingSeen.withTx(tx).get() as
             | { seen?: string[] }
             | undefined;
@@ -2435,15 +2442,16 @@ describe("Phase 3 events-down (serving side)", () => {
       expect(seenView()).toEqual([]);
       expect(sideView()).toBe(0);
 
-      // Hold the wave open once EITHER of the copy's two seals is visible
-      // through the sealed overlay. The seal chain runs emitter → sibling
-      // (committed inline by the handler) → the handler's own tx, so the
-      // sibling's write is the earliest event-handler seal the settle's
-      // barrier can observe — the same chain position the (α3) pin's
-      // handler seal holds; the handler's seal then joins the held wave.
+      // Hold the wave open for the cycle that RUNS the copy: the handler
+      // arms the gate as its first act, and that assignment is sequenced
+      // before the cycle's settle reaches its barrier — the hold catches
+      // the sealing cycle structurally, where a polled overlay read raced
+      // it (the settle could cross the barrier before either seal was
+      // visible, flush the wave, and a later, empty cycle hung instead —
+      // CT-2060). An idle settle already in flight still passes: nothing
+      // arms until the copy actually runs.
       servingManager!.settleGate = gate.promise;
-      servingManager!.settleGateWhen = () =>
-        sideView() === 1 || seenView().includes("ping");
+      servingManager!.settleGateWhen = () => holdArmed;
       let released = false;
       try {
         await w.serving.scheduler.run(emitter as never);


### PR DESCRIPTION
## Summary

- arm the α3 settle gate synchronously from the ping handler
- stop polling sealed-overlay state that can become visible after the sealing cycle crosses its barrier
- preserve idle-settle behavior while keeping the original orphan and sibling assertions intact

This extracts only the original runner test fix from #6177. It intentionally excludes the later watch-set refetch and recovery machinery.

## Verification

- deno fmt --check
- deno lint
- runner Phase 3 events-down suite: 1 passed, 19 steps, 0 failed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

