### PR TITLE
test(data-model): conform the suite to the unit-test style guide

### DIFF
--- a/docs/plans/first-class-serializable-factories.md
+++ b/docs/plans/first-class-serializable-factories.md
@@ -249,7 +249,7 @@ Focused tests:
 - `packages/data-model/test/cloneForMutation.test.ts`
 - `packages/data-model/test/shallowMutableClone.test.ts`
 - `packages/data-model/test/value-clone.test.ts`
-- `packages/data-model/test/valueEquals.test.ts`
+- `packages/data-model/test/valueEqual.test.ts`
 - `packages/data-model/test/value-hash.test.ts`
 
 Each suite must cover all three factory kinds, nested factory state, independent

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -47,269 +47,272 @@ for (let i = 0; i < 32; i++) SAMPLE_HASH[i] = i;
 const HASH = new FabricHash(SAMPLE_HASH, "fid1");
 const TAGGED = HASH.taggedHashString; // "fid1:…"
 
-describe("cell-rep entity-id reference", () => {
-  afterEach(() => {
-    resetModernCellRepConfig();
-  });
-
-  describe("with the flag OFF (legacy plain-object form)", () => {
-    it('produces a `{ "/": string }` object from a string', () => {
-      const ref = entityRefFromString(TAGGED);
-      expect(ref).toEqual({ "/": TAGGED });
-      expect(ref).not.toBeInstanceOf(FabricHash);
-    });
-
-    it('produces a `{ "/": string }` object from a FabricHash', () => {
-      expect(entityRefFrom(HASH)).toEqual({ "/": TAGGED });
-    });
-
-    it("recognizes the plain-object form, not a FabricHash", () => {
-      expect(isEntityRef({ "/": TAGGED })).toBe(true);
-      expect(isEntityRef(HASH)).toBe(false);
-      expect(isEntityRef(undefined)).toBe(false);
-      expect(isEntityRef("plain string")).toBe(false);
-    });
-
-    it("extracts the tagged hash string from the plain-object form", () => {
-      expect(entityRefToString({ "/": TAGGED })).toBe(TAGGED);
-    });
-
-    it("throws extracting from a FabricHash (wrong regime)", () => {
-      expect(() => entityRefToString(HASH as EntityRef)).toThrow();
-    });
-  });
-
-  describe("with the flag ON (modern FabricHash form)", () => {
-    it("produces a FabricHash from a string", () => {
-      setModernCellRepConfig(true);
-      const ref = entityRefFromString(TAGGED);
-      expect(ref).toBeInstanceOf(FabricHash);
-      expect((ref as FabricHash).taggedHashString).toBe(TAGGED);
-    });
-
-    it("returns the FabricHash unchanged from a FabricHash", () => {
-      setModernCellRepConfig(true);
-      expect(entityRefFrom(HASH)).toBe(HASH);
-    });
-
-    it("recognizes a FabricHash, not the plain-object form", () => {
-      setModernCellRepConfig(true);
-      expect(isEntityRef(HASH)).toBe(true);
-      expect(isEntityRef({ "/": TAGGED })).toBe(false);
-    });
-
-    it("extracts the tagged hash string from a FabricHash", () => {
-      setModernCellRepConfig(true);
-      expect(entityRefToString(HASH)).toBe(TAGGED);
-    });
-
-    it("throws extracting from the plain-object form (wrong regime)", () => {
-      setModernCellRepConfig(true);
-      expect(() => entityRefToString({ "/": TAGGED } as EntityRef)).toThrow();
-    });
-  });
-
-  it("round-trips a string through both forms in each regime", () => {
-    for (const enabled of [false, true]) {
-      setModernCellRepConfig(enabled);
-      expect(entityRefToString(entityRefFromString(TAGGED))).toBe(TAGGED);
-      expect(entityRefToString(entityRefFrom(HASH))).toBe(TAGGED);
+describe("cell-rep", () => {
+  describe("entity-id reference", () => {
+    afterEach(() => {
       resetModernCellRepConfig();
-    }
-  });
-});
-
-describe("cell-rep link-ref (legacy envelope form)", () => {
-  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
-
-  it('wraps a payload in the `{ "/": { "link@1": … } }` envelope', () => {
-    expect(linkRefFrom(PAYLOAD)).toEqual({ "/": { [LINK_V1_TAG]: PAYLOAD } });
-  });
-
-  it("recognizes the link-ref envelope", () => {
-    expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
-  });
-
-  it("returns `false` for everything that is not a link-ref envelope", () => {
-    // The `{ "/": string }` entity-ref form is deliberately NOT a link ref.
-    expect(isLinkRef({ "/": "fid1:abc" })).toBe(false);
-    // Envelope with extra keys, or missing the tag, or wrong shape.
-    expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD }, extra: 1 })).toBe(
-      false,
-    );
-    expect(isLinkRef({ "/": {} })).toBe(false);
-    expect(isLinkRef({ other: { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
-    expect(isLinkRef(undefined)).toBe(false);
-    expect(isLinkRef("link")).toBe(false);
-    expect(isLinkRef([])).toBe(false);
-  });
-
-  it("extracts the payload from an envelope", () => {
-    expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
-  });
-
-  it("throws extracting a payload from a non-envelope", () => {
-    expect(() => linkRefPayload({ "/": "fid1:abc" } as never)).toThrow(
-      "Not a link reference",
-    );
-    expect(() => linkRefPayload({} as never)).toThrow("Not a link reference");
-  });
-});
-
-describe("cell-rep link-ref (modern FabricLink form)", () => {
-  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
-
-  afterEach(() => {
-    resetModernCellRepConfig();
-  });
-
-  it("produces a FabricLink wrapping the payload", () => {
-    setModernCellRepConfig(true);
-    const link = linkRefFrom(PAYLOAD);
-    expect(link).toBeInstanceOf(FabricLink);
-    expect((link as FabricLink).payload).toEqual(PAYLOAD);
-  });
-
-  it("recognizes a FabricLink, not the legacy envelope", () => {
-    setModernCellRepConfig(true);
-    expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
-    expect(isLinkRef(new FabricLink(PAYLOAD))).toBe(true);
-    // The legacy envelope is the wrong regime's form, so it is NOT recognized.
-    expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
-  });
-
-  it("extracts the payload from a FabricLink", () => {
-    setModernCellRepConfig(true);
-    expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
-    expect(linkRefPayload(new FabricLink(PAYLOAD))).toEqual(PAYLOAD);
-  });
-
-  it("throws extracting from the legacy envelope (wrong regime)", () => {
-    setModernCellRepConfig(true);
-    expect(() => linkRefPayload({ "/": { [LINK_V1_TAG]: PAYLOAD } } as never))
-      .toThrow("Not a link reference");
-  });
-});
-
-describe("cell-rep link storage-tree probe (legacy)", () => {
-  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
-
-  it('probes two segments down at ["/", "link@1"]', () => {
-    expect(linkProbeSubPath()).toEqual(["/", LINK_V1_TAG]);
-  });
-
-  it("reads the payload back from the value at the probe sub-path", () => {
-    // The envelope is decomposed in the tree, so walking the probe sub-path
-    // lands directly on the payload record.
-    const envelope = linkRefFrom(PAYLOAD);
-    const atProbe = linkProbeSubPath().reduce<unknown>(
-      (node, key) => (node as Record<string, unknown>)[key],
-      envelope,
-    );
-    expect(linkPayloadAtProbe(atProbe)).toEqual(PAYLOAD);
-  });
-
-  it("treats any record at the probe as the payload", () => {
-    expect(linkPayloadAtProbe(PAYLOAD)).toBe(PAYLOAD);
-    expect(linkPayloadAtProbe({})).toEqual({});
-  });
-
-  it("returns `undefined` when the probed value is not a record", () => {
-    expect(linkPayloadAtProbe(undefined)).toBeUndefined();
-    expect(linkPayloadAtProbe(null)).toBeUndefined();
-    expect(linkPayloadAtProbe("redirect")).toBeUndefined();
-    expect(linkPayloadAtProbe(42)).toBeUndefined();
-  });
-});
-
-describe("cell-rep link storage-tree probe (modern)", () => {
-  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
-
-  afterEach(() => {
-    resetModernCellRepConfig();
-  });
-
-  it("probes at the position itself (empty sub-path)", () => {
-    setModernCellRepConfig(true);
-    // A modern link is an atomic value at its position, not a decomposed
-    // envelope, so there is nothing to descend into.
-    expect(linkProbeSubPath()).toEqual([]);
-  });
-
-  it("unwraps a FabricLink read at the probe position", () => {
-    setModernCellRepConfig(true);
-    expect(linkPayloadAtProbe(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
-  });
-
-  it("returns `undefined` for a non-link value at the probe", () => {
-    setModernCellRepConfig(true);
-    // A bare record is the payload in legacy mode, but in modern mode only a
-    // FabricLink denotes a link — plain data and the legacy envelope do not.
-    expect(linkPayloadAtProbe(PAYLOAD)).toBeUndefined();
-    expect(linkPayloadAtProbe({ "/": { [LINK_V1_TAG]: PAYLOAD } }))
-      .toBeUndefined();
-    expect(linkPayloadAtProbe(undefined)).toBeUndefined();
-  });
-});
-
-describe("cell-rep link-ref payload wire serialization", () => {
-  it("round-trips a payload of strings and string arrays", () => {
-    const payload = { id: "of:abc", space: "did:key:z6Mk", path: ["a", "b"] };
-    const wire = linkRefPayloadToString(payload);
-    expect(wire.startsWith("fcl1:")).toBe(true);
-    expect(linkRefPayloadFromString(wire)).toEqual(payload);
-  });
-
-  it("tags the output with the fcl1: prefix followed by the JSON", () => {
-    expect(linkRefPayloadToString({ id: "of:abc" })).toBe(
-      'fcl1:{"id":"of:abc"}',
-    );
-  });
-
-  describe("linkRefPayloadToString validation", () => {
-    const bad = (p: unknown) =>
-      expect(() => linkRefPayloadToString(p as WireLinkRefPayload)).toThrow();
-
-    it("throws on a non-plain-object payload", () => {
-      bad([]);
-      bad("of:abc");
-      bad(null);
     });
 
-    it("throws on a value that is neither string nor array-of-strings", () => {
-      bad({ n: 1 }); // number
-      bad({ o: { k: "v" } }); // nested object (e.g. a `schema`)
-      bad({ a: ["ok", 2] }); // array with a non-string element
+    describe("with the flag OFF (legacy plain-object form)", () => {
+      it('produces a `{ "/": string }` object from a string', () => {
+        const ref = entityRefFromString(TAGGED);
+        expect(ref).toEqual({ "/": TAGGED });
+        expect(ref).not.toBeInstanceOf(FabricHash);
+      });
+
+      it('produces a `{ "/": string }` object from a FabricHash', () => {
+        expect(entityRefFrom(HASH)).toEqual({ "/": TAGGED });
+      });
+
+      it("recognizes the plain-object form, not a FabricHash", () => {
+        expect(isEntityRef({ "/": TAGGED })).toBe(true);
+        expect(isEntityRef(HASH)).toBe(false);
+        expect(isEntityRef(undefined)).toBe(false);
+        expect(isEntityRef("plain string")).toBe(false);
+      });
+
+      it("extracts the tagged hash string from the plain-object form", () => {
+        expect(entityRefToString({ "/": TAGGED })).toBe(TAGGED);
+      });
+
+      it("throws extracting from a FabricHash (wrong regime)", () => {
+        expect(() => entityRefToString(HASH as EntityRef)).toThrow();
+      });
+    });
+
+    describe("with the flag ON (modern FabricHash form)", () => {
+      it("produces a FabricHash from a string", () => {
+        setModernCellRepConfig(true);
+        const ref = entityRefFromString(TAGGED);
+        expect(ref).toBeInstanceOf(FabricHash);
+        expect((ref as FabricHash).taggedHashString).toBe(TAGGED);
+      });
+
+      it("returns the FabricHash unchanged from a FabricHash", () => {
+        setModernCellRepConfig(true);
+        expect(entityRefFrom(HASH)).toBe(HASH);
+      });
+
+      it("recognizes a FabricHash, not the plain-object form", () => {
+        setModernCellRepConfig(true);
+        expect(isEntityRef(HASH)).toBe(true);
+        expect(isEntityRef({ "/": TAGGED })).toBe(false);
+      });
+
+      it("extracts the tagged hash string from a FabricHash", () => {
+        setModernCellRepConfig(true);
+        expect(entityRefToString(HASH)).toBe(TAGGED);
+      });
+
+      it("throws extracting from the plain-object form (wrong regime)", () => {
+        setModernCellRepConfig(true);
+        expect(() => entityRefToString({ "/": TAGGED } as EntityRef)).toThrow();
+      });
+    });
+
+    it("round-trips a string through both forms in each regime", () => {
+      for (const enabled of [false, true]) {
+        setModernCellRepConfig(enabled);
+        expect(entityRefToString(entityRefFromString(TAGGED))).toBe(TAGGED);
+        expect(entityRefToString(entityRefFrom(HASH))).toBe(TAGGED);
+        resetModernCellRepConfig();
+      }
     });
   });
 
-  describe("linkRefPayloadFromString validation", () => {
-    it("throws without the fcl1: prefix", () => {
-      expect(() => linkRefPayloadFromString('{"id":"of:abc"}')).toThrow();
-      expect(() => linkRefPayloadFromString("of:abc")).toThrow();
+  describe("link-ref (legacy envelope form)", () => {
+    const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+    it('wraps a payload in the `{ "/": { "link@1": … } }` envelope', () => {
+      expect(linkRefFrom(PAYLOAD)).toEqual({ "/": { [LINK_V1_TAG]: PAYLOAD } });
     });
 
-    it("throws on invalid JSON after the prefix", () => {
-      expect(() => linkRefPayloadFromString("fcl1:not json")).toThrow();
+    it("recognizes the link-ref envelope", () => {
+      expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
     });
 
-    it("throws when the decoded value is not a plain object", () => {
-      expect(() => linkRefPayloadFromString('fcl1:"x"')).toThrow();
-      expect(() => linkRefPayloadFromString("fcl1:[]")).toThrow();
-      expect(() => linkRefPayloadFromString("fcl1:null")).toThrow();
+    it("returns `false` for everything that is not a link-ref envelope", () => {
+      // The `{ "/": string }` entity-ref form is deliberately NOT a link ref.
+      expect(isLinkRef({ "/": "fid1:abc" })).toBe(false);
+      // Envelope with extra keys, or missing the tag, or wrong shape.
+      expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD }, extra: 1 })).toBe(
+        false,
+      );
+      expect(isLinkRef({ "/": {} })).toBe(false);
+      expect(isLinkRef({ other: { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
+      expect(isLinkRef(undefined)).toBe(false);
+      expect(isLinkRef("link")).toBe(false);
+      expect(isLinkRef([])).toBe(false);
     });
 
-    it("throws when a decoded value is not a string or array-of-strings", () => {
-      expect(() => linkRefPayloadFromString('fcl1:{"n":1}')).toThrow();
-      expect(() => linkRefPayloadFromString('fcl1:{"o":{"k":"v"}}')).toThrow();
-      expect(() => linkRefPayloadFromString('fcl1:{"a":["ok",2]}')).toThrow();
+    it("extracts the payload from an envelope", () => {
+      expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
     });
 
-    it("throws given prototype-pollution keys carried on the wire", () => {
-      expect(() => linkRefPayloadFromString('fcl1:{"__proto__":"x"}'))
-        .toThrow();
-      expect(() => linkRefPayloadFromString('fcl1:{"constructor":"x"}'))
-        .toThrow();
+    it("throws extracting a payload from a non-envelope", () => {
+      expect(() => linkRefPayload({ "/": "fid1:abc" } as never)).toThrow(
+        "Not a link reference",
+      );
+      expect(() => linkRefPayload({} as never)).toThrow("Not a link reference");
+    });
+  });
+
+  describe("link-ref (modern FabricLink form)", () => {
+    const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+    afterEach(() => {
+      resetModernCellRepConfig();
+    });
+
+    it("produces a FabricLink wrapping the payload", () => {
+      setModernCellRepConfig(true);
+      const link = linkRefFrom(PAYLOAD);
+      expect(link).toBeInstanceOf(FabricLink);
+      expect((link as FabricLink).payload).toEqual(PAYLOAD);
+    });
+
+    it("recognizes a FabricLink, not the legacy envelope", () => {
+      setModernCellRepConfig(true);
+      expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
+      expect(isLinkRef(new FabricLink(PAYLOAD))).toBe(true);
+      // The legacy envelope is the wrong regime's form, so it is NOT recognized.
+      expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
+    });
+
+    it("extracts the payload from a FabricLink", () => {
+      setModernCellRepConfig(true);
+      expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
+      expect(linkRefPayload(new FabricLink(PAYLOAD))).toEqual(PAYLOAD);
+    });
+
+    it("throws extracting from the legacy envelope (wrong regime)", () => {
+      setModernCellRepConfig(true);
+      expect(() => linkRefPayload({ "/": { [LINK_V1_TAG]: PAYLOAD } } as never))
+        .toThrow("Not a link reference");
+    });
+  });
+
+  describe("link storage-tree probe (legacy)", () => {
+    const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+    it('probes two segments down at ["/", "link@1"]', () => {
+      expect(linkProbeSubPath()).toEqual(["/", LINK_V1_TAG]);
+    });
+
+    it("reads the payload back from the value at the probe sub-path", () => {
+      // The envelope is decomposed in the tree, so walking the probe sub-path
+      // lands directly on the payload record.
+      const envelope = linkRefFrom(PAYLOAD);
+      const atProbe = linkProbeSubPath().reduce<unknown>(
+        (node, key) => (node as Record<string, unknown>)[key],
+        envelope,
+      );
+      expect(linkPayloadAtProbe(atProbe)).toEqual(PAYLOAD);
+    });
+
+    it("treats any record at the probe as the payload", () => {
+      expect(linkPayloadAtProbe(PAYLOAD)).toBe(PAYLOAD);
+      expect(linkPayloadAtProbe({})).toEqual({});
+    });
+
+    it("returns `undefined` when the probed value is not a record", () => {
+      expect(linkPayloadAtProbe(undefined)).toBeUndefined();
+      expect(linkPayloadAtProbe(null)).toBeUndefined();
+      expect(linkPayloadAtProbe("redirect")).toBeUndefined();
+      expect(linkPayloadAtProbe(42)).toBeUndefined();
+    });
+  });
+
+  describe("link storage-tree probe (modern)", () => {
+    const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+    afterEach(() => {
+      resetModernCellRepConfig();
+    });
+
+    it("probes at the position itself (empty sub-path)", () => {
+      setModernCellRepConfig(true);
+      // A modern link is an atomic value at its position, not a decomposed
+      // envelope, so there is nothing to descend into.
+      expect(linkProbeSubPath()).toEqual([]);
+    });
+
+    it("unwraps a FabricLink read at the probe position", () => {
+      setModernCellRepConfig(true);
+      expect(linkPayloadAtProbe(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
+    });
+
+    it("returns `undefined` for a non-link value at the probe", () => {
+      setModernCellRepConfig(true);
+      // A bare record is the payload in legacy mode, but in modern mode only a
+      // FabricLink denotes a link — plain data and the legacy envelope do not.
+      expect(linkPayloadAtProbe(PAYLOAD)).toBeUndefined();
+      expect(linkPayloadAtProbe({ "/": { [LINK_V1_TAG]: PAYLOAD } }))
+        .toBeUndefined();
+      expect(linkPayloadAtProbe(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("link-ref payload wire serialization", () => {
+    it("round-trips a payload of strings and string arrays", () => {
+      const payload = { id: "of:abc", space: "did:key:z6Mk", path: ["a", "b"] };
+      const wire = linkRefPayloadToString(payload);
+      expect(wire.startsWith("fcl1:")).toBe(true);
+      expect(linkRefPayloadFromString(wire)).toEqual(payload);
+    });
+
+    it("tags the output with the fcl1: prefix followed by the JSON", () => {
+      expect(linkRefPayloadToString({ id: "of:abc" })).toBe(
+        'fcl1:{"id":"of:abc"}',
+      );
+    });
+
+    describe("linkRefPayloadToString validation", () => {
+      const bad = (p: unknown) =>
+        expect(() => linkRefPayloadToString(p as WireLinkRefPayload)).toThrow();
+
+      it("throws on a non-plain-object payload", () => {
+        bad([]);
+        bad("of:abc");
+        bad(null);
+      });
+
+      it("throws on a value that is neither string nor array-of-strings", () => {
+        bad({ n: 1 }); // number
+        bad({ o: { k: "v" } }); // nested object (e.g. a `schema`)
+        bad({ a: ["ok", 2] }); // array with a non-string element
+      });
+    });
+
+    describe("linkRefPayloadFromString validation", () => {
+      it("throws without the fcl1: prefix", () => {
+        expect(() => linkRefPayloadFromString('{"id":"of:abc"}')).toThrow();
+        expect(() => linkRefPayloadFromString("of:abc")).toThrow();
+      });
+
+      it("throws on invalid JSON after the prefix", () => {
+        expect(() => linkRefPayloadFromString("fcl1:not json")).toThrow();
+      });
+
+      it("throws when the decoded value is not a plain object", () => {
+        expect(() => linkRefPayloadFromString('fcl1:"x"')).toThrow();
+        expect(() => linkRefPayloadFromString("fcl1:[]")).toThrow();
+        expect(() => linkRefPayloadFromString("fcl1:null")).toThrow();
+      });
+
+      it("throws when a decoded value is not a string or array-of-strings", () => {
+        expect(() => linkRefPayloadFromString('fcl1:{"n":1}')).toThrow();
+        expect(() => linkRefPayloadFromString('fcl1:{"o":{"k":"v"}}'))
+          .toThrow();
+        expect(() => linkRefPayloadFromString('fcl1:{"a":["ok",2]}')).toThrow();
+      });
+
+      it("throws given prototype-pollution keys carried on the wire", () => {
+        expect(() => linkRefPayloadFromString('fcl1:{"__proto__":"x"}'))
+          .toThrow();
+        expect(() => linkRefPayloadFromString('fcl1:{"constructor":"x"}'))
+          .toThrow();
+      });
     });
   });
 });

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -98,7 +98,7 @@ describe("ProblematicValue", () => {
 
   describe("instance members", () => {
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: recurses state, freezes in place", () => {
+      it("recurses state, freezes in place, via dispatch", () => {
         const child = { x: 1 };
         const pv = new ProblematicValue(
           "Bad@1",
@@ -112,7 +112,7 @@ describe("ProblematicValue", () => {
         expect(isValidDeepFrozenFabricValue(pv)).toBe(true);
       });
 
-      it("via direct member invocation: recurses state, freezes in place", () => {
+      it("recurses state, freezes in place, via direct member invocation", () => {
         const child = { x: 1 };
         const pv = new ProblematicValue(
           "Bad@1",
@@ -126,45 +126,45 @@ describe("ProblematicValue", () => {
         expect(pv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
       });
     });
-  });
 
-  describe("equals()", () => {
-    it("returns `true` for an instance reporting the same fault", () => {
-      const state = { x: 1 };
+    describe("equals()", () => {
+      it("returns `true` for an instance reporting the same fault", () => {
+        const state = { x: 1 };
 
-      expect(new ProblematicValue("T@1", state, "boom").equals(
-        new ProblematicValue("T@1", state, "boom"),
-      )).toBe(true);
-    });
+        expect(new ProblematicValue("T@1", state, "boom").equals(
+          new ProblematicValue("T@1", state, "boom"),
+        )).toBe(true);
+      });
 
-    it("returns `false` when any of the three facts differs", () => {
-      const state = { x: 1 };
-      const pv = new ProblematicValue("T@1", state, "boom");
+      it("returns `false` when any of the three facts differs", () => {
+        const state = { x: 1 };
+        const pv = new ProblematicValue("T@1", state, "boom");
 
-      expect(pv.equals(new ProblematicValue("Other@1", state, "boom")))
-        .toBe(false);
-      expect(pv.equals(new ProblematicValue("T@1", { x: 1 }, "boom")))
-        .toBe(false);
-      expect(pv.equals(new ProblematicValue("T@1", state, "different")))
-        .toBe(false);
-    });
+        expect(pv.equals(new ProblematicValue("Other@1", state, "boom")))
+          .toBe(false);
+        expect(pv.equals(new ProblematicValue("T@1", { x: 1 }, "boom")))
+          .toBe(false);
+        expect(pv.equals(new ProblematicValue("T@1", state, "different")))
+          .toBe(false);
+      });
 
-    it("returns `false` for anything that is not a `ProblematicValue`", () => {
-      const pv = new ProblematicValue("T@1", "s", "boom");
+      it("returns `false` for anything that is not a `ProblematicValue`", () => {
+        const pv = new ProblematicValue("T@1", "s", "boom");
 
-      expect(pv.equals(undefined)).toBe(false);
-      expect(pv.equals(null)).toBe(false);
-      expect(pv.equals("T@1")).toBe(false);
-      expect(pv.equals({ wireTypeTag: "T@1", state: "s", error: "boom" }))
-        .toBe(false);
-    });
+        expect(pv.equals(undefined)).toBe(false);
+        expect(pv.equals(null)).toBe(false);
+        expect(pv.equals("T@1")).toBe(false);
+        expect(pv.equals({ wireTypeTag: "T@1", state: "s", error: "boom" }))
+          .toBe(false);
+      });
 
-    it("compares a non-string tag by the rendering it kept", () => {
-      // The tag is normalized on the way in, so two instances built from the
-      // same unusable tag agree.
-      expect(new ProblematicValue(42, "s", "boom").equals(
-        new ProblematicValue(42, "s", "boom"),
-      )).toBe(true);
+      it("compares a non-string tag by the rendering it kept", () => {
+        // The tag is normalized on the way in, so two instances built from the
+        // same unusable tag agree.
+        expect(new ProblematicValue(42, "s", "boom").equals(
+          new ProblematicValue(42, "s", "boom"),
+        )).toBe(true);
+      });
     });
   });
 

--- a/packages/data-model/test/codec-common/UnknownValue.test.ts
+++ b/packages/data-model/test/codec-common/UnknownValue.test.ts
@@ -76,7 +76,7 @@ describe("UnknownValue", () => {
 
   describe("instance members", () => {
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: recurses state, freezes in place", () => {
+      it("recurses state, freezes in place, via dispatch", () => {
         const child = { y: 2 };
         const uv = new UnknownValue(
           "Fancy@3",
@@ -89,7 +89,7 @@ describe("UnknownValue", () => {
         expect(isValidDeepFrozenFabricValue(uv)).toBe(true);
       });
 
-      it("via direct member invocation: recurses state, freezes in place", () => {
+      it("recurses state, freezes in place, via direct member invocation", () => {
         const child = { y: 2 };
         const uv = new UnknownValue(
           "Fancy@3",

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1234,7 +1234,7 @@ describe("JsonCodecEngine", () => {
         expect(result["outer"]!["/inner"]).toBe(1);
       });
 
-      it("single-key `/`-prefixed object still routes through `#unwrapTag()` (no regression)", () => {
+      it("still routes a single-key `/`-prefixed object through `#unwrapTag()` (no regression)", () => {
         // Single-key `/Tag@N` objects are handled by `#unwrapTag()` rather than
         // the plain-object path, so they produce an `UnknownValue` for the
         // unrecognized tag and never reach the multi-key guard's
@@ -1247,7 +1247,7 @@ describe("JsonCodecEngine", () => {
         );
       });
 
-      it("decoder strips exactly one `/quote` layer — inner `/quote` is preserved literally", () => {
+      it("strips exactly one `/quote` layer — inner `/quote` is preserved literally", () => {
         // The encoded form `{"/quote": {"/quote": "x"}}` is a `/quote`-wrapped
         // literal whose content happens to be `{"/quote": "x"}`. Decoding must
         // return that inner object as a frozen plain object, and must _not_
@@ -1588,7 +1588,7 @@ describe("JsonCodecEngine", () => {
       expect(result.error).toBe("boom");
     });
 
-    it("lenient mode wraps failed handler decoding", () => {
+    it("wraps failed handler decoding in lenient mode", () => {
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestLiveEnvironment();
 
@@ -1649,7 +1649,7 @@ describe("JsonCodecEngine", () => {
       expect(isDeepFrozen(result)).toBe(true);
     });
 
-    it("lenient mode wraps failed class-registry decoding", () => {
+    it("wraps failed class-registry decoding in lenient mode", () => {
       const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
       const runtime = new TestLiveEnvironment();
 
@@ -1672,21 +1672,21 @@ describe("JsonCodecEngine", () => {
   });
 
   describe("freeze guarantees", () => {
-    it("decoded arrays are frozen", () => {
+    it("freezes decoded arrays", () => {
       const result = fromEncodedFormat(
         [1, 2, 3] as JsonCodecValue,
       );
       expect(Object.isFrozen(result)).toBe(true);
     });
 
-    it("decoded objects are frozen", () => {
+    it("freezes decoded objects", () => {
       const result = fromEncodedFormat(
         { a: 1 } as JsonCodecValue,
       ) as Record<string, FabricValue>;
       expect(Object.isFrozen(result)).toBe(true);
     });
 
-    it("mutation of a decoded array throws", () => {
+    it("throws on mutation of a decoded array", () => {
       const result = fromEncodedFormat(
         [1, 2, 3] as JsonCodecValue,
       );
@@ -1695,7 +1695,7 @@ describe("JsonCodecEngine", () => {
       }).toThrow();
     });
 
-    it("mutation of a decoded object throws", () => {
+    it("throws on mutation of a decoded object", () => {
       const result = fromEncodedFormat(
         { a: 1 } as JsonCodecValue,
       ) as Record<string, FabricValue>;
@@ -1704,7 +1704,7 @@ describe("JsonCodecEngine", () => {
       }).toThrow();
     });
 
-    it("nested decoded objects are frozen", () => {
+    it("freezes nested decoded objects", () => {
       const result = fromEncodedFormat(
         { inner: { val: 42 } } as JsonCodecValue,
       ) as Record<string, Record<string, FabricValue>>;
@@ -1712,7 +1712,7 @@ describe("JsonCodecEngine", () => {
       expect(Object.isFrozen(result.inner)).toBe(true);
     });
 
-    it("decoded `/object`-unwrapped objects are frozen", () => {
+    it("freezes decoded `/object`-unwrapped objects", () => {
       const data = { "/object": { "/myKey": "val" } } as JsonCodecValue;
       const result = fromEncodedFormat(data) as Record<
         string,
@@ -1726,7 +1726,7 @@ describe("JsonCodecEngine", () => {
     // `Object.isFrozen()`: an arm that froze only the value it built, and not
     // what it wrapped, would pass the shallow check.
 
-    it("an `UnknownValue` from an unrecognized tag is deep-frozen", () => {
+    it("deep-freezes an `UnknownValue` from an unrecognized tag", () => {
       const result = fromEncodedFormat(
         { "/Nope@1": { a: 1 } } as JsonCodecValue,
       );
@@ -1735,7 +1735,7 @@ describe("JsonCodecEngine", () => {
       expect(isDeepFrozen(result)).toBe(true);
     });
 
-    it("an `UnknownValue` is deep-frozen through its state", () => {
+    it("deep-freezes an `UnknownValue` through its state", () => {
       const result = fromEncodedFormat(
         { "/Nope@1": { inner: { deep: [1, 2] } } } as JsonCodecValue,
       ) as UnknownValue;
@@ -1746,7 +1746,7 @@ describe("JsonCodecEngine", () => {
       expect(Object.isFrozen(state.inner.deep)).toBe(true);
     });
 
-    it("a `ProblematicValue` from a malformed tag is deep-frozen", () => {
+    it("deep-freezes a `ProblematicValue` from a malformed tag", () => {
       // `malformed`, because the wrap helper validates with a strict decode
       // and would otherwise reject the very payload this case is made of.
       const result = fromEncodedFormat(
@@ -1765,7 +1765,7 @@ describe("JsonCodecEngine", () => {
     // freeze. That holds of every other arm too, the unknown-tag fallback
     // included; the cases just above cover those.
 
-    it("codec-produced value is deep-frozen at the boundary", () => {
+    it("deep-freezes a codec-produced value at the boundary", () => {
       // `/EpochNsec@1` dispatches through a registered codec; the
       // decoded FabricEpochNsec must be deep-frozen on return.
       const result = fromEncodedFormat(
@@ -1775,7 +1775,7 @@ describe("JsonCodecEngine", () => {
       expect(isDeepFrozen(result)).toBe(true);
     });
 
-    it("lenient-mode `ProblematicValue` from a codec is deep-frozen", () => {
+    it("deep-freezes a lenient-mode `ProblematicValue` from a codec", () => {
       // `/BigInt@1` with non-string state fails codec validation; the
       // lenient catch produces a ProblematicValue -- still a codec-arm return,
       // so the contract deep-freezes it (not a crash: it is the value
@@ -1793,7 +1793,7 @@ describe("JsonCodecEngine", () => {
       expect(isDeepFrozen(result)).toBe(true);
     });
 
-    it("codec round-trip yields a deep-frozen result", () => {
+    it("yields a deep-frozen result from a codec round-trip", () => {
       const result = roundTrip(
         new FabricEpochNsec(1704067200000000000n),
       );

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -115,7 +115,7 @@ describe("codecs", () => {
     expect(roundTrip(null)).toBe(null);
   });
 
-  it("JSON-safe primitives stringify normally (under the encoding prefix)", () => {
+  it("stringifies JSON-safe primitives normally (under the encoding prefix)", () => {
     expect(jsonFromFabricValue(42)).toBe("fvj1:42");
     expect(jsonFromFabricValue("hello")).toBe('fvj1:"hello"');
     expect(jsonFromFabricValue(true)).toBe("fvj1:true");
@@ -168,12 +168,12 @@ describe("codecs", () => {
       expect(roundTrip(value)).toEqual({ "/foo": "bar" });
     });
 
-    it("decoded objects are frozen", () => {
+    it("freezes decoded objects", () => {
       const value = { a: 1, b: "two" };
       expect(Object.isFrozen(roundTrip(value))).toBe(true);
     });
 
-    it("decoded arrays are frozen", () => {
+    it("freezes decoded arrays", () => {
       const value = [1, 2, 3];
       expect(Object.isFrozen(roundTrip(value))).toBe(true);
     });
@@ -220,12 +220,12 @@ describe("codecs", () => {
       expect(roundTrip(slashKeyed)).toEqual(slashKeyed);
     });
 
-    it("`$stream` marker passes through unchanged", () => {
+    it("passes the `$stream` marker through unchanged", () => {
       const value = { $stream: true };
       expect(roundTrip(value)).toEqual({ $stream: true });
     });
 
-    it("`@Error` marker passes through unchanged", () => {
+    it("passes the `@Error` marker through unchanged", () => {
       const value = {
         "@Error": { name: "TypeError", message: "oops", stack: "" },
       };
@@ -249,7 +249,7 @@ describe("codecs", () => {
       });
     });
 
-    it("mixed value with fabric types and slash-keys round-trips", () => {
+    it("round-trips a mixed value with fabric types and slash-keys", () => {
       const value = {
         count: 42n,
         slashKeyed: { "/": { values: [1, 2, 3], note: "hello" } },
@@ -292,7 +292,7 @@ describe("codecs", () => {
       expect(fabricFromJsonValue('fvj1:{"\/BigInt@1":"Kg"}')).toBe(42n);
     });
 
-    it("explicit `undefined` runtime is equivalent to omission", () => {
+    it("treats an explicit `undefined` runtime as equivalent to omission", () => {
       expect(fabricFromJsonValue('fvj1:{"a":1}', undefined)).toEqual({ a: 1 });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -488,7 +488,7 @@ describe("FabricError", () => {
     // round-trip). These cases pin the template contract for this concrete
     // implementor.
     describe("deepClone()", () => {
-      it("frozen clone is deep-frozen with equal state", () => {
+      it("returns a deep-frozen clone with equal state", () => {
         const fe = FabricError.fromNativeError(
           new Error("boom", { cause: { detail: 1 } }),
         );
@@ -515,7 +515,7 @@ describe("FabricError", () => {
         expect(fe.deepClone(true)).not.toBe(fe);
       });
 
-      it("mutable clone is a distinct, mutable instance with equal state", () => {
+      it("returns a distinct, mutable clone with equal state", () => {
         const fe = FabricError.fromNativeError(
           new Error("outer", { cause: { detail: 1 } }),
         );
@@ -536,7 +536,7 @@ describe("FabricError", () => {
       // `cause` with the original -- contrary to the `deepClone(false)`
       // contract on `FabricInstance`. Pinned to record the actual behavior,
       // not to bless it.
-      it("mutable clone currently SHARES the nested `cause` reference (known gap)", () => {
+      it("returns a mutable clone that currently SHARES the nested `cause` reference (known gap)", () => {
         const cause = { detail: 1 };
         const fe = FabricError.fromNativeError(new Error("outer", { cause }));
         const clone = fe.deepClone(false) as FabricError;

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -128,7 +128,7 @@ describe("FabricLink", () => {
   });
 
   describe("deepClone()", () => {
-    it("frozen clone is deep-frozen with an equal payload", () => {
+    it("returns a deep-frozen clone with an equal payload", () => {
       const link = new FabricLink({ id: "fid1:abc", path: ["a"] });
       const clone = link.deepClone(true) as FabricLink;
       expect(isDeepFrozen(clone)).toBe(true);
@@ -140,7 +140,7 @@ describe("FabricLink", () => {
       expect(link.deepClone(true)).toBe(link);
     });
 
-    it("mutable clone is independent (no shared payload structure)", () => {
+    it("returns an independent mutable clone (no shared payload structure)", () => {
       const link = new FabricLink({ id: "fid1:abc" });
       const clone = link.deepClone(false) as FabricLink;
       expect(Object.isFrozen(clone)).toBe(false);
@@ -149,7 +149,7 @@ describe("FabricLink", () => {
       expect(link.payload.id).toBe("fid1:abc");
     });
 
-    it("frozen clone identity-shares an already-deep-frozen payload subtree", () => {
+    it("returns a frozen clone that identity-shares an already-deep-frozen payload subtree", () => {
       // The `[DEEP_CLONE_CORE](frozen)` core clones the payload to the
       // requested frozenness, so the "maximal structural sharing" the
       // `deepClone()` contract promises holds: a nested subtree that is
@@ -164,7 +164,7 @@ describe("FabricLink", () => {
   });
 
   describe("shallowClone()", () => {
-    it("mutable shallow clone shares the payload reference", () => {
+    it("returns a mutable shallow clone that shares the payload reference", () => {
       const link = new FabricLink({ id: "fid1:abc" });
       const clone = link.shallowClone(false) as FabricLink;
       expect(clone).not.toBe(link);

--- a/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
@@ -160,7 +160,7 @@ describe("FabricEpochDay", () => {
 
   // Exercises the free `shallowFabricFromNativeValue()` rather than a member
   // of the class, so it lives directly under the class `describe()`.
-  describe("shallowFabricFromNativeValue() integration", () => {
+  describe("`shallowFabricFromNativeValue()` integration", () => {
     it("passes through unchanged even with `freeze=false`", () => {
       const days = new FabricEpochDay(456n);
       // freeze=false should still return the same instance (not a copy).

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -180,7 +180,7 @@ describe("FabricEpochNsec", () => {
 
   // Exercises the free `shallowFabricFromNativeValue()` rather than a member
   // of the class, so it lives directly under the class `describe()`.
-  describe("shallowFabricFromNativeValue() integration", () => {
+  describe("`shallowFabricFromNativeValue()` integration", () => {
     it("passes through unchanged even with `freeze=false`", () => {
       const nsec = new FabricEpochNsec(123n);
       // freeze=false should still return the same instance (not a copy).

--- a/packages/data-model/test/fabric-primitives/schema-type.test.ts
+++ b/packages/data-model/test/fabric-primitives/schema-type.test.ts
@@ -89,7 +89,7 @@ describe("schemaTypeOfFabricPrimitive()", () => {
     }
   });
 
-  it("the case table exactly matches the codec-class list", () => {
+  it("matches the codec-class list exactly", () => {
     // Set equality by constructor identity, both directions: a codec class
     // without a table row (the production-throws case) fails here, as does a
     // stale row for a class no longer registered.
@@ -101,7 +101,7 @@ describe("schemaTypeOfFabricPrimitive()", () => {
     expect(codecClasses().length).toBe(CASES.length);
   });
 
-  it("the case table exactly matches the api schema-type vocabulary", () => {
+  it("matches the api schema-type vocabulary exactly", () => {
     const tableNames = new Set(CASES.map(({ name }) => name));
     expect(tableNames.size).toBe(CASES.length);
     for (const name of FABRIC_PRIMITIVE_SCHEMA_TYPES) {
@@ -118,7 +118,7 @@ describe("schemaTypeOfFabricPrimitive()", () => {
       .toThrow(/RogueFabricPrimitive/);
   });
 
-  it("isFabricPrimitiveSchemaType() accepts exactly the vocabulary", () => {
+  it("`isFabricPrimitiveSchemaType()` accepts exactly the vocabulary", () => {
     for (const { name } of CASES) {
       expect(isFabricPrimitiveSchemaType(name)).toBe(true);
     }

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -503,26 +503,26 @@ describe("value-debug", () => {
       expect(toDebugKindString(weird)).toBe("object");
     });
   });
-});
 
-describe("custom inspector", () => {
-  // Without the inspector these all render as `{}`: state lives in private
-  // fields, which have no enumerable own properties for an inspector to find.
-  // The elided `(...)` is the debug renderer's own current limitation, marked
-  // by a TODO there; delegating means this surface inherits the fix.
-  it("renders a FabricPrimitive as its debug string, not `{}`", () => {
-    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
-    expect(Deno.inspect(bytes)).toBe("/Bytes(...)");
-  });
+  describe("custom inspector", () => {
+    // Without the inspector these all render as `{}`: state lives in private
+    // fields, which have no enumerable own properties for an inspector to find.
+    // The elided `(...)` is the debug renderer's own current limitation, marked
+    // by a TODO there; delegating means this surface inherits the fix.
+    it("renders a FabricPrimitive as its debug string, not `{}`", () => {
+      const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+      expect(Deno.inspect(bytes)).toBe("/Bytes(...)");
+    });
 
-  it("renders a FabricInstance as its debug string, not `{}`", () => {
-    const err = FabricError.fromNativeError(new Error("boom"));
-    expect(Deno.inspect(err)).toBe("/Error(...)");
-  });
+    it("renders a FabricInstance as its debug string, not `{}`", () => {
+      const err = FabricError.fromNativeError(new Error("boom"));
+      expect(Deno.inspect(err)).toBe("/Error(...)");
+    });
 
-  it("renders when nested in containers", () => {
-    const bytes = new FabricBytes(new Uint8Array([9]));
-    expect(Deno.inspect({ blob: bytes })).toBe("{ blob: /Bytes(...) }");
-    expect(Deno.inspect([bytes, bytes])).toBe("[ /Bytes(...), /Bytes(...) ]");
+    it("renders when nested in containers", () => {
+      const bytes = new FabricBytes(new Uint8Array([9]));
+      expect(Deno.inspect({ blob: bytes })).toBe("{ blob: /Bytes(...) }");
+      expect(Deno.inspect([bytes, bytes])).toBe("[ /Bytes(...), /Bytes(...) ]");
+    });
   });
 });

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -1099,7 +1099,7 @@ describe("value-hash", () => {
     });
   });
 
-  describe("hashOf() caching", () => {
+  describe("`hashOf()` caching", () => {
     it("returns the same precomputed-constant object for `null`", () => {
       const a = hashOf(null);
       const b = hashOf(null);
@@ -1166,7 +1166,7 @@ describe("value-hash", () => {
     });
   });
 
-  describe("hashOf() native instances", () => {
+  describe("`hashOf()` native instances", () => {
     describe("Date", () => {
       it("hashes a native `Date` without throwing", () => {
         const date = new Date("2024-01-01T00:00:00Z");
@@ -1377,7 +1377,7 @@ describe("value-hash", () => {
   // self-tagged string-rep of `Symbol.keyFor(s)` (i.e., the same byte stream
   // that a plain string of that key would feed). Unique (uninterned) symbols
   // have no portable key and throw.
-  describe("hashOf() interned symbols", () => {
+  describe("`hashOf()` interned symbols", () => {
     it("takes the inline TAG_STRING path for a short key", () => {
       // utf8Length(3) <= MAX_DIRECT_STRING_LENGTH(64), so the key is fed as
       // [TAG_STRING][len][utf8].

--- a/packages/data-model/test/valueEqual.test.ts
+++ b/packages/data-model/test/valueEqual.test.ts
@@ -235,7 +235,7 @@ describe("valueEqual()", () => {
     });
 
     describe("given a special object and a plain value", () => {
-      it("are not equal", () => {
+      it("returns `false`", () => {
         expect(valueEqual(new FabricBytes(new Uint8Array([1])), { 0: 1 }))
           .toBe(false);
         expect(valueEqual(new FabricBytes(new Uint8Array([])), {}))
@@ -303,14 +303,14 @@ describe("valueEqual()", () => {
   // without computing a hash (taken when the sides are not both deep-frozen).
   describe("object-subtype-check branch", () => {
     describe("given a plain object and an array", () => {
-      it("are not equal", () => {
+      it("returns `false`", () => {
         expect(valueEqual({ 0: 1, 1: 2 }, [1, 2])).toBe(false);
         expect(valueEqual([1, 2], { 0: 1, 1: 2 })).toBe(false);
       });
     });
 
     describe("given a Fabric* value and a plain object or array", () => {
-      it("are not equal", () => {
+      it("returns `false`", () => {
         const fb = new FabricBytes(new Uint8Array([1, 2]));
         expect(valueEqual(fb, { 0: 1, 1: 2 })).toBe(false);
         expect(valueEqual({ 0: 1, 1: 2 }, fb)).toBe(false);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

A pass over the `data-model` suite against
[`unit-test-coding-style.md`](../blob/main/docs/development/unit-test-coding-style.md),
fixing the departures whose remedy is unambiguous and reporting the rest.

Nothing about what any test asserts changes. `it()` and `expect()` counts are
identical to `main` (1914 and 3551); `describe()` rises by exactly one, the
block added below.

## What was already clean

Worth stating, since it is most of the guide: no `assertEquals`/`assertThrows`
anywhere, no `should`-prefixed description, no `-0` asserted through `toEqual`,
no `expect(NaN).toBe(NaN)`, no `hashOf()` compared with `toBe`, no polling. The
`test/` tree already mirrors `src/`.

## Fixed

**One top-level `describe()` per file.** `cell-rep.test.ts` had six and
`value-debug.test.ts` two. The six in `cell-rep.test.ts` each began their title
with "cell-rep", so they become nested blocks under one `describe("cell-rep")`
with that prefix dropped. Both files are otherwise a pure re-indent — a
whitespace-insensitive diff shows only the title lines.

**A file named for its source.** `valueEquals.test.ts` tests `valueEqual.ts`,
which exports `valueEqual`; there is no `valueEquals` anywhere in the tree.
Renamed, and the one document listing the old path updated.

**A member's tests under `instance members`.** `equals()` is an instance method
of `ProblematicValue`, and its block sat beside `instance members` rather than
inside it.

**Descriptions that read as a verb phrase completing "it".** Thirty-nine were
noun-subject sentences — "decoded objects are frozen", "mutable clone is
independent", "are not equal" — re-voiced to state the same fact as the
observable output the guide asks for: "freezes decoded objects", "returns an
independent mutable clone", "returns `false`". Six more gained the backticks
the markup rule requires around a code token, which the guide waives only for a
`describe()` title that is entirely one such token.

## Left alone, and why

**43 descriptions in two families**, each needing a decision rather than an
edit:

- *A member as the subject* — `` `register()` throws ``, `` `deepFreeze()`
  freezes the instance… ``. The guide's remedy is a per-member `describe()`,
  which is a restructure of the file rather than a string edit.
- *A label prefix* — "via dispatch: …", "malformed wire: …", "`FabricError`:
  …". These distinguish an invocation path or an input class across a group of
  otherwise identical cases; re-voicing either loses the distinction or invents
  wording.

**Class files with no member grouping.** `CodecRegistry`, `FabricLink`,
`BaseFabricInstance`, and `BaseFabricPrimitive` put instance methods directly
under the class block instead of under `instance members`. Each is a whole-file
restructure, which the guide itself says should be its own deliberate change.

**Three uses of "answers" in prose.** All are the noun ("the answers are
stricter", "a question it answers"), not the verb standing in for `returns`
that `DEVELOPMENT.md` rules out. The third does deploy the rejected metaphor,
but re-voicing it is a rewrite, not a substitution.

## Gates

`deno task check`, `deno lint`, `deno fmt --check`, `deno task check-docs`,
`deno task check-no-waitfor`, `deno task check-skill-facts`, and the
`data-model` suite (51 passed, 0 failed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQJkaKMWPLBQRDEbXET7Dd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

