### PR TITLE
docs(data-model): `encode()` throws a third way

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2337,7 +2337,15 @@ Encoding is specified only for a **valid `FabricValue`** — one that has
 passed, or would pass, `isValidFabricValue()` (Section 1). Given such a value,
 an engine's `encode()` produces its format's serialized form or throws for a
 reason the format names: a `FabricSpecialObject` whose class no codec in the
-registry claims, or a cycle.
+registry claims, a cycle, or an instance whose class a codec does claim but
+whose present state that format cannot write down.
+
+The third reason is why validity does not imply encodability. Whether a value
+can be written down is a question about a format, and formats differ: a
+`FabricKeyPair` holding `CryptoKey` handles crosses a realm boundary as itself
+and has no JSON form at all, its material being unreachable to anything that
+writes bytes. A format refusing such a state is meeting its contract, not
+failing it.
 
 Given anything else, **all error checking is best-effort.** The binding part
 of that is what it forbids rather than what it permits: no check on this path

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -2338,14 +2338,17 @@ passed, or would pass, `isValidFabricValue()` (Section 1). Given such a value,
 an engine's `encode()` produces its format's serialized form or throws for a
 reason the format names: a `FabricSpecialObject` whose class no codec in the
 registry claims, a cycle, or an instance whose class a codec does claim but
-whose present state that format cannot write down.
+whose present state that format cannot express.
 
-The third reason is why validity does not imply encodability. Whether a value
-can be written down is a question about a format, and formats differ: a
-`FabricKeyPair` holding `CryptoKey` handles crosses a realm boundary as itself
-and has no JSON form at all, its material being unreachable to anything that
-writes bytes. A format refusing such a state is meeting its contract, not
-failing it.
+That third reason is a carve-out, and is expected to remain rare. Validity is a
+question about a value; whether it can be written down is a question about a
+format, and the two may disagree — a class can hold a state that one format
+carries and another has no way to represent. A format refusing such a state is
+meeting its contract rather than failing it.
+
+**A class in that position says so in its own documentation.** Nothing in the
+encoding machinery enumerates which classes they are: a format knows what it
+can express, not which classes will hand it something it cannot.
 
 Given anything else, **all error checking is best-effort.** The binding part
 of that is what it forbids rather than what it permits: no check on this path

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -162,7 +162,8 @@ export abstract class BaseCodecEngine<
    * cell fails by name rather than on `undefined`.
    *
    * **The input contract.** `value` must be a valid `FabricValue`, which is
-   * the question `isValidFabricValue()` answers. Given one, this works.
+   * the question `isValidFabricValue()` answers. Given one, this encodes, or
+   * throws for one of the reasons below.
    * Given anything else, what checking happens is best-effort: nothing on
    * this path spends time on correct input in order to catch incorrect
    * input, so a non-member may encode, may encode to something wrong, or may
@@ -171,9 +172,10 @@ export abstract class BaseCodecEngine<
    * valid `FabricValue` as given.
    *
    * @throws If `value` holds something the format cannot carry: a
-   *   `FabricSpecialObject` whose class no codec in the registry claims, or a
-   *   cycle. A value that is no `FabricValue` at all falls under the input
-   *   contract above rather than here.
+   *   `FabricSpecialObject` whose class no codec in the registry claims, a
+   *   cycle, or an instance whose class a codec does claim but whose present
+   *   state this format cannot write down. A value that is no `FabricValue` at
+   *   all falls under the input contract above rather than here.
    */
   encode(
     value: FabricValue,

--- a/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
+++ b/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
@@ -77,6 +77,12 @@ type RealmHandleState = {
  * write down. It crosses a realm boundary as itself instead, structured
  * cloning carrying a `CryptoKey` with its extractability intact.
  *
+ * That refusal makes this class one of the exceptions
+ * `docs/specs/space-model-formal-spec/1-fabric-values.md` allows under
+ * `2.10 Encode Input Contract`: an instance valid as a `FabricValue`, whose
+ * class a codec in the JSON registry claims, and which that format still
+ * cannot express.
+ *
  * Immutable: instances are `Object.freeze()`-d at construction time, and the
  * material arm holds `FabricBytes`, which own their buffers outright. Instance
  * state is elided by the debug renderer, so a private key does not reach a log

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -21,7 +21,10 @@ import {
   fabricFromJsonValue,
   jsonFromFabricValue,
   plainObjectFromJson,
+  realmFromFabricValue,
 } from "@/codecs.ts";
+import { FabricKeyPair } from "@/fabric-primitives/FabricKeyPair.ts";
+import { isValidFabricValue } from "@/fabric-value.ts";
 import { JsonCodecEngine } from "@/codec-json/JsonCodecEngine.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import type { FabricValue } from "@/fabric-value.ts";
@@ -117,6 +120,46 @@ describe("codecs", () => {
     expect(jsonFromFabricValue("hello")).toBe('fvj1:"hello"');
     expect(jsonFromFabricValue(true)).toBe("fvj1:true");
     expect(jsonFromFabricValue(null)).toBe("fvj1:null");
+  });
+
+  describe("a state the format cannot write down", () => {
+    // `2.10 Encode Input Contract` names three reasons `encode()` throws for a
+    // value that is otherwise valid. This is the third: the class is claimed
+    // by a codec in the registry, and that codec refuses this instance's
+    // state. Asserted through the engine rather than the codec, because the
+    // contract the spec states is the engine's.
+    it(
+      "throws through the engine, where the format has no form for it",
+      async () => {
+        const pair = new FabricKeyPair(
+          await crypto.subtle.generateKey("Ed25519", false, [
+            "sign",
+            "verify",
+          ]) as CryptoKeyPair,
+        );
+
+        // Valid, and claimed: neither of the other two reasons applies.
+        expect(isValidFabricValue(pair)).toBe(true);
+        expect(createDefaultJsonRegistry().codecFromValue(pair)).toBeDefined();
+
+        expect(() => jsonFromFabricValue(pair)).toThrow(
+          /no JSON representation/,
+        );
+      },
+    );
+
+    it("encodes for a format that does have a form for it", async () => {
+      const pair = new FabricKeyPair(
+        await crypto.subtle.generateKey("Ed25519", false, [
+          "sign",
+          "verify",
+        ]) as CryptoKeyPair,
+      );
+
+      // The refusal is the JSON format's, not the value's: the same instance
+      // crosses a realm boundary as itself.
+      expect(() => realmFromFabricValue(pair)).not.toThrow();
+    });
   });
 
   describe("edge case", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Independent of the `FabricKeyPair` branches; based on `main`.

## The gap

`2.10 Encode Input Contract` (added by #6182) and `BaseCodecEngine.encode()`
each name two reasons a valid `FabricValue` can fail to encode: a
`FabricSpecialObject` whose class no codec claims, or a cycle. Both read as
exhaustive. Both are short by one.

Measured on `main`, a `FabricKeyPair` built from a non-extractable webcrypto
pair:

| | |
|---|---|
| `isValidFabricValue()` | `true` |
| `jsonFromFabricValue()` | **throws** — "a `CryptoKey` has no JSON representation" |
| `realmFromFabricValue()` | succeeds |

Valid, no cycle, and its class *is* claimed by a codec in the JSON registry —
that codec is the one throwing. So neither named reason applies. `encode()`'s
"Given one, this works" is false as written for that value.

Which is wrong is a real fork, and the answer is the texts, not the code:
refusing to write down a key whose material cannot be extracted is the format
meeting its contract. The predecessor was incomplete on arrival — the codec's
refusal shipped with the class, before the contract was written down — so this
is not a regression, just a sentence that never covered everything.

## What this does

- **The spec states the carve-out generically** and says it is expected to
  remain rare. It does not name an instance: which classes are in that position
  is not something the encoding machinery can know, since a format knows what it
  can express, not which classes will hand it something it cannot.
- **`FabricKeyPair` says it is one**, citing the section that allows it. That is
  where a reader meets the fact, and where it stays true on its own.
- **`BaseCodecEngine`** gains the third reason in the same generic terms, and
  loses "Given one, this works."
- Nothing in `codec-json`, `codec-common` or `codec-interface` names the
  exception; that would invert the dependency.

## The test

The behavior was pinned at the codec (`FabricKeyPair.test.ts`) and **not at the
engine**, which is the level both texts speak about. That gap is now closed.

The new test asserts the other two reasons do not apply — the value is valid,
and `codecFromValue()` finds a codec for it — so a later reader cannot mistake
it for one of those. And it asserts the same instance encodes for `codec-realm`,
which is what makes this a fact about a format rather than about the value.

Ablated: making the JSON codec encode the handles arm instead of refusing fails
the new engine-level test and the existing codec-level one, and nothing else.

## Verification

`deno task check` (41 groups), `fmt --check`, `lint`, `check-docs`,
`check-skill-facts`, `check-docs-history-index`, `check-no-waitfor`: green.
Workspace `deno task test`: all packages passing, 416s.

## One thing left alone

`codec-realm/interface.ts:43` names `FabricKeyPair` while explaining why
`CryptoKey` is in its transport union. Same shape as the rule applied here, and
pre-existing rather than anything this touches, so it is left for a decision
rather than swept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HFv1TWsCHmd525KCRJ2m8


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

