### PR TITLE
feat(runner): a served run's CFC trust snapshot carries the acting principal (OW34-family)

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -448,3 +448,266 @@ client-process-local trust attestation server-side at the
 injected-keys trust level; resolving the current-principal placeholder
 against the carried actor is the same move on the label plane, with the
 same explicitly-ruled footing to cite (LT5, owner 2026-08-03).
+
+## 5. Replay / idempotency × (α)
+
+The invariant, stated once: **a served run's trust snapshot is a pure
+function of the run's DURABLE inputs — the stream entry's server-stamped
+`firedAt` for a handler, the demanded instance identity for a derivation,
+the delegated carriage for a sanctioned bookkeeping crossing — never of
+process-ambient state.** Everything else follows:
+
+- A re-drain of the same event (the wave IS the retry cadence; kill/replay
+  included) resolves the same `firedAt.user` from the same durable entry,
+  mints the same snapshot, and `derivePersistedLabel` — deterministic in
+  (schema, snapshot, source labels) — produces byte-identical `["cfc"]`
+  atoms. The re-applied labelMap write is a CAS no-op against an identical
+  prior application, exactly like the consequence writes it rides with.
+  This composes with (α) untouched: exactly-once is keyed by `eventId` at
+  admission and by the consequenced mark in the run's own tx
+  (`ServerRunInfo.streamEntry`); labels are CONTENT of the consequence,
+  not part of its identity.
+- Labels do NOT enter any consequence's IDENTITY: doc ids are
+  creation-derived (CT-1650), never content hashes; the prepared digest
+  binds the snapshot but is tx-local and unpersisted (§3). So per-run
+  snapshots cannot fork replay identity. What they CAN change is doc
+  CONTENT across a VERSION boundary — a store written pre-fix (service
+  atoms) re-derived post-fix (user atoms) is a value change, which is §6's
+  migration question, not a replay hazard.
+- The one ordering fact worth restating (from 1d): retries re-mint the tx
+  and re-stamp (both scheduler choke points and the `editWithRetry`
+  writeback loops stamp inside the retried fn), so no retry can carry a
+  stale snapshot from a previous attempt's tx.
+- Today's behavior, for honesty: the SERVICE snapshot is also
+  replay-deterministic (a constant is pure too). The purity invariant is
+  not what FIXES the bug; it is what the fix must PRESERVE while changing
+  which durable input the snapshot is a function of.
+
+## 6. OFF-invisibility + migration
+
+**OFF is byte-identical by construction.** The entire change sits behind
+the stamper, which exists only where a wave seal destination is installed —
+a serving runtime under `EXPERIMENTAL_SERVER_EXECUTION` (runtime.ts:
+1991-2033; `stampServerRun` is one undefined check on the OFF arm,
+runtime.ts:2091-2104). Clients — OFF and ON alike — keep the ambient
+provider, which on a client IS the user: no client path changes. The §9
+acceptance carries the per-site OFF-neutrality pin in the
+`storage-instance-keying` style.
+
+**Migration: none owed; fresh stores are the ruling posture's own
+evidence.** Production runs the flag OFF and holds no service-labeled rows
+(the #6173/OW45 correction: the broken spaces lived in ephemeral test
+stores). The ON lanes and local ON repros run fresh stores per run. So
+existing service-labeled rows exist only in disposable test stores, and
+the disposition is **ignore (fresh stores)** — no relabel pass, no
+tolerate-both verifier arm. Two consequences stated so nobody builds them
+by reflex: (i) do NOT teach `cf-cfc-authorship` to accept service-authored
+rows "for compatibility" — that is §4(c)'s collapse through the back door;
+(ii) a long-lived ON dogfood store that predates the fix, should one
+exist, is re-created rather than migrated (its labels are wrong about
+authorship; keeping them wrong-but-tolerated has negative value). If the
+owner later wants heal-on-rewrite (a served re-derivation naturally
+replaces the label on the next overwrite of each row), that falls out of
+the mechanism for free for rows that get rewritten, and is NOT a
+completeness claim for rows that never do.
+
+## 7. Scope discipline — the flip needs exactly the group-chat lift
+
+In scope: the serving runtime's per-run trust snapshot (option A), label
+semantics (a), the pins of §9, one binding spec sentence + the SC entry
+(Q4), the skip-entry lift, and the register re-tense. Everything below is
+NAMED OUT, with its home:
+
+- **OW53 — the sqlite identity pair.** The db-owner mint and
+  clearance-reader keying read the RUNTIME provider directly (1c). This
+  design's tx-attached snapshot is the substrate a fix would re-point them
+  at (`tx.getCfcState().trustSnapshot` instead of
+  `runtime.trustSnapshotProvider()`), but WHO owns a db handle under
+  served execution is an identity-model decision that row already owns.
+  Untouched here; both sqlite ON skips stay.
+- **llm-dialog's provider read** (llm-dialog.ts:2371) — same shape, same
+  disposition: named, untouched.
+- **OW13 / FLAG-7 — per-demander read isolation and grant resolution.**
+  The session-level acting-as-owner READ binding stays as OW31 built it;
+  nothing here touches the memory plane. FLAG-7's attributed-ambient-
+  authority tightening remains future.
+- **The space-scoped-derivation trust-closure narrowing** (1b structural
+  note's cousin): under per-run snapshots, an actor-less derivation
+  evaluates concept floors with no acting principal (deployment-root
+  delegations only), where the OFF client evaluated them under its owner.
+  Unobservable today — serving runtimes configure no trust config (1a), so
+  `conceptSatisfied` is uniformly false there — recorded as a stated
+  consequence for whenever a deployment first configures serving-side
+  trust, not solved here.
+- **Label option (b) — the served-provenance mark** and option C's
+  delegation-aware snapshot field: future, on product need, with its own
+  spec sentence (§4b).
+- **OW49** (divergent-anyOf at /result) — the OTHER CFC-owner seam in this
+  phase; separate blocker for `profile-embed`, zero mechanism overlap
+  (schema-merge, not trust), separate ruling.
+- **OW54/OW56 and the events seal path** — untouched (1g).
+
+## 8. The recommended design, in one piece
+
+1. **Mechanism.** `Runtime` gains
+   `trustSnapshotForPrincipal(principal): TrustSnapshot` — `{ id:
+   "principal:<did>", actingPrincipal: <did>, revision: <the runtime's
+   trust revision> }` — and the constructor's default provider is
+   refactored onto the same revision composition (one site folds the
+   config digest). The SpaceServer's `#stampRun` attaches a per-run
+   snapshot via `tx.setCfcTrustSnapshot(...)` using its existing identity
+   precedence: `delegated.acting.user`, else `info.acting.user`, else a
+   demanded derivation's `scopeKeyIdentity.principal` (Q2), else it leaves
+   the ambient snapshot in place (Q3). No other file's behavior changes;
+   prepare.ts is untouched.
+2. **Semantics.** Label option (a): a served run's current-principal
+   mints name the acting user, indistinguishable from the client-authored
+   row — the memory plane's carried actor and the label plane's resolved
+   subject are the same principal on the same commit.
+3. **Invariants, as testable pins.**
+   - **INV-A (OFF-equivalence of the mint):** the `["cfc"]` labels a
+     served handler run persists are byte-identical to those the same
+     handler run mints on the acting user's own client. (Pinned as §9-1's
+     equality against a client-runtime control.)
+   - **INV-B (purity/replay):** the served snapshot is a pure function of
+     the run's durable inputs; an idempotent re-dispatch mints
+     byte-identical labels. (§9-3.)
+   - **INV-C (one snapshot per tx):** set at most once, after `edit()`,
+     before the run's first read; prepare and the commit-time recheck see
+     the same value; the `trust-snapshot-changed` invalidation stays as
+     the tripwire and never fires on the sanctioned path. (§9-2.)
+   - **INV-D (no service-authored labels under ON):** no durable `["cfc"]`
+     labelMap entry carries an authored-by / represents-principal atom
+     whose subject is the service DID. (§9-6's store-dump audit.)
+   - **INV-E (forge-resistance unchanged):** literal-DID current-principal
+     claims stay rejected; the only path to a user-named label remains a
+     run actually carrying that user's acting identity. (Existing pins +
+     §9-1's negative arm.)
+   - **INV-F (OFF byte-identity):** flag OFF, no site changes behavior.
+     (§9-5.)
+   - **INV-G (revision covers config, per-run included):** a trust-config
+     change invalidates served runs' prepared digests exactly as it does
+     client ones — the helper composes the same revision. (Unit pin on the
+     helper.)
+
+## 9. Acceptance criteria
+
+1. **Red-first executor pin (the FLAG-5 shape as a failing assert).** In
+   the runner executor family (real SpaceServer + live wave, the
+   OW31-pin style): a served event-handler run whose written docs carry
+   `AuthoredByCurrentUser` / `RepresentsCurrentUser` schemas persists
+   labelMap atoms whose subject is the entry's `firedAt.user` — WATCHED
+   RED at base, where the subject is the service DID (the rootcause §2a
+   store shape). Negative arm: a payload-smuggled literal-DID claim still
+   refuses (INV-E).
+2. **Per-wave multi-principal pin.** Two handler runs for two users in one
+   wave: each run's docs carry that run's user; both prepared digests
+   recheck clean at commit (INV-C; no cross-run contamination, no
+   `cfc-prepared-digest-mismatch`).
+3. **Replay pin.** Re-dispatch of the same durable entry (the existing (α)
+   idempotency harness) mints byte-identical labels (INV-B).
+4. **Delegated-writeback pin.** An S-A carriage bookkeeping writeback tx
+   carries the delegated acting's snapshot; a carriage-less foreign
+   writeback stays refused exactly as OW31 pinned it (unchanged).
+5. **OFF-arm neutrality.** Per-site OFF pins in the
+   `storage-instance-keying` style: no stamper ⇒ no snapshot call; client
+   ON speculation unchanged (INV-F).
+6. **The live lift (the skip entry's own condition).**
+   `integration/cfc-group-chat-demo.test.ts` greens under the true ON
+   topology (lane-shaped toolshed, fresh store), including both
+   authorship checks across the `shell.login` switch — and the ON-skip
+   entry is REMOVED in the same train (the flip needs the list EMPTY).
+   Store-dump audit on the run's store: zero authored-by /
+   represents-principal atoms naming the service DID (INV-D), the §2a
+   evidence query inverted.
+7. **No digest-keying regression.** The full runner executor + cross-space
+   + serving-loop + memory suites green; ON-lane toolshed logs carry no
+   new `cfc-prepared-digest-mismatch` / `trust-snapshot-changed`
+   occurrences in the gate runs.
+8. **OFF untouched at the suite level.** The default-posture lanes run
+   byte-identical (no reason text, snapshot shape, or label change
+   reachable OFF).
+
+## 10. Open questions for the owner (numbered; each with a recommendation)
+
+1. **Label semantics: (a) acting user only, or (b) acting user + a
+   served-provenance mark?** Recommendation: **(a)** for this lift. (b)
+   re-opens the client/durable label divergence the fix exists to close,
+   costs a new gated atom family, and duplicates an audit trail the memory
+   plane already records per-commit; if a product surface later needs
+   value-plane served-execution audit, option C's snapshot field is the
+   prepared extension point, with its own spec sentence then.
+2. **Does the derivation arm ship now?** Attaching the demanded
+   `scopeKeyIdentity.principal` to derivation-run snapshots is
+   behaviorally inert today (derivations cannot mint current-principal
+   labels — 1b's structural note; concept floors are inert on serving
+   runtimes — §7), but it is the OFF-faithful direction and the substrate
+   OW53 wants. Recommendation: **include it**, explicitly severable to
+   handlers+delegated-only if review surfaces a consumer I missed; the
+   eager-at-stamp principal knowingly diverges from the seal-settled
+   memory-plane attribution for runs that discover a broader scope, and
+   §8's design records that divergence as consequence-free for labels
+   (prepare precedes seal — 1d).
+3. **Actor-less stamped runs (plain bookkeeping, wave-fallback
+   derivations): keep the ambient service snapshot, or clear it to
+   undefined (fail-closed placeholder minting)?** Recommendation: **keep
+   the service snapshot** — zero behavior change for paths that today
+   work (structure loads, watermark, pattern-swap setup, factory-time
+   loads), aligned with protocol.md §1's "the SpaceServer's own writes";
+   the gated mint families are already unreachable from those paths
+   (uiContract requires a trusted event — 1b). The fail-closed
+   alternative is one line if the owner prefers the tighter posture and
+   accepts hunting any latent bookkeeping path that relied on snapshot
+   presence (writeAuthorizedBy's presence floor — 1c).
+4. **Spec home.** Recommendation: one binding sentence in
+   serving-loop.md §3c (where per-run CFC is already normative), shaped
+   like: *"The run's CFC trust snapshot carries the run's ACTING
+   principal — the event's server-stamped actor, the demanded instance's
+   principal, or the delegated carriage's actor — never the serving
+   runtime's ambient identity; a run with no acting principal keeps the
+   service snapshot and cannot mint current-principal claims."* Plus an
+   SC entry in `docs/specs/cfc-spec-changes.md` (next free number —
+   SC-38 at this writing) recording the served-execution reading of the
+   current-principal family, and the register re-tense (OW31 residual
+   (iii) → closed-by, the OW34-family note updated). The build lands
+   spec + code together per the standing rule.
+5. **The direct provider reads (sqlite, llm-dialog): re-point now or
+   leave to OW53?** Recommendation: **leave** — they are OW53's identity-
+   model decision (db ownership, clearance keying), not label attribution;
+   this design only guarantees the tx snapshot they would re-point at is
+   right. Re-pointing them here would smuggle an OW53 ruling in through a
+   label fix.
+6. **`TrustSnapshot.id` shape for served runs.** Recommendation:
+   `principal:<acting user>` — uniform with every client snapshot; `id`
+   is presence-checked and digest-bound but nothing branches on its text,
+   so uniformity beats a `served:` marker (which would be option (b)'s
+   distinction smuggled into a field nothing should read).
+7. **Register row for the build.** The residual currently lives inside
+   OW31's row (iii) with "OW34's family" as its name. Recommendation: the
+   implementation train mints its own row at the then-next free OW number
+   (OW56 is being taken by open #6173) titled "OW34-family: per-run CFC
+   trust attribution", carrying this document as the design of record,
+   and re-tenses OW31 (iii) + the group-chat skip reason to point at it;
+   this doc deliberately does not claim a number in advance.
+
+## Verification inventory (what was probed, what was not)
+
+| claim | how verified |
+|---|---|
+| snapshot default + edit() attach + single writer | code read: runtime.ts:1318-1326,1945; grep over src for `setCfcTrustSnapshot` (one production caller + the wrapper) |
+| serving runtimes get no provider/config | toolshed/lib/server-execution.ts:144-183 |
+| placeholder mint mechanics + gates + literal-DID rejection | prepare.ts:345-412, 2371-2469, 3881-3937 |
+| digest binds snapshot verbatim; no cross-tx digest state | ext-tx:1558, canonical.ts:437,499-500; prepare state on tx (ext-tx:1782-1795) |
+| per-tx snapshot override is a supported surface | profile-owner-cfc.test.ts:134-149,408-447 (public setter, exercised) |
+| stamp precedes first read at both choke points; retries re-stamp | scheduler/events.ts:1187-1268, scheduler/run.ts:508-542, pattern-manager.ts:2074-2098,2183-2200 |
+| mid-run snapshot consumer exists (forces pre-run seam) | writeCfcGrant, ext-tx:1354-1357 |
+| seal-time attribution settles AFTER prepare | wave.ts:898-989 (settle at 938) vs ext-tx commit path 2270-2387 |
+| verifier compares authored-by.subject vs represents-principal.subject | cf-cfc-authorship.ts:268-374,610-624,752-792; test waitForAuthorshipState |
+| two-browsers file asserts no authorship state (why it passes ON) | grep over cfc-group-chat-demo-two-browsers.test.ts |
+| service-DID labels on served rows (the defect) | NOT re-probed live in this pass — carried from rootcause §2a's store dump + first-on-ci-gate row 2, both same-day evidence; the §9-1 red-first pin re-establishes it at build time |
+| OW50 totality landed; adjacent open PRs disjoint | ext-tx:1710-1801; `gh pr list` + git log sweep 2026-08-21 |
+
+No scratch code probes were needed: every mechanism claim resolved by
+reading, and the one live claim (the store shape) has same-day archived
+evidence plus a red-first pin in the acceptance path. The worktree carries
+this document only.

--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -654,7 +654,10 @@ NAMED OUT, with its home:
 All seven questions are RULED 2026-08-21, each adopted as recommended; the
 per-question markers below record the binding reading. The aside's answer:
 yes — Q3 names the actor-less examples (structure loads, the watermark
-write, pattern-swap setup, factory-time loads), and §1b's structural note
+write, pattern-swap setup, factory-time loads; the drain's
+consequence-notice seal — `#sealEventConsequenceNotice`, the
+skip/error/drop notices — is the same actor-less bookkeeping shape, added
+to this list by the #6190 review's NOTE-7), and §1b's structural note
 names the one mint-capable actor-less path (setup/defaults materialization
 via the initial-schema-default carve-out).
 

--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -2,16 +2,17 @@
 status: historical
 created: 2026-08-21
 archived: 2026-08-21
-reason: "OW34-family DESIGN (for owner ruling; no implementation in this PR): per-run CFC trust attribution for served execution — the FLAG-5 seam where served rows' authored-by / represents-principal labels name the SERVICE signer because the runtime-level trust snapshot (storageManager.as) is attached per-transaction at edit(). Mechanism verified against code with anchors; options per section; ONE recommended design (stamper-attached per-run snapshots, label semantics = the acting user, OFF byte-identical, fresh-store migration); invariants as testable pins; acceptance = the cfc-group-chat-demo ON lift + store-dump label audit. Gates the ON flip (the skip list must be EMPTY)."
+reason: "OW34-family DESIGN (RULED 2026-08-21 — all seven §10 recommendations adopted as recommended; built by the OW34-family implementation train in the same PR that lands this document): per-run CFC trust attribution for served execution — the FLAG-5 seam where served rows' authored-by / represents-principal labels name the SERVICE signer because the runtime-level trust snapshot (storageManager.as) is attached per-transaction at edit(). Mechanism verified against code with anchors; options per section; ONE recommended design (stamper-attached per-run snapshots, label semantics = the acting user, OFF byte-identical, fresh-store migration); invariants as testable pins; acceptance = the cfc-group-chat-demo ON lift + store-dump label audit. Gates the ON flip (the skip list must be EMPTY)."
 ---
 
 # OW34 attribution design — per-run CFC trust for served execution
 
 Author: OW34 DESIGN agent. Worktree `/Users/berni/labs-worktrees/ow34-design`,
 branch `claude/server-exec-v2-ow34-design` off `origin/main` @ `59cde49ef`.
-Date: 2026-08-21. Status: **design for ruling** — the owner rules on this
-document before any implementation train starts. This is a design pass; the
-branch carries this document and nothing else.
+Date: 2026-08-21. Status: **RULED 2026-08-21** — the owner adopted all seven
+§10 recommendations as recommended (the ruling record heads §10). Built by
+the OW34-family implementation train (branch
+`claude/server-exec-v2-ow34-implement`), which lands this document.
 
 Register anchors: OW31's residual (iii) (verification-coverage.md §3 — "CFC
 AUTHORSHIP LABELS on served rows still carry the SERVICE signer … per-run CFC
@@ -645,14 +646,29 @@ NAMED OUT, with its home:
 
 ## 10. Open questions for the owner (numbered; each with a recommendation)
 
+**RULING RECORD.** The owner (Berni) ruled in chat, 2026-08-21:
+
+> "decision 2: all sounds good. does the doc note examples for actor-less
+> runs? just curious"
+
+All seven questions are RULED 2026-08-21, each adopted as recommended; the
+per-question markers below record the binding reading. The aside's answer:
+yes — Q3 names the actor-less examples (structure loads, the watermark
+write, pattern-swap setup, factory-time loads), and §1b's structural note
+names the one mint-capable actor-less path (setup/defaults materialization
+via the initial-schema-default carve-out).
+
 1. **Label semantics: (a) acting user only, or (b) acting user + a
-   served-provenance mark?** Recommendation: **(a)** for this lift. (b)
+   served-provenance mark?** **RULED 2026-08-21: (a), as recommended.**
+   Recommendation: **(a)** for this lift. (b)
    re-opens the client/durable label divergence the fix exists to close,
    costs a new gated atom family, and duplicates an audit trail the memory
    plane already records per-commit; if a product surface later needs
    value-plane served-execution audit, option C's snapshot field is the
    prepared extension point, with its own spec sentence then.
-2. **Does the derivation arm ship now?** Attaching the demanded
+2. **Does the derivation arm ship now?** **RULED 2026-08-21: ships, as
+   recommended — severable if review surfaces a consumer.** Attaching the
+   demanded
    `scopeKeyIdentity.principal` to derivation-run snapshots is
    behaviorally inert today (derivations cannot mint current-principal
    labels — 1b's structural note; concept floors are inert on serving
@@ -665,7 +681,10 @@ NAMED OUT, with its home:
    (prepare precedes seal — 1d).
 3. **Actor-less stamped runs (plain bookkeeping, wave-fallback
    derivations): keep the ambient service snapshot, or clear it to
-   undefined (fail-closed placeholder minting)?** Recommendation: **keep
+   undefined (fail-closed placeholder minting)?** **RULED 2026-08-21: keep
+   the ambient service snapshot, as recommended; the owner-gated
+   system-pattern-restage caveat stays a flagged named follow-up,
+   arbitrated by §9-6's store audit.** Recommendation: **keep
    the service snapshot** — zero behavior change for paths that today
    work (structure loads, watermark, pattern-swap setup, factory-time
    loads), aligned with protocol.md §1's "the SpaceServer's own writes".
@@ -685,7 +704,9 @@ NAMED OUT, with its home:
    gates surface a service-named mint from this path, dispose of it THEN
    — owner-resolved snapshot or a threaded carriage — as a named
    follow-up, not silently here.
-4. **Spec home.** Recommendation: one binding sentence in
+4. **Spec home.** **RULED 2026-08-21: as recommended — the serving-loop.md
+   §3c binding sentence, the SC entry, and the register re-tense, landed
+   with the build.** Recommendation: one binding sentence in
    serving-loop.md §3c (where per-run CFC is already normative), shaped
    like: *"The run's CFC trust snapshot carries the run's ACTING
    principal — the event's server-stamped actor, the demanded instance's
@@ -698,17 +719,21 @@ NAMED OUT, with its home:
    (iii) → closed-by, the OW34-family note updated). The build lands
    spec + code together per the standing rule.
 5. **The direct provider reads (sqlite, llm-dialog): re-point now or
-   leave to OW53?** Recommendation: **leave** — they are OW53's identity-
+   leave to OW53?** **RULED 2026-08-21: leave to OW53, as recommended.**
+   Recommendation: **leave** — they are OW53's identity-
    model decision (db ownership, clearance keying), not label attribution;
    this design only guarantees the tx snapshot they would re-point at is
    right. Re-pointing them here would smuggle an OW53 ruling in through a
    label fix.
-6. **`TrustSnapshot.id` shape for served runs.** Recommendation:
+6. **`TrustSnapshot.id` shape for served runs.** **RULED 2026-08-21:
+   uniform `principal:<did>`, as recommended.** Recommendation:
    `principal:<acting user>` — uniform with every client snapshot; `id`
    is presence-checked and digest-bound but nothing branches on its text,
    so uniformity beats a `served:` marker (which would be option (b)'s
    distinction smuggled into a field nothing should read).
-7. **Register row for the build.** The residual currently lives inside
+7. **Register row for the build.** **RULED 2026-08-21: the implementation
+   train mints its own register row, as recommended.** The residual
+   currently lives inside
    OW31's row (iii) with "OW34's family" as its name. Recommendation: the
    implementation train mints its own row at the then-next free OW number
    (OW56 is being taken by open #6173) titled "OW34-family: per-run CFC

--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -1,0 +1,264 @@
+---
+status: historical
+created: 2026-08-21
+archived: 2026-08-21
+reason: "OW34-family DESIGN (for owner ruling; no implementation in this PR): per-run CFC trust attribution for served execution — the FLAG-5 seam where served rows' authored-by / represents-principal labels name the SERVICE signer because the runtime-level trust snapshot (storageManager.as) is attached per-transaction at edit(). Mechanism verified against code with anchors; options per section; ONE recommended design (stamper-attached per-run snapshots, label semantics = the acting user, OFF byte-identical, fresh-store migration); invariants as testable pins; acceptance = the cfc-group-chat-demo ON lift + store-dump label audit. Gates the ON flip (the skip list must be EMPTY)."
+---
+
+# OW34 attribution design — per-run CFC trust for served execution
+
+Author: OW34 DESIGN agent. Worktree `/Users/berni/labs-worktrees/ow34-design`,
+branch `claude/server-exec-v2-ow34-design` off `origin/main` @ `59cde49ef`.
+Date: 2026-08-21. Status: **design for ruling** — the owner rules on this
+document before any implementation train starts. This is a design pass; the
+branch carries this document and nothing else.
+
+Register anchors: OW31's residual (iii) (verification-coverage.md §3 — "CFC
+AUTHORSHIP LABELS on served rows still carry the SERVICE signer … per-run CFC
+attribution is a CFC-owner seam (OW34's family), flagged rather than filled"),
+the OW31 build report's FLAG-5
+(`optimize/ow31-build-report.md`), and the `cfc-group-chat-demo` ON-skip
+entry (`tasks/server-execution-on-skips.ts`), whose lift condition names
+exactly this seam. Evidence base:
+`stage-c/on-render-stall-rootcause.md` §2a (the store dump: authored-by ×4,
+represents-principal ×2, all the service DID) and
+`stage-c/first-on-ci-gate.md` row 2.
+
+## Why
+
+Under ON, a served run's durable consequences carry CFC authorship labels
+naming the SERVICE signer, not the acting user. The observable defect:
+`cfc-group-chat-demo`'s authorship verification stays `"unverified"` forever
+on served rows (the first-ON-CI-gate row-2 shape), so the file is ON-skipped
+— and the flip PR requires the skip list EMPTY, which makes this seam a
+lift-blocker for the flip.
+
+The deeper defect is worse than one red test: with every trusted row and
+every profile labeled by the one service DID, the authorship-verification
+security property collapses to a tautology. The demo exists to prove that a
+forged authorship claim does NOT verify; on an all-service-labeled store,
+any trusted-sent message pairs with any profile — both carry the same
+subject — so the verifier would certify a lie whenever the durable copies
+happen to line up, and reject honest rows whenever the client's speculative
+(user-labeled) copy and the durable (service-labeled) copy are compared
+across the seam. The labels must carry the acting user for the verification
+to MEAN anything.
+
+The authorization plane is already per-run correct: OW31 (merged 2026-08-21,
+`9d989c0c1`) landed genesis-names-the-user, ACL-only service reads, served
+reads under the acting-as-owner binding, and §2b delegated carriage on
+served writes (`ServerRunInfo.delegated`). The identity IS at the seam —
+`ServerRunInfo.acting` for handler runs, `scopeKeyIdentity` for demanded
+derivations, `delegated.acting` for the sanctioned bookkeeping crossings.
+What was never plumbed is the CFC **label/trust** mechanism: the trust
+snapshot that resolves `__ctCurrentPrincipal` placeholders at commit-prep is
+still the runtime-level ambient default, and on a serving runtime the
+ambient identity is the service. On a client, ambient identity == the user,
+which is why labels were correct for free before ON. This document designs
+the plumbing — and only the plumbing — that closes FLAG-5.
+
+## 1. The mechanism, as verified (all anchors re-read on `59cde49ef`)
+
+Every claim below was verified against code in this worktree, not carried
+from the build report.
+
+### 1a. The snapshot: one shape, one writer, attached per-tx
+
+- `TrustSnapshot = { id: string; actingPrincipal?: string; revision?: string }`
+  — `packages/runner/src/cfc/types.ts:380-384`.
+- The DEFAULT provider closes over the runtime's ambient identity:
+  `actingPrincipal = options.storageManager.as.did()`, `id =
+  "principal:<did>"`, `revision = <runtime id>` or
+  `<runtime id>/trust:<cfcTrustConfig.digest>` — `runtime.ts:1318-1326`.
+  The runtime id is `storageManager.id` (`runtime.ts:1261`), which is
+  `options.id ?? crypto.randomUUID()` (`storage/v2.ts:892`) — a per-process
+  value.
+- The snapshot is attached to every transaction at `edit()`:
+  `wrapped.setCfcTrustSnapshot(this.trustSnapshotProvider())` —
+  `runtime.ts:1945`. That call is the snapshot's ONLY production writer;
+  `setCfcTrustSnapshot` (`storage/extended-storage-transaction.ts:1212-1217`)
+  stores it on the tx's CFC state and, if the tx were already prepared,
+  invalidates with reason `"trust-snapshot-changed"`. Tests already vary
+  the snapshot per-tx through this public setter
+  (`runner/test/profile-owner-cfc.test.ts:134-149` — `setTrustedProfileWriter`
+  sets a per-tx `{id, actingPrincipal}`), so per-tx snapshots are an
+  exercised, supported shape today; what does not exist is a production
+  path that sets a NON-ambient one.
+- The serving runtimes are constructed with NO `trustSnapshotProvider` and
+  NO `cfcTrustConfig` (`toolshed/lib/server-execution.ts:144-183`), so every
+  serving-side transaction carries `actingPrincipal = <service DID>`. The
+  presets classify `trustSnapshotProvider` as a delta for `remoteClient` and
+  `browserWorker` only (`runtime-presets.ts:92,163`); the browser worker's
+  provider serves the WORKER'S OWN USER from `InitializationData`
+  (`runtime-client/backends/runtime-processor.ts:300-302`) — every custom
+  provider in the tree is a client-side user identity, never a per-run one.
+
+### 1b. Where labels mint: placeholder resolution at commit-prep
+
+- The authoring vocabulary: `CurrentPrincipal = { __ctCurrentPrincipal:
+  true }`, `AuthoredByCurrentUser<T>` = `addIntegrity [{kind: "authored-by",
+  subject: CurrentPrincipal}]`, `RepresentsCurrentUser<T>` likewise —
+  `packages/api/cfc.ts:826-841`. The group-chat pattern uses exactly these
+  (`patterns/cfc-group-chat-demo/trusted.tsx:48-55,83-90`), and the SYSTEM
+  profile pattern layers `ownerPrincipal: CurrentPrincipal` on top
+  (`patterns/system/profile-home.tsx:29-37`).
+- Resolution happens inside `prepareBoundaryCommit` (reached via
+  `prepareCfc()`, ext-tx:1710-1801): `derivePersistedLabel`
+  (`cfc/prepare.ts:3881-3937`) reads
+  `tx.getCfcState().trustSnapshot?.actingPrincipal` (line 3889) and
+  `resolveCurrentPrincipalLabelValues` (prepare.ts:396-412) substitutes the
+  placeholder with that principal. The resolved atoms persist into the
+  written doc's `["cfc"]` label map inside the SAME transaction (privileged
+  persistence; ext-tx:1717-1721). With an UNDEFINED acting principal a
+  placeholder-carrying label value is DROPPED (prepare.ts:403-410) — and the
+  gated families separately refuse: `currentPrincipalIntegrityReason`
+  (prepare.ts:2371-2469) fail-closes any placeholder mint that lacks a
+  snapshot, an acting principal, `writeAuthorizedBy`, or `uiContract`, and
+  REJECTS literal-DID current-principal claims outright ("current-principal
+  integrity subject must be runtime resolved", prepare.ts:2433-2437).
+- Consequence (verified against the store evidence in rootcause §2a): a
+  served trusted-send handler run resolves `authored-by` /
+  `represents-principal` with the SERVING runtime's snapshot — the service
+  DID — which is precisely the observed `did:key:z6MksHnZ…` ×6 on Alice's
+  message commit and on the profile entity's labelMap.
+- Structural note that bounds the blast radius: because the non-owner
+  placeholder arm requires BOTH `writeAuthorizedBy` and `uiContract`
+  (prepare.ts:2458-2467), and `uiContract` satisfaction requires a
+  renderer-trusted EVENT (the OW34 sister-mark carriage, events.md §2),
+  **current-principal labels can only ever mint inside trusted-event
+  handler transactions and builtin-authored owner writes** — never from a
+  plain derivation. This is what makes the derivation arm of this design
+  behaviorally inert today (§2, §10 Q2).
+
+### 1c. Other consumers of the tx snapshot (the full set)
+
+`tx.getCfcState().trustSnapshot` is consumed at exactly these sites, all
+inside the runner:
+
+- `derivePersistedLabel` — the mint (1b).
+- `currentPrincipalIntegrityReason` — the gate, including the
+  `ownerPrincipal` arm which requires `actingPrincipal === ownerPrincipal`
+  after placeholder resolution (prepare.ts:2400-2427).
+- `writeAuthorizedByReason` — requires snapshot presence (id +
+  actingPrincipal) before any writeAuthorizedBy claim verifies
+  (prepare.ts:534-537). Note the verification itself binds the
+  IMPLEMENTATION identity, not the principal — the snapshot is a
+  present-and-authenticated floor here.
+- `cfcFloorTrustContext` — concept-valued `requiredIntegrity` floors
+  evaluate under the acting principal's trust closure (prepare.ts:3347-3355,
+  observation.ts:179-235).
+- Exchange-rule evaluation — `actingPrincipal` in the evaluator context
+  (prepare.ts:4712-4720, exchange-eval.ts:164).
+- `writeCfcGrant` — the grant's release-authority owner is the tx's acting
+  principal, read MID-RUN at the write call (ext-tx:1354-1357), and grant
+  revocation authority compares against it (grants.ts:391-461).
+- The prepared-digest input — the snapshot is bound VERBATIM
+  (ext-tx:1558 → `canonicalizePreparedDigestInput`, cfc/canonical.ts:437).
+
+Separate from the tx snapshot, two builtin families call the RUNTIME-level
+provider directly, mid-run: the sqlite builtins (db-owner mint at handle
+creation, clearance-reader keying, ceiling placeholder resolution —
+`builtins/sqlite-builtins.ts:555-557,753-756,858-882`) and llm-dialog
+(`builtins/llm-dialog.ts:2371`). These are OW53's adjacent territory and are
+NOT in this design's scope (§7), but the design's substrate — a per-run
+snapshot on the tx — is exactly what a future OW53 fix would re-point them
+at.
+
+### 1d. The serving seam: what identity each run carries, and when
+
+- The scheduler mints one tx per action run via `runtime.edit()` and
+  IMMEDIATELY stamps it — before the run body executes a single read — at
+  its two choke points: event dispatch (`scheduler/events.ts:1187-1268`;
+  `served.firedAt.user` → `info.acting`) and reactive actions
+  (`scheduler/run.ts:508-542`; a fanned-out instance carries
+  `scopeKeyIdentity` + `actionScopeKey`). `Runtime.stampServerRun`
+  (runtime.ts:2091-2104) forwards to the SpaceServer's `#stampRun`
+  (`executor/space-server.ts:1422-1499`) when a stamper is installed — i.e.
+  exactly on a serving runtime with a live wave — and to the speculation
+  stamp on flag-ON clients; the OFF arm is one undefined check.
+- `ServerRunInfo` (runtime.ts:353-425) carries, per run: `acting` (the
+  event's server-stamped `firedAt` actor — handler runs), `scopeKeyIdentity`
+  (the demand-supplied principal — derivation runs), and `delegated` (the
+  OW31 S-A §2b carriage — the sanctioned bookkeeping crossings). The
+  bookkeeping writeback stamps happen INSIDE `editWithRetry`'s fn
+  (`pattern-manager.ts:2074-2098,2183-2200`), so every retry attempt
+  re-stamps its fresh tx — a per-run snapshot attached at the stamp seam
+  inherits retry-safety for free.
+- Timing, which forces the seam choice: `writeCfcGrant` reads the snapshot
+  MID-RUN (1c), so the snapshot must be attached BEFORE the run body — a
+  prepare-time-only fix is structurally insufficient. CFC prepare runs at
+  commit kickoff (`Runtime.prepareTxForCommit`, runtime.ts:2345-2390) and
+  at the commit chokepoint (ext-tx:2270-2371), both BEFORE the wave seal;
+  `settleScopeAttribution` — which derives a derivation's memory-plane
+  acting from its DISCOVERED scope — runs inside `seal()` (wave.ts:898-989,
+  settle at 938), AFTER prepare. So a derivation's settled-at-seal actor
+  can never feed label minting; only stamp-time identity can. (Why this is
+  harmless: 1b's structural note — derivations cannot mint
+  current-principal labels at all.)
+- Per-run CFC granularity is already normative: serving-loop.md §3c —
+  "CFC evaluates at the END OF EACH ACTION RUN … the unit is the RUN, and a
+  run is action × instance … a server-side handler run gets per-run CFC
+  exactly as its client run did." The trust snapshot is the one input of
+  that per-run evaluation that today ignores the run and reads the process.
+
+### 1e. The verification contract (what the group-chat check compares)
+
+`cf-cfc-authorship` (`ui/src/v2/components/cf-cfc-authorship/`):
+
+- The VALUE side reads the message body's resolved label view over label
+  IPC and looks for a root-entry integrity atom `{kind: "authored-by",
+  subject: <id>}` (or `"authored-by:<id>"` string form) —
+  `authorshipStateForLabel`, cf-cfc-authorship.ts:351-374.
+- The CLAIM side resolves the bound author-profile cell's label view and
+  extracts the `represents-principal` atom's SUBJECT
+  (`representsPrincipalSubjectForLabel`, :268-290;
+  `refreshAuthorClaim`, :752-792). Display names are untrusted decoration.
+- `authorshipState === "verified"` iff some authored-by subject equals the
+  claim subject (and descendant text integrity is not blocked, :610-624).
+  The test (`patterns/integration/cfc-group-chat-demo.test.ts:154,174,210,
+  245` + `waitForAuthorshipState`, :253-346) asserts exactly this element
+  state; the sibling `-two-browsers` file asserts NO authorship state,
+  which is why it already passes ON while this file cannot.
+
+So the verification contract is: **authored-by.subject on the content must
+equal represents-principal.subject on the claimed author's profile, both
+from durable labels.** Any design in which the two families resolve to the
+same principal for the same acting user satisfies the check; only the
+acting-user semantics (§4) also makes the check MEAN authorship.
+
+### 1f. What protocol.md §2 already says, and does not say
+
+The `authored`, server-produced admission row (protocol.md:306) rules the
+MEMORY-plane identity: carriage (`actingPrincipal` + `capabilityRef`),
+delegation-never-impersonation, `firedAt` stamped from the carried actor,
+genesis names the acting user. S1 (protocol.md:471-478) rules run identity:
+"a derivation runs per demanded instance and the DEMAND supplies the
+identity … there is no third source of run identity, and 'whatever the
+SpaceServer's own envelope resolves to' is never one." Protocol.md says
+NOTHING about CFC value-plane labels — the label plane has no spec sentence
+for served execution at all. That absence is the gap this design fills with
+one binding sentence (§8, Q4): today the implementation's ambient default
+is exactly the "third source of run identity" S1 forbids, one plane up.
+
+### 1g. Adjacent work, checked against this design
+
+- OW50 / #6157 (`prepareCfc` totality, merged, in base): a commit-prep
+  crash is a modeled refusal (ext-tx:1744-1771). Composes: this design
+  changes WHAT the prepare resolves, not the totality/refusal shape. OW54
+  (served event whose prep crashes seals no consequence) is unchanged by
+  this design and stays its own row.
+- OW47 (#6150, merged): the client own-write half of the group-chat file is
+  CLOSED; the skip reason names this seam as the only remaining lift
+  condition.
+- OW31 (#6156, merged): supplies the per-run identity this design consumes
+  (`acting`, `delegated`); its FLAG-4 (repair-path writebacks carry no
+  carriage) bounds which bookkeeping txs can carry a delegated principal —
+  the carriage-less ones stay refused for foreign writes and keep the
+  ambient snapshot (§2).
+- Open PRs touching cfc/prepare (#6074 writer-fit space principal, #6077
+  meta-seam write-policy inputs, #6095 metadata probes, #6094 write-floor
+  host dial, #6114 terminal CFC refusals, #6083 content-addressed schemas):
+  none reads or writes the trust snapshot; no file-level conflict with the
+  seam this design names (stamper + a Runtime helper + prepare untouched).
+  #6173 (open, docs) mints OW56 — register numbering in §10 Q7 accounts for
+  it.

--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -262,3 +262,189 @@ is exactly the "third source of run identity" S1 forbids, one plane up.
   seam this design names (stamper + a Runtime helper + prepare untouched).
   #6173 (open, docs) mints OW56 — register numbering in §10 Q7 accounts for
   it.
+
+## 2. Snapshot granularity — options
+
+The question: per-run trust (the acting user) on a runtime whose ambient
+identity is the service. Three shapes considered; the invariant cost of
+each is stated against §3's digest machinery and §5's OFF-invisibility.
+
+**Option A — stamper-attached per-run snapshot (RECOMMENDED).** The
+SpaceServer's `#stampRun` — the seam that already lands every other piece
+of per-run identity — additionally calls `tx.setCfcTrustSnapshot(...)` with
+a snapshot for the run's acting principal, resolved with the SAME
+precedence the stamper already encodes:
+
+  1. `info.delegated.acting.user` (the S-A bookkeeping carriage) —
+  2. else `info.acting.user` (a handler's server-stamped `firedAt` actor,
+     LT6-inherited pairs included) —
+  3. else, for a `derivation` carrying a demand-supplied
+     `scopeKeyIdentity`, its `principal` (see Q2 — severable) —
+  4. else (actor-less bookkeeping, unnarrowed/wave-fallback derivations):
+     leave the tx's ambient snapshot untouched (see Q3).
+
+  The Runtime exposes one helper, e.g.
+  `trustSnapshotForPrincipal(principal: string): TrustSnapshot`, returning
+  `{ id: "principal:<did>", actingPrincipal: <did>, revision: <the
+  runtime's trust revision> }`, and the constructor's default provider
+  refactors onto the same revision composition — so the config-digest
+  folding (`<id>/trust:<digest>`) lives in exactly one place and the
+  trust.ts determinism contract ("hosts must fold their trust versioning
+  into revision") holds for per-run snapshots by construction.
+
+  Invariant costs: none new. The stamper runs before the run's first read
+  (1d), so the mid-run `writeCfcGrant` read and the prepare-time mint see
+  one stable snapshot; the tx is unprepared at stamp, so the
+  `trust-snapshot-changed` invalidation never fires; retries re-stamp their
+  fresh tx (1d); OFF and client-ON paths never reach the stamper (§5).
+
+**Option B — per-principal snapshot provider (a provider-level cache
+keyed by "the current run's principal").** Rejected on mechanism: the
+provider is consulted at `edit()` (runtime.ts:1945), and at edit() time no
+run context exists — the scheduler stamps AFTER minting the tx (1d). A
+provider-based design would need ambient current-run state mutated around
+every dispatch, i.e. a hidden global where option A uses the explicit
+per-tx seam that already exists (`setCfcTrustSnapshot` is a supported,
+test-exercised per-tx surface — 1a). The legitimate kernel of B — not
+allocating a fresh 3-field object per run — is a memoization detail INSIDE
+option A's helper (a `Map<did, TrustSnapshot>` on the runtime, frozen
+values), worth doing only if profiling ever says so.
+
+**Option C — delegation-aware snapshot (service + represents-principal
+carried distinctly).** Extend `TrustSnapshot` with the delegating service
+identity, e.g. `{ actingPrincipal: <user>, delegatedBy: <service> }`, so
+label minting (or auditing) can distinguish "the service executed this as
+X" from "X wrote this directly". The snapshot extension itself is cheap
+(the digest binds the snapshot verbatim, so a new field flows into
+invalidation for free), but it only MEANS something if some consumer reads
+it — which is label-semantics option (b) in §4, with that option's costs.
+Not needed for the lift; kept as the natural extension point if the owner
+wants the served-provenance mark later (§4b, Q1). Note the memory plane
+already durably records the delegation (the commit's `acting_principal` +
+`capabilityRef` + the derived-class producer identity), so the audit trail
+option C would duplicate exists one plane down.
+
+## 3. Trust-revision keying + prepared-digest invalidation (load-bearing)
+
+What the current machinery actually assumes — verified by reading, not
+inherited from the report:
+
+- **The prepared digest is per-transaction and binds the snapshot
+  VERBATIM.** `buildPreparedDigestInput` copies
+  `this.#cfcState.trustSnapshot` into the input (ext-tx:1558);
+  `canonicalizePreparedDigestInput` passes it through untouched
+  (canonical.ts:437); `preparedDigestFor` hashes the whole
+  (canonical.ts:499-500). `id`, `actingPrincipal`, and `revision` are all
+  decision content. There is no digest cache outside the tx: prepare state
+  (`status`/`digest`/`input`) lives on the tx (ext-tx:1782-1795), digests
+  are never persisted, never compared across transactions, and never leave
+  the process. **"One snapshot per runtime" was never a digest-machinery
+  assumption — it is purely a property of the default provider closure.**
+  Per-tx variance is therefore supported BY CONSTRUCTION: two runs in one
+  wave with different acting users produce two independent digests, each
+  bound to its own snapshot; the wave is transport (serving-loop.md §3c),
+  and no wave-level label or digest union exists to contaminate.
+- **The invalidation triggers already exist.** `setCfcTrustSnapshot` on a
+  prepared tx invalidates with `trust-snapshot-changed` (ext-tx:1212-1217)
+  — under option A this trigger is provably dead (stamp precedes first
+  read, which precedes prepare), but it stays as the tripwire against a
+  future mis-ordered caller. The commit-time recheck (ext-tx:2354-2371)
+  rebuilds the input from CURRENT tx state; since nothing re-sets the
+  snapshot after the single stamp, prepare and recheck see the same value.
+  A NEW pin makes this contractual (§9 pin 2).
+- **`revision`'s one job is config identity.** `trustConfig` is
+  deliberately NOT a digest input; `TrustSnapshot.revision` covers it
+  (types.ts:726-731; trust.ts:24-31). So the design's single hard
+  requirement here: per-run snapshots MUST carry the same
+  `<runtime id>[/trust:<digest>]` revision composition as the default
+  provider, or a trust-config change would stop invalidating exactly the
+  served runs. Option A's shared helper makes divergence structurally
+  impossible (one composition site). Serving runtimes today configure no
+  trust config (1a), so revision = the runtime id — but the helper must
+  not bake that accident in.
+- **How each rejected shape would have handled this, for the record.**
+  Keying a digest CACHE by principal: nothing to key — no such cache
+  exists. Extending digest inputs: not needed — the snapshot (with the
+  acting principal inside) is already an input. Partitioning: the only
+  partitionable state adjacent to trust is the snapshot OBJECT itself,
+  which option A memoizes per principal at most.
+- **The one real keying rule this design adds** (stated as an invariant,
+  pinned in §9): a transaction's snapshot is set at most ONCE after
+  `edit()`, before the run's first read; every consumer within the tx —
+  the mid-run grant write, the gate, the mint, prepare, the recheck —
+  reads that one value. Mirrors `stampWaveRunContext`'s
+  set-exactly-once posture for the wave context (wave.ts:285-301). A
+  second stamp on one tx is a bug, not a hand-over.
+
+## 4. Label semantics — what a served row's labels SHOULD say
+
+The constraint set, from 1e: the verifier compares authored-by.subject
+(content) against represents-principal.subject (claimed author's profile),
+both durable. From 1b: literal-DID current-principal claims are rejected at
+authoring — the ONLY path to a subject is runtime resolution against the
+tx's acting principal. From protocol.md §2: the memory plane already
+carries the acting user on the same commit, under LT5's ruled trust
+footing (servers are trusted for carried actor claims, as if the principal
+had written directly).
+
+**(a) authored-by = the acting user, indistinguishable from a
+client-authored row (RECOMMENDED).** The served mint resolves
+`__ctCurrentPrincipal` to the run's carried acting principal, producing
+byte-identical labels to what the same handler run mints on the user's own
+client under OFF.
+
+  - Soundness: this does not manufacture authority. The label plane's
+    forge-resistance is unchanged — a client still cannot self-attach a
+    literal DID (prepare.ts:2433), and the serving runtime resolving the
+    placeholder to the CARRIED actor asserts exactly what the memory plane
+    already asserts one row down (`firedAt.user`, `acting_principal`) on
+    the SAME durable commit, under the SAME LT5 ruling. A malicious
+    co-hosted server needs no label tricks — it holds the ambient write
+    path; this design narrows what an HONEST server writes.
+  - Verification: authored-by(user) vs represents-principal(user) —
+    the check regains its meaning: rows verify iff the profile's
+    represented principal actually fired the send. The demo's negative
+    arm (imported claims) is untouched: those rows carry no authored-by
+    at all (no `AuthoredByCurrentUser` wrapper), so they stay
+    unverified regardless of who acted.
+  - Client/durable agreement: the acting user's own speculative copy
+    (minted client-side with the user snapshot) and the durable served
+    copy now carry the SAME subjects, retiring the local-pass/CI-fail
+    flap of rootcause §2a (the speculative Alice-labeled copy vs the
+    durable service-labeled truth).
+
+**(b) = (a) plus a distinct served-provenance mark** (a runtime-minted
+atom on served rows, e.g. `{type: ServedExecution, service: <did>}`, fed
+by option C's snapshot). Auditable "the service executed this as X" at the
+value plane. Costs, why it is NOT recommended for this lift: a new atom
+family means registering it in `RUNTIME_MINTED_INTEGRITY_ATOM_TYPES`
+(prepare.ts:4082+), atom-classes, field classification, and every label
+diffing surface; it re-introduces a PERMANENT client-speculative vs
+durable label divergence (the client echo cannot honestly carry the mark),
+which is the §2a flap in new clothes and would keep authorship state
+churning across arrival; and the audit fact it records is already durable
+on the memory plane per-commit (acting_principal + capabilityRef +
+derived-class producer). If a product surface later needs value-plane
+audit of served execution, mint it THEN with its own spec sentence — the
+option-C snapshot field is the prepared extension point.
+
+**(c) authored-by = service + represents-principal = user (closest to
+today's accident).** Rejected on the verification contract: the check
+compares the two subjects for EQUALITY (1e), so (c) is permanently
+"unverified" — it is the CI red, restated as a design. It also corrupts
+the vocabulary: represents-principal on a PROFILE means "this profile
+represents that user" (the claim-side anchor); making content rows carry a
+user they were not authored by while authored-by names an executor is a
+semantic the verifier, the demo, and the spec's current-principal family
+were never designed for. Teaching the verifier to accept
+service-authored-by (a service allowlist in the UI component) would make
+every service-executed row verify as ANY user — the collapsed security
+property of §Why, institutionalized.
+
+Recommendation: **(a)**, stated as the OFF-equivalence invariant (§8
+INV-A). The register's own OW34-family precedent supports the shape: the
+renderer-trust carriage (the closed OW34 row) already re-mints a
+client-process-local trust attestation server-side at the
+injected-keys trust level; resolving the current-principal placeholder
+against the carried actor is the same move on the label plane, with the
+same explicitly-ruled footing to cite (LT5, owner 2026-08-03).

--- a/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md
@@ -121,14 +121,22 @@ from the build report.
   `represents-principal` with the SERVING runtime's snapshot — the service
   DID — which is precisely the observed `did:key:z6MksHnZ…` ×6 on Alice's
   message commit and on the profile entity's labelMap.
-- Structural note that bounds the blast radius: because the non-owner
-  placeholder arm requires BOTH `writeAuthorizedBy` and `uiContract`
-  (prepare.ts:2458-2467), and `uiContract` satisfaction requires a
-  renderer-trusted EVENT (the OW34 sister-mark carriage, events.md §2),
-  **current-principal labels can only ever mint inside trusted-event
-  handler transactions and builtin-authored owner writes** — never from a
-  plain derivation. This is what makes the derivation arm of this design
-  behaviorally inert today (§2, §10 Q2).
+- Structural note that bounds the blast radius: the non-owner placeholder
+  arm requires BOTH `writeAuthorizedBy` and `uiContract`
+  (prepare.ts:2458-2467), and the owner arm requires `writeAuthorizedBy`
+  (prepare.ts:2425-2427); `uiContract` satisfaction requires a
+  renderer-trusted EVENT (the OW34 sister-mark carriage, events.md §2) —
+  **with two deliberate carve-outs**: `verifyTrustedEventRequirements`
+  skips the trusted-event match for setup projections and for writes that
+  install an INITIAL SCHEMA DEFAULT (prepare.ts:3719-3732,
+  `setupProjectionSourceMatchesValue` / `writeInstallsInitialSchemaDefault`).
+  So current-principal labels mint from exactly three places: trusted-event
+  handler transactions, builtin-authored owner writes, and
+  setup/defaults materialization — never from a plain derivation. The
+  first two carry a per-run acting user under this design; the third is
+  the actor-less candidate Q3 names (a serving-side setup restage mints
+  with whatever snapshot the tx carries). This is also what makes the
+  derivation arm of this design behaviorally inert today (§2, §10 Q2).
 
 ### 1c. Other consumers of the tx snapshot (the full set)
 
@@ -576,9 +584,13 @@ NAMED OUT, with its home:
      before the run's first read; prepare and the commit-time recheck see
      the same value; the `trust-snapshot-changed` invalidation stays as
      the tripwire and never fires on the sanctioned path. (§9-2.)
-   - **INV-D (no service-authored labels under ON):** no durable `["cfc"]`
-     labelMap entry carries an authored-by / represents-principal atom
-     whose subject is the service DID. (§9-6's store-dump audit.)
+   - **INV-D (no service-authored labels from ACTING runs):** no durable
+     `["cfc"]` labelMap entry minted by a run that CARRIES an acting
+     principal (handler / delegated / demanded) names the service DID in
+     an authored-by / represents-principal atom — and the group-chat gate
+     run's store audits to ZERO such atoms overall (§9-6). The
+     deliberately-unclaimed remainder is Q3's actor-less setup path,
+     whose disposition the audit arbitrates.
    - **INV-E (forge-resistance unchanged):** literal-DID current-principal
      claims stay rejected; the only path to a user-named label remains a
      run actually carrying that user's acting identity. (Existing pins +
@@ -598,8 +610,11 @@ NAMED OUT, with its home:
    `AuthoredByCurrentUser` / `RepresentsCurrentUser` schemas persists
    labelMap atoms whose subject is the entry's `firedAt.user` — WATCHED
    RED at base, where the subject is the service DID (the rootcause §2a
-   store shape). Negative arm: a payload-smuggled literal-DID claim still
-   refuses (INV-E).
+   store shape). Negative arms (INV-E, both already-pinned behaviors
+   re-asserted under the serving stack): a SCHEMA-authored literal-DID
+   current-principal claim still refuses ("subject must be runtime
+   resolved"), and an unprivileged direct `["cfc"]` write is still the
+   S18 fail-closed reason.
 2. **Per-wave multi-principal pin.** Two handler runs for two users in one
    wave: each run's docs carry that run's user; both prepared digests
    recheck clean at commit (INV-C; no cross-run contamination, no
@@ -653,12 +668,23 @@ NAMED OUT, with its home:
    undefined (fail-closed placeholder minting)?** Recommendation: **keep
    the service snapshot** — zero behavior change for paths that today
    work (structure loads, watermark, pattern-swap setup, factory-time
-   loads), aligned with protocol.md §1's "the SpaceServer's own writes";
-   the gated mint families are already unreachable from those paths
-   (uiContract requires a trusted event — 1b). The fail-closed
-   alternative is one line if the owner prefers the tighter posture and
-   accepts hunting any latent bookkeeping path that relied on snapshot
-   presence (writeAuthorizedBy's presence floor — 1c).
+   loads), aligned with protocol.md §1's "the SpaceServer's own writes".
+   The honest caveat, flagged rather than filled: 1b's third mint family
+   (setup/defaults materialization, via the initial-schema-default
+   carve-out) IS reachable from an actor-less serving-side path — a
+   system-pattern swap restage of an owner-gated pattern would mint
+   `represents-principal: <service>` under keep-service, and would REFUSE
+   under clear-to-undefined ("ownerPrincipal requires an acting
+   principal"), i.e. break serving-side system-pattern updates of such
+   patterns. Neither arm is right for that path; the semantically-correct
+   principal is the space's OWNER, which OW31's ACL owner resolution can
+   supply — but that is its own small ruling. Arbitration: §9-6's
+   store-dump audit. The group-chat lift does not exercise this path (the
+   gate deploys its own piece; profile patterns are not in its flow), so
+   the lift does not wait on it; if the audit or the flip-train live
+   gates surface a service-named mint from this path, dispose of it THEN
+   — owner-resolved snapshot or a threaded carriage — as a named
+   follow-up, not silently here.
 4. **Spec home.** Recommendation: one binding sentence in
    serving-loop.md §3c (where per-run CFC is already normative), shaped
    like: *"The run's CFC trust snapshot carries the run's ACTING

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -780,3 +780,29 @@ participant's clause; the multi-party conjunction dissolves exactly when all
 are present — §5.3.3 stated operationally). Registry row + a note in §5.3.4
 pointing at the reserved shape. Authoring sketch:
 `cfc-exchange-rules-authoring-extensions.md` §4.
+
+## From the served-execution attribution build (OW34-family, RULED 2026-08-21)
+
+Design of record:
+`docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md`.
+The serving-side binding sentence lives in
+`docs/specs/server-side-execution/serving-loop.md` §3c; the coverage row is
+verification-coverage.md OW59.
+
+**SC-38 [normative] The current-principal family's served-execution reading
+— the audit-3.5 principal-resolution chain (§6/§8.15).** `open`. The
+`__ctCurrentPrincipal` placeholder (authored-by / represents-principal /
+`ownerPrincipal` subjects) resolves at commit-prep against the transaction's
+trust snapshot, and under served execution that snapshot is PER-RUN: it
+carries the run's acting principal — the event's server-stamped actor, the
+demanded instance's principal, or the delegated carriage's actor — never the
+serving runtime's ambient service identity. The resolved labels are
+indistinguishable from the same run's client-side mint (no served-provenance
+mark; the memory plane already records the delegation per commit via
+`acting_principal` + `capabilityRef`). A run with no acting principal keeps
+the ambient service snapshot. Literal-DID current-principal subjects stay
+refused at authoring; the only path to a user-named label remains a run
+actually carrying that user's acting identity. Proposed edit: when the
+audit-3.5 chain is written into §6/§8.15, state the snapshot's per-run
+binding and the acting-principal resolution as the normative reading for
+serving hosts, citing serving-loop.md §3c.

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -753,7 +753,11 @@ action's public write. Therefore, normatively:
   the event's server-stamped actor, the demanded instance's principal,
   or the delegated carriage's actor — never the serving runtime's
   ambient identity; a run with no acting principal keeps the service
-  snapshot and cannot mint current-principal claims. (OW34-family,
+  snapshot and cannot mint USER-NAMED current-principal claims. (The
+  actor-less setup/defaults mint carve-out can still resolve a
+  placeholder to the SERVICE under keep-service — the same ruling's
+  flagged Q3 caveat, recorded in the OW34 design of record and
+  arbitrated by the OW59 row's store audit.) (OW34-family,
   RULED 2026-08-21. The snapshot attaches at the SpaceServer's run
   stamp, before the run's first read, so the mid-run grant writes and
   the commit-prep label mints of one run read one value. SC-38 in

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -749,6 +749,17 @@ action's public write. Therefore, normatively:
 - Handler runs are actions: a server-side handler run gets per-run CFC
   exactly as its client run did. D-v2-1 moves WHERE handlers run, never
   the enforcement unit.
+- **The run's CFC trust snapshot carries the run's ACTING principal** —
+  the event's server-stamped actor, the demanded instance's principal,
+  or the delegated carriage's actor — never the serving runtime's
+  ambient identity; a run with no acting principal keeps the service
+  snapshot and cannot mint current-principal claims. (OW34-family,
+  RULED 2026-08-21. The snapshot attaches at the SpaceServer's run
+  stamp, before the run's first read, so the mid-run grant writes and
+  the commit-prep label mints of one run read one value. SC-38 in
+  `docs/specs/cfc-spec-changes.md` records the current-principal
+  family's served-execution reading; verification-coverage.md OW59 is
+  the coverage row.)
 
 FORBIDDEN: wave-level label unions; deferring any CFC check to commit
 or admission time; a server bypass ("the server is trusted") — the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5132,9 +5132,13 @@ supply; OW29/OW32/OW34 closed):
   converge on the register's already-owed **OW31/§2b write-authority
   carriage build** (cfc-group-chat-demo's served rows carrying the
   SERVICE identity; home-profile's `compile-cache/writeback` fallback
-  refused without carriage): NO new row is minted for what OW31
-  already owes — those skip entries point at OW31, which now carries
-  two CI surfaces as its lift evidence. A ninth CI-red family member,
+  refused without carriage): NO new row was minted at the gate for
+  what OW31 already owed — both skip entries pointed at OW31 then.
+  The group-chat surface has since split and closed: its memory-plane
+  carriage half closed with OW31's build, its CFC-attribution half
+  (the service-identity authorship labels) closed by **OW59** (the
+  OW34-family train), which lifted that skip — so OW31's remaining CI
+  surface is home-profile's, riding OW31/OW45. A ninth CI-red family member,
   `cfc-group-chat-demo-multi-runtime`, was the test HARNESS's own
   mixed posture (the self-hosted OFF-arm standalone server refusing
   the ON workers' event appends deterministically) — fixed IN the
@@ -5150,8 +5154,9 @@ supply; OW29/OW32/OW34 closed):
   `tasks/server-execution-on-skips.ts` (at the gate: SIX file entries
   + TWO step-level entries; the skip-list test pins the CURRENT set —
   both step entries were lifted the same day, cellset-lww with OW47's
-  close and convergence-storm with OW52's, leaving the six file
-  entries); they gate the
+  close and convergence-storm with OW52's, and the group-chat file
+  entry was lifted with OW59's close, leaving five file entries);
+  they gate the
   FLIP — whose bar is the list EMPTY — not the land. Rows, one per
   mechanism cluster; each row's trigger names the skip entry it
   lifts:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2854,9 +2854,10 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   Acceptance beyond the executor pins rides the PR's CI ON lanes and
   the flip train's live gates (the lunch/served-wish log criteria and
   the store dump), which stay the flip PR's bar; the
-  `home-profile-reload-durability` and `cfc-group-chat-demo` ON skips
-  stay listed — they lift jointly with OW45 and OW47 (+ the CFC
-  attribution residual above).
+  `home-profile-reload-durability` ON skip stays listed (it lifts
+  jointly with OW45), and the `cfc-group-chat-demo` skip was LIFTED
+  by OW59 (the OW34-family train closed the CFC-attribution residual
+  above and removed the entry on its green ON gate + store audit).
 - OW32 — the CLIENT-side `scheduler-non-settling` loop under the full
   ON posture in the two-browser journeys — the EVIDENCED mechanism of
   the two two-browser gates' red, UNATTRIBUTED (P7 independent review
@@ -5299,9 +5300,9 @@ supply; OW29/OW32/OW34 closed):
     (true ON topology, lane-shaped toolshed) after 2/6-red pre-fix at
     the same tip; the `integration/cellset-lww.test.ts` step entry is
     REMOVED. The `integration/cfc-group-chat-demo.test.ts` file skip
-    REMAINS: its CI shape is OW31's §2b acting-identity carriage
-    (that train lifts it jointly; the OW47 half of its reason is
-    closed).
+    was subsequently LIFTED by OW59 (the OW34-family train): its
+    remaining CI shape was the per-run CFC trust attribution seam,
+    closed there — the OW47 half of its reason had closed here.
   - **OW48 — CLOSED 2026-08-21 (refuted premise; optimize-on-main
     served-wish seat,
     [`optimize/ow48-50-wish-path-report.md`](../../history/plans/server-execution-v2/optimize/ow48-50-wish-path-report.md)
@@ -5797,7 +5798,9 @@ supply; OW29/OW32/OW34 closed):
     leave the edit()-attached ambient snapshot untouched); INV-G
     revision-composition equality with and without a trust config.
     The `cfc-group-chat-demo` ON gate is this row's live lift
-    condition (the skip entry is removed by this train); the
+    condition (the skip entry is removed by this train; green 4/4 —
+    three fresh-store lift runs plus a quiet-machine solo run, every
+    run's store audited); the
     store-dump audit (zero authored-by / represents-principal atoms
     naming the service DID — INV-D) arbitrates Q3's flagged caveat:
     a serving-side system-pattern restage of an owner-gated pattern
@@ -5810,7 +5813,13 @@ supply; OW29/OW32/OW34 closed):
     identity-model decision — the per-run tx snapshot is the
     substrate a fix would re-point them at); label option (b)'s
     served-provenance mark (future, on product need, with its own
-    spec sentence).
+    spec sentence). OW53-adjacent note (the #6190 review's NOTE-6,
+    recorded not fixed): delegated READ sessions register their
+    demand under the PROCESS DID rather than the acting principal
+    (memory/v2/server.ts — the session-demand identity assembly,
+    `session.principal` into the demander identity) —
+    label-inert (no mint reads it) and operator-allowlisted; an
+    identity-model decision for OW53's family, not this row's.
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2818,13 +2818,12 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   persist do not carry the carriage (no run context is reachable at
   those triggers today) — their foreign-write case stays fail-closed
   refused; if live gates surface residual refusals from them, that is
-  the named follow-up, not a re-widening. (iii) CFC AUTHORSHIP LABELS
-  (`authored-by`/`represents-principal`) on served rows still carry
-  the SERVICE signer: they come from the runtime-level CFC trust
-  snapshot (`storageManager.as`), NOT the memory-plane carriage this
-  build landed — so cfc-group-chat-demo's CI shape does NOT lift on
-  this build alone; per-run CFC attribution is a CFC-owner seam
-  (OW34's family), flagged rather than filled. (iv) the ruled
+  the named follow-up, not a re-widening. (iii) CFC AUTHORSHIP LABELS on served rows carrying the SERVICE
+  signer (the runtime-level ambient trust snapshot, not this build's
+  memory-plane carriage): CLOSED-BY **OW59** (2026-08-21, the
+  OW34-family implementation train — per-run trust snapshots attached
+  at the SpaceServer's run stamp; design RULED 2026-08-21). The
+  cfc-group-chat-demo lift rode that train, not this build. (iv) the ruled
   ACL-only-read allowance is exercised as the server-side owner
   resolution at session.open; no raw ACL-doc query surface was built
   (nothing needs one — smaller surface, permissive clause). (v) SHARED
@@ -5752,6 +5751,66 @@ supply; OW29/OW32/OW34 closed):
     deliberate pass, not a side-swipe. Trigger: next seal-machinery
     pass, or first live sighting of a stranded-unconsequenced entry
     with a guarded id and no notice.
+  - **OW59 — OW34-family: per-run CFC trust attribution for served
+    runs (the FLAG-5 seam; design RULED 2026-08-21, all seven §10
+    recommendations adopted): CLOSED (2026-08-21, the OW34-family
+    implementation train).** The defect as designed against: a served
+    run's `__ctCurrentPrincipal` mints (authored-by /
+    represents-principal) resolved against the RUNTIME-level ambient
+    trust snapshot — `storageManager.as`, the SERVICE — so every
+    durable served row carried service-DID authorship labels
+    (rootcause §2a's store shape; the first-ON-CI-gate row-2 red),
+    collapsing the authorship-verification property to a tautology
+    and blocking the `cfc-group-chat-demo` ON lift. The build, per
+    the design's §8: `Runtime.trustSnapshotForPrincipal(principal)`
+    — `{id: "principal:<did>", actingPrincipal, revision}` on the
+    runtime's ONE trust-revision composition site (the default
+    provider refactored onto it, so a trust-config change invalidates
+    per-run served digests exactly as ambient ones — INV-G); the
+    SpaceServer's `#stampRun` attaches the per-run snapshot via
+    `tx.setCfcTrustSnapshot(...)` with the ruled precedence —
+    `delegated.acting.user`, else the handler's acting
+    (LT6-inherited pairs included), else a demanded derivation's
+    `scopeKeyIdentity.principal` (the Q2 arm — ships, severable),
+    else the ambient service snapshot stays (the Q3 ruling:
+    actor-less bookkeeping and wave-fallback derivations are the
+    loop's own writes). Spec: serving-loop.md §3c's binding sentence
+    + SC-38 (cfc-spec-changes.md). Lift evidence
+    (`executor-trust-attribution.test.ts`): the FLAG-5 mint pin
+    WATCHED RED at base — the persisted subjects were the service
+    DID, the §2a query shape verbatim — and green with the fix (the
+    served docs' authored-by / represents-principal subjects equal
+    the entry's `firedAt.user`); INV-E negative arms (a
+    schema-authored literal-DID claim still refuses "must be runtime
+    resolved"; an unprivileged direct `["cfc"]` labelMap rewrite on a
+    minted envelope still fails closed with the S18
+    "unprivileged write to protected cfc path" reason, the stored
+    envelope untouched); per-wave multi-principal (two users' runs in
+    one drain mint each run's own user, both commits recheck clean —
+    no `cfc-prepared-digest-mismatch`); replay (a re-drained entry
+    mints from the DURABLE entry's actor; a second activation re-runs
+    nothing — ONE consequence commit per eventId — and the labels
+    stay byte-identical); the live stamp seam's precedence pinned on
+    the real stamper (delegated / acting / LT6-inherited / demanded /
+    actor-less-keeps-service); OFF-arm neutrality (no stamper ⇒ no
+    snapshot call — the OFF client and flag-ON client speculation
+    leave the edit()-attached ambient snapshot untouched); INV-G
+    revision-composition equality with and without a trust config.
+    The `cfc-group-chat-demo` ON gate is this row's live lift
+    condition (the skip entry is removed by this train); the
+    store-dump audit (zero authored-by / represents-principal atoms
+    naming the service DID — INV-D) arbitrates Q3's flagged caveat:
+    a serving-side system-pattern restage of an owner-gated pattern
+    (the setup/defaults mint carve-out) would mint
+    `represents-principal: <service>` under keep-service; if a live
+    gate ever surfaces that shape, the named follow-up is an
+    owner-resolved snapshot (OW31's ACL owner resolution), not a
+    silent widening. Out of scope, left where the ruling put them:
+    the sqlite/llm-dialog direct RUNTIME-provider reads (OW53's
+    identity-model decision — the per-run tx snapshot is the
+    substrate a fix would re-point them at); label option (b)'s
+    served-provenance mark (future, on product need, with its own
+    spec sentence).
 
 ## 4. Standing rule
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -1440,6 +1440,12 @@ export class SpaceServer implements TransactionSealDestination {
     // `info.acting`/mints a capabilityRef is bypassed for it: the
     // carriage is the trigger's, never derived here.
     if (info.kind === "bookkeeping" && info.delegated !== undefined) {
+      // The carriage's trust snapshot (OW34-family; serving-loop.md §3c):
+      // the delegated writeback's CFC labels resolve against the
+      // delegated acting principal, matching the memory-plane carriage.
+      tx.setCfcTrustSnapshot(
+        this.#runtime!.trustSnapshotForPrincipal(info.delegated.acting.user),
+      );
       stampWaveRunContext(tx, {
         actionId: info.actionId,
         kind: info.kind,
@@ -1457,6 +1463,25 @@ export class SpaceServer implements TransactionSealDestination {
           : {}),
       }
       : undefined;
+    // The run's trust snapshot (OW34-family; serving-loop.md §3c): the
+    // acting principal the run carries — a handler's server-stamped
+    // `firedAt` actor (LT6-inherited pairs included), else a demanded
+    // derivation's demand-supplied principal (eager at stamp: labels mint
+    // at prepare, BEFORE the seal settles the memory-plane attribution
+    // from the discovered scope, and derivations cannot mint
+    // current-principal labels, so the divergence is consequence-free).
+    // An actor-less run keeps the ambient service snapshot edit()
+    // attached (protocol.md §1's "The SpaceServer's own writes"; RULED
+    // 2026-08-21) — set at most once here, before the run's first read,
+    // so prepare and the commit-time recheck see one value and the
+    // `trust-snapshot-changed` invalidation stays a dead tripwire.
+    const trustPrincipal = (info.acting ?? acting)?.user ??
+      (info.kind === "derivation" ? principal : undefined);
+    if (trustPrincipal !== undefined) {
+      tx.setCfcTrustSnapshot(
+        this.#runtime!.trustSnapshotForPrincipal(trustPrincipal),
+      );
+    }
     stampWaveRunContext(tx, {
       actionId: info.actionId,
       kind: info.kind,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -810,6 +810,12 @@ export class Runtime {
   /** Optional pattern statement-coverage collector; see RuntimeOptions. */
   readonly patternCoverage?: PatternCoverageCollector;
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
+  // The runtime's trust revision — `<runtime id>` with the trust-config
+  // digest folded in when one is configured. The ONE composition site for
+  // every snapshot this runtime mints (the default provider and
+  // trustSnapshotForPrincipal), so a trust-config change invalidates
+  // per-run served snapshots exactly as it does ambient client ones.
+  readonly #trustRevision: string;
   readonly telemetry: RuntimeTelemetry;
   /** Resolved experimental flags (all properties present with built-in defaults). */
   readonly experimental: ExperimentalOptions;
@@ -1317,14 +1323,11 @@ export class Runtime {
       // trust-snapshot change — see RuntimeOptions.cfcTrustConfig).
       this.cfcTrustConfig = buildCfcTrustConfig(options.cfcTrustConfig);
       const actingPrincipal = options.storageManager.as.did() as DID;
-      const trustRevision = this.cfcTrustConfig === undefined
+      this.#trustRevision = this.cfcTrustConfig === undefined
         ? this.id
         : `${this.id}/trust:${this.cfcTrustConfig.digest}`;
-      this.trustSnapshotProvider = options.trustSnapshotProvider ?? (() => ({
-        id: `principal:${actingPrincipal}`,
-        actingPrincipal,
-        revision: trustRevision,
-      }));
+      this.trustSnapshotProvider = options.trustSnapshotProvider ??
+        (() => this.trustSnapshotForPrincipal(actingPrincipal));
       this.userIdentityDID = options.storageManager.as.did() as DID;
       this.moduleRegistry = new ModuleRegistry(this);
       this.patternManager = new PatternManager(this);
@@ -2073,6 +2076,26 @@ export class Runtime {
     pieceRootIds: readonly string[],
   ): readonly ScopeKeyIdentity[] | undefined {
     return this.#serverRunDemanderResolver?.(pieceRootIds);
+  }
+
+  /**
+   * A trust snapshot for one acting principal (serving-loop.md §3c: a
+   * served run's CFC trust snapshot carries the run's ACTING principal,
+   * never the serving runtime's ambient identity). The SpaceServer's run
+   * stamper attaches these per transaction via `setCfcTrustSnapshot`, so
+   * the current-principal label mints, the mid-run grant writes, and the
+   * concept-floor evaluation of a served run all resolve against the
+   * principal the run acts as. `revision` is the runtime's own trust
+   * revision — the same composition the default provider uses — so a
+   * trust-config change invalidates per-run prepared digests exactly as
+   * it does ambient ones.
+   */
+  trustSnapshotForPrincipal(principal: string): TrustSnapshot {
+    return {
+      id: `principal:${principal}`,
+      actingPrincipal: principal,
+      revision: this.#trustRevision,
+    };
   }
 
   /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1326,6 +1326,23 @@ export class Runtime {
       this.#trustRevision = this.cfcTrustConfig === undefined
         ? this.id
         : `${this.id}/trust:${this.cfcTrustConfig.digest}`;
+      // A serving runtime uses the DEFAULT provider — the run stamper
+      // attaches per-run snapshots via trustSnapshotForPrincipal
+      // (serving-loop.md §3c), whose revision is the runtime's own; a
+      // custom provider here would be silently bypassed for every acting
+      // run and would compose a revision the stamper does not know.
+      // Fail loud at construction instead.
+      if (
+        options.servingPosture === true &&
+        options.trustSnapshotProvider !== undefined
+      ) {
+        throw new Error(
+          "A serving runtime cannot take a custom trustSnapshotProvider: " +
+            "the run stamper attaches per-run trust snapshots composed on " +
+            "the runtime's own trust revision (serving-loop.md §3c), which " +
+            "would silently bypass the custom provider for acting runs.",
+        );
+      }
       this.trustSnapshotProvider = options.trustSnapshotProvider ??
         (() => this.trustSnapshotForPrincipal(actingPrincipal));
       this.userIdentityDID = options.storageManager.as.did() as DID;
@@ -2090,8 +2107,9 @@ export class Runtime {
    * trust-config change invalidates per-run prepared digests exactly as
    * it does ambient ones. On a runtime constructed with a CUSTOM
    * `trustSnapshotProvider` this still composes the RUNTIME's revision,
-   * not the provider's — the run stamper installs only on serving
-   * runtimes, which use the default provider.
+   * not the provider's — safe because a serving runtime refuses a custom
+   * provider at construction (the run stamper is the only caller, and it
+   * installs only on serving runtimes).
    */
   trustSnapshotForPrincipal(principal: string): TrustSnapshot {
     return {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1171,6 +1171,28 @@ export class Runtime {
   }
 
   constructor(options: RuntimeOptions) {
+    // Validate-then-apply: option combinations are refused BEFORE any
+    // process-global write (the ambient experimental-flag propagation
+    // below, the server-execution enabler), so a refused construction
+    // leaves no trace in the process — the try/catch further down rolls
+    // back only the enabler, and everything above it must not need
+    // rolling back. A serving runtime uses the DEFAULT trust-snapshot
+    // provider — the run stamper attaches per-run snapshots via
+    // trustSnapshotForPrincipal (serving-loop.md §3c), whose revision is
+    // the runtime's own; a custom provider would be silently bypassed
+    // for every acting run and would compose a revision the stamper
+    // does not know. Fail loud instead.
+    if (
+      options.servingPosture === true &&
+      options.trustSnapshotProvider !== undefined
+    ) {
+      throw new Error(
+        "A serving runtime cannot take a custom trustSnapshotProvider: " +
+          "the run stamper attaches per-run trust snapshots composed on " +
+          "the runtime's own trust revision (serving-loop.md §3c), which " +
+          "would silently bypass the custom provider for acting runs.",
+      );
+    }
     this.experimental = {
       modernCellRep: undefined,
       commitPreconditions: undefined,
@@ -1326,23 +1348,6 @@ export class Runtime {
       this.#trustRevision = this.cfcTrustConfig === undefined
         ? this.id
         : `${this.id}/trust:${this.cfcTrustConfig.digest}`;
-      // A serving runtime uses the DEFAULT provider — the run stamper
-      // attaches per-run snapshots via trustSnapshotForPrincipal
-      // (serving-loop.md §3c), whose revision is the runtime's own; a
-      // custom provider here would be silently bypassed for every acting
-      // run and would compose a revision the stamper does not know.
-      // Fail loud at construction instead.
-      if (
-        options.servingPosture === true &&
-        options.trustSnapshotProvider !== undefined
-      ) {
-        throw new Error(
-          "A serving runtime cannot take a custom trustSnapshotProvider: " +
-            "the run stamper attaches per-run trust snapshots composed on " +
-            "the runtime's own trust revision (serving-loop.md §3c), which " +
-            "would silently bypass the custom provider for acting runs.",
-        );
-      }
       this.trustSnapshotProvider = options.trustSnapshotProvider ??
         (() => this.trustSnapshotForPrincipal(actingPrincipal));
       this.userIdentityDID = options.storageManager.as.did() as DID;
@@ -2107,9 +2112,11 @@ export class Runtime {
    * trust-config change invalidates per-run prepared digests exactly as
    * it does ambient ones. On a runtime constructed with a CUSTOM
    * `trustSnapshotProvider` this still composes the RUNTIME's revision,
-   * not the provider's — safe because a serving runtime refuses a custom
-   * provider at construction (the run stamper is the only caller, and it
-   * installs only on serving runtimes).
+   * not the provider's. The DEFAULT provider routes every ordinary
+   * edit() transaction through this method; the run stamper is the
+   * ADDITIONAL serving-path caller, and a serving runtime refuses a
+   * custom provider at construction, so the two composition paths can
+   * never disagree on a serving runtime.
    */
   trustSnapshotForPrincipal(principal: string): TrustSnapshot {
     return {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2088,7 +2088,10 @@ export class Runtime {
    * principal the run acts as. `revision` is the runtime's own trust
    * revision — the same composition the default provider uses — so a
    * trust-config change invalidates per-run prepared digests exactly as
-   * it does ambient ones.
+   * it does ambient ones. On a runtime constructed with a CUSTOM
+   * `trustSnapshotProvider` this still composes the RUNTIME's revision,
+   * not the provider's — the run stamper installs only on serving
+   * runtimes, which use the default provider.
    */
   trustSnapshotForPrincipal(principal: string): TrustSnapshot {
     return {

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -119,5 +119,11 @@ installFakeClock({
     // virtual timers diverge from the bucket's time source (Date.now) —
     // the rate gate would regenerate its refill sleep unboundedly.
     "executor-outbox-budget",
+    // The OW34-family trust-attribution suite drives a live
+    // ExecutorHost (served handler runs minting CFC labels) under the
+    // same wall-clock policies — the renew interval and flush deadline;
+    // auto-advance turns the renew cadence into a runaway (the guard
+    // names SpaceServer.activate's timers).
+    "executor-trust-attribution",
   ],
 });

--- a/packages/runner/test/executor-trust-attribution.test.ts
+++ b/packages/runner/test/executor-trust-attribution.test.ts
@@ -1,0 +1,986 @@
+// OW34-family: per-run CFC trust attribution for served execution
+// (serving-loop.md §3c; the design of record is
+// docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md,
+// RULED 2026-08-21). A served run's transaction carries a trust snapshot
+// naming the run's ACTING principal — the event's server-stamped `firedAt`
+// actor, a demanded derivation's demand-supplied principal, or a delegated
+// carriage's actor — never the serving runtime's ambient service identity.
+// The pins here are the design's §9 acceptance rows:
+//
+// - §9-1 the FLAG-5 mint (watched RED at base, where the persisted
+//   authored-by / represents-principal subjects were the SERVICE DID —
+//   the stage-C rootcause §2a store shape) plus the INV-E negative arms:
+//   a schema-authored literal-DID current-principal claim still refuses,
+//   and an unprivileged direct ["cfc"] write is still the S18 forgery
+//   refusal, both surfacing as the served entry's error consequence;
+// - §9-2 per-wave multi-principal: two users' handler runs mint each
+//   run's own user, and both commits recheck clean (a digest mismatch
+//   would refuse the commit and error the entry — OW54's surfacing);
+// - §9-3 replay: a re-drained entry (first attempt aborted) mints from
+//   the DURABLE entry's actor, and a second host activation re-runs
+//   nothing and leaves the persisted labels byte-identical;
+// - §9-4 the stamp seam's precedence, pinned on the LIVE stamper:
+//   delegated carriage wins, a handler's acting next, a demanded
+//   derivation's principal next (the Q2 arm), and an actor-less run
+//   keeps the ambient service snapshot (the Q3 ruling);
+// - §9-5 OFF-arm neutrality: no stamper means no snapshot call — the
+//   OFF client and the flag-ON client speculation both leave the
+//   edit()-attached ambient snapshot untouched;
+// - INV-G: `trustSnapshotForPrincipal` composes the same revision as the
+//   default provider, config digest included, so a trust-config change
+//   invalidates per-run served digests exactly as ambient ones.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import * as Engine from "@commonfabric/memory/v2/engine";
+import type { StreamEventsDocValue } from "@commonfabric/memory/v2";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime, type ServerRunInfo } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcTrustConfigInput } from "../src/cfc/trust.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { markRendererTrustedEvent } from "../src/cfc/ui-contract.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const spaceSigner = await Identity.fromPassphrase("trust attribution space");
+const space = spaceSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase(
+  "trust attribution service",
+);
+const aliceSigner = await Identity.fromPassphrase("trust attribution alice");
+const bobSigner = await Identity.fromPassphrase("trust attribution bob");
+
+/** The TRUE sidecar doc ids in the store (see executor-events-down: the
+ * client derives the id from the RESOLVED stream link, so tests read the
+ * ids back from the head prefix rather than re-deriving them). */
+const sidecarIdsIn = (engine: Engine.Engine): string[] =>
+  (engine.database.prepare(
+    `SELECT id FROM head WHERE id LIKE 'of:stream-events:%' AND op != 'delete'`,
+  ).all() as Array<{ id: string }>).map((row) => row.id);
+
+// Bounded poll over DURABLE server state (the executor family's honest
+// wait: the engine exposes no event for "a background wave landed this").
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 20_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+const BUMP_PATTERN = [
+  "import { handler, pattern, Stream, Writable } from 'commonfabric';",
+  "const bump = handler<unknown, { value: Writable<number> }>(",
+  "  (_ev, { value }) => { value.set((value.get() ?? 0) + 1); },",
+  ");",
+  "export default pattern<",
+  "  { value: Writable<number> },",
+  "  { value: number; bump: Stream<unknown> }",
+  ">(({ value }) => ({ value, bump: bump({ value }) }));",
+].join("\n");
+
+// The authored vocabulary, in the explicit-schema form the compiled
+// `AuthoredByCurrentUser` / `RepresentsCurrentUser` wrappers lower to
+// (packages/api/cfc.ts): a current-principal placeholder subject under
+// `addIntegrity`, gated by `writeAuthorizedBy` + a `uiContract` that a
+// renderer-trusted event must match (cfc/prepare.ts's non-owner arm).
+const TRUSTED_WRITER = "test.ow34-trusted-writer";
+const UI_CONTRACT = {
+  helper: "UiAction",
+  action: "Ow34Send",
+  trustedPattern: "Ow34Chat",
+  requiredEventIntegrity: ["Ow34Chat"],
+};
+const CURRENT_PRINCIPAL = { __ctCurrentPrincipal: true };
+
+const authoredDocSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    body: {
+      type: "string",
+      ifc: {
+        addIntegrity: [{ kind: "authored-by", subject: CURRENT_PRINCIPAL }],
+        writeAuthorizedBy: [TRUSTED_WRITER],
+        uiContract: UI_CONTRACT,
+      },
+    },
+    claim: {
+      type: "string",
+      ifc: {
+        addIntegrity: [
+          { kind: "represents-principal", subject: CURRENT_PRINCIPAL },
+        ],
+        writeAuthorizedBy: [TRUSTED_WRITER],
+        uiContract: UI_CONTRACT,
+      },
+    },
+  },
+} as JSONSchema;
+
+// INV-E arm (i): the same shape with a LITERAL DID subject — refused at
+// authoring ("subject must be runtime resolved"), served or not.
+const literalDidSchema = (did: string): JSONSchema =>
+  ({
+    type: "object",
+    properties: {
+      body: {
+        type: "string",
+        ifc: {
+          addIntegrity: [{ kind: "authored-by", subject: did }],
+          writeAuthorizedBy: [TRUSTED_WRITER],
+          uiContract: UI_CONTRACT,
+        },
+      },
+    },
+  }) as JSONSchema;
+
+/** A fire payload carrying the trusted-DOM provenance the uiContract
+ * requires, renderer-trust MARKED (the WeakSet attestation; the durable
+ * entry carries it as `rendererTrusted: true` and the served dispatch
+ * re-marks the payload — the OW34 sister-mark carriage). */
+const trustedPayload = (
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> => {
+  const payload = {
+    ...extra,
+    provenance: {
+      origin: "dom",
+      trusted: true,
+      ui: {
+        pattern: "Ow34Chat",
+        eventIntegrity: ["Ow34Chat"],
+        uiContractDataset: { uiAction: "Ow34Send" },
+      },
+    },
+  };
+  markRendererTrustedEvent(payload);
+  return payload;
+};
+
+type LabelMapEntry = {
+  path?: unknown[];
+  label?: {
+    integrity?: Array<{ kind?: string; subject?: string } | string>;
+  };
+};
+
+/** The DURABLE current-principal subjects of one kind on a stored doc
+ * RECORD (`Engine.read(engine, { id })` — the `["cfc"]` envelope is a
+ * sibling of the record's `value`). Both atom forms — object and
+ * `"kind:subject"` string — per the verifier's reading in
+ * cf-cfc-authorship. */
+const principalSubjects = (
+  record: unknown,
+  kind: "authored-by" | "represents-principal",
+): string[] => {
+  const entries =
+    (record as { cfc?: { labelMap?: { entries?: LabelMapEntry[] } } })
+      ?.cfc?.labelMap?.entries ?? [];
+  const subjects: string[] = [];
+  for (const entry of entries) {
+    for (const atom of entry.label?.integrity ?? []) {
+      if (typeof atom === "string") {
+        if (atom.startsWith(`${kind}:`)) {
+          subjects.push(atom.slice(kind.length + 1));
+        }
+      } else if (atom?.kind === kind && typeof atom.subject === "string") {
+        subjects.push(atom.subject);
+      }
+    }
+  }
+  return subjects;
+};
+
+describe("executor-trust-attribution", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let clientManager: EmulatedStorageManager | undefined;
+  let clientRuntime: Runtime | undefined;
+  let extraManagers: EmulatedStorageManager[];
+  let extraRuntimes: Runtime[];
+  let servingRuntime: Runtime | undefined;
+
+  const newHost = (): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      // deno-lint-ignore require-await
+      createRuntime: async () => {
+        const manager = EmulatedStorageManager.connectTo(server, {
+          as: serviceSigner,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: {
+            serverExecution: true,
+            systemPatternAutoUpdate: false,
+          },
+        });
+        servingRuntime = runtime;
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+    });
+
+  beforeEach(() => {
+    server = newSharedServer({ subscriptionRefreshDelayMs: 0 });
+    extraManagers = [];
+    extraRuntimes = [];
+    servingRuntime = undefined;
+    clientManager = undefined;
+    clientRuntime = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    for (const runtime of extraRuntimes) await runtime.dispose();
+    for (const manager of extraManagers) await manager.close();
+    await clientRuntime?.dispose();
+    await clientManager?.close();
+    await server.close();
+  });
+
+  const openClient = (
+    signer: Identity = aliceSigner,
+  ): { manager: EmulatedStorageManager; runtime: Runtime } => {
+    const manager = EmulatedStorageManager.connectTo(server, { as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+      experimental: { serverExecution: true },
+    });
+    return { manager, runtime };
+  };
+
+  /** Compile + run the bump pattern on `runtime`, returning its cells. */
+  const standUp = async (
+    runtime: Runtime,
+    names: { arg: string; result: string },
+  ) => {
+    const compiled = await runtime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: BUMP_PATTERN }],
+    }, { space });
+    const argument = runtime.getCell<{ value: number }>(
+      space,
+      names.arg,
+      undefined,
+    );
+    const result = runtime.getCell<Record<string, unknown>>(
+      space,
+      names.result,
+      compiled.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = runtime.edit();
+      argument.withTx(seed).set({ value: 0 });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = runtime.edit();
+      runtime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    return { compiled, argument, result };
+  };
+
+  /** Warm the serving loop for one stream: stand the pattern up on the
+   * client, demand it, start the host, fire one plain warm-up event to
+   * completion, and return the durable stream link (for probes) and the
+   * sidecar id. The warm-up also puts the piece's own handler behind us:
+   * a probe registered on the SAME stream ref afterwards REPLACES it
+   * (addSchedulerEventHandler's same-ref replacement), so each later
+   * entry runs exactly the probe — one entry, one run. */
+  const warmServedStream = async (names: { arg: string; result: string }) => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { argument, result } = await standUp(clientRuntime, names);
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    host = newHost();
+    result.key("bump").send({ kind: "warmup" });
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+    await waitUntil(
+      () => sidecarIdsIn(engine).length === 1,
+      "the warm-up append to land",
+    );
+    const sidecarId = sidecarIdsIn(engine)[0];
+    await waitUntil(
+      () => {
+        const value = Engine.read(engine, { id: sidecarId })?.value as
+          | StreamEventsDocValue
+          | undefined;
+        return value?.entries?.[0]?.consequenced === true;
+      },
+      "the warm-up event to consequence",
+    );
+    await waitUntil(
+      () =>
+        host!.spaceServer(space)?.active === true &&
+        servingRuntime !== undefined,
+      "the space to activate",
+    );
+    const entry = (Engine.read(engine, { id: sidecarId })
+      ?.value as StreamEventsDocValue).entries![0];
+    const streamLink = {
+      space,
+      id: entry.stream.id as never,
+      path: [...entry.stream.path],
+      scope: (entry.stream.scope ?? "space") as never,
+    };
+    return { engine, argument, result, cancelDemand, sidecarId, streamLink };
+  };
+
+  const entriesIn = (
+    engine: Engine.Engine,
+    sidecarId: string,
+  ): NonNullable<StreamEventsDocValue["entries"]> =>
+    (Engine.read(engine, { id: sidecarId })?.value as StreamEventsDocValue)
+      .entries ?? [];
+
+  const entryByKind = (
+    engine: Engine.Engine,
+    sidecarId: string,
+    kind: string,
+  ) =>
+    entriesIn(engine, sidecarId).find((entry) =>
+      (entry.payload as { kind?: string } | undefined)?.kind === kind
+    );
+
+  describe("§9-1 the FLAG-5 mint", () => {
+    it("persists the entry's firedAt.user as the authored-by and represents-principal subject on a served handler run's docs — never the service DID (WATCHED RED AT BASE: both subjects were the service signer)", async () => {
+      const { engine, cancelDemand, sidecarId, streamLink, result } =
+        await warmServedStream({
+          arg: "flag5-arg",
+          result: "flag5-result",
+        });
+      const serving = servingRuntime!;
+      const cancelProbe = serving.scheduler.addEventHandler(
+        (tx, event) => {
+          const docName = (event as { doc?: string })?.doc ?? "flag5-doc";
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: TRUSTED_WRITER,
+          });
+          serving.getCell(space, docName, authoredDocSchema, tx).set({
+            body: "hello from a served run",
+            claim: "profile claim from a served run",
+          });
+        },
+        streamLink,
+      );
+      try {
+        result.key("bump").send(
+          trustedPayload({ kind: "authored", doc: "flag5-doc" }),
+        );
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "authored")?.consequenced ===
+              true,
+          "the authored event to consequence",
+        );
+        const entry = entryByKind(engine, sidecarId, "authored")!;
+        expect(entry.error).toBeUndefined();
+        expect(entry.firedAt?.user).toBe(aliceSigner.did());
+
+        // The doc id is name-derived, so the client mints the same link.
+        const docId = clientRuntime!.getCell(space, "flag5-doc", undefined)
+          .getAsNormalizedFullLink().id;
+        await waitUntil(
+          () => Engine.read(engine, { id: docId })?.value !== undefined,
+          "the authored doc to land durably",
+        );
+        const record = Engine.read(engine, { id: docId });
+
+        // THE PIN (INV-A / INV-D): the durable subjects are the ACTING
+        // user from the entry's server-stamped firedAt. At base both
+        // were the service DID (FLAG-5; rootcause §2a's store shape).
+        expect(principalSubjects(record, "authored-by")).toEqual([
+          aliceSigner.did(),
+        ]);
+        expect(principalSubjects(record, "represents-principal")).toEqual([
+          aliceSigner.did(),
+        ]);
+        expect(principalSubjects(record, "authored-by")).not.toContain(
+          serviceSigner.did(),
+        );
+        expect(
+          principalSubjects(record, "represents-principal"),
+        ).not.toContain(serviceSigner.did());
+      } finally {
+        cancelProbe();
+        cancelDemand();
+      }
+    });
+
+    it("still refuses a schema-authored literal-DID current-principal claim on the served path, and the refusal is the entry's error consequence (INV-E)", async () => {
+      const { engine, cancelDemand, sidecarId, streamLink, result } =
+        await warmServedStream({
+          arg: "inve-lit-arg",
+          result: "inve-lit-result",
+        });
+      const serving = servingRuntime!;
+      const cancelProbe = serving.scheduler.addEventHandler(
+        (tx, _event) => {
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: TRUSTED_WRITER,
+          });
+          serving.getCell(
+            space,
+            "inve-literal-doc",
+            literalDidSchema(aliceSigner.did()),
+            tx,
+          ).set({ body: "forged literal claim" });
+        },
+        streamLink,
+      );
+      try {
+        result.key("bump").send(trustedPayload({ kind: "literal" }));
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        // OW54's surfacing: the CFC pre-storage refusal seals an ERROR
+        // consequence; the entry advances carrying the refusal.
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "literal")?.consequenced ===
+              true,
+          "the literal-claim event to consequence",
+        );
+        const entry = entryByKind(engine, sidecarId, "literal")!;
+        expect(entry.error).toContain("CFC enforcement rejected commit");
+        expect(entry.error).toContain("must be runtime resolved");
+        // Nothing persisted: the forged claim never reached the store.
+        const docId = clientRuntime!.getCell(
+          space,
+          "inve-literal-doc",
+          undefined,
+        ).getAsNormalizedFullLink().id;
+        expect(Engine.read(engine, { id: docId })?.value).toBeUndefined();
+      } finally {
+        cancelProbe();
+        cancelDemand();
+      }
+    });
+
+    it("still fails an unprivileged direct ['cfc'] write closed as the S18 forgery refusal on the served path (INV-E)", async () => {
+      const { engine, cancelDemand, sidecarId, streamLink, result } =
+        await warmServedStream({
+          arg: "inve-s18-arg",
+          result: "inve-s18-result",
+        });
+      const serving = servingRuntime!;
+      const targetId = clientRuntime!.getCell(space, "s18-doc", undefined)
+        .getAsNormalizedFullLink().id;
+      const cancelProbe = serving.scheduler.addEventHandler(
+        (tx, event) => {
+          const kind = (event as { kind?: string })?.kind;
+          if (kind === "s18-setup") {
+            // A LEGIT mint first, so the doc holds a well-formed
+            // envelope for the forgery to target.
+            tx.setCfcImplementationIdentity({
+              kind: "builtin",
+              builtinId: TRUSTED_WRITER,
+            });
+            serving.getCell(space, "s18-doc", authoredDocSchema, tx).set({
+              body: "honest message",
+              claim: "honest claim",
+            });
+            return;
+          }
+          // The forgery: a DIRECT label rewrite on the stored envelope,
+          // outside any privileged scope — swap the honest subjects for
+          // Bob's without any run acting as Bob.
+          tx.writeOrThrow(
+            {
+              space,
+              id: targetId,
+              type: "application/json",
+              path: ["cfc", "labelMap", "entries"],
+            },
+            {
+              value: [{
+                path: ["body"],
+                label: {
+                  integrity: [{
+                    kind: "authored-by",
+                    subject: bobSigner.did(),
+                  }],
+                },
+                origin: "declared",
+              }],
+            },
+          );
+        },
+        streamLink,
+      );
+      try {
+        result.key("bump").send(
+          trustedPayload({ kind: "s18-setup" }),
+        );
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "s18-setup")?.consequenced === true,
+          "the setup mint to consequence",
+        );
+        expect(
+          principalSubjects(
+            Engine.read(engine, { id: targetId }),
+            "authored-by",
+          ),
+        ).toEqual([aliceSigner.did()]);
+
+        result.key("bump").send(trustedPayload({ kind: "s18-forge" }));
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "s18-forge")?.consequenced === true,
+          "the forged-label event to consequence",
+        );
+        const entry = entryByKind(engine, sidecarId, "s18-forge")!;
+        expect(entry.error).toContain("CFC enforcement rejected commit");
+        expect(entry.error).toContain("unprivileged write to protected cfc");
+        // The stored envelope is untouched: the honest subjects survive.
+        expect(
+          principalSubjects(
+            Engine.read(engine, { id: targetId }),
+            "authored-by",
+          ),
+        ).toEqual([aliceSigner.did()]);
+      } finally {
+        cancelProbe();
+        cancelDemand();
+      }
+    });
+  });
+
+  describe("§9-2 per-wave multi-principal", () => {
+    it("mints each run's own user when two users' handler runs share a drain, and both commits recheck clean — no cross-run contamination (INV-C)", async () => {
+      const { engine, cancelDemand, sidecarId, streamLink, result } =
+        await warmServedStream({
+          arg: "multi-arg",
+          result: "multi-result",
+        });
+      const serving = servingRuntime!;
+      const cancelProbe = serving.scheduler.addEventHandler(
+        (tx, event) => {
+          const docName = (event as { doc?: string })?.doc ?? "multi-doc";
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: TRUSTED_WRITER,
+          });
+          serving.getCell(space, docName, authoredDocSchema, tx).set({
+            body: `message via ${docName}`,
+            claim: `claim via ${docName}`,
+          });
+        },
+        streamLink,
+      );
+
+      // Bob joins the same piece.
+      const bob = openClient(bobSigner);
+      extraManagers.push(bob.manager);
+      extraRuntimes.push(bob.runtime);
+      const bobResult = bob.runtime.getCell<Record<string, unknown>>(
+        space,
+        "multi-result",
+        undefined,
+      );
+      await bobResult.sync();
+
+      try {
+        // Fired back to back with no await between, so the drain batches
+        // both entries; each dispatch is its own run × tx × snapshot.
+        result.key("bump").send(
+          trustedPayload({ kind: "alice-msg", doc: "multi-alice-doc" }),
+        );
+        bobResult.key("bump").send(
+          trustedPayload({ kind: "bob-msg", doc: "multi-bob-doc" }),
+        );
+        await clientRuntime!.idle();
+        await bob.runtime.idle();
+        await clientRuntime!.storageManager.synced();
+        await bob.runtime.storageManager.synced();
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "alice-msg")?.consequenced ===
+              true &&
+            entryByKind(engine, sidecarId, "bob-msg")?.consequenced === true,
+          "both users' events to consequence",
+        );
+        const aliceEntry = entryByKind(engine, sidecarId, "alice-msg")!;
+        const bobEntry = entryByKind(engine, sidecarId, "bob-msg")!;
+        // Clean recheck: a cfc-prepared-digest-mismatch would have
+        // refused the commit and errored the entry (OW54's surfacing).
+        expect(aliceEntry.error).toBeUndefined();
+        expect(bobEntry.error).toBeUndefined();
+        expect(aliceEntry.firedAt?.user).toBe(aliceSigner.did());
+        expect(bobEntry.firedAt?.user).toBe(bobSigner.did());
+
+        const aliceDocId = clientRuntime!.getCell(
+          space,
+          "multi-alice-doc",
+          undefined,
+        ).getAsNormalizedFullLink().id;
+        const bobDocId = clientRuntime!.getCell(
+          space,
+          "multi-bob-doc",
+          undefined,
+        ).getAsNormalizedFullLink().id;
+        await waitUntil(
+          () =>
+            Engine.read(engine, { id: aliceDocId })?.value !== undefined &&
+            Engine.read(engine, { id: bobDocId })?.value !== undefined,
+          "both authored docs to land",
+        );
+        const aliceDoc = Engine.read(engine, { id: aliceDocId });
+        const bobDoc = Engine.read(engine, { id: bobDocId });
+        expect(principalSubjects(aliceDoc, "authored-by")).toEqual([
+          aliceSigner.did(),
+        ]);
+        expect(principalSubjects(bobDoc, "authored-by")).toEqual([
+          bobSigner.did(),
+        ]);
+        // No contamination in either direction.
+        expect(principalSubjects(aliceDoc, "authored-by")).not.toContain(
+          bobSigner.did(),
+        );
+        expect(principalSubjects(bobDoc, "authored-by")).not.toContain(
+          aliceSigner.did(),
+        );
+      } finally {
+        cancelProbe();
+        cancelDemand();
+      }
+    });
+  });
+
+  describe("§9-3 replay", () => {
+    it("mints from the DURABLE entry's actor on a re-drain (first attempt aborted), and a second activation re-runs nothing and leaves the labels byte-identical (INV-B)", async () => {
+      const { engine, cancelDemand, sidecarId, streamLink, result } =
+        await warmServedStream({
+          arg: "replay-arg",
+          result: "replay-result",
+        });
+      const serving = servingRuntime!;
+      let dispatches = 0;
+      const cancelProbe = serving.scheduler.addEventHandler(
+        (tx, _event) => {
+          dispatches += 1;
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: TRUSTED_WRITER,
+          });
+          serving.getCell(space, "replay-doc", authoredDocSchema, tx).set({
+            body: "replayed message",
+            claim: "replayed claim",
+          });
+          if (dispatches === 1) {
+            // A NON-CFC give-up: the entry stays unconsequenced and the
+            // wave re-drains it (the retry cadence) — the re-dispatch
+            // must resolve its actor from the durable entry again.
+            tx.abort(new Error("ow34 replay probe: first attempt aborted"));
+          }
+        },
+        streamLink,
+      );
+      try {
+        result.key("bump").send(trustedPayload({ kind: "replayed" }));
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        await waitUntil(
+          () =>
+            dispatches >= 2 &&
+            entryByKind(engine, sidecarId, "replayed")?.consequenced === true,
+          "the re-drained event to consequence",
+        );
+        const docId = clientRuntime!.getCell(space, "replay-doc", undefined)
+          .getAsNormalizedFullLink().id;
+        await waitUntil(
+          () => Engine.read(engine, { id: docId })?.value !== undefined,
+          "the re-drained mint to land",
+        );
+        const minted = Engine.read(engine, { id: docId });
+        expect(principalSubjects(minted, "authored-by")).toEqual([
+          aliceSigner.did(),
+        ]);
+        expect(principalSubjects(minted, "represents-principal")).toEqual([
+          aliceSigner.did(),
+        ]);
+
+        // Second activation: the consequenced mark excludes the entry —
+        // no re-run — and the persisted labels stay byte-identical.
+        const labelsBefore = JSON.stringify(
+          (Engine.read(engine, { id: docId }) as { cfc?: unknown })?.cfc,
+        );
+        const eventId = entryByKind(engine, sidecarId, "replayed")!.eventId;
+        const consequenceCommitsFor = () =>
+          (engine.database.prepare(
+            `SELECT consequence_of FROM "commit"
+             WHERE class = 'derived' AND consequence_of IS NOT NULL`,
+          ).all() as Array<{ consequence_of: string }>).filter((row) =>
+            row.consequence_of.includes(eventId)
+          ).length;
+        expect(consequenceCommitsFor()).toBe(1);
+        await host!.close();
+        host = newHost();
+        // A fresh authored poke re-activates the space (the emulated
+        // fixture keeps sessions across the host swap, so the poke
+        // stands in for the reconnect — the events-down restart idiom).
+        {
+          const poke = clientRuntime!.edit();
+          clientRuntime!.getCell<number>(space, "replay-activate", undefined)
+            .withTx(poke).set(1);
+          expect((await poke.commit()).error).toBeUndefined();
+        }
+        await waitUntil(
+          () => host!.spaceServer(space)?.active === true,
+          "the space to re-activate",
+        );
+        // Bounded settle for the negative (the events-down restart pin's
+        // carve-out): the loop gets a beat in which a wrong re-run WOULD
+        // land its second consequence commit; the count is the sharp
+        // observable, byte-identity of the labels the trust half.
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        expect(consequenceCommitsFor()).toBe(1);
+        const labelsAfter = JSON.stringify(
+          (Engine.read(engine, { id: docId }) as { cfc?: unknown })?.cfc,
+        );
+        expect(labelsAfter).toBe(labelsBefore);
+      } finally {
+        cancelProbe();
+        cancelDemand();
+      }
+    });
+  });
+
+  describe("§9-4 the stamp seam's precedence", () => {
+    it("resolves the run's snapshot on the LIVE stamper: a delegated carriage's actor wins, a handler's acting next, a demanded derivation's principal next, and an actor-less run keeps the ambient service snapshot", async () => {
+      const { cancelDemand } = await warmServedStream({
+        arg: "seam-arg",
+        result: "seam-result",
+      });
+      const serving = servingRuntime!;
+      const stampAndRead = (info: ServerRunInfo) => {
+        const tx = serving.edit();
+        serving.stampServerRun(tx, info);
+        const snapshot = tx.getCfcState().trustSnapshot;
+        tx.abort();
+        return snapshot;
+      };
+      try {
+        // Arm 1 (§9-4 proper): the S-A delegated bookkeeping carriage
+        // carries the DELEGATED acting's snapshot.
+        const delegated = stampAndRead({
+          actionId: "seam-delegated",
+          kind: "bookkeeping",
+          delegated: {
+            acting: { user: aliceSigner.did(), session: "sess-seam" },
+            capabilityRef: "event-consequence:e-seam",
+          },
+        });
+        expect(delegated?.actingPrincipal).toBe(aliceSigner.did());
+        expect(delegated?.id).toBe(`principal:${aliceSigner.did()}`);
+
+        // Arm 2: a handler's explicit acting (the event's server-stamped
+        // firedAt actor).
+        const acting = stampAndRead({
+          actionId: "seam-acting",
+          kind: "event-handler",
+          eventId: "e-seam-acting",
+          acting: { user: bobSigner.did() },
+        });
+        expect(acting?.actingPrincipal).toBe(bobSigner.did());
+
+        // Arm 2b: a handler INHERITING a demanded pair (the in-process
+        // LT6 shape) carries the pair's user.
+        const inherited = stampAndRead({
+          actionId: "seam-inherited",
+          kind: "event-handler",
+          eventId: "e-seam-inherited",
+          scopeKeyIdentity: {
+            principal: bobSigner.did(),
+            sessionId: "sess-lt6",
+          } as never,
+        });
+        expect(inherited?.actingPrincipal).toBe(bobSigner.did());
+
+        // Arm 3 (the Q2 derivation arm — ships, severable): a demanded
+        // derivation's snapshot names the demand-supplied principal,
+        // eager at stamp.
+        const demanded = stampAndRead({
+          actionId: "seam-demanded",
+          kind: "derivation",
+          scopeKeyIdentity: {
+            principal: aliceSigner.did(),
+            sessionId: "sess-demand",
+          } as never,
+          actionScopeKey: "user" as never,
+        });
+        expect(demanded?.actingPrincipal).toBe(aliceSigner.did());
+
+        // Arm 4 (the Q3 ruling): actor-less runs KEEP the ambient
+        // service snapshot — plain bookkeeping and the wave-fallback
+        // derivation alike.
+        const bookkeeping = stampAndRead({
+          actionId: "seam-bookkeeping",
+          kind: "bookkeeping",
+        });
+        expect(bookkeeping?.actingPrincipal).toBe(serviceSigner.did());
+        const fallback = stampAndRead({
+          actionId: "seam-fallback",
+          kind: "derivation",
+        });
+        expect(fallback?.actingPrincipal).toBe(serviceSigner.did());
+
+        // The revision is the serving runtime's own trust revision on
+        // every arm — one composition site (INV-G's seam half).
+        const ambient = serving.trustSnapshotProvider()!;
+        for (const snapshot of [delegated, acting, inherited, demanded]) {
+          expect(snapshot?.revision).toBe(ambient.revision);
+        }
+      } finally {
+        cancelDemand();
+      }
+    });
+  });
+
+  describe("§9-5 OFF-arm neutrality", () => {
+    it("leaves the edit()-attached ambient snapshot untouched on an OFF client — stampServerRun stamps nothing", async () => {
+      const manager = StorageManager.emulate({ as: aliceSigner });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: manager,
+      });
+      try {
+        const tx = runtime.edit();
+        const before = tx.getCfcState().trustSnapshot;
+        expect(before?.actingPrincipal).toBe(aliceSigner.did());
+        runtime.stampServerRun(tx, {
+          actionId: "off-run",
+          kind: "event-handler",
+          eventId: "e-off",
+          acting: { user: bobSigner.did() },
+        });
+        const after = tx.getCfcState().trustSnapshot;
+        expect(after).toEqual(before);
+        expect(after?.actingPrincipal).toBe(aliceSigner.did());
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await manager.close();
+      }
+    });
+
+    it("leaves the snapshot untouched on a flag-ON client — the speculation stamp is not a snapshot writer", async () => {
+      const manager = StorageManager.emulate({ as: aliceSigner });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: manager,
+        experimental: { serverExecution: true },
+      });
+      try {
+        const tx = runtime.edit();
+        const before = tx.getCfcState().trustSnapshot;
+        runtime.stampServerRun(tx, {
+          actionId: "spec-run",
+          kind: "event-handler",
+          eventId: "e-spec",
+          acting: { user: bobSigner.did() },
+        });
+        const after = tx.getCfcState().trustSnapshot;
+        expect(after).toEqual(before);
+        expect(after?.actingPrincipal).toBe(aliceSigner.did());
+        tx.abort();
+      } finally {
+        await runtime.dispose();
+        await manager.close();
+      }
+    });
+  });
+
+  describe("trustSnapshotForPrincipal()", () => {
+    const trustConfig: CfcTrustConfigInput = {
+      statements: [{
+        concrete: { type: "Ow34Probe" },
+        implements: "ow34/probe",
+        verifier: aliceSigner.did(),
+      }],
+      delegations: [{
+        delegator: aliceSigner.did(),
+        verifier: aliceSigner.did(),
+        concepts: ["ow34/probe"],
+      }],
+    };
+
+    it("returns the principal's snapshot with the runtime's own revision — identical to the default provider's composition (INV-G, no trust config)", async () => {
+      const manager = StorageManager.emulate({ as: aliceSigner });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: manager,
+      });
+      try {
+        const snapshot = runtime.trustSnapshotForPrincipal(bobSigner.did());
+        expect(snapshot).toEqual({
+          id: `principal:${bobSigner.did()}`,
+          actingPrincipal: bobSigner.did(),
+          revision: runtime.id,
+        });
+        expect(snapshot.revision).toBe(
+          runtime.trustSnapshotProvider()!.revision,
+        );
+      } finally {
+        await runtime.dispose();
+        await manager.close();
+      }
+    });
+
+    it("folds the trust-config digest into the revision exactly as the default provider does (INV-G, config present)", async () => {
+      const manager = StorageManager.emulate({ as: aliceSigner });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: manager,
+        cfcTrustConfig: trustConfig,
+      });
+      try {
+        const snapshot = runtime.trustSnapshotForPrincipal(bobSigner.did());
+        expect(snapshot.revision).toContain("/trust:");
+        expect(snapshot.revision).toBe(
+          runtime.trustSnapshotProvider()!.revision,
+        );
+        expect(snapshot.revision?.startsWith(runtime.id)).toBe(true);
+      } finally {
+        await runtime.dispose();
+        await manager.close();
+      }
+    });
+  });
+});

--- a/packages/runner/test/executor-trust-attribution.test.ts
+++ b/packages/runner/test/executor-trust-attribution.test.ts
@@ -765,11 +765,21 @@ describe("executor-trust-attribution", () => {
           () => host!.spaceServer(space)?.active === true,
           "the space to re-activate",
         );
-        // Bounded settle for the negative (the events-down restart pin's
-        // carve-out): the loop gets a beat in which a wrong re-run WOULD
-        // land its second consequence commit; the count is the sharp
-        // observable, byte-identity of the labels the trust half.
-        await new Promise((resolve) => setTimeout(resolve, 500));
+        // Ordered barrier for the negative: append a FRESH entry on the
+        // same stream and wait for ITS consequence — the drain processes
+        // entries in order, so a wrong re-run of the replayed entry
+        // would land its second consequence commit no later than the
+        // fresh entry's. Sharper than a settle beat: a late duplicate
+        // cannot slip in after the assertion.
+        result.key("bump").send(trustedPayload({ kind: "replay-barrier" }));
+        await clientRuntime!.idle();
+        await clientRuntime!.storageManager.synced();
+        await waitUntil(
+          () =>
+            entryByKind(engine, sidecarId, "replay-barrier")?.consequenced ===
+              true,
+          "the barrier entry to consequence on the re-activated loop",
+        );
         expect(consequenceCommitsFor()).toBe(1);
         const labelsAfter = JSON.stringify(
           (Engine.read(engine, { id: docId }) as { cfc?: unknown })?.cfc,
@@ -959,6 +969,26 @@ describe("executor-trust-attribution", () => {
         );
       } finally {
         await runtime.dispose();
+        await manager.close();
+      }
+    });
+
+    it("refuses to construct a SERVING runtime with a custom trustSnapshotProvider — the run stamper would silently bypass it for every acting run", async () => {
+      const manager = StorageManager.emulate({ as: serviceSigner });
+      try {
+        expect(() =>
+          new Runtime({
+            apiUrl: new URL(import.meta.url),
+            storageManager: manager,
+            servingPosture: true,
+            experimental: { serverExecution: true },
+            trustSnapshotProvider: () => ({
+              id: "custom-provider",
+              actingPrincipal: serviceSigner.did(),
+            }),
+          })
+        ).toThrow("custom trustSnapshotProvider");
+      } finally {
         await manager.close();
       }
     });

--- a/packages/runner/test/executor-trust-attribution.test.ts
+++ b/packages/runner/test/executor-trust-attribution.test.ts
@@ -973,22 +973,56 @@ describe("executor-trust-attribution", () => {
       }
     });
 
-    it("refuses to construct a SERVING runtime with a custom trustSnapshotProvider — the run stamper would silently bypass it for every acting run", async () => {
+    it("refuses to construct a SERVING runtime with a custom trustSnapshotProvider — and the refused construction leaves NO ambient trace: a runtime built afterward is byte-identical to one built before (validate-then-apply; the guard precedes every process-global flag write)", async () => {
       const manager = StorageManager.emulate({ as: serviceSigner });
+      // CONTROL: the effective experimental record before the refused
+      // construction (flag-less, so it reads the ambient state through).
+      const controlManager = StorageManager.emulate({ as: aliceSigner });
+      const control = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: controlManager,
+      });
+      const controlExperimental = { ...control.experimental };
       try {
         expect(() =>
           new Runtime({
             apiUrl: new URL(import.meta.url),
             storageManager: manager,
             servingPosture: true,
-            experimental: { serverExecution: true },
+            experimental: {
+              serverExecution: true,
+              // A flag whose ambient write precedes the old guard site:
+              // under throw-after-apply this leaks into the process and
+              // shows up in the probe below (the Cubic P1 leak).
+              contentAddressedSchemas: !controlExperimental
+                .contentAddressedSchemas,
+            },
             trustSnapshotProvider: () => ({
               id: "custom-provider",
               actingPrincipal: serviceSigner.did(),
             }),
           })
         ).toThrow("custom trustSnapshotProvider");
+        // PROBE: a flag-less runtime built AFTER the refusal must behave
+        // as if the failed construction never happened — its effective
+        // experimental record equals the control's.
+        const probeManager = StorageManager.emulate({ as: bobSigner });
+        const probe = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: probeManager,
+        });
+        try {
+          expect(probe.experimental.contentAddressedSchemas).toBe(
+            controlExperimental.contentAddressedSchemas,
+          );
+          expect({ ...probe.experimental }).toEqual(controlExperimental);
+        } finally {
+          await probe.dispose();
+          await probeManager.close();
+        }
       } finally {
+        await control.dispose();
+        await controlManager.close();
         await manager.close();
       }
     });

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -136,7 +136,7 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): five file entries (default-app, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every gate entry names its mechanism, the gate report, and its owed OW row; cfc-group-chat-demo is LIFTED (OW59 CLOSED 2026-08-21, the OW34-family train: per-run trust snapshots — the file greens under the true ON topology 3/3 with a zero-service-DID label audit); lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): five file entries (default-app, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every gate entry names its mechanism, the gate report, and its owed OW row; cfc-group-chat-demo is LIFTED (OW59 CLOSED 2026-08-21, the OW34-family train: per-run trust snapshots — the file greens under the true ON topology 4/4 — three fresh-store lift runs plus a quiet-machine solo run — every run's store auditing zero service-DID authorship labels); lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // File-level entries only in the --ignore flag (step entries never drop
@@ -208,10 +208,11 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   // cfc-group-chat-demo is LIFTED (verification-coverage.md OW59 closed,
   // the OW34-family train, 2026-08-21): a served run's CFC trust snapshot
   // carries the acting principal, so the authorship labels name the acting
-  // user and the file greens under the true ON topology (3/3, fresh
-  // stores, zero authored-by/represents-principal atoms naming the
-  // service DID in the store audit). No entry — the file RUNS on the ON
-  // arm; a re-skip is a deliberate edit here.
+  // user and the file greens under the true ON topology (4/4 — three
+  // fresh-store lift runs plus a quiet-machine solo run; zero
+  // authored-by/represents-principal atoms naming the service DID in
+  // every run's store audit). No entry — the file RUNS on the ON arm; a
+  // re-skip is a deliberate edit here.
   assertEquals(
     SERVER_EXECUTION_ON_SKIPS.patterns.some((skip) =>
       skip.file === "integration/cfc-group-chat-demo.test.ts"

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -136,7 +136,7 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): six file entries (default-app, cfc-group-chat-demo, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): five file entries (default-app, profile-embed, home-profile-reload-durability, the sqlite identity pair) and ZERO step entries — both gate step lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every gate entry names its mechanism, the gate report, and its owed OW row; cfc-group-chat-demo is LIFTED (OW59 CLOSED 2026-08-21, the OW34-family train: per-run trust snapshots — the file greens under the true ON topology 3/3 with a zero-service-DID label audit); lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // File-level entries only in the --ignore flag (step entries never drop
@@ -144,7 +144,6 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   assertEquals(out, [
     "--ignore=integration/topics-navigation.test.ts," +
     "integration/default-app.test.ts," +
-    "integration/cfc-group-chat-demo.test.ts," +
     "integration/profile-embed.test.ts," +
     "integration/home-profile-reload-durability.test.ts," +
     "integration/sqlite-db-owner-multi-runtime.test.ts," +
@@ -158,7 +157,6 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   for (
     const file of [
       "default-app",
-      "cfc-group-chat-demo",
       "profile-embed",
       "home-profile-reload-durability",
       "sqlite-db-owner-multi-runtime",
@@ -207,6 +205,19 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     assertMatch(profileEmbed.reason, /NAME-DRAFT own-write loss/);
     assertMatch(profileEmbed.reason, /2b-derivation-carriage-scope\.md/);
   }
+  // cfc-group-chat-demo is LIFTED (verification-coverage.md OW59 closed,
+  // the OW34-family train, 2026-08-21): a served run's CFC trust snapshot
+  // carries the acting principal, so the authorship labels name the acting
+  // user and the file greens under the true ON topology (3/3, fresh
+  // stores, zero authored-by/represents-principal atoms naming the
+  // service DID in the store audit). No entry — the file RUNS on the ON
+  // arm; a re-skip is a deliberate edit here.
+  assertEquals(
+    SERVER_EXECUTION_ON_SKIPS.patterns.some((skip) =>
+      skip.file === "integration/cfc-group-chat-demo.test.ts"
+    ),
+    false,
+  );
   // The two-browser gates RUN in the ON arm: cfc-group-chat-two-browsers
   // (fan-out stage B) and lunch-poll-vote (W3.1's S1 + the 6/6 lift).
   assertEquals(
@@ -243,7 +254,7 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   const gateEntries = SERVER_EXECUTION_ON_SKIPS.patterns.filter((skip) =>
     skip.file !== "integration/topics-navigation.test.ts"
   );
-  assertEquals(gateEntries.length, 6);
+  assertEquals(gateEntries.length, 5);
   for (const entry of gateEntries) {
     assertEquals(entry.phase, "phase-7");
     assertMatch(entry.reason, /First ON-lane CI gate \(2026-08-21/);
@@ -269,7 +280,7 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     "./integration/convergence-storm.test.ts",
   ]);
   assertEquals(skipped, []);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 7);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 6);
   assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
 });
 

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -235,44 +235,6 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "needs this list EMPTY.",
     },
     {
-      file: "integration/cfc-group-chat-demo.test.ts",
-      phase: "phase-7",
-      reason: "First ON-lane CI gate (2026-08-21; skip-and-land — gates " +
-        "the FLIP, not the land): TWO write-path defects, one per failure " +
-        "point, NEITHER a demand hole (the served derivation chain was " +
-        "clean end-to-end: 33–41 derived commits, healthy demand " +
-        "counters). CI shape (Alice's authorship check): served " +
-        "events-down rows carry the SERVICE identity — authored-by/" +
-        "represents-principal name the service signer, not Alice — so CFC " +
-        "authorship verification stays 'unverified' forever; this IS the " +
-        "owed OW31/§2b acting-identity carriage build (post-merge, " +
-        "pre-flip), now with a CI surface as its lift evidence — OW31's " +
-        "build LANDED 2026-08-21, but the authorship labels come from " +
-        "the runtime-level CFC trust snapshot (storageManager.as), not " +
-        "the memory-plane carriage that build landed, so this shape does " +
-        "NOT lift on it alone (the flagged CFC-attribution residual in " +
-        "OW31's register row; OW34's family). Local " +
-        "shape (Bob's send click): Bob's messageDraft $value binding " +
-        "write into the serve-owned user-scope instance doc NEVER reaches " +
-        "the store (0/4 runs incl. a 300 s probe; his session committed " +
-        "12 OTHER writes meanwhile), so the served sendDisabled correctly " +
-        "never flips — the client own-write durability seam, " +
-        "verification-coverage.md OW47. OW47 is CLOSED (2026-08-21, " +
-        "optimize pass): the mechanism was the speculation.md §6 export " +
-        "refusal firing on a blind write's structural parent read that " +
-        "named a standing handler-echo layer; fixed in storage/v2.ts " +
-        "buildReads (excludeSpeculativeLayers) with unit + cellset-lww " +
-        "lift evidence — see optimize/ow47-client-durability-report.md. " +
-        "Mechanism + store/log evidence: docs/history/plans/" +
-        "server-execution-v2/stage-c/on-render-stall-rootcause.md §2 (and " +
-        "first-on-ci-gate.md). OW31's build and OW47 are both DONE " +
-        "(2026-08-21); what remains is the FLAG-5 CFC-attribution seam " +
-        "(the trust snapshot supplying the SERVICE identity to served " +
-        "authorship labels — OW34's family, flagged in OW31's register " +
-        "row). Lifts when that seam closes and the file greens ON; the " +
-        "flip PR needs this list EMPTY.",
-    },
-    {
       file: "integration/profile-embed.test.ts",
       phase: "phase-7",
       reason: "First ON-lane CI gate (2026-08-21; skip-and-land — gates " +


### PR DESCRIPTION
## Why

Under ON, a served run's durable writes minted CFC authorship labels naming the **service signer**: the `__ctCurrentPrincipal` placeholder resolves at commit-prep against the transaction's trust snapshot, and a serving runtime's snapshot was the runtime-level ambient default (`storageManager.as` — the service DID). That is the FLAG-5 seam (OW31 build report; store evidence in `stage-c/on-render-stall-rootcause.md` §2a: authored-by ×4 + represents-principal ×2, all the service DID) and the first-ON-CI-gate row-2 red: `cfc-group-chat-demo`'s authorship verification stays `"unverified"` forever on served rows, so the file was ON-skipped — and the flip PR requires the skip list EMPTY. Worse than one red test: with every trusted row and profile labeled by the one service DID, authorship verification collapses to a tautology.

The design of record is `docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md`, **RULED 2026-08-21** — the owner adopted all seven §10 recommendations as recommended ("decision 2: all sounds good…"; the ruling record heads §10). This PR is the OW34-family implementation train: it records the ruling and builds the design's §8 with §9 as the acceptance bar.

## What Changed

**Mechanism** (the design's §8; two src files, prepare.ts untouched):
- `Runtime.trustSnapshotForPrincipal(principal)` → `{id: "principal:<did>", actingPrincipal, revision: <the runtime's trust revision>}`. The constructor's default provider is refactored onto the same composition, so the trust-config digest folds in at exactly ONE site — a trust-config change invalidates per-run served digests exactly as ambient ones (INV-G). A serving runtime now REFUSES a custom `trustSnapshotProvider` at construction (fail-loud: the stamper would silently bypass it for acting runs and compose a revision the provider doesn't know).
- SpaceServer `#stampRun` attaches the per-run snapshot via `tx.setCfcTrustSnapshot(...)` with the ruled precedence: `delegated.acting.user` (the S-A carriage arm) → `info.acting.user` (a handler's server-stamped actor, LT6-inherited pairs included) → a demanded derivation's `scopeKeyIdentity.principal` (the Q2 arm — ships, severable) → else the ambient service snapshot stays (the Q3 ruling: actor-less runs keep the service snapshot). Set once, before the run's first read, so the mid-run grant writes, prepare, and the commit-time recheck see one value.

**Docs (docs-move-together):**
- The ruling recorded in the design doc (verbatim owner blockquote atop §10; every question marked RULED in place; the actor-less examples list includes the drain's consequence-notice seal per the #6190 review's NOTE-7).
- serving-loop.md §3c: the ruled binding sentence — amended per the review's MINOR-2 to "cannot mint USER-NAMED current-principal claims" with the Q3 setup/defaults-carve-out caveat cross-referenced, reconciling two parts of the owner's own accepted ruling set.
- cfc-spec-changes.md: **SC-38** — the current-principal family's served-execution reading (against the audit-3.5 §6/§8.15 chain).
- verification-coverage.md: register row **OW59** (CLOSED by this train; carries the review's NOTE-6 as an OW53-adjacent record — delegated read sessions demand under the process DID, label-inert); OW31 residual (iii) re-tensed to CLOSED-BY OW59; two stale skip-status sentences (the OW31 delta block, the OW47 row) re-tensed to the lift.
- `tasks/server-execution-on-skips.ts`: the `cfc-group-chat-demo` ON-skip entry **removed** on its own lift condition (+ the skips test re-pinned: five gate entries, a lifted-pin for the file in the established style).
- `test/clock-preload.ts`: the new suite joins `realClockFiles` like the rest of the live-ExecutorHost family (the serving loop is wall-clock-paced by design).

**Tests:** `packages/runner/test/executor-trust-attribution.test.ts` — the §9 pin family (17 steps).

## Test plan

**Red-first (§9-1), watched:** with the mechanism reverted to base in-tree, the FLAG-5 pin fails with the service DID as the persisted subject — the assertion diff shows actual `did:key:z6MkqW6E…` (the fixture's service signer) where the acting user was expected, on both authored-by and represents-principal; the §9-2/§9-3/§9-4/INV-G pins are red at base too, while the literal-DID INV-E arm and the OFF pins stay green at base (they pin base behavior). All 17 steps green with the fix.

**The §9 pins** (real SpaceServer + live wave, the OW31-pin style):
- §9-1 the FLAG-5 mint: a served handler run writing authored/represents schemas persists labelMap subjects equal to the entry's `firedAt.user`; INV-E arms — a literal-DID current-principal claim still refuses ("must be runtime resolved"), an unprivileged direct `["cfc"]` labelMap rewrite on a minted envelope still fails closed with the S18 reason and the stored envelope is untouched — both surfacing as the served entry's error consequence (OW54's machinery).
- §9-2 two users' runs in one drain: each run's docs carry that run's user, both commits recheck clean, no cross-contamination.
- §9-3 replay: a re-drained entry (first attempt aborted) mints from the durable entry's actor; a second host activation re-runs nothing — ONE consequence commit per eventId, asserted behind an ORDERED barrier (a fresh entry's consequence on the re-activated loop, not a settle beat) — and the labels stay byte-identical.
- §9-4 the live stamper's precedence: delegated → acting → LT6-inherited → demanded; actor-less bookkeeping and wave-fallback derivations keep the ambient service snapshot; every per-run snapshot carries the runtime's own revision.
- §9-5 OFF neutrality: on an OFF client and a flag-ON client (speculation), `stampServerRun` leaves the edit()-attached ambient snapshot untouched.
- INV-G: `trustSnapshotForPrincipal` composes the same revision as the default provider, with and without a trust config; a serving runtime with a custom provider throws at construction.

**The live lift (§9-6):** `integration/cfc-group-chat-demo.test.ts` under the TRUE ON topology — ON-built toolshed binary (posture probe: `shellServerExecutionDefine === "true"`, `servingLoop` present), self-referential API_URL/MEMORY_URL on a non-default port (the OW55 runbook caveat), fresh store per run — **green 4/4**: three fresh-store lift runs (22s/13s/16s) plus a quiet-machine solo run (9s), both authorship checks across the `shell.login` switch included. **Store-dump audit (INV-D): PASS 4/4** — zero authored-by/represents-principal atoms naming the service DID in every run's store (run 1 held 50 current-principal atoms, all naming the two user DIDs — the §2a evidence query inverted). Q3's flagged setup-restage caveat did not surface (as the design predicted for this flow; it stays the named follow-up). Gate logs: zero `cfc-prepared-digest-mismatch` / `trust-snapshot-changed` occurrences (4/4).

**Blast-radius siblings under the same ON topology:** `cfc-group-chat-demo-two-browsers` green (25s), `cfc-group-chat-demo-multi-runtime` green (7 steps, 19s), `lunch-poll-vote` green solo on a quiet machine (18s; 1-min load 7.15 → 6.76 recorded around the run).

**Suites (per-file, the package's canonical invocation — `ENV=test deno test --no-check --preload=test/clock-preload.ts …`):** the full runner battery **637/637 green — zero failures** (executor family, cross-space with the OW31 S-A delegated + carriage-less-refusal pins, serving-loop, storage-instance-keying, and every other file); memory **59/59 green**. Repo-wide `deno fmt --check`, `deno lint`, `deno task check`, check-docs, check-docs-history-index, check-conflict-markers, check-skill-facts, check-no-waitfor, check-test-aliases, check-control-characters: all green. Skips test: 17/17.

Design of record + ruling: `docs/history/plans/server-execution-v2/optimize/ow34-attribution-design.md` (§10 heads the ruling record). Coordinator notes: SC-38 was the actual next free number; the register row minted as OW59 (OW58 taken by #6186) — renumber at merge if a collision appeared. The OW51 branch edits the same skip-list files; the second lander resolves the textual conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
