### PR TITLE
fix(scheduler): a served event refused pre-storage by CFC seals an error consequence (OW54)

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
@@ -173,13 +173,13 @@ scope-boundary pin above, green on base and after.
 All at the fixed head, one file per invocation (the runner test
 task's flags):
 
-- `executor-events-down.test.ts`: RED run on base (the pin's timeout,
-  20 other steps green — the two sibling (α3)-family steps included),
-  then at the fix: 4 full-file runs with clean verdicts, all
-  `1 passed (21 steps) | 0 failed`, plus 3 more runs verifying the
-  two "(α3) + a same-eventId SIBLING tx" steps green (OW57
-  corroboration: 8/8 observations of those steps green at/around
-  #6184's construction, zero holds lost).
+- `executor-events-down.test.ts`: two RED runs on base (the pin's
+  timeout; every other step green — the two sibling (α3)-family steps
+  included), then at the fix: 4 full-file runs with clean verdicts,
+  all `1 passed (21 steps) | 0 failed`, plus 3 more runs verifying
+  the two "(α3) + a same-eventId SIBLING tx" steps green (OW57
+  corroboration: 9/9 full-file observations of those steps green at
+  the #6184 construction — 2 base + 7 fixed-head — zero holds lost).
 - Neighbor suites, green per-file: `executor-serving-loop` (25
   steps), `executor-space-server` (15), `cfc-prepare-crash-surfacing`
   (15), `cfc-schema-merge` (58), and the give-up-path binders

--- a/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
@@ -70,8 +70,11 @@ notice machinery lives.
 Docs in the same PR: events.md §5 gains the class (the refusal IS the
 consequence; every other served commit refusal keeps the wave-cadence
 re-drain), and the OW54 register row is CLOSED with the pin as lift
-evidence. OW57 is re-tensed CLOSED on #6184's handler-armed settle
-gate with this PR's runs as corroboration (below).
+evidence. An OW57 closure on #6184's handler-armed settle gate was
+drafted on early corroboration and then WITHDRAWN in the same PR: a
+post-rebase run observed the race at the hardened construction
+(§5 below) — the row instead records #6184 as a hardening that
+reduced but did not eliminate the race.
 
 ## 3. Red-first, watched
 
@@ -173,13 +176,25 @@ scope-boundary pin above, green on base and after.
 All at the fixed head, one file per invocation (the runner test
 task's flags):
 
-- `executor-events-down.test.ts`: two RED runs on base (the pin's
-  timeout; every other step green — the two sibling (α3)-family steps
-  included), then at the fix: 4 full-file runs with clean verdicts,
-  all `1 passed (21 steps) | 0 failed`, plus 3 more runs verifying
-  the two "(α3) + a same-eventId SIBLING tx" steps green (OW57
-  corroboration: 9/9 full-file observations of those steps green at
-  the #6184 construction — 2 base + 7 fixed-head — zero holds lost).
+- `executor-events-down.test.ts` at `ec6361782`: two RED runs on base
+  (the pin's timeout; every other step green — the two sibling
+  (α3)-family steps included), then at the fix: 4 full-file runs with
+  clean verdicts, all `1 passed (21 steps) | 0 failed`, plus 3 more
+  runs verifying the two "(α3) + a same-eventId SIBLING tx" steps
+  green — 9/9 sibling-step observations at that head.
+- `executor-events-down.test.ts` after the rebase onto `b775787b6`
+  (#6083, content-addressed schemas on by default): 8 full-file runs
+  — BOTH new OW54 pins green in all 8; the "(α3) + a same-eventId
+  SIBLING tx (M1)" step red ONCE (run 1, on a loaded machine) with
+  the exact CT-2060 signature: the ping entry durable AND
+  consequenced at the held-wave probe. Attribution runs: 5/5 green on
+  PLAIN origin/main at the same head (no inserted tests), matching
+  the row's original observation that tests inserted ahead shift
+  timing into the window. Consequence: the drafted OW57 closure was
+  withdrawn; the row records #6184 as a hardening that reduced but
+  did not eliminate the race, and keeps the don't-blame clause — a
+  red of that step with the ping already durable at the probe is
+  CT-2060, not this PR's defect.
 - Neighbor suites, green per-file: `executor-serving-loop` (25
   steps), `executor-space-server` (15), `cfc-prepare-crash-surfacing`
   (15), `cfc-schema-merge` (58), and the give-up-path binders

--- a/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
@@ -1,0 +1,189 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "OW54 follow-on build (the RULING-5 report §4 outline, coordinator-green-lit): a served event refused pre-storage by CFC seals an error consequence — mechanism confirmation, the red-first evidence, the which-direction (double-seal) analysis, and the suites run."
+---
+
+# OW54 build — a served event refused pre-storage by CFC seals an error consequence
+
+Seat: OW54 follow-on (the RULING-5 report §4 outline). Branch
+`claude/server-exec-v2-ow54-event-seal` off `origin/main` @
+`ec6361782`. Scope exactly as green-lit: the served give-up arm's
+discriminated `served.onFailure` — no cfc/, no seal machinery, no
+wave code.
+
+## 1. Mechanism, confirmed against the code at this head
+
+The assessment's chain verified end to end before building:
+
+- The CFC pre-storage refusal is minted ONLY in
+  `extended-storage-transaction.ts` (`rejectCommitBeforeStorage`, two
+  sites: "relevant transaction was not prepared[: reason]" and
+  "prepared digest changed"), with `name:
+  "StorageTransactionAborted"` and the "CFC enforcement rejected
+  commit" message prefix — BEFORE the `#sealDestination.seal` branch,
+  so a refused served tx never enters a wave and its consequenced
+  mark never seals.
+- In `classifyCommitDisposition` that error is not permanent
+  (`PreconditionFailedError`), not terminal (`RowLabelCommitError` /
+  `SpeculativeBasisError`), and not stale-basis (`ConflictError` /
+  `StorageTransactionInconsistent`) → `{kind: "give-up", reason:
+  "non-retryable"}` (served copies queue with `retries: false`, but
+  the opt-out branch is unreachable for this class — the non-stale
+  check fires first).
+- The give-up arm settled the callback (`runFinalCommitCallback`) and
+  reported the loss (`reportDroppedCfcRejectedWrite`) but never
+  called `served.onFailure`, so the drain-in-flight guard released in
+  the "queued" state, the durable entry stayed unconsequenced, and
+  the post-wave re-arm re-drained it — the base evidence below shows
+  the give-up disposition firing twice for one eventId across two
+  waves.
+- Pre-OW50 the same crash threw from `prepareTxForCommit` inside the
+  event finalize and took the ERROR arm, whose contract is `"the
+  error IS the consequence"` (`served.onFailure({kind: "error",
+  message})`).
+
+One shape the assessment did not spell out, checked here: the LT1
+in-process copy's `served` carriage (cell.ts's same-space emission)
+carries NO `onFailure`, so for a CFC-refused LT1 copy the new arm is
+a safe no-op — the durable entry then re-drains as a root drain copy
+(which carries the hook and the `streamEntry`) and the consequence
+seals there, one wave later. The seal always happens where the
+notice machinery lives.
+
+## 2. The fix as built
+
+`packages/runner/src/scheduler/events.ts`:
+
+- `isCfcRejectedCommitError` — the message-prefix predicate, extracted
+  so the sealed consequence and the loss report key on the SAME
+  discriminator by construction (`reportDroppedCfcRejectedWrite` now
+  calls it).
+- The give-up arm: when `served !== undefined` and the predicate
+  holds, `served.onFailure({kind: "error", message})` — wrapped in
+  the same try/log isolation as the throw arm — BEFORE
+  `runFinalCommitCallback()`, so the drain's in-flight guard sees the
+  staged notice ("marked") instead of releasing the still-"queued"
+  copy. Every other give-up class is byte-identical.
+
+Docs in the same PR: events.md §5 gains the class (the refusal IS the
+consequence; every other served commit refusal keeps the wave-cadence
+re-drain), and the OW54 register row is CLOSED with the pin as lift
+evidence. OW57 is re-tensed CLOSED on #6184's handler-armed settle
+gate with this PR's runs as corroboration (below).
+
+## 3. Red-first, watched
+
+Two pins in `executor-events-down.test.ts`, both run against the
+UNMODIFIED base (`ec6361782`) first.
+
+- **The main pin** ("the give-up arm's CFC discriminator (OW54)"): a
+  served event whose handler writes a doc with a genuinely-ambiguous
+  STORED envelope (`result.anyOf` with TWO ifc carriers — the class
+  the RULING-5 narrowing still refuses; fixtures mirror
+  cfc-prepare-crash-surfacing.test.ts), the envelope seeded as the
+  doc's first write from the client and pre-pulled into the serving
+  replica before the fire (the live ordering). RED on base:
+
+  ```
+  error: Error: timed out waiting for the CFC refusal to seal an
+  error consequence   (waitUntil, test/executor-events-down.test.ts)
+  ```
+
+  with the served copy taking the give-up disposition TWICE for the
+  same eventId — two `served-event-commit-failed` + two "dropping the
+  write without retry" warns ~250 ms apart (01:48:51.868 and
+  01:48:52.115), the post-wave re-arm's second drain — and the entry
+  never consequenced (a diagnostic run also confirmed the third
+  re-drain waits on the next wave: the quiet harness produces none,
+  which is exactly "the wave IS the retry cadence"). GREEN with the
+  fix: exactly ONE completed run per event, ONE consequence commit
+  naming each eventId, ONE dropped-write report per event, the
+  entry's `error` carries the refusal (matched both the
+  "CFC enforcement rejected commit" prefix and the
+  `/divergent anyOf|commit-prep crashed/` class — the divergence
+  surfaced through the cross-runtime pre-pull), the watermark
+  advances, and a second poisoned fire seals its own consequence
+  behind the first (the stream advances; no second consequence for
+  the first event).
+- **The scope-boundary pin** ("a NON-CFC give-up on a served event
+  keeps the re-drain cadence"): the handler aborts its own
+  transaction (`tx.abort`), a non-CFC give-up. GREEN on base AND
+  after the fix, with the same two-give-ups-per-eventId re-drain
+  shape in both runs — the non-CFC cadence is unchanged, and the pin
+  reddens if the discriminator is ever widened to every give-up.
+
+## 4. Which-direction analysis ((α): exactly-once, no double seal)
+
+The invariant is EXACTLY-ONCE consequence per event entry. Paths that
+can seal a consequence for a served entry, checked one by one:
+
+1. **The handler tx's own mark** (success path): mutually exclusive
+   with the new arm by construction — the arm fires only on a
+   PRE-STORAGE refusal, i.e. the tx that carried the mark never
+   reached the wave and is dead (`rejectCommitBeforeStorage`
+   finalizes the rejection; there is no later landing).
+2. **The ERROR arm** (handler threw): mutually exclusive —
+   `finalize(error)` returns before any commit is attempted, so
+   `handleCommitResult` (and with it the give-up arm) never runs for
+   that dispatch.
+3. **The terminal and permanent arms**: mutually exclusive — one
+   classification switch, one disposition. Neither calls
+   `served.onFailure` (unchanged).
+4. **The LT1 late-seal refusal**: handled by an early return ABOVE
+   the classification; never reaches the give-up arm (and its
+   sentinel error does not carry the CFC prefix).
+5. **Re-dispatch of the same entry**: between `onFailure` and the
+   notice's durable landing the drain-in-flight guard holds
+   ("marked", released only by the wave outcome); after it lands the
+   entry is consequenced and excluded from the drain; if the notice
+   FAILS to seal, the guard releases, the entry re-drains, and the
+   arm seals again — convergence to exactly one durable consequence,
+   the same self-healing loop the existing error/drop notices use.
+   A re-admission of the same eventId at a new seq falls to the
+   existing SKIP arm (its notice annotates the duplicate entry, not
+   this one).
+6. **The dispatch is single-shot**: `tx.commit().then(...)` settles
+   once; `handleCommitResult` runs once per dispatch.
+
+Pinned observables: `probeRuns` exactly 1 per event at the seal, ONE
+consequence commit naming each eventId (re-checked after the second
+fire — still 1 for the first event), ONE dropped-write report per
+event. The reverse direction (the fix must not widen): the
+scope-boundary pin above, green on base and after.
+
+**Flagged, not filled** (unstated semantics ship as questions):
+
+- A served TERMINAL rejection (`RowLabelCommitError` — the
+  storage-time commit-rule refusal, deterministic by its own doc)
+  also seals NO consequence today and would re-drain on the wave
+  cadence, the same shape OW54 had. The green-lit outline scopes this
+  PR to the pre-storage class, so the terminal arm is untouched;
+  recorded in the register row as an adjacent residual for the
+  owner/coordinator, not silently included.
+- Non-CFC give-ups (transport, authorization, handler abort) keep
+  re-draining forever by design ("the wave IS the retry cadence").
+  Whether an AUTHORIZATION denial is deterministic enough to deserve
+  a consequence is the same future question; the boundary is pinned
+  as it stands.
+
+## 5. Suites run
+
+All at the fixed head, one file per invocation (the runner test
+task's flags):
+
+- `executor-events-down.test.ts`: RED run on base (the pin's timeout,
+  20 other steps green — the two sibling (α3)-family steps included),
+  then at the fix: 4 full-file runs with clean verdicts, all
+  `1 passed (21 steps) | 0 failed`, plus 3 more runs verifying the
+  two "(α3) + a same-eventId SIBLING tx" steps green (OW57
+  corroboration: 8/8 observations of those steps green at/around
+  #6184's construction, zero holds lost).
+- Neighbor suites, green per-file: `executor-serving-loop` (25
+  steps), `executor-space-server` (15), `cfc-prepare-crash-surfacing`
+  (15), `cfc-schema-merge` (58), and the give-up-path binders
+  `scheduler-commit-backpressure` (9), `cfc-writer-claim-
+  correspondence` (17), `mergeable-append-multispace-conflict` (2).
+- The full runner battery (`deno task test` in packages/runner) at
+  the end — result in the PR's test plan.

--- a/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow54-build-report.md
@@ -141,10 +141,21 @@ can seal a consequence for a served entry, checked one by one:
    notice's durable landing the drain-in-flight guard holds
    ("marked", released only by the wave outcome); after it lands the
    entry is consequenced and excluded from the drain; if the notice
-   FAILS to seal, the guard releases, the entry re-drains, and the
-   arm seals again — convergence to exactly one durable consequence,
-   the same self-healing loop the existing error/drop notices use.
-   A re-admission of the same eventId at a new seq falls to the
+   fails to seal by THROWING at staging, REJECTING its commit
+   promise, or entering a wave whose outcome withdraws it, the guard
+   releases, the entry re-drains, and the arm seals again —
+   convergence to exactly one durable consequence, the same
+   self-healing loop the existing error/drop notices use. AMENDED by
+   the #6186 adversarial review (MAJOR-1, probe-confirmed): the
+   self-heal does NOT cover a notice commit that RESOLVES `{error}`
+   pre-destination (the `rejectCommitBeforeStorage` shape) — the
+   `.catch` release fires on rejection only, the wave-outcome release
+   covers only wave-carried ids, and the entry then strands
+   guarded-unconsequenced until park. That wedge is PRE-EXISTING
+   (reproduced through the throw arm, this PR's code uninvolved) and
+   is minted as register row OW58 with the owed guard fix; within
+   THIS PR's class the exactly-once claim stands as pinned. A
+   re-admission of the same eventId at a new seq falls to the
    existing SKIP arm (its notice annotates the duplicate entry, not
    this one).
 6. **The dispatch is single-shot**: `tx.commit().then(...)` settles
@@ -201,4 +212,36 @@ task's flags):
   `scheduler-commit-backpressure` (9), `cfc-writer-claim-
   correspondence` (17), `mergeable-append-multispace-conflict` (2).
 - The full runner battery (`deno task test` in packages/runner) at
-  the end — result in the PR's test plan.
+  the rebased head: `ok | 1274 passed (7304 steps) | 0 failed
+  (11m43s)`.
+
+## 6. Review response (the #6186 adversarial round)
+
+Verdict LANDABLE-WITH-FIXES; the src change confirmed correct and
+both pins independently re-established (revert probe red;
+widened-discriminator mutation red on the boundary pin).
+Dispositions:
+
+- **MAJOR-1** (the §4.5 convergence claim's confirmed-false branch):
+  §4.5 amended above to scope the self-heal to
+  thrown/rejected/wave-carried notice failures; the resolved-error
+  guard wedge minted as register row OW58 (pre-existing since
+  Phase 3, probe-confirmed through the throw arm, reachability
+  PLAUSIBLE via a labeled sidecar under enforce mode) with the owed
+  guard fix; the OW54 row cross-references it.
+- **MINOR-2** (the transient prep-crash sub-case): recorded as-built
+  in the OW54 row — the discriminator seals OW50's modeled
+  prep-crash recordings terminally even when the crash cause was
+  transient; the re-drain-instead question goes to the owner's
+  one-liner list, semantics unchanged.
+- **MINOR-3** (events.md §5 parenthetical): aligned — the terminal
+  commit-rule refusal (`RowLabelCommitError`) now named beside
+  transport/authorization/abort.
+- **NOTE-4** (requeue helpers shed `served`): per flag-don't-fill the
+  carriage is NOT copied through (that would silently decide served
+  retry semantics); both `requeueForNameResolution` and
+  `requeueForBackoff` now ASSERT served-absence loudly, with the
+  comment naming the undecided semantics. Unreachable today (served
+  copies queue `retries: false`), so the assert is the tripwire; no
+  red-first pin exists for an unreachable arm.
+- **NOTES 5/6**: no action, per the review.

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -437,7 +437,8 @@ loop's duty).
   `eventWatermark` advances past it, and the unconditional
   dropped-write report still fires; the seal is the served give-up
   arm's discriminated `served.onFailure` (scheduler/events.ts). Every
-  OTHER commit refusal of a served event (transport, authorization, a
+  OTHER commit refusal of a served event (a terminal commit-rule
+  refusal — `RowLabelCommitError` — transport, authorization, a
   handler abort) seals nothing: the entry stays pending and the wave
   cadence re-drains it — served copies opt out of scheduler-side
   backoff because the wave IS their retry cadence (serving-loop.md

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -435,12 +435,13 @@ loop's duty).
   identically): the same rule as the throw above — the refusal IS the
   consequence. The entry carries the refusal message as its `error`,
   `eventWatermark` advances past it, and the unconditional
-  dropped-write report still fires (scheduler/events.ts, the served
-  give-up arm's discriminated `served.onFailure`). Every OTHER commit
-  refusal of a served event (transport, authorization, a handler
-  abort) seals nothing: the entry stays pending and the wave cadence
-  re-drains it — served copies opt out of scheduler-side backoff
-  because the wave IS their retry cadence (serving-loop.md §3d).
+  dropped-write report still fires; the seal is the served give-up
+  arm's discriminated `served.onFailure` (scheduler/events.ts). Every
+  OTHER commit refusal of a served event (transport, authorization, a
+  handler abort) seals nothing: the entry stays pending and the wave
+  cadence re-drains it — served copies opt out of scheduler-side
+  backoff because the wave IS their retry cadence (serving-loop.md
+  §3d).
 - Client offline at fire time (RULED 2026-08-02): events accumulate
   client-side as unacked authored commits and discharge on reconnect
   in fired order — PER STREAM: a stream's sidecar carries only that

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -429,6 +429,18 @@ loop's duty).
   handler-error surface (same shape clients show today) as the derived
   commit for that event, advance `eventWatermark` past it (an error IS
   the consequence — else a poison event wedges the stream), push.
+- Handler commit refused PRE-STORAGE by CFC enforcement, server-side
+  (the deterministic "CFC enforcement rejected commit" class —
+  `rejectCommitBeforeStorage`, whose refusal re-running recomputes
+  identically): the same rule as the throw above — the refusal IS the
+  consequence. The entry carries the refusal message as its `error`,
+  `eventWatermark` advances past it, and the unconditional
+  dropped-write report still fires (scheduler/events.ts, the served
+  give-up arm's discriminated `served.onFailure`). Every OTHER commit
+  refusal of a served event (transport, authorization, a handler
+  abort) seals nothing: the entry stays pending and the wave cadence
+  re-drains it — served copies opt out of scheduler-side backoff
+  because the wave IS their retry cadence (serving-loop.md §3d).
 - Client offline at fire time (RULED 2026-08-02): events accumulate
   client-side as unacked authored commits and discharge on reconnect
   in fired order — PER STREAM: a stream's sidecar carries only that

--- a/docs/specs/server-side-execution/events.md
+++ b/docs/specs/server-side-execution/events.md
@@ -437,12 +437,23 @@ loop's duty).
   `eventWatermark` advances past it, and the unconditional
   dropped-write report still fires; the seal is the served give-up
   arm's discriminated `served.onFailure` (scheduler/events.ts). Every
-  OTHER commit refusal of a served event (a terminal commit-rule
-  refusal — `RowLabelCommitError` — transport, authorization, a
-  handler abort) seals nothing: the entry stays pending and the wave
-  cadence re-drains it — served copies opt out of scheduler-side
-  backoff because the wave IS their retry cadence (serving-loop.md
-  §3d).
+  OTHER failed commit of a served event seals nothing, and its entry
+  — unconsequenced — is re-drained by a later wave. Two delivery
+  paths, one durable fate: a PRE-SEAL refusal (transport,
+  authorization, a handler abort — the non-CFC give-up classes)
+  settles the copy through the scheduler's commit disposition, which
+  drops it without scheduler-side retry (served copies opt out of
+  backoff; the wave IS their retry cadence, serving-loop.md §3d). A
+  STORAGE-TIME commit-rule refusal (`RowLabelCommitError`) never
+  reaches that disposition on a served copy — the handler tx sealed
+  into the wave and its commit resolved at seal-accept — and instead
+  refuses the WAVE's store commit: the refused wave reports the
+  event's contributions as requeued (`aborted: "rejected"`,
+  executor/wave.ts), the drain guard releases, and the pending entry
+  re-drains. The terminal classification of `RowLabelCommitError`
+  (storage/rejection.ts) stops in-flight RETRYING on the
+  direct-commit path; it never stops the durable entry's
+  re-dispatch.
 - Client offline at fire time (RULED 2026-08-02): events accumulate
   client-side as unacked authored commits and discharge on reconnect
   in fired order — PER STREAM: a stream's sidecar carries only that

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5550,11 +5550,18 @@ supply; OW29/OW32/OW34 closed):
     one-liner list; the behavior here is as-built, not ruled. Scope
     honesty, deliberate and pinned: non-CFC
     give-ups (transport, authorization, a handler abort, opt-out)
-    still seal nothing and re-drain on the wave cadence; and a served
-    TERMINAL rejection (`RowLabelCommitError`, the storage-time
-    commit-rule refusal) also seals no consequence today — an
-    adjacent residual of the same shape, FLAGGED (not silently
-    included) in docs/history/plans/server-execution-v2/optimize/
+    still seal nothing and re-drain on the wave cadence; and a
+    storage-time commit-rule refusal (`RowLabelCommitError`) of a
+    served event also seals no consequence today — verified (#6186
+    Cubic round): it never reaches the scheduler's terminal
+    disposition on a served copy (the handler tx sealed and resolved
+    at seal-accept), it refuses the WAVE's store commit instead, and
+    the refused wave reports the event's contributions as requeued
+    (`aborted: "rejected"`, executor/wave.ts) — guard released,
+    unconsequenced entry re-drained, the same durable fate through
+    the wave verdict channel. An adjacent residual of the same shape,
+    FLAGGED (not silently included) in
+    docs/history/plans/server-execution-v2/optimize/
     ow54-build-report.md. The sealed consequence itself rides the
     consequence-notice machinery, whose resolved-error guard wedge is
     the OW58 row below (pre-existing, not introduced by the OW54 fix):

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5660,8 +5660,8 @@ supply; OW29/OW32/OW34 closed):
     pin's PR is not blamed when the lane first flakes; renumbered
     OW56 → OW57 pre-merge for the parallel-mint collision with the
     durability train's #6173, which keeps OW56 for server-owned
-    program compilation): CLOSED (2026-08-21, #6184 —
-    `c31397906`).** The race as filed: the
+    program compilation; tracked as CT-2060): CLOSED (2026-08-21,
+    #6184 — `c31397906`).** The race as filed: the
     "(α3) + a same-eventId SIBLING tx" step's held-wave construction
     (#6096's W3 pins) set `settleGate`/`settleGateWhen` and then
     probed `expect(entriesOf(sidecar)).toEqual([])` — asserting the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5541,14 +5541,25 @@ supply; OW29/OW32/OW34 closed):
     shrunk the exposed class to genuinely ambiguous envelopes; the
     corner is now closed for the whole pre-storage-rejection message
     class (genuine ambiguity, unreadable stored envelopes, prepared
-    digest drift). Scope honesty, deliberate and pinned: non-CFC
+    digest drift). Sub-case honesty (the #6186 review's MINOR-2,
+    recorded as-built): the message class also covers OW50's modeled
+    prep-crash recordings ("commit-prep crashed: …"), so a prep crash
+    caused by TRANSIENT local state seals a terminal error consequence
+    where a re-drain might have succeeded — whether transient
+    prep-crashes deserve the re-drain instead is on the owner's
+    one-liner list; the behavior here is as-built, not ruled. Scope
+    honesty, deliberate and pinned: non-CFC
     give-ups (transport, authorization, a handler abort, opt-out)
     still seal nothing and re-drain on the wave cadence; and a served
     TERMINAL rejection (`RowLabelCommitError`, the storage-time
     commit-rule refusal) also seals no consequence today — an
     adjacent residual of the same shape, FLAGGED (not silently
     included) in docs/history/plans/server-execution-v2/optimize/
-    ow54-build-report.md.
+    ow54-build-report.md. The sealed consequence itself rides the
+    consequence-notice machinery, whose resolved-error guard wedge is
+    the OW58 row below (pre-existing, not introduced by the OW54 fix):
+    a notice whose commit RESOLVES `{error}` pre-destination strands
+    the entry guarded-unconsequenced until park.
   - **OW55 — the serving runtimes' pattern-fetch trust surface
     (adversarial review of PR #6157, F7; the OW48 investigation's
     security-adjacent residual; minted 2026-08-21).** Under ON,
@@ -5688,6 +5699,39 @@ supply; OW29/OW32/OW34 closed):
     THIS step with the ping already durable at the probe is this
     race, not a product regression, and not the inserting PR's
     defect. No lift trigger (test-harness item).
+  - **OW58 — the consequence-notice resolved-error guard wedge
+    (adversarial review of PR #6186, MAJOR-1 — probe-confirmed;
+    minted 2026-08-21; PRE-EXISTING since Phase 3, NOT introduced by
+    #6186).** `#sealEventConsequenceNotice` (executor/space-server.ts)
+    seals the skip/error/drop consequences in its own transaction,
+    and its guard-release paths do not cover a commit that RESOLVES
+    `{error}`: the `.catch` beside the seal releases the
+    drain-in-flight guard on promise REJECTION only, and the
+    wave-outcome release covers only eventIds the wave actually
+    carried — a notice refused PRE-destination
+    (`rejectCommitBeforeStorage`, extended-storage-transaction.ts,
+    which resolves the commit promise with `{error}` rather than
+    rejecting it) never enters a wave, so NEITHER path fires. The
+    guard stays "marked", every re-drain skips the guarded id, and
+    park's `#drainInFlight.clear()` is the only remaining release:
+    the entry strands unconsequenced for the space's whole active
+    tenure — the OPPOSITE failure of OW54's forever-re-drain.
+    Probe evidence (the #6186 reviewer): a flag-gated patch forcing
+    the notice commit to resolve `{error}` left 3 events with
+    runsByKind 1/1/1 and ALL unconsequenced across two scanned waves,
+    reproduced through the THROW arm — the OW54 diff uninvolved.
+    Reachability: PLAUSIBLE, no live repro yet — a LABELED sidecar
+    doc under enforce mode makes the notice tx CFC-relevant (its
+    entry-field writes), and nothing prepares that tx (`commit()`
+    self-prepares only in observe mode), so the commit resolves the
+    CFC pre-storage `{error}` — the wedge shape. Owed: the small
+    guard fix — consume the commit RESULT (`sealed.then((r) => …)`
+    releasing the guard when `r?.error` is set, beside the existing
+    `.catch`) — and consider preparing the notice tx before commit;
+    the seal path is (α)-critical, so the fix belongs to its own
+    deliberate pass, not a side-swipe. Trigger: next seal-machinery
+    pass, or first live sighting of a stranded-unconsequenced entry
+    with a guarded id and no notice.
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5500,37 +5500,55 @@ supply; OW29/OW32/OW34 closed):
     skips.
   - **OW54 — a served EVENT whose commit-prep crashes seals NO
     consequence (adversarial review of PR #6157, F1 —
-    CONFIRMED-by-trace; minted 2026-08-21).** Pre-#6157, a prep crash
-    on the EVENT path threw out of `prepareTxForCommit` inside the
-    event finalize, was caught by the `.catch((error) =>
-    finalize(error))` chain, and took the handler-error arm —
-    `served.onFailure({kind: "error"})` sealed an ERROR consequence
-    and the durable LT1 entry was consequenced. With OW50's totality
-    (`prepareCfc` records the crash as a modeled pre-storage
-    rejection), the same crash now classifies on the event path as a
-    give-up "non-retryable" disposition: `runFinalCommitCallback()` +
-    `reportDroppedCfcRejectedWrite`, but NO `served.onFailure` and
-    nothing seals a consequence (the pre-storage rejection returns
-    before the `#sealDestination.seal` branch). The drain-in-flight
-    guard releases in the "queued" state, the durable entry stays
-    unconsequenced, and the post-wave re-arm re-drains it — "the wave
-    IS the retry cadence" — so a DETERMINISTIC prep crash (the OW49
-    poison-envelope class) is a forever re-drain, and under #6158's
-    settle wait the unretired client intent pays the full bounded
-    quiescence timeout per settle round (bounded and loud by design,
-    but every round). Scope honesty: the give-up-without-consequence
-    gap PRE-EXISTS for modeled CFC refusals; what changed is that the
-    CRASH class — previously the one class that DID seal an error
-    consequence — joins it. Exposure today: none live (the poisoned
-    class is reactive wish docs; profile-embed is skipped ON). Owed:
-    seal an error consequence for a served event whose commit is
-    refused pre-storage with a deterministic CFC reason (mirror the
-    terminal arm's honesty), or route CFC pre-storage rejections on
-    served events through `served.onFailure({kind: "error"})` — the
-    events seal path is (α)-critical, so the fix belongs to a
-    deliberate pass, not a side-swipe. Trigger: the OW49 fix arc or
-    the `integration/profile-embed.test.ts` ON-skip lift, whichever
-    comes first.
+    CONFIRMED-by-trace; minted 2026-08-21): CLOSED (2026-08-21, the
+    OW54 follow-on fix — the give-up arm's discriminated
+    `served.onFailure`).** The gap as confirmed: a deterministic CFC
+    pre-storage rejection of a served event's commit (the
+    "CFC enforcement rejected commit" class,
+    `rejectCommitBeforeStorage` — including a prep CRASH, which OW50's
+    totality records as a modeled rejection of this class) classified
+    give-up "non-retryable", and the give-up arm settled the commit
+    callback and reported the dropped write but sealed NO consequence:
+    the durable entry stayed unconsequenced and re-drained every wave
+    ("the wave IS the retry cadence"), and under #6158's settle wait
+    the unretired client intent paid the full bounded quiescence
+    timeout per settle round. Pre-OW50 the same crash THREW from
+    `prepareTxForCommit` and took the ERROR arm, which seals "the
+    error IS the consequence". The fix restores that contract on the
+    modeled path: the give-up arm, when the event is served AND the
+    error is the deterministic CFC pre-storage rejection (the SAME
+    message-prefix discriminator `reportDroppedCfcRejectedWrite` keys
+    on — `isCfcRejectedCommitError`, scheduler/events.ts), calls
+    `served.onFailure({kind: "error", message})` before settling, and
+    the error consequence seals through the drain's existing notice
+    machinery (events.md §5 now states the class). Lift evidence: the
+    red-first pin in `executor-events-down.test.ts` ("the give-up
+    arm's CFC discriminator (OW54)") — RED on the unmodified base
+    (the served copy took the give-up disposition twice for one
+    eventId across two waves, no consequence, and the wait for the
+    seal timed out), GREEN with the fix (exactly ONE completed run,
+    ONE consequence commit naming the event, ONE dropped-write
+    report, the entry's `error` carries the refusal, the watermark
+    advances, and a second poisoned fire seals its own consequence
+    behind it) — plus the scope-boundary pin ("a NON-CFC give-up on a
+    served event keeps the re-drain cadence": a handler `tx.abort()`
+    re-drains unconsequenced with no frontier advance, green on base
+    AND after, so the non-CFC cadence is byte-identical). #6158
+    interaction, recorded: with the consequence sealed, the client
+    intent retires through the normal arrived-terminal-consequence
+    path, so the unretired-intent settle-timeout class for this shape
+    disappears. RULING-5 interaction, resolved: the narrowing had
+    shrunk the exposed class to genuinely ambiguous envelopes; the
+    corner is now closed for the whole pre-storage-rejection message
+    class (genuine ambiguity, unreadable stored envelopes, prepared
+    digest drift). Scope honesty, deliberate and pinned: non-CFC
+    give-ups (transport, authorization, a handler abort, opt-out)
+    still seal nothing and re-drain on the wave cadence; and a served
+    TERMINAL rejection (`RowLabelCommitError`, the storage-time
+    commit-rule refusal) also seals no consequence today — an
+    adjacent residual of the same shape, FLAGGED (not silently
+    included) in docs/history/plans/server-execution-v2/optimize/
+    ow54-build-report.md.
   - **OW55 — the serving runtimes' pattern-fetch trust surface
     (adversarial review of PR #6157, F7; the OW48 investigation's
     security-adjacent residual; minted 2026-08-21).** Under ON,
@@ -5642,26 +5660,27 @@ supply; OW29/OW32/OW34 closed):
     pin's PR is not blamed when the lane first flakes; renumbered
     OW56 → OW57 pre-merge for the parallel-mint collision with the
     durability train's #6173, which keeps OW56 for server-owned
-    program compilation).** The
+    program compilation): CLOSED (2026-08-21, #6184 —
+    `c31397906`).** The race as filed: the
     "(α3) + a same-eventId SIBLING tx" step's held-wave construction
-    (#6096's W3 pins) sets `settleGate`/`settleGateWhen` and then
-    probes `expect(entriesOf(sidecar)).toEqual([])` — asserting the
-    wave is still HELD (its "ping" entry not yet durable). The gate
-    engages at the settle's `inputSynced` barrier, and the
-    when-predicate flips only once a seal is visible through the
-    sealed overlay — so a commit whose settle pass checked the gate
-    BEFORE the predicate flipped can complete in that same cycle,
-    landing the ping before the probe: measured 2/15 full-suite reds
-    at #6170's head vs 0/10 on main's version (the pin inserted
-    ahead plausibly shifts timing into the window;
-    fresh-server-per-step rules out state coupling). An event-driven
-    closure is NOT cheap: an unconditional gate starves the drain
-    the step needs (the step's own comment), and holding reliably
-    means restructuring the construction to re-arm on a lost race.
-    Owed: the hardened construction (or an owner call to
-    accept-and-retry the step); until then a red of THIS step with
-    the ping already durable at the probe is this race, not a
-    product regression. No lift trigger (test-harness item).
+    (#6096's W3 pins) set `settleGate`/`settleGateWhen` and then
+    probed `expect(entriesOf(sidecar)).toEqual([])` — asserting the
+    wave still HELD — but the when-predicate flipped only once a seal
+    was visible through the sealed overlay, so a commit whose settle
+    pass checked the gate BEFORE the flip could complete in that same
+    cycle, landing the ping before the probe (measured 2/15
+    full-suite reds at #6170's head). #6184 landed the hardened
+    construction the row owed: the gate now ARMS from the handler
+    itself — a flag set synchronously as the handler starts, ordered
+    before that cycle's settle reaches its `inputSynced` barrier — so
+    the sealing cycle is held structurally while idle cycles pass
+    (nothing arms until the copy actually runs). Corroboration (the
+    OW54 follow-on PR's runs, 2026-08-21): eight full-file runs of
+    `executor-events-down.test.ts` at and around the #6184
+    construction, both (α3)-family sibling steps green in all eight,
+    zero holds lost. A red of this step with the ping already durable
+    at the probe would now be a NEW defect, not this race. No lift
+    trigger (test-harness item).
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5660,27 +5660,34 @@ supply; OW29/OW32/OW34 closed):
     pin's PR is not blamed when the lane first flakes; renumbered
     OW56 → OW57 pre-merge for the parallel-mint collision with the
     durability train's #6173, which keeps OW56 for server-owned
-    program compilation; tracked as CT-2060): CLOSED (2026-08-21,
-    #6184 — `c31397906`).** The race as filed: the
+    program compilation; tracked as CT-2060).** The
     "(α3) + a same-eventId SIBLING tx" step's held-wave construction
-    (#6096's W3 pins) set `settleGate`/`settleGateWhen` and then
-    probed `expect(entriesOf(sidecar)).toEqual([])` — asserting the
-    wave still HELD — but the when-predicate flipped only once a seal
-    was visible through the sealed overlay, so a commit whose settle
-    pass checked the gate BEFORE the flip could complete in that same
-    cycle, landing the ping before the probe (measured 2/15
-    full-suite reds at #6170's head). #6184 landed the hardened
-    construction the row owed: the gate now ARMS from the handler
-    itself — a flag set synchronously as the handler starts, ordered
-    before that cycle's settle reaches its `inputSynced` barrier — so
-    the sealing cycle is held structurally while idle cycles pass
-    (nothing arms until the copy actually runs). Corroboration (the
-    OW54 follow-on PR's runs, 2026-08-21): nine full-file runs of
-    `executor-events-down.test.ts` at the #6184 construction, both
-    (α3)-family sibling steps green in all nine, zero holds lost. A
-    red of this step with the ping already durable
-    at the probe would now be a NEW defect, not this race. No lift
-    trigger (test-harness item).
+    (#6096's W3 pins) sets `settleGate`/`settleGateWhen` and then
+    probes `expect(entriesOf(sidecar)).toEqual([])` — asserting the
+    wave is still HELD (its "ping" entry not yet durable). As
+    originally filed, the when-predicate flipped only once a seal was
+    visible through the sealed overlay, so a commit whose settle pass
+    checked the gate BEFORE the flip could complete in that same
+    cycle, landing the ping before the probe: measured 2/15
+    full-suite reds at #6170's head vs 0/10 on main's version (a pin
+    inserted ahead plausibly shifts timing into the window;
+    fresh-server-per-step rules out state coupling). #6184
+    (`c31397906`) landed a HARDENING: the gate now ARMS from the
+    handler itself — a flag set synchronously as the handler starts —
+    intending the sealing cycle to be held structurally while idle
+    cycles pass. The hardening REDUCED but did not eliminate the
+    race. Measured at the #6184 construction (the OW54 follow-on
+    PR's runs, 2026-08-21, with that PR's two tests inserted ahead
+    of the step): 14/15 full-file runs green, ONE red with the
+    identical signature — the ping durable AND consequenced at the
+    probe (`expect(...).toEqual([])` received the consequenced ping
+    entry) — on a loaded machine at `b775787b6`; five runs of plain
+    main's version at the same head were green. Owed, still: a
+    construction that holds under insertion-shifted timing (or an
+    owner call to accept-and-retry the step); until then a red of
+    THIS step with the ping already durable at the probe is this
+    race, not a product regression, and not the inserting PR's
+    defect. No lift trigger (test-harness item).
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5675,10 +5675,10 @@ supply; OW29/OW32/OW34 closed):
     before that cycle's settle reaches its `inputSynced` barrier — so
     the sealing cycle is held structurally while idle cycles pass
     (nothing arms until the copy actually runs). Corroboration (the
-    OW54 follow-on PR's runs, 2026-08-21): eight full-file runs of
-    `executor-events-down.test.ts` at and around the #6184
-    construction, both (α3)-family sibling steps green in all eight,
-    zero holds lost. A red of this step with the ping already durable
+    OW54 follow-on PR's runs, 2026-08-21): nine full-file runs of
+    `executor-events-down.test.ts` at the #6184 construction, both
+    (α3)-family sibling steps green in all nine, zero holds lost. A
+    red of this step with the ping already durable
     at the probe would now be a NEW defect, not this race. No lift
     trigger (test-harness item).
 

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -1332,6 +1332,20 @@ export async function dispatchQueuedEvent(state: {
   // originStatus() fallback ("confirmed") would let a descendant of a failed
   // origin run.
   const requeueForNameResolution = () => {
+    // The rebuilt entry does NOT carry `served`, and no served copy may
+    // reach this path: both served constructors (the drain's and cell.ts's
+    // LT1 emission) queue with retries: false, whose RetryImmediately
+    // branch drops instead of requeueing. Requeueing one anyway would
+    // silently shed the acting identity and the failure hook — and what a
+    // served RETRY even means (which wave owns it, who re-seals) is
+    // UNSTATED semantics that must be decided, not defaulted, if this
+    // assert ever fires.
+    if (queuedEvent.served !== undefined) {
+      throw new Error(
+        "requeueForNameResolution reached with a served event; served " +
+          "retry semantics are undecided (see the comment at this assert)",
+      );
+    }
     const requeued: QueuedEvent = {
       id: queuedEvent.id,
       // The flag rides every requeue with the id it describes: dropping it
@@ -1367,6 +1381,18 @@ export async function dispatchQueuedEvent(state: {
     deadline: number,
     runAt: number,
   ) => {
+    // Same served-absence assert as the name-resolution requeue above:
+    // served copies queue with retries: false, so a stale-basis failure
+    // classifies give-up "opt-out" and never reaches the backoff window —
+    // the wave is a served copy's retry cadence. A served entry rebuilt
+    // here would silently shed the acting identity and the failure hook;
+    // served retry semantics are undecided, so fail loudly instead.
+    if (queuedEvent.served !== undefined) {
+      throw new Error(
+        "requeueForBackoff reached with a served event; served retry " +
+          "semantics are undecided (see the comment at this assert)",
+      );
+    }
     const requeued: QueuedEvent = {
       id: queuedEvent.id,
       // Same as the name-resolution requeue above: the flag travels with the

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -88,6 +88,20 @@ function normalizeEventCommitRejection(reason: unknown): EventCommitError {
 }
 
 /**
+ * Whether a commit error is CFC enforcement's DETERMINISTIC pre-storage
+ * rejection (`rejectCommitBeforeStorage` in extended-storage-transaction.ts):
+ * the transaction was refused before it reached storage, and re-running
+ * recomputes the identical refused write. The served give-up arm and
+ * {@link reportDroppedCfcRejectedWrite} key on this one predicate, so the
+ * sealed error consequence and the loss report cover exactly the same class.
+ */
+export function isCfcRejectedCommitError(
+  error: { message?: string } | undefined,
+): error is { message: string } {
+  return error?.message?.startsWith("CFC enforcement rejected commit") === true;
+}
+
+/**
  * A CFC-enforcement-rejected commit on a give-up disposition is silent data
  * loss of user intent — the UI's write simply never lands (labs#4772 shipped
  * that way for weeks behind the opt-in scheduler logger, which is disabled in
@@ -98,7 +112,7 @@ export function reportDroppedCfcRejectedWrite(
   error: { message?: string } | undefined,
   handlerId: unknown,
 ): void {
-  if (!error?.message?.startsWith("CFC enforcement rejected commit")) {
+  if (!isCfcRejectedCommitError(error)) {
     return;
   }
   console.error(
@@ -1546,6 +1560,31 @@ export async function dispatchQueuedEvent(state: {
           runFinalCommitCallback();
           break;
         case "give-up":
+          // A served event's DETERMINISTIC CFC pre-storage refusal seals an
+          // error consequence (events.md §5: the error IS the consequence —
+          // the same honesty as the throw arm in `finalize` above). Without
+          // one the durable entry stays unconsequenced and every wave
+          // re-drains it into the identical refusal. Scoped to exactly the
+          // class `reportDroppedCfcRejectedWrite` reports below: every other
+          // give-up (transport, authorization, a handler abort, opt-out)
+          // leaves the entry pending for the wave cadence to re-drain.
+          // Ordered before the commit callback so the drain's in-flight
+          // guard sees the staged notice ("marked") rather than releasing
+          // the still-"queued" copy.
+          if (served !== undefined && isCfcRejectedCommitError(error)) {
+            try {
+              served.onFailure?.({
+                kind: "error",
+                message: error.message,
+              });
+            } catch (callbackError) {
+              logger.error(
+                "schedule-error",
+                "Error in served event failure callback:",
+                callbackError,
+              );
+            }
+          }
           runFinalCommitCallback();
           reportDroppedCfcRejectedWrite(error, handlerId);
           logger.warn(

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -251,8 +251,11 @@ export type ServedEventDispatch = {
   lt1?: { emitterTx: IExtendedStorageTransaction };
   onFailure?: (
     outcome: {
-      /** `error`: the handler THREW — the error is the consequence
-       * (events.md §5). `dropped`: no runnable handler exists — §5's
+      /** `error`: the handler THREW, or its commit was refused
+       * PRE-STORAGE by deterministic CFC enforcement (the served
+       * give-up arm's discriminated call, scheduler/events.ts) —
+       * either way the error is the consequence (events.md §5).
+       * `dropped`: no runnable handler exists — §5's
        * drop predicate, the notice is the consequence. `deferred`: the
        * handler could not be REACHED yet (a cold-view piece load — the
        * creation-race shape OW19 warns about): no consequence is
@@ -348,9 +351,11 @@ export type QueuedEvent = {
    * per-event carriage. `firedAt` is the server-stamped acting identity
    * the handler runs as (LD1); `streamEntry` locates the durable entry
    * whose `consequenced` mark rides the handler's own transaction; and
-   * `onFailure` is the drain's hook for the two arms that need a
-   * consequence written OUTSIDE the handler tx — the handler THREW (the
-   * error is the consequence, events.md §5) or the event DROPPED (no
+   * `onFailure` is the drain's hook for the arms that need a
+   * consequence written OUTSIDE the handler tx — the handler THREW, the
+   * commit was refused pre-storage by deterministic CFC enforcement
+   * (the give-up arm's discriminated call; both: the error is the
+   * consequence, events.md §5), or the event DROPPED (no
    * runnable handler — the §5 drop predicate). Success needs no
    * callback: the mark rode the tx. Absent on every client-side event.
    */

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -45,6 +45,7 @@ import type {
   IExtendedStorageTransaction,
   MemorySpace,
 } from "../src/storage/interface.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
 import { readWatermarkSeq } from "../src/executor/watermark.ts";
 import {
@@ -181,6 +182,43 @@ const THROW_PATTERN = [
   "  { value: number; explode: Stream<unknown> }",
   ">(({ value }) => ({ value, explode: explode({ value }) }));",
 ].join("\n");
+
+// OW54's refused-commit class (verification-coverage.md §3): a stored
+// envelope whose `result.anyOf` carries TWO ifc branches is genuinely
+// ambiguous — the class the RULING-5 narrowing still refuses
+// (cfc/schema-merge.ts). The FIRST writer's commit lands (nothing is
+// stored yet, so no merge runs), poisoning the stored envelope; every
+// later merging writer's commit-prep records the refusal and the
+// commit is rejected PRE-STORAGE with the "CFC enforcement rejected
+// commit" message class (extended-storage-transaction.ts). The
+// fixtures mirror cfc-prepare-crash-surfacing.test.ts, which pins the
+// mechanism at the transaction level; here the same refusal lands on a
+// SERVED event's commit, where it classifies as a give-up disposition
+// (scheduler/events.ts).
+const ow54ProfileViewSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string", ifc: { confidentiality: ["secret"] } },
+  },
+} as JSONSchema;
+
+const ow54AltProfileViewSchema: JSONSchema = {
+  type: "string",
+  ifc: { confidentiality: ["other"] },
+} as JSONSchema;
+
+const ow54AmbiguousEnvelopeSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    result: {
+      anyOf: [
+        ow54ProfileViewSchema,
+        ow54AltProfileViewSchema,
+      ],
+    },
+    candidates: { type: "array", items: ow54ProfileViewSchema },
+  },
+} as JSONSchema;
 
 describe("Phase 3 events-down (serving side)", () => {
   let server: MemoryV2Server.Server;
@@ -944,6 +982,264 @@ describe("Phase 3 events-down (serving side)", () => {
     });
     expect((doc?.value as { value?: number })?.value).toBe(0);
     cancelDemand();
+  });
+
+  it("the give-up arm's CFC discriminator (OW54): a served event whose commit is refused PRE-STORAGE by CFC enforcement — a genuinely-ambiguous stored envelope, the class RULING 5 still refuses — seals an ERROR consequence and the stream advances: ONE completed run, ONE consequence commit naming the event, ONE dropped-write report, the entry carries the refusal as its error, and a second poisoned fire seals its own consequence behind it (events.md §5; mutation: the discriminated `served.onFailure` call removed → the entry never consequences and the drain re-runs the handler every wave)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { result } = await standUp(clientRuntime, BUMP_PATTERN, {
+      arg: "ow54-arg",
+      result: "ow54-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    // Poison the stored envelope before the serving side exists: the
+    // first writer's commit lands, and the stored envelope is then
+    // genuinely ambiguous for every later merging writer.
+    const poisonedDocName = "ow54-poisoned-envelope";
+    {
+      const tx = clientRuntime.edit();
+      const cell = clientRuntime.getCell(
+        space,
+        poisonedDocName,
+        ow54AmbiguousEnvelopeSchema,
+        tx,
+      );
+      cell.set({ candidates: [{ name: "Bob" }] });
+      tx.prepareCfc();
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    // Warm-up fire through the pattern's own handler: activates the
+    // space, lands the sidecar, and hands the probe its stream link.
+    result.key("bump").send({ kind: "warmup" });
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the warm-up append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    const entriesOf = () => ((Engine.read(engine, { id: sidecarId })?.value as
+      | StreamEventsDocValue
+      | undefined)?.entries ?? []);
+    const entryByKind = (kind: string) =>
+      entriesOf().find((entry) =>
+        (entry.payload as { kind?: string } | undefined)?.kind === kind
+      );
+    const watermarkNow = () =>
+      (Engine.read(engine, { id: sidecarId })?.value as
+        | StreamEventsDocValue
+        | undefined)?.eventWatermark;
+    await waitUntil(
+      () => entryByKind("warmup")?.consequenced === true,
+      "the warm-up event to consequence",
+    );
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "the space to activate",
+    );
+
+    // The served dispatch target: the entry's self-describing stream
+    // link (the same derivation the drain uses).
+    const warmup = entryByKind("warmup")!;
+    const streamLink = {
+      space,
+      id: warmup.stream.id as never,
+      path: [...warmup.stream.path],
+      scope: (warmup.stream.scope ?? "space") as never,
+    };
+    // The live ordering: the poisoned doc (and its label metadata) is
+    // in the serving replica before the served handler's own
+    // transaction preps.
+    await servingRuntime!.getCell(
+      space,
+      poisonedDocName,
+      ow54AmbiguousEnvelopeSchema,
+    ).sync();
+
+    // The probe replaces the pattern's handler on the serving runtime:
+    // a served handler whose write meets the stored ambiguous envelope,
+    // so its commit-prep records the refusal and the commit is rejected
+    // before storage.
+    let probeRuns = 0;
+    const cancelProbe = servingRuntime!.scheduler.addEventHandler(
+      (tx, _event) => {
+        probeRuns += 1;
+        const resolved = servingRuntime!.getCell<{ name: string }>(
+          space,
+          `${poisonedDocName}-resolved`,
+          ow54ProfileViewSchema,
+          tx,
+        );
+        resolved.set({ name: "Ada" });
+        servingRuntime!.getCell(
+          space,
+          poisonedDocName,
+          ow54AmbiguousEnvelopeSchema,
+          tx,
+        ).set({ result: resolved, candidates: [] });
+      },
+      streamLink,
+    );
+
+    const beforePoison = Engine.serverSeq(engine);
+    const consequenceCommitsNaming = (eventId: string) =>
+      (engine.database.prepare(
+        `SELECT seq, consequence_of FROM "commit"
+         WHERE seq > :from_seq AND class = 'derived'
+           AND consequence_of IS NOT NULL`,
+      ).all({ from_seq: beforePoison }) as Array<
+        { seq: number; consequence_of: string }
+      >).filter((row) => row.consequence_of.includes(eventId));
+    // The unconditional dropped-write report (the give-up arm's loss
+    // report) is the direct witness that the copy took the give-up
+    // disposition — count it per event.
+    const droppedWriteReports: string[] = [];
+    const realConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      const line = args.map((a) => String(a)).join(" ");
+      if (line.includes("Owner-protected write dropped")) {
+        droppedWriteReports.push(line);
+        return;
+      }
+      realConsoleError(...args);
+    };
+    try {
+      result.key("bump").send({ kind: "poison-1" });
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(() => probeRuns >= 1, "the served probe to run");
+
+      // THE PIN (red pre-fix: the refused copy settles with no
+      // consequence, the entry re-drains every wave, and this wait
+      // times out): the deterministic refusal seals an error
+      // consequence and the frontier advances past it.
+      await waitUntil(
+        () => {
+          const entry = entryByKind("poison-1");
+          return entry?.consequenced === true &&
+            typeof entry?.error === "string" &&
+            watermarkNow() === entry?.seq;
+        },
+        "the CFC refusal to seal an error consequence",
+      );
+      const poison1 = entryByKind("poison-1")!;
+      expect(poison1.error).toContain("CFC enforcement rejected commit");
+      expect(poison1.error).toMatch(/divergent anyOf|commit-prep crashed/);
+      // Exactly-once (the (α) invariant): one completed run, one
+      // consequence commit naming the event, one give-up report.
+      expect(probeRuns).toBe(1);
+      expect(consequenceCommitsNaming(poison1.eventId).length).toBe(1);
+      expect(droppedWriteReports.length).toBe(1);
+
+      // The stream advances: a second poisoned fire drains BEHIND the
+      // sealed consequence and seals its own — no wedge, and no second
+      // consequence for the first event.
+      result.key("bump").send({ kind: "poison-2" });
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => {
+          const entry = entryByKind("poison-2");
+          return entry?.consequenced === true &&
+            typeof entry?.error === "string" &&
+            watermarkNow() === entry?.seq;
+        },
+        "the second refusal to seal its own error consequence",
+      );
+      const poison2 = entryByKind("poison-2")!;
+      expect(probeRuns).toBe(2);
+      expect(consequenceCommitsNaming(poison1.eventId).length).toBe(1);
+      expect(consequenceCommitsNaming(poison2.eventId).length).toBe(1);
+      expect(droppedWriteReports.length).toBe(2);
+    } finally {
+      console.error = realConsoleError;
+      cancelProbe();
+      cancelDemand();
+    }
+  });
+
+  it("a NON-CFC give-up on a served event keeps the re-drain cadence (OW54's scope boundary): a handler that aborts its own transaction leaves the entry UNCONSEQUENCED — no error, no notice, no frontier advance — and a later wave re-drains it (mutation: the give-up arm's discriminator widened to every give-up → this entry seals a consequence and the re-drain stops)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { result } = await standUp(clientRuntime, BUMP_PATTERN, {
+      arg: "giveup-arg",
+      result: "giveup-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    result.key("bump").send({ kind: "warmup" });
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the warm-up append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    const entriesOf = () => ((Engine.read(engine, { id: sidecarId })?.value as
+      | StreamEventsDocValue
+      | undefined)?.entries ?? []);
+    const entryByKind = (kind: string) =>
+      entriesOf().find((entry) =>
+        (entry.payload as { kind?: string } | undefined)?.kind === kind
+      );
+    await waitUntil(
+      () => entryByKind("warmup")?.consequenced === true,
+      "the warm-up event to consequence",
+    );
+    await waitUntil(
+      () => host!.spaceServer(space)?.active === true,
+      "the space to activate",
+    );
+
+    const warmup = entryByKind("warmup")!;
+    const streamLink = {
+      space,
+      id: warmup.stream.id as never,
+      path: [...warmup.stream.path],
+      scope: (warmup.stream.scope ?? "space") as never,
+    };
+    // A give-up that is NOT the CFC pre-storage refusal: the handler
+    // discards its own transaction, so the commit settles with a
+    // non-CFC rejection and the give-up arm must NOT seal a
+    // consequence for it.
+    let probeRuns = 0;
+    const cancelProbe = servingRuntime!.scheduler.addEventHandler(
+      (tx, _event) => {
+        probeRuns += 1;
+        tx.abort(new Error("served give-up cadence probe"));
+      },
+      streamLink,
+    );
+    try {
+      result.key("bump").send({ kind: "aborted" });
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      // The wave IS the retry cadence: the unconsequenced entry is
+      // dispatched again on a later wave.
+      await waitUntil(() => probeRuns >= 2, "the entry to re-drain");
+      const aborted = entryByKind("aborted")!;
+      expect(aborted.consequenced).not.toBe(true);
+      expect(aborted.error).toBeUndefined();
+      expect((aborted as { status?: unknown }).status).toBeUndefined();
+      // The frontier stayed at the warm-up entry.
+      expect(
+        (Engine.read(engine, { id: sidecarId })?.value as StreamEventsDocValue)
+          .eventWatermark,
+      ).toBe(entryByKind("warmup")!.seq);
+    } finally {
+      cancelProbe();
+      cancelDemand();
+    }
   });
 
   it("the renderer-trust attestation rides the durable entry and is RE-MARKED at the served dispatch (fan-out stage B, OW34's sister-mark carriage): a fire whose event carried the process-local renderer-trust mark appends `rendererTrusted: true`, the served handler sees a renderer-trusted event; an unmarked fire appends no attestation and the served handler sees none; a forged attestation value is refused at admission", async () => {


### PR DESCRIPTION
## Why

A deterministic CFC pre-storage rejection of a SERVED event's commit (the "CFC enforcement rejected commit" class from `rejectCommitBeforeStorage`) classifies `{kind: "give-up", reason: "non-retryable"}` — and the give-up arm settled the commit callback and reported the dropped write but never called `served.onFailure`. Nothing sealed a consequence, so the durable entry stayed unconsequenced and the post-wave re-arm re-drained it into the identical refusal, every wave, forever ("the wave IS the retry cadence"); under #6158's settle wait, the unretired client intent additionally paid the full bounded quiescence timeout per settle round.

Pre-OW50 this class THREW from `prepareTxForCommit` inside the event finalize and took the ERROR arm, whose contract is "the error IS the consequence" (`served.onFailure({kind: "error", message})`, events.md §5). OW50's totality (prep crashes recorded as modeled pre-storage rejections) moved the class onto the give-up path and lost the seal — the regression the adversarial review of #6157 confirmed as OW54. This PR restores the pre-OW50 contract on the modeled path, per the coordinator-green-lit outline in the RULING-5 report §4 (`docs/history/plans/server-execution-v2/optimize/ruling5-ow49-report.md`).

## What Changed

- `packages/runner/src/scheduler/events.ts`:
  - `isCfcRejectedCommitError` — the message-prefix predicate, extracted so the sealed consequence and the loss report key on the SAME discriminator by construction (`reportDroppedCfcRejectedWrite` now calls it).
  - The give-up arm: when `served !== undefined` and the error is the deterministic CFC pre-storage rejection, call `served.onFailure({kind: "error", message})` — with the throw arm's try/log isolation — BEFORE `runFinalCommitCallback()`, so the drain's in-flight guard sees the staged notice ("marked") rather than releasing the still-"queued" copy. Every other give-up class (transport, authorization, handler abort, opt-out) is byte-identical.
- `docs/specs/server-side-execution/events.md` §5: the class stated — the refusal IS the consequence; every other served commit refusal keeps the wave-cadence re-drain.
- `docs/specs/server-side-execution/verification-coverage.md`: the OW54 row CLOSED (pin as lift evidence, the #6158 settle-interaction note, the RULING-5 interaction resolved, the served-terminal-rejection residual FLAGGED, not silently included). The OW57 row updated — see the honesty note below.
- `docs/history/plans/server-execution-v2/optimize/ow54-build-report.md`: the build record (mechanism confirmation, red-first evidence, which-direction analysis, suites run).

(α)-criticality — the which-direction obligation (no DOUBLE seal), checked path by path in the build report §4: the handler tx's own mark is dead by construction on a pre-storage refusal; the ERROR arm and the terminal/permanent arms are mutually exclusive with the give-up arm; the LT1 late-seal refusal early-returns above the classification; re-dispatch is held by the drain-in-flight guard ("marked" until the wave outcome) and a failed notice self-heals to exactly one durable consequence; the dispatch is single-shot. The LT1 in-process copy's carriage has no `onFailure`, so a CFC-refused LT1 copy is a safe no-op and the consequence seals from the next wave's drain copy.

**OW57 honesty note (in-PR reversal, deliberate):** an OW57 closure on #6184's handler-armed settle gate was drafted on early corroboration (9/9 sibling-step observations green at `ec6361782`) and then WITHDRAWN in this same PR: after rebasing onto `b775787b6`, one of 8 full-file runs reproduced the exact CT-2060 signature (the ping durable AND consequenced at the held-wave probe) at the hardened construction, while 5/5 runs of plain main's version stayed green — consistent with the row's original observation that tests inserted ahead shift timing into the window. The row now records #6184 as a hardening that reduced but did not eliminate the race, restores the don't-blame clause, and keeps the owed line. If CI flakes that step on this PR, it is CT-2060, not this diff (this diff touches neither the step nor the gate).

## Test plan

Red-first, watched, on the unmodified base (`ec6361782`):

- **The main pin** (`executor-events-down.test.ts`, "the give-up arm's CFC discriminator (OW54)"): a served handler writes a doc whose STORED envelope is genuinely ambiguous (`result.anyOf` with TWO ifc carriers — the class RULING 5 still refuses; fixtures mirror `cfc-prepare-crash-surfacing.test.ts`), seeded as the doc's first write and pre-pulled into the serving replica. RED on base:

  ```
  error: Error: timed out waiting for the CFC refusal to seal an error consequence
  ```

  with the served copy taking the give-up disposition TWICE for the same eventId (two `served-event-commit-failed` + two "dropping the write without retry" warns ~250 ms apart — the post-wave re-arm's second drain) and the entry never consequenced. GREEN with the fix: exactly ONE completed run per event, ONE consequence commit naming each eventId, ONE dropped-write report per event, the entry's `error` carries the refusal (both the message prefix and the `divergent anyOf` class matched), the watermark advances, and a second poisoned fire seals its own consequence behind the first.
- **The scope-boundary pin** ("a NON-CFC give-up on a served event keeps the re-drain cadence"): handler `tx.abort()` → re-drains unconsequenced, no frontier advance. Green on base AND after — the non-CFC cadence is unchanged, and the pin reddens if the discriminator is ever widened.

Suites (one file per invocation):

- `executor-events-down.test.ts`: at `ec6361782`, 4 fixed-head runs with clean verdicts (`1 passed (21 steps) | 0 failed`) + 3 runs confirming the (α3)-family sibling steps. After the rebase onto `b775787b6`: 8 runs — both OW54 pins green in all 8; one CT-2060 flake of the pre-existing (α3)+M1 step (see the honesty note; 5/5 green on plain main at the same head).
- Neighbors at `ec6361782`, green per-file: `executor-serving-loop` (25 steps), `executor-space-server` (15), `cfc-prepare-crash-surfacing` (15), `cfc-schema-merge` (58), `scheduler-commit-backpressure` (9), `cfc-writer-claim-correspondence` (17), `mergeable-append-multispace-conflict` (2). Re-run at the rebased head: all seven green — `executor-serving-loop` (25), `executor-space-server` (15), `cfc-prepare-crash-surfacing` (15), `cfc-schema-merge` (58), `scheduler-commit-backpressure` (9), `cfc-writer-claim-correspondence` (17), `mergeable-append-multispace-conflict` (2).
- Repo gates at the rebased head: `deno fmt --check`, `deno lint`, `deno task check` (full typecheck), `check-docs`, `check-docs-history-index`, `check-no-waitfor`, `check-conflict-markers`, `check-control-characters` — all green.
- Full runner battery (`deno task test`, one invocation, rebased head): `ok | 1274 passed (7304 steps) | 0 failed (11m43s)` — zero failed steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




ACCEPT_COVERAGE_DEBT: packages/runner +4 lines

(The +4 are the two `served`-absence tripwire asserts in the requeue helpers — review NOTE-4, delta-verified: unreachable by construction while served-retry semantics stay deliberately undecided, so they cannot be covered without deciding those semantics. Accepted as coordinator.)
