### PR TITLE
docs(data-model): the realm encoding admits self-dealing storage

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1264,10 +1264,10 @@ holding material is constructed from an algorithm name and the two keys' bytes,
 which it copies unless handed a `FabricBytes`, that being already immutable and
 sole-owned.
 
-**Only the material state can be written down.** A `CryptoKey`'s material is
-reachable only through `SubtleCrypto.exportKey()`, which is asynchronous where
-a codec's `encode()` is synchronous, and which a non-extractable key refuses
-outright. So:
+**Only the material state has a byte representation.** A `CryptoKey`'s
+material is reachable only through `SubtleCrypto.exportKey()`, which is
+asynchronous where a codec's `encode()` is synchronous, and which a
+non-extractable key refuses outright. So:
 
 - The JSON encoding **refuses** a pair holding handles: encoding one throws
   (Section 3 of [3-json-encoding.md](./3-json-encoding.md), under
@@ -1280,14 +1280,21 @@ outright. So:
   [4-realm-encoding.md](./4-realm-encoding.md)), which is what a transport
   preserving `CryptoKey` makes possible.
 
-The refusals are the point rather than a gap. A format that writes a value
-down is exactly the one that must not be able to represent a key whose whole
-purpose is that its material cannot be extracted. Carrying a handle is a
-different thing: the key arrives with its extractability unchanged, and
-whoever reads it gains nothing a holder of the original did not have. That is
-what lets a pair holding handles reach a durable structured-clone store
-(Section 1.2 of [4-realm-encoding.md](./4-realm-encoding.md)) while staying
-unrepresentable in JSON.
+The refusals are the point rather than a gap, and they follow from the key
+rather than from any policy about formats. A pair holding handles has no bytes
+for a synchronous `encode()` to reach, so a format writing bytes down has
+nothing to write; a pair holding material has them, and such a format uses
+them. Which state a key is in is settled where it is minted, and that is
+upstream of every format here: an algorithm Web Crypto does not implement has
+no handle to hold, and an implementation wanting its keys exportable mints
+them so.
+
+Carrying a handle is a third thing, and neither writes material down nor needs
+it: the key arrives with its extractability unchanged, and whoever reads it
+gains nothing a holder of the original did not have. That is what lets a pair
+holding handles reach a durable structured-clone store (Section 1.2 of
+[4-realm-encoding.md](./4-realm-encoding.md)) while staying unrepresentable in
+JSON.
 
 #### 1.4.12 `FabricLink`
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1264,10 +1264,10 @@ holding material is constructed from an algorithm name and the two keys' bytes,
 which it copies unless handed a `FabricBytes`, that being already immutable and
 sole-owned.
 
-**Only the material state is representable outside a live realm.** A
-`CryptoKey`'s material is reachable only through `SubtleCrypto.exportKey()`,
-which is asynchronous where a codec's `encode()` is synchronous, and which a
-non-extractable key refuses outright. So:
+**Only the material state can be written down.** A `CryptoKey`'s material is
+reachable only through `SubtleCrypto.exportKey()`, which is asynchronous where
+a codec's `encode()` is synchronous, and which a non-extractable key refuses
+outright. So:
 
 - The JSON encoding **refuses** a pair holding handles: encoding one throws
   (Section 3 of [3-json-encoding.md](./3-json-encoding.md), under
@@ -1280,9 +1280,14 @@ non-extractable key refuses outright. So:
   [4-realm-encoding.md](./4-realm-encoding.md)), which is what a transport
   preserving `CryptoKey` makes possible.
 
-The refusals are the point rather than a gap. The formats that persist and
-inspect a value are exactly the ones that must not be able to represent a key
-whose whole purpose is that its material cannot be extracted.
+The refusals are the point rather than a gap. A format that writes a value
+down is exactly the one that must not be able to represent a key whose whole
+purpose is that its material cannot be extracted. Carrying a handle is a
+different thing: the key arrives with its extractability unchanged, and
+whoever reads it gains nothing a holder of the original did not have. That is
+what lets a pair holding handles reach a durable structured-clone store
+(Section 1.2 of [4-realm-encoding.md](./4-realm-encoding.md)) while staying
+unrepresentable in JSON.
 
 #### 1.4.12 `FabricLink`
 

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -22,8 +22,9 @@ owed interoperability, which is what lets the format be as narrow as it is.
 
 Worker IPC is the case it was written for: a value constructed, handed to a
 transport that clones it, decoded on the far side, and discarded. A durable
-store that a runtime writes and later reads back (Section 1.2) is the same
-boundary with time in it, and is the reason the format states its
+store that a runtime writes and later reads back is the same boundary with
+time in it, on the conditions Section 1.2 states, and is the reason the
+format states its
 requirements of a transport rather than of a mechanism. A value that crosses
 to another party, or that must be read through a transport not meeting
 Section 1.1, uses the JSON encoding.
@@ -84,20 +85,24 @@ The structured clone algorithm provides all three.
 
 Storage is the self-dealing boundary with time in it: a runtime writes a
 value to a durable store and reads it back later, with no other party in it.
-`IndexedDB` is the case in hand, and it qualifies by the same mechanism worker
-IPC does — that store serializes with the structured clone algorithm, so what
-satisfies Section 1.1 for `postMessage()` satisfies it here.
+`IndexedDB` is the case in hand. What it supplies is Section 1.1, by the same
+mechanism worker IPC does — that store serializes with the structured clone
+algorithm, so what satisfies those requirements for `postMessage()` satisfies
+them here — and Section 1.1 is the whole of what a medium can supply. Whether
+a given *use* of that store is self-dealing is a separate question, settled by
+the conditions below.
 
 What the time costs is Section 2.4. A durable payload can outlive the build
 that wrote it, so a reader must expect that refusal rather than treat it as
-unreachable. Three conditions follow, and a store meeting all three stays
-within this boundary:
+unreachable. Three conditions follow, and a use meeting all three stays within
+this boundary:
 
 1. **The stored value must be reconstructible from something the store does
    not hold.** This is the condition that decides the question, because it is
-   what makes a version bump a cache flush rather than data loss. A store
-   holding the only copy of anything is not self-dealing, whatever else is
-   true of it.
+   what makes a version bump a cache flush rather than data loss. A use whose
+   store holds the only copy of anything is outside this boundary, whatever
+   else is true of it, and the medium meeting Section 1.1 does not soften
+   that.
 2. **A reader must treat a refused payload as absent**, rather than report it
    as an error. A version bump refuses every stored payload at once, which is
    an expected path and has to be written as one.

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -23,11 +23,10 @@ owed interoperability, which is what lets the format be as narrow as it is.
 Worker IPC is the case it was written for: a value constructed, handed to a
 transport that clones it, decoded on the far side, and discarded. A durable
 store that a runtime writes and later reads back is the same boundary with
-time in it, on the conditions Section 1.2 states, and is the reason the
-format states its
-requirements of a transport rather than of a mechanism. A value that crosses
-to another party, or that must be read through a transport not meeting
-Section 1.1, uses the JSON encoding.
+time in it, on the conditions Section 1.2 states, and is the reason the format
+states its requirements of a transport rather than of a mechanism. A value
+that crosses to another party, or that must be read through a transport not
+meeting Section 1.1, uses the JSON encoding.
 
 Time is what the two instances do not share, and Section 1.2 turns on the
 difference. Section 1.1 is what a transport must preserve; Section 2.4 is
@@ -101,8 +100,7 @@ this boundary:
    not hold.** This is the condition that decides the question, because it is
    what makes a version bump a cache flush rather than data loss. A use whose
    store holds the only copy of anything is outside this boundary, whatever
-   else is true of it, and the medium meeting Section 1.1 does not soften
-   that.
+   else is true of it, and a medium meeting Section 1.1 does not soften it.
 2. **A reader must treat a refused payload as absent**, rather than report it
    as an error. A version bump refuses every stored payload at once, which is
    an expected path and has to be written as one.

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -17,12 +17,11 @@ Draft formal spec — the realm-crossing counterpart to
 
 This format is built around one boundary: worker IPC, where a value is
 constructed, handed to a transport that clones it, decoded on the far side,
-and discarded.
-Everything it asks of a transport is Section 1.1, and what it declines to
-offer is Section 2.4: a payload is readable only by a build implementing the
-same format version. A value that must outlive the build that wrote it, or
-that must be read by something holding no structured-clone channel to the
-writer, uses the JSON encoding.
+and discarded. Everything it asks of a transport is Section 1.1, and what it
+declines to offer is Section 2.4: a payload is readable only by a build
+implementing the same format version. A value that must outlive the build
+that wrote it, or that must be read through a transport not meeting
+Section 1.1, uses the JSON encoding.
 
 Those are separate questions, and Section 1.2 turns on their being separate.
 A durable structured-clone store meets Section 1.1 in full while placing an

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -2,9 +2,9 @@
 
 This document specifies the wire format used to carry `FabricValue`s between
 realms over a structured-clone transport — `structuredClone()` and
-`postMessage()` — including the outer envelope and its marker, the tagged
-form, per-type encodings, the ownership contract on decode, and what the
-format refuses.
+`postMessage()`, and a durable store one realm writes for a later one to read
+— including the outer envelope and its marker, the tagged form, per-type
+encodings, the ownership contract on decode, and what the format refuses.
 
 ## Status
 

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -15,11 +15,20 @@ Draft formal spec — the realm-crossing counterpart to
 
 ## 1. Overview
 
-This format exists for one boundary: worker IPC, where a value is constructed,
-handed to a transport that clones it, decoded on the far side, and discarded.
-It is not a storage format and has no persistence story. A value written down
-for later, or read by something that did not receive it directly, uses the JSON
-encoding.
+This format is built around one boundary: worker IPC, where a value is
+constructed, handed to a transport that clones it, decoded on the far side,
+and discarded.
+Everything it asks of a transport is Section 1.1, and what it declines to
+offer is Section 2.4: a payload is readable only by a build implementing the
+same format version. A value that must outlive the build that wrote it, or
+that must be read by something holding no structured-clone channel to the
+writer, uses the JSON encoding.
+
+Those are separate questions, and Section 1.2 turns on their being separate.
+A durable structured-clone store meets Section 1.1 in full while placing an
+unbounded gap between encode and decode, so its two ends need not be the same
+build. Such a store may carry this format under the conditions of Section 1.2,
+and not otherwise.
 
 The two formats divide along what their transports carry. JSON reaches a
 `string`, so every type JavaScript has and JSON lacks — `bigint`, `undefined`,
@@ -63,6 +72,40 @@ ordinary data as a tagged value. A transport is therefore something to verify
 against this contract before use, not something to try and see.
 
 The structured clone algorithm provides all three.
+
+### 1.2 Self-Dealing Storage
+
+A **self-dealing** use of this format writes a value to a durable store and
+reads it back later from the same origin, with no other party in it. Such a
+use is admitted, and `IndexedDB` is the case it is admitted for: that store
+serializes with the structured clone algorithm, so the same mechanism that
+satisfies Section 1.1 for `postMessage()` satisfies it here.
+
+What the gap costs is Section 2.4. A durable payload can outlive the build
+that wrote it, so a reader must expect that refusal rather than treat it as
+unreachable. Three conditions follow, and a use meeting all three is
+self-dealing:
+
+1. **The stored value must be reconstructible from something the store does
+   not hold.** This is the condition that decides the question, because it is
+   what makes a version bump a cache flush rather than data loss. A store
+   holding the only copy of anything is not self-dealing, whatever else is
+   true of it.
+2. **A reader must treat a refused payload as absent**, rather than report it
+   as an error. A version bump refuses every stored payload at once, which is
+   an expected path and has to be written as one.
+3. **A reader must decode strictly.** A lenient decode yields a
+   `ProblematicValue` at the root, which is worse here than a miss: it is a
+   result that reads as one.
+
+A `CryptoKey` is what this admits that no other format could carry, and
+Section 1.1 is also what makes storing one safe: extractability arrives
+unchanged, so a key held as a handle is still a handle when it comes back, and
+its material was never written down to begin with.
+
+None of this obliges a store to be durable in fact. A browser evicts what it
+likes, and a reader built for the refusal in condition 2 is already built for
+that.
 
 ## 2. The Outer Envelope and the Marker
 
@@ -169,11 +212,18 @@ otherwise control: `postMessage()` spans tabs, windows and frames, any of which
 could pair two different deployments, and a payload written by a build the
 decoder does not understand is refused rather than walked.
 
-The check earns little in the deployment this format is for, where both ends
-are the same build and the marker always matches. It costs one comparison, and
-it is what makes adoption safe to state as a rule: without it a decoder takes
-an arbitrary object as its marker, every tagged form beneath goes unrecognized,
-and a foreign tree decodes as ordinary data instead of being refused.
+The check earns little across worker IPC, where both ends are the same build
+and the marker always matches. It costs one comparison, and it is what makes
+adoption safe to state as a rule: without it a decoder takes an arbitrary
+object as its marker, every tagged form beneath goes unrecognized, and a
+foreign tree decodes as ordinary data instead of being refused.
+
+On a self-dealing store (Section 1.2) it earns everything, and is the whole of
+what that use rests on. There a mismatch is expected rather than exceptional:
+a payload written before a version bump is refused on the first read after it,
+and a reader takes that refusal as a miss. This format offers no reading of an
+earlier version's payload and no decoder is obliged to attempt one, which is
+why Section 1.2 admits only stores whose contents can be rebuilt.
 
 ## 3. Type Encodings
 
@@ -388,6 +438,10 @@ On the boundary this format exists for, none of this costs a caller anything —
 the tree is the receiver's own clone of a value it will not be handed again,
 which is the whole reason the copy can be elided. A caller wanting two readings
 of one payload keeps the value it decoded, not the tree it decoded from.
+
+A self-dealing store (Section 1.2) satisfies this the same way and for the
+same reason: a read deserializes afresh, so what it hands back is the reader's
+own and reading twice means reading the store twice.
 
 ## 6. Refusals
 

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -15,19 +15,27 @@ Draft formal spec — the realm-crossing counterpart to
 
 ## 1. Overview
 
-This format is built around one boundary: worker IPC, where a value is
-constructed, handed to a transport that clones it, decoded on the far side,
-and discarded. Everything it asks of a transport is Section 1.1, and what it
-declines to offer is Section 2.4: a payload is readable only by a build
-implementing the same format version. A value that must outlive the build
-that wrote it, or that must be read through a transport not meeting
+This format is built around one kind of boundary: a **self-dealing** one,
+internal to a runtime, where whatever encodes a value is what decodes it and
+no other party reads what passes between. Nothing crossing such a boundary is
+owed interoperability, which is what lets the format be as narrow as it is.
+
+Worker IPC is the case it was written for: a value constructed, handed to a
+transport that clones it, decoded on the far side, and discarded. A durable
+store that a runtime writes and later reads back (Section 1.2) is the same
+boundary with time in it, and is the reason the format states its
+requirements of a transport rather than of a mechanism. A value that crosses
+to another party, or that must be read through a transport not meeting
 Section 1.1, uses the JSON encoding.
 
-Those are separate questions, and Section 1.2 turns on their being separate.
-A durable structured-clone store meets Section 1.1 in full while placing an
-unbounded gap between encode and decode, so its two ends need not be the same
-build. Such a store may carry this format under the conditions of Section 1.2,
-and not otherwise.
+Time is what the two instances do not share, and Section 1.2 turns on the
+difference. Section 1.1 is what a transport must preserve; Section 2.4 is
+what the format declines to offer, namely a payload readable by a build other
+than the one that wrote it. Worker IPC closes the gap so completely that the
+second never arises. A durable store meets Section 1.1 in full while leaving
+the gap unbounded, so its two ends need not be the same build — which is what
+Section 1.2's conditions are about, and why a value that must outlive the
+build that wrote it belongs in the JSON encoding.
 
 The two formats divide along what their transports carry. JSON reaches a
 `string`, so every type JavaScript has and JSON lacks — `bigint`, `undefined`,
@@ -74,16 +82,16 @@ The structured clone algorithm provides all three.
 
 ### 1.2 Self-Dealing Storage
 
-A **self-dealing** use of this format writes a value to a durable store and
-reads it back later from the same origin, with no other party in it. Such a
-use is admitted, and `IndexedDB` is the case it is admitted for: that store
-serializes with the structured clone algorithm, so the same mechanism that
+Storage is the self-dealing boundary with time in it: a runtime writes a
+value to a durable store and reads it back later, with no other party in it.
+`IndexedDB` is the case in hand, and it qualifies by the same mechanism worker
+IPC does — that store serializes with the structured clone algorithm, so what
 satisfies Section 1.1 for `postMessage()` satisfies it here.
 
-What the gap costs is Section 2.4. A durable payload can outlive the build
+What the time costs is Section 2.4. A durable payload can outlive the build
 that wrote it, so a reader must expect that refusal rather than treat it as
-unreachable. Three conditions follow, and a use meeting all three is
-self-dealing:
+unreachable. Three conditions follow, and a store meeting all three stays
+within this boundary:
 
 1. **The stored value must be reconstructible from something the store does
    not hold.** This is the condition that decides the question, because it is

--- a/docs/specs/space-model-formal-spec/README.md
+++ b/docs/specs/space-model-formal-spec/README.md
@@ -41,7 +41,8 @@ system, schemas.
   objects, standard type encodings, detection, escaping, and the `/`-key
   reservation rule.
 - [4-realm-encoding.md](./4-realm-encoding.md) -- The realm-crossing wire
-  format, for `structuredClone()` and `postMessage()`: the `[marker, tree]`
+  format, for `structuredClone()` and `postMessage()` and for self-dealing
+  storage in a durable structured-clone store: the `[marker, tree]`
   outer envelope, identity-based detection, standard type encodings, cycles
   and sharing, and the ownership contract each direction carries -- an encoded
   tree sharing structure with the value it came from, and a decoded one

--- a/docs/specs/space-model-formal-spec/README.md
+++ b/docs/specs/space-model-formal-spec/README.md
@@ -41,9 +41,10 @@ system, schemas.
   objects, standard type encodings, detection, escaping, and the `/`-key
   reservation rule.
 - [4-realm-encoding.md](./4-realm-encoding.md) -- The realm-crossing wire
-  format, for `structuredClone()` and `postMessage()` and for self-dealing
-  storage in a durable structured-clone store: the `[marker, tree]`
-  outer envelope, identity-based detection, standard type encodings, cycles
-  and sharing, and the ownership contract each direction carries -- an encoded
-  tree sharing structure with the value it came from, and a decoded one
-  carrying no guarantee of being usable again.
+  format, for the self-dealing boundary internal to a runtime --
+  `structuredClone()` and `postMessage()`, and a durable structured-clone
+  store read back later: the `[marker, tree]` outer envelope, identity-based
+  detection, standard type encodings, cycles and sharing, and the ownership
+  contract each direction carries -- an encoded tree sharing structure with
+  the value it came from, and a decoded one carrying no guarantee of being
+  usable again.

--- a/packages/data-model/src/codec-realm/RealmCodecEngine.ts
+++ b/packages/data-model/src/codec-realm/RealmCodecEngine.ts
@@ -8,7 +8,8 @@ import { type RealmCodecValue, type RealmEncodedValue } from "./interface.ts";
 /**
  * Whole-value codec engine for the realm-crossing wire format: the form a
  * `FabricValue` takes when it is handed to `structuredClone()` or
- * `postMessage()` to reach another realm.
+ * `postMessage()` to reach another realm, or to a durable store that
+ * serializes the same way.
  *
  * The format is specified by `4-realm-encoding.md` of the formal spec, which
  * is the authority on the shape of an encoded value, the marker and its rules,


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## What

`docs/specs/space-model-formal-spec/4-realm-encoding.md` opened by saying the
realm encoding "is not a storage format and has no persistence story", and
directed a value written down for later to the JSON encoding. This change
replaces that with a statement of the boundary the format is actually built
for, and adds a Section 1.2 covering the storage instance of it.

## Why

The old wording fuses two separate questions:

* What a transport must preserve — already stated abstractly in Section 1.1
  (the emitted types, sparse-array holes, and object reference identity in
  both directions).
* How long the gap between encode and decode is, and therefore whether both
  ends are the same build — which is what Section 2.4's version refusal is
  about.

A durable structured-clone store shows they are independent. `IndexedDB`
serializes with the structured clone algorithm, so it meets Section 1.1 by the
same mechanism `postMessage()` does, while placing an unbounded gap between the
two ends. A file or a network hop, by contrast, fails Section 1.1 at the first
requirement and needs no rule about time at all. "Storage" was standing in for
"transport that does not meet Section 1.1", and there is at least one storage
medium that does meet it.

The escape hatch the old sentence offered is also unavailable for the value
that most wants such a store. A `CryptoKey` has no JSON representation — the
JSON codec for `FabricKeyPair` throws for the handles arm, since a key's
material is reachable only through `exportKey()`, which is asynchronous and
which a non-extractable key refuses outright. So "a value written down for
later uses the JSON encoding" has no answer for a pair holding handles.

## The boundary, and its two instances

Section 1 now names what the format is built for: a **self-dealing** boundary,
internal to a runtime, where whatever encodes a value is what decodes it and no
other party reads what passes between. Nothing crossing such a boundary is owed
interoperability, which is what lets the format be as narrow as it is.

Worker IPC and a durable store are two instances of that one boundary rather
than a rule and an exception to it. Time is the only thing they do not share,
and that difference is precisely Section 2.4 — which is why Section 1.2 exists,
and why a value that must outlive the build that wrote it still belongs in
JSON.

## The conditions

Section 1.2 gates the storage instance on three conditions:

1. The stored value must be reconstructible from something the store does not
   hold.
2. A reader must treat a refused payload as absent rather than report it as an
   error.
3. A reader must decode strictly, a lenient decode's root `ProblematicValue`
   being worse than a miss.

The first is the one that decides the question, because it is what makes a
format version bump a cache flush rather than data loss. It is also what makes
the wording discriminate rather than merely permit: an opportunistic cache of a
pure function passes it, and a queue of unsent writes — which is persisted
precisely because nothing else holds it — does not.

## Also in this change

* **Section 2.4** gains what its refusal is worth on a durable store, where a
  version mismatch is expected rather than exceptional. Its existing claim that
  both ends are always the same build now names worker IPC rather than the
  format at large.
* **Section 5.2** notes that a store deserializing afresh on each read
  satisfies the ceding contract by the same argument the IPC boundary does.
* **`1-fabric-values.md`** stated that "the formats that persist and inspect a
  value are exactly the ones that must not be able to represent" a
  non-extractable key. The premise that the realm encoding never persists is
  what that rested on. The replacement does not put a rule in its place: the
  refusals follow from the key rather than from any policy about formats, since
  `exportKey()` is asynchronous where `encode()` is synchronous and a
  non-extractable key refuses it, so a synchronous encode has nothing to write.
  Which state a key is in is settled where it is minted — an algorithm Web
  Crypto does not implement has no handle to hold, and an implementation
  wanting its keys exportable mints them so — which is upstream of every format
  the section describes.
* The series `README.md` entry and the `RealmCodecEngine` doc comment, both of
  which described the format's reach in terms of `structuredClone()` and
  `postMessage()` alone.

## Scope

Specification and comments only. No behavior changes, and no caller adopts the
storage instance here — the conditions are written so that a future one can be
checked against them.

## Checks

`deno task check`, `deno lint`, `deno fmt --check`, `deno task check-docs` (564
blocks), `check-skill-facts`, `check-docs-history-index`, and
`check-conflict-markers` all pass; `deno task test` in `data-model` passes (57
tests, 2692 steps). Note that `deno fmt` does not cover markdown under `docs/`,
so the 80-column wrap on the prose was audited separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kmk7vivdHYK1uWXWXcwhjY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


