### PR TITLE
fix(runner): a served run's send to a foreign stream crosses via the outbox — the LT1 axis is the wave's home space, not the sending cell's

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
+++ b/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
@@ -207,7 +207,31 @@ Also remaining, flagged (not filled here):
   seat rather than ride this fix.
 - **OW54's give-up-without-consequence corner** stands as recorded
   (its trigger names this lift).
-- **home-profile**: the shared refusal layer clears with this fix;
-  its lift additionally needs the S-B barrier verified on its reload
-  path — reported to the coordinator with a fresh ON run in the PR,
-  not forced here.
+- **home-profile** (one fresh-store ON run at the fix head; reported,
+  not forced): step 1 GREEN in 8 s; step 2 RED at the summary's
+  "Alan Turing" wait (5m18s), and the store decomposes the residual
+  precisely. The S-B question is ANSWERED: every rapid-create space
+  holds its PROGRAM durably (Alan's at seq 3, 124,973 B — the reload
+  did not lose it; the old program-loss orphan class did not
+  reproduce), and zero isolation errors (this flow crosses no amend
+  events, so this PR's fix is not implicated either way). The
+  remaining blocker is an ORDERING race on the derivation-demand
+  seam: Grace's space got setup(seq 2) BEFORE her space's serving
+  tenure, which then derived her name (seq 5, derived, service
+  holder); Alan's space's transient tenure came FIRST (watermark at
+  seq 2), parked, and his setup landed at seq 5 while the creating
+  client's sessions were dead mid-reload — an authored admission
+  into a lease-less space with no live session and no events
+  activates NOTHING (T11.Q7's designed parking), and no later
+  trigger ever arrives: the post-reload summary reads his missing
+  computed name through the HOME space's free cross-space read
+  (which registers a HOME-side wake, not target-side demand) and
+  renders the id placeholder forever. What home-profile's lift
+  needs is a ruling-shaped answer to "what demands a foreign
+  space's underived computed for a cross-space read" — candidates
+  visible in the ruled text: the activation sentence's third,
+  unimplemented trigger ("explicit warm request", serving-loop.md
+  §1) issued by the reading loop for a demanded-but-underived
+  foreign computed; a client session opened on the summarized
+  space; or S-C-shaped healing. Flagged for the owner, not chosen
+  here.

--- a/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
+++ b/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
@@ -1,0 +1,213 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "The cf:module cross-space §2b derivation-carriage residual scoped and closed: the rulings already select the profile space's own serving loop as the deriver (arm c) with the outbox as the amend's crossing (arm b, already built) — no fork; the live blocker was ONE send-site defect — cell.ts picked LT1-vs-outbox by the sending cell's space instead of the wave's home space — fixed red-first. The ten-run gate then separated the families: the amends cross durably in every run that writes them (the bio amend durable 10/10, red runs included), and the remaining red is a DIFFERENT class — the client name-draft own-write loss (OW47's family) — so the profile-embed skip is re-scoped to it, not lifted."
+---
+
+# The §2b derivation-carriage residual — scope, verdict, and the fix
+
+Seat: the OW45/OW31-family cross-space-derivation residual (the
+profile-embed amend-convergence blocker;
+[`ruling5-ow49-report.md`](ruling5-ow49-report.md) §3). Branch
+`claude/server-exec-v2-2b-derivation-carriage` off `origin/main` @
+`ec6361782`.
+
+## 1. Verdict: DETERMINED — no fork
+
+The scoping question was which sanctioned crossing carries a
+derivation's consequences when a HOME-space serving wave runs a
+foreign piece's graph. The ruled sentences already decide it, and
+they decide it *against* the question's framing: the consequences
+never cross, because the derivation itself belongs to the other
+space's loop.
+
+- **(a) §2b delegated carriage extended to derivation consequences —
+  REFUSED by ruled text.** protocol.md §2b's crossing table:
+  "`derived` commit into a foreign space | FORBIDDEN — SpaceServer(B)
+  is B's only deriver; A never derives into B." README §3.1: "a
+  piece's graph is run by its home space's runtime … derived commits
+  never target foreign spaces." The S-A precedent does not
+  generalize: OW31's build stamped the compile-cache writeback as "an
+  explicit carriage for the bookkeeping-kind materialization family"
+  (`#stampRun`'s `info.kind === "bookkeeping" && info.delegated`
+  arm) — content-addressed, idempotent program materialization,
+  authored-class. A lift's output is a derivation write (§3d, RULED
+  2026-08-05: "every write of a derivation run is a pure derivation
+  write"); carrying it cross-space would mint a second deriver for
+  the target space.
+- **(b) The outbox — YES, for the amend EVENT, and it was already
+  built.** The amend reaches the profile space as a cross-space
+  event append: protocol.md §2b ("an event append to a foreign
+  stream — the ONLY cross-space mutation … carried by the OUTBOX",
+  with acting identity + `capabilityRef`; LT4's no-retry on
+  deterministic rejection), LT5 (envelope = the producing server's
+  service identity; admissibility from the validated grant), LT6
+  (a demanded run's identity inherits into its emissions uniformly).
+  The send site (cell.ts's serving branch), the wave staging
+  (`stageOutboundAppend` → FP1 rows inside the wave transaction),
+  the delivery admission, and the eventId dedupe all existed and
+  were pinned (`executor-outbox.test.ts`).
+- **(c) The profile space's own serving loop activates and the
+  cf:module derivation runs THERE — YES; this is the ruled
+  end-state, and at this head it already happens.** Activation:
+  serving-loop.md §1 ("Activation on: session open, event append, or
+  explicit warm request"; the provisioned space "stays parked until
+  its first session or event", T11.Q7). Both hooks are live
+  (`memory/v2/server.ts` `#notifySessionOpened` at session.open;
+  `executor/host.ts` `#onCommitAdmitted` — an event-append admission
+  activates even with no session). Live at `ec6361782`: the profile
+  space acquires a lease, its program docs land server-authored via
+  S-A's carriage, and its own wave derives the initial name
+  ("Ada Lovelace" in a derived commit of the profile store, basis
+  rows written). The OW49 report's "the profile space NEVER
+  activates a serving wave" does not reproduce at this head; what
+  DOES reproduce (pre-fix) is the amend loss, whose mechanism is §2
+  below.
+
+Answer to the standing question "is the never-activates state the
+defect or the demand model working as designed": at the RULING-5
+head it was a composite symptom; at today's head activation works
+as designed and the surviving defect was not in the demand model at
+all — it was one wrong comparison at the send site. NOT a demand
+hole, consistent with the rootcause report's headline.
+
+## 2. The live blocker, root-caused: the send site's LT1-vs-outbox
+## axis was the sending cell's space, not the wave's home space
+
+Reproduced at `ec6361782` on the ON binary (fresh store,
+self-referential `API_URL`/`MEMORY_URL`, `servingLoop` posture
+verified): profile-embed FAILED in 5m09s at the "Grace Hopper"
+badge assert, with the amended values durably absent from every
+store — the OW49 report §3 shape exactly. The server log carries
+the mechanism, twice, with full stacks:
+
+```
+Uncaught error in action: StorageTransactionWriteIsolationError:
+Can not open transaction writer for <PROFILE space> because
+transaction has writer open for <TEST space>
+  at CellImpl.set (cell.ts:1776) ← the LT1 same-space arm's raw entries write
+  at CellImpl.send (cell.ts:2069)
+  at eval (/system/profile-embed.tsx:103) ← saveName → setName.send
+  (and :121 ← saveBio → setBio.send)
+  at dispatchQueuedEvent …
+```
+
+Chain: the click's save event lands in the TEST space
+(events-down); the TEST wave dispatches the served `saveName`
+handler; the handler's tx already holds the TEST-space writer (the
+`consequenced` mark, `space-server.ts` `#stampRun`); the handler
+calls `profileWish.result.setName.send({name})`. The setName stream
+is a DIRECT FOREIGN CELL HANDLE — `cell.space === resolved.space
+=== the PROFILE space` — so the serving branch's arm selector
+
+```ts
+if (resolvedToValueLink.space === this.space) { /* LT1 same-space */ }
+```
+
+took the LT1 arm and raw-wrote the profile space's entries doc
+inside the home-anchored tx: the one-tx-one-space isolation error
+(protocol.md §2b's "an UNMARKED crossing always a bug", firing
+correctly). The handler run died, no consequence staged, the
+outbox arm was never reached, and the emission was lost — the
+client's speculative echo painted "Grace Hopper" with nothing
+durable underneath (the which-direction hazard shape the report
+named). The standing 60–70 `foreign-write-refused` per run are the
+SEPARATE, harmless-by-refusal signature of the home wave also
+running the foreign piece's lifts (§4).
+
+LT1's ruled sentence names the axis: "the SAME-SPACE server-emitted
+append's durable entry is a WRITE within the wave's own derived
+commit" — same-space as the WAVE. The code proxied that with the
+sending cell's space, which agrees on every same-space piece (the
+lunch/chat gates) and disagrees exactly on a foreign stream reached
+through a foreign handle — the wish-embed topology, first exercised
+by profile-embed. The proxy was wrong in both directions (an
+aliased home target through a foreign handle would have taken the
+outbox to the wave's OWN space).
+
+## 3. The fix (determined; red-first)
+
+- `packages/runner/src/storage/interface.ts`:
+  `TransactionSealDestination` gains optional `readonly space` — the
+  wave's home space; the SpaceServer and the wave accumulator
+  already expose it structurally.
+- `packages/runner/src/cell.ts` (serving branch): the arm selector
+  compares `resolvedToValueLink.space` against the installed
+  destination's `space`, falling back to the old cell-space proxy
+  only for destinations that name none (bare same-space test
+  doubles).
+
+Red-first pin (`packages/runner/test/executor-cross-space.test.ts`,
+"a served run's send to a FOREIGN stream cell crosses via the
+outbox"): a served event-handler-stamped run, home-anchored, sends
+to a stream cell whose own space IS the foreign space. Watched RED
+on the unmodified tree — `StorageTransactionWriteIsolationError` at
+`CellImpl.send`, byte-identical to the live stack — then GREEN with
+the fix: the outbox delivers the entry into the foreign sidecar
+with `firedAt` from the CARRIED actor, and the delivered append
+ACTIVATES the target space's own loop (the (c) arm's trigger).
+
+Suites at the fix (one file per invocation): executor-cross-space
+14, executor-events-down 19, executor-outbox 18, executor-wave 43,
+executor-run-supply 14, executor-serving-loop 25 — all green.
+
+## 4. The ten-run gate: the families separate; re-scope, not lift
+
+Ten fresh-store ON runs at the fix head (ON binary rebuilt with the
+fix; per-iteration fresh store; self-referential
+`API_URL`/`MEMORY_URL`; `servingLoop` posture verified per run; load
+averages recorded — full table in the PR body). The durability bar
+is store-queried, never the render. Outcome: **7 green / 3 red**.
+The greens complete in
+11–23 s with BOTH amends durably present — the profile store carries
+the outbox-delivered authored append (`acting_principal` = the user,
+`capability_ref` = `stream-append:<sidecar>`) AND the profile wave's
+own derived consequence; the test space carries the client intent
+and the home re-derivation. The three reds are 300 s badge timeouts
+with a NEW, separated signature: the BIO amend is durably present
+cross-space (the fixed chain end to end) while the NAME never lands
+because the name DRAFT — a plain client `$value` write into the
+TEST space — never lands as ANY commit; the served `saveName` then
+reads an empty draft and correctly no-ops. `fillCfInput`'s host
+`commit()` resolves and verifies the DOM value; the store never
+sees it; no refusal surfaces anywhere. Not load-correlated: a green
+passed at load 18 while the reds landed at loads 8–15. Zero
+`StorageTransactionWriteIsolationError` in any run: the send-site
+defect is extinct. (Pre-fix baseline at the same protocol: 4/10
+green with the amended values durably absent from every store, the
+greens riding the echo — the report §3 shape reproduced locally
+before the fix as a 5m09s red with the two isolation-error stacks.)
+
+That is OW47's family (client own-write durability), not the §2b
+family: the cellset-lww fix closed the BLIND-write structural-read
+mechanism, while this write races the served `startEditing` SEED
+echo standing on the draft doc (the seed writes the current name
+into the draft; the echo's standing window is a full served round
+trip) — the value-consuming arm the OW47 fix deliberately kept
+refusing, or a sibling loss on the same doc. It needs OW47's
+instrumented-client tracing method and its own seat; per
+flag-don't-fill it is NOT patched here. The profile-embed skip
+entry is RE-SCOPED to name it precisely (the third re-scope, each
+naming a strictly smaller blocker); the lift bar (10/10 green +
+store-durable amends) is met for the amend-crossing mechanism and
+not yet for the file.
+
+Also remaining, flagged (not filled here):
+
+- **The home wave still RUNS the foreign piece's lifts** (the
+  standing ~60 refusals per run — `applyInitialName`, `__cfLift_*`
+  refused at the accept gate). Fail-closed correct, wasted work and
+  log noise: the serving runtime instantiates a piece it renders
+  regardless of the piece's home (the wish pulls the foreign piece
+  root). The clean end-state under README §3.1 ("a piece's graph is
+  run by its home space's runtime") is for the home runtime not to
+  RUN foreign-piece derivations at all — a scheduler/demand
+  cleanliness item, not a correctness blocker; it should get its own
+  seat rather than ride this fix.
+- **OW54's give-up-without-consequence corner** stands as recorded
+  (its trigger names this lift).
+- **home-profile**: the shared refusal layer clears with this fix;
+  its lift additionally needs the S-B barrier verified on its reload
+  path — reported to the coordinator with a fresh ON run in the PR,
+  not forced here.

--- a/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
+++ b/docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md
@@ -134,9 +134,30 @@ outbox to the wave's OWN space).
   already expose it structurally.
 - `packages/runner/src/cell.ts` (serving branch): the arm selector
   compares `resolvedToValueLink.space` against the installed
-  destination's `space`, falling back to the old cell-space proxy
-  only for destinations that name none (bare same-space test
-  doubles).
+  destination's `space`. Fail-closed: an outbox-capable destination
+  (`stageOutboundAppend` present) that names no `space` is refused
+  loudly — guessing from the cell's space is the mis-axis itself;
+  the cell-space proxy survives only for seal-only test doubles
+  with no outbox at all (same-space harnesses by construction,
+  whose cross-space arm refuses on the missing outbox anyway).
+  `stageOutboundAppend` is declared on the interface (the
+  structural cast retired).
+
+The axis change moves TWO routing cells, and both are deliberate:
+
+- **(cell=foreign, resolved=foreign)** — the defect cell: previously
+  the LT1 raw write (the isolation-error kill); now the outbox's
+  cross-space append. The observed profile-embed blocker.
+- **(cell=foreign, resolved=home)** — an aliased HOME target reached
+  through a foreign handle: previously the OUTBOX, self-addressed at
+  the wave's own space (post-commit self-delivery under the
+  producing server's service envelope, LT5's crossing shape); now
+  LT1. That is the ruled reading — events.md §2's same-space
+  emission is never a separate commit and never the outbox — and
+  its identity model changes with the move: a write-level LT1 entry
+  inside the wave's own derived commit, the inherited actor at
+  write level, `eventWatermark` dedupe, same-wave in-process
+  processing.
 
 Red-first pin (`packages/runner/test/executor-cross-space.test.ts`,
 "a served run's send to a FOREIGN stream cell crosses via the
@@ -144,9 +165,20 @@ outbox"): a served event-handler-stamped run, home-anchored, sends
 to a stream cell whose own space IS the foreign space. Watched RED
 on the unmodified tree — `StorageTransactionWriteIsolationError` at
 `CellImpl.send`, byte-identical to the live stack — then GREEN with
-the fix: the outbox delivers the entry into the foreign sidecar
-with `firedAt` from the CARRIED actor, and the delivered append
-ACTIVATES the target space's own loop (the (c) arm's trigger).
+the fix: the outbox delivers EXACTLY ONE entry into the foreign
+sidecar with `firedAt` carrying the acting user AND session (the
+LT5/LT6 carriage halves), and the delivered append ACTIVATES the
+target space's own loop (the (c) arm's trigger). The activation
+assertion is bound non-vacuously (the adversarial review's
+MINOR-1): the foreign stream doc is created ENGINE-DIRECT, so no
+session and no admission ever touches the space before the send — a
+pre-send probe asserts the space INACTIVE, and that probe was
+watched FAILING against two weaker constructions (a shared client
+creating the doc after host attach; a dedicated setup client
+disposed pre-attach whose session lingered server-side) before the
+engine-direct shape made it hold. What the final wait then binds is
+exactly the carries-events admission arm — a delivered cross-space
+append activating a sessionless target.
 
 Suites at the fix (one file per invocation): executor-cross-space
 14, executor-events-down 19, executor-outbox 18, executor-wave 43,

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5379,9 +5379,22 @@ supply; OW29/OW32/OW34 closed):
     blocker (the resolved-profile amend steps intermittently red 6/10
     with the amended values durably absent from every store; the
     OW45+OW31-family cross-space derivation signatures in every run —
-    triage in optimize/ruling5-ow49-report.md §3). Closure and the
-    successor's row-mapping are the coordinator's; the skip entry now
-    names the amend-convergence blocker.
+    triage in optimize/ruling5-ow49-report.md §3). That
+    amend-convergence blocker was ROOT-CAUSED AND CLOSED 2026-08-21
+    by the §2b derivation-carriage scoping pass
+    (optimize/2b-derivation-carriage-scope.md): ONE send-site defect —
+    cell.ts's serving branch picked the LT1-vs-outbox arm by the
+    sending CELL's space instead of the WAVE's home space, so the
+    served amend handlers' sends into the profile's exported streams
+    (direct foreign cell handles) raw-wrote the foreign space and
+    died on the one-tx-one-space isolation error — fixed red-first
+    (executor-cross-space.test.ts's outbox-arm pin); the amends now
+    cross via the outbox with the carried actor and are durably
+    present in both stores. The ten-run gate at that fix head
+    separated a REMAINING, different-family red (the client
+    name-draft own-write loss, OW47's family — the skip entry names
+    it), so profile-embed's green-ON condition is still open. Closure
+    and the successor's row-mapping are the coordinator's.
   - **OW50 — CLOSED 2026-08-21 (built; optimize-on-main served-wish
     seat,
     [`optimize/ow48-50-wish-path-report.md`](../../history/plans/server-execution-v2/optimize/ow48-50-wish-path-report.md)

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1739,12 +1739,28 @@ export class CellImpl<T extends FabricValue>
           // the same-space arm's raw entries write would open a second
           // space's writer inside the run's home-anchored transaction —
           // the one-tx-one-space isolation error (protocol.md §2b) that
-          // kills the handler run and loses the emission. A destination
-          // that names no space (bare test doubles) keeps the
-          // cell-space proxy: those harnesses are same-space by
-          // construction.
-          const servingSpace = this.runtime.installedSealDestination?.space ??
-            this.space;
+          // kills the handler run and loses the emission. Fail-closed:
+          // an OUTBOX-CAPABLE destination that names no home space
+          // cannot route this decision, and guessing from the cell's
+          // space is exactly the mis-axis this branch exists to avoid —
+          // refuse loudly. A destination with no outbox at all (bare
+          // seal-only test doubles) keeps the cell-space proxy: those
+          // harnesses are same-space by construction, and their
+          // cross-space arm below refuses on the missing outbox anyway.
+          const destination = this.runtime.installedSealDestination;
+          if (
+            destination?.stageOutboundAppend !== undefined &&
+            destination.space === undefined
+          ) {
+            throw new Error(
+              "server-side emission refused: the installed seal " +
+                "destination stages outbound appends but names no home " +
+                "space, so the LT1-vs-outbox routing axis (the WAVE's " +
+                "home space — events.md §2; protocol.md §2b) cannot be " +
+                "resolved. Expose `space` on the destination.",
+            );
+          }
+          const servingSpace = destination?.space ?? this.space;
           if (resolvedToValueLink.space === servingSpace) {
             // LT1 same-space carriage: the entry rides the current tx.
             // The engine stamps its stream `seq` at the wave commit
@@ -1892,14 +1908,6 @@ export class CellImpl<T extends FabricValue>
                 }
                 : {}),
             };
-            const destination = this.runtime.installedSealDestination as
-              | {
-                stageOutboundAppend?: (
-                  tx: IExtendedStorageTransaction,
-                  row: OutboxAppendRow,
-                ) => void;
-              }
-              | undefined;
             if (destination?.stageOutboundAppend === undefined) {
               throw new Error(
                 "cross-space event emission requires the serving loop's " +

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1729,7 +1729,23 @@ export class CellImpl<T extends FabricValue>
           // is refused at the seal — the early-emit guard, fail-closed.
           // Handler runs (explicit `firedAt` actor) are unchanged.
           const acting = actingForEmission(context, this.tx);
-          if (resolvedToValueLink.space === this.space) {
+          // The LT1-vs-outbox axis is the WAVE'S HOME SPACE (LT1: a
+          // SAME-SPACE server-emitted append rides the wave's own
+          // derived commit; events.md §2's cross-space arm is the
+          // outbox). The sending CELL's space is not that axis: a
+          // foreign stream reached through a direct foreign cell handle
+          // (a wish-result export — profile-embed's `setName`) has
+          // cell.space === resolved.space === the FOREIGN space, and
+          // the same-space arm's raw entries write would open a second
+          // space's writer inside the run's home-anchored transaction —
+          // the one-tx-one-space isolation error (protocol.md §2b) that
+          // kills the handler run and loses the emission. A destination
+          // that names no space (bare test doubles) keeps the
+          // cell-space proxy: those harnesses are same-space by
+          // construction.
+          const servingSpace = this.runtime.installedSealDestination?.space ??
+            this.space;
+          if (resolvedToValueLink.space === servingSpace) {
             // LT1 same-space carriage: the entry rides the current tx.
             // The engine stamps its stream `seq` at the wave commit
             // (the batch declares it); `firedAt` is the inherited

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1313,6 +1313,18 @@ export interface TransactionSealDestination {
   seal(tx: IExtendedStorageTransaction): Promise<Result<Unit, CommitError>>;
 
   /**
+   * The HOME space of the wave this destination seals into (the space
+   * the serving loop serves). The send site's LT1-vs-outbox decision
+   * reads it: an emission targeting THIS space rides the wave's own
+   * commit (LT1's same-space arm), any other space stages the outbox's
+   * cross-space append (events.md §2; protocol.md §2b). The SpaceServer
+   * and the wave accumulator both expose it; a destination that names
+   * none (bare test doubles) leaves the send site on the sending cell's
+   * own space as the proxy — a same-space-only harness shape.
+   */
+  readonly space?: MemorySpace;
+
+  /**
    * Take ownership of a sealed transaction's post-commit effects
    * (server-execution v2 stage G, serving-loop.md §3/§5): the loop hands
    * external effects to the OUTBOX post-wave-commit — never at seal

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -18,6 +18,7 @@ import type {
   SqliteQueryResult,
   SqliteRegisterDiskSourceResult,
 } from "@commonfabric/memory/v2";
+import type { OutboxAppendRow } from "@commonfabric/memory/v2/execution-outbox";
 import type { EntityId } from "../create-ref.ts";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
 import {
@@ -1320,9 +1321,26 @@ export interface TransactionSealDestination {
    * cross-space append (events.md §2; protocol.md §2b). The SpaceServer
    * and the wave accumulator both expose it; a destination that names
    * none (bare test doubles) leaves the send site on the sending cell's
-   * own space as the proxy — a same-space-only harness shape.
+   * own space as the proxy — a same-space-only harness shape. An
+   * outbox-capable destination ({@link stageOutboundAppend} present)
+   * MUST name it: the send site refuses the decision rather than
+   * guessing (a wrong guess is the pre-fix cross-space raw write).
    */
   readonly space?: MemorySpace;
+
+  /**
+   * Stage a cross-space event append onto the CURRENT wave for the run
+   * owning `tx` (events.md §2's cross-space arm; serving-loop.md §5):
+   * the entry becomes a durable outbox row inside the wave's own store
+   * transaction — iff the run's contribution survives the wave commit —
+   * and the acting identity travels WITH it. The send site (cell.ts's
+   * serving branch) dispatches here whenever a served run's emission
+   * targets a space other than {@link space}.
+   */
+  stageOutboundAppend?(
+    tx: IExtendedStorageTransaction,
+    row: OutboxAppendRow,
+  ): void;
 
   /**
    * Take ownership of a sealed transaction's post-commit effects

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -43,9 +43,14 @@ import {
 } from "@commonfabric/memory/v2/scheduler-basis";
 import {
   applyCommit,
+  read as readDoc,
   selectDocHead,
   serverSeq,
 } from "@commonfabric/memory/v2/engine";
+import {
+  streamEntriesDocId,
+  type StreamEventsDocValue,
+} from "@commonfabric/memory/v2";
 import { UI } from "../src/builder/types.ts";
 import {
   getPatternEnvironment,
@@ -775,6 +780,118 @@ describe("Phase 5 cross-space serving", () => {
       expect(meta.class).toBe("authored");
       expect(meta.acting_principal).toBe(aliceSigner.did());
       expect(meta.capability_ref).toBe("event-consequence:e-sa");
+    } finally {
+      cancel();
+    }
+  });
+
+  it("a served run's send to a FOREIGN stream cell crosses via the outbox: LT1's same-space axis is the WAVE's home space, never the sending cell's space (LT1/LT5; events.md §2; protocol.md §2b)", async () => {
+    host = newHost();
+
+    // Alice's client creates the FOREIGN stream doc natively, then
+    // demands a home doc so the HOME space activates.
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    const clientStream = clientRuntime.getCell<unknown>(
+      foreignSpace,
+      "xspace-send-stream",
+      undefined,
+    );
+    await clientStream.sync();
+    {
+      const tx = clientRuntime.edit();
+      clientStream.withTx(tx).setRaw({ $stream: true });
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    await clientRuntime.storageManager.synced();
+
+    const demandCell = clientRuntime.getCell<{ ping: number }>(
+      homeSpace,
+      "xspace-send-demand",
+      undefined,
+    );
+    const cancel = demandCell.sink(() => {});
+    try {
+      await waitUntil(
+        () =>
+          servingRuntime !== undefined &&
+          host!.spaceServer(homeSpace)?.active === true,
+        "home space activation",
+      );
+      const serving = servingRuntime!;
+
+      // The DIRECT FOREIGN HANDLE shape (a wish-result export's
+      // `setName` stream): the sending cell's OWN space IS the foreign
+      // target space, so cell.space === resolved.space === FOREIGN.
+      const servingStream = serving.getCell<unknown>(
+        foreignSpace,
+        "xspace-send-stream",
+        undefined,
+      );
+      await servingStream.sync();
+      const homeAnchor = serving.getCell<{ n: number }>(
+        homeSpace,
+        "xspace-send-anchor",
+        undefined,
+      );
+
+      // A served event-handler run, HOME-anchored: the run's tx holds
+      // the home writer before the handler body sends (the consequenced
+      // mark's shape on a real dispatch).
+      const tx = serving.edit();
+      stampWaveRunContext(tx, {
+        actionId: "xspace-send-handler",
+        kind: "event-handler",
+        eventId: "e-xspace-send",
+        acting: { user: aliceSigner.did(), session: "sess-xspace" },
+        capabilityRef: "event-consequence:e-xspace-send",
+      });
+      homeAnchor.withTx(tx).set({ n: 1 });
+      // Pre-fix this send took the LT1 same-space arm (the axis was the
+      // sending cell's space) and its raw entries write opened a second
+      // space's writer inside the home-anchored tx — the
+      // one-tx-one-space isolation error (protocol.md §2b) killed the
+      // handler run and the emission was LOST. The axis is the wave's
+      // home space: a foreign target stages the outbox row instead.
+      servingStream.withTx(tx).send({ hello: "across" });
+      expect((await tx.commit()).error).toBeUndefined();
+
+      // The outbox delivers the append into the FOREIGN stream's
+      // sidecar, firedAt stamped from the CARRIED actor (LT5: the
+      // envelope is the producing server's service identity;
+      // admissibility and attribution from the validated carriage).
+      const fEngine = await server.engineForSpace(foreignSpace);
+      const sidecarId = streamEntriesDocId({
+        id: servingStream.getAsNormalizedFullLink().id,
+        path: [],
+      });
+      await waitUntil(
+        () => {
+          const value = readDoc(fEngine, { id: sidecarId })?.value as
+            | StreamEventsDocValue
+            | undefined;
+          return (value?.entries ?? []).some((entry) =>
+            entry.firedAt?.user === aliceSigner.did()
+          );
+        },
+        "the outbox-delivered entry with the carried actor",
+        30_000,
+      );
+      // The delivered append is an AUTHORED admission carrying an
+      // event: the arrival activates the target space's own serving
+      // loop (serving-loop.md §1's event-append criterion) — the
+      // single deriver that consequences it (protocol.md §2b's
+      // derived-into-foreign FORBIDDEN row stays intact).
+      await waitUntil(
+        () => host!.spaceServer(foreignSpace)?.active === true,
+        "the target space's activation on the delivered append",
+        30_000,
+      );
     } finally {
       cancel();
     }

--- a/packages/runner/test/executor-cross-space.test.ts
+++ b/packages/runner/test/executor-cross-space.test.ts
@@ -788,8 +788,16 @@ describe("Phase 5 cross-space serving", () => {
   it("a served run's send to a FOREIGN stream cell crosses via the outbox: LT1's same-space axis is the WAVE's home space, never the sending cell's space (LT1/LT5; events.md §2; protocol.md §2b)", async () => {
     host = newHost();
 
-    // Alice's client creates the FOREIGN stream doc natively, then
-    // demands a home doc so the HOME space activates.
+    // Alice's client demands a home doc so the HOME space activates.
+    // The client never touches the FOREIGN space: the foreign stream
+    // doc is created ENGINE-DIRECT below, so no session and no
+    // admission notice ever reaches the host for that space — it is
+    // genuinely INACTIVE until the delivered append, and the
+    // activation assertion at the end binds the carries-events
+    // admission arm (host.ts #onCommitAdmitted), not a leftover
+    // session-open activation. (Probe-verified: with a client session
+    // creating the stream doc instead, the pre-send inactive probe
+    // below fails — the space is already active before the send.)
     clientManager = SharedServerStorageManager.connectTo(server, {
       as: aliceSigner,
     });
@@ -797,19 +805,28 @@ describe("Phase 5 cross-space serving", () => {
       apiUrl: new URL(import.meta.url),
       storageManager: clientManager,
     });
-    const clientStream = clientRuntime.getCell<unknown>(
+    const streamDocId = clientRuntime.getCell<unknown>(
       foreignSpace,
       "xspace-send-stream",
       undefined,
-    );
-    await clientStream.sync();
+    ).getAsNormalizedFullLink().id;
     {
-      const tx = clientRuntime.edit();
-      clientStream.withTx(tx).setRaw({ $stream: true });
-      expect((await tx.commit()).error).toBeUndefined();
+      const fEngine = await server.engineForSpace(foreignSpace);
+      applyCommit(fEngine, {
+        sessionId: "xspace-setup",
+        space: foreignSpace,
+        principal: aliceSigner.did(),
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: streamDocId,
+            value: { value: { $stream: true } } as never,
+          }],
+        },
+      });
     }
-    await clientRuntime.storageManager.synced();
-
     const demandCell = clientRuntime.getCell<{ ping: number }>(
       homeSpace,
       "xspace-send-demand",
@@ -828,6 +845,8 @@ describe("Phase 5 cross-space serving", () => {
       // The DIRECT FOREIGN HANDLE shape (a wish-result export's
       // `setName` stream): the sending cell's OWN space IS the foreign
       // target space, so cell.space === resolved.space === FOREIGN.
+      // The serving runtime's own foreign read session is
+      // service-principal and never activates the space.
       const servingStream = serving.getCell<unknown>(
         foreignSpace,
         "xspace-send-stream",
@@ -839,6 +858,11 @@ describe("Phase 5 cross-space serving", () => {
         "xspace-send-anchor",
         undefined,
       );
+
+      // The pre-send inactive probe: the foreign space has no
+      // SpaceServer yet — what activates it below must therefore be
+      // the DELIVERED APPEND, nothing earlier.
+      expect(host!.spaceServer(foreignSpace)?.active ?? false).toBe(false);
 
       // A served event-handler run, HOME-anchored: the run's tx holds
       // the home writer before the handler body sends (the consequenced
@@ -852,12 +876,11 @@ describe("Phase 5 cross-space serving", () => {
         capabilityRef: "event-consequence:e-xspace-send",
       });
       homeAnchor.withTx(tx).set({ n: 1 });
-      // Pre-fix this send took the LT1 same-space arm (the axis was the
-      // sending cell's space) and its raw entries write opened a second
-      // space's writer inside the home-anchored tx — the
-      // one-tx-one-space isolation error (protocol.md §2b) killed the
-      // handler run and the emission was LOST. The axis is the wave's
-      // home space: a foreign target stages the outbox row instead.
+      // The routing axis under test: the emission's target space is
+      // judged against the WAVE's home space, so this foreign-handle
+      // send stages the outbox's cross-space append (events.md §2) —
+      // never a raw entries write into a second space's writer, which
+      // the one-tx-one-space rule refuses (protocol.md §2b).
       servingStream.withTx(tx).send({ hello: "across" });
       expect((await tx.commit()).error).toBeUndefined();
 
@@ -870,28 +893,39 @@ describe("Phase 5 cross-space serving", () => {
         id: servingStream.getAsNormalizedFullLink().id,
         path: [],
       });
+      const deliveredEntries = () => {
+        const value = readDoc(fEngine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return (value?.entries ?? []).filter((entry) =>
+          entry.firedAt?.user === aliceSigner.did()
+        );
+      };
       await waitUntil(
-        () => {
-          const value = readDoc(fEngine, { id: sidecarId })?.value as
-            | StreamEventsDocValue
-            | undefined;
-          return (value?.entries ?? []).some((entry) =>
-            entry.firedAt?.user === aliceSigner.did()
-          );
-        },
+        () => deliveredEntries().length > 0,
         "the outbox-delivered entry with the carried actor",
         30_000,
       );
+      // EXACTLY ONE delivery (the eventId dedupe holds), carrying the
+      // full LT5/LT6 identity: the acting session travels with the
+      // acting user.
+      expect(deliveredEntries().length).toBe(1);
+      expect(deliveredEntries()[0].firedAt?.session).toBe("sess-xspace");
       // The delivered append is an AUTHORED admission carrying an
       // event: the arrival activates the target space's own serving
-      // loop (serving-loop.md §1's event-append criterion) — the
-      // single deriver that consequences it (protocol.md §2b's
+      // loop (serving-loop.md §1's event-append criterion; the
+      // carries-events arm activates even with no client session) —
+      // the single deriver that consequences it (protocol.md §2b's
       // derived-into-foreign FORBIDDEN row stays intact).
       await waitUntil(
         () => host!.spaceServer(foreignSpace)?.active === true,
         "the target space's activation on the delivered append",
         30_000,
       );
+      // A later observation point (post-activation): the delivery is
+      // STILL exactly one entry — no duplicate landed behind the first
+      // probe.
+      expect(deliveredEntries().length).toBe(1);
     } finally {
       cancel();
     }

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -136,7 +136,7 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): six file entries (default-app, cfc-group-chat-demo, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss) — every gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): six file entries (default-app, cfc-group-chat-demo, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // File-level entries only in the --ignore flag (step entries never drop
@@ -191,6 +191,22 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     ),
     false,
   );
+  // profile-embed's entry names its CURRENT blocker, not a closed one:
+  // the §2b derivation-carriage close (2026-08-21) landed the amend
+  // crossing (send-site LT1-vs-outbox axis; the amends are durably
+  // present cross-space), so the entry's reason must now name the
+  // remaining client name-draft own-write loss — pinned so a stale
+  // re-broadening is a deliberate edit.
+  {
+    const profileEmbed = SERVER_EXECUTION_ON_SKIPS.patterns.find((skip) =>
+      skip.file === "integration/profile-embed.test.ts"
+    );
+    if (profileEmbed === undefined) {
+      throw new Error("missing profile-embed entry");
+    }
+    assertMatch(profileEmbed.reason, /NAME-DRAFT own-write loss/);
+    assertMatch(profileEmbed.reason, /2b-derivation-carriage-scope\.md/);
+  }
   // The two-browser gates RUN in the ON arm: cfc-group-chat-two-browsers
   // (fan-out stage B) and lunch-poll-vote (W3.1's S1 + the 6/6 lift).
   assertEquals(

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -276,36 +276,44 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
       file: "integration/profile-embed.test.ts",
       phase: "phase-7",
       reason: "First ON-lane CI gate (2026-08-21; skip-and-land — gates " +
-        "the FLIP, not the land), re-scoped twice by the optimize-on-main " +
-        "served-wish seat. The ORIGINAL killer — OW49, " +
-        "`assertNoDivergentIfcBranches` refusing the wish builtin's own " +
-        '`anyOf[{type:"undefined"}, <requested schema>]` /result ' +
-        "declaration — is FIXED: RULING 5 (CFC owner, 2026-08-21) narrowed " +
-        "the assert to actual ambiguity (verification-coverage.md OW49; " +
-        "runner cfc/schema-merge.ts), and 10 fresh-store live ON runs at " +
-        "the ruling head show the assert EXTINCT (0 occurrences; the wish " +
-        "UI mounts and the profile resolves every run). The lift attempt " +
-        "then surfaced the NEXT blocker: the resolved-profile AMEND steps " +
-        "are intermittently red (6/10 — setName/badge 4x, setBio 2x, " +
-        "300 s waits; passes take 19–41 s), and the amended values are " +
-        "durably ABSENT from EVERY run's store, pass and fail — the " +
-        "passing renders ride a non-durable echo. Standing signatures in " +
-        "every run: 60–70 foreign-write refusals of the home wave running " +
-        "the profile module's lifts (cf:module/…:applyInitialName, " +
-        "__cfLift_*) into the profile's own space with no §2b carriage, " +
-        "and the profile space never activates a serving wave — the " +
-        "rootcause §1 / OW45+OW31-family surface, newly REACHABLE now " +
-        "that OW49's kill is gone; row-mapping with the coordinator " +
-        "(triage: optimize/ruling5-ow49-report.md §3). NOT a demand " +
-        "hole. Gate record: docs/history/plans/server-execution-v2/" +
-        "stage-c/first-on-ci-gate.md; seat evidence: " +
-        "docs/history/plans/server-execution-v2/optimize/" +
-        "ow48-50-wish-path-report.md. " +
-        "OW48 was REFUTED as environment contamination (stale " +
-        "localhost:8000 toolshed serving pre-#6019 sources); OW50's " +
-        "failure surfacing is BUILT. Lifts when the amend-convergence " +
-        "blocker closes and the file greens ON; the flip PR needs this " +
-        "list EMPTY.",
+        "the FLIP, not the land), re-scoped THREE times as each blocker " +
+        "fell. OW49's divergent-anyOf kill: FIXED (RULING 5; " +
+        "verification-coverage.md OW49), live-extinct. The " +
+        "amend-convergence blocker (the OW45+OW31-family signature — " +
+        "amended values durably absent from EVERY store, the passing " +
+        "renders riding a non-durable echo): ROOT-CAUSED AND CLOSED by " +
+        "the §2b derivation-carriage scoping pass — ONE send-site " +
+        "defect, cell.ts's serving branch picking the LT1-vs-outbox arm " +
+        "by the sending CELL's space instead of the WAVE's home space, " +
+        "so the served saveName/saveBio handlers' sends into the " +
+        "profile's exported streams (direct foreign cell handles) " +
+        "raw-wrote the foreign space and died on the one-tx-one-space " +
+        "isolation error; the emission was lost. Fixed red-first " +
+        "(executor-cross-space.test.ts's outbox-arm pin); the amends now " +
+        "cross via the outbox with the carried actor, the profile " +
+        "space's own loop activates and derives, and the values are " +
+        "durably present in both stores — the BIO amend landed durably " +
+        "in EVERY gate run, red runs included. Evidence: docs/history/" +
+        "plans/server-execution-v2/optimize/" +
+        "2b-derivation-carriage-scope.md. REMAINING blocker (the " +
+        "re-scope): the NAME-DRAFT own-write loss — the client's " +
+        "cf-input $value write of the name draft (a plain TEST-space " +
+        "authored write) intermittently never lands as ANY commit " +
+        "(fillCfInput's host commit() resolves and verifies, yet the " +
+        "store never sees the value), so the served saveName reads an " +
+        "empty draft and correctly no-ops; 3 of 10 fresh-store gate " +
+        "runs at the fix head (300 s badge timeouts; greens take " +
+        "11-23 s; not load-correlated — a green passed at load 18 and " +
+        "reds landed at 8-15, and the BIO amend crossed durably in " +
+        "every red). OW47's family (client own-write " +
+        "durability; its cellset-lww fix landed a DIFFERENT mechanism — " +
+        "the blind-write structural read; this write dies with the " +
+        "startEditing seed echo standing on the draft doc, the " +
+        "value-consuming arm OW47 deliberately kept refusing). NOT a " +
+        "demand hole. Gate record: docs/history/plans/" +
+        "server-execution-v2/stage-c/first-on-ci-gate.md. Lifts when " +
+        "the draft-write loss closes and the file greens ON; the flip " +
+        "PR needs this list EMPTY.",
     },
     {
       file: "integration/home-profile-reload-durability.test.ts",


### PR DESCRIPTION
## Why

Under ON, a served run's `stream.send()` decided LT1-vs-outbox by comparing the resolved stream's space to the **sending cell's** space. That proxy agrees with the ruled axis — the **wave's home space** (LT1: "the SAME-SPACE server-emitted append's durable entry is a WRITE within the wave's own derived commit"; events.md §2's cross-space arm is the outbox) — on every same-space piece, and disagrees exactly on a foreign stream reached through a direct foreign cell handle: `cell.space === resolved.space === the FOREIGN space`. That is the wish-embed topology: profile-embed's served `saveName`/`saveBio` handlers send into the resolved profile's exported owner-protected streams, took the LT1 arm, raw-wrote the profile space's entries doc inside the home-anchored handler tx, and died on the one-tx-one-space isolation error (protocol.md §2b's unmarked-crossing guard, firing correctly):

```
Uncaught error in action: StorageTransactionWriteIsolationError:
Can not open transaction writer for <PROFILE> because transaction has
writer open for <TEST>
  at CellImpl.set (cell.ts:1776)  ← the LT1 arm's raw entries write
  at CellImpl.send (cell.ts:2069)
  at eval (/system/profile-embed.tsx:103)  ← saveName → setName.send
```

The emission was lost, the amend never crossed, and the client's speculative echo painted the new name with nothing durable underneath — the OW49 report §3 "amended values durably ABSENT from EVERY store, pass and fail" shape (`docs/history/plans/server-execution-v2/optimize/ruling5-ow49-report.md`). This was the profile-embed skip's named blocker and the shared refusal-layer family under home-profile.

The scoping memo (`docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md`) maps the three candidate arms against the ruled sentences — **no fork**: (a) extending §2b carriage to derivation consequences is refused by the FORBIDDEN row ("A never derives into B"; S-A's carriage is explicitly bookkeeping-family); (b) the outbox is the ruled and already-built carrier for the amend *event*; (c) the profile space's own serving loop is the single deriver that consequences it — and at this head it activates and derives (lease held, program docs landed via S-A, the initial name derived in its own wave). Only the send-site selector between two already-ruled arms was wrong.

## What Changed

- `packages/runner/src/storage/interface.ts`: `TransactionSealDestination` declares optional `readonly space` — the wave's home space (the SpaceServer and the wave accumulator already expose it structurally) — and `stageOutboundAppend?` (the send site's structural cast retired; review NOTE-3).
- `packages/runner/src/cell.ts` (serving branch): the LT1-vs-outbox arm selects on `installedSealDestination?.space`. Fail-closed (review NOTE-1): an outbox-capable destination that names no `space` is refused loudly — guessing from the cell's space is the mis-axis itself; the cell-space proxy survives only for seal-only test doubles with no outbox (same-space harnesses by construction). No production or test implementer trips the guard (SpaceServer and the wave accumulator both expose `space`; no test double carries `stageOutboundAppend`).
- **The axis change moves TWO routing cells, both deliberate** (review NOTE-2): (cell=foreign, resolved=foreign) — the defect cell — moves from the LT1 raw write (the isolation-error kill) to the outbox's cross-space append; and (cell=foreign, resolved=home) — an aliased HOME target reached through a foreign handle — moves from a self-addressed outbox row (post-commit self-delivery under the service envelope) to LT1, the ruled reading (events.md §2: a same-space emission is never a separate commit, never the outbox). The second cell's identity model changes with the move: a write-level LT1 entry inside the wave's own derived commit with the inherited actor at write level, `eventWatermark` dedupe, and same-wave in-process processing.
- Red-first pin in `packages/runner/test/executor-cross-space.test.ts`: a served event-handler-stamped, home-anchored run sends to a stream cell whose OWN space is foreign. Watched RED on the unmodified tree (the exact live `StorageTransactionWriteIsolationError` at `CellImpl.send`); GREEN with the fix — the outbox delivers EXACTLY ONE entry into the foreign sidecar with `firedAt` carrying the acting user AND session (`sess-xspace`; the LT5/LT6 carriage — review MINOR-2), and the delivered append ACTIVATES the target space's serving loop. The activation assert is bound non-vacuously (review MINOR-1 / Cubic P2 / Codex P2): the foreign stream doc is created ENGINE-DIRECT so no session or admission touches the space pre-send; a pre-send probe asserts the space INACTIVE, and that probe was watched FAILING against two weaker constructions (shared-client setup after host attach; a disposed setup client whose session lingered server-side) before the engine-direct shape made it hold — the final wait binds the carries-events admission arm (a delivered cross-space append activating a sessionless target).
- `tasks/server-execution-on-skips.ts` (+ its test): profile-embed's entry RE-SCOPED (third time, strictly smaller blocker) — the amend-crossing mechanism is closed; the remaining blocker is the client NAME-DRAFT own-write loss (OW47's family, see below). Not lifted: the gate is not 10/10.
- `docs/specs/server-side-execution/verification-coverage.md`: factual pointer on the OW49 row (the amend-convergence blocker root-caused and closed; the remaining different-family red named; closure stays the coordinator's).
- New memo: `docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md` — the determined-vs-forked analysis, the mechanism trace, the gate table, and the flagged residuals.

## Test plan

- Red-first: the new executor-cross-space pin watched failing on unmodified main (`StorageTransactionWriteIsolationError`), green with the fix.
- Executor family, one file per invocation, all green: cross-space 14, events-down 19, outbox 18, wave 43, run-supply 14, serving-loop 25, plus the full `executor-*.test.ts` sweep and the speculation suites (table below).
- `deno task check` (repo typecheck), `deno fmt --check`, `deno lint`, `check-docs-history-index`, `check-conflict-markers`, `tasks/server-execution-on-skips.test.ts` (17/17) — green.
- **Ten-run live gate** (ON binary built with the fix; per-iteration FRESH store; self-referential `API_URL`/`MEMORY_URL`; `servingLoop` posture verified per run; store durability queried, never trusted from the render):

| run | verdict | duration | "Grace Hopper" commits | "Countess" commits | lift-refusal noise | load (1/5/15m) |
|---|---|---|---|---|---|---|
| 1 | green | 23 s | 4 | 4 | 62 | (first fixed-binary run) |
| 2 | green | 17 s | 4 | 4 | 60 | 18.29 18.42 17.09 |
| 3 | RED | 312 s | 0 | 4 | 60 | 15.22 17.69 16.87 |
| 4 | green | 11 s | 4 | 4 | 86 | 15.23 14.42 15.30 |
| 5 | green | 12 s | 4 | 4 | 60 | 12.44 13.85 15.07 |
| 6 | RED | 312 s | 0 | 4 | 54 | 11.45 13.51 14.92 |
| 7 | green | 17 s | 4 | 4 | 60 | 7.79 9.73 12.63 |
| 8 | green | 16 s | 4 | 4 | 60 | 8.12 9.68 12.54 |
| 9 | RED | 313 s | 0 | 4 | 60 | 7.83 9.52 12.40 |
| 10 | green | 19 s | 4 | 4 | 60 | 7.28 9.81 11.85 |

**7 green / 3 red.** Pre-fix baseline at the same protocol (the OW49 report §3): 4/10 green with the amended values durably absent from every store even in the greens; locally reproduced pre-fix as a 5m09s red with the two isolation-error stacks.

Every green run: both amends durably present — the profile store carries the outbox-delivered authored append (`acting_principal` = the user, `capability_ref` = `stream-append:<sidecar>`) AND the profile wave's own derived consequence. Every RED run: the BIO amend is durably present cross-space (the fixed chain end to end) while the NAME never lands because the name DRAFT — a plain client `$value` write into the TEST space — never lands as ANY commit; the served `saveName` reads an empty draft and correctly no-ops. Zero isolation errors in any run: the send-site defect is extinct. The remaining red is OW47's family (client own-write durability; plausibly the value-consuming-over-standing-echo refusal the OW47 fix deliberately kept, with the served `startEditing` seed echo standing on the draft doc) — flagged for its own seat, not filled here.

## home-profile (reported, not forced)

One fresh-store ON run at the fix head (same protocol; posture verified). **Step 1 green in 8 s. Step 2 RED** at the summary's "Alan Turing" wait (5m18s) — and the store decomposes the residual:

- **The S-B durability question is ANSWERED**: every rapid-create profile space holds its PROGRAM durably (Alan's at seq 3, 124,973 B — the reload did not lose it; the old program-loss orphan class did not reproduce). Zero isolation errors (this flow crosses no amend events, so this PR's fix is not implicated either way); the 13 standing cf:module lift refusals are the same fail-closed noise.
- **The remaining blocker is an ordering race on the derivation-demand seam.** Grace's space: setup landed (seq 2) before her space's serving tenure, which derived her name (seq 5, derived-class, service holder) — the summary shows her resolved. Alan's space: a transient tenure came FIRST (watermark at seq 2), parked, and his setup landed at seq 5 while the creating client's sessions were dead mid-reload — an authored admission into a lease-less space with no live session and no events activates NOTHING (T11.Q7's designed parking), and no later trigger ever arrives. The post-reload summary reads his missing computed name through the HOME space's free cross-space read (a HOME-side wake, not target-side demand) and renders the id placeholder forever.
- What home-profile's lift needs is a ruling-shaped answer to "what demands a foreign space's underived computed for a cross-space read" — candidates visible in the ruled text: serving-loop.md §1's third, unimplemented activation trigger ("explicit warm request") issued by the reading loop for a demanded-but-underived foreign computed; a client session opened on the summarized space; or S-C-shaped healing. Flagged for the owner/coordinator, not chosen here. The committed home-profile skip reason remains accurate as written.

Do NOT merge on the green checks alone — coordinator reviews and merges (per the seat's protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
