### PR TITLE
fix(tasks): trust dev server readiness event

### DIFF
--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
+import { FakeTime } from "@std/testing/time";
 import ports from "@commonfabric/ports" with { type: "json" };
 import {
   buildFilteredTestArgs,
@@ -11,6 +12,7 @@ import {
   runPackageIntegration,
   selectIntegrationTestFiles,
   selectPatternTestFiles,
+  startServers,
 } from "./integration.ts";
 
 Deno.test("selectPatternTestFiles assigns every file by stable FNV-1a hash", () => {
@@ -319,6 +321,30 @@ Deno.test("runPackageIntegration returns false when a filtered run matches nothi
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }
+});
+
+Deno.test("startServers returns when the startup script completes", async () => {
+  using time = new FakeTime();
+  let ran = false;
+  let settled = false;
+  const completion = startServers(
+    17,
+    "/repo",
+    {},
+    () => {
+      ran = true;
+      return Promise.resolve({ success: true, code: 0 });
+    },
+  ).then((code) => {
+    settled = true;
+    return code;
+  });
+
+  await time.tickAsync(0);
+
+  assertEquals(ran, true);
+  assertEquals(settled, true);
+  assertEquals(await completion, 0);
 });
 
 // Every offset the choice can return, collected by sweeping its random input

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -347,6 +347,17 @@ Deno.test("startServers returns when the startup script completes", async () => 
   assertEquals(await completion, 0);
 });
 
+Deno.test("startServers returns the startup script failure", async () => {
+  const code = await startServers(
+    17,
+    "/repo",
+    {},
+    () => Promise.resolve({ success: false, code: 3 }),
+  );
+
+  assertEquals(code, 3);
+});
+
 // Every offset the choice can return, collected by sweeping its random input
 // finely enough that nothing it can produce is missed.
 function generatedPortOffsets(): number[] {

--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -348,14 +348,15 @@ Deno.test("startServers returns when the startup script completes", async () => 
 });
 
 Deno.test("startServers returns the startup script failure", async () => {
+  const failureCode = 42;
   const code = await startServers(
     17,
     "/repo",
     {},
-    () => Promise.resolve({ success: false, code: 3 }),
+    () => Promise.resolve({ success: false, code: failureCode }),
   );
 
-  assertEquals(code, 3);
+  assertEquals(code, failureCode);
 });
 
 // Every offset the choice can return, collected by sweeping its random input

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -173,10 +173,8 @@ async function startServers(
     return result.code;
   }
 
-  // Wait a bit more for servers to be fully ready
-  console.log("Waiting for servers to be fully ready...");
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-
+  // Successful completion means both servers have bound, passed their
+  // readiness probes, and served the shell through the toolshed.
   return 0;
 }
 

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -173,8 +173,9 @@ async function startServers(
     return result.code;
   }
 
-  // Successful completion means both servers have bound, passed their
-  // readiness probes, and served the shell through the toolshed.
+  // Successful completion of start-local-dev.sh is the readiness event: both
+  // servers have bound, passed their probes, and served the shell through the
+  // toolshed.
   return 0;
 }
 

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -157,13 +157,14 @@ export function chooseGeneratedPortOffset(
 // Starts the dev servers for the given offset. Returns the start-local-dev.sh
 // exit code: 0 on success, PORT_IN_USE_EXIT on a port collision, or another
 // non-zero code for any other startup failure.
-async function startServers(
+export async function startServers(
   portOffset: number,
   rootDir: string,
   env: Record<string, string> = {},
+  run: typeof runCommand = runCommand,
 ): Promise<number> {
   console.log(`Starting servers with PORT_OFFSET=${portOffset}...`);
-  const result = await runCommand(
+  const result = await run(
     ["bash", "scripts/start-local-dev.sh", `--port-offset=${portOffset}`],
     { cwd: rootDir, env, inheritStdio: true },
   );


### PR DESCRIPTION
The integration runner waited three seconds after start-local-dev.sh reported success. This delay observed no condition, added a fixed floor to every server-backed suite, and still could not guarantee readiness.

Treat successful completion of the startup command as the boundary instead. The startup script reports success only after both servers bind, answer their health probes, and the toolshed serves the shell route that tests load.

Verified with the integration-runner unit suite, a focused basic-persistence integration run against the required T5 server offset, the workspace type check, the no-waitFor gate, and repo-wide formatting and lint.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

