### PR TITLE
docs(data-model): rewrap ragged prose in the formal spec and data-model comments

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -31,8 +31,9 @@ JavaScript "wild west" (unknown/any) <-> Strongly typed (FabricValue) <-> Serial
 ```
 
 - **Left layer — JS wild west.** Arbitrary JavaScript values (`unknown`/`any`),
-  including native objects like `Error`, `Map`, `Set`, `Date`, `RegExp`, and `Uint8Array`.
-  Code in this layer has no type guarantees about what it is handling.
+  including native objects like `Error`, `Map`, `Set`, `Date`, `RegExp`, and
+  `Uint8Array`. Code in this layer has no type guarantees about what it is
+  handling.
 
 - **Middle layer — `FabricValue`.** The strongly typed core of the data model.
   Contains only primitives, `FabricInstance` implementations (including wrapper
@@ -54,9 +55,9 @@ the full specification of these functions.
 
 ### 1.2 Type Universe
 
-A `FabricValue` is defined as the following union. This is the **middle
-layer** — the strongly typed core. Raw native JS objects (`Error`, `Map`, `Set`,
-`Date`, `RegExp`, `Uint8Array`) do not appear here; they are handled by the conversion
+A `FabricValue` is defined as the following union. This is the **middle layer**
+— the strongly typed core. Raw native JS objects (`Error`, `Map`, `Set`, `Date`,
+`RegExp`, `Uint8Array`) do not appear here; they are handled by the conversion
 layer (Section 8) and represented in `FabricValue` trees as `FabricInstance`
 wrapper classes (Section 1.4).
 
@@ -65,32 +66,30 @@ wrapper classes (Section 1.4).
 > (`FabricSpecialObject`, `FabricInstance`, `FabricPrimitive`) are declared in
 > `interface.ts`, and the in-process lifecycle symbols (`DEEP_FREEZE`,
 > `IS_DEEP_FROZEN`) in `fabric-bases/`, on `BaseFabricInstance` alongside the
-> abstract base that carries them (Section 8.6). The codec vocabulary (the `CODEC` symbol,
-> `FabricCodec`, `LiveEnvironment`) lives in `codec-interface/` (Section 2),
-> and the machinery that acts on it in `codec-common/` -- including
-> `BaseEncodeAct` and `BaseDecodeAct`, which are classes the walk carries
-> rather than contracts a caller implements. The conversion functions are in
+> abstract base that carries them (Section 8.6). The codec vocabulary (the
+> `CODEC` symbol, `FabricCodec`, `LiveEnvironment`) lives in `codec-interface/`
+> (Section 2), and the machinery that acts on it in `codec-common/` -- including
+> `BaseEncodeAct` and `BaseDecodeAct`, which are classes the walk carries rather
+> than contracts a caller implements. The conversion functions are in
 > `native-conversion.ts` (Section 8).
 >
 > **Where a thing is declared is not where it is imported from**, and the
 > modules named here divide on that point. `interface.ts` and
-> `native-conversion.ts` are internal: they are not exported subpaths, and
-> their contents are reached through `@commonfabric/data-model/fabric-value`,
-> which re-exports them. `codec-interface/` is internal in the same way: it
-> is reached through `@commonfabric/data-model/codec-common`, which
-> re-exports it. `codec-common/`, `fabric-bases/` and `fabric-instances/` are
-> exported subpaths in their own right and are imported directly under those
-> names;
-> `fabric-value` does *not* re-export the codec vocabulary, so
-> `LiveEnvironment` and its siblings come from
-> `@commonfabric/data-model/codec-common`. Cite a module to say where
-> something is defined; consult the package's `exports` map to know where to
-> import it from.
+> `native-conversion.ts` are internal: they are not exported subpaths, and their
+> contents are reached through `@commonfabric/data-model/fabric-value`, which
+> re-exports them. `codec-interface/` is internal in the same way: it is reached
+> through `@commonfabric/data-model/codec-common`, which re-exports it.
+> `codec-common/`, `fabric-bases/` and `fabric-instances/` are exported subpaths
+> in their own right and are imported directly under those names; `fabric-value`
+> does *not* re-export the codec vocabulary, so `LiveEnvironment` and its
+> siblings come from `@commonfabric/data-model/codec-common`. Cite a module to
+> say where something is defined; consult the package's `exports` map to know
+> where to import it from.
 >
-> Type declarations visible to patterns are in `packages/api/index.ts`
-> (inline `interface` + `declare const` pattern), and must agree with the
-> `data-model` declarations — nothing checks that mechanically.
-> `packages/runner/` wires concrete implementations into builder exports.
+> Type declarations visible to patterns are in `packages/api/index.ts` (inline
+> `interface` + `declare const` pattern), and must agree with the `data-model`
+> declarations — nothing checks that mechanically. `packages/runner/` wires
+> concrete implementations into builder exports.
 
 ```typescript
 // Shown at module scope.
@@ -141,14 +140,13 @@ same set while saying more about it. Read the split as this document's
 elaboration of one implementation arm.
 
 > **Fabric values are deeply read-only, with one intentional hole.** The
-> container arms are read-only, and because their element and property types
-> are themselves `FabricValue`, that read-only-ness is inherited all the way
-> down: a `FabricValue` tree cannot be written through at any depth. The
-> implementation names the two container arms `FabricArray`
-> (`ReadonlyArray<FabricValue>`) and `FabricPlainObject`
-> (`Readonly<Record<string, FabricValue>>`); this is the type-level
-> counterpart of the runtime deep-freeze contract in Section 8.6, and the two
-> are meant to agree.
+> container arms are read-only, and because their element and property types are
+> themselves `FabricValue`, that read-only-ness is inherited all the way down: a
+> `FabricValue` tree cannot be written through at any depth. The implementation
+> names the two container arms `FabricArray` (`ReadonlyArray<FabricValue>`) and
+> `FabricPlainObject` (`Readonly<Record<string, FabricValue>>`); this is the
+> type-level counterpart of the runtime deep-freeze contract in Section 8.6, and
+> the two are meant to agree.
 >
 > The hole is the `FabricInstance` arm. An instance exposes arbitrary members,
 > and a member can change instance state — including which values the instance
@@ -162,24 +160,24 @@ elaboration of one implementation arm.
 > **Construction is the exception that proves the rule.** Building a container
 > requires writing to it, so the implementation provides
 > `MutableFabricValueLayer` — a value whose *root* container is mutable
-> (`MutableFabricArrayLayer` is `FabricValue[]`,
-> `MutableFabricPlainObjectLayer` is `Record<string, FabricValue>`) while
-> everything nested within it remains an ordinary read-only `FabricValue`. It
-> is a single construction layer, not a deep thaw, and it is a builder's type:
-> a value that has finished being built is a `FabricValue`.
+> (`MutableFabricArrayLayer` is `FabricValue[]`, `MutableFabricPlainObjectLayer`
+> is `Record<string, FabricValue>`) while everything nested within it remains an
+> ordinary read-only `FabricValue`. It is a single construction layer, not a
+> deep thaw, and it is a builder's type: a value that has finished being built
+> is a `FabricValue`.
 
 > **Restricted and excluded JS types.**
 >
-> - `symbol` — **Conditionally** part of the universe. Registry-interned
->   symbols (`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string)
->   are first-class `FabricValue`s: they are portable across realms and
->   processes via their registry key. **Unique** symbols (`Symbol(desc)`,
->   where `Symbol.keyFor(s)` returns `undefined`) have no portable
->   representation and are rejected. The TypeScript `symbol` type cannot
->   express this distinction, so it is enforced at runtime by the
->   conversion, hashing, and encoding boundaries (Sections 4.9, 6,
->   and 5). Symbol-keyed *properties* on plain objects are a separate
->   matter — see Section 1.5 (Recursive Containers / Objects).
+> - `symbol` — **Conditionally** part of the universe. Registry-interned symbols
+>   (`Symbol.for(key)`, where `Symbol.keyFor(s)` returns a string) are
+>   first-class `FabricValue`s: they are portable across realms and processes
+>   via their registry key. **Unique** symbols (`Symbol(desc)`, where
+>   `Symbol.keyFor(s)` returns `undefined`) have no portable representation and
+>   are rejected. The TypeScript `symbol` type cannot express this distinction,
+>   so it is enforced at runtime by the conversion, hashing, and encoding
+>   boundaries (Sections 4.9, 6, and 5). Symbol-keyed *properties* on plain
+>   objects are a separate matter — see Section 1.5 (Recursive Containers /
+>   Objects).
 > - `function` — Functions are opaque closures with no portable representation.
 >   They are explicitly **not** representable as `FabricValue`s, eliciting a
 >   thrown error from `fabricFromNativeValue()` and a `false` return value from
@@ -187,25 +185,25 @@ elaboration of one implementation arm.
 >   this sense — they are class instances whose encoding is handled by their
 >   class's `[CODEC]`.)
 >
->   A proposed, deliberately narrow exception adds a `FabricFactory` arm for
->   builder-created factories and codec-decoded factory shells admitted to the
->   internal data-model brand table. The function itself is the `FabricValue`
->   and encodes through `Factory@1`; there is no non-callable wrapper class.
->   This data-type brand does not grant executable trust, which is established
->   separately by resolving a content-addressed builder artifact. The exception
->   is not automatic under the current protocol: it requires branded-function
->   dispatch before generic function rejection, plus factory-state handling in
->   conversion, freezing, cloning, equality, hashing, and traversal. Every
->   unbranded function remains rejected. See
->   [First-Class Encodable Factories](../pattern-construction/node-factory-shipping.md).
+> A proposed, deliberately narrow exception adds a `FabricFactory` arm for
+> builder-created factories and codec-decoded factory shells admitted to the
+> internal data-model brand table. The function itself is the `FabricValue` and
+> encodes through `Factory@1`; there is no non-callable wrapper class. This
+> data-type brand does not grant executable trust, which is established
+> separately by resolving a content-addressed builder artifact. The exception is
+> not automatic under the current protocol: it requires branded-function
+> dispatch before generic function rejection, plus factory-state handling in
+> conversion, freezing, cloning, equality, hashing, and traversal. Every
+> unbranded function remains rejected. See [First-Class Encodable
+> Factories](../pattern-construction/node-factory-shipping.md).
 >
 > Of the two JS primitive types whose `typeof` results (`"symbol"` and
 > `"function"`) describe non-data values, `symbol` has a corresponding
-> `FabricValue` arm (with the runtime interned-vs-unique restriction
-> above) and `"function"` does not **in the current model**. The proposal above
-> adds only the branded `FabricFactory` function arm. All other `typeof` results
-> (`"undefined"`, `"boolean"`, `"number"`, `"string"`, `"bigint"`,
-> `"object"`) have unconditional `FabricValue` arms.
+> `FabricValue` arm (with the runtime interned-vs-unique restriction above) and
+> `"function"` does not **in the current model**. The proposal above adds only
+> the branded `FabricFactory` function arm. All other `typeof` results
+> (`"undefined"`, `"boolean"`, `"number"`, `"string"`, `"bigint"`, `"object"`)
+> have unconditional `FabricValue` arms.
 
 #### `FabricNativeObject`
 
@@ -249,14 +247,14 @@ type FabricConvertibleValue =
 
 `Map` and `Set` are named with unconstrained type arguments: their contents are
 checked when they are converted, not by the type. The constraint has nowhere to
-bind in any case while `FabricMap` and `FabricSet` remain stubbed
-(Sections 1.4.3 and 1.4.4).
+bind in any case while `FabricMap` and `FabricSet` remain stubbed (Sections
+1.4.3 and 1.4.4).
 
 Neither type is ever a member of `FabricValue`; both exist solely at the
-conversion boundary (Section 8). Of the two, **`FabricConvertibleValue`
-is the one the boundary actually speaks**, and it exists because
-`FabricValue | FabricNativeObject` cannot say "or a tree of these." A container
-arm of `FabricValue` holds `FabricValue`s, so it cannot hold an `Error`; and a
+conversion boundary (Section 8). Of the two, **`FabricConvertibleValue` is the
+one the boundary actually speaks**, and it exists because `FabricValue |
+FabricNativeObject` cannot say "or a tree of these." A container arm of
+`FabricValue` holds `FabricValue`s, so it cannot hold an `Error`; and a
 `FabricNativeObject` is a single native object, not a container of them.
 Converting a `FabricError` yields an `Error`, so an array of `FabricError`s
 converts to an array of `Error`s — a value that is neither a `FabricValue` nor a
@@ -264,8 +262,8 @@ converts to an array of `Error`s — a value that is neither a `FabricValue` nor
 `fabricFromNativeValue()` succeeds on, what `nativeFromFabricValue()` returns,
 and what `isValidFabricConvertibleValue()` tests (Sections 8.3 and 8.4). It is a
 precondition rather than a parameter type: the conversion functions that accept
-arbitrary input declare `unknown` and reject what they cannot convert
-(Section 8.2).
+arbitrary input declare `unknown` and reject what they cannot convert (Section
+8.2).
 
 Every arm names a specific native class. There is no duck-typed arm: a value
 becomes fabric-representable by being one of these, by implementing the fabric
@@ -286,78 +284,74 @@ function-valued member is not representable.
 | `symbol` | Registry-interned only | Only symbols for which `Symbol.keyFor(s)` returns a string (i.e., `Symbol.for(key)` symbols) are admitted. Unique symbols (`Symbol(desc)`) are rejected. See the callout below. |
 
 > **`undefined` as a first-class fabric value.** `undefined` is a first-class
-> `FabricValue` that round-trips faithfully through encoding. Because most
-> wire formats (including JSON) have no native `undefined` representation, the
-> codec system uses a dedicated tagged form for `undefined` — the same
-> tagged form regardless of context (array element, object property value, or
-> top-level value). See Section 3 of `3-json-encoding.md` for the specific JSON encoding. Deletion
-> semantics (e.g., removing a cell's value when `undefined` is written at top
-> level) are an application-level concern, not an encoding concern: the
+> `FabricValue` that round-trips faithfully through encoding. Because most wire
+> formats (including JSON) have no native `undefined` representation, the codec
+> system uses a dedicated tagged form for `undefined` — the same tagged form
+> regardless of context (array element, object property value, or top-level
+> value). See Section 3 of `3-json-encoding.md` for the specific JSON encoding.
+> Deletion semantics (e.g., removing a cell's value when `undefined` is written
+> at top level) are an application-level concern, not an encoding concern: the
 > encoder faithfully records `undefined` and the application layer interprets
 > the result.
 
 > **`-0`, `NaN`, and `±Infinity`.** The hashing layer (Section 6.4 and
 > `2-hash-byte-format.md` Section 4.3) and the JSON wire format (Section 5;
-> `3-json-encoding.md` Section 3, `SpecialNumber@1`) both faithfully
-> represent `-0`, `NaN`, `+Infinity`, and `-Infinity` as first-class
-> values, distinct from `0` and from each other. All four values pass
-> through `shallowFabricFromNativeValue()` and `fabricFromNativeValue()`
-> (Section 4.9) unchanged — `-0` retains its sign
-> (`Object.is(result, -0) === true`), and `NaN` / `±Infinity` round-trip
-> through hashing and JSON encoding via the byte-level forms in
-> `2-hash-byte-format.md` Section 4.3 and the `SpecialNumber@1` envelope in
-> `3-json-encoding.md` Section 3. Value-equality among these values follows
-> `Object.is()` — `-0` is distinct from `+0` while all `NaN`s are equal — as
-> specified in Section 6.7.
+> `3-json-encoding.md` Section 3, `SpecialNumber@1`) both faithfully represent
+> `-0`, `NaN`, `+Infinity`, and `-Infinity` as first-class values, distinct from
+> `0` and from each other. All four values pass through
+> `shallowFabricFromNativeValue()` and `fabricFromNativeValue()` (Section 4.9)
+> unchanged — `-0` retains its sign (`Object.is(result, -0) === true`), and
+> `NaN` / `±Infinity` round-trip through hashing and JSON encoding via the
+> byte-level forms in `2-hash-byte-format.md` Section 4.3 and the
+> `SpecialNumber@1` envelope in `3-json-encoding.md` Section 3. Value-equality
+> among these values follows `Object.is()` — `-0` is distinct from `+0` while
+> all `NaN`s are equal — as specified in Section 6.7.
 
 > **Interned vs. unique symbols.** The hashing layer (Section 6.4 and
-> `2-hash-byte-format.md` Section 4.6) and the JSON wire format
-> (Section 5; `3-json-encoding.md` Section 3, `Symbol@1`) both faithfully
-> represent registry-interned symbols, identifying them by their registry
-> key (`Symbol.keyFor(s)`). Unique symbols (`Symbol(desc)` — those for
-> which `Symbol.keyFor(s)` returns `undefined`) have no portable
-> representation and are rejected at every layer. Interned symbols pass
-> through `shallowFabricFromNativeValue()` and `fabricFromNativeValue()`
-> (Section 4.9) unchanged: round-trip via `Symbol.for(key)` yields a result
-> that is `===` to any other `Symbol.for(key)` in the same realm. Unique
-> symbols throw with the message
-> ``"Not representable as a `FabricValue`: unique (uninterned) symbol"``.
+> `2-hash-byte-format.md` Section 4.6) and the JSON wire format (Section 5;
+> `3-json-encoding.md` Section 3, `Symbol@1`) both faithfully represent
+> registry-interned symbols, identifying them by their registry key
+> (`Symbol.keyFor(s)`). Unique symbols (`Symbol(desc)` — those for which
+> `Symbol.keyFor(s)` returns `undefined`) have no portable representation and
+> are rejected at every layer. Interned symbols pass through
+> `shallowFabricFromNativeValue()` and `fabricFromNativeValue()` (Section 4.9)
+> unchanged: round-trip via `Symbol.for(key)` yields a result that is `===` to
+> any other `Symbol.for(key)` in the same realm. Unique symbols throw with the
+> message ``"Not representable as a `FabricValue`: unique (uninterned)
+> symbol"``.
 
 ### 1.4 Native Object Wrapper Classes
 
-Certain built-in JS types (`Error`, `Map`, `Set`) cannot
-have `Symbol`-keyed methods added via prototype patching in a reliable,
-cross-realm way. Rather than handling them with special-case logic in the
-encoder, the system defines **wrapper classes** — one per native type — that
-implement `FabricInstance`. The conversion layer (Section 8) wraps raw native
-objects into these classes when bridging from the JS wild west to `FabricValue`,
-and unwraps them when bridging back. (Native `RegExp` is also bridged by the
-conversion layer, but into the `FabricRegExp` **primitive** rather than a
-wrapper — see Section 1.4.5.)
+Certain built-in JS types (`Error`, `Map`, `Set`) cannot have `Symbol`-keyed
+methods added via prototype patching in a reliable, cross-realm way. Rather than
+handling them with special-case logic in the encoder, the system defines
+**wrapper classes** — one per native type — that implement `FabricInstance`. The
+conversion layer (Section 8) wraps raw native objects into these classes when
+bridging from the JS wild west to `FabricValue`, and unwraps them when bridging
+back. (Native `RegExp` is also bridged by the conversion layer, but into the
+`FabricRegExp` **primitive** rather than a wrapper — see Section 1.4.5.)
 
-Because each wrapper genuinely implements `FabricInstance` and hosts a
-`[CODEC]` (Section 2.4), the codec system processes them through
-the same uniform codec dispatch as every other fabric class — no special
-cases needed in the encoder. The hashing system also uses the standard
-`TAG_INSTANCE` path for all wrappers. `FabricBytes` (the byte-sequence type)
-has a dedicated `TAG_BYTES` tag for content-level identity (see Section 6.3),
-but it is a `FabricPrimitive`, not a `FabricInstance`.
+Because each wrapper genuinely implements `FabricInstance` and hosts a `[CODEC]`
+(Section 2.4), the codec system processes them through the same uniform codec
+dispatch as every other fabric class — no special cases needed in the encoder.
+The hashing system also uses the standard `TAG_INSTANCE` path for all wrappers.
+`FabricBytes` (the byte-sequence type) has a dedicated `TAG_BYTES` tag for
+content-level identity (see Section 6.3), but it is a `FabricPrimitive`, not a
+`FabricInstance`.
 
 The **special primitive** types (`FabricEpochNsec`, `FabricEpochDay`,
 `FabricHash`, `FabricBytes`, `FabricKeyPair`, `FabricRegExp`) are **not**
-`FabricInstance`s —
-they are `FabricPrimitive` subclasses (Section 1.4.6). `FabricPrimitive` extends
-`FabricSpecialObject`, and the `FabricValue` union includes
-`FabricSpecialObject`, so all `FabricPrimitive` subclasses are implicitly
-members of `FabricValue`. They are always-frozen value types that bypass the
-`freeze` option in conversion functions. Each hosts its own codec for
-wire-format encoding, but bound per wire format — under
-`[JSON_CODEC]` for JSON — rather than under the format-neutral `[CODEC]` a
-wrapper binds, because a primitive's codec terminates an encoding where a
-wrapper's only decomposes. What further distinguishes them
-is the hashing layer, where each has a dedicated primitive hash tag rather
-than the `TAG_INSTANCE` path (Section 6.3). They do not carry a
-`wireTypeTag` property (no fabric type does, save `UnknownValue` and
+`FabricInstance`s — they are `FabricPrimitive` subclasses (Section 1.4.6).
+`FabricPrimitive` extends `FabricSpecialObject`, and the `FabricValue` union
+includes `FabricSpecialObject`, so all `FabricPrimitive` subclasses are
+implicitly members of `FabricValue`. They are always-frozen value types that
+bypass the `freeze` option in conversion functions. Each hosts its own codec for
+wire-format encoding, but bound per wire format — under `[JSON_CODEC]` for JSON
+— rather than under the format-neutral `[CODEC]` a wrapper binds, because a
+primitive's codec terminates an encoding where a wrapper's only decomposes. What
+further distinguishes them is the hashing layer, where each has a dedicated
+primitive hash tag rather than the `TAG_INSTANCE` path (Section 6.3). They do
+not carry a `wireTypeTag` property (no fabric type does, save `UnknownValue` and
 `ProblematicValue`; the wire tag is the codec's concern).
 
 #### 1.4.1 Wrapper Class Summary
@@ -379,15 +373,15 @@ Each wrapper class above:
   which in turn extends `FabricInstance`), inheriting the `shallowClone()`
   frozenness-management template method from `BaseFabricInstance` and
   providing a `toNativeValue(frozen)` method for unwrapping.
-- **Hosts a static `[CODEC]`** (Section 2.4) whose `encode()` extracts
-  essential state and whose `decode()` returns an instance of the wrapper
-  class — **not** the raw native type. Callers who need the underlying
-  native object use `nativeFromFabricValue()` (Section 8) to unwrap it.
-  The wire tag (e.g., `"Error@1"`) is carried by the codec, not by the
-  instances.
-- **Has `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` methods plus a `deepClone(frozen)`
-  method** per the `FabricInstance` protocol (Section 2.3); the deep-freeze
-  pair participates in the generic `deepFreeze()` dispatch (Section 8.6).
+- **Hosts a static `[CODEC]`** (Section 2.4) whose `encode()` extracts essential
+  state and whose `decode()` returns an instance of the wrapper class — **not**
+  the raw native type. Callers who need the underlying native object use
+  `nativeFromFabricValue()` (Section 8) to unwrap it. The wire tag (e.g.,
+  `"Error@1"`) is carried by the codec, not by the instances.
+- **Has `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` methods plus a
+  `deepClone(frozen)` method** per the `FabricInstance` protocol (Section 2.3);
+  the deep-freeze pair participates in the generic `deepFreeze()` dispatch
+  (Section 8.6).
 
 ##### `FabricNativeWrapper<T>` Base Class
 
@@ -458,34 +452,32 @@ through 1.4.11.
 #### Extra Enumerable Properties
 
 **`FabricError`** MAY carry extra enumerable properties beyond the standard
-fields (`type`, `name`, `message`, `stack`, `cause`). Custom properties on `Error`
-objects are common JavaScript practice (e.g., `error.code`, `error.statusCode`),
-so `FabricError` preserves them in an "extras" bag: the codec's `encode()`
-includes them in its output, and `decode()` restores them on the
-decoded instance (Section 1.4.2).
+fields (`type`, `name`, `message`, `stack`, `cause`). Custom properties on
+`Error` objects are common JavaScript practice (e.g., `error.code`,
+`error.statusCode`), so `FabricError` preserves them in an "extras" bag: the
+codec's `encode()` includes them in its output, and `decode()` restores them on
+the decoded instance (Section 1.4.2).
 
-**`FabricMap`, `FabricSet`, `FabricRegExp`, `FabricEpochNsec`,
-`FabricEpochDay`, `FabricHash`, `FabricBytes`, `FabricKeyPair`** must NOT carry
-extra enumerable
-properties. Their
-stored value contains only the essential native data (entries, items,
-epoch value, bytes respectively). Extra enumerable properties on the source
-native object cause **rejection** — the conversion function throws. This follows
-the principle "Death before confusion!" (Mark Miller): it is better to fail
-loudly than to silently lose data. This is in the same spirit as the treatment
-of arrays, where extra non-index properties also cause rejection (Section 1.5)
-— though the array rule is stricter still, rejecting non-enumerable and
-symbol-keyed properties as well. Unlike `Error`,
-these native types have no established convention for custom properties.
+**`FabricMap`, `FabricSet`, `FabricRegExp`, `FabricEpochNsec`, `FabricEpochDay`,
+`FabricHash`, `FabricBytes`, `FabricKeyPair`** must NOT carry extra enumerable
+properties. Their stored value contains only the essential native data (entries,
+items, epoch value, bytes respectively). Extra enumerable properties on the
+source native object cause **rejection** — the conversion function throws. This
+follows the principle "Death before confusion!" (Mark Miller): it is better to
+fail loudly than to silently lose data. This is in the same spirit as the
+treatment of arrays, where extra non-index properties also cause rejection
+(Section 1.5) — though the array rule is stricter still, rejecting
+non-enumerable and symbol-keyed properties as well. Unlike `Error`, these native
+types have no established convention for custom properties.
 
 #### 1.4.2 `FabricError`
 
 Unlike a thin wrapper holding a native `Error`, `FabricError` stores
-**structured `FabricValue`-typed state** — fixed-schema slots (`type`,
-`name`, `message`, `stack`, `cause`) plus a hidden "extras" bag of custom
-enumerable properties accessed via map-like methods. The native `Error`
-form is a *projection*, produced on demand by `toNativeValue()` (and
-cached once the instance is frozen, when it can no longer go stale).
+**structured `FabricValue`-typed state** — fixed-schema slots (`type`, `name`,
+`message`, `stack`, `cause`) plus a hidden "extras" bag of custom enumerable
+properties accessed via map-like methods. The native `Error` form is a
+*projection*, produced on demand by `toNativeValue()` (and cached once the
+instance is frozen, when it can no longer go stale).
 
 ```typescript
 // Shown for illustration only.
@@ -655,24 +647,22 @@ export class FabricError extends FabricNativeWrapper<Error> {
 }
 ```
 
-The native projection (`#buildNativeError()`, reached via
-`toNativeValue()`) decodes the appropriate `Error` subclass from
-`type` (via a constructor-name lookup, defaulting to `Error`), restores
-`name` when it differs, and copies `stack`, `cause`, and the extras onto
-the result. While the instance is mutable the projection is rebuilt on
-each access; once frozen it is cached.
+The native projection (`#buildNativeError()`, reached via `toNativeValue()`)
+decodes the appropriate `Error` subclass from `type` (via a constructor-name
+lookup, defaulting to `Error`), restores `name` when it differs, and copies
+`stack`, `cause`, and the extras onto the result. While the instance is mutable
+the projection is rebuilt on each access; once frozen it is cached.
 
 #### 1.4.3 `FabricMap`
 
-> **Implementation status: stubbed (tag reserved).** The live class
-> exists with the full wrapper shape (including the native-projection
-> members, with `toNativeFrozen()` producing a `FrozenMap`), and its
-> `Map@1` tag is reserved in `CODEC_TYPE_TAGS`, but the protocol members
-> and the codec's `encode()`/`decode()` currently throw
-> (`"FabricMap: not yet implemented"`) — `FabricMap` is not yet used and
-> is being reworked separately. The code below is the **normative
-> target** the implementation must converge on; the wire format matches
-> Section 1.4.1.
+> **Implementation status: stubbed (tag reserved).** The live class exists with
+> the full wrapper shape (including the native-projection members, with
+> `toNativeFrozen()` producing a `FrozenMap`), and its `Map@1` tag is reserved
+> in `CODEC_TYPE_TAGS`, but the protocol members and the codec's
+> `encode()`/`decode()` currently throw (`"FabricMap: not yet implemented"`) —
+> `FabricMap` is not yet used and is being reworked separately. The code below
+> is the **normative target** the implementation must converge on; the wire
+> format matches Section 1.4.1.
 
 ```typescript
 // Shown at module scope.
@@ -728,11 +718,10 @@ export class FabricMap
 #### 1.4.4 `FabricSet`
 
 > **Implementation status: stubbed (tag reserved)**, exactly parallel to
-> `FabricMap` (Section 1.4.3): the class shape and reserved `Set@1` tag
-> exist (with `toNativeFrozen()` producing a `FrozenSet`); the protocol
-> members and codec currently throw (`"FabricSet: not yet implemented"`).
-> The code below is the **normative target**; the wire format matches
-> Section 1.4.1.
+> `FabricMap` (Section 1.4.3): the class shape and reserved `Set@1` tag exist
+> (with `toNativeFrozen()` producing a `FrozenSet`); the protocol members and
+> codec currently throw (`"FabricSet: not yet implemented"`). The code below is
+> the **normative target**; the wire format matches Section 1.4.1.
 
 ```typescript
 // Shown at module scope.
@@ -782,14 +771,14 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
 #### 1.4.5 `FabricRegExp`
 
 `FabricRegExp` is a `FabricPrimitive` subclass, not a native-object wrapper. A
-regular expression is a leaf type with respect to references (it holds no
-nested `FabricValue`s) and is reasonably conceived of as stateless: although a
-JS `RegExp` carries mutable internal state (notably `lastIndex`), a
-`FabricRegExp` never hands out its stored `RegExp` un-cloned, so no mutable
-state is exposed. It therefore has a dedicated hash tag (`TAG_REGEXP`,
-Section 6.3). Like every fabric class, it hosts its own `[CODEC]` (tag
-`RegExp@1`) for wire-format encoding; being a `FabricPrimitive`, it
-does not implement the `FabricInstance` members.
+regular expression is a leaf type with respect to references (it holds no nested
+`FabricValue`s) and is reasonably conceived of as stateless: although a JS
+`RegExp` carries mutable internal state (notably `lastIndex`), a `FabricRegExp`
+never hands out its stored `RegExp` un-cloned, so no mutable state is exposed.
+It therefore has a dedicated hash tag (`TAG_REGEXP`, Section 6.3). Like every
+fabric class, it hosts its own `[CODEC]` (tag `RegExp@1`) for wire-format
+encoding; being a `FabricPrimitive`, it does not implement the `FabricInstance`
+members.
 
 ```typescript
 // Shown for illustration only.
@@ -854,11 +843,11 @@ FabricSpecialObject (abstract root)
 a single `instanceof FabricSpecialObject` check wherever code needs to recognize
 any fabric-system value without caring which branch it belongs to.
 
-It is **nominal**, not structural: the `@commonfabric/FabricSpecialObject` member is a
-brand that exists only in the type system (`declare` emits no runtime member,
-and nothing reads the key). This matters for what `FabricValue` means as a
-static claim. TypeScript is structurally typed, so were the class empty, every
-object would satisfy `FabricSpecialObject` — and therefore satisfy
+It is **nominal**, not structural: the `@commonfabric/FabricSpecialObject`
+member is a brand that exists only in the type system (`declare` emits no
+runtime member, and nothing reads the key). This matters for what `FabricValue`
+means as a static claim. TypeScript is structurally typed, so were the class
+empty, every object would satisfy `FabricSpecialObject` — and therefore satisfy
 `FabricValue`, since the union includes this type. Annotating a value
 `FabricValue` would then assert nothing at all. The brand is what makes the
 annotation carry information.
@@ -1101,8 +1090,7 @@ The hash bytes are private (`#hash`). The public API provides:
   the first colon; entity URI schemes like `of:`/`computed:` are NOT part of
   this string and must be stripped — and preserved — by the caller).
 
-The `tag` field is an opaque string identifier.
-Known algorithm tags:
+The `tag` field is an opaque string identifier. Known algorithm tags:
 
 | Algorithm Tag | Meaning | Hash Algorithm | Output Size |
 |:--------------|:--------|:---------------|:------------|
@@ -1114,10 +1102,9 @@ identity — two `FabricHash` instances with the same hash bytes but
 different algorithm tags are distinct values.
 
 Like every `FabricPrimitive`, `FabricHash` hosts a `[JSON_CODEC]` (tag
-`Hash@1`).
-Its encoded state is `{ tag, hash }` — the algorithm tag plus the hash as
-an unpadded base64url string (i.e., `.hashString`); `canDecode()` refuses a
-state that is not a record of two strings, and `decode()` produces a
+`Hash@1`). Its encoded state is `{ tag, hash }` — the algorithm tag plus the
+hash as an unpadded base64url string (i.e., `.hashString`); `canDecode()`
+refuses a state that is not a record of two strings, and `decode()` produces a
 `ProblematicValue` for a `hash` that is not valid base64url. See Section 5 of
 `3-json-encoding.md` for the wire format.
 
@@ -1301,9 +1288,8 @@ JSON.
 `FabricLink` is a fabric-native `FabricInstance` — like the wrapper classes of
 Sections 1.4.2–1.4.4, but not wrapping any native JS type — that represents a
 **link**: the modern, object-shaped form of a reference to data stored in the
-fabric. It
-wraps a single **payload**, a plain object (`FabricPlainObject`) of addressing
-fields, as its sole nested `FabricValue`.
+fabric. It wraps a single **payload**, a plain object (`FabricPlainObject`) of
+addressing fields, as its sole nested `FabricValue`.
 
 A link is a `FabricInstance` rather than a `FabricPrimitive` because its
 payload is an **outgoing reference**, not leaf data: the payload may itself
@@ -1324,13 +1310,13 @@ form. Keeping the field set unconstrained is what lets `FabricLink` be reused
 across consumers, each specializing the general link value in its own way.
 
 Like every fabric class, `FabricLink` hosts a static `[CODEC]` (Section 2.4)
-with wire tag `Link@1`. Its encoded state **is** the payload object: the
-codec's `encode()` returns the payload directly, and `decode()` rebuilds a
-`FabricLink` from it (or a `ProblematicValue`, Section 3.5, if the payload is
-malformed). The JSON wire form is the `/Link@1`-tagged envelope
-`{ "/Link@1": <payload> }`; see Section 3 of `3-json-encoding.md` for the wire
-encoding, and the migration table in Section 4 for how legacy link forms
-(the IPLD sigil `{ "/": { "link@1": … } }`) map onto it.
+with wire tag `Link@1`. Its encoded state **is** the payload object: the codec's
+`encode()` returns the payload directly, and `decode()` rebuilds a `FabricLink`
+from it (or a `ProblematicValue`, Section 3.5, if the payload is malformed). The
+JSON wire form is the `/Link@1`-tagged envelope `{ "/Link@1": <payload> }`; see
+Section 3 of `3-json-encoding.md` for the wire encoding, and the migration table
+in Section 4 for how legacy link forms (the IPLD sigil `{ "/": { "link@1": … }
+}`) map onto it.
 
 ```typescript
 // Shown for illustration only.
@@ -1356,37 +1342,32 @@ export class FabricLink extends BaseFabricInstance {
 
 `bigint` is a JavaScript primitive (`typeof x === 'bigint'`), not an object. It
 rides through the `FabricValue` layer directly, like `undefined`. No
-`FabricBigInt` wrapper class is needed. The codec layer handles
-`bigint` with a standalone codec (`BigIntCodec`, analogous to
-`UndefinedCodec` — there is no owned class to host a `[CODEC]`); see
-Section 4.5.
+`FabricBigInt` wrapper class is needed. The codec layer handles `bigint` with a
+standalone codec (`BigIntCodec`, analogous to `UndefinedCodec` — there is no
+owned class to host a `[CODEC]`); see Section 4.5.
 
 #### 1.4.14 Design Notes
 
 > **Why wrapper classes instead of inline encoder branches?** Each wrapper
 > genuinely implements `FabricInstance` and hosts its own `[CODEC]`, so the
-> codec system dispatches every wrapper through the same uniform
-> codec path as any other fabric class — no per-type branches in the
-> encoder. This gives the codec layer a uniform, simpler
-> structure: it handles codec-dispatched values and the structural types
-> (arrays, objects, primitives), with no knowledge of specific native JS
-> types.
+> codec system dispatches every wrapper through the same uniform codec path as
+> any other fabric class — no per-type branches in the encoder. This gives the
+> codec layer a uniform, simpler structure: it handles codec-dispatched values
+> and the structural types (arrays, objects, primitives), with no knowledge of
+> specific native JS types.
 >
-> **Decoding returns the wrapper.** The `FabricError` codec's
-> `decode()` returns
+> **Decoding returns the wrapper.** The `FabricError` codec's `decode()` returns
 > a `FabricError`, not a raw `Error`. This is consistent with the three-layer
-> separation: the middle layer (`FabricValue`) contains wrappers, not raw
-> native objects. Code that needs the underlying native type uses
+> separation: the middle layer (`FabricValue`) contains wrappers, not raw native
+> objects. Code that needs the underlying native type uses
 > `nativeFromFabricValue()` (Section 8) as a separate step.
 >
-> **File organization.** Each `FabricInstance` and `FabricPrimitive` class
-> lives in its own file: the `FabricInstance` subclasses (including the
-> native object wrappers `FabricError`, `FabricMap`, `FabricSet`
-> and the explicit-tag-value family) under
-> `packages/data-model/fabric-instances/`; the `FabricPrimitive`
-> subclasses (`FabricEpochNsec`, `FabricEpochDay`, `FabricHash`,
-> `FabricBytes`, `FabricRegExp`) under
-> `packages/data-model/fabric-primitives/`.
+> **File organization.** Each `FabricInstance` and `FabricPrimitive` class lives
+> in its own file: the `FabricInstance` subclasses (including the native object
+> wrappers `FabricError`, `FabricMap`, `FabricSet` and the explicit-tag-value
+> family) under `packages/data-model/fabric-instances/`; the `FabricPrimitive`
+> subclasses (`FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricBytes`,
+> `FabricRegExp`) under `packages/data-model/fabric-primitives/`.
 
 ### 1.5 Recursive Containers
 
@@ -1404,7 +1385,8 @@ Section 4.5.
 - Elements may be `undefined` (a first-class `FabricValue`; see Section 1.3)
 - Sparse arrays (arrays with holes) are supported; holes are distinct from
   `undefined` and are represented using run-length encoding in serialized forms
-  (see below and Section 3 of `3-json-encoding.md` for the specific JSON encoding)
+  (see below and Section 3 of `3-json-encoding.md` for the specific JSON
+  encoding)
 - Non-index keys cause rejection, `length` aside: named (string-keyed) and
   symbol-keyed properties alike, whether or not they are enumerable
 - Every present index must hold a *data* property: an accessor-backed
@@ -1414,24 +1396,24 @@ Section 4.5.
   enumeration-driven copying
 
 > **Holes vs. `undefined`.** A hole (sparse slot) is distinct from an
-> explicitly-set `undefined` element. Given `const a = [1, , 3]`, index `1` is
-> a hole — `1 in a` is `false`. Given `const b = [1, undefined, 3]`, index `1`
-> is an explicit `undefined` — `1 in b` is `true`. Both must round-trip
-> faithfully:
+> explicitly-set `undefined` element. Given `const a = [1, , 3]`, index `1` is a
+> hole — `1 in a` is `false`. Given `const b = [1, undefined, 3]`, index `1` is
+> an explicit `undefined` — `1 in b` is `true`. Both must round-trip faithfully:
 >
 > - Explicit `undefined` elements have a dedicated tagged representation in
 >   serialized forms (distinct from `null`).
 > - Holes have their own tagged representation, using run-length encoding:
 >   each hole entry carries a positive integer count of consecutive holes.
 >
-> On decoding, hole entries are decoded as true holes (absent
-> indices in the resulting array, not `undefined` assignments), preserving the
-> `in`-operator distinction. See Section 3 of `3-json-encoding.md` for the specific JSON encodings.
+> On decoding, hole entries are decoded as true holes (absent indices in the
+> resulting array, not `undefined` assignments), preserving the `in`-operator
+> distinction. See Section 3 of `3-json-encoding.md` for the specific JSON
+> encodings.
 
-> **Array encoding strategy.** Even when an array contains holes, it is
-> encoded as an array (not an object or other structure). Runs of consecutive
-> holes are replaced by a single hole marker carrying the run length, preserving
-> the array structure while efficiently encoding sparse arrays. See Section 3 of
+> **Array encoding strategy.** Even when an array contains holes, it is encoded
+> as an array (not an object or other structure). Runs of consecutive holes are
+> replaced by a single hole marker carrying the run length, preserving the array
+> structure while efficiently encoding sparse arrays. See Section 3 of
 > `3-json-encoding.md` for the specific JSON encoding and examples.
 
 **Objects:**
@@ -1441,21 +1423,22 @@ Section 4.5.
   prototype has no representation as object content, so accepting one could
   only mean dropping it silently. A record therefore has exactly one shape,
   the one the natural syntax produces
-- Keys must be strings; symbol-keyed *properties* cause rejection (this
-  is distinct from symbol *values*, which are admitted per Section 1.2
-  with the runtime restriction in Section 1.3)
+- Keys must be strings; symbol-keyed *properties* cause rejection (this is
+  distinct from symbol *values*, which are admitted per Section 1.2 with the
+  runtime restriction in Section 1.3)
 - Every property must be an enumerable *data* property: an accessor-backed
   (getter and/or setter) property causes rejection, because an accessor is
   live code rather than an inert value, and a non-enumerable key causes
   rejection because it has no representation as a property name in
   name-driven copying or encoding
-- Values must be valid `FabricValue`s; properties whose value is `undefined` are preserved
-  (not omitted) — `undefined` is a first-class value, not a signal for deletion
+- Values must be valid `FabricValue`s; properties whose value is `undefined` are
+  preserved (not omitted) — `undefined` is a first-class value, not a signal for
+  deletion
 - **Host restriction, not a model rule:** the property names `__proto__` and
   `constructor` cause rejection in the JavaScript implementation. See the
   callout below
-- Decoding produces regular plain objects, which is the only object
-  shape a `FabricValue` has
+- Decoding produces regular plain objects, which is the only object shape a
+  `FabricValue` has
 
 > **Property names this implementation reserves.** A `FabricPlainObject`'s keys
 > are strings, and the model attaches no meaning to any particular one: a
@@ -1464,8 +1447,8 @@ Section 4.5.
 > neither of which is a limit of the language, and both of which are removable.
 >
 > `__proto__` cannot be rebuilt by the copying this implementation performs.
-> Records are decoded at each boundary — conversion, cloning, decoding —
-> by assignment (`target[key] = value`) and `Object.assign()`, and for this name
+> Records are decoded at each boundary — conversion, cloning, decoding — by
+> assignment (`target[key] = value`) and `Object.assign()`, and for this name
 > both reach `Object.prototype`'s accessor rather than creating a property: the
 > value is dropped, and the copy's prototype is repointed as well when that
 > value is an object or `null`. Mechanisms that carry the name faithfully do
@@ -1512,13 +1495,12 @@ so.
 
 **Conversion is decided separately from encoding, and refuses a cycle.**
 `fabricFromNativeValue()` builds a `FabricValue` out of native data, and will
-not
-build one containing a cycle; it preserves shared references, so the converted
-form for a given original is reused and structural sharing survives. That is a
-third answer under the same rule, not an exception to it: membership admits a
-cycle -- `isValidFabricValue()` handles one and returns `true` -- while this
-entry point declines to construct one. A value holding a cycle therefore reaches
-the model by being built directly rather than converted.
+not build one containing a cycle; it preserves shared references, so the
+converted form for a given original is reused and structural sharing survives.
+That is a third answer under the same rule, not an exception to it: membership
+admits a cycle -- `isValidFabricValue()` handles one and returns `true` -- while
+this entry point declines to construct one. A value holding a cycle therefore
+reaches the model by being built directly rather than converted.
 
 Note that preserving shared references means preserving _structure_: the same
 encoded subtree appears at each position it appeared at. Whether the decoded
@@ -1538,27 +1520,27 @@ one.
 ### 2.1 Overview
 
 Types that the system controls opt into storability by implementing members
-keyed by well-known symbols. This allows the system to encode and
-decode custom types without central registration at the type level.
+keyed by well-known symbols. This allows the system to encode and decode custom
+types without central registration at the type level.
 
 The protocol has two complementary halves:
 
 - The **instance protocol** (Section 2.3) covers in-process lifecycle: deep
   freezing and cloning. Its members live on each instance.
-- The **codec protocol** (Section 2.4) covers encoding: each class hosts
-  a `FabricCodec` — an encoder-decoder object that is the **single source of
-  truth** for how instances of that class are encoded — as a static
-  getter keyed by the `CODEC` symbol.
+- The **codec protocol** (Section 2.4) covers encoding: each class hosts a
+  `FabricCodec` — an encoder-decoder object that is the **single source of
+  truth** for how instances of that class are encoded — as a static getter keyed
+  by the `CODEC` symbol.
 
 This split deliberately separates wire-format concerns from live in-process
 representation: the codec vocabulary lives in its own module area
 (`codec-interface/`), separate again from the machinery that reads it
-(`codec-common/`), and the dependency-free `interface.ts` carries no
-codec machinery at all. Two motivations drove this shape: the seam
-between `FabricValue`'s encoding/decoding and the JSON-layer serialization
-had grown rough and needed harmonizing, and the previous design had no clean
-affordance for legacy-data migration/import (see the decode-only tag
-discussion in Section 2.4).
+(`codec-common/`), and the dependency-free `interface.ts` carries no codec
+machinery at all. Two motivations drove this shape: the seam between
+`FabricValue`'s encoding/decoding and the JSON-layer serialization had grown
+rough and needed harmonizing, and the previous design had no clean affordance
+for legacy-data migration/import (see the decode-only tag discussion in Section
+2.4).
 
 ### 2.2 Symbols
 
@@ -1785,33 +1767,32 @@ export abstract class BaseFabricInstance extends FabricInstance {
 }
 ```
 
-> **Why an abstract class, not an interface?** An abstract class is what
-> lets `shallowClone()` be an effectively-final template method (on
-> `BaseFabricInstance`),
-> encapsulating the frozenness-management contract (clone-if-necessary,
-> freeze-if-requested) in one place. Concrete subclasses implement only
-> `[SHALLOW_UNFROZEN_CLONE]()` (the type-specific copy logic) plus the
-> deep-freeze pair; encoding lives on the class's `[CODEC]`
-> (Section 2.4). Brand detection uses `instanceof FabricInstance` directly
-> — no type guard function is needed (see Section 2.6).
+> **Why an abstract class, not an interface?** An abstract class is what lets
+> `shallowClone()` be an effectively-final template method (on
+> `BaseFabricInstance`), encapsulating the frozenness-management contract
+> (clone-if-necessary, freeze-if-requested) in one place. Concrete subclasses
+> implement only `[SHALLOW_UNFROZEN_CLONE]()` (the type-specific copy logic)
+> plus the deep-freeze pair; encoding lives on the class's `[CODEC]` (Section
+> 2.4). Brand detection uses `instanceof FabricInstance` directly — no type
+> guard function is needed (see Section 2.6).
 
 > **Why a separate `BaseFabricInstance`?** Keeping `FabricInstance` pure
-> abstract (no implementations) gives the protocol surface a clean,
-> minimal definition for external consumers: the api-layer mirror in
-> `packages/api/` exposes `FabricInstance` with its protocol members as
-> abstract declarations, and `BaseFabricInstance` stays an internal
-> implementation detail of the data-model package. External code written
-> against `FabricInstance` is therefore stable against changes to the
-> template-method scaffolding, and the `instanceof FabricInstance` brand
-> check still catches every concrete `FabricInstance` value.
+> abstract (no implementations) gives the protocol surface a clean, minimal
+> definition for external consumers: the api-layer mirror in `packages/api/`
+> exposes `FabricInstance` with its protocol members as abstract declarations,
+> and `BaseFabricInstance` stays an internal implementation detail of the
+> data-model package. External code written against `FabricInstance` is
+> therefore stable against changes to the template-method scaffolding, and the
+> `instanceof FabricInstance` brand check still catches every concrete
+> `FabricInstance` value.
 
 ### 2.4 Codec Protocol
 
-Encoding participation is class-level, not instance-level: a class
-hosts a **codec** — an encoder-decoder object implementing
-`FabricCodec<Encoded>` — as a static getter keyed by a well-known symbol. The
-codec is the **single source of truth** for how instances of that class are
-encoded; nothing about encoding lives on the instances themselves.
+Encoding participation is class-level, not instance-level: a class hosts a
+**codec** — an encoder-decoder object implementing `FabricCodec<Encoded>` — as a
+static getter keyed by a well-known symbol. The codec is the **single source of
+truth** for how instances of that class are encoded; nothing about encoding
+lives on the instances themselves.
 
 `Encoded` is the domain a codec's essential state lives in, and it divides
 codecs into two kinds. A **nonterminal** codec's state is made of
@@ -1835,11 +1816,11 @@ symbol a class binds under is a separate question from the kind. Binding
 terminal codec can never make that claim, since its state is in one format's
 domain, so a class binding here supplies a nonterminal one. Nothing enforces
 that: a registry refuses only a codec extending neither base, so a terminal
-codec bound here is accepted and its state reaches the wire unexpanded. A class the formats
-want to treat differently — in the state produced, in the kind of codec, or
-both — binds one per format under that format's own symbol instead, such as
-`JSON_CODEC` for the JSON wire format, and what it supplies there may be of
-either kind.
+codec bound here is accepted and its state reaches the wire unexpanded. A class
+the formats want to treat differently — in the state produced, in the kind of
+codec, or both — binds one per format under that format's own symbol instead,
+such as `JSON_CODEC` for the JSON wire format, and what it supplies there may be
+of either kind.
 
 So the symbol tracks whether the formats agree about the class, while the kind
 is settled per (class, format). `FabricRegExp` shows both halves at once: it
@@ -2071,10 +2052,10 @@ naming any particular format.
 Key contracts:
 
 - **Codecs are shallow.** `encode()` returns one layer of essential state
-  without recursing into nested values; `decode()` receives state whose
-  nested values have already been decoded. The codec engine owns
-  recursion and tag-wrapping (Section 4.5), which keeps the format
-  mechanics in one place rather than spread across every codec.
+  without recursing into nested values; `decode()` receives state whose nested
+  values have already been decoded. The codec engine owns recursion and
+  tag-wrapping (Section 4.5), which keeps the format mechanics in one place
+  rather than spread across every codec.
 - **`canDecode()` runs before every decode.** The engine asks it of each state
   it is about to dispatch, so a state reaches `decode()` only once that codec
   has accepted it and is of the type that method declares. A refusal is a
@@ -2082,24 +2063,23 @@ Key contracts:
   `lenient` exactly as it settles one the codec raises from inside the
   decoding (Section 4.5).
 - **`decode()` is codec-side, not constructor-side**, for two reasons: it
-  receives a `LiveEnvironment` (Section 2.5) which shouldn't be
-  mandated in a constructor signature, and it may return an existing
-  instance (interning) rather than creating a new one — essential for
-  types like `Cell` where identity matters.
-- **`recognizedTypeTag` vs. `decode()`'s `typeTag` parameter.** The former
-  is the single tag a codec is *registered* under; the latter is whatever
-  tag the value *actually carried* on the wire. They usually agree, but
-  the distinction is deliberate: a registry can route a legacy or
-  alternate tag to an equivalent codec (a decode-only hookup), which is
-  the affordance for legacy-data migration/import. The canonical tag
-  constants (`CODEC_TYPE_TAGS`, `codec-interface/codec-type-tags.ts`)
-  reserve a section for exactly such decode-only "non-primary versions"
-  of classes (e.g., a future `Map@2` decoding into the same class as
-  `Map@1`).
-- **The wire surface is explicit and curated.** Which classes participate
-  in encoding is determined by curated `codecClasses()` lists (one
-  each in `fabric-primitives/` and `fabric-instances/`), not by ad-hoc
-  registration scattered across the codebase. See Section 4.5.
+  receives a `LiveEnvironment` (Section 2.5) which shouldn't be mandated in a
+  constructor signature, and it may return an existing instance (interning)
+  rather than creating a new one — essential for types like `Cell` where
+  identity matters.
+- **`recognizedTypeTag` vs. `decode()`'s `typeTag` parameter.** The former is
+  the single tag a codec is *registered* under; the latter is whatever tag the
+  value *actually carried* on the wire. They usually agree, but the distinction
+  is deliberate: a registry can route a legacy or alternate tag to an equivalent
+  codec (a decode-only hookup), which is the affordance for legacy-data
+  migration/import. The canonical tag constants (`CODEC_TYPE_TAGS`,
+  `codec-interface/codec-type-tags.ts`) reserve a section for exactly such
+  decode-only "non-primary versions" of classes (e.g., a future `Map@2` decoding
+  into the same class as `Map@1`).
+- **The wire surface is explicit and curated.** Which classes participate in
+  encoding is determined by curated `codecClasses()` lists (one each in
+  `fabric-primitives/` and `fabric-instances/`), not by ad-hoc registration
+  scattered across the codebase. See Section 4.5.
 
 ### 2.5 Live Environment
 
@@ -2164,10 +2144,9 @@ if (value instanceof FabricInstance) {
 No dedicated type guard function is needed.
 
 > **Why `instanceof` rather than a property-brand check.** `FabricInstance`
-> being an abstract class, `instanceof` is both the natural check and the
-> more robust one: a property-brand test such as `DECONSTRUCT in value`
-> admits any object that happens to carry that property without extending
-> the base class.
+> being an abstract class, `instanceof` is both the natural check and the more
+> robust one: a property-brand test such as `DECONSTRUCT in value` admits any
+> object that happens to carry that property without extending the base class.
 
 ### 2.7 Example: Temperature (Illustrative)
 
@@ -2268,33 +2247,31 @@ class Temperature extends BaseFabricInstance {
 }
 ```
 
-> **Runtime validation in `canDecode()`.** `TemperatureCodec.canDecode()`
-> above is what lets `decode()` read `state.value` and `state.unit`
-> without a cast: the state has been through encoding and decoding and need
-> not conform to any TypeScript type until something checks it at run time.
-> Every codec owes that check, and `canDecode()` is where the cheap part of it
-> goes. See Section 7.4 for the full rationale.
+> **Runtime validation in `canDecode()`.** `TemperatureCodec.canDecode()` above
+> is what lets `decode()` read `state.value` and `state.unit` without a cast:
+> the state has been through encoding and decoding and need not conform to any
+> TypeScript type until something checks it at run time. Every codec owes that
+> check, and `canDecode()` is where the cheap part of it goes. See Section 7.4
+> for the full rationale.
 
-**Why the protocol matters.** Without the codec protocol, the encoding
-system would see a `Temperature` as an opaque object and either reject it or
-flatten it into `{ value: 100, unit: "C" }`. With the protocol, the
-codec system:
+**Why the protocol matters.** Without the codec protocol, the encoding system
+would see a `Temperature` as an opaque object and either reject it or flatten it
+into `{ value: 100, unit: "C" }`. With the protocol, the codec system:
 
 1. Finds the class's codec (via the registry; Section 4.5) and calls
    `codec.encode(value, env)` to extract the essential state.
-2. Encodes that state (recursively handling any nested `FabricValue`s)
-   and wraps it with the tag from `codec.tagForValue(value)`.
+2. Encodes that state (recursively handling any nested `FabricValue`s) and wraps
+   it with the tag from `codec.tagForValue(value)`.
 3. On decoding, routes the tag back to the codec, asks
    `codec.canDecode(state)`, and calls `codec.decode(tag, state, env)` for a
    state it accepts, producing a real `Temperature` instance with its methods
    intact.
 
-**Reference types and `LiveEnvironment`.** The `Temperature` example
-above is a simple value type -- its codec's `decode()` creates a fresh
-instance each time. Reference types (such as the runtime's internal `Cell`
-type) use the `LiveEnvironment` parameter to look up or intern
-existing instances, ensuring that two references to the same logical entity
-decode to the same object.
+**Reference types and `LiveEnvironment`.** The `Temperature` example above is a
+simple value type -- its codec's `decode()` creates a fresh instance each time.
+Reference types (such as the runtime's internal `Cell` type) use the
+`LiveEnvironment` parameter to look up or intern existing instances, ensuring
+that two references to the same logical entity decode to the same object.
 
 ### 2.8 Encoded State and Recursion
 
@@ -2302,26 +2279,25 @@ The value returned by a codec's `encode()` can contain any value that is
 itself a `FabricValue` — including other `FabricInstance`s (such as native
 object wrappers), primitives, and plain objects/arrays.
 
-**The codec system handles recursion, not the individual codecs.**
-An `encode()` implementation returns one shallow layer of essential state
-without recursively encoding nested values. The codec does not have access
-to the codec machinery — by design, as it would be a layering
-violation.
+**The codec system handles recursion, not the individual codecs.** An `encode()`
+implementation returns one shallow layer of essential state without recursively
+encoding nested values. The codec does not have access to the codec machinery —
+by design, as it would be a layering violation.
 
 Similarly, `decode()` receives state where nested values have already been
-decoded by the codec system. Importantly, `decode()` returns the
-**wrapper type**, not the raw native type. For example, the `FabricError`
-codec produces a `FabricError` instance, not a raw `Error`. Unwrapping to
-native types is a separate step via `nativeFromFabricValue()` (Section 8).
+decoded by the codec system. Importantly, `decode()` returns the **wrapper
+type**, not the raw native type. For example, the `FabricError` codec produces a
+`FabricError` instance, not a raw `Error`. Unwrapping to native types is a
+separate step via `nativeFromFabricValue()` (Section 8).
 
 ### 2.9 Decode Guarantees
 
 The system follows an **immutable-forward** design:
 
-- **Plain objects and arrays** are frozen (`Object.freeze()`) upon
-  decoding. This applies to all decoding output paths, including
-  `/quote` (Section 6 of `3-json-encoding.md`) — the freeze is a property of the decoding
-  boundary, not of whether type-tag decoding occurred.
+- **Plain objects and arrays** are frozen (`Object.freeze()`) upon decoding.
+  This applies to all decoding output paths, including `/quote` (Section 6 of
+  `3-json-encoding.md`) — the freeze is a property of the decoding boundary, not
+  of whether type-tag decoding occurred.
 - **`FabricInstance`s** should ideally be frozen as well — this is the north
   star, though not yet a strict requirement.
 - Decoding always produces regular plain objects, that being the only
@@ -2331,17 +2307,16 @@ This immutability guarantee enables safe sharing of decoded values and
 aligns with the reactive system's assumption that values don't mutate in place.
 
 > **Immutability of native object wrappers.** Under the three-layer
-> architecture, decoding produces `FabricInstance` wrappers
-> (`FabricMap`, `FabricSet`, etc.), not raw native types. Because the
-> system controls the shape of these wrapper classes, they can be properly
-> frozen with `Object.freeze()` — unlike the native types they wrap (e.g.,
-> `Object.freeze()` on a `Map` does not prevent mutation via `set()`/`delete()`).
-> The underlying native objects stored inside wrappers (e.g.,
-> `FabricMap.map`) are not directly exposed to consumers of `FabricValue`
-> — callers who need the native types use `nativeFromFabricValue()`
-> (Section 8), which returns `FrozenMap` and `FrozenSet`
-> (effectively-immutable wrappers) for collection types, preserving the
-> immutability guarantee even after unwrapping.
+> architecture, decoding produces `FabricInstance` wrappers (`FabricMap`,
+> `FabricSet`, etc.), not raw native types. Because the system controls the
+> shape of these wrapper classes, they can be properly frozen with
+> `Object.freeze()` — unlike the native types they wrap (e.g., `Object.freeze()`
+> on a `Map` does not prevent mutation via `set()`/`delete()`). The underlying
+> native objects stored inside wrappers (e.g., `FabricMap.map`) are not directly
+> exposed to consumers of `FabricValue` — callers who need the native types use
+> `nativeFromFabricValue()` (Section 8), which returns `FrozenMap` and
+> `FrozenSet` (effectively-immutable wrappers) for collection types, preserving
+> the immutability guarantee even after unwrapping.
 
 ### 2.10 Encode Input Contract
 
@@ -2424,17 +2399,16 @@ an instance holding one could not be encoded to anything readable.
 
 A rendering is deliberately not a conversion — a string plainly reads as a
 description of a value rather than the value, which is the honest answer where
-fidelity is not on offer.
-Each class hosts its own `[CODEC]`, and the two are shaped differently for the
-reason above.
+fidelity is not on offer. Each class hosts its own `[CODEC]`, and the two are
+shaped differently for the reason above.
 
 `UnknownValue`'s codec is a deliberate "snowflake": it declares **no
 `recognizedTypeTag`** (its instances each carry a per-instance tag, which
 `tagForValue()` reads back), so it is not registered for tag-based decode
-dispatch — an unrecognized tag reaches it through the engine's
-unknown-tag arm instead (Section 4.5). Its `encode()` returns the preserved
-**bare `state`** (not an envelope), so an instance round-trips to the *same*
-storage form as the value it stands in for.
+dispatch — an unrecognized tag reaches it through the engine's unknown-tag arm
+instead (Section 4.5). Its `encode()` returns the preserved **bare `state`**
+(not an envelope), so an instance round-trips to the *same* storage form as the
+value it stands in for.
 
 `ProblematicValue`'s codec is ordinary: it declares `Problematic@1`, is
 tag-routed on decode like any other, and its `encode()` returns a record of the
@@ -2536,11 +2510,11 @@ export class UnknownValue extends BaseFabricInstance {
 
 ### 3.4 Behavior
 
-- When the codec system encounters an unknown type tag during
-  decoding, it constructs an `UnknownValue` directly from the
-  original tag and (already-decoded) state. (The unknown-tag arm is the
-  one decode path that does not route through a registered codec — there
-  is, by definition, none to route to.)
+- When the codec system encounters an unknown type tag during decoding, it
+  constructs an `UnknownValue` directly from the original tag and
+  (already-decoded) state. (The unknown-tag arm is the one decode path that does
+  not route through a registered codec — there is, by definition, none to route
+  to.)
 - When re-encoding an `UnknownValue`, its codec's `tagForValue()` reads
   back the preserved tag and `encode()` returns the preserved bare state,
   reproducing the original wire format byte-for-byte.
@@ -2549,11 +2523,10 @@ export class UnknownValue extends BaseFabricInstance {
 ### 3.5 `ProblematicValue` (Recommended)
 
 It is recommended that implementations provide a `ProblematicValue` type,
-analogous to `UnknownValue`, for cases where encoding or decoding fails
-partway through. This allows graceful degradation rather than hard
-failures — for example, a type whose codec `decode()` throws can be
-preserved as a `ProblematicValue` with the original tag, state, and error
-information.
+analogous to `UnknownValue`, for cases where encoding or decoding fails partway
+through. This allows graceful degradation rather than hard failures — for
+example, a type whose codec `decode()` throws can be preserved as a
+`ProblematicValue` with the original tag, state, and error information.
 
 ```typescript
 // Shown for illustration only.
@@ -2686,11 +2659,10 @@ others is worse than one that heals for none. `UnknownValue` is the type that
 heals, and it can because its tag is checked to be a real one.
 
 Whether a decode failure surfaces as a `ProblematicValue` or as a throw is the
-engine's `lenient` setting alone, not the codec's: a strict engine (e.g.,
-tests) raises either form of rejection, while a lenient one (e.g., production
-decoding) degrades either into a value. The exception is this
-class's own codec, whose successful product is a `ProblematicValue` — see
-Section 3.2.
+engine's `lenient` setting alone, not the codec's: a strict engine (e.g., tests)
+raises either form of rejection, while a lenient one (e.g., production decoding)
+degrades either into a value. The exception is this class's own codec, whose
+successful product is a `ProblematicValue` — see Section 3.2.
 
 ---
 
@@ -2698,16 +2670,15 @@ Section 3.2.
 
 ### 4.1 Overview
 
-Classes provide the *capability* to encode via the fabric protocol, but
-they don't own the wire format. A **codec engine** owns the mapping
-between classes and wire format tags, and handles format-specific
-encoding/decoding.
+Classes provide the *capability* to encode via the fabric protocol, but they
+don't own the wire format. A **codec engine** owns the mapping between classes
+and wire format tags, and handles format-specific encoding/decoding.
 
 ### 4.2 Codec Value Types
 
-`JsonCodecEngine` uses an intermediate tree representation during encoding
-and decoding. This type is internal to the JSON implementation — it
-is not part of the public boundary interface.
+`JsonCodecEngine` uses an intermediate tree representation during encoding and
+decoding. This type is internal to the JSON implementation — it is not part of
+the public boundary interface.
 
 ```typescript
 // file: packages/data-model/codec-json/interface.ts
@@ -2741,11 +2712,10 @@ Every engine exposes `encode()` and `decode()`, parameterized by the boundary
 type — `string` for JSON, `Uint8Array` for a binary format. An engine may add a
 pair for a second boundary type, though none does: a second pair over the same
 walk is API a caller can write for itself, and it invites the two forms to
-drift.
-Both are supplied by the base class and are not overridden: they mint the act
-and hand the work to it. An engine is otherwise its configuration — the codec
-registry and the leniency setting — and the two factories that say which act
-classes this format uses.
+drift. Both are supplied by the base class and are not overridden: they mint the
+act and hand the work to it. An engine is otherwise its configuration — the
+codec registry and the leniency setting — and the two factories that say which
+act classes this format uses.
 
 The walk itself, and the format's account of how a container is written down,
 belong to the acts. That is what lets the walk be written without a threaded
@@ -2779,9 +2749,9 @@ abstract class ExampleDecodeAct {
 }
 ```
 
-Minting the act in the base rather than in each engine is what makes
-*per act* structural: an engine cannot hold one across calls, because it
-never gets to decide when one is made.
+Minting the act in the base rather than in each engine is what makes *per act*
+structural: an engine cannot hold one across calls, because it never gets to
+decide when one is made.
 
 `encodedFromSerializedForm()` is where a format checks that what it was
 handed is its own. What arrives there is data off a channel like anything
@@ -2794,29 +2764,28 @@ validates*: it runs before anything has established that the form is this
 format's at all.
 
 The act is what the walk threads from node to node: the caller's
-`LiveEnvironment`, and the values whose encoding or decoding is in
-progress. Holding it per call rather than on the engine is what lets
-a codec reach back through a public entry point while a walk is already
-running — the inner act gets its own bookkeeping instead of corrupting the
-outer one's. A format needing more than the base class knows about, such as a
-wire marker minted per call, subclasses the act and carries it there.
+`LiveEnvironment`, and the values whose encoding or decoding is in progress.
+Holding it per call rather than on the engine is what lets a codec reach back
+through a public entry point while a walk is already running — the inner act
+gets its own bookkeeping instead of corrupting the outer one's. A format needing
+more than the base class knows about, such as a wire marker minted per call,
+subclasses the act and carries it there.
 
 `JsonCodecEngine` supplies both directions at its one boundary type:
 
 - `encode(value, env?)` encodes a `FabricValue` into the `/<Type>@<Version>`
   tagged wire format, then stringifies the result.
-- `decode(data, env)` parses a JSON string, then decodes tagged
-  forms back into runtime types.
+- `decode(data, env)` parses a JSON string, then decodes tagged forms back into
+  runtime types.
 
 A caller wanting bytes encodes the string itself. The format's boundary is the
 string, and a second entry point for the same walk was API without a purpose.
 
-> **Why the boundary is this narrow.** Tag wrapping and unwrapping belong to
-> the acts rather than to an engine's public surface, leaving only
-> `encode(value, env?) -> SerializedForm` and
-> `decode(data, env) -> FabricValue` — as public API. The engine owns the full pipeline rather than
-> the tag step alone, and its public surface says so by exposing no step of
-> it.
+> **Why the boundary is this narrow.** Tag wrapping and unwrapping belong to the
+> acts rather than to an engine's public surface, leaving only `encode(value,
+> env?) -> SerializedForm` and `decode(data, env) -> FabricValue` — as public
+> API. The engine owns the full pipeline rather than the tag step alone, and its
+> public surface says so by exposing no step of it.
 
 ### 4.4 Encode and Decode Flow
 
@@ -2977,9 +2946,9 @@ curated**: fabric classes whose instances have a fixed wire tag supply their
 codec as a static getter, and the curated `codecClasses()` list from each of
 `fabric-primitives/` and `fabric-instances/` is the source of truth for which
 classes participate. Each list is read through the symbol its classes bind —
-`[JSON_CODEC]` for a primitive, `[CODEC]` for an instance — the wire surface is curated there, in one obvious
-place per area, rather than implied by scattered registrations. A caller
-needing classes of its own extends what this returns.
+`[JSON_CODEC]` for a primitive, `[CODEC]` for an instance — the wire surface is
+curated there, in one obvious place per area, rather than implied by scattered
+registrations. A caller needing classes of its own extends what this returns.
 
 | Registration | Codec / type | Tag | Notes |
 |--------------|--------------|-----|-------|
@@ -3013,24 +2982,24 @@ types) are handled by the walker itself after no codec matches.
 
 The encoding act's walk processes the `FabricValue` tree:
 
-1. **Codec dispatch** — `codecFromValue()` finds how to encode the value.
-   A `SELF_REP` result means the value is its own wire form (emitted
-   as-is). A codec result drives the standard tagged encoding: the walker
-   reads the tag via `codec.tagForValue(value)`, gets one shallow layer of
-   state via `codec.encode(value)`, **recursively encodes that state
-   itself**, and wraps the result as `{ "/<tag>": state }`. (The walker
-   uses `tagForValue()` rather than any property of the value, because it
-   is up to the codec — not the value — to determine the correct tag.)
+1. **Codec dispatch** — `codecFromValue()` finds how to encode the value. A
+   `SELF_REP` result means the value is its own wire form (emitted as-is). A
+   codec result drives the standard tagged encoding: the walker reads the tag
+   via `codec.tagForValue(value)`, gets one shallow layer of state via
+   `codec.encode(value)`, **recursively encodes that state itself**, and wraps
+   the result as `{ "/<tag>": state }`. (The walker uses `tagForValue()` rather
+   than any property of the value, because it is up to the codec — not the value
+   — to determine the correct tag.)
 2. **Mandate guard** — a `FabricSpecialObject` that no codec matched is a
    hard error: every fabric class's wire form must be explicitly
    represented by a registered codec.
-3. **Arrays** — encoded element-by-element; sparse arrays use
-   run-length encoded `hole` entries (Section 1.5).
-4. **Plain objects** — encoded key-by-key, iterating keys in UTF-8 byte
-   order (matching the canonical key order used by hashing; see Section 10
-   of `3-json-encoding.md`), making the encoding deterministic across
-   insertion orders; `/object` / `/quote` escaping applied per Section 6
-   of `3-json-encoding.md`.
+3. **Arrays** — encoded element-by-element; sparse arrays use run-length encoded
+   `hole` entries (Section 1.5).
+4. **Plain objects** — encoded key-by-key, iterating keys in UTF-8 byte order
+   (matching the canonical key order used by hashing; see Section 10 of
+   `3-json-encoding.md`), making the encoding deterministic across insertion
+   orders; `/object` / `/quote` escaping applied per Section 6 of
+   `3-json-encoding.md`.
 
 Circular references are detected via a `Set<object>` tracked during the walk.
 
@@ -3055,27 +3024,25 @@ The decoding act's walk processes the `JsonCodecValue` tree:
 4. **Codec dispatch** — `codecFromTag()` routes the tag to its registered
    codec's `decode()`, and settles the codec's verdict against `lenient`:
    leniently, a throw becomes a `ProblematicValue`; strictly, a
-   `ProblematicValue` the codec returned becomes a throw. Values returned
-   from this arm
-   are guaranteed deep-frozen at the walker boundary (the contract holds
-   for both the codec-produced value and the lenient-mode
+   `ProblematicValue` the codec returned becomes a throw. Values returned from
+   this arm are guaranteed deep-frozen at the walker boundary (the contract
+   holds for both the codec-produced value and the lenient-mode
    `ProblematicValue`), so callers need not each freeze. Every other arm
-   guarantees the same, the unknown-tag arm (step 5) included, so a caller
-   need not ask which arm produced what it was handed. See Section 8.6 for
-   the full deep-freeze protocol and the egress-freezing call sites.
+   guarantees the same, the unknown-tag arm (step 5) included, so a caller need
+   not ask which arm produced what it was handed. See Section 8.6 for the full
+   deep-freeze protocol and the egress-freezing call sites.
 5. **Unknown tags** — a syntactically valid tag with no registered codec
    produces an `UnknownValue` wrapping the tag and (already-decoded) state,
    preserving the form for round-tripping (Section 3). Syntax is what
    separates this from step 3: a tag names a type nothing here knows,
    whereas a non-tag names nothing at all.
 6. **Primitives** — pass through.
-7. **Arrays** — recursively decoded; `hole` entries decoded as
-   true holes (absent indices).
-8. **Plain objects** — recursively decoded; output frozen. Any
-   `/`-prefixed key in a plain (non-single-key-tagged) object is reserved, as
-   is any name this runtime reserves: rather than silently round-trip it, the
-   walker rejects it, settled against `lenient` as in step 3 (Section 9 of
-   `3-json-encoding.md`).
+7. **Arrays** — recursively decoded; `hole` entries decoded as true holes
+   (absent indices).
+8. **Plain objects** — recursively decoded; output frozen. Any `/`-prefixed key
+   in a plain (non-single-key-tagged) object is reserved, as is any name this
+   runtime reserves: rather than silently round-trip it, the walker rejects it,
+   settled against `lenient` as in step 3 (Section 9 of `3-json-encoding.md`).
 
 > **Where a tag comes from.** There is no tag→class registry: a concrete type
 > decodes through its own codec, and a tag no codec claims falls straight to
@@ -3083,8 +3050,8 @@ The decoding act's walk processes the `JsonCodecValue` tree:
 > `recognizedTypeTag` or whatever `tagForValue()` returns for the specific
 > value. Only `UnknownValue` carries a per-instance `wireTypeTag` that its
 > `tagForValue()` reads back, holding a tag whose codec is unknown.
-> `ProblematicValue` preserves a tag too, but encodes under `Problematic@1`
-> and carries the preserved one as data, that tag being possibly no tag at all
+> `ProblematicValue` preserves a tag too, but encodes under `Problematic@1` and
+> carries the preserved one as data, that tag being possibly no tag at all
 > (Section 3.2).
 
 > **Why the walks belong to an act.** `encodeValue()` and `decodeValue()` are
@@ -3116,8 +3083,8 @@ The boundaries where encoding occurs:
 | **Network sync** | `toolshed` <-> remote peers | WebSocket/HTTP |
 | **Cross-space** | space A <-> space B | if in separate processes |
 
-Each boundary uses a codec engine appropriate to its format and
-version requirements.
+Each boundary uses a codec engine appropriate to its format and version
+requirements.
 
 > **Note:** The `html` package reconciler (`html/src/worker/reconciler.ts`)
 > calls `convertCellsToLinks` in a web worker context. Threading encoding
@@ -3282,8 +3249,8 @@ construction.
 ### 6.3 Suggested Tag Bytes
 
 The following single-byte type tags are used by the hash byte format and are
-recommended for any binary encoding of `FabricValue`s. They are
-organized into four categories by high nibble:
+recommended for any binary encoding of `FabricValue`s. They are organized into
+four categories by high nibble:
 
 **Meta tags (`0x0N`)** — structural markers that are not themselves value types:
 
@@ -3333,8 +3300,8 @@ regardless of nibble range.
 
 > **Scope.** These tag bytes are defined here for use by any wire format that
 > needs to distinguish `FabricValue` types at the byte level. The hash byte
-> format (`2-hash-byte-format.md`) is the first consumer; future binary
-> encoding formats may reuse the same tag assignments.
+> format (`2-hash-byte-format.md`) is the first consumer; future binary encoding
+> formats may reuse the same tag assignments.
 
 ### 6.4 Hashing Algorithm
 
@@ -3497,9 +3464,9 @@ export function hashOf(value: unknown): FabricHash {
 > (`2-hash-byte-format.md`, Section 4.4) for the precise encoding.
 
 > **Map/Set ordering in hashing.** Hashing preserves insertion order for
-> `FabricMap` entries and `FabricSet` elements, matching the serialized
-> form. This means two `FabricMap`s or `FabricSet`s with the same elements
-> in different insertion order will hash differently. This is intentional:
+> `FabricMap` entries and `FabricSet` elements, matching the serialized form.
+> This means two `FabricMap`s or `FabricSet`s with the same elements in
+> different insertion order will hash differently. This is intentional:
 > insertion order is part of the observable semantics of `Map`/`Set` in
 > JavaScript, so values that behave differently should not hash the same. (By
 > contrast, plain objects are hashed with sorted keys, matching the existing
@@ -3509,9 +3476,9 @@ export function hashOf(value: unknown): FabricHash {
 
 Hashing operates on `FabricValue` directly, using codec-encoded state for
 `FabricInstance`s (including the native object wrappers; via `codecOf()`,
-Section 2.4) and type-specific handling for primitives and containers.
-This makes identity hashing independent of any particular wire encoding —
-the same hash whether later serialized to JSON, CBOR, or Automerge.
+Section 2.4) and type-specific handling for primitives and containers. This
+makes identity hashing independent of any particular wire encoding — the same
+hash whether later serialized to JSON, CBOR, or Automerge.
 
 ### 6.6 Use Cases
 
@@ -3584,8 +3551,8 @@ boundary-only encoding and the three-layer architecture:
    (Section 8).
 4. Add `nativeFromFabricValue()` for unwrapping back to native types
    (Section 8).
-5. Remove early conversion points (e.g., `convertCellsToLinks()`,
-   legacy `Error` wrapping as `{ "@Error": ... }`).
+5. Remove early conversion points (e.g., `convertCellsToLinks()`, legacy `Error`
+   wrapping as `{ "@Error": ... }`).
 6. Introduce a codec engine at each boundary (Section 4.7).
 7. Update internal code to work with `FabricValue` types rather than JSON
    shapes or raw native objects.
@@ -3596,10 +3563,10 @@ boundary-only encoding and the three-layer architecture:
 > by carrying one. An object bearing `toJSON` is read as the record it is, so
 > the method itself is an ordinary member — a function, which no record may
 > hold. Anything that needs a representation of its own implements the fabric
-> protocol (`FabricInstance` + `[CODEC]`); anything that a caller wants
-> encoded on its way in is that caller's to encode before it reaches the
-> conversion. Honoring `toJSON()` would eagerly convert to JSON-compatible
-> shapes, which is incompatible with late serialization.
+> protocol (`FabricInstance` + `[CODEC]`); anything that a caller wants encoded
+> on its way in is that caller's to encode before it reaches the conversion.
+> Honoring `toJSON()` would eagerly convert to JSON-compatible shapes, which is
+> incompatible with late serialization.
 
 ### 7.2 Unifying JSON Encoding
 
@@ -3645,10 +3612,9 @@ from the very rule that gives `/` its meaning.
 | `$stream` marker | Streams (`runner/src/builder/types.ts`) | `{ "$stream": true }` | `{ "/Stream@1": null }` |
 
 > **Note on `$stream`:** `$stream` is a stateless marker — it signals that a
-> cell path is a stream endpoint rather than carrying decodable state.
-> Under the unified encoding it becomes `{ "/Stream@1": null }` (a stateless
-> tagged type per Section 5 of `3-json-encoding.md`), preserving its marker
-> semantics.
+> cell path is a stream endpoint rather than carrying decodable state. Under the
+> unified encoding it becomes `{ "/Stream@1": null }` (a stateless tagged type
+> per Section 5 of `3-json-encoding.md`), preserving its marker semantics.
 
 > **The link-ref envelope has a named owner.** `sigil-types.ts` states that the
 > envelope and its tag belong to `data-model/cell-rep`, the chokepoint that
@@ -3672,14 +3638,13 @@ from the very rule that gives `/` its meaning.
 > callers.
 
 > **On counting what remains.** A bare search for `$`-prefixed tokens badly
-> overstates the residue: JSON Schema keywords (`$ref`, `$defs`, `$schema`),
-> CFC datalog variables (`{ var: "$s" }` and kin), and Pattern authoring
-> vocabulary (`$UI`, `$NAME`, `$TYPE`) all match and none are on this arc — the
-> datalog variables alone outnumber `$stream` several times over. Any figure
-> quoted for this work should come from a classified count, and a count of
-> occurrences measures distance from the end state rather than the effort to
-> close it, since it does not distinguish a live wire path from a debugging or
-> inspection one.
+> overstates the residue: JSON Schema keywords (`$ref`, `$defs`, `$schema`), CFC
+> datalog variables (`{ var: "$s" }` and kin), and Pattern authoring vocabulary
+> (`$UI`, `$NAME`, `$TYPE`) all match and none are on this arc — the datalog
+> variables alone outnumber `$stream` several times over. Any figure quoted for
+> this work should come from a classified count, and a count of occurrences
+> measures distance from the end state rather than the effort to close it, since
+> it does not distinguish a live wire path from a debugging or inspection one.
 
 ### 7.3 Replacing CID-Based Hashing
 
@@ -3690,11 +3655,11 @@ on the logical data structure directly.
 
 ### 7.4 Untrusted Decoded Input
 
-**Decoded values must not be trusted for type safety.** After
-encoding and decoding, a value may not conform to the TypeScript
-type that code assumes — the wire format carries no type guarantees, and a
-round-trip through JSON (or any other encoding) can silently produce values
-whose runtime shape does not match their static type.
+**Decoded values must not be trusted for type safety.** After encoding and
+decoding, a value may not conform to the TypeScript type that code assumes — the
+wire format carries no type guarantees, and a round-trip through JSON (or any
+other encoding) can silently produce values whose runtime shape does not match
+their static type.
 
 This applies at every point where decoded data is consumed:
 
@@ -3706,8 +3671,8 @@ This applies at every point where decoded data is consumed:
   predicate over the codec's own state type, and the engine asking it of every
   state before dispatch is what makes the narrower `state` parameter `decode()`
   declares true rather than asserted. `decode()` keeps the checks whose only
-  implementation is the decoding itself.
-  See the note in Section 2.7 for a concrete example.
+  implementation is the decoding itself. See the note in Section 2.7 for a
+  concrete example.
 
 - **JSON-side codec decoding** (Section 3 of `3-json-encoding.md`) must
   validate the format of its state before processing. Malformed input must
@@ -3716,9 +3681,9 @@ This applies at every point where decoded data is consumed:
   returning a `ProblematicValue`, and the engine settles all three against its
   `lenient` setting (Section 4.5).
 
-- **Hashing** (Section 6.3) may operate on values that have been
-  through a decoding round-trip. Code that extracts properties from
-  `FabricInstance` values must validate those properties at runtime.
+- **Hashing** (Section 6.3) may operate on values that have been through a
+  decoding round-trip. Code that extracts properties from `FabricInstance`
+  values must validate those properties at runtime.
 
 - **Application code** that reads values from cells, IPC messages, or any other
   boundary listed in Section 4.7 should treat the values as untrusted until
@@ -3817,33 +3782,32 @@ export function fabricFromNativeValue(
 
 > **Implementation: tag-based type dispatch.** The conversion functions use a
 > tag-based dispatch mechanism (`tagFromNativeValue()` in
-> `packages/data-model/native-type-tags.ts`) to classify values in O(1) via a `switch` on
-> the value's constructor. This replaces sequential `instanceof` chains with a
-> single constructor lookup that returns a tag string (e.g., `"Error"`,
-> `"Date"`, `"RegExp"`, `"Array"`, `"Object"`, `"Primitive"`,
-> `"FabricInstance"`). The conversion function then switches on the tag to
-> route to the appropriate wrapping logic. An array is the exception to the
-> constructor lookup: `Array.isArray()` is consulted first and returns
-> `"Array"` unconditionally, so a subclass instance, a severed-prototype array,
-> and a cross-realm array all reach array handling and are handled by the
-> array rule of Section 1.5, rather than being rejected as some unrecognized
-> class or routed elsewhere by something the array carries. Fallback paths
-> handle exotic Error subclasses (via `Error.isError()`) and null-prototype
-> objects. Tagging a null-prototype
-> object `"Object"` classifies more broadly than the type admits, for the same
-> reason the array tag does: it is what lets the object rule of Section 1.5
-> reject the value by name rather than as some unrecognized class.
+> `packages/data-model/native-type-tags.ts`) to classify values in O(1) via a
+> `switch` on the value's constructor. This replaces sequential `instanceof`
+> chains with a single constructor lookup that returns a tag string (e.g.,
+> `"Error"`, `"Date"`, `"RegExp"`, `"Array"`, `"Object"`, `"Primitive"`,
+> `"FabricInstance"`). The conversion function then switches on the tag to route
+> to the appropriate wrapping logic. An array is the exception to the
+> constructor lookup: `Array.isArray()` is consulted first and returns `"Array"`
+> unconditionally, so a subclass instance, a severed-prototype array, and a
+> cross-realm array all reach array handling and are handled by the array rule
+> of Section 1.5, rather than being rejected as some unrecognized class or
+> routed elsewhere by something the array carries. Fallback paths handle exotic
+> Error subclasses (via `Error.isError()`) and null-prototype objects. Tagging a
+> null-prototype object `"Object"` classifies more broadly than the type admits,
+> for the same reason the array tag does: it is what lets the object rule of
+> Section 1.5 reject the value by name rather than as some unrecognized class.
 
 > **Implementation: centralized shallow-clone utility.** The conversion
 > functions use a centralized `cloneIfNecessary()` utility (in
-> `packages/data-model/value-clone.ts`) to handle frozenness adjustment
-> for values that are already valid `FabricValue` but whose freeze state
-> does not match the requested `freeze` argument. This function dispatches on
-> the same native tag to clone primitives (no-op), arrays (shallow copy
-> preserving sparse holes), plain objects (spread copy), and
-> `FabricInstance` values (via the protocol's `shallowClone()` method from
-> Section 2.3). It is the single home for clone-for-frozenness logic, which
-> every conversion call site reaches rather than implementing itself.
+> `packages/data-model/value-clone.ts`) to handle frozenness adjustment for
+> values that are already valid `FabricValue` but whose freeze state does not
+> match the requested `freeze` argument. This function dispatches on the same
+> native tag to clone primitives (no-op), arrays (shallow copy preserving sparse
+> holes), plain objects (spread copy), and `FabricInstance` values (via the
+> protocol's `shallowClone()` method from Section 2.3). It is the single home
+> for clone-for-frozenness logic, which every conversion call site reaches
+> rather than implementing itself.
 
 #### Freeze Semantics
 
@@ -3866,28 +3830,26 @@ after the call returns. (Wrapper objects like `FabricError` are freshly
 constructed by the conversion function, so freezing them is not a mutation of
 caller state.)
 
-**`deepFreeze` at schema merge/combine sites.** The `deepFreeze()` utility
-(in `packages/data-model/deep-freeze.ts`) recursively freezes an object tree in
+**`deepFreeze` at schema merge/combine sites.** The `deepFreeze()` utility (in
+`packages/data-model/deep-freeze.ts`) recursively freezes an object tree in
 place; see Section 8.6 for its full protocol, dispatch shape, and the
-boundary-crossing egress contracts. At sites where schema objects are
-merged or combined (e.g., schema `merge()` and `combine()` functions),
-pass-through paths — where the input is returned as the result without
-structural modification — must copy the value before freezing to avoid
-mutating caller-owned schema objects. The general principle: `deepFreeze()`
-freezes in place, so if the caller retains a reference to a mutable
-object, the function must not freeze that object as a side effect. Callers
-at these sites should copy before freezing rather than relying on the
-input being "safe to freeze."
+boundary-crossing egress contracts. At sites where schema objects are merged or
+combined (e.g., schema `merge()` and `combine()` functions), pass-through paths
+— where the input is returned as the result without structural modification —
+must copy the value before freezing to avoid mutating caller-owned schema
+objects. The general principle: `deepFreeze()` freezes in place, so if the
+caller retains a reference to a mutable object, the function must not freeze
+that object as a side effect. Callers at these sites should copy before freezing
+rather than relying on the input being "safe to freeze."
 
 **Always-frozen types bypass the `freeze` option.** JS primitives (`null`,
 `boolean`, `number`, `string`, `undefined`, `bigint`) are inherently immutable
-and pass through unchanged regardless of the `freeze` setting.
-`FabricPrimitive` instances (`FabricEpochNsec`, `FabricEpochDay`,
-`FabricHash`, `FabricBytes`, `FabricKeyPair`, `FabricRegExp`) are treated the
-same way — they are always returned as-is,
-never copied or modified by the freeze/thaw logic. Their state is immutable by
-construction (readonly fields, no mutation methods), so `Object.freeze()` is
-unnecessary and thawing is meaningless. See Section 1.4.6.
+and pass through unchanged regardless of the `freeze` setting. `FabricPrimitive`
+instances (`FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricBytes`,
+`FabricKeyPair`, `FabricRegExp`) are treated the same way — they are always
+returned as-is, never copied or modified by the freeze/thaw logic. Their state
+is immutable by construction (readonly fields, no mutation methods), so
+`Object.freeze()` is unnecessary and thawing is meaningless. See Section 1.4.6.
 
 If the input is already frozen (or deep-frozen for the deep variant), the same
 object is returned — no defensive copying. This avoids unnecessary allocation
@@ -3965,8 +3927,8 @@ if the value is:
 - A `FabricNativeObject` (`Error`, `Map`, `Set`, `Date`, `RegExp`,
   `Uint8Array`)
 - An array where every present element satisfies
-  `isValidFabricConvertibleValue()`, and
-  which the array rule of Section 1.5 accepts
+  `isValidFabricConvertibleValue()`, and which the array rule of Section 1.5
+  accepts
 - A plain object where every value satisfies `isValidFabricConvertibleValue()`
 
 It returns `false` for unsupported types (`WeakMap`, `Promise`, DOM nodes,
@@ -4036,20 +3998,19 @@ export function nativeFromFabricValue(
 | Arrays | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 | Plain objects | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 
-The output type is `FabricConvertibleValue` (Section 1.2), reflecting
-that the result may contain native JS types at any depth — a container of them
-is neither a `FabricValue` nor a `FabricNativeObject`, so the recursive type is
-what names it.
+The output type is `FabricConvertibleValue` (Section 1.2), reflecting that the
+result may contain native JS types at any depth — a container of them is neither
+a `FabricValue` nor a `FabricNativeObject`, so the recursive type is what names
+it.
 
-> **Implementation: `FabricNativeWrapper` dispatch.** The unwrapping
-> functions use a single `instanceof FabricNativeWrapper` check to identify
-> all native object wrappers, then delegate to `toNativeValue(frozen)` on the
-> base class. This replaces the previous pattern of per-wrapper `instanceof`
-> cascades (`instanceof FabricError`, `instanceof FabricMap`, etc.) with
-> a single branch. The `toNativeValue()` method (defined on
-> `FabricNativeWrapper`, Section 1.4.1) handles the freeze-state check and
-> delegates to the subclass's `toNativeFrozen()` or `toNativeThawed()` when a
-> state change is needed.
+> **Implementation: `FabricNativeWrapper` dispatch.** The unwrapping functions
+> use a single `instanceof FabricNativeWrapper` check to identify all native
+> object wrappers, then delegate to `toNativeValue(frozen)` on the base class.
+> This replaces the previous pattern of per-wrapper `instanceof` cascades
+> (`instanceof FabricError`, `instanceof FabricMap`, etc.) with a single branch.
+> The `toNativeValue()` method (defined on `FabricNativeWrapper`, Section 1.4.1)
+> handles the freeze-state check and delegates to the subclass's
+> `toNativeFrozen()` or `toNativeThawed()` when a state change is needed.
 
 **The `frozen` parameter is always honored.** The freeze state of every value in
 the output tree matches the `frozen` argument. Specifically:
@@ -4070,37 +4031,35 @@ need no freeze/thaw action. A new object is constructed only when the freeze
 state differs between the stored value and the requested output.
 
 **Recurses into `FabricError` internals.** The function recurses into
-`FabricError` internals —
-specifically, the `cause` chain and custom enumerable properties — unwrapping any
-nested `FabricInstance` values. This ensures the output is fully "native JS"
-with no fabric wrappers at any depth. Without this recursion, an Error's
-`cause` could still contain `FabricInstance` wrappers (e.g., a nested
-`FabricError`).
+`FabricError` internals — specifically, the `cause` chain and custom enumerable
+properties — unwrapping any nested `FabricInstance` values. This ensures the
+output is fully "native JS" with no fabric wrappers at any depth. Without this
+recursion, an Error's `cause` could still contain `FabricInstance` wrappers
+(e.g., a nested `FabricError`).
 
-> **Why `FrozenMap` / `FrozenSet`?** `Object.freeze()` does not prevent
-> mutation of `Map` and `Set` — their `set()`, `delete()`, `add()`, and
-> `clear()` methods remain callable on a frozen instance. `FrozenMap` and
-> `FrozenSet` are thin wrappers that expose the read-only subset of the
-> `Map`/`Set` API (`get`, `has`, `entries`, `forEach`, `size`, etc.) and throw
-> on any mutation attempt. This ensures that data round-tripped through the
-> fabric layer remains effectively immutable even after unwrapping. The exact
-> API of `FrozenMap` and `FrozenSet` is an implementation decision.
+> **Why `FrozenMap` / `FrozenSet`?** `Object.freeze()` does not prevent mutation
+> of `Map` and `Set` — their `set()`, `delete()`, `add()`, and `clear()` methods
+> remain callable on a frozen instance. `FrozenMap` and `FrozenSet` are thin
+> wrappers that expose the read-only subset of the `Map`/`Set` API (`get`,
+> `has`, `entries`, `forEach`, `size`, etc.) and throw on any mutation attempt.
+> This ensures that data round-tripped through the fabric layer remains
+> effectively immutable even after unwrapping. The exact API of `FrozenMap` and
+> `FrozenSet` is an implementation decision.
 
 > **Why `FabricPrimitive` subclasses pass through unchanged.**
 > `FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricBytes`,
 > `FabricKeyPair`, and `FabricRegExp` are all `FabricPrimitive` subclasses —
-> always frozen at construction time with no mutable state. Most have no
-> native equivalent to unwrap to (unlike `FabricError` → `Error` or
-> `FabricMap` → `Map`). Where one does exist it is reached through a member —
+> always frozen at construction time with no mutable state. Most have no native
+> equivalent to unwrap to (unlike `FabricError` → `Error` or `FabricMap` →
+> `Map`). Where one does exist it is reached through a member —
 > `FabricRegExp.value`, `FabricKeyPair.cryptoKeyPair` — rather than by
 > unwrapping, so the unwrap function returns every one of them as-is.
 
-> **Why `FabricBytes` owns its input.** `FabricBytes` is a
-> `FabricPrimitive` — always frozen at construction time, holding bytes no
-> other code can reach. `FabricBytes` has no native equivalent to unwrap to,
-> so it is the byte representation rather than a wrapper around one. Callers
-> who need raw bytes use `slice()`, `sliceBuffer()`, or `copyInto()` on the
-> instance directly.
+> **Why `FabricBytes` owns its input.** `FabricBytes` is a `FabricPrimitive` —
+> always frozen at construction time, holding bytes no other code can reach.
+> `FabricBytes` has no native equivalent to unwrap to, so it is the byte
+> representation rather than a wrapper around one. Callers who need raw bytes
+> use `slice()`, `sliceBuffer()`, or `copyInto()` on the instance directly.
 
 ### 8.5 Round-Trip Guarantees
 
@@ -4118,10 +4077,10 @@ the output always matches the `frozen` argument**: when `frozen` is `true` (the
 default), the output tree is fully frozen — arrays and plain objects are frozen
 via `Object.freeze()`, a mutable `Map` becomes a `FrozenMap`, a mutable `Set`
 becomes a `FrozenSet`, every `FabricPrimitive` (`FabricEpochNsec`,
-`FabricEpochDay`, `FabricHash`, `FabricBytes`, `FabricKeyPair`,
-`FabricRegExp`) passes through unchanged, and `Error`s are frozen. When `frozen` is `false`, the output tree is
-fully mutable. The data content is preserved; the mutability matches the `frozen`
-argument.
+`FabricEpochDay`, `FabricHash`, `FabricBytes`, `FabricKeyPair`, `FabricRegExp`)
+passes through unchanged, and `Error`s are frozen. When `frozen` is `false`, the
+output tree is fully mutable. The data content is preserved; the mutability
+matches the `frozen` argument.
 
 Similarly, for any `FabricValue` `sv`:
 
@@ -4140,14 +4099,14 @@ across the four kinds of values that can appear in a `FabricValue` tree.
 
 #### Instance protocol members
 
-Every concrete `FabricInstance` provides the three members below
-(Section 2.3). Their declarations are split by concern: the freeze-protocol
-members `[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` are declared on
-`BaseFabricInstance` — the abstract base that concrete instance classes extend
-— keeping this implementation plumbing off the pure-protocol `FabricInstance`
-interface, while `deepClone()` and the inherited `shallowClone()` are declared
-on `FabricInstance` itself. These members, plus the class-side `[CODEC]`
-(encoding; Section 2.4), are the whole instance protocol:
+Every concrete `FabricInstance` provides the three members below (Section 2.3).
+Their declarations are split by concern: the freeze-protocol members
+`[DEEP_FREEZE]` and `[IS_DEEP_FROZEN]` are declared on `BaseFabricInstance` —
+the abstract base that concrete instance classes extend — keeping this
+implementation plumbing off the pure-protocol `FabricInstance` interface, while
+`deepClone()` and the inherited `shallowClone()` are declared on
+`FabricInstance` itself. These members, plus the class-side `[CODEC]` (encoding;
+Section 2.4), are the whole instance protocol:
 
 - **`[DEEP_FREEZE](subFreeze)`** — Deeply freezes this instance in place
   and returns it. The implementation freezes the instance's own internal
@@ -4158,18 +4117,17 @@ on `FabricInstance` itself. These members, plus the class-side `[CODEC]`
   is introduced.
 
 - **`[IS_DEEP_FROZEN](subIsDeepFrozen)`** — Side-effect-free sibling of
-  `[DEEP_FREEZE]`: returns `true` if this instance's own internal slot(s)
-  are in canonical deep-frozen form and every nested `FabricValue`
-  (visited via the `subIsDeepFrozen` callback) is also deep-frozen.
-  An instance that is not in canonical deep-frozen form returns `false`;
-  the check must not throw.
+  `[DEEP_FREEZE]`: returns `true` if this instance's own internal slot(s) are in
+  canonical deep-frozen form and every nested `FabricValue` (visited via the
+  `subIsDeepFrozen` callback) is also deep-frozen. An instance that is not in
+  canonical deep-frozen form returns `false`; the check must not throw.
 
 - **`deepClone(frozen)`** — Returns a new deep clone of this instance with
-  equivalent data but no shared structure for any unfrozen data in the
-  original. When `frozen === true`, produces a frozen instance with
-  maximal structural sharing (including returning `this` if already
-  deep-frozen). When `frozen === false`, produces a deeply-mutable
-  instance with no visible shared reference structure with the original.
+  equivalent data but no shared structure for any unfrozen data in the original.
+  When `frozen === true`, produces a frozen instance with maximal structural
+  sharing (including returning `this` if already deep-frozen). When `frozen ===
+  false`, produces a deeply-mutable instance with no visible shared reference
+  structure with the original.
 
 The `subFreeze` / `subIsDeepFrozen` callbacks (rather than direct utility
 imports) keep the protocol layering clean and let the outer utility thread
@@ -4177,13 +4135,12 @@ its shared cycle-detection state through implementations transparently.
 
 #### `deepFreeze()` and the 4-arm dispatch
 
-The generic top-level utility (`packages/data-model/deep-freeze.ts`)
-recursively freezes a `FabricValue` in place. It dispatches on four arms
-in order:
+The generic top-level utility (`packages/data-model/deep-freeze.ts`) recursively
+freezes a `FabricValue` in place. It dispatches on four arms in order:
 
-1. **Necessarily- or already-known-deep-frozen value** — primitives
-   (`null` and `typeof !== "object"`) and objects already recorded in the
-   internal deep-frozen cache. Short-circuits unchanged.
+1. **Necessarily- or already-known-deep-frozen value** — primitives (`null` and
+   `typeof !== "object"`) and objects already recorded in the internal
+   deep-frozen cache. Short-circuits unchanged.
 
 2. **`FabricPrimitive` instance** — `FabricPrimitive` subclasses
    (`FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricBytes`,
@@ -4193,13 +4150,12 @@ in order:
    two `FabricBytes`, but privately, and each froze itself in its own
    constructor.)
 
-3. **`FabricInstance`** — Delegates to the instance's `[DEEP_FREEZE]`
-   member with a `subFreeze` callback that recurses back through the same
-   utility, threading the shared cycle-detection state. The dispatch
-   gates on `instanceof` against the abstract base; it does not enumerate
-   concrete subclasses. The (now deep-frozen) result is recorded in the
-   deep-frozen cache so subsequent `isDeepFrozen()` checks short-circuit
-   in O(1).
+3. **`FabricInstance`** — Delegates to the instance's `[DEEP_FREEZE]` member
+   with a `subFreeze` callback that recurses back through the same utility,
+   threading the shared cycle-detection state. The dispatch gates on
+   `instanceof` against the abstract base; it does not enumerate concrete
+   subclasses. The (now deep-frozen) result is recorded in the deep-frozen cache
+   so subsequent `isDeepFrozen()` checks short-circuit in O(1).
 
 4. **Plain object or array** — Recurses into children, then freezes the
    container with `Object.freeze()`. Arrays preserve sparse holes. The
@@ -4221,15 +4177,15 @@ of `deepFreeze()`. It mirrors the same arm shape:
 3. `FabricInstance` instances delegate to their `[IS_DEEP_FROZEN]` member
    with a `subIsDeepFrozen` callback that recurses back through the same
    guard.
-4. Plain objects and arrays must be `Object.isFrozen` and have every
-   child accepted by the guard.
+4. Plain objects and arrays must be `Object.isFrozen` and have every child
+   accepted by the guard.
 
 Visited objects are tracked in a per-call `Set` for cycle safety.
 
 #### Egress-freezing call sites
 
-The deep-freeze contract is enforced at the points where decoded
-values cross from internal codec machinery to callers:
+The deep-freeze contract is enforced at the points where decoded values cross
+from internal codec machinery to callers:
 
 - **Every value the decode walker returns is deep-frozen at the boundary**,
   whichever arm produced it. The arms reach that by two routes. A leaf arm
@@ -4247,18 +4203,18 @@ values cross from internal codec machinery to callers:
   each call site, so a caller reaching it outside the walker gets the same
   guarantee.
 
-- **`JsonCodecValue` parse boundary.** The `parseWireText()` helper
-  (invoked by `decode()`) deep-freezes the parsed tree
-  before handing it to the decode walker. This is what makes the
-  decode-side `JsonCodecValue` invariant load-bearing: tag-unwrap and
-  the `/quote` arm can hand back extracted sub-trees directly without
-  further copying because the input tree is already deep-frozen.
+- **`JsonCodecValue` parse boundary.** The `parseWireText()` helper (invoked by
+  `decode()`) deep-freezes the parsed tree before handing it to the decode
+  walker. This is what makes the decode-side `JsonCodecValue` invariant
+  load-bearing: tag-unwrap and the `/quote` arm can hand back extracted
+  sub-trees directly without further copying because the input tree is already
+  deep-frozen.
 
 - **Codec `decode()` implementations honoring `shouldDeepFreeze`.** When a
-  decode call's `LiveEnvironment.shouldDeepFreeze` is
-  `true` (Section 2.5; the safe default), each codec `decode()`
-  implementation produces a deep-frozen result (typically via the
-  instance's own `[DEEP_FREEZE]`, recursing through `deepFreeze()`).
+  decode call's `LiveEnvironment.shouldDeepFreeze` is `true` (Section 2.5; the
+  safe default), each codec `decode()` implementation produces a deep-frozen
+  result (typically via the instance's own `[DEEP_FREEZE]`, recursing through
+  `deepFreeze()`).
 
 - **`deepFreeze()` at schema merge/combine sites.** See Section 8.2.
 
@@ -4288,12 +4244,12 @@ spec from being implementable.
   (sequencing of flag introductions, criteria for graduating each flag to
   default-on) will be addressed in a separate document.
 
-- **`LiveEnvironment` extensibility**: The minimal interface defined in
-  Section 2.5 covers `Cell` decoding. Other future fabric types may
-  need additional environment methods. Should the interface be extended, or should
-  types cast to a broader interface? Recommendation: extend the interface as
-  needed; the indirection through an interface (rather than depending on
-  `Runtime` directly) makes this straightforward.
+- **`LiveEnvironment` extensibility**: The minimal interface defined in Section
+  2.5 covers `Cell` decoding. Other future fabric types may need additional
+  environment methods. Should the interface be extended, or should types cast to
+  a broader interface? Recommendation: extend the interface as needed; the
+  indirection through an interface (rather than depending on `Runtime` directly)
+  makes this straightforward.
 
 - **`getRaw()` / `setRaw()` middle-layer contract**: Emerging consensus is
   that `Cell.getRaw()` and `Cell.setRaw()` should traffic in `FabricValue`

--- a/docs/specs/space-model-formal-spec/2-hash-byte-format.md
+++ b/docs/specs/space-model-formal-spec/2-hash-byte-format.md
@@ -46,9 +46,9 @@ produce different hashes even though both could be represented as a zero byte).
 The authoritative tag assignments are in formal spec Section 6.3. Tags are
 organized into four categories by high nibble: **meta** (`0x0N`) for structural
 markers like `TAG_END` and `TAG_HOLE`, **compound** (`0x1N`) for containers
-whose children are tagged values, **primitive** (`0x2N`) for leaf value
-types, and **optimized** (`0xFN`) for hash-level encodings of primitive values
-that substitute a digest for the raw payload (see Section 4.4 for the long-string
+whose children are tagged values, **primitive** (`0x2N`) for leaf value types,
+and **optimized** (`0xFN`) for hash-level encodings of primitive values that
+substitute a digest for the raw payload (see Section 4.4 for the long-string
 optimization). All unassigned values are reserved for future use.
 
 ---
@@ -63,8 +63,8 @@ optimization). All unassigned values are reserved for future use.
   arrays) and hole run counts.
 
   Examples: `0` encodes as `0x00` (1 byte); `5` as `0x05` (1 byte); `127` as
-  `0x7F` (1 byte); `128` as `0x80 0x01` (2 bytes); `300` as `0xAC 0x02`
-  (2 bytes).
+  `0x7F` (1 byte); `128` as `0x80 0x01` (2 bytes); `300` as `0xAC 0x02` (2
+  bytes).
 
 - **`TAG_END` sentinel** — compound types (arrays and objects) use `TAG_END`
   (`0x00`) to mark the end of their element or key-value sequence, instead of
@@ -77,8 +77,8 @@ optimization). All unassigned values are reserved for future use.
 
 For each type, the subsections below specify the exact byte sequence fed to the
 SHA-256 context. "Feed" means the bytes are appended to the running hash state
-in order; the overall hash is finalized only after the entire value tree has been
-traversed.
+in order; the overall hash is finalized only after the entire value tree has
+been traversed.
 
 ### 4.1 `null`
 
@@ -133,8 +133,8 @@ four special values that JSON cannot represent natively (`-0`, `NaN`,
   distinct from the `===` operator, under which a `NaN` compares unequal even
   to itself.
 
-> **Conversion-gate cross-reference.** Whether `-0`, `NaN`, or `±Infinity`
-> reach this layer depends on the `FabricValue` conversion gate; see
+> **Conversion-gate cross-reference.** Whether `-0`, `NaN`, or `±Infinity` reach
+> this layer depends on the `FabricValue` conversion gate; see
 > `1-fabric-values.md` Section 4.9. The byte-level encoding above is the
 > hasher's contract regardless of how the values arrived.
 
@@ -186,16 +186,15 @@ the byte stream fed to the outer hasher and enables a string-representation
 cache keyed by the JavaScript string. Because the two encodings use different
 type tags (`0x24` vs. `0xF0`), they are unambiguous and cannot collide.
 
-**The two forms produce different hashes for the same string.** The
-64-byte threshold is part of the format, and conforming implementations
-must use the threshold when deciding which form to emit.
+**The two forms produce different hashes for the same string.** The 64-byte
+threshold is part of the format, and conforming implementations must use the
+threshold when deciding which form to emit.
 
 The hashed form applies everywhere this spec encodes a string via the
-`TAG_STRING` layout: standalone strings (this section), `symbol` keys
-(Section 4.6), object keys (Section 4.13), `FabricInstance` type tags
-(Section 4.14), `FabricHash` algorithm tags (Section 4.11),
-`FabricRegExp` source/flags/flavor strings (Section 4.16), and
-`FabricKeyPair` algorithm names (Section 4.17).
+`TAG_STRING` layout: standalone strings (this section), `symbol` keys (Section
+4.6), object keys (Section 4.13), `FabricInstance` type tags (Section 4.14),
+`FabricHash` algorithm tags (Section 4.11), `FabricRegExp` source/flags/flavor
+strings (Section 4.16), and `FabricKeyPair` algorithm names (Section 4.17).
 
 ### 4.5 `bigint`
 
@@ -243,10 +242,10 @@ ensures that a `Symbol.for("foo")` and the string `"foo"` produce different
 hashes, while inheriting the short/long string-encoding delegation
 unchanged.
 
-> **Conversion-gate cross-reference.** Whether a symbol value reaches this
-> layer depends on the `FabricValue` conversion gate; see
-> `1-fabric-values.md` Section 4.9. The byte-level encoding above is the
-> hasher's contract regardless of how the value arrived.
+> **Conversion-gate cross-reference.** Whether a symbol value reaches this layer
+> depends on the `FabricValue` conversion gate; see `1-fabric-values.md` Section
+> 4.9. The byte-level encoding above is the hasher's contract regardless of how
+> the value arrived.
 
 ### 4.7 `undefined`
 
@@ -397,13 +396,12 @@ Bytes: TAG_INSTANCE  TYPE_TAG_STRING  STATE
 - **Encoded state**: The value returned by the codec's `encode()`, hashed
   recursively as a complete tagged value.
 
-> **Note on types with dedicated tags.** `FabricBytes`,
-> `FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricRegExp`, and
-> `FabricKeyPair` are **not** hashed via `TAG_INSTANCE`. Each has a dedicated
-> type tag and is encoded directly (see Sections 4.8, 4.9, 4.10, 4.11, 4.16
-> and 4.17 respectively). These are all `FabricPrimitive` subclasses — at this
-> layer they are hashed from their own stored values, not via their wire
-> codecs.
+> **Note on types with dedicated tags.** `FabricBytes`, `FabricEpochNsec`,
+> `FabricEpochDay`, `FabricHash`, `FabricRegExp`, and `FabricKeyPair` are
+> **not** hashed via `TAG_INSTANCE`. Each has a dedicated type tag and is
+> encoded directly (see Sections 4.8, 4.9, 4.10, 4.11, 4.16 and 4.17
+> respectively). These are all `FabricPrimitive` subclasses — at this layer they
+> are hashed from their own stored values, not via their wire codecs.
 
 ### 4.15 Holes (sparse array elements)
 
@@ -514,14 +512,14 @@ the sort order and the hash encoding use the same byte representation.
 >   for U+FFFF).
 >
 > For example, U+10000 (UTF-16: `D800 DC00`; UTF-8: `F0 90 80 80`) sorts
-> *before* U+E000 (UTF-16: `E000`; UTF-8: `EE 80 80`) in UTF-16 code unit
-> order, but *after* it in UTF-8 byte order.
+> *before* U+E000 (UTF-16: `E000`; UTF-8: `EE 80 80`) in UTF-16 code unit order,
+> but *after* it in UTF-8 byte order.
 >
 > For strings containing only BMP characters (U+0000--U+FFFF) — the practical
 > common case for object keys — the two orderings are equivalent. An
-> implementation that needs to match the hash sort order must sort by
-> UTF-8 bytes (or equivalently, by Unicode code point), not by JavaScript's
-> default string comparison, if supplementary characters may appear in keys.
+> implementation that needs to match the hash sort order must sort by UTF-8
+> bytes (or equivalently, by Unicode code point), not by JavaScript's default
+> string comparison, if supplementary characters may appear in keys.
 
 ---
 
@@ -771,14 +769,13 @@ The **boundary case** at exactly 64 UTF-8 bytes uses the direct form, since
 the rule is "64 bytes or fewer → direct". A 65-byte UTF-8 string uses the
 hashed form.
 
-This rule applies to every string the hasher feeds, including standalone
-strings (Section 4.4), `symbol` keys (Section 4.6), object keys (Section
-4.13), `FabricInstance` type tags (Section 4.14), `FabricHash`
-algorithm tags (Section 4.11), `FabricRegExp` source/flags/flavor
-strings (Section 4.16), and `FabricKeyPair` algorithm names
-(Section 4.17). The threshold is evaluated per-string
-independently: an object may mix short keys (direct form) and long keys
-(hashed form) in the same key-value sequence.
+This rule applies to every string the hasher feeds, including standalone strings
+(Section 4.4), `symbol` keys (Section 4.6), object keys (Section 4.13),
+`FabricInstance` type tags (Section 4.14), `FabricHash` algorithm tags (Section
+4.11), `FabricRegExp` source/flags/flavor strings (Section 4.16), and
+`FabricKeyPair` algorithm names (Section 4.17). The threshold is evaluated
+per-string independently: an object may mix short keys (direct form) and long
+keys (hashed form) in the same key-value sequence.
 
 ---
 
@@ -786,18 +783,17 @@ independently: an object may mix short keys (direct form) and long keys
 
 The following JavaScript values must never be passed to the hasher:
 
-- **Unique (uninterned) `Symbol` values** — those for which
-  `Symbol.keyFor(s)` returns `undefined`. Registry-interned symbols
-  (`Symbol.for(key)`) **are** hashable; see Section 4.6. The required
-  error message is `"Cannot hash unique (uninterned) symbol"`.
+- **Unique (uninterned) `Symbol` values** — those for which `Symbol.keyFor(s)`
+  returns `undefined`. Registry-interned symbols (`Symbol.for(key)`) **are**
+  hashable; see Section 4.6. The required error message is `"Cannot hash unique
+  (uninterned) symbol"`.
 - **`Function` values** — opaque closures with no portable representation.
 - **A `FabricKeyPair` holding `CryptoKey` handles** — the keys' material is
   unreachable, so the value has no content to hash; see Section 4.17.
 
-A conforming implementation should throw an error if it encounters any of
-these rather than producing a hash. (`NaN`, `±Infinity`, and `-0` are
-**not** rejected; they have well-defined byte encodings — see Section
-4.3.)
+A conforming implementation should throw an error if it encounters any of these
+rather than producing a hash. (`NaN`, `±Infinity`, and `-0` are **not**
+rejected; they have well-defined byte encodings — see Section 4.3.)
 
 ---
 

--- a/docs/specs/space-model-formal-spec/3-json-encoding.md
+++ b/docs/specs/space-model-formal-spec/3-json-encoding.md
@@ -2,8 +2,8 @@
 
 This document specifies the JSON-compatible wire format used to represent
 `FabricValue`s, including the `fvj1:` encoding prefix, the tagged-object
-convention, escaping mechanisms, codec engine responsibilities, and
-the reservation rules for `/`-prefixed keys.
+convention, escaping mechanisms, codec engine responsibilities, and the
+reservation rules for `/`-prefixed keys.
 
 ## Status
 
@@ -90,11 +90,11 @@ round-trip correctly.
 > **Base64url encoding convention.** All base64-encoded values in the JSON wire
 > format use the URL-safe base64url alphabet (`A-Za-z0-9-_`, per RFC 4648
 > Section 5). Encoders **must omit** trailing `=` padding characters. Decoders
-> **must accept** both padded and unpadded input for compatibility; standard-base64
-> characters (`+`, `/`) are still invalid and must be rejected. This convention
-> applies to `Bytes@1`, `BigInt@1`, `EpochNsec@1`, and `EpochDay@1` state
-> values, to the `hash` field of `Hash@1` state, and to the `publicKey` and
-> `privateKey` fields of `KeyPair@1` state.
+> **must accept** both padded and unpadded input for compatibility;
+> standard-base64 characters (`+`, `/`) are still invalid and must be rejected.
+> This convention applies to `Bytes@1`, `BigInt@1`, `EpochNsec@1`, and
+> `EpochDay@1` state values, to the `hash` field of `Hash@1` state, and to the
+> `publicKey` and `privateKey` fields of `KeyPair@1` state.
 
 The JSON key for a tagged value is the tag with `/` prepended, per Section 2:
 a value under `Link@1` is written `{ "/Link@1": <state> }`. What follows
@@ -240,35 +240,34 @@ See `1-fabric-values.md` Section 3.5.
 > Each codec must reject a state it did not write, rather than silently
 > producing garbage from one — wrong type, invalid format, or missing fields
 > alike. The rejection has two homes, and which one a check belongs in is
-> settled by what asking costs. `canDecode()` holds what is cheap to ask and
-> not already asked by the decoding: that the state is a `string`, that a
-> record carries the fields the decoding reads and that they are strings, that
-> a literal is one of a fixed set. `decode()` holds a check whose only
+> settled by what asking costs. `canDecode()` holds what is cheap to ask and not
+> already asked by the decoding: that the state is a `string`, that a record
+> carries the fields the decoding reads and that they are strings, that a
+> literal is one of a fixed set. `decode()` holds a check whose only
 > implementation is the decoding itself — that a base64url string (such as
-> `BigInt@1`, `EpochNsec@1`, `EpochDay@1`, or `Bytes@1`) is valid base64url
-> is answered by decoding it, so asking first costs that work twice.
+> `BigInt@1`, `EpochNsec@1`, `EpochDay@1`, or `Bytes@1`) is valid base64url is
+> answered by decoding it, so asking first costs that work twice.
 >
 > A codec may reject from `decode()` by throwing, or by returning a
-> `ProblematicValue` (see `1-fabric-values.md` Section 3.5); with a refusal
-> from `canDecode()` that makes three ways, and all three are equivalent,
-> because the engine settles them into one answer according to its own
-> `lenient` setting (see `1-fabric-values.md` Section 4.5). Which one a codec
-> uses is therefore a matter of what reads well where it is written, and
-> carries no meaning for a caller. This principle applies to all codecs. Wire
-> data is untrusted input. See `1-fabric-values.md` Section 7.4 for the
-> broader principle that applies to all code consuming decoded values.
+> `ProblematicValue` (see `1-fabric-values.md` Section 3.5); with a refusal from
+> `canDecode()` that makes three ways, and all three are equivalent, because the
+> engine settles them into one answer according to its own `lenient` setting
+> (see `1-fabric-values.md` Section 4.5). Which one a codec uses is therefore a
+> matter of what reads well where it is written, and carries no meaning for a
+> caller. This principle applies to all codecs. Wire data is untrusted input.
+> See `1-fabric-values.md` Section 7.4 for the broader principle that applies to
+> all code consuming decoded values.
 
 > **Sparse array encoding in JSON.** Even when an array contains holes, it is
-> encoded as a JSON array. Runs of consecutive holes are represented by
-> `hole` entries, each carrying the run length as a positive integer. This
-> preserves the array-as-array structure while efficiently encoding sparse
-> arrays:
+> encoded as a JSON array. Runs of consecutive holes are represented by `hole`
+> entries, each carrying the run length as a positive integer. This preserves
+> the array-as-array structure while efficiently encoding sparse arrays:
 >
-> - `[1, , undefined, 3]` encodes as
->   `[1, { "/hole": 1 }, { "/Undefined@1": null }, 3]`.
+> - `[1, , undefined, 3]` encodes as `[1, { "/hole": 1 }, { "/Undefined@1": null
+>   }, 3]`.
 > - `[1, , , , 5]` encodes as `[1, { "/hole": 3 }, 5]`.
-> - A very sparse array like `a = []; a[1000000] = 'x'` encodes as
->   `[{ "/hole": 1000000 }, "x"]`.
+> - A very sparse array like `a = []; a[1000000] = 'x'` encodes as `[{ "/hole":
+>   1000000 }, "x"]`.
 
 ## 4. Detection
 
@@ -278,18 +277,18 @@ built-in escape, or an encoding error.
 
 > **Data level vs. wire level.** User-data plain objects may carry any keys,
 > including `/`-prefixed ones. The `/object` and `/quote` escapes (Section 6)
-> exist precisely to represent such objects in encoded form without ambiguity.
-> A conforming encoder always wraps user-data objects that contain `/`-prefixed
-> keys via one of these escapes before they reach the wire, so bare
-> `/`-prefixed keys in the wire format are always encoding signals, never
-> literal user-data keys.
+> exist precisely to represent such objects in encoded form without ambiguity. A
+> conforming encoder always wraps user-data objects that contain `/`-prefixed
+> keys via one of these escapes before they reach the wire, so bare `/`-prefixed
+> keys in the wire format are always encoding signals, never literal user-data
+> keys.
 
 > **JS implementation note.** "Any keys" is the format's rule and this
 > implementation does not yet meet it: a plain object carrying `__proto__` or
-> `constructor` is refused rather than encoded, on both sides of the wire and
-> in the inert check that decides what a `FabricValue` is at all. Neither name
-> is reserved by the format, and neither is a limit of JavaScript. Both are
-> about copying: this implementation rebuilds a record by assignment, which for
+> `constructor` is refused rather than encoded, on both sides of the wire and in
+> the inert check that decides what a `FabricValue` is at all. Neither name is
+> reserved by the format, and neither is a limit of JavaScript. Both are about
+> copying: this implementation rebuilds a record by assignment, which for
 > `__proto__` reaches a prototype accessor instead of creating a property, and
 > other boundaries here already drop `constructor`. An implementation on a host
 > that does not route property assignment through a prototype chain reserves no
@@ -335,9 +334,8 @@ are still processed normally during decoding:
 { "/object": { "/myKey": { "/Link@1": { "id": "..." } } } }
 ```
 
-Decodes to: `{ "/myKey": <decoded Link> }`. The `/object` wrapper
-is stripped; inner keys are taken literally; inner values go through normal
-decoding.
+Decodes to: `{ "/myKey": <decoded Link> }`. The `/object` wrapper is stripped;
+inner keys are taken literally; inner values go through normal decoding.
 
 A state under this tag that is **not** a plain object is malformed wire data,
 and is refused rather than unwrapped — settled against `lenient` like any
@@ -353,23 +351,23 @@ makes the wire output most readable, not a correctness requirement.
 
 ### `/quote` — Fully Literal
 
-Wraps a value that should be returned exactly as-is, with no decoding
-of any nested special forms:
+Wraps a value that should be returned exactly as-is, with no decoding of any
+nested special forms:
 
 ```json
 { "/quote": { "/Link@1": { "id": "..." } } }
 ```
 
-Decodes to: `{ "/Link@1": { "id": "..." } }` — the inner structure is
-*not* decoded. It remains a plain object.
+Decodes to: `{ "/Link@1": { "id": "..." } }` — the inner structure is *not*
+decoded. It remains a plain object.
 
 **Freeze guarantee.** Although `/quote` skips type-tag interpretation, the
 result is still deep-frozen (arrays and plain objects within the quoted value
 are frozen via `Object.freeze()`). The immutability guarantee (see
-`1-fabric-values.md` Section 2.9) is a property of decoding output, not
-of whether decoding occurred. A caller receiving a value from the
-engine's `decode()` can always assume it is immutable, regardless of whether
-it came from a `/quote` path, a decoded type, or a plain literal.
+`1-fabric-values.md` Section 2.9) is a property of decoding output, not of
+whether decoding occurred. A caller receiving a value from the engine's
+`decode()` can always assume it is immutable, regardless of whether it came from
+a `/quote` path, a decoded type, or a plain literal.
 
 Use cases:
 - Storing schemas or examples that describe special types without instantiating
@@ -413,8 +411,8 @@ properties a decoder preserves regardless of which form it sees.
 The JSON engine generates and parses `/<Type>@<Version>` keys. It is also
 responsible for:
 
-- Owning recursion and tag-wrapping around the shallow per-type codecs
-  (see `1-fabric-values.md` Sections 2.4 and 4.5): tags come from
+- Owning recursion and tag-wrapping around the shallow per-type codecs (see
+  `1-fabric-values.md` Sections 2.4 and 4.5): tags come from
   `codec.tagForValue(value)` on encode, and decode routes each tag to its
   registered codec via the `CodecRegistry`.
 - Re-wrapping unknown types using the per-instance `wireTypeTag` preserved
@@ -515,20 +513,20 @@ including:
 > of the order in which their keys were inserted. This in turn lets two
 > independently-built encoders agree on a single byte-for-byte encoding for the
 > same logical value, which simplifies content addressing, deduplication, and
-> diffing. The sort key is the same UTF-8 byte order used by hashing, so the
-> two systems share one specification of "canonical key order."
+> diffing. The sort key is the same UTF-8 byte order used by hashing, so the two
+> systems share one specification of "canonical key order."
 >
 > The keys of a single-key tagged object (`/<Type>@<Version>`, `/object`,
-> `/quote`, `/hole`, etc.) are trivially "sorted" — there is only one key.
-> The requirement is meaningful only for plain objects with two or more keys,
-> and for the inner contents of `/object` and `/quote` wrappers.
+> `/quote`, `/hole`, etc.) are trivially "sorted" — there is only one key. The
+> requirement is meaningful only for plain objects with two or more keys, and
+> for the inner contents of `/object` and `/quote` wrappers.
 
 > **JS implementation note.** JavaScript's native string comparison (`<`, `>`,
 > `Array.prototype.sort` with no comparator) sorts by UTF-16 code units, which
 > differs from UTF-8 byte order when supplementary characters (U+10000 and
-> above) are present. An implementation must use a UTF-8-aware comparator
-> (or equivalently, sort by Unicode code point) when supplementary characters
-> may appear in keys. See `2-hash-byte-format.md` Section 5 for the detailed
+> above) are present. An implementation must use a UTF-8-aware comparator (or
+> equivalently, sort by Unicode code point) when supplementary characters may
+> appear in keys. See `2-hash-byte-format.md` Section 5 for the detailed
 > rationale and example.
 
 > **Decoder behavior.** A decoder is **not** required to validate that incoming

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -170,10 +170,10 @@ existence before the walk starts, and none of them can be the marker. **The
 confinement requirement is what makes the argument hold without resting on
 that.** An encoder is handed values by callers, not by the type system; a value
 carrying live code — an accessor that runs mid-walk, after the marker exists —
-is outside the model, and confinement means such a value still has
-nowhere to read the marker from. It is stated as a requirement rather than
-left to inertness because a rule that fails open on out-of-model input is not
-worth much.
+is outside the model, and confinement means such a value still has nowhere to
+read the marker from. It is stated as a requirement rather than left to
+inertness because a rule that fails open on out-of-model input is not worth
+much.
 
 A marker held across calls fails the first of these. A value may legitimately
 contain a subtree of some *earlier* encoding — the code that assembled it is
@@ -343,12 +343,11 @@ own. A decoder tells the two apart by the type in the key slots.
 That second state is the reason this format admits `CryptoKey` at all. A
 non-extractable key's material is reachable through no synchronous call and, by
 construction, through no call whatever, so a format that writes bytes down
-cannot represent one: the JSON encoding refuses a pair in that state
-(Section 3 of [3-json-encoding.md](./3-json-encoding.md), under `KeyPair@1`)
-and its hash is
-undefined (Section 4.17 of
-[2-hash-byte-format.md](./2-hash-byte-format.md)). Here the key crosses as
-itself, which is what the transport requirement in Section 1.1 asks for.
+cannot represent one: the JSON encoding refuses a pair in that state (Section 3
+of [3-json-encoding.md](./3-json-encoding.md), under `KeyPair@1`) and its hash
+is undefined (Section 4.17 of [2-hash-byte-format.md](./2-hash-byte-format.md)).
+Here the key crosses as itself, which is what the transport requirement in
+Section 1.1 asks for.
 
 Types binding a format-neutral codec — `FabricError`, `UnknownValue`,
 `ProblematicValue`, and every `FabricInstance` — encode the same way under both
@@ -523,12 +522,13 @@ This is a requirement rather than an observation. An implementation that
 coerced instead would satisfy every other claim in this document while
 producing values a sender never sent.
 
-**Do not guard against shapes the transport cannot deliver.** `structuredClone()`
-normalizes what it carries: a plain object arrives with `Object.prototype`
-however its original was made, an `Array` subclass arrives as a plain `Array`,
-and an accessor arrives as a data property. A check for a null-prototype record, an
-exotic array, or a getter-backed index is therefore unreachable, and reads to a
-later maintainer as though the boundary defended against something it does not.
+**Do not guard against shapes the transport cannot deliver.**
+`structuredClone()` normalizes what it carries: a plain object arrives with
+`Object.prototype` however its original was made, an `Array` subclass arrives as
+a plain `Array`, and an accessor arrives as a data property. A check for a
+null-prototype record, an exotic array, or a getter-backed index is therefore
+unreachable, and reads to a later maintainer as though the boundary defended
+against something it does not.
 
 What the transport *does* carry faithfully is an array's extra own properties,
 which arrive intact. Nothing here emits one, which is what rules them out --

--- a/docs/specs/space-model-formal-spec/README.md
+++ b/docs/specs/space-model-formal-spec/README.md
@@ -1,9 +1,9 @@
 # Space Model Formal Spec: Data Model
 
 This directory contains the formal specification for the Space Model data model.
-It is derived from the proposal sections of the original
-[data model spec](../space-model/1-data-model.md), reformulated as a
-self-contained, implementable specification.
+It is derived from the proposal sections of the original [data model
+spec](../space-model/1-data-model.md), reformulated as a self-contained,
+implementable specification.
 
 ## Scope
 
@@ -14,8 +14,8 @@ This spec covers:
   `[CODEC]` or `[JSON_CODEC]` -- yielding a `FabricCodec`) for custom type
   participation in encoding
 - **Unknown types** (Section 3) -- forward-compatibility via `UnknownValue`
-- **Codec engines** (Section 4) -- boundary-crossing encoding
-  strategy, the `encode()`/`decode()` boundary, and boundary inventory
+- **Codec engines** (Section 4) -- boundary-crossing encoding strategy, the
+  `encode()`/`decode()` boundary, and boundary inventory
 - **JSON encoding** -- the `fvj1:` encoding prefix, the `/<Type>@<Version>`
   wire format for special types, escaping, detection rules, and the `/`-key
   reservation rule
@@ -34,8 +34,8 @@ system, schemas.
   three-layer architecture, the fabric protocol, unknown types, encoding
   contexts, hashing, implementation guidance, and conversion functions.
   (Sections 1-4, 6-8.)
-- [2-hash-byte-format.md](./2-hash-byte-format.md) --
-  Byte-level encoding for the hash algorithm.
+- [2-hash-byte-format.md](./2-hash-byte-format.md) -- Byte-level encoding for
+  the hash algorithm.
 - [3-json-encoding.md](./3-json-encoding.md) -- The JSON wire format for
   `FabricValue`s: the `fvj1:` encoding prefix, `/<Type>@<Version>` tagged
   objects, standard type encodings, detection, escaping, and the `/`-key

--- a/packages/data-model/src/SchemaAndHash.ts
+++ b/packages/data-model/src/SchemaAndHash.ts
@@ -4,13 +4,13 @@ import { isDeepFrozen } from "./deep-freeze.ts";
 import type { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 
 /**
- * Deep-frozen container pairing a `JSONSchema` with its content hash.
- * Ensures that schemas are always stored in their canonical deep-frozen
- * form and that the hash is computed once.
+ * Deep-frozen container pairing a `JSONSchema` with its content hash. Ensures
+ * that schemas are always stored in their canonical deep-frozen form and that
+ * the hash is computed once.
  *
- * To create instances, use `internSchema()` from `schema-hash.ts` —
- * it handles freezing, hashing, and caching. The constructor is public
- * for direct use when both the frozen schema and hash are already in hand.
+ * To create instances, use `internSchema()` from `schema-hash.ts` — it handles
+ * freezing, hashing, and caching. The constructor is public for direct use when
+ * both the frozen schema and hash are already in hand.
  *
  * This class accepts `undefined` as its "schema" upon construction as a
  * concession to making the schema intern mechanism work straightforwardly with
@@ -24,10 +24,10 @@ export class SchemaAndHash {
   readonly #hash: FabricHash;
 
   /**
-   * Constructs an instance, from an already-deep-frozen schema and
-   * its pre-computed hash. Throws if the schema is not deep-frozen.
-   * Prefer `internSchema()` from `schema-hash.ts` for the friendly entry
-   * point that handles freezing, hashing, and interning.
+   * Constructs an instance, from an already-deep-frozen schema and its
+   * pre-computed hash. Throws if the schema is not deep-frozen. Prefer
+   * `internSchema()` from `schema-hash.ts` for the friendly entry point that
+   * handles freezing, hashing, and interning.
    */
   constructor(schema: JSONSchema | undefined, hash: FabricHash) {
     if (!isDeepFrozen(schema)) {

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -114,10 +114,10 @@ export const LINK_V1_TAG = "link@1" as const;
 
 /**
  * A link reference, wrapping a link payload. Its concrete shape is
- * flag-dispatched: with the modern cell representation _off_ it is the plain
- * `{ "/": { "link@1": … } }` envelope; with it _on_ it is a
- * {@link FabricLink} instance. This is the link analog of
- * {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}.
+ * flag-dispatched: with the modern cell representation _off_ it is the plain `{
+ * "/": { "link@1": … } }` envelope; with it _on_ it is a {@link FabricLink}
+ * instance. This is the link analog of {@link EntityRef}'s `{ "/": string }` →
+ * {@link FabricHash}.
  *
  * Construction ({@link linkRefFrom}), recognition ({@link isLinkRef}) and
  * extraction ({@link linkRefPayload}) are gathered here so this chokepoint is
@@ -127,11 +127,10 @@ export const LINK_V1_TAG = "link@1" as const;
  *
  * `Payload` is bounded by {@link FabricPlainObject} (the payload is always a
  * stored/serialized one) but otherwise open, so this layer needn't know the
- * exact field types (URI / MemorySpace / JSONSchema — those stay in
- * `runner`). In modern mode the payload type is erased: a {@link FabricLink}
- * holds an unparameterized {@link FabricPlainObject}, just as
- * {@link FabricHash} is unparameterized on the modern arm of
- * {@link EntityRef}.
+ * exact field types (URI / MemorySpace / JSONSchema — those stay in `runner`).
+ * In modern mode the payload type is erased: a {@link FabricLink} holds an
+ * unparameterized {@link FabricPlainObject}, just as {@link FabricHash} is
+ * unparameterized on the modern arm of {@link EntityRef}.
  */
 export type LinkRef<Payload extends FabricPlainObject> =
   | FabricLink
@@ -160,9 +159,9 @@ function isLegacyLinkEnvelope(
 }
 
 /**
- * Recognizes a {@link LinkRef} for the currently active regime: a
- * {@link FabricLink} in modern mode, or the `{ "/": { "link@1": … } }` envelope
- * (no other props) in legacy mode.
+ * Recognizes a {@link LinkRef} for the currently active regime: a {@link
+ * FabricLink} in modern mode, or the `{ "/": { "link@1": … } }` envelope (no
+ * other props) in legacy mode.
  */
 export function isLinkRef(value: unknown): value is LinkRef<FabricPlainObject> {
   return modernCellRepEnabled
@@ -193,12 +192,12 @@ export function linkRefPayload<Payload extends FabricPlainObject>(
  * themselves.
  *
  * The sub-path is flag-dispatched to match the regime's storage layout. In
- * legacy mode a link is a decomposed plain-object envelope
- * (`{ "/": { "link@1": … } }`), so the recognizable payload sits two segments
- * down at `["/", "link@1"]`. In modern mode a link is an atomic
- * {@link FabricLink} value at the position itself, so the sub-path is empty.
- * Pair with {@link linkPayloadAtProbe} to interpret whatever is read at
- * `position + linkProbeSubPath()`.
+ * legacy mode a link is a decomposed plain-object envelope (`{ "/": { "link@1":
+ * … } }`), so the recognizable payload sits two segments down at `["/",
+ * "link@1"]`. In modern mode a link is an atomic {@link FabricLink} value at
+ * the position itself, so the sub-path is empty. Pair with {@link
+ * linkPayloadAtProbe} to interpret whatever is read at `position +
+ * linkProbeSubPath()`.
  */
 export function linkProbeSubPath(): readonly string[] {
   return modernCellRepEnabled ? [] : ["/", LINK_V1_TAG];

--- a/packages/data-model/src/codec-common/BaseCodecEngine.ts
+++ b/packages/data-model/src/codec-common/BaseCodecEngine.ts
@@ -18,40 +18,40 @@ import { NULL_LIVE_ENVIRONMENT } from "@/codec-interface/NullLiveEnvironment.ts"
  * tree is not necessarily what crosses its public boundary. `Encoded` is the
  * tree the walk and the codecs work in; `SerializedForm` is what `encode()`
  * returns and `decode()` accepts. JSON's differ -- a `JsonCodecValue` tree,
- * reduced to a `string` by a stringify step -- and a format whose tree is
- * what crosses leaves the second to default to the first.
+ * reduced to a `string` by a stringify step -- and a format whose tree is what
+ * crosses leaves the second to default to the first.
  *
- * The other two are the acts of encoding and decoding themselves, and
- * default to the base classes, so a format needing no more than the walk's
- * own bookkeeping names neither. A format that does -- one whose tagged
- * form carries a marker minted per call, say -- subclasses an act and binds
- * it here. Its overrides then receive the narrowed type by
- * construction: the signatures match exactly, so nothing needs a cast.
+ * The other two are the acts of encoding and decoding themselves, and default
+ * to the base classes, so a format needing no more than the walk's own
+ * bookkeeping names neither. A format that does -- one whose tagged form
+ * carries a marker minted per call, say -- subclasses an act and binds it here.
+ * Its overrides then receive the narrowed type by construction: the signatures
+ * match exactly, so nothing needs a cast.
  *
  * The division is between what a format decides and what it must not:
  *
  * * A self-representing value is emitted as it stands, and a value matching no
  *   codec is either a container or an error.
- * * A terminal codec's state is final and a nonterminal codec's is walked
- *   again -- read off the codec's base class, on both sides of the trip.
+ * * A terminal codec's state is final and a nonterminal codec's is walked again
+ *   -- read off the codec's base class, on both sides of the trip.
  * * A tag comes from `tagForValue()` rather than from the value.
- * * An unrecognized tag becomes an `UnknownValue`, and one that is not a tag
- *   at all an error, per Section 9 of the formal spec.
+ * * An unrecognized tag becomes an `UnknownValue`, and one that is not a tag at
+ *   all an error, per Section 9 of the formal spec.
  * * A codec's `decode()` result is deep-frozen, and a throw from one is
  *   re-raised or wrapped according to `lenient`.
  *
  * None of those is a property of a wire format, and every one of them is a
  * decision a walker could quietly get wrong: a state expanded when it should
- * have been passed through, or the reverse, surfaces far from the dispatch
- * that decided it, and where a state is a record of strings the two choices
- * emit byte-identical output. Holding them in one place is worth more than the
- * lines it saves.
+ * have been passed through, or the reverse, surfaces far from the dispatch that
+ * decided it, and where a state is a record of strings the two choices emit
+ * byte-identical output. Holding them in one place is worth more than the lines
+ * it saves.
  *
  * What a subclass owns is everything about containers, and that is where a
  * format is entitled to differ: whether keys are ordered, whether a key can
  * collide with the tag form and so needs escaping, and how an absent array
- * index is written down. A format that answers those differently is not
- * varying an implementation detail; it is being a different format.
+ * index is written down. A format that answers those differently is not varying
+ * an implementation detail; it is being a different format.
  */
 export abstract class BaseCodecEngine<
   Encoded,
@@ -88,24 +88,21 @@ export abstract class BaseCodecEngine<
   //
 
   /**
-   * Constructs one act of encoding, around the live
-   * environment the caller gave. Called once per `encode()`, and the hook by
-   * which a format carries more through its walk than the base class knows
-   * about.
+   * Constructs one act of encoding, around the live environment the caller
+   * gave. Called once per `encode()`, and the hook by which a format carries
+   * more through its walk than the base class knows about.
    */
   protected abstract newEncodeAct(env: LiveEnvironment): EncAct;
 
   /**
-   * Constructs one act of decoding, around the live
-   * environment the caller gave and the form about to be decoded. Called
-   * once per `decode()`.
+   * Constructs one act of decoding, around the live environment the caller gave
+   * and the form about to be decoded. Called once per `decode()`.
    *
-   * `data` is here so that a format whose walk needs something carried in
-   * the form itself -- a marker read off an envelope, say -- can take it
-   * now. It **sniffs rather than validates**: this runs before anything
-   * has checked that `data` is this format's at all, so an implementation
-   * reads defensively and leaves the refusing to
-   * {@link #encodedFromSerializedForm}.
+   * `data` is here so that a format whose walk needs something carried in the
+   * form itself -- a marker read off an envelope, say -- can take it now. It
+   * **sniffs rather than validates**: this runs before anything has checked
+   * that `data` is this format's at all, so an implementation reads defensively
+   * and leaves the refusing to {@link #encodedFromSerializedForm}.
    */
   protected abstract newDecodeAct(
     env: LiveEnvironment,

--- a/packages/data-model/src/codec-common/BaseDecodeAct.ts
+++ b/packages/data-model/src/codec-common/BaseDecodeAct.ts
@@ -219,10 +219,9 @@ export abstract class BaseDecodeAct<Encoded, SerializedForm = Encoded>
    *
    * Three of the arms below walk the state again -- a nonterminal codec's, an
    * unknown tag's, and a malformed tag's -- and each runs that walk on this
-   * act. Entering the state is not this method's business: it is
-   * {@link #decodeValue} that visits every node of the tree, the tagged form
-   * included, and entering there is what keeps one node from being entered
-   * twice.
+   * act. Entering the state is not this method's business: it is {@link
+   * #decodeValue} that visits every node of the tree, the tagged form included,
+   * and entering there is what keeps one node from being entered twice.
    */
   decodeTagged(
     tag: any,

--- a/packages/data-model/src/codec-common/CodecRegistry.ts
+++ b/packages/data-model/src/codec-common/CodecRegistry.ts
@@ -1,15 +1,15 @@
 /**
  * The registry a wire format's walker consults: tag to codec on the way in,
- * value to codec on the way out. On the encode side the match is by class
- * where a value has a useful one and by primitive type otherwise, with a value
- * that is already its own wire form answering to neither and getting a
- * sentinel in place of a codec.
+ * value to codec on the way out. On the encode side the match is by class where
+ * a value has a useful one and by primitive type otherwise, with a value that
+ * is already its own wire form answering to neither and getting a sentinel in
+ * place of a codec.
  *
  * A registry is mutable while it is being assembled and immutable once frozen,
  * and that is a safety property rather than a convenience. An engine holds the
  * registry it was constructed with, so one handed out unfrozen could gain a
- * registration underneath an engine already relying on it. Building further on a
- * frozen registry means extending it into a new one.
+ * registration underneath an engine already relying on it. Building further on
+ * a frozen registry means extending it into a new one.
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";

--- a/packages/data-model/src/codec-common/ProblematicValue.ts
+++ b/packages/data-model/src/codec-common/ProblematicValue.ts
@@ -32,10 +32,10 @@ type ProblematicValueState = {
 };
 
 /**
- * Container for a value whose encoding or decoding failed.
- * Preserves the tag and raw state at fault, for round-tripping and debugging.
- * Used in lenient mode to allow graceful degradation rather than hard
- * failures. See Section 3.5 of the formal spec.
+ * Container for a value whose encoding or decoding failed. Preserves the tag
+ * and raw state at fault, for round-tripping and debugging. Used in lenient
+ * mode to allow graceful degradation rather than hard failures. See Section 3.5
+ * of the formal spec.
  *
  * Both of the things it preserves are whatever was at fault, which is why the
  * constructor takes anything at all for either: the one thing this class must
@@ -44,20 +44,20 @@ type ProblematicValueState = {
  * `toReportableState()` for the state, `toReportableTag()` for the tag.
  *
  * A rendering is deliberately not a conversion. A `Uint8Array` could be turned
- * into a `FabricBytes` and a `RegExp` into a `FabricRegExp`, and doing so
- * would misreport the wire: a reader would find a `FabricBytes` in `state` and
+ * into a `FabricBytes` and a `RegExp` into a `FabricRegExp`, and doing so would
+ * misreport the wire: a reader would find a `FabricBytes` in `state` and
  * conclude the payload carried one, when it carried raw bytes this format does
  * not accept. A string plainly reads as a description of the value rather than
  * the value, which is the honest answer where fidelity is not available.
  *
  * **This class encodes under a tag of its own**, `Problematic@1`, and carries
- * the preserved tag as data beside the state and the error. `UnknownValue`
- * does the opposite, round-tripping to the tag it preserved -- and can,
- * because that tag is a real tag. Here the preserved tag need not be one:
- * reporting a malformed tag is among the things this class is for, and a value
- * whose whole content is "this tag was not a tag" cannot go back out under
- * that tag. Encoding under a fixed tag keeps the wire form decodable whatever
- * was preserved, and keeps it a single shape rather than one shape per kind of
+ * the preserved tag as data beside the state and the error. `UnknownValue` does
+ * the opposite, round-tripping to the tag it preserved -- and can, because that
+ * tag is a real tag. Here the preserved tag need not be one: reporting a
+ * malformed tag is among the things this class is for, and a value whose whole
+ * content is "this tag was not a tag" cannot go back out under that tag.
+ * Encoding under a fixed tag keeps the wire form decodable whatever was
+ * preserved, and keeps it a single shape rather than one shape per kind of
  * fault.
  */
 export class ProblematicValue extends BaseFabricInstance {

--- a/packages/data-model/src/codec-common/UnknownValue.ts
+++ b/packages/data-model/src/codec-common/UnknownValue.ts
@@ -18,16 +18,16 @@ import { ProblematicStateError } from "./ProblematicStateError.ts";
 
 /**
  * Container for an unrecognized type's data, used for round-tripping. When the
- * codec system encounters a tag no codec claims during decoding,
- * it wraps the tag and state here; on re-encoding, the preserved pair
- * reproduces the original wire form. See Section 3.3 of the formal spec.
+ * codec system encounters a tag no codec claims during decoding, it wraps the
+ * tag and state here; on re-encoding, the preserved pair reproduces the
+ * original wire form. See Section 3.3 of the formal spec.
  *
- * The tag is a real tag, checked at construction. That is what makes the
- * round trip a promise rather than a hope: this class encodes back to
- * `<its tag>` over its state, so a tag a decoder would refuse would make an
- * instance that encodes and cannot be read back. A tag that is not a tag is
- * not an unknown type -- it names no type at all -- and belongs in a
- * `ProblematicValue`, which is built to carry one.
+ * The tag is a real tag, checked at construction. That is what makes the round
+ * trip a promise rather than a hope: this class encodes back to `<its tag>`
+ * over its state, so a tag a decoder would refuse would make an instance that
+ * encodes and cannot be read back. A tag that is not a tag is not an unknown
+ * type -- it names no type at all -- and belongs in a `ProblematicValue`, which
+ * is built to carry one.
  */
 export class UnknownValue extends BaseFabricInstance {
   /** The value of {@link #wireTypeTag}. */

--- a/packages/data-model/src/codec-common/index.ts
+++ b/packages/data-model/src/codec-common/index.ts
@@ -1,30 +1,30 @@
 /**
  * This directory holds the codec system's active machinery: the registry that
  * indexes codecs, the lookup that finds a class's codec, the engine base, the
- * per-act encode and decode classes, and the two classes a fault produces. It is also the
- * package's public face for the codec system as a whole, re-exporting the
- * declarations in `codec-interface/` so that an outside caller has one entry
- * point rather than two.
+ * per-act encode and decode classes, and the two classes a fault produces. It
+ * is also the package's public face for the codec system as a whole,
+ * re-exporting the declarations in `codec-interface/` so that an outside caller
+ * has one entry point rather than two.
  *
- * That convenience is for callers. A module inside this directory imports
- * the file it wants directly, which is what keeps a module that only needs
- * to name a codec from pulling the machinery in behind it, and is the point
- * of the two directories.
+ * That convenience is for callers. A module inside this directory imports the
+ * file it wants directly, which is what keeps a module that only needs to name
+ * a codec from pulling the machinery in behind it, and is the point of the two
+ * directories.
  *
  * Everything here is format-agnostic. Nothing in this directory knows which
- * wire format is in play, and a codec that exists because one particular
- * format cannot carry some type belongs with that format instead:
- * `codec-json/` holds the four that JSON needs.
+ * wire format is in play, and a codec that exists because one particular format
+ * cannot carry some type belongs with that format instead: `codec-json/` holds
+ * the four that JSON needs.
  *
  * The one abstract base here is `BaseCodecEngine`, what an ENGINE extends, one
  * per wire format -- the thing that walks `FabricValue`s and drives their
  * codecs. What such a value itself extends is a different question with a
  * different answer, and lives in `fabric-bases/`.
  *
- * Besides it, the classes here are `UnknownValue` and `ProblematicValue`,
- * which exist only because a decode found a tag no codec claimed or went
- * wrong outright. A class a caller models data with belongs in `fabric-instances/`
- * or `fabric-primitives/` instead.
+ * Besides it, the classes here are `UnknownValue` and `ProblematicValue`, which
+ * exist only because a decode found a tag no codec claimed or went wrong
+ * outright. A class a caller models data with belongs in `fabric-instances/` or
+ * `fabric-primitives/` instead.
  */
 
 export * from "@/codec-interface/index.ts";

--- a/packages/data-model/src/codec-interface/BaseLiveEnvironment.ts
+++ b/packages/data-model/src/codec-interface/BaseLiveEnvironment.ts
@@ -1,7 +1,7 @@
 /**
  * Base class for `LiveEnvironment` implementations. Centralizes the
- * `shouldDeepFreeze` getter so every live environment declares the (required) member
- * via a single shared implementation instead of repeating it.
+ * `shouldDeepFreeze` getter so every live environment declares the (required)
+ * member via a single shared implementation instead of repeating it.
  */
 
 import type { FabricInstance } from "@/interface.ts";

--- a/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
+++ b/packages/data-model/src/codec-interface/NullLiveEnvironment.ts
@@ -41,10 +41,10 @@ export class NullLiveEnvironment extends BaseLiveEnvironment {
 }
 
 /**
- * Shared `NullLiveEnvironment` instance with `.shouldDeepFreeze ===
- * true` and whose `getCell()` always throws. Pass this when a codec wants a
- * live environment but isn't expected to need a cell; if a cell ref does turn
- * up, the throw makes the unexpected lookup obvious instead of silent.
+ * Shared `NullLiveEnvironment` instance with `.shouldDeepFreeze === true` and
+ * whose `getCell()` always throws. Pass this when a codec wants a live
+ * environment but isn't expected to need a cell; if a cell ref does turn up,
+ * the throw makes the unexpected lookup obvious instead of silent.
  */
 export const NULL_LIVE_ENVIRONMENT: LiveEnvironment = Object
   .freeze(new NullLiveEnvironment(true));

--- a/packages/data-model/src/codec-interface/interface.ts
+++ b/packages/data-model/src/codec-interface/interface.ts
@@ -149,22 +149,21 @@ export interface FabricCodec<Encoded> {
 
   /**
    * Decodes a value from the given essential state, which is (alleged /
-   * supposed) to be a value that was produced by an earlier call to
-   * {@link #encode} on a compatible class to this one. The result is expected
-   * to be a _shallow_ decoding; the codec system handles recursively
-   * converting `state` contents as necessary.
+   * supposed) to be a value that was produced by an earlier call to {@link
+   * #encode} on a compatible class to this one. The result is expected to be a
+   * _shallow_ decoding; the codec system handles recursively converting `state`
+   * contents as necessary.
    *
    * The given `typeTag` is what was associated with the given `state` and does
    * not necessarily correspond to {@link #recognizedTypeTag} (depending on how
    * an instance of this class got hooked up).
    *
    * Only ever called on a state for which {@link #canDecode} has returned
-   * `true`, which is the decode side's counterpart to the way
-   * {@link #canEncode} precedes {@link #encode}. That is what lets an
-   * implementation declare the narrower state type it actually decodes and
-   * read its parts as such. `state` is the whole of `Encoded` here because
-   * this interface is what a registry holds, and the codecs in one agree on
-   * nothing narrower.
+   * `true`, which is the decode side's counterpart to the way {@link
+   * #canEncode} precedes {@link #encode}. That is what lets an implementation
+   * declare the narrower state type it actually decodes and read its parts as
+   * such. `state` is the whole of `Encoded` here because this interface is what
+   * a registry holds, and the codecs in one agree on nothing narrower.
    */
   decode(
     typeTag: string,
@@ -208,26 +207,26 @@ export interface FabricCodec<Encoded> {
 export type NonterminalCodec = FabricCodec<FabricValue>;
 
 /**
- * A codec whose essential state is **terminal**: it is already in the domain
- * of one particular wire format, and the walker passes it through rather than
+ * A codec whose essential state is **terminal**: it is already in the domain of
+ * one particular wire format, and the walker passes it through rather than
  * expanding it further.
  *
  * Instantiating {@link FabricCodec} at a format's own value type is what says
  * so. Such a codec is bound to that one format, and a class needing one
  * supplies a separate instance per format it participates in.
  *
- * `FabricBytes` is the clearest case: JSON's codec produces a base64url
- * string, where a format that carries bytes natively wants the bytes
- * themselves, and no one codec can answer both.
+ * `FabricBytes` is the clearest case: JSON's codec produces a base64url string,
+ * where a format that carries bytes natively wants the bytes themselves, and no
+ * one codec can answer both.
  *
  * The difference between the two kinds is not in the shape of a codec -- both
  * have the same members -- but in what its state means to the walker. A class
  * declares which it is by the base class it extends, and that declaration is
  * the only record of it.
  *
- * `Encoded` ranges over the wire formats' own value types. `FabricValue` is
- * not among them, and instantiating at it is unsound; see
- * {@link BaseTerminalCodec}.
+ * `Encoded` ranges over the wire formats' own value types. `FabricValue` is not
+ * among them, and instantiating at it is unsound; see {@link
+ * BaseTerminalCodec}.
  */
 export type TerminalCodec<Encoded> = FabricCodec<Encoded>;
 
@@ -298,20 +297,19 @@ export interface LiveEnvironment {
   ): FabricInstance;
 
   /**
-   * Signals whether a decode call should produce a deep-frozen
-   * result: `true` means the decoded value should be deep-frozen,
-   * `false` means a mutable result is acceptable. Same contract as `frozen`
-   * passed to `cloneIfNecessary()` (see `value-clone.ts`):
-   * `shouldDeepFreeze === true` corresponds to
-   * `cloneIfNecessary(value, { frozen: true })`.
+   * Signals whether a decode call should produce a deep-frozen result: `true`
+   * means the decoded value should be deep-frozen, `false` means a mutable
+   * result is acceptable. Same contract as `frozen` passed to
+   * `cloneIfNecessary()` (see `value-clone.ts`): `shouldDeepFreeze === true`
+   * corresponds to `cloneIfNecessary(value, { frozen: true })`.
    *
    * Required (not optional): every live environment declares it, and gets it
-   * for free by extending `BaseLiveEnvironment`, which centralizes the
-   * getter; the `cloneIfNecessary`-style `true` default lives there.
+   * for free by extending `BaseLiveEnvironment`, which centralizes the getter;
+   * the `cloneIfNecessary`-style `true` default lives there.
    *
-   * Enforcement: a decode deep-freezes its result, and a codec that builds
-   * a value cheaper when it may stay thawed reads this to decide,
-   * producing a deep-frozen result when it is `true`.
+   * Enforcement: a decode deep-freezes its result, and a codec that builds a
+   * value cheaper when it may stay thawed reads this to decide, producing a
+   * deep-frozen result when it is `true`.
    */
   get shouldDeepFreeze(): boolean;
 }

--- a/packages/data-model/src/codec-json/BigIntCodec.ts
+++ b/packages/data-model/src/codec-json/BigIntCodec.ts
@@ -16,9 +16,9 @@ import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
  * string encoding the bigint's two's-complement big-endian byte representation.
  * Wire format: `{ "/BigInt@1": "<base64>" }`.
  *
- * The byte encoding is the same one used by the hash
- * (`2-hash-byte-format.md` Section 4.5): minimal two's-complement big-endian, with sign extension
- * as needed.
+ * The byte encoding is the same one used by the hash (`2-hash-byte-format.md`
+ * Section 4.5): minimal two's-complement big-endian, with sign extension as
+ * needed.
  *
  * `BigInt` is a non-`new`-able pseudo-constructor, so it is cast to
  * `Constructor` (a "white lie") to seed the class fast-path; `canEncode()`

--- a/packages/data-model/src/codec-json/JsonCodecEngine.ts
+++ b/packages/data-model/src/codec-json/JsonCodecEngine.ts
@@ -53,9 +53,8 @@ export class JsonCodecEngine extends BaseCodecEngine<JsonCodecValue, string> {
   /**
    * @inheritDoc
    *
-   * A plain one: this walk never enters a node, for the reason
-   * {@link #decode} gives, so the act's in-progress set is never
-   * allocated.
+   * A plain one: this walk never enters a node, for the reason {@link #decode}
+   * gives, so the act's in-progress set is never allocated.
    */
   protected override newDecodeAct(
     env: LiveEnvironment,

--- a/packages/data-model/src/codec-json/JsonDecodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonDecodeAct.ts
@@ -62,7 +62,8 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
     if (decoded !== null) {
       const { tag, state: rawState } = decoded;
 
-      // `CODEC_META_TAGS.quote` literal handling (`3-json-encoding.md` Section 6).
+      // `CODEC_META_TAGS.quote` literal handling (`3-json-encoding.md` Section
+      // 6).
       if (tag === CODEC_META_TAGS.quote) {
         // TODO(danfuzz): Quote content is returned whole, so a key this
         // implementation reserves is admitted here where the `/object` and
@@ -194,9 +195,9 @@ export class JsonDecodeAct extends BaseDecodeAct<JsonCodecValue, string> {
   }
 
   /**
-   * Plain objects: recursively decode values and freeze. Any
-   * `/`-prefixed key is reserved per spec — return `ProblematicValue` on
-   * first occurrence rather than silently round-tripping the object.
+   * Plain objects: recursively decode values and freeze. Any `/`-prefixed key
+   * is reserved per spec — return `ProblematicValue` on first occurrence rather
+   * than silently round-tripping the object.
    */
   #decodePlainObject(
     data: Record<string, JsonCodecValue>,

--- a/packages/data-model/src/codec-json/JsonEncodeAct.ts
+++ b/packages/data-model/src/codec-json/JsonEncodeAct.ts
@@ -92,10 +92,10 @@ export class JsonEncodeAct extends BaseEncodeAct<JsonCodecValue, string> {
    * order. See `3-json-encoding.md` Section 10.
    *
    * A `/`-prefixed key collides with the tag form, so an object bearing one is
-   * escaped per `3-json-encoding.md` Section 6: all values are encoded first, and if every one is
-   * quote-safe the whole object is wrapped in `/quote` with any `/quote`
-   * children collapsed into it, and otherwise in `/object` so that the decoder
-   * walks the entries.
+   * escaped per `3-json-encoding.md` Section 6: all values are encoded first,
+   * and if every one is quote-safe the whole object is wrapped in `/quote` with
+   * any `/quote` children collapsed into it, and otherwise in `/object` so that
+   * the decoder walks the entries.
    */
   protected override encodePlainObject(
     value: Record<string, FabricValue>,

--- a/packages/data-model/src/codec-json/SpecialNumberCodec.ts
+++ b/packages/data-model/src/codec-json/SpecialNumberCodec.ts
@@ -21,16 +21,16 @@ type SpecialNumberState = keyof typeof SPECIAL_NUMBERS;
 
 /**
  * Codec for the four "special" numeric values that JSON cannot represent
- * faithfully: `-0`, `NaN`, `+Infinity`, and `-Infinity`. Wire format:
- * `{ "/SpecialNumber@1": "<literal>" }`, where `<literal>` is one of `-0`,
- * `NaN`, `+Infinity`, or `-Infinity`.
+ * faithfully: `-0`, `NaN`, `+Infinity`, and `-Infinity`. Wire format: `{
+ * "/SpecialNumber@1": "<literal>" }`, where `<literal>` is one of `-0`, `NaN`,
+ * `+Infinity`, or `-Infinity`.
  *
  * String state (rather than a JSON number) is used because `JSON.stringify`
  * emits `null` for `NaN`/`±Infinity` and drops the sign on `-0`, which would
  * make a numeric-state form lossy through the JSON layer.
  *
- * Any NaN bit pattern encodes as the literal `"NaN"` and round-trips
- * back to `Number.NaN`.
+ * Any NaN bit pattern encodes as the literal `"NaN"` and round-trips back to
+ * `Number.NaN`.
  */
 export class SpecialNumberCodec
   extends BaseTerminalCodec<JsonCodecValue, SpecialNumberState> {

--- a/packages/data-model/src/codec-json/interface.ts
+++ b/packages/data-model/src/codec-json/interface.ts
@@ -15,25 +15,25 @@ import { JSON_CODEC } from "@/codec-interface/interface.ts";
 /**
  * Tag prefix on the encoded form of a `FabricValue`. The prefix is explicit so
  * as to make it unambiguous whether a given JSON-ish text string is the result
- * of encoding by `JsonCodecEngine` vs. being JSON from some other source. The tag
- * stands for "Fabric Value Json, version 1."
+ * of encoding by `JsonCodecEngine` vs. being JSON from some other source. The
+ * tag stands for "Fabric Value Json, version 1."
  */
 export const ENCODING_PREFIX_TAG = "fvj1:" as const;
 
 /**
  * JSON-compatible codec value. This is the intermediate tree representation
- * used during encode tree walking -- NOT the final serialized form
- * (which is `string`). Internal to the JSON implementation.
+ * used during encode tree walking -- NOT the final serialized form (which is
+ * `string`). Internal to the JSON implementation.
  *
- * Deep-frozen invariant: every such tree that *enters decoding* is
- * deep-frozen. This is enforced at the one construction site that feeds the
- * decode walk, `parseWireText()`, and is what lets `unwrapTag()` /
- * the `/quote` arm hand back extracted sub-trees directly (see their
- * contracts). The transient trees built on the *encode* side are not covered
- * by this invariant: they are `JSON.stringify`-ed and discarded by `encode()`
- * and never reach a caller. (The encode-side `/quote` form happens to be
- * deep-frozen as a side effect of `#unquote()`'s recursive rebuild, but no
- * other encode output is, and none needs to be.)
+ * Deep-frozen invariant: every such tree that *enters decoding* is deep-frozen.
+ * This is enforced at the one construction site that feeds the decode walk,
+ * `parseWireText()`, and is what lets `unwrapTag()` / the `/quote` arm hand
+ * back extracted sub-trees directly (see their contracts). The transient trees
+ * built on the *encode* side are not covered by this invariant: they are
+ * `JSON.stringify`-ed and discarded by `encode()` and never reach a caller.
+ * (The encode-side `/quote` form happens to be deep-frozen as a side effect of
+ * `#unquote()`'s recursive rebuild, but no other encode output is, and none
+ * needs to be.)
  */
 export type JsonCodecValue =
   | null

--- a/packages/data-model/src/codec-realm/RealmCodecEngine.ts
+++ b/packages/data-model/src/codec-realm/RealmCodecEngine.ts
@@ -8,11 +8,11 @@ import { type RealmCodecValue, type RealmEncodedValue } from "./interface.ts";
 /**
  * Whole-value codec engine for the realm-crossing wire format: the form a
  * `FabricValue` takes when it is handed to `structuredClone()` or
- * `postMessage()` to reach another realm, or to a durable store that
- * serializes the same way.
+ * `postMessage()` to reach another realm, or to a durable store that serializes
+ * the same way.
  *
- * The format is specified by `4-realm-encoding.md` of the formal spec, which
- * is the authority on the shape of an encoded value, the marker and its rules,
+ * The format is specified by `4-realm-encoding.md` of the formal spec, which is
+ * the authority on the shape of an encoded value, the marker and its rules,
  * what the walks refuse, and what each direction does with the memory it is
  * given. Two of its terms are worth naming here because they are what the
  * methods below are written in: the **outer envelope** is the two-element
@@ -27,18 +27,18 @@ import { type RealmCodecValue, type RealmEncodedValue } from "./interface.ts";
  *
  * **Cycles are refused and a shared reference survives exactly where nothing
  * beneath it needed encoding**, per Section 1.6 of the formal spec, which
- * requires an engine to say which of these it does. Section 4 of the realm
- * spec gives both, and the encode and decode sides of the ownership contract
- * are Section 5 -- the half a caller is likeliest to get wrong being that an
+ * requires an engine to say which of these it does. Section 4 of the realm spec
+ * gives both, and the encode and decode sides of the ownership contract are
+ * Section 5 -- the half a caller is likeliest to get wrong being that an
  * encoded tree shares structure with the value it came from and is not frozen.
  *
  * TODO(danfuzz): A memo from each visited object to its encoded counterpart
  * closes cycles and sharing at once: a repeat visit yields the node already
  * built for it, which preserves sharing through a rebuild and lets a back-edge
- * resolve instead of recursing. It belongs on `BaseEncodeAct` and `BaseDecodeAct`,
- * beside the in-progress set, since a cycle can run through
- * a codec-matched object as readily as through a container and both walks
- * need it.
+ * resolve instead of recursing. It belongs on `BaseEncodeAct` and
+ * `BaseDecodeAct`, beside the in-progress set, since a cycle can run through a
+ * codec-matched object as readily as through a container and both walks need
+ * it.
  */
 export class RealmCodecEngine extends BaseCodecEngine<
   RealmCodecValue,

--- a/packages/data-model/src/codec-realm/RealmDecodeAct.ts
+++ b/packages/data-model/src/codec-realm/RealmDecodeAct.ts
@@ -17,10 +17,10 @@ import { markerOf } from "./marker.ts";
  * One act of decoding for the realm boundary, and the marker read off the
  * envelope that arrived.
  *
- * The marker is the sender's, taken off the envelope by
- * {@link #encodedFromSerializedForm}, and what every tagged form beneath that
- * envelope is checked against: a form carrying anything else is data rather
- * than structure.
+ * The marker is the sender's, taken off the envelope by {@link
+ * #encodedFromSerializedForm}, and what every tagged form beneath that envelope
+ * is checked against: a form carrying anything else is data rather than
+ * structure.
  */
 export class RealmDecodeAct
   extends BaseDecodeAct<RealmCodecValue, RealmEncodedValue> {
@@ -218,25 +218,24 @@ export class RealmDecodeAct
    * Unwraps a tagged wire representation. Returns `{ tag, state }`, or `null`
    * if `data` is not one. The `state` is extracted directly from `data`.
    *
-   * Slot zero decides, and only by identity: an array of the right length
-   * whose first element is some *other* object -- or an equal-looking marker
-   * some payload built for itself -- is a payload's own array and is walked as
-   * one. Nothing about the shape is evidence, which is why the comparison is
-   * `===` and not a structural test.
+   * Slot zero decides, and only by identity: an array of the right length whose
+   * first element is some *other* object -- or an equal-looking marker some
+   * payload built for itself -- is a payload's own array and is walked as one.
+   * Nothing about the shape is evidence, which is why the comparison is `===`
+   * and not a structural test.
    *
-   * With no marker in hand there is nothing to compare against, so nothing is
-   * a tagged form. Stated rather than left to `===`: `undefined` is a value
-   * this format carries directly, so a payload can put one in slot zero for
-   * free, and identity against an absent marker would match it. The walk
-   * reaches here only from `decode()`, which always has one, and this is the
-   * counterpart to `wrapTag()` refusing to build a tagged form without one.
+   * With no marker in hand there is nothing to compare against, so nothing is a
+   * tagged form. Stated rather than left to `===`: `undefined` is a value this
+   * format carries directly, so a payload can put one in slot zero for free,
+   * and identity against an absent marker would match it. The walk reaches here
+   * only from `decode()`, which always has one, and this is the counterpart to
+   * `wrapTag()` refusing to build a tagged form without one.
    *
-   * The tag is handed over as it was found, of whatever type.
-   * {@link RealmTaggedValue} says a tag is a `string`, but that describes what
-   * this format _emits_, and decoding is where data from somewhere else
-   * arrives. Whether what sits there is a tag belongs to `decodeTagged()`,
-   * which asks it the same way for every format and settles the answer against
-   * `lenient`.
+   * The tag is handed over as it was found, of whatever type. {@link
+   * RealmTaggedValue} says a tag is a `string`, but that describes what this
+   * format _emits_, and decoding is where data from somewhere else arrives.
+   * Whether what sits there is a tag belongs to `decodeTagged()`, which asks it
+   * the same way for every format and settles the answer against `lenient`.
    */
   #unwrapTag(
     data: RealmCodecValue,

--- a/packages/data-model/src/codec-realm/RealmEncodeAct.ts
+++ b/packages/data-model/src/codec-realm/RealmEncodeAct.ts
@@ -132,7 +132,8 @@ export class RealmEncodeAct
         const key = keys[i]!;
 
         // Checked on every object, not just the ones that get rebuilt, so that
-        // the answer does not depend on whether some sibling happened to change.
+        // the answer does not depend on whether some sibling happened to
+        // change.
         RealmEncodeAct.assertEncodableKey(key);
 
         const original = value[key]!;

--- a/packages/data-model/src/codec-realm/interface.ts
+++ b/packages/data-model/src/codec-realm/interface.ts
@@ -25,30 +25,30 @@ import { REALM_CODEC } from "@/codec-interface/interface.ts";
  * The union names what this format emits, which is narrower than everything
  * cloning accepts. Five arms are worth calling out:
  *
- * * `bigint` and `undefined` appear directly, as do `-0`, `NaN` and
- *   `±Infinity` under `number`. Cloning carries each as itself.
+ * * `bigint` and `undefined` appear directly, as do `-0`, `NaN` and `±Infinity`
+ *   under `number`. Cloning carries each as itself.
  * * `ArrayBuffer` appears, because bytes cross as bytes. This is the whole
  *   point of a second format: JSON has to represent a `FabricBytes` as
  *   base64url text, and a receiver that wants bytes back has to rebuild them.
- *   The two forms are not interchangeable. Bytes travel as a bare
- *   `ArrayBuffer` rather than as a view onto one, that being what
- *   `postMessage()` can *transfer*, so a caller assembling a transfer list
- *   finds the transferable object in the tree rather than having to reach
- *   through a view and reason about its offset. Both byte-carrying classes do
- *   this: a `FabricBytes` encodes to one directly, and a `FabricHash` to one
- *   beside its algorithm tag. A bare `Uint8Array` is therefore not a form this
- *   format emits, and `decodeValue()` refuses one.
+ *   The two forms are not interchangeable. Bytes travel as a bare `ArrayBuffer`
+ *   rather than as a view onto one, that being what `postMessage()` can
+ *   *transfer*, so a caller assembling a transfer list finds the transferable
+ *   object in the tree rather than having to reach through a view and reason
+ *   about its offset. Both byte-carrying classes do this: a `FabricBytes`
+ *   encodes to one directly, and a `FabricHash` to one beside its algorithm
+ *   tag. A bare `Uint8Array` is therefore not a form this format emits, and
+ *   `decodeValue()` refuses one.
  * * `CryptoKey` appears, because a key that cannot be exported can still be
- *   carried. Cloning preserves one whole, extractability and algorithm
- *   intact, which is what lets a `FabricKeyPair` holding handles cross at all
- *   -- and only here: no format that writes bytes down can represent it. Like
+ *   carried. Cloning preserves one whole, extractability and algorithm intact,
+ *   which is what lets a `FabricKeyPair` holding handles cross at all -- and
+ *   only here: no format that writes bytes down can represent it. Like
  *   `ArrayBuffer`, it reaches the transport only inside a terminal codec's
  *   state, so the walk never descends into one.
- * * An array is both the tagged form and the outer envelope -- see
- *   {@link RealmTaggedValue} and {@link RealmEncodedValue}. Neither is
- *   distinguishable by shape from a payload's own arrays, and neither is meant
- *   to be: what marks them is the identity of the object in slot zero, which
- *   {@link RealmFormatMarker} explains.
+ * * An array is both the tagged form and the outer envelope -- see {@link
+ *   RealmTaggedValue} and {@link RealmEncodedValue}. Neither is distinguishable
+ *   by shape from a payload's own arrays, and neither is meant to be: what
+ *   marks them is the identity of the object in slot zero, which {@link
+ *   RealmFormatMarker} explains.
  *
  * `symbol` is absent: cloning refuses one outright, so this format registers
  * the shared `SymbolCodec` and a symbol crosses under a tag like any other
@@ -83,49 +83,48 @@ export const REALM_FORMAT_VERSION = "fvr1";
  * the outer envelope and of every tagged form beneath it. A receiver takes it
  * from the outer envelope and recognizes the rest by `===` against it.
  *
- * That works because structured cloning preserves shared references: one
- * object referenced from many positions arrives as one object referenced from
- * many positions. It is the only property of the transport this format leans
- * on beyond carrying its types, and it is the whole of what makes either form
+ * That works because structured cloning preserves shared references: one object
+ * referenced from many positions arrives as one object referenced from many
+ * positions. It is the only property of the transport this format leans on
+ * beyond carrying its types, and it is the whole of what makes either form
  * unmistakable.
  *
- * **It must be an object.** Recognition is `===`, which on a primitive is
- * value equality rather than identity, so a primitive in slot zero would be
- * reproducible by any payload that happened to hold the same one --
- * and the argument below would evaporate. `decode()` refuses an outer envelope
- * whose slot zero is not a one-element array holding this version, which is
- * that requirement and the version check at once.
+ * **It must be an object.** Recognition is `===`, which on a primitive is value
+ * equality rather than identity, so a primitive in slot zero would be
+ * reproducible by any payload that happened to hold the same one -- and the
+ * argument below would evaporate. `decode()` refuses an outer envelope whose
+ * slot zero is not a one-element array holding this version, which is that
+ * requirement and the version check at once.
  *
- * **A payload cannot contain the marker**, and two facts together are what
- * say so.
+ * **A payload cannot contain the marker**, and two facts together are what say
+ * so.
  *
  * It is *younger than the value*: created after the value exists, so nothing
- * already assembled can hold a reference to it, whatever its author has seen
- * of some earlier encoding. That is why it is minted per call rather than per
+ * already assembled can hold a reference to it, whatever its author has seen of
+ * some earlier encoding. That is why it is minted per call rather than per
  * engine -- a long-lived one could be embedded in a value by code that had
  * legitimately seen an earlier encoded tree, and the walk would carry it
  * through to a data position where the decoder would read it as a tagged form.
  *
- * And it is *confined*: it never leaves the engine until `encode()` returns.
- * It lives in a private field and in the tagged forms the walk is building,
+ * And it is *confined*: it never leaves the engine until `encode()` returns. It
+ * lives in a private field and in the tagged forms the walk is building,
  * neither of which anything outside can reach, and a nested `encode()` mints
  * and retires its own. Age alone would not settle it, because a value's
  * contents need not all exist when the walk starts -- a getter runs mid-walk,
  * after the marker exists. What closes that gap is that such a getter has
  * nowhere to read the marker from.
  *
- * It is a frozen array of one string, which is also a `FabricValue` this
- * format encodes by identity. That matters: a value holding some *earlier*
- * call's marker has to encode without complaint, being ordinary data, and a
- * marker shaped as something the walk refuses would make such a value
- * unencodable.
+ * It is a frozen array of one string, which is also a `FabricValue` this format
+ * encodes by identity. That matters: a value holding some *earlier* call's
+ * marker has to encode without complaint, being ordinary data, and a marker
+ * shaped as something the walk refuses would make such a value unencodable.
  *
  * It is not a secret and not an authentication token. Whatever asks for an
  * encoding is trusted with the result, and whatever receives a payload is
  * trusted to read it; a hostile peer builds its own marker and forges freely,
- * exactly as it could send any tagged value it liked. What the marker rules
- * out is *confusion within a payload this engine encoded* -- which is the
- * escaping problem, and the whole of what it is for.
+ * exactly as it could send any tagged value it liked. What the marker rules out
+ * is *confusion within a payload this engine encoded* -- which is the escaping
+ * problem, and the whole of what it is for.
  */
 export type RealmFormatMarker = readonly [typeof REALM_FORMAT_VERSION];
 

--- a/packages/data-model/src/data-uri-codec.ts
+++ b/packages/data-model/src/data-uri-codec.ts
@@ -1,8 +1,8 @@
 /**
- * The `data:` URI codec, complete and self-contained: the media-type
- * facts, the mint half ({@link dataUriFromValue}), and the read half
- * ({@link valueFromDataUri}, {@link extractDataUriPayloadText},
- * {@link valueFromDataUriPayloadText}).
+ * The `data:` URI codec, complete and self-contained: the media-type facts, the
+ * mint half ({@link dataUriFromValue}), and the read half ({@link
+ * valueFromDataUri}, {@link extractDataUriPayloadText}, {@link
+ * valueFromDataUriPayloadText}).
  */
 
 import { backtickQuote } from "@commonfabric/utils/markdown";
@@ -39,30 +39,30 @@ export function hasDataUriScheme(id: string): boolean {
 }
 
 /**
- * Is `mediaType` the `data:` URI media type? Exactly one type is
- * accepted; there are no parameters (the payload is always base64url of
- * UTF-8 text, so none are needed).
+ * Is `mediaType` the `data:` URI media type? Exactly one type is accepted;
+ * there are no parameters (the payload is always base64url of UTF-8 text, so
+ * none are needed).
  */
 export function isDataUriMediaType(mediaType: string): boolean {
   return mediaType === DATA_URI_MEDIA_TYPE;
 }
 
 /**
- * Does `id` carry this codec's media type? This is the narrow test of the
- * pair, for readers that go on to decode the payload;
- * {@link hasDataUriScheme} accepts any media type. Only the prefix is
- * examined; the payload is not validated.
+ * Does `id` carry this codec's media type? This is the narrow test of the pair,
+ * for readers that go on to decode the payload; {@link hasDataUriScheme}
+ * accepts any media type. Only the prefix is examined; the payload is not
+ * validated.
  */
 export function isFabricDataUri(id: string): boolean {
   return id.startsWith(`data:${DATA_URI_MEDIA_TYPE}`);
 }
 
 /**
- * Assembles a `data:` URI carrying (the encoding of) `value` -- the
- * single place the URI shape is put together: scheme, media type, and the
+ * Assembles a `data:` URI carrying (the encoding of) `value` -- the single
+ * place the URI shape is put together: scheme, media type, and the
  * base64url-of-UTF-8 `fvj1:` payload. Unlike the runner's
- * `dataUriFromValueWithResolvedLinks()`, this does no link rewriting or
- * other preparation of `value`; callers hand it a ready `FabricValue`.
+ * `dataUriFromValueWithResolvedLinks()`, this does no link rewriting or other
+ * preparation of `value`; callers hand it a ready `FabricValue`.
  */
 export function dataUriFromValue(value: FabricValue): UriString {
   const payload = toUnpaddedBase64urlFromText(jsonFromFabricValue(value));
@@ -118,9 +118,9 @@ export function extractDataUriPayloadText(
   }
 
   try {
-    // Note that `textDecoder` uses the default configuration of
-    // `fatal: false`, so its `decode()` never throws; only the base64url
-    // decode can land in the `catch`.
+    // Note that `textDecoder` uses the default configuration of `fatal: false`,
+    // so its `decode()` never throws; only the base64url decode can land in the
+    // `catch`.
     const bytes = fromBase64url(data);
     return { mediaType, text: textDecoder.decode(bytes) };
   } catch {

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -90,18 +90,16 @@ export type FabricErrorState = {
  * Wrapper for `Error` instances in the fabric type system. Bridges native
  * `Error` (JS wild west) into the strongly-typed `FabricValue` layer by
  * implementing `FabricInstance`. The publicly observable state is entirely
- * `FabricValue`-typed: fixed-schema slots (`type`, `name`, `message`,
- * `stack`, `cause`) plus a hidden extras bag accessed via map-like methods
- * (`getExtra`, `setExtra`, `hasExtra`, `deleteExtra`, `extraKeys`,
- * `extraEntries`). The native `Error` form is produced on demand by
- * `toNativeValue()`.
+ * `FabricValue`-typed: fixed-schema slots (`type`, `name`, `message`, `stack`,
+ * `cause`) plus a hidden extras bag accessed via map-like methods (`getExtra`,
+ * `setExtra`, `hasExtra`, `deleteExtra`, `extraKeys`, `extraEntries`). The
+ * native `Error` form is produced on demand by `toNativeValue()`.
  *
- * Like all `FabricInstance`s, a `FabricError` is wholeheartedly mutable
- * until frozen and immutable thereafter. Every mutator -- the slot setters
- * along with `setExtra` / `deleteExtra` -- throws once the instance is
- * `Object.freeze`'d. The codec layer handles `FabricError` via its
- * static `[CODEC]`, which is the source of truth for the encoded form.
- * See Section 1.4.1 of the formal spec.
+ * Like all `FabricInstance`s, a `FabricError` is wholeheartedly mutable until
+ * frozen and immutable thereafter. Every mutator -- the slot setters along with
+ * `setExtra` / `deleteExtra` -- throws once the instance is `Object.freeze`'d.
+ * The codec layer handles `FabricError` via its static `[CODEC]`, which is the
+ * source of truth for the encoded form. See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error>
   implements ApiFabricError {
@@ -133,9 +131,8 @@ export class FabricError extends FabricNativeWrapper<Error>
 
   /**
    * Constructs an instance from a `FabricErrorState` record. All state values
-   * must already
-   * be in `FabricValue` form -- the conversion layer is responsible for
-   * ensuring this when constructing from a native `Error`. Use
+   * must already be in `FabricValue` form -- the conversion layer is
+   * responsible for ensuring this when constructing from a native `Error`. Use
    * `FabricError.fromNativeError()` for shallow conversion from a native
    * `Error`.
    */

--- a/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
+++ b/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
@@ -7,10 +7,9 @@ import {
 
 /**
  * Abstract base class for `FabricInstance` wrappers that bridge native JS
- * objects into the `FabricValue` layer.
- * Provides a common `toNativeValue()` method used by both the shallow and
- * deep unwrap functions, replacing their `instanceof` cascades with a single
- * `instanceof FabricNativeWrapper` check.
+ * objects into the `FabricValue` layer. Provides a common `toNativeValue()`
+ * method used by both the shallow and deep unwrap functions, replacing their
+ * `instanceof` cascades with a single `instanceof FabricNativeWrapper` check.
  */
 export abstract class FabricNativeWrapper<T extends object>
   extends BaseFabricInstance {

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -37,9 +37,9 @@ type FabricHashState = {
 /**
  * Content-addressed identifier: a hash digest paired with an algorithm tag.
  *
- * Stringification produces `<tag>:<base64urlHash>` where
- * `<base64urlHash>` is the unpadded base64url encoding (RFC 4648 section 5)
- * of the hash bytes. For example: `fid1:abc123...`
+ * Stringification produces `<tag>:<base64urlHash>` where `<base64urlHash>` is
+ * the unpadded base64url encoding (RFC 4648 section 5) of the hash bytes. For
+ * example: `fid1:abc123...`
  *
  * Immutable: instances are `Object.freeze()`-d at construction time, and an
  * instance owns its hash bytes outright, holding a buffer no other code can

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -51,8 +51,7 @@ type FabricRegExpState = {
  * validates the pattern syntax eagerly and makes `value` cheap. Other flavors
  * are stored faithfully (`source` / `flags` / `flavor`) but cannot yet produce
  * a native `RegExp`, so `value` throws for them -- leaving room to represent
- * other regex syntaxes in the future.
- * See Section 1.4.1 of the formal spec.
+ * other regex syntaxes in the future. See Section 1.4.1 of the formal spec.
  */
 export class FabricRegExp extends BaseFabricPrimitive
   implements ApiFabricRegExp {

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -1,9 +1,9 @@
 /**
  * Type-only declarations, the `FabricInstance` base class, and the protocol
  * symbols keyed on a fabric class, for the fabric data model. This file is
- * intentionally free of runtime imports from other
- * data-model modules (only `import type` is used) so that it can be imported
- * by any module without creating circular dependencies.
+ * intentionally free of runtime imports from other data-model modules (only
+ * `import type` is used) so that it can be imported by any module without
+ * creating circular dependencies.
  *
  * NOTE: `packages/api/index.ts` mirrors these types (and those from
  * `fabric-primitives/FabricHash.ts`, `fabric-primitives/FabricEpochNsec.ts`)

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -62,21 +62,21 @@ function rejectExtraProperties(value: object, typeName: string): void {
  * Returns a shallow clone of the given array carrying nothing but its
  * enumerable index properties and `length`, that is, one which satisfies
  * `isInertArray()` -- a direct `Array` instance, whatever the given array's
- * prototype. Holes are preserved as holes, and
- * elements are copied by reference without themselves being converted or
- * validated, this being a shallow operation.
+ * prototype. Holes are preserved as holes, and elements are copied by reference
+ * without themselves being converted or validated, this being a shallow
+ * operation.
  *
  * This exists for a caller holding an array that has picked up non-index own
- * properties which it knows are not content -- a runtime annotation, say --
- * and which the conversion functions here would therefore reject outright.
- * Calling this is how such a caller says explicitly that it means to drop
- * them. Code with no such warrant should let the rejection happen ("death
- * before confusion").
+ * properties which it knows are not content -- a runtime annotation, say -- and
+ * which the conversion functions here would therefore reject outright. Calling
+ * this is how such a caller says explicitly that it means to drop them. Code
+ * with no such warrant should let the rejection happen ("death before
+ * confusion").
  *
  * The given array's index properties must all be enumerable data properties:
  * the copy reads elements through enumeration, which would execute an
- * accessor-backed index (silently flattening it to its momentary value)
- * and would turn a non-enumerable data index into a hole.
+ * accessor-backed index (silently flattening it to its momentary value) and
+ * would turn a non-enumerable data index into a hole.
  *
  * @param value The array to clean.
  * @param frozen Whether to freeze the result. Defaults to `true`.
@@ -127,9 +127,8 @@ export function shallowCleanArray(
 /**
  * Returns a shallow clone of the given object carrying nothing but its
  * enumerable string-keyed properties, that is, one which satisfies
- * `isInertPlainObject()`. Values are copied by reference
- * without themselves being converted or validated, this being a shallow
- * operation.
+ * `isInertPlainObject()`. Values are copied by reference without themselves
+ * being converted or validated, this being a shallow operation.
  *
  * This is the object counterpart of `shallowCleanArray()`, and exists for the
  * same reason: a caller holding an object that has picked up keys which it
@@ -334,9 +333,9 @@ export function shallowFabricFromNativeValue(
     }
 
     case NATIVE_TAGS.FabricInstance: {
-      // `FabricInstance` values (`FabricError`, `UnknownValue`, etc.)
-      // are already valid `FabricValue` members. Delegate frozenness
-      // handling to `cloneHelper()`.
+      // `FabricInstance` values (`FabricError`, `UnknownValue`, etc.) are
+      // already valid `FabricValue` members. Delegate frozenness handling to
+      // `cloneHelper()`.
       return cloneHelper(
         value as FabricValue,
         freeze,
@@ -494,8 +493,8 @@ function fabricFromNativeValueInternal(
   }
 
   // `FabricSpecialObject` (primitives and protocol types) -- pass through
-  // as-is. Primitives are always frozen; protocol types are managed by
-  // the caller.
+  // as-is. Primitives are always frozen; protocol types are managed by the
+  // caller.
   if (value instanceof FabricSpecialObject) {
     if (isOriginalRecord) {
       converted.set(original, value);
@@ -599,9 +598,8 @@ function rebuildFabricErrorDeep(
  * types. It checks recursively, so all nested values in arrays and objects must
  * also be fabric-convertible.
  *
- * This function is a TypeScript type guard for
- * `FabricConvertibleValue`, which names the recursive shape described
- * above.
+ * This function is a TypeScript type guard for `FabricConvertibleValue`, which
+ * names the recursive shape described above.
  */
 export function isValidFabricConvertibleValue(
   value: unknown,

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -147,10 +147,10 @@ export function tagFromNativeClass(
  * the array rule, which alone decides what an array may be.
  *
  * Otherwise dispatches via the value's constructor (O(1) switch in
- * `tagFromNativeClass`, which matches `Error` subclasses via
- * `prototype instanceof Error`), falling back to native error detection for
- * values whose constructor is unreachable -- a severed prototype, or another
- * realm -- and to a prototype check for null-prototype objects.
+ * `tagFromNativeClass`, which matches `Error` subclasses via `prototype
+ * instanceof Error`), falling back to native error detection for values whose
+ * constructor is unreachable -- a severed prototype, or another realm -- and to
+ * a prototype check for null-prototype objects.
  */
 export function tagFromNativeValue(value: unknown): NativeTag | null {
   if (value === null || typeof value !== "object") {

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -179,9 +179,9 @@ export function schemaWithProperties(
 
   // Both `schema` and `overrides` are objects.
 
-  // `shallowMutableClone()` gives a mutable top-level object whose
-  // bound children are deep-frozen -- cloning any mutable ones rather than
-  // freezing the `schema`/`overrides` inputs in place -- so the subsequent
+  // `shallowMutableClone()` gives a mutable top-level object whose bound
+  // children are deep-frozen -- cloning any mutable ones rather than freezing
+  // the `schema`/`overrides` inputs in place -- so the subsequent
   // `toDeepFrozenSchema(result, true)` only has to seal the (owned) top.
   const result = shallowMutableClone(
     { ...schema, ...overrides },
@@ -471,17 +471,16 @@ export function internPathSelector(
 }
 
 /**
- * Canonical "reject everything at the root" path selector. Used by sites
- * that want to record a doc dependency (or normalize a `{ schema: false,
- * ... }` input) without actually traversing into it.
+ * Canonical "reject everything at the root" path selector. Used by sites that
+ * want to record a doc dependency (or normalize a `{ schema: false, ... }`
+ * input) without actually traversing into it.
  *
- * Frozen at module load, but its `schema: false` member is NOT routed
- * through `internSchema()` here (because doing so during `schema-utils.ts`'s
- * module-load would reach into a not-yet-initialized `schema-hash.ts`
- * due to the pre-existing circular import between the two modules). The
- * boolean-schema intern path uses prefab singletons anyway, so
- * lazy-interning the `false` on first real selector use is
- * behaviorally equivalent to interning here.
+ * Frozen at module load, but its `schema: false` member is NOT routed through
+ * `internSchema()` here (because doing so during `schema-utils.ts`'s
+ * module-load would reach into a not-yet-initialized `schema-hash.ts` due to
+ * the pre-existing circular import between the two modules). The boolean-schema
+ * intern path uses prefab singletons anyway, so lazy-interning the `false` on
+ * first real selector use is behaviorally equivalent to interning here.
  */
 export const REJECTING_SELECTOR: SchemaPathSelector = Object.freeze({
   path: Object.freeze([]) as readonly string[],
@@ -489,13 +488,13 @@ export const REJECTING_SELECTOR: SchemaPathSelector = Object.freeze({
 });
 
 /**
- * Canonical "accept the full value" path selector. `SchemaPathSelector`s
- * are relative to the doc root, so to look at the value of the doc the
- * path needs to have `"value"` in it.
+ * Canonical "accept the full value" path selector. `SchemaPathSelector`s are
+ * relative to the doc root, so to look at the value of the doc the path needs
+ * to have `"value"` in it.
  *
- * Frozen at module load; like `REJECTING_SELECTOR`, the boolean
- * `schema: true` member is not routed through `internSchema()` here
- * (same circular-import reason — see `REJECTING_SELECTOR` doc comment).
+ * Frozen at module load; like `REJECTING_SELECTOR`, the boolean `schema: true`
+ * member is not routed through `internSchema()` here (same circular-import
+ * reason — see `REJECTING_SELECTOR` doc comment).
  */
 export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
   path: Object.freeze(["value"]) as readonly string[],

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -30,10 +30,10 @@ import { BaseFabricPrimitive } from "./fabric-bases/BaseFabricPrimitive.ts";
 /**
  * Indicates whether the value is a `FabricValue`, accepting
  * `FabricSpecialObject`s (both `FabricInstance` and `FabricPrimitive`),
- * `undefined`, and arrays with `undefined` elements or sparse holes
- * -- in addition to the base fabric types (`null`, `boolean`, `number`,
- * `string`, plain objects, dense arrays). An array must be a direct `Array`
- * instance; a subclass instance is not a `FabricValue`.
+ * `undefined`, and arrays with `undefined` elements or sparse holes -- in
+ * addition to the base fabric types (`null`, `boolean`, `number`, `string`,
+ * plain objects, dense arrays). An array must be a direct `Array` instance; a
+ * subclass instance is not a `FabricValue`.
  *
  * This function is a TypeScript type guard for `FabricValueLayer`.
  */
@@ -216,14 +216,14 @@ export function isValidFabricPlainObject(
 /**
  * Indicates whether a `FabricValue` is a plain object, an array, or a
  * `FabricSpecialObject` -- everything a `typeof value === "object"` test
- * accepts, minus `null`. The name states the array case because "object"
- * alone reads as excluding it.
+ * accepts, minus `null`. The name states the array case because "object" alone
+ * reads as excluding it.
  *
  * The runtime behavior matches a bare `isObjectOrArray()` exactly. The
- * difference is static: `isObjectOrArray()` narrows to
- * `Record<string, unknown>`, which discards the fact that the value is a
- * `FabricValue` -- so a guarded value can no longer be handed to a
- * `FabricValue` API. This keeps that half.
+ * difference is static: `isObjectOrArray()` narrows to `Record<string,
+ * unknown>`, which discards the fact that the value is a `FabricValue` -- so a
+ * guarded value can no longer be handed to a `FabricValue` API. This keeps that
+ * half.
  *
  * Contrast `isFabricPlainObject()`, which is strictly narrower at RUNTIME: it
  * accepts only plain objects, rejecting arrays and `FabricSpecialObject`s. The
@@ -240,9 +240,9 @@ export function isFabricObjectOrArray(
  * object whose prototype is `Object.prototype` or `null`. This rejects arrays,
  * `FabricSpecialObject`s, and other class instances (`Date`, `Map`, …), none of
  * which are representable as a `FabricPlainObject`. Unlike a bare
- * `isObjectOrArray()`
- * check, it preserves the value type — `FabricPlainObject`'s string index of
- * `FabricValue` keeps an indexed value typed as a `FabricValue`.
+ * `isObjectOrArray()` check, it preserves the value type —
+ * `FabricPlainObject`'s string index of `FabricValue` keeps an indexed value
+ * typed as a `FabricValue`.
  *
  * This asks a shape question -- "may I read this by property name?" -- of a
  * value the type already says is a `FabricValue`, and a null-prototype object

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -271,17 +271,16 @@ export function cloneHelper(
 /**
  * Categorical kinds of error that `cloneForMutation()` can fail with.
  *
- * - `"non-mutable-root"` — empty `path` and the root value isn't a kind
- *   for which a mutable handle exists (a primitive, a `FabricPrimitive`,
- *   etc.).
- * - `"non-container-root"` — non-empty `path` and the root isn't a plain
- *   object or array, so there's nothing to descend into.
- * - `"missing-segment"` — a `path` segment names a slot that doesn't
- *   exist on its container, and `createMissing` is `false`.
- * - `"non-container-descent"` — an intermediate segment lands on a value
- *   that isn't a plain object or array, so descent can't continue.
- * - `"non-mutable-leaf"` — the final segment lands on a value for which
- *   no mutable handle exists (a primitive or `FabricPrimitive`).
+ * - `"non-mutable-root"` — empty `path` and the root value isn't a kind for
+ *   which a mutable handle exists (a primitive, a `FabricPrimitive`, etc.).
+ * - `"non-container-root"` — non-empty `path` and the root isn't a plain object
+ *   or array, so there's nothing to descend into.
+ * - `"missing-segment"` — a `path` segment names a slot that doesn't exist on
+ *   its container, and `createMissing` is `false`.
+ * - `"non-container-descent"` — an intermediate segment lands on a value that
+ *   isn't a plain object or array, so descent can't continue.
+ * - `"non-mutable-leaf"` — the final segment lands on a value for which no
+ *   mutable handle exists (a primitive or `FabricPrimitive`).
  */
 export type CloneForMutationErrorKind =
   | "non-mutable-root"
@@ -378,33 +377,32 @@ export interface CloneForMutationOptions {
    * helper descends. Default: `false` (throws `CloneForMutationError` with kind
    * `"missing-segment"` on the first missing slot).
    *
-   * When `createMissing: true`, at each path step where the container at
-   * that key is absent, the helper allocates a fresh container and
-   * splices it into its parent before descending. The new container's
-   * shape (array vs. plain object) is chosen from the NEXT segment that
-   * will be used as a key against it:
+   * When `createMissing: true`, at each path step where the container at that
+   * key is absent, the helper allocates a fresh container and splices it into
+   * its parent before descending. The new container's shape (array vs. plain
+   * object) is chosen from the NEXT segment that will be used as a key against
+   * it:
    *
    * - For intermediate path steps, the next segment is `path[i+1]`.
    * - For the final path step, the next segment is `nextKeyAfterPath` if
    *   supplied; otherwise the empty string (which selects a plain object).
    *
    * Array-index-shaped keys (`isArrayIndexPropertyName(key)`) and the
-   * JSON-Pointer append marker `"-"` select an array; everything else
-   * selects a plain object.
+   * JSON-Pointer append marker `"-"` select an array; everything else selects a
+   * plain object.
    */
   createMissing?: boolean;
 
   /**
-   * Hint for the container shape to create at the final path step when
-   * it's missing and `createMissing: true`. Should be the next key the
-   * caller intends to access against the value-at-path. Ignored when
-   * `createMissing: false` or when the final path step already exists.
-   * Default: `""` (selects a plain object).
+   * Hint for the container shape to create at the final path step when it's
+   * missing and `createMissing: true`. Should be the next key the caller
+   * intends to access against the value-at-path. Ignored when `createMissing:
+   * false` or when the final path step already exists. Default: `""` (selects a
+   * plain object).
    *
-   * Same shape-selection rule as for intermediate steps: array-index-
-   * shaped values (per `isArrayIndexPropertyName`) and the JSON-Pointer
-   * append marker `"-"` select an array; everything else selects a
-   * plain object.
+   * Same shape-selection rule as for intermediate steps: array-index- shaped
+   * values (per `isArrayIndexPropertyName`) and the JSON-Pointer append marker
+   * `"-"` select an array; everything else selects a plain object.
    *
    * Mirrors `v2-path.ensureParentContainers`'s `lastKey` parameter.
    */

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -400,7 +400,7 @@ export interface CloneForMutationOptions {
    * false` or when the final path step already exists. Default: `""` (selects a
    * plain object).
    *
-   * Same shape-selection rule as for intermediate steps: array-index- shaped
+   * Same shape-selection rule as for intermediate steps: array-index-shaped
    * values (per `isArrayIndexPropertyName`) and the JSON-Pointer append marker
    * `"-"` select an array; everything else selects a plain object.
    *

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -156,9 +156,8 @@ class DebugStringifier {
           let fullTag;
           try {
             // A `FabricPrimitive` binds no `[CODEC]`, so its JSON codec
-            // supplies the tag here.
-            // TODO(danfuzz): Replace `JSON_CODEC` with `DEBUG_CODEC` once the
-            // latter exists.
+            // supplies the tag here. TODO(danfuzz): Replace `JSON_CODEC` with
+            // `DEBUG_CODEC` once the latter exists.
             fullTag = codecOf(value, JSON_CODEC).tagForValue(value);
           } catch {
             // Never let the debug formatter throw; fall back to the class name.

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -189,8 +189,8 @@ function feedLength(hasher: IncrementalHasher, value: number): void {
 }
 
 /**
- * Feeds a single `FabricValue` into the hasher, using the type-tagged
- * byte format from the byte-level spec.
+ * Feeds a single `FabricValue` into the hasher, using the type-tagged byte
+ * format from the byte-level spec.
  */
 function feedValue(hasher: IncrementalHasher, value: unknown): void {
   switch (typeof value) {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

A paragraph that gets edited in place tends to keep its old line breaks, so the
edited line grows past 80 columns while its neighbors stay short. This rewraps
the paragraphs where that has visibly happened, in the space model formal spec
and in the `data-model` source comments.

## The rule

Greedy-fill at 80 columns, but only for a paragraph or comment run that has a
line over 80 columns, or a line under-filled by 6 or more columns. A paragraph
off by 1 to 5 columns is left byte-identical, which is what keeps this from
becoming a whole-file reflow: at that threshold the spec would have taken 375
paragraphs instead of 156, and roughly two thirds of that churn would have been
lines only a word's width short of full.

`docs/` is excluded from `deno fmt`, which is why this drift accumulated there;
the width and fill rule applied here are the ones the repo's own `fmt` config
already names (`lineWidth: 80`, `proseWrap: "always"`).

## No words change

Each check below has a control that makes it fail, run against this diff:

- The content-word multiset is identical over the whole diff, per file and in
  total, with each line's structural markers (`//`, a doc-comment `*`, a
  blockquote `>`) removed.
- The counts of structural lines are unchanged: blank lines, bare `>`
  separators, bare comment-marker lines, headings, fences, table rows, list
  starts, and doc-comment tags. This is the check that catches a rewrap merging
  two blockquote paragraphs, or moving a token to line start so that prose
  becomes a list item — neither of which moves a word, so the word check alone
  reports them clean.
- In the `.ts` files, the source with all comments stripped is byte-identical,
  so nothing outside a comment moved.

## Line lengths

Lines over 80 columns go from 145 to 109, and rise in no file. The residue is 75
markdown table rows, 21 lines inside fenced code blocks, and 13 pre-existing
code lines (long import specifiers and template literals) — none of which prose
rewrapping can reach.

## Gates

`deno task check`, `deno lint`, `deno fmt --check`, `deno task check-docs`, and
the `data-model` test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQJkaKMWPLBQRDEbXET7Dd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

