### PR TITLE
docs(data-model): the realm format names no class

### DIFF
--- a/packages/data-model/src/codec-realm/interface.ts
+++ b/packages/data-model/src/codec-realm/interface.ts
@@ -28,22 +28,19 @@ import { REALM_CODEC } from "@/codec-interface/interface.ts";
  * * `bigint` and `undefined` appear directly, as do `-0`, `NaN` and `±Infinity`
  *   under `number`. Cloning carries each as itself.
  * * `ArrayBuffer` appears, because bytes cross as bytes. This is the whole
- *   point of a second format: JSON has to represent a `FabricBytes` as
- *   base64url text, and a receiver that wants bytes back has to rebuild them.
- *   The two forms are not interchangeable. Bytes travel as a bare `ArrayBuffer`
- *   rather than as a view onto one, that being what `postMessage()` can
- *   *transfer*, so a caller assembling a transfer list finds the transferable
- *   object in the tree rather than having to reach through a view and reason
- *   about its offset. Both byte-carrying classes do this: a `FabricBytes`
- *   encodes to one directly, and a `FabricHash` to one beside its algorithm
- *   tag. A bare `Uint8Array` is therefore not a form this format emits, and
- *   `decodeValue()` refuses one.
+ *   point of a second format: JSON reaches only `string`, so bytes have to be
+ *   written down as base64url text and rebuilt by a receiver that wants bytes
+ *   back. The two forms are not interchangeable. Bytes travel as a bare
+ *   `ArrayBuffer` rather than as a view onto one, that being what
+ *   `postMessage()` can *transfer*, so a caller assembling a transfer list
+ *   finds the transferable object in the tree rather than having to reach
+ *   through a view and reason about its offset. A bare `Uint8Array` is
+ *   therefore not a form this format emits, and `decodeValue()` refuses one.
  * * `CryptoKey` appears, because a key that cannot be exported can still be
  *   carried. Cloning preserves one whole, extractability and algorithm intact,
- *   which is what lets a `FabricKeyPair` holding handles cross at all -- and
- *   only here: no format that writes bytes down can represent it. Like
- *   `ArrayBuffer`, it reaches the transport only inside a terminal codec's
- *   state, so the walk never descends into one.
+ *   where a format that writes bytes down can carry only a key whose material
+ *   can be read. Like `ArrayBuffer`, it reaches the transport only inside a
+ *   terminal codec's state, so the walk never descends into one.
  * * An array is both the tagged form and the outer envelope -- see {@link
  *   RealmTaggedValue} and {@link RealmEncodedValue}. Neither is distinguishable
  *   by shape from a payload's own arrays, and neither is meant to be: what


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Documentation only, one doc comment, based on `main`.

## The gap

`RealmCodecValue`'s doc comment explains two of its arms by citing what a
particular class gains from them:

- **`ArrayBuffer`** — "JSON has to represent a `FabricBytes` as base64url text",
  and "Both byte-carrying classes do this: a `FabricBytes` encodes to one
  directly, and a `FabricHash` to one beside its algorithm tag."
- **`CryptoKey`** — "which is what lets a `FabricKeyPair` holding handles cross
  at all".

That is the shape ruled against in #6188, one format over: a format knows what
it can express, not which classes will hand it something it cannot. The
`CryptoKey` sentence is the one that motivated this; the `ArrayBuffer` ones are
the same move in the same comment, so leaving them would make the rule look
like a preference about one class.

## What this does

Each arm states its own reason instead. `ArrayBuffer` is there because JSON
reaches only `string`, so bytes have to be written as text and rebuilt.
`CryptoKey` is there because a format that writes bytes down can carry only a
key whose material can be read.

Everything else in the two bullets is untouched — the bare-buffer-not-a-view
rule and its transfer-list reason, the `Uint8Array` refusal, and the fact that
both arms reach the transport only inside a terminal codec's state.

## Nothing is lost, and here is where each fact still lives

- Which class encodes to what, `FabricHash`'s algorithm tag included: Section
  3.4 of `docs/specs/space-model-formal-spec/4-realm-encoding.md`, which is a
  per-type table and the right place to name types.
- Why this format admits `CryptoKey` at all: the same section, under
  `FabricKeyPair`, where the class is the subject.
- That a pair holding handles crosses a realm as itself: `FabricKeyPair`'s own
  class doc comment, which already said so and needed no edit.

## Why it is worth doing

`codec-realm/` imports nothing from `fabric-primitives` — every class binds its
own `[REALM_CODEC]`, so the format has no code-level knowledge of any of them.
These three citations were the only mention of a concrete class in the whole
directory, and no gate reads a comment, so nothing would have caught them going
stale.

## Verification

`deno fmt --check`, `deno lint`, `deno task check` (all groups), and
`deno task check-docs` (564 blocks) all pass; `data-model`'s own
`deno task test` is `ok | 57 passed (2692 steps) | 0 failed`. No behavior is
reachable from this change, so there is nothing to ablate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GvQfhJCV8kDSbhGpsrL6K


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

