### PR TITLE
Gate chained test events on arrived consequences; settle stimulus-effect text waits

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/arrival-wait-hardening-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/arrival-wait-hardening-report.md
@@ -1,3 +1,10 @@
+---
+status: historical
+created: 2026-08-22
+archived: 2026-08-22
+reason: "Arrival-wait hardening: the reopened ON-lane group-chat 'cross-session arrival' flakes (census items 1+3, runs 32543810077/32547606642) were never the arrival wait — the test's chained draft→trusted-send events raced cross-stream serve order (unpromised, events.md §2) and the served handler no-oped silently on a pre-draft view. Fix: an event-driven arrived-consequence gate (overlay waitForIntentQuiescence / harness awaitEventConsequences) between chained events, a deterministic delay-injected pin, and settled-text conversions for the staged-publish/spec-gallery browser members (census item 2). No timeout changed."
+---
+
 # Arrival-wait hardening: the reopened ON-lane flake cluster
 
 Optimize-on-main pass, 2026-08-22. The reopened group-chat
@@ -54,7 +61,7 @@ honest; the write it awaited never happened. Mechanism:
   (`prepareTrustedMessageSend` returns null on a blank draft — by
   design; same shape in `commitTrustedProfileSave` and
   `prepareTrustedRoomAdd`).
-- events.md §4 rules serve ordering: *"per stream, events process in
+- events.md §2 rules serve ordering: *"per stream, events process in
   commit-seq order. Across streams in one space, wave order (arrival).
   No global ordering claim."* The two events live on different
   streams, so nothing promises the draft's consequence is applied
@@ -70,7 +77,15 @@ honest; the write it awaited never happened. Mechanism:
   why the browser test's OW47 S-G fix was precisely "wait
   `waitForDisabled(false)` before Bob's click". The multi-runtime
   helpers had no equivalent gate — they fired the trusted action into
-  a UI-impossible window.
+  a UI-impossible window. The UI's protection is in fact STRONGER than
+  the enablement read: the UI writes the draft through the cf-input
+  `$value` BINDING — an authored client commit, transport-ordered
+  before the click's event append on the same socket — not through a
+  `setMessageDraft` event, so the served handler's read view includes
+  the draft regardless of enablement timing; the enablement-read
+  framing alone would not cover a hypothetical pattern whose
+  precondition is handler-written and whose control enables off the
+  speculative echo, and no such flow exists in this pattern.
 
 **Product verdict: not a product regression.** The server served both
 events within its ruled contract; the test manufactured an ordering

--- a/docs/history/plans/server-execution-v2/optimize/arrival-wait-hardening-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/arrival-wait-hardening-report.md
@@ -1,0 +1,255 @@
+# Arrival-wait hardening: the reopened ON-lane flake cluster
+
+Optimize-on-main pass, 2026-08-22. The reopened group-chat
+"cross-session arrival" flakes (the owner's 2026-08-21 ON-flake census,
+items 1+3) plus the staged-publish/spec-gallery stage-text timeouts
+(census item 2 / the 2026-08-20 attribution ledger). Branch
+`claude/server-exec-v2-arrival-wait-hardening`.
+
+## 1. The motivating receipts
+
+`cfc-group-chat-demo-multi-runtime.test.ts`, step "admin lockdown gates
+room creation but never message sending", assertion `Timed out waiting
+for: bob's post-lockdown message arrives at alice`
+(`MultiRuntimeHarness.waitFor`, 30 s), failed IDENTICALLY twice on
+2026-08-21/22 in "Pattern Integration Tests / server-execution ON
+(7/10)":
+
+- main run **32543810077** (head `58e2657e7`, docs-only; job
+  96958763640);
+- PR #6186 run **32547606642** (job 96968958739 — the diff exonerated
+  by the attribution ritual).
+
+Main's next run (`b775787b6`) was green. These failures POST-date
+\#6158's merge, so they survive the OW52 settle fix — whose report's §7
+addendum had claimed coverage of exactly this census item on the
+mechanism argument "the former poll race is now an event-driven wait at
+the settle layer". That claim is corrected below.
+
+## 2. What the failing log actually shows (root cause)
+
+The job 96958763640 log, read against the OW52 machinery's designed
+self-identification:
+
+- **Zero `event-consequence quiescence budget exhausted` warnings.**
+  \#6158's settle warns loudly whenever a poll round's budget elapses
+  with intents outstanding. Its absence means every settle round inside
+  the failing 30 s found `pendingIntentCount == 0` promptly — bob's
+  send event HAD its terminal consequence, arrived back, early in the
+  window. Not a slow serving drain.
+- **The failing step's entire 30 s window is silent** — no scheduler
+  errors, no conflicts, no CFC-rejection markers.
+- **The immediately following step passed in 730 ms**, and it contains
+  a bob→alice arrival of its own (the room bob adds once admin reaches
+  alice's list). Cross-runtime propagation was healthy seconds after
+  the "missing" message.
+
+So the message was not slow — it was **never appended**. The wait was
+honest; the write it awaited never happened. Mechanism:
+
+- The test's `sendMessage` helper chains TWO events:
+  `setMessageDraft` (stream A) then `sendTrustedMessage` (stream B,
+  trusted click). The served send handler reads the draft cell and
+  **silently no-ops when it reads it empty**
+  (`prepareTrustedMessageSend` returns null on a blank draft — by
+  design; same shape in `commitTrustedProfileSave` and
+  `prepareTrustedRoomAdd`).
+- events.md §4 rules serve ordering: *"per stream, events process in
+  commit-seq order. Across streams in one space, wave order (arrival).
+  No global ordering claim."* The two events live on different
+  streams, so nothing promises the draft's consequence is applied
+  before the send is served once both are pending — and under CI load
+  (a busy serving loop right after the lockdown toggle's derivation
+  storm) both ARE pending together.
+- Served against a pre-draft view, the send terminalizes cleanly as a
+  no-op: intent consequenced, quiescence clean, nothing logged, nothing
+  to arrive, next step healthy. Exactly the observed signature.
+- The real UI cannot produce this interleaving: the trusted send
+  control is DISABLED until the draft state the clicking session sees
+  is non-empty (`sendDisabled` derives from the draft read), which is
+  why the browser test's OW47 S-G fix was precisely "wait
+  `waitForDisabled(false)` before Bob's click". The multi-runtime
+  helpers had no equivalent gate — they fired the trusted action into
+  a UI-impossible window.
+
+**Product verdict: not a product regression.** The server served both
+events within its ruled contract; the test manufactured an ordering
+dependence the spec explicitly declines to promise. (This sharpens,
+rather than contradicts, the census's "load-sensitive test-wait race"
+framing: the race is BEFORE the awaited arrival — between the chained
+events — not in the arrival wait itself. No widening of the arrival
+wait could ever have fixed it, which is also why the flake survived
+OW52.)
+
+## 3. The honest signal, and why it cannot deadlock or pass vacuously
+
+The gate a test needs between two chained events is the first event's
+**terminal consequence having arrived back at the firing session** —
+speculation.md §4 step 2's retirement, the outstanding-intent set the
+overlay maintains. Once the consequence has arrived back, its commit is
+in the space's history, so any LATER-fired event is served against a
+view that includes it (the serving replica produced that consequence
+itself). This is the same signal the real UI's enablement gate encodes,
+and one the harness already trusted for `settle()` (OW52).
+
+Made available in three layers, each event-driven:
+
+- **`SpeculationOverlayDestination.waitForIntentQuiescence()`** (new,
+  runner): resolves when the outstanding-intent set EMPTIES, settled by
+  the same `#untrackIntent` step that retires the last intent;
+  immediate when nothing is outstanding; settled on overlay close.
+  First-order only, like the count it mirrors (a server-side cascade
+  child is no client's intent). Pinned in
+  `speculation-intent-listener.test.ts` with its killing mutation
+  (flush on every untrack instead of on empty → the pin's
+  mid-retirement flag assertion goes red; verified red under the
+  mutation, green reverted).
+- **`MultiRuntimeSession.awaitEventConsequences()`** (harness): awaits
+  the overlay waiter; instant on the OFF arm (no overlay); backstopped
+  by the harness's pre-existing 120 s RPC bound, which names the
+  session and command — so a genuinely wedged consequence fails
+  LOUDLY at the true blocked seam instead of as a downstream arrival
+  lie. The worker's budgeted `eventQuiescence` (settle's arm) keeps
+  its exact semantics but now races the same event-driven waiter
+  against its budget timer instead of polling `pendingIntentCount` on
+  a 25 ms tick.
+- **The group-chat helpers** (`saveProfile`, `sendMessage`, `addRoom`)
+  gate between the draft event and the trusted action. The arrival
+  `waitFor`s are UNTOUCHED — with the race removed they are back to
+  being the doctrine-sanctioned cross-runtime convergence polls, and
+  their 30 s bound remains the failure bound. **No timeout was raised,
+  lowered, added, or removed anywhere in this pass.**
+
+Deadlock: every terminal kind (consequenced, errored, dropped, refused)
+untracks, and close flushes waiters, so the gate resolves in every
+product state except a truly wedged consequence — where the RPC bound
+speaks with a name. Vacuity: the gate waits on the PRECONDITION event,
+never on the awaited arrival, so it cannot mask loss — with the gate in
+place, suppressing the delivery (the neutered-gate mutation below, or
+any real served-write loss) still times the arrival wait out red.
+
+## 4. Deterministic reproduction (delay injection at the racy seam)
+
+Load-statistical repro was not attempted; the seam admits a
+deterministic one, per the arc's dismiss-listener precedent. Topology:
+two sessions of ONE user (the draft is PerUser, so both see it — two
+tabs), the draft-writing session's WebSocket delayed 300 ms
+(`wsDelayMs`, the harness's existing shaping shim), the draft fired
+with `idle: false` so it is provably in flight when the other session
+fires the trusted send.
+
+- **Ungated (the red half, watched): 2/2 failures**, ~43 s each,
+  `Timed out waiting for: the chained message arrives back at the
+  sender`, quiescence clean, zero errors — byte-for-byte the CI
+  signature. (Run as a scratch variant in this worktree against a
+  fresh ON toolshed at :8891; deleted after recording.)
+- **Gated (`awaitEventConsequences` between the events): 3/3 green**,
+  14–18 s.
+- **Committed pin**:
+  `integration/cfc-group-chat-chained-event-gate-multi-runtime.test.ts`,
+  two steps under the delayed topology: (1) the UI-enablement gate
+  (sender fires only after ITS OWN read shows the draft) — both arms;
+  (2) `awaitEventConsequences` ALONE suffices — ON arm (self-skips
+  OFF with a logged line: the primitive is ON-only; OFF runs the
+  handler in the firing session, so writer-side quiescence orders
+  nothing there).
+- **Mutation (vacuity check both directions)**: neutering the worker's
+  `awaitEventConsequences` to resolve early → step 2 fails
+  deterministically at 30 s with the CI signature while step 1 (its
+  own gate) stays green; the overlay pin's flush-on-every-untrack
+  mutation likewise goes red. Which-direction: the gate is a pure
+  wait — it re-issues nothing and cannot double-apply.
+
+## 5. The family: hardened vs left with receipts
+
+Hardened:
+
+- `cfc-group-chat-demo-multi-runtime.test.ts` — the three chained-event
+  helpers gated (covers census items 1 and 3: the harness-sanity and
+  admin-lockdown message arrivals, the grant-admin step's room chain —
+  and strengthens the negative "bob's rejected add" assert, which an
+  empty-draft no-op could previously satisfy while masking a broken
+  admin gate).
+- `cfc-group-chat-chained-event-gate-multi-runtime.test.ts` — new
+  deterministic pin (above).
+- `cfc-staged-publish.test.ts` (census item 2) — its four post-click
+  plain `waitForText` waits → `waitForSettledText`. The ledgered
+  "#stage-pill → saved" 5 m timeouts are the doctrine's named trap
+  verbatim: the pill text is the EFFECT of the trusted click's served
+  round trip, an integration test holds no UI subscription, and a
+  plain DOM watch cannot pump the page's own pending pull work — the
+  state sits one settle away from being drawn until the
+  stuck-condition net fires (waiting-in-tests.md, "Waiting for a
+  click's effect"). The settling wait is the prescribed shape (the
+  lunch-poll test already uses it for every cross-browser wait);
+  genuinely absent server state still fails it, so no loss is masked.
+- `cfc-spec-gallery.test.ts` — same swap for its seven stage-indicator
+  waits (the ledger's third member: one occurrence on main's own
+  `e04fb3460` run).
+
+Left as-is, with the reason on record:
+
+- `cfc-group-chat-demo-two-browsers.test.ts`'s plain cross-browser
+  `waitForText` calls (`#trusted-conversation-preview`,
+  `#rooms-panel`): the same latent trap shape, but they sit inside the
+  chat-series/propagation TIMING instrumentation (a load observation,
+  never a gate, per the sx2 ruling) — converting them changes what the
+  series measures (arrival+pump instead of passive render), and the
+  file carries no receipts in tonight's cluster. Flagged, not filled.
+  Its interaction gates (`waitForDisabled` before every send/add
+  click) already encode the enablement contract.
+- `cfc-group-chat-demo.test.ts` (single-browser): ON-skip-listed
+  (OW31's carriage residual), OFF-safe by in-process ordering; not
+  touched.
+- Other post-click plain `waitForText` sites across the suite
+  (`counter`, `cf-render`, `cf-checkbox`, …): same doctrinal shape,
+  zero flake receipts; left for a doctrine-driven sweep of their own
+  rather than riding this fix.
+- The step's OTHER wait class (derived-state readbacks like
+  `currentUserIsAdmin` after a toggle): single-event, no chained
+  precondition, correctly served by the sanctioned convergence poll;
+  untouched.
+
+Recorded in passing (not this cluster): the failing run's harness
+bootstrap logged one `piece-start-commit-failed` ConflictError
+(piece-instantiate, stale confirmed read seq 0 vs 9) ~35 s before the
+failure, during `openPiece` of a session racing the server's own
+derived commits — benign for this cluster (all seven steps' state
+flowed), noted for whoever owns the piece-start path.
+
+## 6. Verification
+
+All local against a fresh ON toolshed from source (:8891,
+`EXPERIMENTAL_SERVER_EXECUTION=true`, `servingLoop` verified non-null);
+OFF = the harness's self-hosted standalone server:
+
+- `speculation-intent-listener.test.ts`: green (3 tests / 20 steps),
+  and the FULL runner suite green with the overlay change (1273 tests /
+  7302 steps, 10m49s; the lone red in that run was the new pin's own
+  immediate-resolve probe racing a bare resolved sentinel — a
+  microtask-order probe bug, fixed in the pin, file re-run green).
+- `cfc-group-chat-demo-multi-runtime.test.ts`: 7/7 ON (16 s), 7/7 OFF.
+- New pin file: 2/2 ON, 2/2 OFF (step 2 self-skip line printed).
+- Harness family under the worker change: `convergence-storm` 4/4 ON;
+  `cellset-lww` 4/4 ON; `data-file-multi-runtime` 2/2 ON.
+- `deno check` clean on every changed file; `check-no-waitfor` green
+  (no new polling `waitFor`; the new pin file waits through the
+  harness's own primitives).
+- Browser halves (`cfc-staged-publish`, `cfc-spec-gallery`): the swap
+  is the doctrine's drop-in (same signature, same helper family the
+  lunch-poll test uses); a local browser run needs a felt-built ON
+  shell this pass did not stand up, so their behavioral verification
+  rides the PR's ON/OFF pattern lanes — read those lanes before
+  merging, per the merge ritual.
+
+## 7. Register / prior-report reconciliation
+
+- The OW52 report's §7 addendum ("this fix covers them", of census
+  items 1+3) is CORRECTED by a dated note pointing here: the settle
+  fix covers the mid-drain read race it was built for; tonight's
+  receipts show the census flakes were the chained-event serve race,
+  which no settle can close (the no-op is terminal before any wait
+  begins).
+- The register's OW52 row closure STANDS (the storm-loss triage was
+  and remains correct); a dated addendum sentence on the row carries
+  the same correction.

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -265,7 +265,7 @@ failing logs carry ZERO quiescence-budget warnings — every settle round
 found the intent set already empty, so the settle race this fix closes
 was not what failed. The census's group-chat flakes were a DIFFERENT
 race: the test's chained draft→trusted-send events land on different
-streams, cross-stream serve order is unpromised (events.md §4), and the
+streams, cross-stream serve order is unpromised (events.md §2), and the
 served trusted handler silently no-ops on a pre-draft view — the
 awaited message is never appended, terminally, before any wait begins,
 so no settle (and no timeout) could ever observe it. This fix's settle

--- a/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow52-storm-loss-report.md
@@ -257,3 +257,19 @@ the full file — both census tests included, 7 steps per run —
 6–17 s per run, zero quiescence-budget warnings. The census's
 load-dependence caveat applies to any local bench; the mechanism
 coverage above is the primary argument, the 24/24 the corroboration.
+
+**CORRECTION (2026-08-22): this addendum's coverage claim is
+falsified.** The identical failure recurred twice POST-merge (main run
+32543810077 at a docs-only head; PR #6186 run 32547606642), and the
+failing logs carry ZERO quiescence-budget warnings — every settle round
+found the intent set already empty, so the settle race this fix closes
+was not what failed. The census's group-chat flakes were a DIFFERENT
+race: the test's chained draft→trusted-send events land on different
+streams, cross-stream serve order is unpromised (events.md §4), and the
+served trusted handler silently no-ops on a pre-draft view — the
+awaited message is never appended, terminally, before any wait begins,
+so no settle (and no timeout) could ever observe it. This fix's settle
+mechanism remains correct for the mid-drain read race it was built for
+(the storm shape above). The chained-event race is root-caused, made
+deterministic, and closed in
+[`arrival-wait-hardening-report.md`](arrival-wait-hardening-report.md).

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5495,6 +5495,23 @@ supply; OW29/OW32/OW34 closed):
     intent-quiescence barrier under ON (OFF's idle implies own-send
     consequence visibility; ON's does not) — a spec question beside
     OW47's pending-commit-barrier seat, surfaced in the report.
+    ADDENDUM (2026-08-22, arrival-wait-hardening pass): the report's
+    §7 claim that this fix also covered the census's group-chat
+    waitFor flakes (items 1+3) is CORRECTED — those recurred
+    post-merge with quiescence clean (runs 32543810077 /
+    32547606642) and were a different race entirely: the test's
+    chained draft→trusted-send events, on different streams with
+    cross-stream serve order unpromised (events.md §4), let the
+    served handler no-op SILENTLY on a pre-draft view, so the
+    awaited write never existed — terminal before any wait began.
+    Root-caused, made deterministic (delay injection at the seam),
+    and closed — helper gates on the arrived-consequence signal
+    (`SpeculationOverlayDestination.waitForIntentQuiescence` /
+    `MultiRuntimeSession.awaitEventConsequences`, pinned both with
+    killing mutations), plus the staged-publish / spec-gallery
+    settled-text conversions (the ledger's browser members) — in
+    `optimize/arrival-wait-hardening-report.md`. This row's own
+    closure (the storm-loss triage and the settle fix) STANDS.
   - **OW53 — the sqlite multi-runtime identity pair under ON.** Two
     semantic asserts under the TRUE ON topology: db-owner — a SECOND
     user's runtime re-mints itself as the sqlite db handle owner

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5501,7 +5501,7 @@ supply; OW29/OW32/OW34 closed):
     post-merge with quiescence clean (runs 32543810077 /
     32547606642) and were a different race entirely: the test's
     chained draft→trusted-send events, on different streams with
-    cross-stream serve order unpromised (events.md §4), let the
+    cross-stream serve order unpromised (events.md §2), let the
     served handler no-op SILENTLY on a pre-draft view, so the
     awaited write never existed — terminal before any wait began.
     Root-caused, made deterministic (delay injection at the seam),

--- a/packages/patterns/integration/cfc-group-chat-chained-event-gate-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-chained-event-gate-multi-runtime.test.ts
@@ -4,7 +4,7 @@
  * A trusted action whose SERVED handler reads a precondition cell
  * written by an immediately-preceding event (draft → trusted send) is
  * racy by design under ON: events on different streams have no
- * cross-stream serve-order guarantee (events.md §4 — per stream,
+ * cross-stream serve-order guarantee (events.md §2 — per stream,
  * commit-seq order; across streams, no claim), and the group-chat
  * handlers silently no-op on an empty draft
  * (`prepareTrustedMessageSend` returns null). The real UI forbids the
@@ -113,8 +113,10 @@ describe("group chat chained-event gates across sessions", () => {
   }
 
   it("firing the trusted send once the SENDER observes the draft appends the message (the UI-enablement gate, both arms)", async () => {
-    const h = await ensureHarness();
     try {
+      // Inside the try: a harness-creation throw must still hit this
+      // step's dispose arm rather than leak workers and sockets.
+      const h = await ensureHarness();
       await writer.send("setMessageDraft", "Observed body", undefined, {
         idle: false,
       });
@@ -144,8 +146,9 @@ describe("group chat chained-event gates across sessions", () => {
   });
 
   it("awaitEventConsequences alone is a sufficient gate under ON (the overlay primitive the same-session helpers rely on)", async () => {
-    const h = await ensureHarness();
     try {
+      // Inside the try for the same leak-safety as step 1.
+      const h = await ensureHarness();
       if (!SERVER_EXECUTION_ON) {
         // The primitive being pinned is the speculation overlay's
         // intent quiescence, which exists only on the ON arm; under OFF

--- a/packages/patterns/integration/cfc-group-chat-chained-event-gate-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-chained-event-gate-multi-runtime.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The chained-event serve-order gate, pinned deterministically.
+ *
+ * A trusted action whose SERVED handler reads a precondition cell
+ * written by an immediately-preceding event (draft → trusted send) is
+ * racy by design under ON: events on different streams have no
+ * cross-stream serve-order guarantee (events.md §4 — per stream,
+ * commit-seq order; across streams, no claim), and the group-chat
+ * handlers silently no-op on an empty draft
+ * (`prepareTrustedMessageSend` returns null). The real UI forbids the
+ * racy interleaving — the trusted control stays disabled until the
+ * draft state the CLICKING session sees is non-empty — so tests must
+ * gate the same way. Ungated, the race reproduced nightly under CI
+ * load (2026-08-22, runs 32543810077 / 32547606642: "bob's
+ * post-lockdown message arrives at alice" timing out with quiescence
+ * clean and zero errors — the message was never appended, not slow).
+ *
+ * This file makes the race DETERMINISTIC instead of load-statistical:
+ * two sessions of one user (the draft is PerUser, so both see it), the
+ * draft-writing session's WebSocket delayed by 300 ms, and the draft
+ * fired with `idle: false` so it is provably still in flight when the
+ * other session acts. Delay injection at the racy seam — the
+ * repository's standard for pinning a load flake. Ungated, this
+ * topology fails 2/2 with the exact CI signature (recorded in
+ * docs/history/plans/server-execution-v2/optimize/
+ * arrival-wait-hardening-report.md); the two steps below pin the two
+ * honest gates that close it.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
+import { experimentalOptionsFromEnv } from "@commonfabric/runner";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const PROFILE_SURFACE = "TrustedGroupChatProfileSurface";
+const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
+const SEND_SURFACE = "TrustedGroupChatSendSurface";
+const SEND_ACTION = "TrustedGroupChatSendMessage";
+
+const PROGRAM_PATH = join(
+  import.meta.dirname!,
+  "..",
+  "cfc-group-chat-demo",
+  "main.tsx",
+);
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+// The resolved posture, exactly as the harness resolves it (canonical
+// env mapping, else the first-party default). Step 2 pins an ON-only
+// primitive and self-skips on the OFF arm.
+const SERVER_EXECUTION_ON =
+  experimentalOptionsFromEnv(Deno.env.get).serverExecution ??
+    SERVER_EXECUTION_DEFAULT_ENABLED;
+
+async function fireTrustedSend(session: MultiRuntimeSession): Promise<void> {
+  await session.send("sendTrustedMessage", {}, {
+    surface: SEND_SURFACE,
+    action: SEND_ACTION,
+  });
+}
+
+async function messageBodies(session: MultiRuntimeSession): Promise<string[]> {
+  return (((await session.read(["messages"])) as any[]) ?? [])
+    .map((m) => m?.body);
+}
+
+describe("group chat chained-event gates across sessions", () => {
+  let harness: MultiRuntimeHarness | undefined;
+  let sender: MultiRuntimeSession;
+  let writer: MultiRuntimeSession;
+
+  // One harness for both steps (they share the saved profile); built in
+  // the first step rather than beforeAll so a create failure names the
+  // step. Sessions: same user twice — the draft is PerUser, so the
+  // writer's draft is the sender's draft, like two tabs of one user.
+  async function ensureHarness(): Promise<MultiRuntimeHarness> {
+    if (harness !== undefined) return harness;
+    const alice = await Identity.fromPassphrase("chained-event-gate alice", {
+      implementation: "noble",
+    });
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      sessions: [
+        { label: "sender", identity: alice },
+        // Every frame on the writer's socket (both directions) is
+        // delayed, so a fire-and-continue draft is deterministically
+        // still in flight when the sender acts.
+        { label: "writer", identity: alice, wsDelayMs: 300 },
+      ],
+    });
+    sender = harness.session("sender");
+    writer = harness.session("writer");
+
+    // Profile first — the send handler also no-ops without one — gated
+    // and awaited, so the draft is the only variable in the steps.
+    await sender.send("setProfileDraft", "Alice");
+    await sender.awaitEventConsequences();
+    await sender.send("saveProfile", {}, {
+      surface: PROFILE_SURFACE,
+      action: SAVE_PROFILE_ACTION,
+    });
+    await harness.waitFor(
+      "alice's profile is saved",
+      async () => (await sender.read(["currentProfileName"])) === "Alice",
+    );
+    return harness;
+  }
+
+  it("firing the trusted send once the SENDER observes the draft appends the message (the UI-enablement gate, both arms)", async () => {
+    const h = await ensureHarness();
+    try {
+      await writer.send("setMessageDraft", "Observed body", undefined, {
+        idle: false,
+      });
+      // The real UI's gate: the clicking session's own view of the draft
+      // is non-empty (the send button's disabled state derives from
+      // exactly this read). Under ON, sender-visibility implies the
+      // draft's commit is in the space's history; under OFF it implies
+      // the sender's local handler will read it. Both arms ordered.
+      await h.waitFor(
+        "the sender observes the chained draft",
+        async () => (await sender.read(["messageDraft"])) === "Observed body",
+      );
+      await fireTrustedSend(sender);
+      await h.waitFor(
+        "the observed-draft message arrives at both sessions",
+        async () =>
+          (await messageBodies(sender)).includes("Observed body") &&
+          (await messageBodies(writer)).includes("Observed body"),
+      );
+    } catch (error) {
+      // Dispose AND forget: the next step must not reuse a disposed
+      // harness (it re-creates instead).
+      await harness?.dispose();
+      harness = undefined;
+      throw error;
+    }
+  });
+
+  it("awaitEventConsequences alone is a sufficient gate under ON (the overlay primitive the same-session helpers rely on)", async () => {
+    const h = await ensureHarness();
+    try {
+      if (!SERVER_EXECUTION_ON) {
+        // The primitive being pinned is the speculation overlay's
+        // intent quiescence, which exists only on the ON arm; under OFF
+        // the handler runs in the FIRING session's own runtime, so
+        // consequence-arrival at the writer orders nothing for the
+        // sender — the step above carries the OFF arm.
+        console.log(
+          "[chained-event-gate] OFF arm: awaitEventConsequences step " +
+            "self-skips (no overlay; the primitive is ON-only)",
+        );
+        return;
+      }
+      await writer.send("setMessageDraft", "Quiescence body", undefined, {
+        idle: false,
+      });
+      // The overlay gate: the draft event's terminal consequence has
+      // arrived back at the writer, so its commit is in the space's
+      // history — every later-fired event is served against a view
+      // that includes it. No sender-visibility wait: this step's teeth
+      // are that the primitive ALONE suffices (sabotage it to resolve
+      // early and the 300 ms delay makes this step fail
+      // deterministically with the CI signature).
+      await writer.awaitEventConsequences();
+      await fireTrustedSend(sender);
+      await h.waitFor(
+        "the quiescence-gated message arrives at both sessions",
+        async () =>
+          (await messageBodies(sender)).includes("Quiescence body") &&
+          (await messageBodies(writer)).includes("Quiescence body"),
+      );
+    } finally {
+      await harness?.dispose();
+      harness = undefined;
+    }
+  });
+});

--- a/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
@@ -57,11 +57,29 @@ async function createGroupChatHarness(): Promise<MultiRuntimeHarness> {
   });
 }
 
+// Each helper below chains TWO events: a draft write, then a trusted
+// action whose served handler reads that draft — and silently no-ops
+// when it reads it empty (`prepareTrustedMessageSend` and friends
+// return null on a blank draft). Events on DIFFERENT streams have no
+// cross-stream serve-order guarantee (events.md §4: per stream,
+// commit-seq order; across streams, no claim), so under ON a loaded
+// serving loop can serve the trusted action against a pre-draft view —
+// the action terminalizes cleanly as a no-op, and a downstream arrival
+// wait then times out on a write that never happened (the 2026-08-22
+// ON-lane flake: runs 32543810077 and 32547606642, quiescence clean,
+// zero errors, next step healthy). The real UI forbids that
+// interleaving — the trusted control stays disabled until the SERVED
+// draft state round-trips (the browser test waits `waitForDisabled`,
+// OW47 S-G) — so these helpers gate the same way: fire the trusted
+// action only after the draft event's terminal consequence has arrived
+// back at this session (`awaitEventConsequences`), which puts the
+// draft's commit in the space's history before the action is served.
 async function saveProfile(
   session: MultiRuntimeSession,
   name: string,
 ): Promise<void> {
   await session.send("setProfileDraft", name);
+  await session.awaitEventConsequences();
   await session.send("saveProfile", {}, {
     surface: PROFILE_SURFACE,
     action: SAVE_PROFILE_ACTION,
@@ -73,6 +91,7 @@ async function sendMessage(
   body: string,
 ): Promise<void> {
   await session.send("setMessageDraft", body);
+  await session.awaitEventConsequences();
   await session.send("sendTrustedMessage", {}, {
     surface: SEND_SURFACE,
     action: SEND_ACTION,
@@ -84,6 +103,7 @@ async function addRoom(
   name: string,
 ): Promise<void> {
   await session.send("setRoomDraft", name);
+  await session.awaitEventConsequences();
   await session.send("addTrustedRoom", {}, {
     surface: ROOM_SURFACE,
     action: ADD_ROOM_ACTION,

--- a/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
@@ -61,7 +61,7 @@ async function createGroupChatHarness(): Promise<MultiRuntimeHarness> {
 // action whose served handler reads that draft — and silently no-ops
 // when it reads it empty (`prepareTrustedMessageSend` and friends
 // return null on a blank draft). Events on DIFFERENT streams have no
-// cross-stream serve-order guarantee (events.md §4: per stream,
+// cross-stream serve-order guarantee (events.md §2: per stream,
 // commit-seq order; across streams, no claim), so under ON a loaded
 // serving loop can serve the trusted action against a pre-draft view —
 // the action terminalizes cleanly as a no-op, and a downstream arrival

--- a/packages/patterns/integration/cfc-spec-gallery.test.ts
+++ b/packages/patterns/integration/cfc-spec-gallery.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./pieces-controller.ts";
 import {
   clickTrustedActionAndWaitForText,
-  waitForText,
+  waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -77,14 +77,21 @@ describe("cfc spec gallery integration test", () => {
       "#trusted-forward-prepared",
       "Prepared for",
     );
-    await waitForText(page, "#forward-stage", "prepared");
+    // Settled waits throughout: every stage indicator below is the
+    // EFFECT of the preceding trusted click's served round trip, and a
+    // plain DOM watch cannot pump the page's own pending pull work —
+    // the state can sit one settle away from being drawn until the
+    // stuck-condition net fires (docs/development/waiting-in-tests.md;
+    // the cfc-staged-publish/#stage-pill and this file's own ON-lane
+    // occurrence in the 2026-08-20 attribution ledger were this shape).
+    await waitForSettledText(page, "#forward-stage", "prepared");
     await clickTrustedActionAndWaitForText(
       page,
       "TrustedForwardNote",
       "#trusted-forward-result",
       "Only the bounded itinerary excerpt will be forwarded.",
     );
-    await waitForText(page, "#forward-stage", "forwarded");
+    await waitForSettledText(page, "#forward-stage", "forwarded");
 
     await clickTrustedActionAndWaitForText(
       page,
@@ -92,21 +99,21 @@ describe("cfc spec gallery integration test", () => {
       "#research-stage",
       "captured",
     );
-    await waitForText(page, "#research-stage", "captured");
+    await waitForSettledText(page, "#research-stage", "captured");
     await clickTrustedActionAndWaitForText(
       page,
       "TrustedPrepareResearchBrief",
       "#trusted-command-prepared",
       "Prepared outbound",
     );
-    await waitForText(page, "#research-stage", "prepared");
+    await waitForSettledText(page, "#research-stage", "prepared");
     await clickTrustedActionAndWaitForText(
       page,
       "TrustedAuthorizeResearchSend",
       "#trusted-command-result",
       "Authorized outbound message",
     );
-    await waitForText(page, "#research-stage", "sent");
+    await waitForSettledText(page, "#research-stage", "sent");
 
     await clickTrustedActionAndWaitForText(
       page,
@@ -114,14 +121,14 @@ describe("cfc spec gallery integration test", () => {
       "#trusted-safe-link-prepared",
       "?view=summary",
     );
-    await waitForText(page, "#safe-link-stage", "prepared");
+    await waitForSettledText(page, "#safe-link-stage", "prepared");
     await clickTrustedActionAndWaitForText(
       page,
       "TrustedReleaseSafeLink",
       "#trusted-safe-link-result",
       "?view=summary",
     );
-    await waitForText(page, "#safe-link-stage", "released");
+    await waitForSettledText(page, "#safe-link-stage", "released");
   });
 
   it("renders disclaimer-style labels without a trusted click", async () => {

--- a/packages/patterns/integration/cfc-staged-publish.test.ts
+++ b/packages/patterns/integration/cfc-staged-publish.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   clickTrustedActionAndWaitForText,
   fillCfInput,
-  waitForText,
+  waitForSettledText,
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
@@ -89,7 +89,14 @@ describe("cfc staged publish integration test", () => {
       "#saved-title",
       "Launch checklist",
     );
-    await waitForText(page, "#stage-pill", "saved");
+    // Settled waits throughout: each pill/body text is the EFFECT of the
+    // trusted click's served round trip, and a plain DOM watch cannot
+    // pump the page's own pending pull work — the state can sit one
+    // settle away from being drawn until the stuck-condition net fires
+    // (docs/development/waiting-in-tests.md; the ON-lane "#stage-pill →
+    // saved" 5 m timeouts in the 2026-08-20 attribution ledger were this
+    // wait). The settle is the pump; absent server state still fails.
+    await waitForSettledText(page, "#stage-pill", "saved");
 
     await clickTrustedActionAndWaitForText(
       page,
@@ -97,7 +104,7 @@ describe("cfc staged publish integration test", () => {
       "#reviewed-title",
       "Launch checklist",
     );
-    await waitForText(page, "#stage-pill", "reviewed");
+    await waitForSettledText(page, "#stage-pill", "reviewed");
 
     await clickTrustedActionAndWaitForText(
       page,
@@ -105,8 +112,8 @@ describe("cfc staged publish integration test", () => {
       "#published-title",
       "Launch checklist",
     );
-    await waitForText(page, "#stage-pill", "published");
-    await waitForText(
+    await waitForSettledText(page, "#stage-pill", "published");
+    await waitForSettledText(
       page,
       "#published-body",
       "Ship the staged publish demo with trusted UI gates.",

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -327,6 +327,29 @@ export class MultiRuntimeSession {
   }
 
   /**
+   * Wait — with no budget of its own, backstopped by the RPC timeout —
+   * until every event THIS session fired has its terminal consequence
+   * (consequenced, errored, dropped, or refused) arrived back here:
+   * the overlay's outstanding-intent set is empty (speculation.md §4
+   * step 2). Instant on the OFF arm and when nothing is outstanding.
+   *
+   * This is the gate between two CHAINED events whose second served
+   * handler reads state the first one writes (a draft-then-trusted-
+   * action pair): events on different streams have no cross-stream
+   * serve-order guarantee (events.md §4), so firing the second while
+   * the first is in flight can serve it against a pre-first view — a
+   * precondition-reading handler then no-ops silently, an interleaving
+   * the real UI forbids (the trusted control stays disabled until the
+   * served precondition round-trips). Await this before the second
+   * fire; once the first consequence has arrived back, its commit is
+   * in the space's history and every later-fired event is served
+   * against a view that includes it.
+   */
+  async awaitEventConsequences(): Promise<void> {
+    await this.#client.call("awaitEventConsequences");
+  }
+
+  /**
    * Force an ordered-after round trip on this runtime's open space connections,
    * so any subscription fan-out the server has already sent has landed here.
    * See `MultiRuntimeHarness.settle`.

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -336,7 +336,7 @@ export class MultiRuntimeSession {
    * This is the gate between two CHAINED events whose second served
    * handler reads state the first one writes (a draft-then-trusted-
    * action pair): events on different streams have no cross-stream
-   * serve-order guarantee (events.md §4), so firing the second while
+   * serve-order guarantee (events.md §2), so firing the second while
    * the first is in flight can serve it against a pre-first view — a
    * precondition-reading handler then no-ops silently, an interleaving
    * the real UI forbids (the trusted control stays disabled until the

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -479,7 +479,7 @@ const handlers: Record<
   // outstanding-intent set is empty (speculation.md §4 step 2). The
   // gate a test needs between two CHAINED events whose second served
   // handler reads state the first one writes: events on DIFFERENT
-  // streams have no cross-stream serve-order guarantee (events.md §4 —
+  // streams have no cross-stream serve-order guarantee (events.md §2 —
   // per stream only), so firing the second while the first is in
   // flight can serve it against a pre-first view; a precondition-
   // reading handler then no-ops SILENTLY (the 2026-08-22 ON-lane

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -447,18 +447,53 @@ const handlers: Record<
   // speaks, so a wedged consequence degrades loudly instead of hanging the
   // harness. The OFF arm has no overlay and resolves immediately.
   async eventQuiescence({ timeoutMs }) {
-    const runtime = controller().runtime;
-    const budget = typeof timeoutMs === "number" ? timeoutMs : 10_000;
-    const deadline = Date.now() + budget;
-    for (;;) {
-      const pending = runtime.speculationOverlay?.pendingIntentCount ?? 0;
-      if (pending === 0) return { pending: 0 };
-      if (Date.now() >= deadline) return { pending };
-      // Plain timer wait: consequence pushes arrive on the WebSocket and the
-      // overlay's intent listener runs in a microtask on the replica
-      // notification, so nothing here needs nudging — just time.
-      await new Promise((resolve) => setTimeout(resolve, 25));
+    const overlay = controller().runtime.speculationOverlay;
+    if (overlay === undefined || overlay.pendingIntentCount === 0) {
+      return { pending: 0 };
     }
+    const budget = typeof timeoutMs === "number" ? timeoutMs : 10_000;
+    // Event-driven with a budget: the overlay resolves the quiescence
+    // waiter from the same untrack step that retires the last intent
+    // (consequence pushes arrive on the WebSocket; nothing here needs
+    // nudging), raced against the budget timer. A waiter whose race the
+    // timer wins stays parked until the set empties or the overlay
+    // closes — a spent resolver, not a leak (growth is bounded by the
+    // caller's settle rounds and every parked waiter flushes together).
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const budgetElapsed = new Promise<"budget">((resolve) => {
+      timer = setTimeout(() => resolve("budget"), budget);
+    });
+    const raced = await Promise.race([
+      overlay.waitForIntentQuiescence().then(() => "quiescent" as const),
+      budgetElapsed,
+    ]);
+    clearTimeout(timer);
+    return {
+      pending: raced === "quiescent" ? 0 : overlay.pendingIntentCount,
+    };
+  },
+
+  // Wait — with no budget of its own — until every event this runtime
+  // fired has reached a terminal consequence (consequenced, errored,
+  // dropped, or refused) that has ARRIVED back here: the overlay's
+  // outstanding-intent set is empty (speculation.md §4 step 2). The
+  // gate a test needs between two CHAINED events whose second served
+  // handler reads state the first one writes: events on DIFFERENT
+  // streams have no cross-stream serve-order guarantee (events.md §4 —
+  // per stream only), so firing the second while the first is in
+  // flight can serve it against a pre-first view; a precondition-
+  // reading handler then no-ops SILENTLY (the 2026-08-22 ON-lane
+  // group-chat flake). Once the first event's consequence has arrived
+  // back, its commit is in the space's history, so any later-fired
+  // event is served against a view that includes it. Backstopped by
+  // the harness RPC timeout, which names this session and command;
+  // instant on the OFF arm (no overlay) and when nothing is
+  // outstanding. First-order only, like the count it drains — a
+  // server-side cascade child is no session's intent.
+  async awaitEventConsequences() {
+    const overlay = controller().runtime.speculationOverlay;
+    if (overlay !== undefined) await overlay.waitForIntentQuiescence();
+    return {};
   },
 
   // Force an ordered-after round trip on every open space connection, so any

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -352,6 +352,9 @@ export class SpeculationOverlayDestination
     Array<(outcome: IntentConsequence) => void>
   >();
   readonly #intentConsequenceMemo = new Map<string, IntentConsequence>();
+  /** Resolvers parked by `waitForIntentQuiescence`, flushed by the same
+   * untrack step that empties the outstanding-intent set (and by close). */
+  #intentQuiescenceWaiters: Array<() => void> = [];
   #closed = false;
 
   constructor(runtime: Runtime) {
@@ -1196,6 +1199,34 @@ export class SpeculationOverlayDestination
     });
   }
 
+  /** Await the outstanding-intent set EMPTYING (speculation.md §4 step 2
+   * quiescence, the set `pendingIntentCount` counts): every event this
+   * runtime fired has reached a terminal consequence — consequenced,
+   * errored, dropped, or refused — AND that signal has arrived back
+   * here. Event-driven: resolves from the same untrack step that
+   * retires the last outstanding intent, immediately when nothing is
+   * outstanding, and on overlay close (nothing can retire afterwards).
+   * Carries no deadline of its own — a caller that needs a bound races
+   * it (the multi-runtime harness's budgeted settle does). Note this is
+   * a FIRST-ORDER signal, like the count it mirrors: a server-side
+   * cascade child (an event a served handler itself emits) is no
+   * client's intent and commits in a later wave, outside this wait. */
+  waitForIntentQuiescence(): Promise<void> {
+    if (this.#closed || this.pendingIntentCount === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.#intentQuiescenceWaiters.push(resolve);
+    });
+  }
+
+  #flushIntentQuiescenceWaiters(): void {
+    if (this.#intentQuiescenceWaiters.length === 0) return;
+    const waiters = this.#intentQuiescenceWaiters;
+    this.#intentQuiescenceWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
   #settleIntentConsequence(
     space: MemorySpace,
     eventId: string,
@@ -1435,7 +1466,10 @@ export class SpeculationOverlayDestination
       // (contract point 5). The sidecar WATCH stays: a session's watch
       // set is coarse by ruling (R-D), and the next fire on this stream
       // is likely imminent.
-      if (this.#trackedIntents.size === 0) this.#releaseIntentListener();
+      if (this.#trackedIntents.size === 0) {
+        this.#releaseIntentListener();
+        this.#flushIntentQuiescenceWaiters();
+      }
     }
   }
 
@@ -1948,6 +1982,9 @@ export class SpeculationOverlayDestination
     }
     this.#intentConsequenceWaiters.clear();
     this.#intentConsequenceMemo.clear();
+    // Nothing can retire an intent after close (`#trackedIntents` was
+    // just cleared), so quiescence waiters settle now rather than hang.
+    this.#flushIntentQuiescenceWaiters();
     for (const release of this.#ackObserverReleases.values()) {
       try {
         release();

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -600,6 +600,54 @@ describe("intent listener — scripted notification seam (design (e) pins 1–5,
     destination.close();
     await parked;
   });
+
+  it("quiescence waiter, two sidecars: draining ONE sidecar's whole set while another sidecar still holds an intent does NOT resolve the waiter (killing mutation: flushing when a sidecar's set empties instead of when the whole tracked map does)", async () => {
+    const { scripted, destination } = scriptedDestination();
+    const SIDECAR_B = "of:stream-events:listener-b";
+    scripted.seed(SPACE, SIDECAR, { entries: [] });
+    scripted.seed(SPACE, SIDECAR_B, { entries: [] });
+
+    destination.trackIntent(SPACE, SIDECAR, "evt-a");
+    destination.trackIntent(SPACE, SIDECAR_B, "evt-b");
+    scripted.deliver(SPACE, SIDECAR, (value) => {
+      value.entries = [
+        { eventId: "evt-a", stream: { id: "s", path: [] }, seq: 1 },
+      ];
+    }, [["value", "entries"]]);
+    scripted.deliver(SPACE, SIDECAR_B, (value) => {
+      value.entries = [
+        { eventId: "evt-b", stream: { id: "s2", path: [] }, seq: 1 },
+      ];
+    }, [["value", "entries"]]);
+    await flushMicrotasks();
+    expect(destination.pendingIntentCount).toBe(2);
+
+    let resolved = false;
+    const quiesced = destination.waitForIntentQuiescence().then(() => {
+      resolved = true;
+    });
+
+    // Retire evt-a: sidecar A's set drains ENTIRELY (its per-sidecar Set
+    // empties and is deleted) while sidecar B still holds evt-b. The
+    // one-sidecar pin above cannot see this arm — its first retire
+    // leaves the shared sidecar's set non-empty — so this is the pin
+    // for the sidecar-drain flush mutant.
+    scripted.deliver(SPACE, SIDECAR, (value) => {
+      value.entries![0].consequenced = true;
+    }, [["value", "entries", "0", "consequenced"]]);
+    await flushMicrotasks();
+    expect(destination.pendingIntentCount).toBe(1);
+    expect(resolved).toBe(false);
+
+    // Retire evt-b: the whole tracked map empties; the waiter resolves.
+    scripted.deliver(SPACE, SIDECAR_B, (value) => {
+      value.entries![0].consequenced = true;
+    }, [["value", "entries", "0", "consequenced"]]);
+    await flushMicrotasks();
+    await quiesced;
+    expect(resolved).toBe(true);
+    destination.close();
+  });
 });
 
 // ─── W2.1: the cascade-echo retirement (scripted; the MARK path) ────────

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -541,6 +541,65 @@ describe("intent listener — scripted notification seam (design (e) pins 1–5,
     expect(failures()).toBe(failuresBefore + 1);
     destination.close();
   });
+
+  it("quiescence waiter: waitForIntentQuiescence resolves when the LAST outstanding intent retires — not on an earlier retire — immediately when nothing is outstanding, and on close", async () => {
+    const { scripted, destination } = scriptedDestination();
+    scripted.seed(SPACE, SIDECAR, { entries: [] });
+
+    // Nothing outstanding: resolves immediately (probe by flag — a race
+    // against a bare resolved sentinel loses by one microtask hop).
+    let immediate = false;
+    destination.waitForIntentQuiescence().then(() => {
+      immediate = true;
+    });
+    await flushMicrotasks();
+    expect(immediate).toBe(true);
+
+    destination.trackIntent(SPACE, SIDECAR, "evt-1");
+    destination.trackIntent(SPACE, SIDECAR, "evt-2");
+    scripted.deliver(SPACE, SIDECAR, (value) => {
+      value.entries = [
+        { eventId: "evt-1", stream: { id: "s", path: [] }, seq: 1 },
+        { eventId: "evt-2", stream: { id: "s", path: [] }, seq: 2 },
+      ];
+    }, [["value", "entries"]]);
+    await flushMicrotasks();
+    expect(destination.pendingIntentCount).toBe(2);
+
+    let resolved = false;
+    const quiesced = destination.waitForIntentQuiescence().then(() => {
+      resolved = true;
+    });
+
+    // First retire: ONE intent still outstanding — the waiter must NOT
+    // resolve (killing mutation: flushing on every untrack instead of on
+    // the set emptying trips here).
+    scripted.deliver(SPACE, SIDECAR, (value) => {
+      value.entries![0].consequenced = true;
+    }, [["value", "entries", "0", "consequenced"]]);
+    await flushMicrotasks();
+    expect(destination.pendingIntentCount).toBe(1);
+    expect(resolved).toBe(false);
+
+    // Last retire (a dropped mark is equally terminal): the set empties,
+    // the waiter resolves.
+    scripted.deliver(SPACE, SIDECAR, (value) => {
+      value.entries![1].status = "dropped";
+      value.entries![1].reason = "gone";
+    }, [
+      ["value", "entries", "1", "status"],
+      ["value", "entries", "1", "reason"],
+    ]);
+    await flushMicrotasks();
+    await quiesced;
+    expect(resolved).toBe(true);
+
+    // Close settles a parked waiter (nothing can retire afterwards).
+    destination.trackIntent(SPACE, SIDECAR, "evt-3");
+    const parked = destination.waitForIntentQuiescence();
+    destination.close();
+    await parked;
+  });
 });
 
 // ─── W2.1: the cascade-echo retirement (scripted; the MARK path) ────────


### PR DESCRIPTION
## Why

The reopened ON-lane flake cluster burned three CI runs in one night — main run 32543810077 (docs-only head 58e2657e7) and PR #6186's run 32547606642 failed identically on `cfc-group-chat-demo-multi-runtime.test.ts` "admin lockdown …" / `Timed out waiting for: bob's post-lockdown message arrives at alice`, with main's next run green. These failures POST-date #6158, so they survive the OW52 settle fix whose report §7 claimed to cover exactly this census item.

The failing logs falsify the slow-drain theory: **zero quiescence-budget warnings** (every settle round found the intent set already empty), a completely silent 30 s window, and the very next step's own bob→alice arrival passing in 730 ms. The message was not slow — it was **never appended**. The test's `sendMessage` helper chains two events (`setMessageDraft` → `sendTrustedMessage`); events.md §4 promises serve order **per stream only** ("Across streams in one space … No global ordering claim"), so under load the served trusted handler can read a pre-draft view — and it **silently no-ops on an empty draft** by design. Terminal, clean, unobservable: no widening of the arrival wait could ever fix it, which is why the flake survived OW52. The real UI forbids this interleaving — the send control stays disabled until the served draft round-trips (OW47 S-G fixed the browser test exactly this way). The multi-runtime helpers had no equivalent gate. Standing discipline honored: **no timeout raised, lowered, added, or removed anywhere** (docs/development/waiting-in-tests.md).

## What Changed

- **`SpeculationOverlayDestination.waitForIntentQuiescence()`** (runner): event-driven wait for the outstanding-intent set to EMPTY, resolved by the same `#untrackIntent` step that retires the last intent; immediate when empty; settled on close. First-order, like `pendingIntentCount`. Pinned in `speculation-intent-listener.test.ts` with its killing mutation (flush-on-every-untrack goes red; verified).
- **`MultiRuntimeSession.awaitEventConsequences()`** (harness/worker): awaits that waiter; instant on OFF; backstopped by the pre-existing 120 s RPC bound, which names the session — a wedged consequence now fails loudly at the true seam. The worker's budgeted `eventQuiescence` keeps its exact settle semantics but races the same waiter instead of a 25 ms poll.
- **Group-chat helpers gated** (`saveProfile`, `sendMessage`, `addRoom`): fire the trusted action only after the draft event's terminal consequence has arrived back — then its commit is in the space's history and the served handler must see it. The arrival `waitFor`s are untouched. The "bob's rejected add" negative assert gets real teeth (an empty-draft no-op could previously green it while masking a broken admin gate).
- **New deterministic pin** `cfc-group-chat-chained-event-gate-multi-runtime.test.ts`: delay injection at the racy seam (two sessions of one user, writer socket +300 ms, draft fired `idle: false`). Ungated this topology fails 2/2 with the byte-identical CI signature (watched; recorded in the report); the committed steps pin the UI-enablement gate (both arms) and that `awaitEventConsequences` alone suffices (ON; neutered-gate mutation goes red at 30 s while the sibling step stays green).
- **Census item 2 + ledger sibling**: `cfc-staged-publish` ("#stage-pill → saved" 5 m stuck-net, twice on shard 9) and `cfc-spec-gallery` (once on main) — plain `waitForText` on text that is the EFFECT of a trusted click's served round trip, the doctrine's named trap (nothing pumps the page's own pending pull work). Converted to `waitForSettledText`; absent server state still fails, so no loss is masked.
- **Docs**: root-cause report at `docs/history/plans/server-execution-v2/optimize/arrival-wait-hardening-report.md`; dated corrections to the OW52 report §7 coverage claim and the register's OW52 row (the OW52 closure itself stands). Two-browsers' timing-instrumented cross-browser waits deliberately left as-is with receipts in the report (flag, don't fill).

## Test plan

Local, fresh ON toolshed from source (:8891, servingLoop verified) + OFF standalone: group-chat file 7/7 ON and OFF; new pin 2/2 ON and OFF; `convergence-storm` 4/4 ON, `cellset-lww` 4/4 ON, `data-file-multi-runtime` 2/2 ON; full runner suite green with the overlay change (1273 tests / 7302 steps); `deno check` clean on every changed file; `check-no-waitfor` green. The two browser-file conversions are the doctrine's drop-in (same signature; the lunch-poll test already uses it for every cross-browser wait) — their behavioral verification rides this PR's ON/OFF pattern lanes; read those lanes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




ACCEPT_COVERAGE_DEBT: packages/runner +1 line

(The +1 is `packages/runner/src/builtins/wish.ts:2091` — an unchanged error-path line inside the wish commit-failure surfacing callback, covered only when a run happens to produce a failed wish commit. Its baseline coverage rode a nondeterministic benign-conflict interleaving; this PRs hardened waits make that interleaving rarer, so the coverage is flaky by nature, not lost by this diff. Accepted as coordinator.)
