### PR TITLE
Server-execution v2: the explicit warm request — staged setup activates and derives in a parked, sessionless space

### DIFF
--- a/docs/specs/server-side-execution/scenario-traces.md
+++ b/docs/specs/server-side-execution/scenario-traces.md
@@ -718,7 +718,14 @@ these.
   NOTIFIES but the ACTIVE criteria decide, so the provisioning
   write alone leaves C parked. (Was a CONTRADICTION between §2b and
   serving-loop §1's plane (b) — RECONCILED in serving-loop §1 with
-  this fold; vetoable.)
+  this fold; vetoable.) *(Amended 2026-08-21, answer unchanged: §1's
+  third trigger — the explicit warm request — is now implemented,
+  and a SERVED provisioning wave issues one for the setup it stages,
+  so C activates promptly in that flow. The write itself still
+  activates nothing; a provisioning admission with no issuer — a
+  client's multi-space commit, a system write — parks exactly as
+  this cell rules. serving-loop.md §1's warm-request paragraph
+  carries the mechanism and the RULED marker.)*
 
 ### T12 (adjudicated COMPLETE) (re-verified after the 2026-08-05 Q1 ruling; Q4 cell updated)
 - Q1: speculate pure structural + handlers + optimistic navigate +

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -142,7 +142,14 @@ the tenure — recompute-on-demand, §6 step 2, is the recovery posture
 for anything a dying tenure drops), and the request itself is a
 one-shot in-process signal, not a durable row — loss across a process
 crash in the staged-but-underived window is the OW46 silent-park
-observability family.
+observability family. One deliberate side effect, stated: the
+warm notice rides `noteExecutorCommit`, whose dirtiness marking means a
+foreign provisioning batch's staged writes now also PUSH to any client
+session subscribed to those docs in the target space — previously those
+engine-direct commits produced no notice at all, so a subscribed client
+saw them only on its next own sync. Beneficial (staleness removed),
+never load-bearing: no client in the ruled flows subscribes to setup
+docs before activation.
 
 Wiring, by plane. Every byte between these components travels on
 exactly ONE of two planes; the split is what keeps bookkeeping off

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -116,6 +116,34 @@ per-space check: stream head past `eventWatermark` means undelivered
 events, so activate. A park racing an incoming commit self-heals: the
 hook re-fires on the next admission.
 
+The EXPLICIT WARM REQUEST *(RULED 2026-08-21 — the owner adopted the
+recommendation set for the home-profile setup-after-park residual;
+implemented the same day)*: the SERVING-SIDE PROVISIONING PATH issues
+it — the wave commit step reports every durably committed foreign
+provisioning batch (§2b's sanctioned authored crossing: a served
+`.inSpace()` create's scaffolding, the delegated program-
+materialization writeback) to the co-hosted memory server as a
+warm-marked admission notice carrying the staged doc instances. The
+host activates a parked target on it even with NO live session and NO
+events (the carries-events arm's sibling), and the target's tenure
+takes the staged instances as identity-less WARM DEMAND — the
+anonymous-session shape, a demand key with no demanding pair, unioned
+into the demand pass for that tenure — so the staged piece
+structure-loads and derives. This is the one deliberate extension of
+the demand union beyond client sessions: the issuer is the
+provisioning run that KNOWS it staged setup needing derivation — a
+scoped signal, never a blanket write-trigger — so T11.Q7 stays as
+designed (the admission hook alone still notifies without activating;
+a provisioning write ALONE still parks). Lifecycle: idempotent
+against an active target (the union is a no-op under standing client
+demand); a request racing a park re-carries itself into the successor
+activation; the captured warm demand is TENURE-scoped (it dies with
+the tenure — recompute-on-demand, §6 step 2, is the recovery posture
+for anything a dying tenure drops), and the request itself is a
+one-shot in-process signal, not a durable row — loss across a process
+crash in the staged-but-underived window is the OW46 silent-park
+observability family.
+
 Wiring, by plane. Every byte between these components travels on
 exactly ONE of two planes; the split is what keeps bookkeeping off
 the commit stream (README §3.3):
@@ -1225,6 +1253,7 @@ structureLoadFailures, structureLoadDeferred, structureLoadStuck,
 structureLoadTerminal,
 structureLoadRearmed, watermarkClamped,
 unstampedSealRefusals, foreignWriteRefusals, foreignEngineFailures,
+warmRequests,
 watermarkLag, demandArrivals, undemandedNarrowingRuns, earlyEmitRefusals,
 demand: {demandedRows, demandedInstances, demandedInstancesMax,
 demandedPairs, demandedWriters, demandedWritersMax, demandRootEnters,
@@ -1272,7 +1301,11 @@ accept-gate refusals — carriage-less AND ungranted foreign writes,
 both action-scoped; `foreignEngineFailures` counts commit-step
 foreign-engine resolutions that failed and were isolated per space —
 a growing count names a foreign store that persistently cannot open,
-never a home-space outage) (`effectAcks` counts
+never a home-space outage; `warmRequests` counts explicit warm
+requests issued — one per foreign provisioning batch a wave durably
+committed (§1's third activation trigger, RULED 2026-08-21) — so a
+provisioning flow whose target never derives its staged setup is
+diagnosable from the issue count against the target's activity) (`effectAcks` counts
 effect-channel ack writes, so the
 §3 amplification metric is computable from counters alone —
 `settleAdvances` counts S1's drain-settle quiescence advances (RULED

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1258,7 +1258,7 @@ watermarkLag, demandArrivals, undemandedNarrowingRuns, earlyEmitRefusals,
 demand: {demandedRows, demandedInstances, demandedInstancesMax,
 demandedPairs, demandedWriters, demandedWritersMax, demandRootEnters,
 demandRootLeaves, notCurrentRearms, demandPasses, demandPassMs,
-pushGrowthWakes, watchWakes}, settle: {series, dropped},
+pushGrowthWakes, watchWakes, warmWakes}, settle: {series, dropped},
 settleAdvances: {count, lastDelta, series, dropped}, events:
 {appended, processed, coalescedPerWaveMax, skippedIdempotent,
 drainInFlightSkips, lt1LeftoversPurged, lt1LateSealsRefused,
@@ -1346,8 +1346,10 @@ time — which INCLUDES the awaited structure-load segments
 (`ensurePieceRunning`) for first-demand/pending root keys, NOT only the
 O(rows) reconcile (the reconcile does no per-row engine read and runs on
 registry deltas; the label is wall time, review MINOR-3);
-`pushGrowthWakes`/`watchWakes` count NOTIFIES (the push-time
-`demandChanged` and the `session.watch.set`/`.add` notifies) BEFORE the
+`pushGrowthWakes`/`watchWakes`/`warmWakes` count NOTIFIES (the push-time
+`demandChanged`, the `session.watch.set`/`.add` notifies, and the warm
+request's staged-instance captures — the third kept apart so
+`watchWakes` keeps meaning exactly the session-watch notifies) BEFORE the
 300 ms-grace coalescing — a burst is several notifies but one demand pass,
 so these exceed the pass-wake count (review NIT-5); the service (loopback)
 session's notifies are DROPPED — its tracked-set growth is the serving

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5295,6 +5295,22 @@ supply; OW29/OW32/OW34 closed):
     stayed quiet. The counter's live purpose stands unchanged for
     genuinely dead spaces (OW45's named die-before-flush residual;
     its revisit trigger reads this counter in real ON usage).
+    **Family variant, closed same-day (the warm request's adversarial
+    review; no crash required)**: an activation FAILURE after the
+    host drained buffered warm notices into it — `activate()`
+    refusing on a rival process's unexpired lease, or throwing —
+    stranded the staged setup underived with no crash anywhere: the
+    warm one-shot died with the failed server and nothing re-issued
+    it. Fixed red-first (the host re-buffers the consumed warm
+    notices on either failure arm; `executor-warm-request.test.ts`'s
+    post-drain-failure pin, watched red at the drained root never
+    reaching the eventual successor). The remaining loss window of
+    this family is the PROCESS-crash one recorded above. Review
+    observation, recorded: a tenure's warm-demand key set grows
+    monotonically until park — bounded by the provisioning volume
+    aimed at the space per tenure, and worth a stats eye
+    (`warmRequests` per space) if a provisioning-heavy space ever
+    holds a very long tenure.
   - **OW47 — client own-write durability under ON (seats S-E/S-F/S-G;
     rootcause §2b + the cellset-lww reproducer). CLOSED 2026-08-21
     (optimize-on-main client-durability pass; report:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5310,13 +5310,25 @@ supply; OW29/OW32/OW34 closed):
     it. Fixed red-first (the host re-buffers the consumed warm
     notices on either failure arm; `executor-warm-request.test.ts`'s
     post-drain-failure pin, watched red at the drained root never
-    reaching the eventual successor). The remaining loss window of
-    this family is the PROCESS-crash one recorded above. Review
-    observation, recorded: a tenure's warm-demand key set grows
-    monotonically until park — bounded by the provisioning volume
-    aimed at the space per tenure, and worth a stats eye
-    (`warmRequests` per space) if a provisioning-heavy space ever
-    holds a very long tenure.
+    reaching the eventual successor). The re-buffer collects what the
+    activation CONSUMED — its argument and the drained buffer — so
+    the family's remaining losses are TWO: the PROCESS-crash window
+    recorded above, and a mid-activate-arrival SLIVER (no crash
+    required): a warm notice arriving AFTER the successor registered
+    and BEFORE its `activate()` failed routes through the
+    existing-server arm straight into the doomed server's feed — in
+    neither re-buffer collection. Recovery caveat, stated: re-buffered
+    notices activate nothing by themselves — they recover on the next
+    QUALIFYING trigger (a session open, an event, or another warm
+    request), which in the strict no-backstop shape may be indefinite;
+    the diagnostic read is §7's `warmRequests` against the target
+    space's subsequent serving activity (requests issued with no
+    derived commits following). Review observation, recorded: a
+    tenure's warm-demand key set grows monotonically until park —
+    bounded by the provisioning volume aimed at the space per tenure,
+    and worth a stats eye (`warmRequests` — a loop-global counter; no
+    per-space breakdown exists today) if a provisioning-heavy space
+    ever holds a very long tenure.
   - **OW47 — client own-write durability under ON (seats S-E/S-F/S-G;
     rootcause §2b + the cellset-lww reproducer). CLOSED 2026-08-21
     (optimize-on-main client-durability pass; report:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -2854,8 +2854,9 @@ Delta 2026-08-15 — Phase 6 independent-review fixes (same PR):
   Acceptance beyond the executor pins rides the PR's CI ON lanes and
   the flip train's live gates (the lunch/served-wish log criteria and
   the store dump), which stay the flip PR's bar; the
-  `home-profile-reload-durability` ON skip stays listed (it lifts
-  jointly with OW45), and the `cfc-group-chat-demo` skip was LIFTED
+  `home-profile-reload-durability` ON skip was LIFTED 2026-08-21 (the
+  explicit warm request — OW45's row carries the ruling and the 6/6
+  gate), and the `cfc-group-chat-demo` skip was LIFTED the same day
   by OW59 (the OW34-family train closed the CFC-attribution residual
   above and removed the entry on its green ON gate + store audit).
 - OW32 — the CLIENT-side `scheduler-non-settling` loop under the full
@@ -5155,10 +5156,11 @@ supply; OW29/OW32/OW34 closed):
   + TWO step-level entries; the skip-list test pins the CURRENT set —
   both step entries were lifted the same day, cellset-lww with OW47's
   close and convergence-storm with OW52's, the group-chat file entry
-  was lifted with OW59's close, and default-app's file entry converted
-  to its OW45 reload-step entry with OW51's close, leaving four file
-  entries beside default-app's step entry);
-  they gate the
+  was lifted with OW59's close, default-app's file entry converted
+  to its OW45 reload-step entry with OW51's close, and
+  home-profile-reload-durability's file entry lifted the same day too
+  with the explicit warm request (OW45's row), leaving THREE file
+  entries beside default-app's step entry); they gate the
   FLIP — whose bar is the list EMPTY — not the land. Rows, one per
   mechanism cluster; each row's trigger names the skip entry it
   lifts:
@@ -5220,14 +5222,42 @@ supply; OW29/OW32/OW34 closed):
     shelf-ready start (client-side heal riding `replicateClosures`
     under the client's own identity, green red-first runner pins,
     serving posture pinned fail-closed; marked do-not-merge).
-    Trigger: lifts the
-    `integration/home-profile-reload-durability.test.ts` ON skip
-    JOINTLY with OW31's cf:module cross-space run residual — S-A and
-    S-B are both MERGED (9d989c0c1, b27a2fb43), and the optimize
-    pass's joint preview run had step 1 green in ~10 s with step 2
-    red ONLY on that residual. Also now gates
+    Trigger DISCHARGED for the home-profile half — the
+    `integration/home-profile-reload-durability.test.ts` ON skip is
+    LIFTED (2026-08-21). The last blocker was not a carriage residual:
+    the §2b derivation-carriage scoping pass
+    (`optimize/2b-derivation-carriage-scope.md` §4) decomposed step
+    2's red to a SETUP-AFTER-PARK ORDERING RACE — authored setup
+    landing in a parked, sessionless space activates nothing (T11.Q7's
+    designed parking) and nothing ever re-demands it (the post-reload
+    summary reads the missing computed through the HOME space's free
+    cross-space read, which registers no target-side demand) — and
+    flagged three candidate mechanisms for the owner. **RULED
+    2026-08-21 (owner: "three decisions: i agree with all
+    recommendations")**: implement serving-loop.md §1's third,
+    then-unimplemented activation trigger — the EXPLICIT WARM REQUEST,
+    issued by the SERVING-SIDE PROVISIONING PATH when it stages setup
+    into a parked space (not a synthetic client session, and not
+    S-C-shape healing). BUILT the same day: the wave commit step
+    reports every durably committed foreign provisioning batch as a
+    warm-marked notice; the host activates a sessionless target on it
+    (the carries-events arm's sibling; T11.Q7's write-alone parking
+    untouched); the target tenure takes the staged instances as
+    identity-less warm demand, so the setup derives. The build also
+    closed the latent sink localSeq collision the warm activation
+    exposed (per-space counters under the process-stable holder
+    session — a home sink's foreign batches consumed pairs the
+    target's own sink later re-minted, killing its waves as replay
+    mismatches; now one process-global counter). Red-first:
+    `executor-warm-request.test.ts` (watched failing at the
+    activation wait, then at the derivation on the collision, then
+    green end to end). Lift evidence: 6/6 fresh-store ON gate runs at
+    the fix head, BOTH steps green in 12–24 s (the prior shape: step 1
+    ~10 s green, step 2 red at 5m+ on "Alan Turing"), posture verified
+    and loads (4.3–5.9) recorded per run, `warmRequests` 4–6 per run
+    in the live stats. The row's REMAINING charge: it gates
     `integration/default-app.test.ts`'s "persist and reload every
-    rapidly created notebook note" STEP: the OW51 fix (2026-08-21)
+    rapidly created notebook note" STEP — the OW51 fix (2026-08-21)
     lifted that file's FILE skip and UNMASKED this same
     reload-durability surface there — the reloaded notebook's
     `noteCount` reads `undefined` past the step's wait (1/10 local ON);
@@ -5257,9 +5287,14 @@ supply; OW29/OW32/OW34 closed):
     `executor-space-server.test.ts` (a pattern-unloadable root
     deferring per cycle: stuck stays 0 below the threshold, crosses
     to exactly 1, never re-counts while the streak grows; the OW19
-    terminal/re-arm pins unchanged). Residual (the original
-    trigger): the home-profile lift run should show the park
-    counted/logged — that run belongs to OW45/OW31's joint lift.
+    terminal/re-arm pins unchanged). Residual DISCHARGED with the
+    lift (2026-08-21): the home-profile lift landed via the explicit
+    warm request (OW45's row), which PREVENTS the parked state in
+    that flow — the staged setup activates and derives, so the 6/6
+    gate runs had no stuck park to count and the counter correctly
+    stayed quiet. The counter's live purpose stands unchanged for
+    genuinely dead spaces (OW45's named die-before-flush residual;
+    its revisit trigger reads this counter in real ON usage).
   - **OW47 — client own-write durability under ON (seats S-E/S-F/S-G;
     rootcause §2b + the cellset-lww reproducer). CLOSED 2026-08-21
     (optimize-on-main client-durability pass; report:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5260,9 +5260,15 @@ supply; OW29/OW32/OW34 closed):
     rapidly created notebook note" STEP — the OW51 fix (2026-08-21)
     lifted that file's FILE skip and UNMASKED this same
     reload-durability surface there — the reloaded notebook's
-    `noteCount` reads `undefined` past the step's wait (1/10 local ON);
-    an event-driven wait on `noteCount` is the test-side close, this
-    row's territory.
+    `noteCount` reads `undefined` past the step's wait (1/10 local ON
+    at the OW51 build; re-measured 2026-08-22 by the warm-request P-1
+    probe as heavily LOAD-SENSITIVE: 5/10 red on pure main and 7/10
+    red on the warm-request head — statistically indistinguishable at
+    n=10 — on a shared box at loads 3-16, every red the same
+    `undefined`-vs-7 shape, and the warm request structurally INERT in
+    this flow: `warmRequests` 0 in 10/10, the notebook stages no
+    foreign provisioning); an event-driven wait on `noteCount` is the
+    test-side close, this row's territory.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -187,6 +187,20 @@ export const scopeOfScopeKey = (scopeKey: string): CellScope => {
 };
 
 /**
+ * The canonical (id, scope key) -> dirty/demand key encoding — the ONE
+ * identity every demand/dirtiness surface keys instances by (the memory
+ * server's dirty marking, the serving loop's demand registry, the warm
+ * request's staged-instance capture). Lives HERE, on the shared
+ * browser-safe vocabulary surface beside {@link resolveScopeKey}, so
+ * client-bundled modules (the runner's wave carriage among them) can
+ * key with it without importing any server-only module.
+ */
+export const toDirtyKey = (
+  id: string,
+  scopeKey: ScopeKey = "space",
+): string => `${scopeKey}\0${id}`;
+
+/**
  * Whether a scope key is in the APPLICABLE SET of the given identity
  * (protocol.md §3): `space`, `user:<me>`, `session:<me>:<sid>`. Push is
  * filtered per recipient by this predicate — a subscriber receives only

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -1096,10 +1096,10 @@ export const fromDocKey = (key: QueryDocKey): {
  * hosts every instance. At cardinality 1 per session the re-keyed form
  * partitions exactly as the name form did (key-vocabulary.md §2).
  */
-export const toDirtyKey = (
-  id: string,
-  scopeKey: ScopeKey = "space",
-): string => `${scopeKey}\0${id}`;
+// Relocated to the shared browser-safe vocabulary surface (v2.ts, beside
+// resolveScopeKey) so client-bundled modules can key with it; re-exported
+// here for this module's existing importers.
+export { toDirtyKey } from "../v2.ts";
 
 export const fromDirtyKey = (
   key: string,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -418,6 +418,12 @@ export type AdmittedCommitNotice = {
   warm?: true;
 };
 
+// The canonical demand/dirty key encoding, re-exported beside the
+// notice type whose `writes` it keys: the serving loop's warm-demand
+// capture (space-server.ts) keys staged instances with it so warm keys
+// can never drift from the client demand keys the registry holds.
+export { toDirtyKey } from "./query.ts";
+
 /**
  * The ExecutorHost's in-process observer (serving-loop.md §1's wiring):
  * plane (b) — `commitAdmitted` is the admission-side activation hook (an

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -404,6 +404,18 @@ export type AdmittedCommitNotice = {
    * doc instance + the eventId); the SpaceServer's drain reads the
    * stamped entries from the store, never from this record. */
   eventAppends?: Array<{ id: string; scopeKey: ScopeKey; eventId: string }>;
+  /** The EXPLICIT WARM REQUEST (serving-loop.md §1's third activation
+   * trigger; RULED 2026-08-21): set only by the serving-side
+   * provisioning path — a wave's foreign provisioning batch reported
+   * through `noteExecutorCommit` — when this authored commit STAGED
+   * SETUP into another space (protocol.md §2b's sanctioned crossing).
+   * The host activates the target on it even with no live session and
+   * no events (the deliberate, scoped signal the notify-only admission
+   * hook is not — T11.Q7's write-alone parking stays as designed), and
+   * the target's serving loop takes the commit's `writes` as
+   * identity-less warm demand so the staged setup derives. Never set on
+   * client transacts, system writes, or event deliveries. */
+  warm?: true;
 };
 
 /**

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -418,12 +418,6 @@ export type AdmittedCommitNotice = {
   warm?: true;
 };
 
-// The canonical demand/dirty key encoding, re-exported beside the
-// notice type whose `writes` it keys: the serving loop's warm-demand
-// capture (space-server.ts) keys staged instances with it so warm keys
-// can never drift from the client demand keys the registry holds.
-export { toDirtyKey } from "./query.ts";
-
 /**
  * The ExecutorHost's in-process observer (serving-loop.md §1's wiring):
  * plane (b) — `commitAdmitted` is the admission-side activation hook (an

--- a/packages/runner/src/executor/engine-wave-sink.ts
+++ b/packages/runner/src/executor/engine-wave-sink.ts
@@ -72,13 +72,19 @@ export class EngineWaveCommitSink implements WaveCommitSink {
    * Replay keying — the stage-F choice, made and enforced here: the
    * engine dedupes commits by UNIQUE (session_id, local_seq), returning
    * the STORED result for a byte-identical replay and throwing "commit
-   * replay mismatch" for a different one. The SpaceServer holds ONE
-   * long-lived counter per (space, process) — `localSeqRef`, owned by
-   * the ExecutorHost, starting at 0 — and uses the DR1 HOLDER identity
+   * replay mismatch" for a different one. Every sink in the process
+   * shares ONE long-lived counter — `localSeqRef`, owned by the
+   * ExecutorHost, starting at 0 — and uses the DR1 HOLDER identity
    * as the `sessionId`, which is simultaneously what the
    * derived-envelope admission requires (protocol.md §2, RULED
    * 2026-08-05: the producing session must BE the holder's own service
-   * session). Freshness is structural, not queried: the holder's
+   * session). The counter is process-global rather than per-space
+   * because the session is: a home sink's FOREIGN provisioning batches
+   * (protocol.md §2b) land in other spaces' engines under this same
+   * session, so per-space counters re-mint pairs another writer already
+   * consumed there and the engine kills the later wave as a replay
+   * mismatch (the ExecutorHost's `#sinkLocalSeq` doc carries the
+   * incident shape). Freshness is structural, not queried: the holder's
    * process-instance component makes a new process a NEW engine
    * session, so 0 never collides; a park/re-activate within one
    * process reuses the counter. (A holder scheme WITHOUT a process

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -399,6 +399,11 @@ export class ExecutorHost {
       await this.#backoffSleep(delayMs);
       if (this.#closed || this.#spaces.get(space)?.active) return;
     }
+    // The warm notices this activation CONSUMES (the argument now; the
+    // drained buffer appends at drain time): re-buffered by the failure
+    // arms below — see #rebufferConsumedWarm. Collected from the start
+    // so an early throw (the engine open) loses nothing either.
+    const consumedWarm = pending.filter((notice) => notice.warm === true);
     try {
       const engine = await this.#options.server.engineForSpace(space);
       // The sink's session key IS the DR1 holder, whose process-instance
@@ -459,10 +464,14 @@ export class ExecutorHost {
       if (buffered !== undefined) {
         this.#pendingNotices.delete(space);
         for (const notice of buffered) server.enqueueCommit(notice);
+        for (const notice of buffered) {
+          if (notice.warm === true) consumedWarm.push(notice);
+        }
       }
       const activated = await server.activate();
       if (!activated) {
         this.#spaces.delete(space);
+        this.#rebufferConsumedWarm(space, consumedWarm);
         return;
       }
       if (this.#closed) {
@@ -474,8 +483,35 @@ export class ExecutorHost {
       }
     } catch (error) {
       this.#spaces.delete(space);
+      this.#rebufferConsumedWarm(space, consumedWarm);
       logger.error("activate-failed", `activation of ${space} failed`, error);
     }
+  }
+
+  /** Re-buffer the warm notices a FAILED activation consumed — its
+   * `pending` argument plus what it drained from `#pendingNotices` —
+   * so the next trigger's activation drains them into a live
+   * successor. A warm notice is a ONE-SHOT signal from a provisioning
+   * wave that has already committed: nothing re-issues it, and in the
+   * home-profile shape there is no client backstop — an activation
+   * dying AFTER the drain (`activate()` refusing on a rival process's
+   * unexpired lease, or throwing) would otherwise strand the staged
+   * setup underived with no crash anywhere (the OW46-family
+   * no-crash-required loss; pinned in executor-warm-request.test.ts).
+   * Prepended: the consumed notices are older than anything buffered
+   * while the failed activation was in flight. */
+  #rebufferConsumedWarm(
+    space: MemorySpace,
+    consumedWarm: readonly AdmittedCommitNotice[],
+  ): void {
+    if (consumedWarm.length === 0) return;
+    const standing = this.#pendingNotices.get(space);
+    this.#pendingNotices.set(
+      space,
+      standing === undefined
+        ? [...consumedWarm]
+        : [...consumedWarm, ...standing],
+    );
   }
 
   /** A cancellable backoff sleep: close() flushes the wakers so a

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -206,15 +206,33 @@ export class ExecutorHost {
       // no longer active, no activation in flight) is the third case:
       // chain a fresh activation behind the park so a space with live
       // demand is never left unserved by the race. A WARM notice racing
-      // the park re-carries itself into the successor activation: the
-      // dying tenure's feed (and its captured warm demand) dies with
-      // it, so the fresh SpaceServer must re-capture from the notice.
+      // the park BUFFERS for the successor activation (drained at its
+      // registration, exactly like the mid-activation window below):
+      // the dying tenure's feed — and the warm capture that just went
+      // into it — die with the tenure, and SEVERAL warm notices in one
+      // park window chain ONE shared reactivation, so a notice passed
+      // by argument would be dropped for every notice but the first
+      // (#activate joins the in-flight activation without merging its
+      // pending list — the #6191 review's P1).
       existing.enqueueCommit(notice);
       if (!existing.active && !this.#activating.has(notice.space)) {
+        if (notice.warm === true) {
+          // Only in the true parking window (no successor in flight):
+          // once a successor is activating, the enqueue above already
+          // reached a feed that survives — its registration drain has
+          // either run against this buffer or the notice landed on the
+          // registered server directly.
+          let buffered = this.#pendingNotices.get(notice.space);
+          if (buffered === undefined) {
+            buffered = [];
+            this.#pendingNotices.set(notice.space, buffered);
+          }
+          buffered.push(notice);
+        }
         this.#reactivateAfterPark(
           existing,
           notice.space as MemorySpace,
-          notice.warm === true ? notice : undefined,
+          notice.warm === true,
         );
       }
       return;
@@ -300,20 +318,23 @@ export class ExecutorHost {
    * event-only admission racing the park (a delegated cross-space
    * delivery with no client anywhere) chains through here, and a
    * sessions-only gate declined it — the delivered event sat unserved
-   * until an unrelated trigger. A WARM notice racing the park
-   * (`warmNotice`) satisfies the gate the same way — the staged setup
-   * is durable and undemanded, exactly the state the warm request
-   * exists for — and re-enters the successor's feed so its warm demand
-   * is re-captured (the dying tenure's capture died with it). */
+   * until an unrelated trigger. A WARM notice racing the park (`warm`)
+   * satisfies the gate the same way — the staged setup is durable and
+   * undemanded, exactly the state the warm request exists for. The
+   * notice itself travels through `#pendingNotices` (buffered by the
+   * caller, drained at the successor's registration), NOT as an
+   * argument: several warm notices in one park window share ONE
+   * reactivation, and only a buffer merges them all (the #6191
+   * review's P1). */
   #reactivateAfterPark(
     parking: SpaceServer,
     space: MemorySpace,
-    warmNotice?: AdmittedCommitNotice,
+    warm = false,
   ): void {
     void parking.whenParked.then(async () => {
       if (this.#closed || this.#spaces.get(space)?.active) return;
       if (
-        warmNotice === undefined &&
+        !warm &&
         !this.#options.server.hasLiveSessionsForSpace(space, {
           excludePrincipal: this.#options.serviceIdentity,
         })
@@ -332,7 +353,7 @@ export class ExecutorHost {
         // The engine read awaited: re-check the activation preconditions.
         if (this.#closed || this.#spaces.get(space)?.active) return;
       }
-      void this.#activate(space, warmNotice === undefined ? [] : [warmNotice]);
+      void this.#activate(space, []);
     });
   }
 

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -5,8 +5,13 @@
 // - plane (b): the memory server's admission observer notifies the host
 //   on any AUTHORED admission (an admission-side hook, never a poll) and
 //   on session open; the host activates the space when it meets the
-//   ACTIVE criteria (≥1 live client session or undelivered events — the
-//   latter has no instances until Phase 3 lands events on the wire);
+//   ACTIVE criteria — ≥1 live client session, undelivered events (an
+//   event-carrying admission), or an EXPLICIT WARM REQUEST
+//   (serving-loop.md §1's third trigger, RULED 2026-08-21): a
+//   warm-marked admission notice, set only by the serving-side
+//   provisioning path when its wave staged setup into the space, which
+//   activates a sessionless target where an ordinary authored write
+//   deliberately does not (T11.Q7's write-alone parking);
 // - plane (c): lease acquire/renew by direct table write (the
 //   SpaceServer's cycle);
 // - plane (d): admitted-commit records route to the space's SpaceServer
@@ -15,7 +20,8 @@
 // A park racing an incoming commit self-heals: the hook re-fires on the
 // next admission. Host boot discovery (stream head past eventWatermark ⇒
 // undelivered events ⇒ activate) has nothing to discover until Phase 3;
-// spaces activate on their first session or authored admission.
+// spaces activate on their first session, event, warm request, or
+// session-implying authored admission.
 
 import {
   type AdmittedCommitNotice,

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -83,10 +83,24 @@ export class ExecutorHost {
    * feed at registration — an admission racing activation must never be
    * dropped (its seq may pass the activation's scan head). */
   readonly #pendingNotices = new Map<string, AdmittedCommitNotice[]>();
-  /** Process-lifetime localSeq counters per space (the sink's replay
-   * keying — engine-wave-sink.ts): survive park/re-activate, floored at
-   * the engine's stored max on first use. */
-  readonly #localSeqBySpace = new Map<string, { value: number }>();
+  /** The ONE process-lifetime localSeq counter for every sink this host
+   * builds (the replay keying — engine-wave-sink.ts): survives
+   * park/re-activate, shared across ALL spaces. It must be
+   * process-global, not per-space, because every sink commits under the
+   * SAME process-stable session id (the DR1 holder) and a HOME space's
+   * sink writes FOREIGN provisioning batches into OTHER spaces' engines
+   * (protocol.md §2b): with per-space counters, a target space's own
+   * sink later re-mints (session, localSeq) pairs the home sink's
+   * foreign batches already consumed in that engine, and the engine's
+   * replay detection kills the target's waves as "commit replay
+   * mismatch" — dropping their derivations with nothing to re-arm them
+   * (exposed by the warm request's activation of freshly provisioned
+   * spaces; the executor-warm-request pin). One shared monotonic
+   * counter makes every (session, localSeq) pair globally unique across
+   * writers and engines; per-session localSeq gaps are already normal
+   * in every store (the engine keys replay by equality, never
+   * contiguity). */
+  readonly #sinkLocalSeq = { value: 0 };
   /** Consecutive `loop-failed` parks per space (the re-activation
    * backoff's streak). Incremented at each failure park, cleared by a
    * successfully committed wave — real served progress, not merely a
@@ -191,10 +205,17 @@ export class ExecutorHost {
       // only commits before its head). A PARKING server (registered,
       // no longer active, no activation in flight) is the third case:
       // chain a fresh activation behind the park so a space with live
-      // demand is never left unserved by the race.
+      // demand is never left unserved by the race. A WARM notice racing
+      // the park re-carries itself into the successor activation: the
+      // dying tenure's feed (and its captured warm demand) dies with
+      // it, so the fresh SpaceServer must re-capture from the notice.
       existing.enqueueCommit(notice);
       if (!existing.active && !this.#activating.has(notice.space)) {
-        this.#reactivateAfterPark(existing, notice.space as MemorySpace);
+        this.#reactivateAfterPark(
+          existing,
+          notice.space as MemorySpace,
+          notice.warm === true ? notice : undefined,
+        );
       }
       return;
     }
@@ -220,12 +241,20 @@ export class ExecutorHost {
     // server's service session, and the target may have no client).
     // System/direct writes alone activate nothing — a provisioning
     // write into a lease-less space stays parked until its first
-    // session or event (trace finding T11.Q7).
+    // session or event (trace finding T11.Q7). The one further
+    // activation trigger is the EXPLICIT WARM REQUEST (serving-loop.md
+    // §1's third trigger; RULED 2026-08-21): a warm-marked notice — set
+    // only by the serving-side provisioning path when its wave staged
+    // setup into this space — activates like the carries-events arm,
+    // sessionless target included. T11.Q7 stays as designed: the
+    // admission ALONE still activates nothing; the warm mark is the
+    // provisioning run's own deliberate signal, never a property of
+    // ordinary writes.
     if (notice.class !== "authored") return;
     const carriesEvents = notice.eventAppends !== undefined &&
       notice.eventAppends.length > 0;
     if (
-      !carriesEvents &&
+      !carriesEvents && notice.warm !== true &&
       !this.#options.server.hasLiveSessionsForSpace(notice.space, {
         excludePrincipal: this.#options.serviceIdentity,
       })
@@ -271,11 +300,20 @@ export class ExecutorHost {
    * event-only admission racing the park (a delegated cross-space
    * delivery with no client anywhere) chains through here, and a
    * sessions-only gate declined it — the delivered event sat unserved
-   * until an unrelated trigger. */
-  #reactivateAfterPark(parking: SpaceServer, space: MemorySpace): void {
+   * until an unrelated trigger. A WARM notice racing the park
+   * (`warmNotice`) satisfies the gate the same way — the staged setup
+   * is durable and undemanded, exactly the state the warm request
+   * exists for — and re-enters the successor's feed so its warm demand
+   * is re-captured (the dying tenure's capture died with it). */
+  #reactivateAfterPark(
+    parking: SpaceServer,
+    space: MemorySpace,
+    warmNotice?: AdmittedCommitNotice,
+  ): void {
     void parking.whenParked.then(async () => {
       if (this.#closed || this.#spaces.get(space)?.active) return;
       if (
+        warmNotice === undefined &&
         !this.#options.server.hasLiveSessionsForSpace(space, {
           excludePrincipal: this.#options.serviceIdentity,
         })
@@ -294,7 +332,7 @@ export class ExecutorHost {
         // The engine read awaited: re-check the activation preconditions.
         if (this.#closed || this.#spaces.get(space)?.active) return;
       }
-      void this.#activate(space, []);
+      void this.#activate(space, warmNotice === undefined ? [] : [warmNotice]);
     });
   }
 
@@ -336,19 +374,14 @@ export class ExecutorHost {
     }
     try {
       const engine = await this.#options.server.engineForSpace(space);
-      let localSeqRef = this.#localSeqBySpace.get(space);
-      if (localSeqRef === undefined) {
-        // Fresh per (space, process): the sink's session key IS the DR1
-        // holder, whose process-instance component makes a new process a
-        // NEW engine session — no stored localSeqs to collide with, so
-        // the counter starts at 0. Same-process park/re-activate reuses
-        // this ref, which is the whole replay-keying obligation
-        // (engine-wave-sink.ts). A holder scheme WITHOUT a process
-        // component would need a stored-max floor here instead; no such
-        // scheme exists, so none is kept.
-        localSeqRef = { value: 0 };
-        this.#localSeqBySpace.set(space, localSeqRef);
-      }
+      // The sink's session key IS the DR1 holder, whose process-instance
+      // component makes a new process a NEW engine session — so the
+      // process-global counter starting at 0 never collides with a prior
+      // process's commits, and sharing ONE counter across every space's
+      // sink keeps same-process writers from colliding with each OTHER
+      // (see #sinkLocalSeq: a home sink's foreign provisioning batches
+      // land in other spaces' engines under this same session).
+      const localSeqRef = this.#sinkLocalSeq;
       const server = new SpaceServer({
         space,
         server: this.#options.server,

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -466,6 +466,23 @@ export class SpaceServer implements TransactionSealDestination {
   #passDemandNoteGen = 0;
   /** The demand wake's grace timer (see noteDemandChanged). */
   #demandWakeTimer: ReturnType<typeof setTimeout> | undefined;
+  /** WARM DEMAND (the explicit warm request's demand half —
+   * serving-loop.md §1's third activation trigger, RULED 2026-08-21):
+   * the staged doc instances of warm-marked feed notices, captured at
+   * `enqueueCommit` BEFORE the activation scan's feed filter (a warm
+   * notice's seq is ≤ the scan head on a warm activation, so the feed
+   * record itself is dropped — the capture must not be). The demand
+   * pass unions these as identity-less ROOT keys — the anonymous-
+   * session shape: a key with no demander pair — so a warmed,
+   * SESSIONLESS tenure structure-loads the staged piece and derives it.
+   * Tenure-scoped by construction: the map dies with this SpaceServer
+   * at park (a fresh activation builds a fresh instance), and
+   * recompute-on-demand is the ruled recovery posture for anything a
+   * dying tenure drops (serving-loop.md §6 step 2). */
+  readonly #warmDemandKeys = new Map<
+    string,
+    { id: string; scopeKey: string }
+  >();
   // ---- (d′) — server-settle instrumentation (design §6 W4's
   // metric; §2.8 (c)). Per authored input: admission (the feed notice's
   // arrival, `enqueueCommit`) → COVERAGE (the wave commit whose
@@ -1009,6 +1026,23 @@ export class SpaceServer implements TransactionSealDestination {
    * this space, own derived commits included (skipped by class + holder
    * below — serving-loop.md §3's self-echo rule). */
   enqueueCommit(record: AdmittedCommitNotice): void {
+    if (record.warm === true) {
+      // The warm request's demand half (see #warmDemandKeys): captured
+      // for every warm notice — pre-activation pendings, the
+      // registration drain, and mid-tenure arrivals alike — and a
+      // fresh capture notes a demand change so an idle-waiting loop
+      // runs a fresh demand pass over it (the same grace-coalesced
+      // latch a session's watch change uses).
+      let captured = false;
+      for (const write of record.writes) {
+        const key = `${write.scopeKey}\0${write.id}`;
+        if (!this.#warmDemandKeys.has(key)) {
+          this.#warmDemandKeys.set(key, write);
+          captured = true;
+        }
+      }
+      if (captured) this.noteDemandChanged();
+    }
     this.#feed.push(record);
     if (
       record.class === "authored" && this.#active &&
@@ -2770,6 +2804,25 @@ export class SpaceServer implements TransactionSealDestination {
       }
       pairs.set(demanderPairKey(identity), identity);
     }
+    // WARM DEMAND KEYS (the explicit warm request's demand half — see
+    // #warmDemandKeys): the staged instances enter the key set
+    // identity-less (the anonymous-session shape — a key with no
+    // demander pair) and as structure-load ROOTS, so a warmed,
+    // sessionless tenure loads the staged piece and its writers become
+    // demand roots. Client rows subsume: a key a session already
+    // tracks contributes nothing new here, and the union keeps warm
+    // keys out of the DEPARTED retirement below for this tenure.
+    for (const [key, write] of this.#warmDemandKeys) {
+      if (!rowByKey.has(key)) {
+        rowByKey.set(key, {
+          id: write.id,
+          scope: scopeOfScopeKey(write.scopeKey) as CellScope,
+          scopeKey: write.scopeKey as (typeof rows)[number]["scopeKey"],
+          root: true,
+        });
+      }
+      rootKeys.add(key);
+    }
     // NIT-4: `rowByKey` is already the current-key set (a Map with O(1)
     // `has`); no separate `currentKeys` Set is needed.
     const addressOf = (key: string, row?: { id: string; scope?: string }) => {
@@ -3616,6 +3669,31 @@ export class SpaceServer implements TransactionSealDestination {
       ? advanceTo
       : this.#watermark;
     const outcome = await closing.commitWave(this.#sink!, { derivedThrough });
+    // The EXPLICIT WARM REQUEST (serving-loop.md §1's third activation
+    // trigger; RULED 2026-08-21): every foreign provisioning batch this
+    // wave durably committed is reported to the co-hosted memory server
+    // as a warm-marked authored admission — the serving-side
+    // provisioning path telling the host it STAGED SETUP into another
+    // space. The host activates a parked, SESSIONLESS target on it (the
+    // carries-events arm's sibling), and the target's tenure takes the
+    // staged instances as warm demand, so the setup derives — closing
+    // the setup-after-park ordering race (the home-profile reload
+    // residual: an authored admission alone activates nothing by
+    // design, T11.Q7, and nothing else ever re-demanded the setup).
+    // Reported on EVERY outcome shape: a wave that aborted AFTER some
+    // foreign batches landed still staged that setup durably (§2b never
+    // rolls a landed foreign commit back).
+    for (const foreign of outcome.foreignCommits) {
+      this.#options.stats.warmRequests += 1;
+      this.#options.server.noteExecutorCommit({
+        space: foreign.space,
+        seq: foreign.seq,
+        class: "authored",
+        sessionId: this.#holder,
+        writes: foreign.writes,
+        warm: true,
+      });
+    }
     await closing.settled();
     // The drain's in-flight guard: the store has now spoken for every
     // event this wave carried — committed (its mark landed) or requeued

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -38,12 +38,12 @@
 import {
   type AdmittedCommitNotice,
   type Server as MemoryServer,
-  toDirtyKey,
 } from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
-import type {
-  StreamEventEntry,
-  StreamEventsDocValue,
+import {
+  type StreamEventEntry,
+  type StreamEventsDocValue,
+  toDirtyKey,
 } from "@commonfabric/memory/v2";
 import type { OutboxAppendRow } from "@commonfabric/memory/v2/execution-outbox";
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -38,6 +38,7 @@
 import {
   type AdmittedCommitNotice,
   type Server as MemoryServer,
+  toDirtyKey,
 } from "@commonfabric/memory/v2/server";
 import * as Engine from "@commonfabric/memory/v2/engine";
 import type {
@@ -1035,13 +1036,15 @@ export class SpaceServer implements TransactionSealDestination {
       // latch a session's watch change uses).
       let captured = false;
       for (const write of record.writes) {
-        const key = `${write.scopeKey}\0${write.id}`;
+        // The canonical key encoding (the registry's own), so warm keys
+        // can never drift from client demand keys.
+        const key = toDirtyKey(write.id, write.scopeKey);
         if (!this.#warmDemandKeys.has(key)) {
           this.#warmDemandKeys.set(key, write);
           captured = true;
         }
       }
-      if (captured) this.noteDemandChanged();
+      if (captured) this.noteDemandChanged("warm");
     }
     this.#feed.push(record);
     if (
@@ -1144,17 +1147,22 @@ export class SpaceServer implements TransactionSealDestination {
    * derivations of that piece (protocol.md §4: a fresh subscription's
    * recompute lands in a LATER derived commit; arrival is later demand).
    * Input-driven cycles are unaffected (they run their pass regardless). */
-  noteDemandChanged(reason: "watch" | "push-growth" = "watch"): void {
+  noteDemandChanged(reason: "watch" | "push-growth" | "warm" = "watch"): void {
     // MINOR-1: a fresh demand note — bump the generation so a pass that
     // already snapshotted its rows re-latches on completion.
     this.#demandNoteGeneration += 1;
     // (d′) — flag 1/2 instrumentation: count the wake sources
     // (the push-growth notify is the NEW site) and remember that a growth
     // wake fired, so the settle series can class the inputs it covers.
+    // A WARM capture (the explicit warm request's staged instances
+    // entering #warmDemandKeys) counts apart from client watch changes,
+    // so `watchWakes` keeps meaning exactly the session-watch notifies.
     if (reason === "push-growth") {
       this.#options.stats.demand.pushGrowthWakes += 1;
       this.#growthWakeCounter += 1;
       this.#noteGrowthWakeForSettle();
+    } else if (reason === "warm") {
+      this.#options.stats.demand.warmWakes += 1;
     } else {
       this.#options.stats.demand.watchWakes += 1;
     }

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -228,6 +228,13 @@ export type ServingLoopStats = {
     demandPassMs: number;
     pushGrowthWakes: number;
     watchWakes: number;
+    /** Demand-pass wakes from WARM captures (the explicit warm
+     * request's staged instances entering the tenure's warm demand,
+     * serving-loop.md §1; RULED 2026-08-21) — counted apart so
+     * `watchWakes` keeps meaning exactly the session-watch notifies.
+     * Like the other wake counters, counts notifies before the grace
+     * coalescing. */
+    warmWakes: number;
   };
   /** SERVER SETTLE per authored input (serving-loop.md §7; stage-C design
    * §6 W4's metric): from the authored commit's ADMISSION on the server
@@ -405,6 +412,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
     demandPassMs: 0,
     pushGrowthWakes: 0,
     watchWakes: 0,
+    warmWakes: 0,
   },
   settle: { series: [], dropped: 0 },
   settleAdvances: { count: 0, lastDelta: 0, series: [], dropped: 0 },

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -154,6 +154,15 @@ export type ServingLoopStats = {
    * cannot open (disk trouble, or a provisioning target with an
    * unusable path). */
   foreignEngineFailures: number;
+  /** EXPLICIT WARM REQUESTS issued (serving-loop.md §1's third
+   * activation trigger; RULED 2026-08-21): one per foreign provisioning
+   * batch a wave durably committed — the serving-side provisioning path
+   * telling the host that staged setup landed in another space, so a
+   * parked, SESSIONLESS target activates and derives it (the
+   * setup-after-park ordering race's fix — the home-profile reload
+   * residual). Counted at issue; an already-active target consumes the
+   * request as a demand-union no-op. */
+  warmRequests: number;
   /** Server-execution v2 fan-out stage B (design §B5, RULED 2026-08-16
    * accept-and-count): derivation runs under the wave-level FALLBACK
    * identity — an action NOBODY demands with an identity — that
@@ -377,6 +386,7 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
   reactivationBackoffs: 0,
   foreignWriteRefusals: 0,
   foreignEngineFailures: 0,
+  warmRequests: 0,
   undemandedNarrowingRuns: 0,
   earlyEmitRefusals: 0,
   demandArrivals: 0,

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -36,8 +36,8 @@ import {
   type ScopeKey,
   type ScopeKeyIdentity,
   STREAM_ENTRIES_DOC_PREFIX,
+  toDirtyKey,
 } from "@commonfabric/memory/v2";
-import { toDirtyKey } from "@commonfabric/memory/v2/server";
 import type { OutboxAppendRow } from "@commonfabric/memory/v2/execution-outbox";
 import type {
   CommitError,

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -593,6 +593,22 @@ export interface WaveCommitOutcome {
    * loop's `events.orphanDeliveriesRefused` feeds from this. */
   orphanDeliveriesRefused: number;
   dispositions: ContributionDisposition[];
+  /** Foreign provisioning batches this wave DURABLY COMMITTED, in commit
+   * order — the serving loop's input for the EXPLICIT WARM REQUEST
+   * (serving-loop.md §1's third activation trigger; RULED 2026-08-21).
+   * Populated as each foreign batch lands, so an abort AFTER some
+   * batches landed still reports them (§2b never rolls a landed foreign
+   * commit back — its setup is durable and the target should warm
+   * regardless of the home commit's fate). `writes` are the staged doc
+   * instances: space-scope ops as `"space"`, scoped ops resolved
+   * against the batch's carried delegated identity (an op the carried
+   * identity cannot name is omitted — it could not be demanded by that
+   * name either). */
+  foreignCommits: Array<{
+    space: MemorySpace;
+    seq: number;
+    writes: Array<{ id: string; scopeKey: ScopeKey }>;
+  }>;
 }
 
 const docInstanceKey = (id: string, scopeKey: string): string =>
@@ -1415,6 +1431,7 @@ export class WaveAccumulator
       committedEventIds: [],
       orphanDeliveriesRefused: 0,
       dispositions: this.#contributions.map(() => ({ kind: "committed" })),
+      foreignCommits: [],
     };
 
     // The lease check (serving-loop.md §2's stop-committing MUST): work
@@ -1846,6 +1863,17 @@ export class WaveAccumulator
         return outcome;
       }
       foreignSeqs.set(key, result.ok.seq);
+      // The warm request's payload (serving-loop.md §1; RULED
+      // 2026-08-21): this batch durably STAGED SETUP into another
+      // space. Recorded immediately — before the home commit's fate is
+      // known — because §2b never rolls a landed foreign commit back:
+      // whatever the wave does next, this setup is durable and its
+      // target should warm.
+      outcome.foreignCommits.push({
+        space: batch.space,
+        seq: result.ok.seq,
+        writes: this.#warmWritesOf(batch),
+      });
     }
 
     // ---- the home commit, re-resolving on sink-reported races ----
@@ -2631,6 +2659,43 @@ export class WaveAccumulator
       }
     }
     return [...batches.entries()].map(([key, batch]) => ({ key, batch }));
+  }
+
+  /** The staged doc instances of one foreign provisioning batch — the
+   * warm request's payload (see `WaveCommitOutcome.foreignCommits`).
+   * Space-scope ops key as `"space"`; scoped ops resolve against the
+   * batch's carried delegated identity, exactly as the engine's
+   * delegated admission keys them (scopes.md §5) — an op the carried
+   * identity cannot name is omitted, since the target could not demand
+   * it by that name either. Deduped per (id, scopeKey). */
+  #warmWritesOf(
+    batch: WaveSpaceCommit,
+  ): Array<{ id: string; scopeKey: ScopeKey }> {
+    const writes = new Map<string, { id: string; scopeKey: ScopeKey }>();
+    for (const op of batch.operations) {
+      if (op.op === "sqlite") continue;
+      let scopeKey: ScopeKey;
+      const scope = normalizeCellScope(op.scope);
+      if (scope === "space") {
+        scopeKey = "space";
+      } else if (batch.delegated !== undefined) {
+        try {
+          scopeKey = resolveScopeKey(scope, {
+            principal: batch.delegated.actingPrincipal,
+            ...(batch.delegated.actingSession !== undefined
+              ? { sessionId: batch.delegated.actingSession as never }
+              : {}),
+          });
+        } catch {
+          continue;
+        }
+      } else {
+        continue;
+      }
+      const key = `${scopeKey}\0${op.id}`;
+      if (!writes.has(key)) writes.set(key, { id: op.id, scopeKey });
+    }
+    return [...writes.values()];
   }
 
   /**

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -614,6 +614,45 @@ export interface WaveCommitOutcome {
 const docInstanceKey = (id: string, scopeKey: string): string =>
   `${id} ${scopeKey}`;
 
+/** The staged doc instances of one foreign provisioning batch — the
+ * warm request's payload (see `WaveCommitOutcome.foreignCommits`).
+ * Space-scope ops key as `"space"`; scoped ops resolve against the
+ * batch's carried delegated identity, exactly as the engine's
+ * delegated admission keys them (scopes.md §5) — an op the carried
+ * identity cannot name is omitted, since the target could not demand
+ * it by that name either; sqlite ops carry no doc instance (and the
+ * sink refuses them in foreign batches anyway). Deduped per
+ * (id, scopeKey). Exported for its own contract tests. */
+export const warmWritesOf = (
+  batch: WaveSpaceCommit,
+): Array<{ id: string; scopeKey: ScopeKey }> => {
+  const writes = new Map<string, { id: string; scopeKey: ScopeKey }>();
+  for (const op of batch.operations) {
+    if (op.op === "sqlite") continue;
+    let scopeKey: ScopeKey;
+    const scope = normalizeCellScope(op.scope);
+    if (scope === "space") {
+      scopeKey = "space";
+    } else if (batch.delegated !== undefined) {
+      try {
+        scopeKey = resolveScopeKey(scope, {
+          principal: batch.delegated.actingPrincipal,
+          ...(batch.delegated.actingSession !== undefined
+            ? { sessionId: batch.delegated.actingSession as never }
+            : {}),
+        });
+      } catch {
+        continue;
+      }
+    } else {
+      continue;
+    }
+    const key = `${scopeKey}\0${op.id}`;
+    if (!writes.has(key)) writes.set(key, { id: op.id, scopeKey });
+  }
+  return [...writes.values()];
+};
+
 /** The eventIds of the seq-LESS stream entries one sealed op appends —
  * the NEW events a wave carries (an engine-stamped entry carries its
  * seq; a rewrite of one needs no declaration). Mirrors the batch build's
@@ -1872,7 +1911,7 @@ export class WaveAccumulator
       outcome.foreignCommits.push({
         space: batch.space,
         seq: result.ok.seq,
-        writes: this.#warmWritesOf(batch),
+        writes: warmWritesOf(batch),
       });
     }
 
@@ -2659,43 +2698,6 @@ export class WaveAccumulator
       }
     }
     return [...batches.entries()].map(([key, batch]) => ({ key, batch }));
-  }
-
-  /** The staged doc instances of one foreign provisioning batch — the
-   * warm request's payload (see `WaveCommitOutcome.foreignCommits`).
-   * Space-scope ops key as `"space"`; scoped ops resolve against the
-   * batch's carried delegated identity, exactly as the engine's
-   * delegated admission keys them (scopes.md §5) — an op the carried
-   * identity cannot name is omitted, since the target could not demand
-   * it by that name either. Deduped per (id, scopeKey). */
-  #warmWritesOf(
-    batch: WaveSpaceCommit,
-  ): Array<{ id: string; scopeKey: ScopeKey }> {
-    const writes = new Map<string, { id: string; scopeKey: ScopeKey }>();
-    for (const op of batch.operations) {
-      if (op.op === "sqlite") continue;
-      let scopeKey: ScopeKey;
-      const scope = normalizeCellScope(op.scope);
-      if (scope === "space") {
-        scopeKey = "space";
-      } else if (batch.delegated !== undefined) {
-        try {
-          scopeKey = resolveScopeKey(scope, {
-            principal: batch.delegated.actingPrincipal,
-            ...(batch.delegated.actingSession !== undefined
-              ? { sessionId: batch.delegated.actingSession as never }
-              : {}),
-          });
-        } catch {
-          continue;
-        }
-      } else {
-        continue;
-      }
-      const key = `${scopeKey}\0${op.id}`;
-      if (!writes.has(key)) writes.set(key, { id: op.id, scopeKey });
-    }
-    return [...writes.values()];
   }
 
   /**

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -37,6 +37,7 @@ import {
   type ScopeKeyIdentity,
   STREAM_ENTRIES_DOC_PREFIX,
 } from "@commonfabric/memory/v2";
+import { toDirtyKey } from "@commonfabric/memory/v2/server";
 import type { OutboxAppendRow } from "@commonfabric/memory/v2/execution-outbox";
 import type {
   CommitError,
@@ -647,7 +648,7 @@ export const warmWritesOf = (
     } else {
       continue;
     }
-    const key = `${scopeKey}\0${op.id}`;
+    const key = toDirtyKey(op.id, scopeKey);
     if (!writes.has(key)) writes.set(key, { id: op.id, scopeKey });
   }
   return [...writes.values()];

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -125,5 +125,11 @@ installFakeClock({
     // auto-advance turns the renew cadence into a runaway (the guard
     // names SpaceServer.activate's timers).
     "executor-trust-attribution",
+    // The explicit warm-request suite drives a live ExecutorHost (the
+    // staged-setup provisioning + warm activation journeys, park-race
+    // pin included) under the same wall-clock policies — the renew
+    // interval and flush deadline; auto-advance turns the renew cadence
+    // into a runaway (the guard names SpaceServer.activate's timers).
+    "executor-warm-request",
   ],
 });

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -31,7 +31,11 @@ import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { MemorySpace } from "../src/storage/interface.ts";
 import { ExecutorHost } from "../src/executor/host.ts";
-import { stampWaveRunContext } from "../src/executor/wave.ts";
+import {
+  stampWaveRunContext,
+  warmWritesOf,
+  type WaveSpaceCommit,
+} from "../src/executor/wave.ts";
 import {
   applyCommit,
   read as readDoc,
@@ -414,5 +418,90 @@ describe("executor-warm-request", () => {
     } finally {
       cancel();
     }
+  });
+});
+
+describe("warmWritesOf()", () => {
+  // The warm request's payload contract in isolation: which staged doc
+  // instances a foreign provisioning batch contributes as warm demand.
+  const batchWith = (
+    operations: WaveSpaceCommit["operations"],
+    delegated?: WaveSpaceCommit["delegated"],
+  ): WaveSpaceCommit => ({
+    space: homeSpace,
+    home: false,
+    basisSeq: 0,
+    rebasedHeads: [],
+    operations,
+    preconditions: [],
+    annotations: [],
+    consequenceOf: [],
+    basisInstances: [],
+    holder: undefined,
+    ...(delegated === undefined ? {} : { delegated }),
+  });
+  const setOp = (
+    id: string,
+    scope?: "space" | "user" | "session",
+  ): WaveSpaceCommit["operations"][number] =>
+    ({
+      op: "set",
+      id,
+      type: "application/json",
+      value: {},
+      ...(scope === undefined ? {} : { scope }),
+    }) as WaveSpaceCommit["operations"][number];
+
+  it("keys space-scope ops (explicit or default) as `space` and dedupes per (id, scopeKey)", () => {
+    const writes = warmWritesOf(batchWith([
+      setOp("of:a"),
+      setOp("of:a", "space"),
+      setOp("of:b", "space"),
+    ]));
+    expect(writes).toEqual([
+      { id: "of:a", scopeKey: "space" },
+      { id: "of:b", scopeKey: "space" },
+    ]);
+  });
+
+  it("resolves scoped ops against the batch's carried delegated identity — the same keying as the engine's delegated admission", () => {
+    const writes = warmWritesOf(batchWith(
+      [setOp("of:u", "user"), setOp("of:s", "session")],
+      {
+        actingPrincipal: "did:key:alice",
+        actingSession: "sess-1",
+        capabilityRef: "event-consequence:e",
+      },
+    ));
+    expect(writes.map((write) => write.id)).toEqual(["of:u", "of:s"]);
+    expect(writes[0].scopeKey.startsWith("user:")).toBe(true);
+    expect(writes[1].scopeKey.startsWith("session:")).toBe(true);
+  });
+
+  it("omits a scoped op the carried identity cannot name — a session-scope op with no acting session", () => {
+    const writes = warmWritesOf(batchWith(
+      [setOp("of:s", "session"), setOp("of:keep", "space")],
+      {
+        actingPrincipal: "did:key:alice",
+        capabilityRef: "event-consequence:e",
+      },
+    ));
+    expect(writes).toEqual([{ id: "of:keep", scopeKey: "space" }]);
+  });
+
+  it("omits scoped ops entirely when the batch carries no delegated identity", () => {
+    const writes = warmWritesOf(batchWith([
+      setOp("of:u", "user"),
+      setOp("of:keep", "space"),
+    ]));
+    expect(writes).toEqual([{ id: "of:keep", scopeKey: "space" }]);
+  });
+
+  it("omits folded sqlite ops — they carry no doc instance", () => {
+    const sqliteOp = {
+      op: "sqlite",
+    } as unknown as WaveSpaceCommit["operations"][number];
+    const writes = warmWritesOf(batchWith([sqliteOp, setOp("of:keep")]));
+    expect(writes).toEqual([{ id: "of:keep", scopeKey: "space" }]);
   });
 });

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -93,12 +93,24 @@ describe("executor-warm-request", () => {
   let clientManager: SharedServerStorageManager;
   let clientRuntime: Runtime;
   let servingRuntime: Runtime | undefined;
+  /** One-shot activation-failure stub (the post-drain failure pin): the
+   * next runtime construction for this space THROWS — the activation
+   * dies inside `server.activate()` and lands in the host's
+   * activate-failed arm, the same landing as a lease-unavailable
+   * refusal for the state under test. Cleared when consumed. */
+  let failNextRuntimeFor: MemorySpace | undefined;
 
   const newHost = (): ExecutorHost =>
     new ExecutorHost({
       server,
       serviceIdentity: serviceSigner.did(),
       createRuntime: (space) => {
+        if (failNextRuntimeFor === space) {
+          failNextRuntimeFor = undefined;
+          return Promise.reject(
+            new Error("stubbed one-shot activation failure (test)"),
+          );
+        }
         const manager = SharedServerStorageManager.connectTo(server, {
           as: serviceSigner,
           servingHomeSpace: space,
@@ -124,6 +136,7 @@ describe("executor-warm-request", () => {
   beforeEach(() => {
     server = newSharedServer();
     servingRuntime = undefined;
+    failNextRuntimeFor = undefined;
   });
 
   afterEach(async () => {
@@ -413,6 +426,100 @@ describe("executor-warm-request", () => {
       await waitUntil(
         () => terminals() >= t1 + 3,
         "BOTH warm notices' staged roots reaching the successor's demand pass",
+        30_000,
+      );
+    } finally {
+      cancel();
+    }
+  });
+
+  it("re-buffers drained warm notices when the activation they were drained into FAILS — the warm demand reaches the eventual successor (OW46-family, no crash required)", async () => {
+    host = newHost();
+
+    // A live target, activated the ordinary way (as in the park-race
+    // pin); the failure under test is downstream of ordinary activation.
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    const pSigner = await Identity.fromPassphrase("warm fail space");
+    const pSpace = pSigner.did() as MemorySpace;
+    const demandCell = clientRuntime.getCell<{ ping: number }>(
+      pSpace,
+      "warm-fail-demand",
+      undefined,
+    );
+    const cancel = demandCell.sink(() => {});
+    try {
+      await waitUntil(
+        () => host!.spaceServer(pSpace)?.active === true,
+        "the fail target's initial activation",
+      );
+      const target = host!.spaceServer(pSpace)!;
+      const pEngine = await server.engineForSpace(pSpace);
+      const terminals = () => host!.stats().structureLoadTerminal;
+      const t0 = terminals();
+      await waitUntil(
+        () => terminals() >= t0 + 1,
+        "the first tenure terminalizing the client's absent watch root",
+        30_000,
+      );
+      const t1 = terminals();
+
+      // Arm the one-shot failure, then fire ONE warm notice in the park
+      // window: the host buffers it and chains the reactivation, whose
+      // activation DRAINS the buffer into the successor and then dies
+      // on the stubbed runtime construction — the post-drain failure
+      // (the lease-unavailable refusal lands in the same arm). Before
+      // the fix, the drained notice died with that server and nothing
+      // re-issued it.
+      failNextRuntimeFor = pSpace;
+      const parked = target.park("idle");
+      const seq = serverSeq(pEngine);
+      server.noteExecutorCommit({
+        space: pSpace,
+        seq,
+        class: "authored",
+        sessionId: "warm-fail-issuer",
+        writes: [{ id: "of:warm-fail-c1", scopeKey: "space" }],
+        warm: true,
+      });
+      await parked;
+      // The stubbed failure has consumed the reactivation (the stub
+      // clears itself when it fires) and the space has no server.
+      await waitUntil(
+        () =>
+          failNextRuntimeFor === undefined &&
+          host!.spaceServer(pSpace) === undefined,
+        "the stubbed activation failure consuming the reactivation",
+        30_000,
+      );
+
+      // The recovery trigger: a SECOND warm notice (a later provisioning
+      // batch) activates the space for real. The re-buffered first
+      // notice must ride along — the successor's demand pass must hold
+      // BOTH staged roots (+ the session's re-terminalizing watch root):
+      // delta +3. Before the fix this wait timed out at +2 — c1's warm
+      // demand died with the failed activation.
+      server.noteExecutorCommit({
+        space: pSpace,
+        seq: serverSeq(pEngine),
+        class: "authored",
+        sessionId: "warm-fail-issuer",
+        writes: [{ id: "of:warm-fail-c2", scopeKey: "space" }],
+        warm: true,
+      });
+      await waitUntil(
+        () => host!.spaceServer(pSpace)?.active === true,
+        "the recovery activation on the second warm notice",
+        30_000,
+      );
+      await waitUntil(
+        () => terminals() >= t1 + 3,
+        "BOTH warm roots (the re-buffered and the fresh) reaching the successor's demand pass",
         30_000,
       );
     } finally {

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -1,0 +1,324 @@
+// Server-execution v2 — the EXPLICIT WARM REQUEST (serving-loop.md §1's
+// third activation trigger; RULED 2026-08-21):
+//
+// A serving-side provisioning run that stages authored SETUP into another
+// space (program materialization via `replicatePatternToSpace`, a served
+// `.inSpace()` create's piece scaffolding — the wave's foreign
+// provisioning batches, protocol.md §2b) issues a warm request for the
+// target with the staged doc instances. The host activates a parked,
+// SESSIONLESS target on it (the sibling of the carries-events admission
+// arm), and the target's serving loop takes the staged instances as
+// identity-less warm demand, so the setup derives.
+//
+// T11.Q7 stays as designed: the admission hook alone still activates
+// nothing — an authored admission into a lease-less space with no live
+// session and no events leaves it parked. The warm request is a separate,
+// deliberate signal from the run that KNOWS it staged setup needing
+// derivation, never a blanket write-trigger.
+//
+// The pin reproduces the home-profile reload residual (the §2b
+// derivation-carriage report §4's ordering race): setup lands AFTER the
+// target's transient tenure parked, the creating client's sessions are
+// gone, and — before this fix — nothing ever re-demands it, so the
+// staged piece's computed stays underived forever.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import { ExecutorHost } from "../src/executor/host.ts";
+import { stampWaveRunContext } from "../src/executor/wave.ts";
+import {
+  applyCommit,
+  read as readDoc,
+  serverSeq,
+} from "@commonfabric/memory/v2/engine";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static override connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    return super.connectTo(server, options) as SharedServerStorageManager;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
+  });
+
+const homeSigner = await Identity.fromPassphrase("warm request home");
+const homeSpace = homeSigner.did() as MemorySpace;
+const serviceSigner = await Identity.fromPassphrase("warm request service");
+const aliceSigner = await Identity.fromPassphrase("warm request alice");
+
+// Bounded observation of engine/host state that becomes true as a side
+// effect of the serving loop's own cycles — no event boundary exists for
+// a test-side waiter without adding one to production code
+// (waiting-in-tests.md: the no-callback-to-hang-a-promise-on shape; the
+// same helper the neighboring executor E2Es use).
+const waitUntil = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+};
+
+describe("executor-warm-request", () => {
+  let server: MemoryV2Server.Server;
+  let host: ExecutorHost | undefined;
+  let clientManager: SharedServerStorageManager;
+  let clientRuntime: Runtime;
+  let servingRuntime: Runtime | undefined;
+
+  const newHost = (): ExecutorHost =>
+    new ExecutorHost({
+      server,
+      serviceIdentity: serviceSigner.did(),
+      createRuntime: async (space) => {
+        const manager = SharedServerStorageManager.connectTo(server, {
+          as: serviceSigner,
+          servingHomeSpace: space,
+        });
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: manager,
+          servingPosture: true,
+          experimental: { serverExecution: true },
+        });
+        servingRuntime ??= runtime;
+        return {
+          runtime,
+          dispose: async () => {
+            await runtime.dispose();
+            await manager.close();
+          },
+        };
+      },
+      policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
+    });
+
+  beforeEach(() => {
+    server = newSharedServer();
+    servingRuntime = undefined;
+  });
+
+  afterEach(async () => {
+    await host?.close();
+    host = undefined;
+    await clientRuntime?.dispose();
+    await clientManager?.close();
+    await server.close();
+  });
+
+  it("activates a parked, sessionless target on staged setup and derives it — the serving-side provisioning path's warm request (serving-loop.md §1; T11.Q7's write-alone parking untouched)", async () => {
+    host = newHost();
+
+    // Alice's client demands a HOME doc so the home space activates and
+    // its serving loop (the provisioning run's host) is live. The client
+    // never touches the provisioned space: its genesis lands
+    // ENGINE-DIRECT below and every later write reaches it through the
+    // serving wave's foreign batches (service-principal machinery), so
+    // no client session and no event ever exists for it — what
+    // activates it below can only be the warm request.
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    const demandCell = clientRuntime.getCell<{ ping: number }>(
+      homeSpace,
+      "warm-demand",
+      undefined,
+    );
+    const cancel = demandCell.sink(() => {});
+    try {
+      await waitUntil(
+        () =>
+          servingRuntime !== undefined &&
+          host!.spaceServer(homeSpace)?.active === true,
+        "home space activation",
+      );
+      const serving = servingRuntime!;
+
+      // The pattern whose materialization is the staged SETUP: compiled
+      // in the HOME space (the instantiating side), replicated into the
+      // provisioned space under the triggering run's §2b carriage — the
+      // OW31 S-A writeback, i.e. exactly the commit that landed in the
+      // parked space in the home-profile residual.
+      const compiled = await serving.patternManager.compilePattern({
+        main: "/warm.tsx",
+        files: [{
+          name: "/warm.tsx",
+          contents: [
+            "import { computed, pattern } from 'commonfabric';",
+            "export default pattern<{ n: number }, { out: number }>(",
+            "  ({ n }) => ({ out: computed(() => n + 1) }),",
+            ");",
+          ].join("\n"),
+        }],
+      }, { space: homeSpace });
+      await serving.patternManager.flushCompileCacheWrites();
+
+      // The provisioned target: genesis ACL landed engine-direct (the
+      // B4 ordering — commit #1 IS the ACL), naming the acting user
+      // OWNER. Engine-direct means NO session and no admission notice
+      // ever reaches the host for this space.
+      const pSigner = await Identity.fromPassphrase("warm provisioned space");
+      const pSpace = pSigner.did() as MemorySpace;
+      const pEngine = await server.engineForSpace(pSpace);
+      applyCommit(pEngine, {
+        sessionId: "warm-genesis",
+        space: pSpace,
+        principal: pSpace,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: `of:${pSpace}`,
+            value: {
+              value: { [aliceSigner.did()]: "OWNER", "*": "WRITE" },
+            },
+          }],
+        },
+      });
+
+      // The pre-setup INACTIVE probe: the provisioned space has no
+      // SpaceServer — what activates it below must therefore be the
+      // warm request carried by the staged setup, nothing earlier.
+      expect(host!.spaceServer(pSpace)?.active ?? false).toBe(false);
+
+      // Stage the setup, serving-side. (1) The program docs: the
+      // delegated compile-cache writeback into the target's own store.
+      serving.patternManager.replicatePatternToSpace(
+        compiled,
+        pSpace,
+        homeSpace,
+        {
+          acting: { user: aliceSigner.did(), session: "sess-warm" },
+          capabilityRef: "event-consequence:e-warm",
+        },
+      );
+      await serving.patternManager.flushCompileCacheWrites();
+      await waitUntil(
+        () => serverSeq(pEngine) > 1,
+        "the delegated program writeback landing in the provisioned space",
+        30_000,
+      );
+
+      // (2) The piece scaffolding: a served, stamped provisioning run —
+      // the T11 `.inSpace()` shape — instantiates the piece INTO the
+      // provisioned space (argument + result + wiring cross via the
+      // wave's foreign provisioning batch under the carried actor).
+      const argumentCell = serving.getCell<{ n: number }>(
+        pSpace,
+        "warm-argument",
+        undefined,
+      );
+      const resultCell = serving.getCell<{ out: number }>(
+        pSpace,
+        "warm-result",
+        compiled.resultSchema,
+      );
+      await argumentCell.sync();
+      await resultCell.sync();
+      const homeAnchor = serving.getCell<{ linked: boolean }>(
+        homeSpace,
+        "warm-home-link",
+        undefined,
+      );
+      const tx = serving.edit();
+      stampWaveRunContext(tx, {
+        actionId: "warm-provision",
+        kind: "event-handler",
+        eventId: "e-warm",
+        acting: { user: aliceSigner.did(), session: "sess-warm" },
+        capabilityRef: "event-consequence:e-warm",
+      });
+      tx.enableMultiSpaceWrites?.([pSpace, homeSpace]);
+      argumentCell.withTx(tx).set({ n: 42 });
+      serving.run(tx, compiled, argumentCell, resultCell);
+      homeAnchor.withTx(tx).set({ linked: true });
+      expect((await tx.commit()).error).toBeUndefined();
+
+      const resultId = resultCell.getAsNormalizedFullLink().id;
+      const setupSeq = () => serverSeq(pEngine);
+      await waitUntil(
+        () => setupSeq() > 2,
+        "the staged piece scaffolding landing in the provisioned space",
+        30_000,
+      );
+
+      // THE PIN. Before the warm request existed, this wait timed out:
+      // the setup is durably present, the space is lease-less with no
+      // live session and no events, the admission hook activates
+      // nothing (T11.Q7's designed parking), and nothing ever
+      // re-demands the staged setup — the home-profile "Alan Turing"
+      // inertness. WITH the warm request, the provisioning path's
+      // signal activates the target's own serving loop.
+      await waitUntil(
+        () => host!.spaceServer(pSpace)?.active === true,
+        "the target space's activation on the staged setup's warm request",
+        30_000,
+      );
+
+      // The demand half: the staged instances are the tenure's warm
+      // demand, so the loop structure-loads the staged piece and its
+      // derivation LANDS in the target's own store — a derived-class
+      // commit (the target space's single deriver), with the computed's
+      // value durably present.
+      const derivedCommits = () =>
+        (pEngine.database.prepare(
+          `SELECT COUNT(*) AS n FROM "commit" WHERE class = 'derived'`,
+        ).get() as { n: number }).n;
+      await waitUntil(
+        () => derivedCommits() > 0,
+        "the staged setup's derivation committing in the target space",
+        30_000,
+      );
+      // The result doc's `out` is a LINK to the computed's own doc; the
+      // derived VALUE lives there. Follow it and read 42 + 1 durably.
+      const outLinkId = () => {
+        const doc = readDoc(pEngine, { id: resultId }) as {
+          value?: { out?: { "/"?: { "link@1"?: { id?: string } } } };
+        } | null;
+        return doc?.value?.out?.["/"]?.["link@1"]?.id;
+      };
+      await waitUntil(
+        () => {
+          const id = outLinkId();
+          return id !== undefined &&
+            JSON.stringify(readDoc(pEngine, { id }) ?? {}).includes("43");
+        },
+        "the derived computed value (42 + 1) durably present in the target's own store",
+        30_000,
+      );
+      // The warm request is observable in the loop's own counters.
+      expect(host!.stats().warmRequests).toBeGreaterThan(0);
+    } finally {
+      cancel();
+    }
+  });
+});

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -94,7 +94,7 @@ describe("executor-warm-request", () => {
     new ExecutorHost({
       server,
       serviceIdentity: serviceSigner.did(),
-      createRuntime: async (space) => {
+      createRuntime: (space) => {
         const manager = SharedServerStorageManager.connectTo(server, {
           as: serviceSigner,
           servingHomeSpace: space,
@@ -106,13 +106,13 @@ describe("executor-warm-request", () => {
           experimental: { serverExecution: true },
         });
         servingRuntime ??= runtime;
-        return {
+        return Promise.resolve({
           runtime,
           dispose: async () => {
             await runtime.dispose();
             await manager.close();
           },
-        };
+        });
       },
       policy: { flushDeadlineMs: 5_000, idleParkMs: 600_000 },
     });

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -321,4 +321,98 @@ describe("executor-warm-request", () => {
       cancel();
     }
   });
+
+  it("merges EVERY warm notice racing one park into the successor tenure's demand — a second notice in the park window is not dropped (PR #6191 review P1)", async () => {
+    host = newHost();
+
+    // A live target space: client demand activates it the ordinary way
+    // (the race under test is downstream of activation mechanics, so
+    // the plain session-open trigger is the cheapest live tenure).
+    clientManager = SharedServerStorageManager.connectTo(server, {
+      as: aliceSigner,
+    });
+    clientRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: clientManager,
+    });
+    const pSigner = await Identity.fromPassphrase("warm race space");
+    const pSpace = pSigner.did() as MemorySpace;
+    const demandCell = clientRuntime.getCell<{ ping: number }>(
+      pSpace,
+      "warm-race-demand",
+      undefined,
+    );
+    const cancel = demandCell.sink(() => {});
+    try {
+      await waitUntil(
+        () => host!.spaceServer(pSpace)?.active === true,
+        "the race target's initial activation",
+      );
+      const target = host!.spaceServer(pSpace)!;
+      const pEngine = await server.engineForSpace(pSpace);
+      const terminals = () => host!.stats().structureLoadTerminal;
+      // Let the FIRST tenure's demand pass settle: the client's watch
+      // root is an absent doc with no pattern meta, so it terminalizes
+      // exactly once — the baseline the successor's arithmetic builds
+      // on (the session's registry rows survive the park, so the
+      // SUCCESSOR terminalizes the same root once again).
+      const t0 = terminals();
+      await waitUntil(
+        () => terminals() >= t0 + 1,
+        "the first tenure terminalizing the client's absent watch root",
+        30_000,
+      );
+      const t1 = terminals();
+
+      // The park-window race: park() flips the tenure inactive
+      // SYNCHRONOUSLY and tears down asynchronously, so two warm
+      // notices fired here land while the server is REGISTERED,
+      // INACTIVE, and NOT yet re-activating — each chains the
+      // park-reactivation continuation, and only ONE #activate call
+      // wins. The fix buffers both notices for the successor; before
+      // it, the second notice's warm demand died with the old tenure.
+      const parked = target.park("idle");
+      const seq = serverSeq(pEngine);
+      server.noteExecutorCommit({
+        space: pSpace,
+        seq,
+        class: "authored",
+        sessionId: "warm-race-issuer",
+        writes: [{ id: "of:warm-race-c1", scopeKey: "space" }],
+        warm: true,
+      });
+      server.noteExecutorCommit({
+        space: pSpace,
+        seq,
+        class: "authored",
+        sessionId: "warm-race-issuer",
+        writes: [{ id: "of:warm-race-c2", scopeKey: "space" }],
+        warm: true,
+      });
+      await parked;
+
+      // The successor tenure must hold BOTH staged instances as warm
+      // demand: each is an absent doc with no pattern meta, so each
+      // captured root TERMINALIZES exactly once (stage P2-F's
+      // confirmed-synced-no-meta state) — the per-root, once-per-
+      // episode counter that distinguishes one captured root from
+      // two. The successor's expected delta is exactly THREE: the
+      // client session's surviving watch root re-terminalizes, plus
+      // c1, plus c2. Before the fix this wait timed out at +2 — the
+      // first notice reactivated the space, the second was dropped
+      // with the dying tenure.
+      await waitUntil(
+        () => host!.spaceServer(pSpace)?.active === true,
+        "reactivation on the warm notices racing the park",
+        30_000,
+      );
+      await waitUntil(
+        () => terminals() >= t1 + 3,
+        "BOTH warm notices' staged roots reaching the successor's demand pass",
+        30_000,
+      );
+    } finally {
+      cancel();
+    }
+  });
 });

--- a/tasks/server-execution-on-skips.test.ts
+++ b/tasks/server-execution-on-skips.test.ts
@@ -136,7 +136,7 @@ Deno.test("main: empty lists print the report on stderr and nothing on stdout", 
   assertMatch(err[0], /shell: no skips — full suite runs/);
 });
 
-Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): FOUR file entries (profile-embed, home-profile-reload-durability, the sqlite identity pair) and ONE step entry (default-app's reload step, under OW45) — the gate step lifts and two file lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss; default-app's FILE skip with OW51's close — the splitDefinitions crash fixed, its create-note step runs ON, only its reload step stays under OW45; cfc-group-chat-demo with OW59's close, the OW34-family train: per-run trust snapshots — the file greens under the true ON topology 4/4, every run's store auditing zero service-DID authorship labels); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every FILE gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
+Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture entry, re-justified by Phase 7) + the FIRST ON-LANE CI GATE set (2026-08-21, skip-and-land): THREE file entries (profile-embed, the sqlite identity pair) and ONE step entry (default-app's reload step, under OW45) — the gate step lifts and three file lifts landed the same day (cellset-lww's own-write race with OW47's close, the optimize pass; convergence-storm's storm step with OW52's close — its red was the harness settle racing the serving drain, not a loss; default-app's FILE skip with OW51's close — the splitDefinitions crash fixed, its create-note step runs ON, only its reload step stays under OW45; cfc-group-chat-demo with OW59's close, the OW34-family train: per-run trust snapshots — the file greens under the true ON topology 4/4, every run's store auditing zero service-DID authorship labels; home-profile-reload-durability with the explicit warm request, RULED 2026-08-21 — the serving-side provisioning path's staged setup now activates and derives in a parked, sessionless space, 6/6 fresh-store ON gate); profile-embed's entry was re-scoped a third time by the §2b derivation-carriage close (the send-site LT1-vs-outbox axis fix landed the amend crossing durably; the remaining blocker is the client name-draft own-write loss, OW47's family) — every FILE gate entry names its mechanism, the gate report, and its owed OW row; lunch-poll-vote (W3.1's lift) and cfc-group-chat-demo-two-browsers (fan-out B) still RUN — printed loudly, never silent", async () => {
   const { out, err, io } = captureIo();
   assertEquals(await main(["patterns"], io), 0);
   // File-level entries only in the --ignore flag (step entries never drop
@@ -144,7 +144,6 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   assertEquals(out, [
     "--ignore=integration/topics-navigation.test.ts," +
     "integration/profile-embed.test.ts," +
-    "integration/home-profile-reload-durability.test.ts," +
     "integration/sqlite-db-owner-multi-runtime.test.ts," +
     "integration/sqlite-read-clearance-multi-runtime.test.ts",
   ]);
@@ -156,7 +155,6 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   for (
     const file of [
       "profile-embed",
-      "home-profile-reload-durability",
       "sqlite-db-owner-multi-runtime",
       "sqlite-read-clearance-multi-runtime",
     ]
@@ -195,6 +193,18 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
       skip.file === "integration/cellset-lww.test.ts"
     ),
     false,
+  );
+  // home-profile-reload-durability is LIFTED (the explicit warm request,
+  // serving-loop.md §1's third activation trigger, RULED 2026-08-21: the
+  // serving-side provisioning path's staged setup activates and derives
+  // in a parked, sessionless space — the §2b report §4's setup-after-park
+  // ordering race closed; 6/6 fresh-store ON gate runs, both steps
+  // green): no entry, so the file RUNS on the ON arm — pinned here so a
+  // re-skip is a deliberate edit.
+  assert(
+    !report.includes("integration/home-profile-reload-durability.test.ts"),
+    "home-profile-reload-durability must carry NO skip entry (the warm " +
+      "request landed; the file runs ON)",
   );
   // profile-embed's entry names its CURRENT blocker, not a closed one:
   // the §2b derivation-carriage close (2026-08-21) landed the amend
@@ -259,13 +269,13 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
   const gateEntries = SERVER_EXECUTION_ON_SKIPS.patterns.filter((skip) =>
     skip.file !== "integration/topics-navigation.test.ts"
   );
-  assertEquals(gateEntries.length, 5);
-  // Every ORIGINAL first-ON-CI-gate FILE entry (the four that have not
+  assertEquals(gateEntries.length, 4);
+  // Every ORIGINAL first-ON-CI-gate FILE entry (the three that have not
   // lifted): phase-7, the gate report path, an owed register row (OW31 or a
   // freshly minted OW45–OW53), the honest no-demand-hole classification, and
   // the flip's EMPTY-list condition.
   const fileGateEntries = gateEntries.filter((skip) => skip.step === undefined);
-  assertEquals(fileGateEntries.length, 4);
+  assertEquals(fileGateEntries.length, 3);
   for (const entry of fileGateEntries) {
     assertEquals(entry.phase, "phase-7");
     assertMatch(entry.reason, /First ON-lane CI gate \(2026-08-21/);
@@ -318,7 +328,7 @@ Deno.test("main: the patterns list = topics-navigation (Phase 4's mixed-posture 
     "./integration/convergence-storm.test.ts",
   ]);
   assertEquals(skipped, []);
-  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 6);
+  assertEquals(SERVER_EXECUTION_ON_SKIPS.patterns.length, 5);
   assertEquals(SERVER_EXECUTION_ON_SKIPS.shell.length, 0);
 });
 

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -277,37 +277,22 @@ export const SERVER_EXECUTION_ON_SKIPS: Record<
         "the draft-write loss closes and the file greens ON; the flip " +
         "PR needs this list EMPTY.",
     },
-    {
-      file: "integration/home-profile-reload-durability.test.ts",
-      phase: "phase-7",
-      reason: "First ON-lane CI gate (2026-08-21; skip-and-land — gates " +
-        "the FLIP, not the land): under ON the created profile piece's " +
-        "PROGRAM (code + CFC labelMap + schema docs) is only ever written " +
-        "by the client's own post-arrival commit; the reload kills the " +
-        "trailing create's program commit, and the server's fallback — " +
-        "`compile-cache/writeback` into the profile space — is REFUSED as " +
-        "a foreign-space write with no §2b delegated carriage " +
-        "(seal-space-commit-failed, 17 refusals per space observed), so " +
-        "the space's serving loop parks the structure load forever, " +
-        "SILENTLY, and the name renders the #id placeholder. NOT a demand " +
-        "hole — the identical demand derived the name wherever the " +
-        "program write survived (72 basis rows on Grace's space; 0 on the " +
-        "broken two). The carriage half (S-A) LANDED 2026-08-21 with " +
-        "OW31's build — the replicate trigger's writebacks now ride the " +
-        "instantiating run's §2b carriage; the client barriers and " +
-        "heal-on-read are " +
-        "verification-coverage.md OW45 (S-B/S-C); the silent forever-park " +
-        "is OW46 (S-D). Mechanism + store/log evidence: docs/history/" +
-        "plans/server-execution-v2/stage-c/on-render-stall-rootcause.md " +
-        "§1 (and first-on-ci-gate.md). OW31's build is DONE " +
-        "(2026-08-21), OW45's client half too (S-B merged; S-C SKIPPED " +
-        "by owner ruling 2026-08-21 — off the lift critical path, the " +
-        "test's own idle-barrier contract covers every create before " +
-        "any reload); lifts when OW31's cf:module cross-space run " +
-        "residual closes and the file greens ON (the optimize pass's " +
-        "joint run had step 1 green in ~10 s and step 2 red ONLY on " +
-        "that residual); the flip PR needs this list EMPTY.",
-    },
+    // home-profile-reload-durability LIFTED (2026-08-21, the explicit
+    // warm request — serving-loop.md §1's third activation trigger,
+    // RULED 2026-08-21): the §2b derivation-carriage report's §4 had
+    // decomposed the residual to a setup-after-park ORDERING RACE —
+    // authored setup landing in a parked, sessionless space activates
+    // nothing (T11.Q7's designed parking) and nothing ever re-demands
+    // it. The serving-side provisioning path now issues a warm request
+    // when its wave stages setup into another space; the target
+    // activates and derives it (plus the sink localSeq collision fix
+    // the warm activation exposed — executor-warm-request.test.ts pins
+    // both). Lift evidence: 6/6 fresh-store ON gate runs at the fix
+    // head, both steps green in 12–24 s (the prior red: step 2's
+    // "Alan Turing" wait timing out at 5m+), posture verified and
+    // loads recorded per run; warmRequests 4–6 per run in the live
+    // stats. The entry's full history: git log on this file and
+    // verification-coverage.md's OW45 row.
     {
       file: "integration/sqlite-db-owner-multi-runtime.test.ts",
       phase: "phase-7",

--- a/tasks/worker-bundle-graph.test.ts
+++ b/tasks/worker-bundle-graph.test.ts
@@ -1,0 +1,129 @@
+// The CLIENT WORKER's code-reachable module set must never contain a
+// server-only module. The class this pins: a VALUE import added to a
+// module the worker bundle reaches (`executor/wave.ts` is imported by
+// cell/runtime/runner/scheduler) drags the whole server side — the
+// memory v2 server, its sqlite engine — into the browser worker, which
+// dies at startup with no error surfaced anywhere near the cause: the
+// observed shape was every named-space login timing out ("Timed out
+// waiting for runtime login") while the worker fetched its chunks and
+// never issued one /api request (PR #6191's toDirtyKey import; caught
+// manually by an ON gate probe against a pure-main control, fixed by
+// relocating the helper to the browser-safe `memory/v2.ts` surface).
+// TYPE-only imports of server modules are fine — they erase at compile
+// — which is exactly the code-vs-type edge discrimination `deno info`
+// exposes and this walk follows.
+
+import { assert, assertEquals } from "@std/assert";
+
+const WORKER_ENTRY = "packages/runtime-client/backends/web-worker/index.ts";
+
+/** Server-only modules the worker's CODE-reachable set must not hold:
+ * the memory v2 server, its engine, and the sqlite disk source (the
+ * engine's storage backend — present iff the engine side leaked). */
+const FORBIDDEN_SUFFIXES = [
+  "packages/memory/v2/server.ts",
+  "packages/memory/v2/engine.ts",
+  "packages/memory/v2/sqlite/disk-source.ts",
+];
+
+/** Modules the code walk MUST reach — the sanity floor that keeps this
+ * test from passing vacuously on a broken graph read: the wave carriage
+ * (the module whose import regressed) and the browser-safe memory
+ * surface it now imports from. */
+const REQUIRED_SUFFIXES = [
+  "packages/runner/src/executor/wave.ts",
+  "packages/memory/v2.ts",
+];
+
+type DenoInfoDependency = {
+  code?: { specifier?: string };
+  type?: { specifier?: string };
+};
+
+type DenoInfoModule = {
+  specifier: string;
+  dependencies?: DenoInfoDependency[];
+};
+
+type DenoInfoGraph = {
+  roots: string[];
+  redirects?: Record<string, string>;
+  modules: DenoInfoModule[];
+};
+
+/** The specifiers reachable from the graph's roots over CODE edges only
+ * (dynamic imports included — they ship too; type-only edges skipped:
+ * they erase at compile). Redirects are resolved before lookup. */
+const codeReachable = (graph: DenoInfoGraph): Set<string> => {
+  const redirects = graph.redirects ?? {};
+  const resolve = (specifier: string): string =>
+    redirects[specifier] ?? specifier;
+  const bySpecifier = new Map(
+    graph.modules.map((module) => [module.specifier, module]),
+  );
+  const reached = new Set<string>();
+  const queue = graph.roots.map(resolve);
+  while (queue.length > 0) {
+    const specifier = queue.pop()!;
+    if (reached.has(specifier)) continue;
+    reached.add(specifier);
+    const module = bySpecifier.get(specifier);
+    if (module === undefined) continue;
+    for (const dependency of module.dependencies ?? []) {
+      const code = dependency.code?.specifier;
+      if (code !== undefined) queue.push(resolve(code));
+    }
+  }
+  return reached;
+};
+
+Deno.test("the client worker's code-reachable module set holds no server-only module (and really reaches the runtime graph)", async () => {
+  const repoRoot = new URL("../", import.meta.url);
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--no-lock", "--json", WORKER_ENTRY],
+    cwd: repoRoot.pathname,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  if (!output.success) {
+    throw new Error(
+      `deno info failed: ${new TextDecoder().decode(output.stderr)}`,
+    );
+  }
+  const graph = JSON.parse(
+    new TextDecoder().decode(output.stdout),
+  ) as DenoInfoGraph;
+  assertEquals(graph.roots.length, 1);
+  const reached = codeReachable(graph);
+
+  // The sanity floor first: a walk that reached almost nothing (a moved
+  // entry, a broken parse) must fail HERE, not "pass" the absence
+  // asserts below.
+  assert(
+    reached.size > 100,
+    `implausibly small code-reachable set (${reached.size} modules) — ` +
+      "the walk or the entry point is broken",
+  );
+  for (const suffix of REQUIRED_SUFFIXES) {
+    assert(
+      [...reached].some((specifier) => specifier.endsWith(suffix)),
+      `the code walk no longer reaches ${suffix} — the sanity anchor ` +
+        "moved; update REQUIRED_SUFFIXES with the graph change that " +
+        "moved it",
+    );
+  }
+
+  for (const suffix of FORBIDDEN_SUFFIXES) {
+    const hit = [...reached].find((specifier) => specifier.endsWith(suffix));
+    assert(
+      hit === undefined,
+      `server-only module in the WORKER's code-reachable set: ${hit} — ` +
+        "a value import somewhere in the worker graph now pulls the " +
+        "server side into the browser bundle (the worker dies at " +
+        "startup; logins time out). Find the importing edge with " +
+        `\`deno info ${WORKER_ENTRY}\` and make it type-only or import ` +
+        "from the browser-safe surface (memory/v2.ts) instead.",
+    );
+  }
+});


### PR DESCRIPTION
## Why

The last blocker on the `home-profile-reload-durability` ON skip was a
setup-after-park ordering race (the §2b derivation-carriage report §4,
`docs/history/plans/server-execution-v2/optimize/2b-derivation-carriage-scope.md`):
authored setup landing in a parked, sessionless space activates nothing —
T11.Q7's designed parking — and nothing ever re-demands it. In the failing
trace, Alan's space's transient tenure parked at watermark seq 2, his setup
landed at seq 5 while the creating client's sessions were dead mid-reload,
and the post-reload summary read his missing computed name through the HOME
space's free cross-space read (a home-side wake, no target-side demand) —
the id placeholder rendered forever.

The report flagged three candidate mechanisms for the owner. **RULED
2026-08-21** (owner Berni: "three decisions: i agree with all
recommendations") — adopting the recommendation: implement the spec's
**explicit warm request** (serving-loop.md §1's third, designed-but-
unimplemented activation trigger), issued by the **serving-side
provisioning path** when it stages setup into a parked space — not a
synthetic client session, and not S-C-shape healing.

## Scoping (verified against the ruled text before building)

1. **What the ruled text sanctions.** "Activation on: session open, event
   append, or explicit warm request" (serving-loop.md §1:47) is the
   phrase's ONLY occurrence in the spec corpus — no issuer, payload, or
   lifecycle is specified anywhere, and no code implemented it. Nothing
   pins it client-only. The ruling fills the open issuer: the wave commit
   step's foreign provisioning batches (§2b's sanctioned authored
   crossing — a served `.inSpace()` create's scaffolding, the S-A
   delegated program-materialization writeback). Payload: the staged doc
   instances (the batch's writes). Receiver: the host's activation
   machinery (the plane-(b) observer), then the activated tenure's demand
   pass.

2. **Why setup does not qualify today, and why warm is not
   every-write-wakes.** T11.Q7 ruled the notify/decide split: the
   admission hook NOTIFIES on any authored admission; the ACTIVE criteria
   (≥1 live client session, or undelivered events) DECIDE — "the
   provisioning write alone leaves C parked." Mechanically the inertness
   was even deeper: the wave's foreign batches commit engine-direct and
   produced NO notice at all. The warm request does not widen the
   admission trigger — it is a separate, deliberate signal issued only by
   the provisioning run that KNOWS it staged setup needing derivation.
   Client transacts, system writes, and direct writes issue nothing;
   T11.Q7's answer stays literally true (the trace cell is amended
   answer-unchanged).

3. **Idempotency/lifecycle (pinned in serving-loop.md §1).** Against an
   active target: a demand-union no-op. Racing a park: the host
   re-carries the notice into the successor activation. Racing an
   in-flight activation: buffered and drained at registration. Once a
   tenure consumes the warm keys they are tenure-scoped (they die with
   the tenure; recompute-on-demand, §6 step 2, is the ruled recovery
   posture). The request is a one-shot in-process signal, not a durable
   row: loss across a process crash in the staged-but-underived window is
   the OW46 silent-park observability family, recorded as such. The
   client-demand backstop (any later session open or event append still
   activates and derives) exists in general but NOT in the home-profile
   shape — which is exactly why the warm request is the fix.

**One deliberate semantic extension, stated rather than buried:** for the
ruled behavior ("the serving loop runs, the setup derives") the warm
request must supply demand — the (d′) model derives only demanded
instances, and a warmed space has no client sessions by construction. The
staged instances therefore enter the demand pass as identity-less warm
demand keys — the model's existing anonymous-session shape (a key with no
demander pair) — for that tenure only. serving-loop.md §1 now names this
as the one extension of the demand union beyond client sessions.

## What changed

- `packages/memory/v2/server.ts` — `AdmittedCommitNotice.warm?: true`.
- `packages/runner/src/executor/wave.ts` — `WaveCommitOutcome.foreignCommits`
  (space, seq, staged writes; recorded per landed batch, abort shapes
  included — §2b never rolls a landed foreign commit back) + `#warmWritesOf`.
- `packages/runner/src/executor/space-server.ts` — the issuer (post-
  `commitWave`, every outcome shape: `noteExecutorCommit` warm-marked,
  counted as `warmRequests`); the consumer (`#warmDemandKeys` captured at
  `enqueueCommit` before the activation scan's feed filter, unioned into
  the demand pass as identity-less ROOT rows, `noteDemandChanged` on
  fresh capture).
- `packages/runner/src/executor/host.ts` — the activation gate honors
  `warm` beside `carriesEvents`; `#reactivateAfterPark` re-carries a warm
  notice past the park race. **Plus the latent sink localSeq collision
  fix the warm activation exposed**: every sink commits under the
  process-stable DR1-holder session, and a home sink's foreign batches
  consumed (session, localSeq) pairs in the TARGET's engine from the
  home's per-space counter — the target's own sink then re-minted those
  pairs and the engine killed its piece-derivation waves as "commit
  replay mismatch", dropping the derivations with nothing to re-arm
  them. The host now holds ONE process-global counter (globally unique
  pairs; the engine keys replay by equality, never contiguity —
  per-session localSeq gaps are already normal in every store).
- `packages/runner/src/executor/stats.ts` + serving-loop.md §7 — the
  `warmRequests` counter.
- `tasks/server-execution-on-skips.ts` / `.test.ts` — the home-profile
  entry LIFTED, with a no-entry pin so a re-skip is a deliberate edit
  (FOUR file entries remain after the rebase over #6190, whose OW59
  close lifted cfc-group-chat-demo the same day — the merged test
  title and counts carry both lifts).
- Docs move together: serving-loop.md §1 (the implemented mechanism +
  RULED marker), scenario-traces.md T11.Q7 (answer-unchanged amendment),
  verification-coverage.md (OW45 records the ruling verbatim + the lift;
  OW46's lift-run residual discharged; gate preamble and OW31 tail
  re-tensed).

## Red-first evidence

`packages/runner/test/executor-warm-request.test.ts` — engine-direct
construction with the pre-setup INACTIVE probe (the #6187 pin's shape:
no session and no admission ever touches the target before the staging).
Watched FAILING on the unmodified tree at the activation wait (31 s
timeout — the "Alan Turing" inertness at executor level); after the
trigger landed, watched failing at the derivation waits on the localSeq
collision (store dump: both derived commits were watermark-only, the
piece waves rejected as replay mismatches); green end to end with the
counter fix — activation + derived-class commit + the computed value
(42 + 1) durably present in the target's own store + `warmRequests > 0`.

## The home-profile ON gate (fresh store per run, posture verified, ON binary at the fix head, sha256 0479736f80…)

| run | load before | outcome | elapsed | warmRequests |
|---|---|---|---|---|
| 1 | 4.59 | 2/2 steps green | 20 s | 5 |
| 2 | 5.91 | 2/2 steps green | 17 s | 6 |
| 3 | 5.41 | 2/2 steps green | 12 s | 4 |
| 4 | 5.28 | 2/2 steps green | 12 s | 4 |
| 5 | 4.35 | 2/2 steps green | 18 s | 6 |
| 6 | 4.89 | 2/2 steps green | 22 s | 6 |

**6/6 GREEN** (prior shape: step 1 green ~10 s; step 2 red at 5 m+).
Protocol per run: fresh CACHE_DIR store, self-referential
API_URL/MEMORY_URL, `/api/meta` shellServerExecutionDefine=="true" and
`/api/health/stats` servingLoop!=null verified, load averages recorded.

## Rebase over #6190 (OW34-family trust snapshots)

Main moved by #6190 mid-train; rebased over it (conflicts: the skip-list
test title/counts and two register lines — both sides lifted a different
skip entry the same day, and the both-wrote-N-1 auto-merge on the count
assertions was caught and corrected to the merged truth of four).
Re-verified at the joint head: warm pin green, skips test 17 green,
cross-space 14 / serving-loop 25 / space-server 15 green, and the ON
binary REBUILT at the rebased head (sha256 8fddc86f13…) with two more
home-profile gate runs — both steps green in 12 s and 20 s
(warmRequests 5, 4; loads 6.2-6.4) — **8/8 across both heads**.

## Review round (Cubic P1) — fixed red-first

Cubic's P1: several warm notices racing ONE park window chained one
shared reactivation, and only the first notice's pending list reached
`#activate` — the rest were dropped with the dying tenure. Confirmed
with a deterministic pin (park() flips inactive synchronously; the pin
fires two warm notices after an unawaited park() and was watched RED at
+2 of the expected +3 structure-load-terminal delta), then fixed: warm
notices in the parking window buffer through `#pendingNotices` — the
same merge point the mid-activation window uses, drained at the
successor's registration. 5/5 stable green; neighbors re-run green.
Two more home-profile gate runs at this final head (ON binary sha256
6af9967e91…): both steps green in 18 s and 19 s (warmRequests 4, 6) —
**10/10 across all three heads**.

## CI round + review P2s (head 50d5ce8c4)

The first full CI run at the review-fix head was green everywhere except
Runner Tests (7/8): the runner lane preloads the auto-advancing fake
clock, and the new warm suite drives a live ExecutorHost whose renew
cadence is wall-clock policy — the runaway guard killed the file (1997
renew timers). Fixed by listing `executor-warm-request` in the
package's `realClockFiles`, exactly like every other live-ExecutorHost
suite (the `executor-trust-attribution` entry's rationale verbatim);
verified green locally under the CI preload invocation. The same push
addresses Cubic's three P2s: warm keys use the canonical `toDirtyKey`
(re-exported beside the notice type), warm captures count as
`demand.warmWakes` instead of polluting `watchWakes`, and the host's
module overview names the warm request beside the session/event
criteria.

## Coverage round (head f05eb1c2d)

The coverage ratchet flagged +2 uncovered `packages/runner` lines —
`warmWritesOf`'s scoped-op arms, real payload contract the E2E pins
never reach (their batches are space-scoped; and the previous run's
clock kill meant the pin file contributed no coverage at all).
Extracted as an exported pure function and pinned each arm directly:
space-scope keying + dedupe, delegated-identity resolution (user and
session), the unresolvable-scoped-op omission, the no-delegated
omission, and the sqlite omission.

## Test plan

- New: `executor-warm-request.test.ts` (red-first, above).
- Neighboring executor suites, one file per invocation, all green:
  cross-space 14, events-down 21, outbox 18, wave 43, run-supply 14,
  serving-loop 25, space-server 15, stats 3, watermark 2,
  effect-channel 15, settle-advance 5, fan-out 11.
- Memory: v2-demand-changed-principal 1, v2-commit-class 5.
- `tasks/server-execution-on-skips.test.ts` 17 (the lift re-pinned).
- Repo-wide `deno fmt --check` (4992 files), `deno lint` (4901),
  `deno task check`, check-docs (564 blocks), check-no-waitfor,
  check-conflict-markers, check-docs-history-index, check-skill-facts —
  all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Coverage acceptance (delta-pass round)

The Coverage lane's remaining red is baseline wobble the tool itself
declares non-attributable — its own report line: "Regression not
attributable to this PR's added lines: 3 line(s) across 1 unchanged
file(s) that the baseline run covered." Accepted per the coordinator:

ACCEPT_COVERAGE_DEBT: packages/memory +3 lines
