### PR TITLE
test(data-model): group by axis and by member, per the style guide

### DIFF
--- a/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
+++ b/packages/data-model/test/codec-common/BaseCodecEngine.test.ts
@@ -510,7 +510,7 @@ describe("BaseCodecEngine", () => {
     });
   });
 
-  describe("`lenient`", () => {
+  describe("lenient", () => {
     // A codec rejects a state in one of three ways, and which it picks is the
     // codec author's business rather than a caller's. `lenient` is what
     // decides what a caller sees, so it has to settle ALL of them -- which is

--- a/packages/data-model/test/codec-common/CodecRegistry.test.ts
+++ b/packages/data-model/test/codec-common/CodecRegistry.test.ts
@@ -304,260 +304,295 @@ describe("CodecRegistry", () => {
     });
   });
 
-  describe("registerClass()", () => {
-    it("registers the codec bound under the format's own symbol", () => {
-      const codec = new TestTerminalCodec("FromFormat@1", FabricRegExp);
-      class Formatted {
-        static get [TEST_CODEC](): TerminalCodec<string> {
-          return codec;
+  describe("instance members", () => {
+    describe("registerClass()", () => {
+      it("registers the codec bound under the format's own symbol", () => {
+        const codec = new TestTerminalCodec("FromFormat@1", FabricRegExp);
+        class Formatted {
+          static get [TEST_CODEC](): TerminalCodec<string> {
+            return codec;
+          }
         }
-      }
-      const registry = new CodecRegistry(TEST_FORMAT);
+        const registry = new CodecRegistry(TEST_FORMAT);
 
-      registry.registerClass(Formatted);
+        registry.registerClass(Formatted);
 
-      expect(registry.codecFromTag("FromFormat@1")).toBe(codec);
-    });
-
-    it("registers a class's `[CODEC]` when it has one", () => {
-      const codec = new TestCodec("FromCodec@1", FabricRegExp);
-      class Neutral {
-        static get [CODEC](): NonterminalCodec {
-          return codec;
-        }
-      }
-      const registry = new CodecRegistry(TEST_FORMAT);
-
-      registry.registerClass(Neutral);
-
-      expect(registry.codecFromTag("FromCodec@1")).toBe(codec);
-    });
-
-    it("prefers `[CODEC]` over the format's symbol when a class binds both", () => {
-      // The format-neutral codec is the one that serves every format, so it
-      // wins wherever a class offers a choice.
-      const neutral = new TestCodec("Neutral@1", FabricRegExp);
-      const formatted = new TestTerminalCodec("Formatted@1", FabricRegExp);
-      class Both {
-        static get [CODEC](): NonterminalCodec {
-          return neutral;
-        }
-        static get [TEST_CODEC](): TerminalCodec<string> {
-          return formatted;
-        }
-      }
-      const registry = new CodecRegistry(TEST_FORMAT);
-
-      registry.registerClass(Both);
-
-      expect(registry.codecFromTag("Neutral@1")).toBe(neutral);
-      expect(registry.codecFromTag("Formatted@1")).toBeUndefined();
-    });
-
-    it("throws given a class binding neither symbol", () => {
-      class Neither {}
-      const registry = new CodecRegistry(TEST_FORMAT);
-
-      expect(() => registry.registerClass(Neither)).toThrow(
-        "Shouldn't happen: class supplies no codec",
-      );
-    });
-
-    it("ignores a codec bound under some other format's symbol", () => {
-      // Two formats' symbols on one class is the arrangement this exists to
-      // serve; a registry reads only its own.
-      const other: unique symbol = Symbol("other.codec");
-      const codec = new TestTerminalCodec("Other@1", FabricRegExp);
-      class OtherFormatOnly {
-        static get [other](): TerminalCodec<string> {
-          return codec;
-        }
-      }
-      const registry = new CodecRegistry(TEST_FORMAT);
-
-      expect(() => registry.registerClass(OtherFormatOnly)).toThrow(
-        "Shouldn't happen: class supplies no codec",
-      );
-    });
-  });
-
-  describe("codecFromValue()", () => {
-    for (
-      const { classSource, example, counter } of [
-        { classSource: Boolean, example: false, counter: [1, 2, 3] },
-        { classSource: BigInt, example: 914n, counter: true },
-        { classSource: Number, example: 123, counter: "florp" },
-        { classSource: String, example: "blorp", counter: null },
-        {
-          classSource: Symbol,
-          example: Symbol.for("bleep"),
-          counter: undefined,
-        },
-        {
-          classSource: FabricRegExp, // a `FabricPrimitive`
-          example: new FabricRegExp(/123/),
-          counter: { a: "boop" },
-        },
-        {
-          classSource: UnknownValue, // a `FabricInstance`
-          example: new UnknownValue("Unk@12", { muffin: "corn" }),
-          counter: 123n,
-        },
-      ] as const
-    ) {
-      const sourceName = classSource.name;
-      const exampleStr = toCompactDebugString(example);
-      const counterStr = toCompactDebugString(counter);
-      const cls = classSource as unknown as Constructor;
-
-      it(`given ${exampleStr}, finds the ${sourceName} codec by class`, () => {
-        const { first, handler, last, registry } = buildRegistry(
-          cls,
-          example,
-        );
-        expect(registry.codecFromValue(example)).toBe(handler);
-        // Only the class-matched codec is consulted -- there is no linear scan.
-        expect(first.canEncodeCalled).toBe(false);
-        expect(handler.canEncodeCalled).toBe(true);
-        expect(last.canEncodeCalled).toBe(false);
+        expect(registry.codecFromTag("FromFormat@1")).toBe(codec);
       });
 
-      it(`returns undefined for ${counterStr} (no ${sourceName} match)`, () => {
-        const { first, handler, last, registry } = buildRegistry(
-          cls,
-          example,
-        );
-        expect(registry.codecFromValue(counter)).toBeUndefined();
-        // A class miss consults no codec (no linear scan).
-        expect(first.canEncodeCalled).toBe(false);
-        expect(handler.canEncodeCalled).toBe(false);
-        expect(last.canEncodeCalled).toBe(false);
+      it("registers a class's `[CODEC]` when it has one", () => {
+        const codec = new TestCodec("FromCodec@1", FabricRegExp);
+        class Neutral {
+          static get [CODEC](): NonterminalCodec {
+            return codec;
+          }
+        }
+        const registry = new CodecRegistry(TEST_FORMAT);
+
+        registry.registerClass(Neutral);
+
+        expect(registry.codecFromTag("FromCodec@1")).toBe(codec);
       });
-    }
 
-    it("returns `undefined` for a `null`-prototype object", () => {
-      const { registry } = buildRegistry(
-        FabricRegExp,
-        new FabricRegExp(/x/),
-      );
-      const nullProto = Object.create(null) as Record<string, FabricValue>;
-      nullProto.a = 1;
+      it("prefers `[CODEC]` over the format's symbol when a class binds both", () => {
+        // The format-neutral codec is the one that serves every format, so it
+        // wins wherever a class offers a choice.
+        const neutral = new TestCodec("Neutral@1", FabricRegExp);
+        const formatted = new TestTerminalCodec("Formatted@1", FabricRegExp);
+        class Both {
+          static get [CODEC](): NonterminalCodec {
+            return neutral;
+          }
+          static get [TEST_CODEC](): TerminalCodec<string> {
+            return formatted;
+          }
+        }
+        const registry = new CodecRegistry(TEST_FORMAT);
 
-      expect(registry.codecFromValue(nullProto)).toBeUndefined();
-    });
-  });
+        registry.registerClass(Both);
 
-  describe("registerPrimitive()", () => {
-    it("dispatches a primitive value to its codec (encode + decode)", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("Big@1", undefined, 42n);
-      registry.registerPrimitive("bigint", codec);
-      expect(registry.codecFromValue(42n)).toBe(codec);
-      expect(registry.codecFromTag("Big@1")).toBe(codec);
-    });
+        expect(registry.codecFromTag("Neutral@1")).toBe(neutral);
+        expect(registry.codecFromTag("Formatted@1")).toBeUndefined();
+      });
 
-    it("returns `undefined` when the codec's `canEncode()` says no", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      registry.registerPrimitive(
-        "bigint",
-        new TestCodec("Big@1", undefined, 42n),
-      );
-      expect(registry.codecFromValue(99n)).toBeUndefined();
-    });
-  });
+      it("throws given a class binding neither symbol", () => {
+        class Neither {}
+        const registry = new CodecRegistry(TEST_FORMAT);
 
-  describe("registerSelfRep()", () => {
-    it("returns `SELF_REP` for a self-representing primitive value", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      registry.registerSelfRep("string");
-      expect(registry.codecFromValue("hi")).toBe(SELF_REP);
-    });
+        expect(() => registry.registerClass(Neither)).toThrow(
+          "Shouldn't happen: class supplies no codec",
+        );
+      });
 
-    it("tries the type's codec before falling to self-rep", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("Num@1", undefined, 42);
-      registry.registerPrimitive("number", codec);
-      registry.registerSelfRep("number");
-      expect(registry.codecFromValue(42)).toBe(codec); // codec match
-      expect(registry.codecFromValue(99)).toBe(SELF_REP); // self-rep fallback
-    });
-  });
+      it("ignores a codec bound under some other format's symbol", () => {
+        // Two formats' symbols on one class is the arrangement this exists to
+        // serve; a registry reads only its own.
+        const other: unique symbol = Symbol("other.codec");
+        const codec = new TestTerminalCodec("Other@1", FabricRegExp);
+        class OtherFormatOnly {
+          static get [other](): TerminalCodec<string> {
+            return codec;
+          }
+        }
+        const registry = new CodecRegistry(TEST_FORMAT);
 
-  describe("`extend()`", () => {
-    it("returns a different instance", () => {
-      const base = new CodecRegistry(TEST_FORMAT);
-      expect(base.extend()).not.toBe(base);
+        expect(() => registry.registerClass(OtherFormatOnly)).toThrow(
+          "Shouldn't happen: class supplies no codec",
+        );
+      });
     });
 
-    it("returns a frozen instance", () => {
-      expect(Object.isFrozen(new CodecRegistry(TEST_FORMAT).extend())).toBe(
-        true,
-      );
+    describe("codecFromValue()", () => {
+      for (
+        const { classSource, example, counter } of [
+          { classSource: Boolean, example: false, counter: [1, 2, 3] },
+          { classSource: BigInt, example: 914n, counter: true },
+          { classSource: Number, example: 123, counter: "florp" },
+          { classSource: String, example: "blorp", counter: null },
+          {
+            classSource: Symbol,
+            example: Symbol.for("bleep"),
+            counter: undefined,
+          },
+          {
+            classSource: FabricRegExp, // a `FabricPrimitive`
+            example: new FabricRegExp(/123/),
+            counter: { a: "boop" },
+          },
+          {
+            classSource: UnknownValue, // a `FabricInstance`
+            example: new UnknownValue("Unk@12", { muffin: "corn" }),
+            counter: 123n,
+          },
+        ] as const
+      ) {
+        const sourceName = classSource.name;
+        const exampleStr = toCompactDebugString(example);
+        const counterStr = toCompactDebugString(counter);
+        const cls = classSource as unknown as Constructor;
+
+        it(`given ${exampleStr}, finds the ${sourceName} codec by class`, () => {
+          const { first, handler, last, registry } = buildRegistry(
+            cls,
+            example,
+          );
+          expect(registry.codecFromValue(example)).toBe(handler);
+          // Only the class-matched codec is consulted -- there is no linear scan.
+          expect(first.canEncodeCalled).toBe(false);
+          expect(handler.canEncodeCalled).toBe(true);
+          expect(last.canEncodeCalled).toBe(false);
+        });
+
+        it(`returns undefined for ${counterStr} (no ${sourceName} match)`, () => {
+          const { first, handler, last, registry } = buildRegistry(
+            cls,
+            example,
+          );
+          expect(registry.codecFromValue(counter)).toBeUndefined();
+          // A class miss consults no codec (no linear scan).
+          expect(first.canEncodeCalled).toBe(false);
+          expect(handler.canEncodeCalled).toBe(false);
+          expect(last.canEncodeCalled).toBe(false);
+        });
+      }
+
+      it("returns `undefined` for a `null`-prototype object", () => {
+        const { registry } = buildRegistry(
+          FabricRegExp,
+          new FabricRegExp(/x/),
+        );
+        const nullProto = Object.create(null) as Record<string, FabricValue>;
+        nullProto.a = 1;
+
+        expect(registry.codecFromValue(nullProto)).toBeUndefined();
+      });
     });
 
-    it("carries over every kind of registration the base holds", () => {
-      const base = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("Carried@1", undefined);
-      const primitive = new TestCodec("Prim@1", undefined);
-      base.register(codec);
-      base.registerPrimitive("bigint", primitive);
-      base.registerSelfRep("string");
+    describe("registerPrimitive()", () => {
+      it("dispatches a primitive value to its codec (encode + decode)", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        const codec = new TestCodec("Big@1", undefined, 42n);
+        registry.registerPrimitive("bigint", codec);
+        expect(registry.codecFromValue(42n)).toBe(codec);
+        expect(registry.codecFromTag("Big@1")).toBe(codec);
+      });
 
-      const extended = base.extend();
-
-      expect(extended.codecFromTag("Carried@1")).toBe(codec);
-      expect(extended.codecFromTag("Prim@1")).toBe(primitive);
-      expect(extended.codecFromValue("florp")).toBe(SELF_REP);
+      it("returns `undefined` when the codec's `canEncode()` says no", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        registry.registerPrimitive(
+          "bigint",
+          new TestCodec("Big@1", undefined, 42n),
+        );
+        expect(registry.codecFromValue(99n)).toBeUndefined();
+      });
     });
 
-    it("registers a codec given on its own", () => {
-      const added = new TestCodec("Added@1", undefined);
-      const extended = new CodecRegistry(TEST_FORMAT).extend(added);
+    describe("registerSelfRep()", () => {
+      it("returns `SELF_REP` for a self-representing primitive value", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        registry.registerSelfRep("string");
+        expect(registry.codecFromValue("hi")).toBe(SELF_REP);
+      });
 
-      expect(extended.codecFromTag("Added@1")).toBe(added);
+      it("tries the type's codec before falling to self-rep", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        const codec = new TestCodec("Num@1", undefined, 42);
+        registry.registerPrimitive("number", codec);
+        registry.registerSelfRep("number");
+        expect(registry.codecFromValue(42)).toBe(codec); // codec match
+        expect(registry.codecFromValue(99)).toBe(SELF_REP); // self-rep fallback
+      });
     });
 
-    it("registers codecs given individually and in lists, in any mix", () => {
-      const loose = new TestCodec("Loose@1", undefined);
-      const listed = new TestCodec("Listed@1", undefined);
-      const alsoListed = new TestCodec("AlsoListed@1", undefined);
+    describe("extend()", () => {
+      it("returns a different instance", () => {
+        const base = new CodecRegistry(TEST_FORMAT);
+        expect(base.extend()).not.toBe(base);
+      });
 
-      const extended = new CodecRegistry(TEST_FORMAT)
-        .extend(loose, [listed, alsoListed]);
+      it("returns a frozen instance", () => {
+        expect(Object.isFrozen(new CodecRegistry(TEST_FORMAT).extend())).toBe(
+          true,
+        );
+      });
 
-      expect(extended.codecFromTag("Loose@1")).toBe(loose);
-      expect(extended.codecFromTag("Listed@1")).toBe(listed);
-      expect(extended.codecFromTag("AlsoListed@1")).toBe(alsoListed);
+      it("carries over every kind of registration the base holds", () => {
+        const base = new CodecRegistry(TEST_FORMAT);
+        const codec = new TestCodec("Carried@1", undefined);
+        const primitive = new TestCodec("Prim@1", undefined);
+        base.register(codec);
+        base.registerPrimitive("bigint", primitive);
+        base.registerSelfRep("string");
+
+        const extended = base.extend();
+
+        expect(extended.codecFromTag("Carried@1")).toBe(codec);
+        expect(extended.codecFromTag("Prim@1")).toBe(primitive);
+        expect(extended.codecFromValue("florp")).toBe(SELF_REP);
+      });
+
+      it("registers a codec given on its own", () => {
+        const added = new TestCodec("Added@1", undefined);
+        const extended = new CodecRegistry(TEST_FORMAT).extend(added);
+
+        expect(extended.codecFromTag("Added@1")).toBe(added);
+      });
+
+      it("registers codecs given individually and in lists, in any mix", () => {
+        const loose = new TestCodec("Loose@1", undefined);
+        const listed = new TestCodec("Listed@1", undefined);
+        const alsoListed = new TestCodec("AlsoListed@1", undefined);
+
+        const extended = new CodecRegistry(TEST_FORMAT)
+          .extend(loose, [listed, alsoListed]);
+
+        expect(extended.codecFromTag("Loose@1")).toBe(loose);
+        expect(extended.codecFromTag("Listed@1")).toBe(listed);
+        expect(extended.codecFromTag("AlsoListed@1")).toBe(alsoListed);
+      });
+
+      it("leaves the base without the added registrations", () => {
+        const base = new CodecRegistry(TEST_FORMAT);
+        base.extend(new TestCodec("Added@1", undefined));
+
+        expect(base.codecFromTag("Added@1")).toBe(undefined);
+      });
     });
 
-    it("leaves the base without the added registrations", () => {
-      const base = new CodecRegistry(TEST_FORMAT);
-      base.extend(new TestCodec("Added@1", undefined));
+    describe("codecFromTag()", () => {
+      it("returns the codec registered under a tag", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        const codec = new TestCodec("Foo@1", undefined);
+        registry.register(codec);
+        expect(registry.codecFromTag("Foo@1")).toBe(codec);
+      });
 
-      expect(base.codecFromTag("Added@1")).toBe(undefined);
+      it("returns `undefined` for an unregistered tag", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        registry.register(new TestCodec("Foo@1", undefined));
+        expect(registry.codecFromTag("Bar@2")).toBeUndefined();
+      });
+
+      it("resolves the last registration when a tag is reused", () => {
+        const registry = new CodecRegistry(TEST_FORMAT);
+        const first = new TestCodec("Dup@1", undefined);
+        const second = new TestCodec("Dup@1", undefined);
+        registry.register(first);
+        registry.register(second);
+        expect(registry.codecFromTag("Dup@1")).toBe(second);
+      });
     });
   });
 
   describe("frozen instances", () => {
     // `Object.freeze()` cannot reach a private `Map` or `Set`, so each mutator
     // has to refuse on its own; these cases pin that each one does.
-    it("`register()` throws", () => {
-      const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
-      expect(() => registry.register(new TestCodec("Nope@1", undefined)))
-        .toThrow("Cannot modify frozen `CodecRegistry`");
+    describe("register()", () => {
+      it("throws", () => {
+        const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
+        expect(() => registry.register(new TestCodec("Nope@1", undefined)))
+          .toThrow("Cannot modify frozen `CodecRegistry`");
+      });
     });
 
-    it("`registerPrimitive()` throws", () => {
-      const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
-      expect(() =>
-        registry.registerPrimitive("bigint", new TestCodec("Nope@1", undefined))
-      ).toThrow("Cannot modify frozen `CodecRegistry`");
+    describe("registerPrimitive()", () => {
+      it("throws", () => {
+        const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
+        expect(() =>
+          registry.registerPrimitive(
+            "bigint",
+            new TestCodec("Nope@1", undefined),
+          )
+        ).toThrow("Cannot modify frozen `CodecRegistry`");
+      });
     });
 
-    it("`registerSelfRep()` throws", () => {
-      const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
-      expect(() => registry.registerSelfRep("string"))
-        .toThrow("Cannot modify frozen `CodecRegistry`");
+    describe("registerSelfRep()", () => {
+      it("throws", () => {
+        const registry = Object.freeze(new CodecRegistry(TEST_FORMAT));
+        expect(() => registry.registerSelfRep("string"))
+          .toThrow("Cannot modify frozen `CodecRegistry`");
+      });
     });
 
     it("still returns a codec for a registered tag", () => {
@@ -567,30 +602,6 @@ describe("CodecRegistry", () => {
       Object.freeze(base);
 
       expect(base.codecFromTag("Readable@1")).toBe(codec);
-    });
-  });
-
-  describe("codecFromTag()", () => {
-    it("returns the codec registered under a tag", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      const codec = new TestCodec("Foo@1", undefined);
-      registry.register(codec);
-      expect(registry.codecFromTag("Foo@1")).toBe(codec);
-    });
-
-    it("returns `undefined` for an unregistered tag", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      registry.register(new TestCodec("Foo@1", undefined));
-      expect(registry.codecFromTag("Bar@2")).toBeUndefined();
-    });
-
-    it("resolves the last registration when a tag is reused", () => {
-      const registry = new CodecRegistry(TEST_FORMAT);
-      const first = new TestCodec("Dup@1", undefined);
-      const second = new TestCodec("Dup@1", undefined);
-      registry.register(first);
-      registry.register(second);
-      expect(registry.codecFromTag("Dup@1")).toBe(second);
     });
   });
 });

--- a/packages/data-model/test/codec-common/ProblematicValue.test.ts
+++ b/packages/data-model/test/codec-common/ProblematicValue.test.ts
@@ -98,32 +98,36 @@ describe("ProblematicValue", () => {
 
   describe("instance members", () => {
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("recurses state, freezes in place, via dispatch", () => {
-        const child = { x: 1 };
-        const pv = new ProblematicValue(
-          "Bad@1",
-          child,
-          "oops",
-        );
-        const result = deepFreeze(pv);
-        expect(result).toBe(pv);
-        expect(Object.isFrozen(pv)).toBe(true);
-        expect(Object.isFrozen(child)).toBe(true);
-        expect(isValidDeepFrozenFabricValue(pv)).toBe(true);
+      describe("via dispatch", () => {
+        it("recurses state, freezes in place", () => {
+          const child = { x: 1 };
+          const pv = new ProblematicValue(
+            "Bad@1",
+            child,
+            "oops",
+          );
+          const result = deepFreeze(pv);
+          expect(result).toBe(pv);
+          expect(Object.isFrozen(pv)).toBe(true);
+          expect(Object.isFrozen(child)).toBe(true);
+          expect(isValidDeepFrozenFabricValue(pv)).toBe(true);
+        });
       });
 
-      it("recurses state, freezes in place, via direct member invocation", () => {
-        const child = { x: 1 };
-        const pv = new ProblematicValue(
-          "Bad@1",
-          child,
-          "oops",
-        );
-        const result = pv[DEEP_FREEZE](subFreeze);
-        expect(result).toBe(pv);
-        expect(Object.isFrozen(pv)).toBe(true);
-        expect(Object.isFrozen(child)).toBe(true);
-        expect(pv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      describe("via direct member invocation", () => {
+        it("recurses state, freezes in place", () => {
+          const child = { x: 1 };
+          const pv = new ProblematicValue(
+            "Bad@1",
+            child,
+            "oops",
+          );
+          const result = pv[DEEP_FREEZE](subFreeze);
+          expect(result).toBe(pv);
+          expect(Object.isFrozen(pv)).toBe(true);
+          expect(Object.isFrozen(child)).toBe(true);
+          expect(pv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+        });
       });
     });
 

--- a/packages/data-model/test/codec-common/UnknownValue.test.ts
+++ b/packages/data-model/test/codec-common/UnknownValue.test.ts
@@ -76,30 +76,34 @@ describe("UnknownValue", () => {
 
   describe("instance members", () => {
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("recurses state, freezes in place, via dispatch", () => {
-        const child = { y: 2 };
-        const uv = new UnknownValue(
-          "Fancy@3",
-          child,
-        );
-        const result = deepFreeze(uv);
-        expect(result).toBe(uv);
-        expect(Object.isFrozen(uv)).toBe(true);
-        expect(Object.isFrozen(child)).toBe(true);
-        expect(isValidDeepFrozenFabricValue(uv)).toBe(true);
+      describe("via dispatch", () => {
+        it("recurses state, freezes in place", () => {
+          const child = { y: 2 };
+          const uv = new UnknownValue(
+            "Fancy@3",
+            child,
+          );
+          const result = deepFreeze(uv);
+          expect(result).toBe(uv);
+          expect(Object.isFrozen(uv)).toBe(true);
+          expect(Object.isFrozen(child)).toBe(true);
+          expect(isValidDeepFrozenFabricValue(uv)).toBe(true);
+        });
       });
 
-      it("recurses state, freezes in place, via direct member invocation", () => {
-        const child = { y: 2 };
-        const uv = new UnknownValue(
-          "Fancy@3",
-          child,
-        );
-        const result = uv[DEEP_FREEZE](subFreeze);
-        expect(result).toBe(uv);
-        expect(Object.isFrozen(uv)).toBe(true);
-        expect(Object.isFrozen(child)).toBe(true);
-        expect(uv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      describe("via direct member invocation", () => {
+        it("recurses state, freezes in place", () => {
+          const child = { y: 2 };
+          const uv = new UnknownValue(
+            "Fancy@3",
+            child,
+          );
+          const result = uv[DEEP_FREEZE](subFreeze);
+          expect(result).toBe(uv);
+          expect(Object.isFrozen(uv)).toBe(true);
+          expect(Object.isFrozen(child)).toBe(true);
+          expect(uv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+        });
       });
     });
   });

--- a/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
+++ b/packages/data-model/test/codec-json/JsonCodecEngine.test.ts
@@ -1132,7 +1132,7 @@ describe("JsonCodecEngine", () => {
         expect(result["/x"]!["/y"]).toBe(123);
       });
 
-      it("boundary contrast: literal subtree uses `/quote`, Fabric type uses `/object`", () => {
+      it("uses `/quote` for a literal subtree and `/object` for a Fabric type", () => {
         // All-literal: single /quote wraps the whole structure.
         const literal = { "/x": { "/y": 123 } };
         expect(toEncodedFormat(literal)).toEqual({
@@ -1195,22 +1195,24 @@ describe("JsonCodecEngine", () => {
     });
 
     describe("general", () => {
-      it("malformed wire: multi-key object with `/`-prefixed key produces `ProblematicValue`", () => {
-        // Wire data without a `/quote` or `/object` wrapper: the decoder must
-        // not silently round-trip it as a plain object.
-        const data = { a: 1, "/b": 2 } as JsonCodecValue;
-        const result = fromEncodedFormat(data, true);
-        expect(result).toBeInstanceOf(ProblematicValue);
-      });
+      describe("malformed wire", () => {
+        it("produces `ProblematicValue` for a multi-key object with a `/`-prefixed key", () => {
+          // Wire data without a `/quote` or `/object` wrapper: the decoder must
+          // not silently round-trip it as a plain object.
+          const data = { a: 1, "/b": 2 } as JsonCodecValue;
+          const result = fromEncodedFormat(data, true);
+          expect(result).toBeInstanceOf(ProblematicValue);
+        });
 
-      it("malformed wire: bare `/`-keyed object produces `ProblematicValue`", () => {
-        // Per spec §9, a single-key object whose key is bare `/` (empty tag
-        // after stripping the leading slash) is an encoding error. Decoding
-        // must produce a `ProblematicValue`, not an `UnknownValue` with an
-        // empty tag.
-        const data = { "/": "x" } as JsonCodecValue;
-        const result = fromEncodedFormat(data, true);
-        expect(result).toBeInstanceOf(ProblematicValue);
+        it("produces `ProblematicValue` for a bare `/`-keyed object", () => {
+          // Per spec §9, a single-key object whose key is bare `/` (empty tag
+          // after stripping the leading slash) is an encoding error. Decoding
+          // must produce a `ProblematicValue`, not an `UnknownValue` with an
+          // empty tag.
+          const data = { "/": "x" } as JsonCodecValue;
+          const result = fromEncodedFormat(data, true);
+          expect(result).toBeInstanceOf(ProblematicValue);
+        });
       });
 
       it("does not wrap plain object with no `/`-prefixed keys", () => {
@@ -1868,7 +1870,7 @@ describe("JsonCodecEngine", () => {
       }).toThrow();
     });
 
-    it("`encode()`→`/quote`→`decode()` round-trip is deep-frozen end-to-end", () => {
+    it("returns a deep-frozen value end-to-end from an `encode()`→`/quote`→`decode()` round-trip", () => {
       // An object whose keys are all /-prefixed but whose values are all
       // quote-safe routes through the encode-side /quote path, then back
       // through the decode /quote `return state` arm.
@@ -1883,27 +1885,43 @@ describe("JsonCodecEngine", () => {
   });
 
   describe("entry points", () => {
-    it("`encode()` returns a prefixed JSON string", () => {
-      const jsonCodecEngine = newDefaultJsonCodecEngine();
-      const result = jsonCodecEngine.encode(42);
-      expect(typeof result).toBe("string");
-      expect(JsonCodecEngine.seemsLikeEncoded(result)).toBe(true);
-      expect(
-        JSON.parse(JsonCodecEngine.unwrapEncodedValueForTesting(result)),
-      ).toBe(42);
+    describe("encode()", () => {
+      it("returns a prefixed JSON string", () => {
+        const jsonCodecEngine = newDefaultJsonCodecEngine();
+        const result = jsonCodecEngine.encode(42);
+        expect(typeof result).toBe("string");
+        expect(JsonCodecEngine.seemsLikeEncoded(result)).toBe(true);
+        expect(
+          JSON.parse(JsonCodecEngine.unwrapEncodedValueForTesting(result)),
+        ).toBe(42);
+      });
     });
 
-    it("`decode()` parses a prefixed JSON string back to a value", () => {
-      const jsonCodecEngine = newDefaultJsonCodecEngine();
-      const runtime = new TestLiveEnvironment();
-      const result = jsonCodecEngine.decode(
-        JsonCodecEngine.wrapEncodedValueForTesting("42"),
-        runtime,
-      );
-      expect(result).toBe(42);
+    describe("decode()", () => {
+      it("parses a prefixed JSON string back to a value", () => {
+        const jsonCodecEngine = newDefaultJsonCodecEngine();
+        const runtime = new TestLiveEnvironment();
+        const result = jsonCodecEngine.decode(
+          JsonCodecEngine.wrapEncodedValueForTesting("42"),
+          runtime,
+        );
+        expect(result).toBe(42);
+      });
     });
 
-    it("`encode()`/`decode()` round-trip for tagged types", () => {
+    describe(".lenient", () => {
+      it("defaults to `false`", () => {
+        const jsonCodecEngine = newDefaultJsonCodecEngine();
+        expect(jsonCodecEngine.lenient).toBe(false);
+      });
+
+      it("can be set to `true`", () => {
+        const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
+        expect(jsonCodecEngine.lenient).toBe(true);
+      });
+    });
+
+    it("round-trips tagged types through `encode()`/`decode()`", () => {
       const jsonCodecEngine = newDefaultJsonCodecEngine();
       const runtime = new TestLiveEnvironment();
       const se = FabricError.fromNativeError(new Error("test"));
@@ -1911,16 +1929,6 @@ describe("JsonCodecEngine", () => {
       const decoded = jsonCodecEngine.decode(encoded, runtime);
       expect(decoded).toBeInstanceOf(FabricError);
       expect((decoded as unknown as FabricError).message).toBe("test");
-    });
-
-    it("`.lenient` defaults to `false`", () => {
-      const jsonCodecEngine = newDefaultJsonCodecEngine();
-      expect(jsonCodecEngine.lenient).toBe(false);
-    });
-
-    it("`.lenient` can be set to `true`", () => {
-      const jsonCodecEngine = newDefaultJsonCodecEngine({ lenient: true });
-      expect(jsonCodecEngine.lenient).toBe(true);
     });
   });
 
@@ -2031,7 +2039,7 @@ describe("JsonCodecEngine", () => {
     });
   });
 
-  describe("`seemsLikeEncoded()`", () => {
+  describe("seemsLikeEncoded()", () => {
     // Decides on the prefix alone and never parses, so these cases are about
     // where that suffices and where it would be too eager: the bare prefix
     // counts, a prefix that is partial or not at the front does not, and plain
@@ -2086,7 +2094,7 @@ describe("JsonCodecEngine", () => {
   });
 
   describe("test-only prefix helpers", () => {
-    describe("`unwrapEncodedValueForTesting()`", () => {
+    describe("unwrapEncodedValueForTesting()", () => {
       it("yields the JSON text under the tag", () => {
         const encoded = newDefaultJsonCodecEngine().encode(42);
         expect(JsonCodecEngine.unwrapEncodedValueForTesting(encoded))
@@ -2149,7 +2157,7 @@ describe("JsonCodecEngine", () => {
       });
     });
 
-    describe("`wrapEncodedValueForTesting()`", () => {
+    describe("wrapEncodedValueForTesting()", () => {
       it("produces something the codec accepts", () => {
         const { runtime } = makeTestCodec();
         const encoded = JsonCodecEngine.wrapEncodedValueForTesting(
@@ -2195,7 +2203,7 @@ describe("JsonCodecEngine", () => {
       });
     });
 
-    describe("`isMalformed`", () => {
+    describe("isMalformed", () => {
       // `Map@1`'s codec always throws on decode, so it stands in for any
       // payload the codec cannot decode. Reaching that codec takes a
       // registry that has it: against the format-only default, `Map@1` is

--- a/packages/data-model/test/codecs.test.ts
+++ b/packages/data-model/test/codecs.test.ts
@@ -60,7 +60,7 @@ function expectEncodedFormat(value: FabricValue, expected: unknown): void {
 }
 
 describe("codecs", () => {
-  describe("`createDefaultJsonRegistry()`", () => {
+  describe("createDefaultJsonRegistry()", () => {
     it("returns a frozen registry", () => {
       expect(Object.isFrozen(createDefaultJsonRegistry())).toBe(true);
     });
@@ -83,22 +83,26 @@ describe("codecs", () => {
     expect(roundTrip(42n)).toBe(42n);
   });
 
-  it("`jsonFromFabricValue()` encodes `undefined` to tagged JSON", () => {
-    expectEncodedFormat(undefined, { "/Undefined@1": null });
+  describe("jsonFromFabricValue()", () => {
+    it("encodes `undefined` to tagged JSON", () => {
+      expectEncodedFormat(undefined, { "/Undefined@1": null });
+    });
+
+    it("encodes `bigint` to tagged JSON", () => {
+      expectEncodedFormat(42n, { "/BigInt@1": "Kg" });
+    });
   });
 
-  it("`jsonFromFabricValue()` encodes `bigint` to tagged JSON", () => {
-    expectEncodedFormat(42n, { "/BigInt@1": "Kg" });
-  });
+  describe("fabricFromJsonValue()", () => {
+    it("decodes tagged `undefined`", () => {
+      const json = 'fvj1:{"\/Undefined@1":null}';
+      expect(fabricFromJsonValue(json, mockRuntime)).toBe(undefined);
+    });
 
-  it("`fabricFromJsonValue()` decodes tagged `undefined`", () => {
-    const json = 'fvj1:{"\/Undefined@1":null}';
-    expect(fabricFromJsonValue(json, mockRuntime)).toBe(undefined);
-  });
-
-  it("`fabricFromJsonValue()` decodes tagged `bigint`", () => {
-    const json = 'fvj1:{"\/BigInt@1":"Kg"}';
-    expect(fabricFromJsonValue(json, mockRuntime)).toBe(42n);
+    it("decodes tagged `bigint`", () => {
+      const json = 'fvj1:{"\/BigInt@1":"Kg"}';
+      expect(fabricFromJsonValue(json, mockRuntime)).toBe(42n);
+    });
   });
 
   it("round-trips plain objects", () => {

--- a/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
@@ -141,138 +141,143 @@ describe("BaseFabricInstance", () => {
     });
   });
 
-  describe("isInstance()", () => {
-    it("is `true` for a `BaseFabricInstance`", () => {
-      expect(BaseFabricInstance.isInstance(new Probe("t"))).toBe(true);
+  describe("instance members", () => {
+    describe("shallowClone()", () => {
+      describe("when `frozen` is `true`", () => {
+        it("returns `this` for an already-frozen instance (no clone call)", () => {
+          const probe = new Probe("t");
+          Object.freeze(probe);
+
+          const result = probe.shallowClone(true);
+
+          expect(result).toBe(probe);
+          expect(probe.counter.calls).toBe(0);
+        });
+
+        it("returns a new frozen instance for an unfrozen one", () => {
+          const probe = new Probe("t");
+
+          const result = probe.shallowClone(true);
+
+          expect(result).not.toBe(probe);
+          expect(result instanceof Probe).toBe(true);
+          expect((result as Probe).wireTypeTag).toBe("t");
+          expect(Object.isFrozen(result)).toBe(true);
+          // Original is left unfrozen.
+          expect(Object.isFrozen(probe)).toBe(false);
+          expect(probe.counter.calls).toBe(1);
+        });
+      });
+
+      describe("when `frozen` is `false`", () => {
+        it("returns a new unfrozen instance from a frozen original", () => {
+          const probe = new Probe("t");
+          Object.freeze(probe);
+
+          const result = probe.shallowClone(false);
+
+          expect(result).not.toBe(probe);
+          expect(result instanceof Probe).toBe(true);
+          expect((result as Probe).wireTypeTag).toBe("t");
+          expect(Object.isFrozen(result)).toBe(false);
+          // The identity-when-frozen optimization is `frozen===true` only;
+          // a `frozen===false` call always allocates.
+        });
+
+        it("returns a new unfrozen instance from an unfrozen original", () => {
+          const probe = new Probe("t");
+
+          const result = probe.shallowClone(false);
+
+          expect(result).not.toBe(probe);
+          expect(Object.isFrozen(result)).toBe(false);
+          expect(probe.counter.calls).toBe(1);
+        });
+      });
     });
 
-    it("is `false` for a `FabricValue` that is not a `BaseFabricInstance`", () => {
-      expect(BaseFabricInstance.isInstance(null)).toBe(false);
-      expect(BaseFabricInstance.isInstance(42)).toBe(false);
-      expect(BaseFabricInstance.isInstance("x")).toBe(false);
-      expect(BaseFabricInstance.isInstance({})).toBe(false);
-      expect(BaseFabricInstance.isInstance([])).toBe(false);
-    });
+    describe("deepClone()", () => {
+      describe("when `frozen` is `true`", () => {
+        it("returns `this` for an already-deep-frozen instance (no core call)", () => {
+          const probe = deepFreeze(new DeepProbe({ n: 1 }));
 
-    it("throws for a `FabricInstance` that is not a `BaseFabricInstance`", () => {
-      expect(() => BaseFabricInstance.isInstance(new RogueInstance())).toThrow(
-        "Shouldn't happen",
-      );
+          const result = probe.deepClone(true);
+
+          expect(result).toBe(probe);
+          expect(probe.counter.calls).toBe(0);
+        });
+
+        it("does NOT identity-return a merely-shallowly-frozen instance", () => {
+          // Frozen instance slot, still-mutable nested state: not deep-frozen,
+          // so the deep identity gate (`isDeepFrozen`, not `Object.isFrozen`)
+          // must allocate rather than alias.
+          const probe = new DeepProbe({ n: 1 });
+          Object.freeze(probe);
+
+          expect(Object.isFrozen(probe)).toBe(true);
+          expect(isDeepFrozen(probe)).toBe(false);
+          expect(probe.deepClone(true)).not.toBe(probe);
+          expect(probe.counter.calls).toBe(1);
+        });
+
+        it("returns a new deep-frozen instance for an unfrozen one", () => {
+          const probe = new DeepProbe({ n: 1 });
+
+          const result = probe.deepClone(true);
+
+          expect(result).not.toBe(probe);
+          expect(isDeepFrozen(result)).toBe(true);
+          // Original is left unfrozen.
+          expect(Object.isFrozen(probe)).toBe(false);
+          expect(probe.counter.calls).toBe(1);
+        });
+      });
+
+      describe("when `frozen` is `false`", () => {
+        it("returns a fresh mutable clone with independent nested state", () => {
+          const probe = new DeepProbe({ n: 1 });
+
+          const result = probe.deepClone(false) as DeepProbe;
+
+          expect(result).not.toBe(probe);
+          expect(Object.isFrozen(result)).toBe(false);
+          expect(result.state).not.toBe(probe.state);
+          result.state.n = 2;
+          expect(probe.state.n).toBe(1);
+        });
+
+        it("allocates even from a deep-frozen original (identity gate is `frozen===true` only)", () => {
+          const probe = deepFreeze(new DeepProbe({ n: 1 }));
+
+          const result = probe.deepClone(false);
+
+          expect(result).not.toBe(probe);
+          expect(Object.isFrozen(result)).toBe(false);
+          expect(probe.counter.calls).toBe(1);
+        });
+      });
     });
   });
 
-  describe("shallowClone()", () => {
-    describe("when `frozen` is `true`", () => {
-      it("returns `this` for an already-frozen instance (no clone call)", () => {
-        const probe = new Probe("t");
-        Object.freeze(probe);
-
-        const result = probe.shallowClone(true);
-
-        expect(result).toBe(probe);
-        expect(probe.counter.calls).toBe(0);
+  describe("static members", () => {
+    describe("isInstance()", () => {
+      it("is `true` for a `BaseFabricInstance`", () => {
+        expect(BaseFabricInstance.isInstance(new Probe("t"))).toBe(true);
       });
 
-      it("returns a new frozen instance for an unfrozen one", () => {
-        const probe = new Probe("t");
-
-        const result = probe.shallowClone(true);
-
-        expect(result).not.toBe(probe);
-        expect(result instanceof Probe).toBe(true);
-        expect((result as Probe).wireTypeTag).toBe("t");
-        expect(Object.isFrozen(result)).toBe(true);
-        // Original is left unfrozen.
-        expect(Object.isFrozen(probe)).toBe(false);
-        expect(probe.counter.calls).toBe(1);
-      });
-    });
-
-    describe("when `frozen` is `false`", () => {
-      it("returns a new unfrozen instance from a frozen original", () => {
-        const probe = new Probe("t");
-        Object.freeze(probe);
-
-        const result = probe.shallowClone(false);
-
-        expect(result).not.toBe(probe);
-        expect(result instanceof Probe).toBe(true);
-        expect((result as Probe).wireTypeTag).toBe("t");
-        expect(Object.isFrozen(result)).toBe(false);
-        // The identity-when-frozen optimization is `frozen===true` only;
-        // a `frozen===false` call always allocates.
+      it("is `false` for a `FabricValue` that is not a `BaseFabricInstance`", () => {
+        expect(BaseFabricInstance.isInstance(null)).toBe(false);
+        expect(BaseFabricInstance.isInstance(42)).toBe(false);
+        expect(BaseFabricInstance.isInstance("x")).toBe(false);
+        expect(BaseFabricInstance.isInstance({})).toBe(false);
+        expect(BaseFabricInstance.isInstance([])).toBe(false);
       });
 
-      it("returns a new unfrozen instance from an unfrozen original", () => {
-        const probe = new Probe("t");
-
-        const result = probe.shallowClone(false);
-
-        expect(result).not.toBe(probe);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(probe.counter.calls).toBe(1);
-      });
-    });
-  });
-
-  describe("deepClone()", () => {
-    describe("when `frozen` is `true`", () => {
-      it("returns `this` for an already-deep-frozen instance (no core call)", () => {
-        const probe = deepFreeze(new DeepProbe({ n: 1 }));
-
-        const result = probe.deepClone(true);
-
-        expect(result).toBe(probe);
-        expect(probe.counter.calls).toBe(0);
-      });
-
-      it("does NOT identity-return a merely-shallowly-frozen instance", () => {
-        // Frozen instance slot, still-mutable nested state: not deep-frozen,
-        // so the deep identity gate (`isDeepFrozen`, not `Object.isFrozen`)
-        // must allocate rather than alias.
-        const probe = new DeepProbe({ n: 1 });
-        Object.freeze(probe);
-
-        expect(Object.isFrozen(probe)).toBe(true);
-        expect(isDeepFrozen(probe)).toBe(false);
-        expect(probe.deepClone(true)).not.toBe(probe);
-        expect(probe.counter.calls).toBe(1);
-      });
-
-      it("returns a new deep-frozen instance for an unfrozen one", () => {
-        const probe = new DeepProbe({ n: 1 });
-
-        const result = probe.deepClone(true);
-
-        expect(result).not.toBe(probe);
-        expect(isDeepFrozen(result)).toBe(true);
-        // Original is left unfrozen.
-        expect(Object.isFrozen(probe)).toBe(false);
-        expect(probe.counter.calls).toBe(1);
-      });
-    });
-
-    describe("when `frozen` is `false`", () => {
-      it("returns a fresh mutable clone with independent nested state", () => {
-        const probe = new DeepProbe({ n: 1 });
-
-        const result = probe.deepClone(false) as DeepProbe;
-
-        expect(result).not.toBe(probe);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(result.state).not.toBe(probe.state);
-        result.state.n = 2;
-        expect(probe.state.n).toBe(1);
-      });
-
-      it("allocates even from a deep-frozen original (identity gate is `frozen===true` only)", () => {
-        const probe = deepFreeze(new DeepProbe({ n: 1 }));
-
-        const result = probe.deepClone(false);
-
-        expect(result).not.toBe(probe);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(probe.counter.calls).toBe(1);
+      it("throws for a `FabricInstance` that is not a `BaseFabricInstance`", () => {
+        expect(() => BaseFabricInstance.isInstance(new RogueInstance()))
+          .toThrow(
+            "Shouldn't happen",
+          );
       });
     });
   });

--- a/packages/data-model/test/fabric-bases/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/fabric-bases/BaseFabricPrimitive.test.ts
@@ -44,32 +44,36 @@ describe("BaseFabricPrimitive", () => {
     });
   });
 
-  describe("isInstance()", () => {
-    it("is `true` for a `BaseFabricPrimitive`", () => {
-      expect(BaseFabricPrimitive.isInstance(new ProbePrimitive())).toBe(true);
-    });
-
-    it("is `false` for a `FabricValue` that is not a `BaseFabricPrimitive`", () => {
-      expect(BaseFabricPrimitive.isInstance(null)).toBe(false);
-      expect(BaseFabricPrimitive.isInstance(42)).toBe(false);
-      expect(BaseFabricPrimitive.isInstance("x")).toBe(false);
-      expect(BaseFabricPrimitive.isInstance({})).toBe(false);
-      expect(BaseFabricPrimitive.isInstance([])).toBe(false);
-    });
-
-    it("throws for a `FabricPrimitive` that is not a `BaseFabricPrimitive`", () => {
-      expect(() => BaseFabricPrimitive.isInstance(new RoguePrimitive()))
-        .toThrow(
-          "Shouldn't happen",
+  describe("instance members", () => {
+    describe("`[EXAMPLE_METHOD]` (placeholder seed)", () => {
+      it("throws when invoked (unimplemented stub)", () => {
+        expect(() => new ProbePrimitive()[EXAMPLE_METHOD]()).toThrow(
+          "Not implemented",
         );
+      });
     });
   });
 
-  describe("`[EXAMPLE_METHOD]` (placeholder seed)", () => {
-    it("throws when invoked (unimplemented stub)", () => {
-      expect(() => new ProbePrimitive()[EXAMPLE_METHOD]()).toThrow(
-        "Not implemented",
-      );
+  describe("static members", () => {
+    describe("isInstance()", () => {
+      it("is `true` for a `BaseFabricPrimitive`", () => {
+        expect(BaseFabricPrimitive.isInstance(new ProbePrimitive())).toBe(true);
+      });
+
+      it("is `false` for a `FabricValue` that is not a `BaseFabricPrimitive`", () => {
+        expect(BaseFabricPrimitive.isInstance(null)).toBe(false);
+        expect(BaseFabricPrimitive.isInstance(42)).toBe(false);
+        expect(BaseFabricPrimitive.isInstance("x")).toBe(false);
+        expect(BaseFabricPrimitive.isInstance({})).toBe(false);
+        expect(BaseFabricPrimitive.isInstance([])).toBe(false);
+      });
+
+      it("throws for a `FabricPrimitive` that is not a `BaseFabricPrimitive`", () => {
+        expect(() => BaseFabricPrimitive.isInstance(new RoguePrimitive()))
+          .toThrow(
+            "Shouldn't happen",
+          );
+      });
     });
   });
 });

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -420,66 +420,76 @@ describe("FabricError", () => {
       });
     });
 
-    describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: `[DEEP_FREEZE]` freezes wrapper + recurses cause", () => {
-        const inner = FabricError.fromNativeError(new Error("cause"));
-        const fe = FabricError.fromNativeError(
-          new Error("outer", { cause: inner }),
-        );
-        const result = deepFreeze(fe);
-        expect(result).toBe(fe); // freeze-in-place identity
-        expect(Object.isFrozen(fe)).toBe(true);
-        expect(isDeepFrozen(inner)).toBe(true);
+    describe("[DEEP_FREEZE]", () => {
+      describe("via dispatch", () => {
+        it("freezes wrapper + recurses cause", () => {
+          const inner = FabricError.fromNativeError(new Error("cause"));
+          const fe = FabricError.fromNativeError(
+            new Error("outer", { cause: inner }),
+          );
+          const result = deepFreeze(fe);
+          expect(result).toBe(fe); // freeze-in-place identity
+          expect(Object.isFrozen(fe)).toBe(true);
+          expect(isDeepFrozen(inner)).toBe(true);
+        });
+
+        it("recurses enumerable custom props (preserved via extras)", () => {
+          const err = new Error("e");
+          const childObj = { nested: 1 };
+          (err as unknown as Record<string, unknown>).custom = childObj;
+          const fe = FabricError.fromNativeError(err);
+          deepFreeze(fe);
+          // Non-string custom state is preserved AND deep-frozen.
+          expect(fe.getExtra("custom")).toBe(childObj);
+          expect(Object.isFrozen(childObj)).toBe(true);
+        });
       });
 
-      it("via dispatch: `[DEEP_FREEZE]` recurses enumerable custom props (preserved via extras)", () => {
-        const err = new Error("e");
-        const childObj = { nested: 1 };
-        (err as unknown as Record<string, unknown>).custom = childObj;
-        const fe = FabricError.fromNativeError(err);
-        deepFreeze(fe);
-        // Non-string custom state is preserved AND deep-frozen.
-        expect(fe.getExtra("custom")).toBe(childObj);
-        expect(Object.isFrozen(childObj)).toBe(true);
+      describe("via direct member invocation", () => {
+        it("freezes wrapper + recurses cause", () => {
+          const inner = FabricError.fromNativeError(new Error("cause"));
+          const fe = FabricError.fromNativeError(
+            new Error("outer", { cause: inner }),
+          );
+          const result = fe[DEEP_FREEZE](subFreeze);
+          expect(result).toBe(fe); // freeze-in-place identity
+          expect(Object.isFrozen(fe)).toBe(true);
+          expect(isDeepFrozen(inner)).toBe(true);
+        });
+
+        it("recurses enumerable custom props (preserved via extras)", () => {
+          const err = new Error("e");
+          const childObj = { nested: 1 };
+          (err as unknown as Record<string, unknown>).custom = childObj;
+          const fe = FabricError.fromNativeError(err);
+          fe[DEEP_FREEZE](subFreeze);
+          // Non-string custom state is preserved AND deep-frozen.
+          expect(fe.getExtra("custom")).toBe(childObj);
+          expect(Object.isFrozen(childObj)).toBe(true);
+        });
+      });
+    });
+
+    describe("[IS_DEEP_FROZEN]", () => {
+      describe("via dispatch", () => {
+        it("is `true` only when wrapper + cause are frozen", () => {
+          const fe = FabricError.fromNativeError(new Error("test"));
+          expect(isValidDeepFrozenFabricValue(fe)).toBe(false);
+          Object.freeze(fe); // wrapper only; some descendants still mutable
+          // (May be true since this particular FabricError has no nested
+          // FabricValue descendants beyond primitive strings.)
+          deepFreeze(fe);
+          expect(isValidDeepFrozenFabricValue(fe)).toBe(true);
+        });
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` is `true` only when wrapper + cause are frozen", () => {
-        const fe = FabricError.fromNativeError(new Error("test"));
-        expect(isValidDeepFrozenFabricValue(fe)).toBe(false);
-        Object.freeze(fe); // wrapper only; some descendants still mutable
-        // (May be true since this particular FabricError has no nested
-        // FabricValue descendants beyond primitive strings.)
-        deepFreeze(fe);
-        expect(isValidDeepFrozenFabricValue(fe)).toBe(true);
-      });
-
-      it("via direct member invocation: `[DEEP_FREEZE]` freezes wrapper + recurses cause", () => {
-        const inner = FabricError.fromNativeError(new Error("cause"));
-        const fe = FabricError.fromNativeError(
-          new Error("outer", { cause: inner }),
-        );
-        const result = fe[DEEP_FREEZE](subFreeze);
-        expect(result).toBe(fe); // freeze-in-place identity
-        expect(Object.isFrozen(fe)).toBe(true);
-        expect(isDeepFrozen(inner)).toBe(true);
-      });
-
-      it("via direct member invocation: `[DEEP_FREEZE]` recurses enumerable custom props (preserved via extras)", () => {
-        const err = new Error("e");
-        const childObj = { nested: 1 };
-        (err as unknown as Record<string, unknown>).custom = childObj;
-        const fe = FabricError.fromNativeError(err);
-        fe[DEEP_FREEZE](subFreeze);
-        // Non-string custom state is preserved AND deep-frozen.
-        expect(fe.getExtra("custom")).toBe(childObj);
-        expect(Object.isFrozen(childObj)).toBe(true);
-      });
-
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` is `true` only when wrapper is frozen", () => {
-        const fe = FabricError.fromNativeError(new Error("test"));
-        expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
-        fe[DEEP_FREEZE](subFreeze);
-        expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      describe("via direct member invocation", () => {
+        it("is `true` only when wrapper is frozen", () => {
+          const fe = FabricError.fromNativeError(new Error("test"));
+          expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
+          fe[DEEP_FREEZE](subFreeze);
+          expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+        });
       });
     });
 

--- a/packages/data-model/test/fabric-instances/FabricLink.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricLink.test.ts
@@ -100,80 +100,88 @@ describe("FabricLink", () => {
   });
 
   describe("deep-freeze protocol", () => {
-    it("`deepFreeze()` freezes the instance, its payload, and nested values", () => {
-      const link = new FabricLink({
-        id: "fid1:abc",
-        schema: { type: "object" },
+    describe("deepFreeze()", () => {
+      it("freezes the instance, its payload, and nested values", () => {
+        const link = new FabricLink({
+          id: "fid1:abc",
+          schema: { type: "object" },
+        });
+        const frozen = deepFreeze(link);
+        expect(frozen).toBe(link); // frozen in place
+        expect(isDeepFrozen(frozen)).toBe(true);
+        expect(Object.isFrozen(frozen.payload)).toBe(true);
+        expect(Object.isFrozen(frozen.payload.schema)).toBe(true);
       });
-      const frozen = deepFreeze(link);
-      expect(frozen).toBe(link); // frozen in place
-      expect(isDeepFrozen(frozen)).toBe(true);
-      expect(Object.isFrozen(frozen.payload)).toBe(true);
-      expect(Object.isFrozen(frozen.payload.schema)).toBe(true);
     });
 
-    it("`isDeepFrozen()` is `false` for a mutable instance", () => {
-      expect(isDeepFrozen(new FabricLink({ id: "fid1:abc" }))).toBe(false);
+    describe("isDeepFrozen()", () => {
+      it("is `false` for a mutable instance", () => {
+        expect(isDeepFrozen(new FabricLink({ id: "fid1:abc" }))).toBe(false);
+      });
     });
 
-    it("`[IS_DEEP_FROZEN]` (direct) is `false` before and `true` after `[DEEP_FREEZE]`", () => {
-      // Direct member invocation: `isDeepFrozen()` short-circuits via
-      // `deepFreeze()`'s cache, so the protocol method only runs when called
-      // straight, as here.
-      const link = new FabricLink({ id: "fid1:abc", path: ["a"] });
-      expect(link[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
-      link[DEEP_FREEZE](subFreeze);
-      expect(link[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
-    });
-  });
-
-  describe("deepClone()", () => {
-    it("returns a deep-frozen clone with an equal payload", () => {
-      const link = new FabricLink({ id: "fid1:abc", path: ["a"] });
-      const clone = link.deepClone(true) as FabricLink;
-      expect(isDeepFrozen(clone)).toBe(true);
-      expect(clone.payload).toEqual(link.payload);
-    });
-
-    it("identity-returns an already-deep-frozen instance", () => {
-      const link = deepFreeze(new FabricLink({ id: "fid1:abc" }));
-      expect(link.deepClone(true)).toBe(link);
-    });
-
-    it("returns an independent mutable clone (no shared payload structure)", () => {
-      const link = new FabricLink({ id: "fid1:abc" });
-      const clone = link.deepClone(false) as FabricLink;
-      expect(Object.isFrozen(clone)).toBe(false);
-      expect(clone.payload).not.toBe(link.payload);
-      (clone.payload as MutableFabricPlainObjectLayer).id = "fid1:xyz";
-      expect(link.payload.id).toBe("fid1:abc");
-    });
-
-    it("returns a frozen clone that identity-shares an already-deep-frozen payload subtree", () => {
-      // The `[DEEP_CLONE_CORE](frozen)` core clones the payload to the
-      // requested frozenness, so the "maximal structural sharing" the
-      // `deepClone()` contract promises holds: a nested subtree that is
-      // already deep-frozen rides into the frozen clone by identity.
-      const schema = deepFreeze({ type: "object" });
-      const link = new FabricLink({ id: "fid1:abc", schema });
-      const clone = link.deepClone(true) as FabricLink;
-      expect(clone).not.toBe(link);
-      expect(isDeepFrozen(clone)).toBe(true);
-      expect(clone.payload.schema).toBe(schema);
+    describe("`[IS_DEEP_FROZEN]` (direct)", () => {
+      it("is `false` before and `true` after `[DEEP_FREEZE]`", () => {
+        // Direct member invocation: `isDeepFrozen()` short-circuits via
+        // `deepFreeze()`'s cache, so the protocol method only runs when called
+        // straight, as here.
+        const link = new FabricLink({ id: "fid1:abc", path: ["a"] });
+        expect(link[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
+        link[DEEP_FREEZE](subFreeze);
+        expect(link[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      });
     });
   });
 
-  describe("shallowClone()", () => {
-    it("returns a mutable shallow clone that shares the payload reference", () => {
-      const link = new FabricLink({ id: "fid1:abc" });
-      const clone = link.shallowClone(false) as FabricLink;
-      expect(clone).not.toBe(link);
-      expect(clone.payload).toBe(link.payload);
+  describe("instance members", () => {
+    describe("deepClone()", () => {
+      it("returns a deep-frozen clone with an equal payload", () => {
+        const link = new FabricLink({ id: "fid1:abc", path: ["a"] });
+        const clone = link.deepClone(true) as FabricLink;
+        expect(isDeepFrozen(clone)).toBe(true);
+        expect(clone.payload).toEqual(link.payload);
+      });
+
+      it("identity-returns an already-deep-frozen instance", () => {
+        const link = deepFreeze(new FabricLink({ id: "fid1:abc" }));
+        expect(link.deepClone(true)).toBe(link);
+      });
+
+      it("returns an independent mutable clone (no shared payload structure)", () => {
+        const link = new FabricLink({ id: "fid1:abc" });
+        const clone = link.deepClone(false) as FabricLink;
+        expect(Object.isFrozen(clone)).toBe(false);
+        expect(clone.payload).not.toBe(link.payload);
+        (clone.payload as MutableFabricPlainObjectLayer).id = "fid1:xyz";
+        expect(link.payload.id).toBe("fid1:abc");
+      });
+
+      it("returns a frozen clone that identity-shares an already-deep-frozen payload subtree", () => {
+        // The `[DEEP_CLONE_CORE](frozen)` core clones the payload to the
+        // requested frozenness, so the "maximal structural sharing" the
+        // `deepClone()` contract promises holds: a nested subtree that is
+        // already deep-frozen rides into the frozen clone by identity.
+        const schema = deepFreeze({ type: "object" });
+        const link = new FabricLink({ id: "fid1:abc", schema });
+        const clone = link.deepClone(true) as FabricLink;
+        expect(clone).not.toBe(link);
+        expect(isDeepFrozen(clone)).toBe(true);
+        expect(clone.payload.schema).toBe(schema);
+      });
     });
 
-    it("identity-returns an already-frozen instance when asked for frozen", () => {
-      const link = deepFreeze(new FabricLink({ id: "fid1:abc" }));
-      expect(link.shallowClone(true)).toBe(link);
+    describe("shallowClone()", () => {
+      it("returns a mutable shallow clone that shares the payload reference", () => {
+        const link = new FabricLink({ id: "fid1:abc" });
+        const clone = link.shallowClone(false) as FabricLink;
+        expect(clone).not.toBe(link);
+        expect(clone.payload).toBe(link.payload);
+      });
+
+      it("identity-returns an already-frozen instance when asked for frozen", () => {
+        const link = deepFreeze(new FabricLink({ id: "fid1:abc" }));
+        expect(link.shallowClone(true)).toBe(link);
+      });
     });
   });
 

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -79,43 +79,53 @@ describe("FabricMap", () => {
 
     // The protocol methods are unimplemented stubs that throw, which these
     // cases pin at both entry points: dispatch and direct invocation.
-    describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
-        const fm = new FabricMap(
-          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
-        );
-        expect(() => deepFreeze(fm)).toThrow(
-          "`FabricMap`: not yet implemented",
-        );
+    describe("[DEEP_FREEZE]", () => {
+      describe("via dispatch", () => {
+        it("throws not-yet-implemented", () => {
+          const fm = new FabricMap(
+            new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+          );
+          expect(() => deepFreeze(fm)).toThrow(
+            "`FabricMap`: not yet implemented",
+          );
+        });
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` throws not-yet-implemented (via type guard)", () => {
-        const fm = new FabricMap(
-          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
-        );
-        Object.freeze(fm);
-        expect(() => isValidDeepFrozenFabricValue(fm)).toThrow(
-          "`FabricMap`: not yet implemented",
-        );
+      describe("via direct member invocation", () => {
+        it("throws not-yet-implemented", () => {
+          const fm = new FabricMap(
+            new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+          );
+          expect(() => fm[DEEP_FREEZE](subFreeze)).toThrow(
+            "`FabricMap`: not yet implemented",
+          );
+        });
+      });
+    });
+
+    describe("[IS_DEEP_FROZEN]", () => {
+      describe("via dispatch", () => {
+        it("throws not-yet-implemented (via type guard)", () => {
+          const fm = new FabricMap(
+            new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+          );
+          Object.freeze(fm);
+          expect(() => isValidDeepFrozenFabricValue(fm)).toThrow(
+            "`FabricMap`: not yet implemented",
+          );
+        });
       });
 
-      it("via direct member invocation: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
-        const fm = new FabricMap(
-          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
-        );
-        expect(() => fm[DEEP_FREEZE](subFreeze)).toThrow(
-          "`FabricMap`: not yet implemented",
-        );
-      });
-
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` throws not-yet-implemented", () => {
-        const fm = new FabricMap(
-          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
-        );
-        Object.freeze(fm);
-        expect(() => fm[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
-          "`FabricMap`: not yet implemented",
-        );
+      describe("via direct member invocation", () => {
+        it("throws not-yet-implemented", () => {
+          const fm = new FabricMap(
+            new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+          );
+          Object.freeze(fm);
+          expect(() => fm[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
+            "`FabricMap`: not yet implemented",
+          );
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -71,35 +71,45 @@ describe("FabricSet", () => {
       });
     });
 
-    describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
-        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
-        expect(() => deepFreeze(fs)).toThrow(
-          "`FabricSet`: not yet implemented",
-        );
+    describe("[DEEP_FREEZE]", () => {
+      describe("via dispatch", () => {
+        it("throws not-yet-implemented", () => {
+          const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+          expect(() => deepFreeze(fs)).toThrow(
+            "`FabricSet`: not yet implemented",
+          );
+        });
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` throws not-yet-implemented (via type guard)", () => {
-        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
-        Object.freeze(fs);
-        expect(() => isValidDeepFrozenFabricValue(fs)).toThrow(
-          "`FabricSet`: not yet implemented",
-        );
+      describe("via direct member invocation", () => {
+        it("throws not-yet-implemented", () => {
+          const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+          expect(() => fs[DEEP_FREEZE](subFreeze)).toThrow(
+            "`FabricSet`: not yet implemented",
+          );
+        });
+      });
+    });
+
+    describe("[IS_DEEP_FROZEN]", () => {
+      describe("via dispatch", () => {
+        it("throws not-yet-implemented (via type guard)", () => {
+          const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+          Object.freeze(fs);
+          expect(() => isValidDeepFrozenFabricValue(fs)).toThrow(
+            "`FabricSet`: not yet implemented",
+          );
+        });
       });
 
-      it("via direct member invocation: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
-        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
-        expect(() => fs[DEEP_FREEZE](subFreeze)).toThrow(
-          "`FabricSet`: not yet implemented",
-        );
-      });
-
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` throws not-yet-implemented", () => {
-        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
-        Object.freeze(fs);
-        expect(() => fs[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
-          "`FabricSet`: not yet implemented",
-        );
+      describe("via direct member invocation", () => {
+        it("throws not-yet-implemented", () => {
+          const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+          Object.freeze(fs);
+          expect(() => fs[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
+            "`FabricSet`: not yet implemented",
+          );
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -206,7 +206,7 @@ describe("FabricBytes", () => {
   });
 
   describe("static members", () => {
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricBytes[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.Bytes;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDay.test.ts
@@ -62,7 +62,7 @@ describe("FabricEpochDay", () => {
   });
 
   describe("static members", () => {
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricEpochDay[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.EpochDay;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -68,7 +68,7 @@ describe("FabricEpochNsec", () => {
   });
 
   describe("static members", () => {
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricEpochNsec[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.EpochNsec;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -198,7 +198,7 @@ describe("FabricHash", () => {
       });
     });
 
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricHash[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.Hash;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricKeyPair.test.ts
@@ -252,7 +252,7 @@ describe("FabricKeyPair", () => {
   });
 
   describe("static members", () => {
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricKeyPair[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.KeyPair;
       const env = NULL_LIVE_ENVIRONMENT;
@@ -356,7 +356,7 @@ describe("FabricKeyPair", () => {
       });
     });
 
-    describe("`[REALM_CODEC]`", () => {
+    describe("[REALM_CODEC]", () => {
       const codec = FabricKeyPair[REALM_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.KeyPair;
       const env = NULL_LIVE_ENVIRONMENT;

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -141,7 +141,7 @@ describe("FabricRegExp", () => {
   });
 
   describe("static members", () => {
-    describe("`[JSON_CODEC]`", () => {
+    describe("[JSON_CODEC]", () => {
       const codec = FabricRegExp[JSON_CODEC];
       const expectedTag = CODEC_TYPE_TAGS.RegExp;
       const env = NULL_LIVE_ENVIRONMENT;
@@ -342,17 +342,23 @@ describe("FabricRegExp", () => {
   });
 
   describe("tag functions", () => {
-    it("`tagFromNativeValue()` returns the `RegExp` tag for `RegExp` instances", () => {
-      expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
+    describe("tagFromNativeValue()", () => {
+      it("returns the `RegExp` tag for `RegExp` instances", () => {
+        expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
+      });
     });
 
-    it("`tagFromNativeClass()` returns the `RegExp` tag for the `RegExp` constructor", () => {
-      expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
+    describe("tagFromNativeClass()", () => {
+      it("returns the `RegExp` tag for the `RegExp` constructor", () => {
+        expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
+      });
     });
 
-    it("`isValidFabricNativeObject()` returns `true` for `RegExp`", () => {
-      expect(isValidFabricNativeObject(/abc/)).toBe(true);
-      expect(isValidFabricNativeObject(new RegExp("test", "gi"))).toBe(true);
+    describe("isValidFabricNativeObject()", () => {
+      it("returns `true` for `RegExp`", () => {
+        expect(isValidFabricNativeObject(/abc/)).toBe(true);
+        expect(isValidFabricNativeObject(new RegExp("test", "gi"))).toBe(true);
+      });
     });
   });
 

--- a/packages/data-model/test/fabric-primitives/schema-type.test.ts
+++ b/packages/data-model/test/fabric-primitives/schema-type.test.ts
@@ -82,47 +82,51 @@ const CASES: readonly {
   },
 ];
 
-describe("schemaTypeOfFabricPrimitive()", () => {
-  it("maps an instance of each primitive class to its schema type name", () => {
-    for (const { make, name } of CASES) {
-      expect(schemaTypeOfFabricPrimitive(make())).toBe(name);
-    }
+describe("schema-type", () => {
+  describe("schemaTypeOfFabricPrimitive()", () => {
+    it("maps an instance of each primitive class to its schema type name", () => {
+      for (const { make, name } of CASES) {
+        expect(schemaTypeOfFabricPrimitive(make())).toBe(name);
+      }
+    });
+
+    it("matches the codec-class list exactly", () => {
+      // Set equality by constructor identity, both directions: a codec class
+      // without a table row (the production-throws case) fails here, as does a
+      // stale row for a class no longer registered.
+      const tableCtors = new Set<unknown>(CASES.map(({ ctor }) => ctor));
+      expect(tableCtors.size).toBe(CASES.length);
+      for (const cls of codecClasses()) {
+        expect(tableCtors.has(cls)).toBe(true);
+      }
+      expect(codecClasses().length).toBe(CASES.length);
+    });
+
+    it("matches the api schema-type vocabulary exactly", () => {
+      const tableNames = new Set(CASES.map(({ name }) => name));
+      expect(tableNames.size).toBe(CASES.length);
+      for (const name of FABRIC_PRIMITIVE_SCHEMA_TYPES) {
+        expect(tableNames.has(name)).toBe(true);
+      }
+      expect(FABRIC_PRIMITIVE_SCHEMA_TYPES.length).toBe(CASES.length);
+    });
+
+    it("throws on a FabricPrimitive subclass outside the mapping", () => {
+      // Death before confusion: a primitive class that reaches the mapping
+      // without a schema type name must fail loudly, not degrade to "object".
+      class RogueFabricPrimitive extends BaseFabricPrimitive {}
+      expect(() => schemaTypeOfFabricPrimitive(new RogueFabricPrimitive()))
+        .toThrow(/RogueFabricPrimitive/);
+    });
   });
 
-  it("matches the codec-class list exactly", () => {
-    // Set equality by constructor identity, both directions: a codec class
-    // without a table row (the production-throws case) fails here, as does a
-    // stale row for a class no longer registered.
-    const tableCtors = new Set<unknown>(CASES.map(({ ctor }) => ctor));
-    expect(tableCtors.size).toBe(CASES.length);
-    for (const cls of codecClasses()) {
-      expect(tableCtors.has(cls)).toBe(true);
-    }
-    expect(codecClasses().length).toBe(CASES.length);
-  });
-
-  it("matches the api schema-type vocabulary exactly", () => {
-    const tableNames = new Set(CASES.map(({ name }) => name));
-    expect(tableNames.size).toBe(CASES.length);
-    for (const name of FABRIC_PRIMITIVE_SCHEMA_TYPES) {
-      expect(tableNames.has(name)).toBe(true);
-    }
-    expect(FABRIC_PRIMITIVE_SCHEMA_TYPES.length).toBe(CASES.length);
-  });
-
-  it("throws on a FabricPrimitive subclass outside the mapping", () => {
-    // Death before confusion: a primitive class that reaches the mapping
-    // without a schema type name must fail loudly, not degrade to "object".
-    class RogueFabricPrimitive extends BaseFabricPrimitive {}
-    expect(() => schemaTypeOfFabricPrimitive(new RogueFabricPrimitive()))
-      .toThrow(/RogueFabricPrimitive/);
-  });
-
-  it("`isFabricPrimitiveSchemaType()` accepts exactly the vocabulary", () => {
-    for (const { name } of CASES) {
-      expect(isFabricPrimitiveSchemaType(name)).toBe(true);
-    }
-    expect(isFabricPrimitiveSchemaType("object")).toBe(false);
-    expect(isFabricPrimitiveSchemaType("FabricNope")).toBe(false);
+  describe("isFabricPrimitiveSchemaType()", () => {
+    it("accepts exactly the vocabulary", () => {
+      for (const { name } of CASES) {
+        expect(isFabricPrimitiveSchemaType(name)).toBe(true);
+      }
+      expect(isFabricPrimitiveSchemaType("object")).toBe(false);
+      expect(isFabricPrimitiveSchemaType("FabricNope")).toBe(false);
+    });
   });
 });

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -36,7 +36,7 @@ function instanceNamed(name: string): object {
 // leading backtick merges into the opening delimiter.
 const HOSTILE = ["a`b", "a``b", "`lead", "trail`", "`", "``"];
 
-describe("message quoting", () => {
+describe("message-quoting", () => {
   describe("FabricHash.fromString()", () => {
     it("hands back the source it refused, whatever backticks it held", () => {
       for (const source of HOSTILE) {

--- a/packages/data-model/test/message-quoting.test.ts
+++ b/packages/data-model/test/message-quoting.test.ts
@@ -37,7 +37,7 @@ function instanceNamed(name: string): object {
 const HOSTILE = ["a`b", "a``b", "`lead", "trail`", "`", "``"];
 
 describe("message quoting", () => {
-  describe("`FabricHash.fromString()`", () => {
+  describe("FabricHash.fromString()", () => {
     it("hands back the source it refused, whatever backticks it held", () => {
       for (const source of HOSTILE) {
         let message = "";
@@ -53,7 +53,7 @@ describe("message quoting", () => {
     });
   });
 
-  describe("`hashOf()`", () => {
+  describe("hashOf()", () => {
     it("hands back the class name it refused", () => {
       for (const name of HOSTILE) {
         let message = "";
@@ -69,7 +69,7 @@ describe("message quoting", () => {
     });
   });
 
-  describe("`cloneIfNecessary()`", () => {
+  describe("cloneIfNecessary()", () => {
     it("hands back the class name it refused", () => {
       for (const name of HOSTILE) {
         let message = "";
@@ -83,7 +83,7 @@ describe("message quoting", () => {
     });
   });
 
-  describe("`JsonCodecEngine.decode()`", () => {
+  describe("JsonCodecEngine.decode()", () => {
     it("hands back the excerpt it refused", () => {
       const env = new NullLiveEnvironment(false);
       for (const data of HOSTILE) {

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -448,46 +448,60 @@ describe("native-conversion", () => {
     const frozenCtx = new DummyLiveEnvironment(true);
     const mutableCtx = new DummyLiveEnvironment(false);
 
-    it("`FabricError`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      const state = {
-        type: "Error",
-        name: null,
-        message: "boom",
-      };
-      const frozen = FabricError[CODEC].decode(
-        CODEC_TYPE_TAGS.Error,
-        state,
-        frozenCtx,
-      );
-      expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = FabricError[CODEC].decode(
-        CODEC_TYPE_TAGS.Error,
-        state,
-        mutableCtx,
-      );
-      expect(Object.isFrozen(mutable)).toBe(false);
+    describe("FabricError", () => {
+      it("is deep-frozen when `shouldDeepFreeze` is `true`, mutable when `false`", () => {
+        const state = {
+          type: "Error",
+          name: null,
+          message: "boom",
+        };
+        const frozen = FabricError[CODEC].decode(
+          CODEC_TYPE_TAGS.Error,
+          state,
+          frozenCtx,
+        );
+        expect(isDeepFrozen(frozen)).toBe(true);
+        const mutable = FabricError[CODEC].decode(
+          CODEC_TYPE_TAGS.Error,
+          state,
+          mutableCtx,
+        );
+        expect(Object.isFrozen(mutable)).toBe(false);
+      });
     });
 
-    it("`ProblematicValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      // Tag travels separately; the bare inner state is the codec payload,
-      // which for this class is a record of the three facts it preserves.
-      const state = { tag: "Bad@1", state: { x: 1 }, error: "oops" };
-      const frozen = ProblematicValue[CODEC].decode("Bad@1", state, frozenCtx);
-      expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = ProblematicValue[CODEC].decode(
-        "Bad@1",
-        state,
-        mutableCtx,
-      );
-      expect(Object.isFrozen(mutable)).toBe(false);
+    describe("ProblematicValue", () => {
+      it("is deep-frozen when `shouldDeepFreeze` is `true`, mutable when `false`", () => {
+        // Tag travels separately; the bare inner state is the codec payload,
+        // which for this class is a record of the three facts it preserves.
+        const state = { tag: "Bad@1", state: { x: 1 }, error: "oops" };
+        const frozen = ProblematicValue[CODEC].decode(
+          "Bad@1",
+          state,
+          frozenCtx,
+        );
+        expect(isDeepFrozen(frozen)).toBe(true);
+        const mutable = ProblematicValue[CODEC].decode(
+          "Bad@1",
+          state,
+          mutableCtx,
+        );
+        expect(Object.isFrozen(mutable)).toBe(false);
+      });
     });
 
-    it("`UnknownValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      const state = { y: 2 };
-      const frozen = UnknownValue[CODEC].decode("Fancy@3", state, frozenCtx);
-      expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = UnknownValue[CODEC].decode("Fancy@3", state, mutableCtx);
-      expect(Object.isFrozen(mutable)).toBe(false);
+    describe("UnknownValue", () => {
+      it("is deep-frozen when `shouldDeepFreeze` is `true`, mutable when `false`", () => {
+        const state = { y: 2 };
+        const frozen = UnknownValue[CODEC].decode("Fancy@3", state, frozenCtx);
+        expect(isDeepFrozen(frozen)).toBe(true);
+        const mutable = UnknownValue[CODEC].decode(
+          "Fancy@3",
+          state,
+          mutableCtx,
+        );
+        expect(Object.isFrozen(mutable)).toBe(false);
+      });
     });
   });
 
@@ -500,37 +514,47 @@ describe("native-conversion", () => {
   // clean fast throw, not a hang); `.not.toThrow()` is the discriminating
   // assertion.
   describe("cycle behavior via `[DEEP_FREEZE]`", () => {
-    it("`FabricError`: cycle through `error.cause` terminates", () => {
-      // Build a cycle: a plain-object wrapper holds the FabricError, and the
-      // FabricError's `error.cause` points back at the wrapper. When
-      // `deepFreeze(wrapper)` runs Arm 4 it recurses into the FabricError
-      // (Arm 3), which subFreezes `error.cause` = wrapper, which re-enters
-      // `deepFreeze()` -> the FabricError again -> ...
-      const err = new Error("cycle-cause");
-      const fe = FabricError.fromNativeError(err);
-      const wrapper: Record<string, unknown> = { fe };
-      err.cause = wrapper;
-      expect(() => deepFreeze(wrapper)).not.toThrow();
-      expect(Object.isFrozen(wrapper)).toBe(true);
-      expect(Object.isFrozen(fe)).toBe(true);
+    describe("FabricError", () => {
+      it("terminates on a cycle through `error.cause`", () => {
+        // Build a cycle: a plain-object wrapper holds the FabricError, and the
+        // FabricError's `error.cause` points back at the wrapper. When
+        // `deepFreeze(wrapper)` runs Arm 4 it recurses into the FabricError
+        // (Arm 3), which subFreezes `error.cause` = wrapper, which re-enters
+        // `deepFreeze()` -> the FabricError again -> ...
+        const err = new Error("cycle-cause");
+        const fe = FabricError.fromNativeError(err);
+        const wrapper: Record<string, unknown> = { fe };
+        err.cause = wrapper;
+        expect(() => deepFreeze(wrapper)).not.toThrow();
+        expect(Object.isFrozen(wrapper)).toBe(true);
+        expect(Object.isFrozen(fe)).toBe(true);
+      });
     });
 
-    it("`ProblematicValue`: cycle through `state` terminates", () => {
-      const cycle: Record<string, unknown> = { x: 1 };
-      const pv = new ProblematicValue("Cycle@1", cycle as FabricValue, "oops");
-      cycle.back = pv;
-      expect(() => deepFreeze(pv)).not.toThrow();
-      expect(Object.isFrozen(pv)).toBe(true);
-      expect(Object.isFrozen(cycle)).toBe(true);
+    describe("ProblematicValue", () => {
+      it("terminates on a cycle through `state`", () => {
+        const cycle: Record<string, unknown> = { x: 1 };
+        const pv = new ProblematicValue(
+          "Cycle@1",
+          cycle as FabricValue,
+          "oops",
+        );
+        cycle.back = pv;
+        expect(() => deepFreeze(pv)).not.toThrow();
+        expect(Object.isFrozen(pv)).toBe(true);
+        expect(Object.isFrozen(cycle)).toBe(true);
+      });
     });
 
-    it("`UnknownValue`: cycle through `state` terminates", () => {
-      const cycle: Record<string, unknown> = { y: 2 };
-      const uv = new UnknownValue("Cycle@1", cycle as FabricValue);
-      cycle.back = uv;
-      expect(() => deepFreeze(uv)).not.toThrow();
-      expect(Object.isFrozen(uv)).toBe(true);
-      expect(Object.isFrozen(cycle)).toBe(true);
+    describe("UnknownValue", () => {
+      it("terminates on a cycle through `state`", () => {
+        const cycle: Record<string, unknown> = { y: 2 };
+        const uv = new UnknownValue("Cycle@1", cycle as FabricValue);
+        cycle.back = uv;
+        expect(() => deepFreeze(uv)).not.toThrow();
+        expect(Object.isFrozen(uv)).toBe(true);
+        expect(Object.isFrozen(cycle)).toBe(true);
+      });
     });
 
     it("terminates on a cross-instance cycle (`FabricError` <-> `ProblematicValue`)", () => {

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -61,7 +61,7 @@ describe("schema-utils", () => {
       });
     }
 
-    describe("`canShare=true`", () => {
+    describe("canShare=true", () => {
       it("freezes input in place", () => {
         const originalProperties = {
           name: { type: "string" } as JSONSchemaObj,
@@ -98,7 +98,7 @@ describe("schema-utils", () => {
       });
     });
 
-    describe("`canShare=false`", () => {
+    describe("canShare=false", () => {
       it("clones before freezing", () => {
         const schema: JSONSchemaObj = {
           type: "object",
@@ -852,13 +852,13 @@ describe("schema-utils", () => {
     testType("FabricHash", new FabricHash(new Uint8Array(32), "fid1"));
     testType("FabricRegExp", new FabricRegExp(/x/));
 
-    describe("`undefined`", () => {
+    describe("undefined", () => {
       it("returns `undefined`", () => {
         expect(schemaForValueType(undefined)).toBe(undefined);
       });
     });
 
-    describe("`bigint`", () => {
+    describe("bigint", () => {
       it("returns `undefined`", () => {
         expect(schemaForValueType(BigInt(42))).toBe(undefined);
       });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

The 43 descriptions left standing by #6203, settled. Two families needed a
grouping decision rather than a reworded string, and making both decisions also
settles the four class files that had no member grouping.

Nothing about what any test asserts changes. See "How that is checked" below.

## A label prefix becomes a `describe()`

"via dispatch: …", "`FabricError`: …", "malformed wire: …" each named an axis
across a group of otherwise identical cases. The guide asks for a nested block
rather than a banner, so each axis is now one.

Two labels occurred exactly once — "boundary contrast: …" and the
`encode()`→`/quote`→`decode()` round-trip — and name no axis, so they re-voice
in place rather than earning a block that would hold a single test.

## A member as the subject becomes a `describe()`

`` `register()` throws `` becomes `describe("register()")` holding
`it("throws")`, and likewise for the rest.

## Both at once, where both applied

In the deep-freeze protocol blocks each remedy wanted a level, and the member
takes the outer one: the guide asks for one block per member, so that is the
axis belonging directly under `instance members`. Nesting it outside splits the
combined `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]` block into one block per member:

```
instance members
  [DEEP_FREEZE]
    via dispatch                    it("freezes wrapper + recurses cause")
    via direct member invocation    it("freezes wrapper + recurses cause")
  [IS_DEEP_FROZEN]
    via dispatch                    it("is `true` only when wrapper + cause are frozen")
    via direct member invocation    it("is `true` only when wrapper is frozen")
```

Tests reorder there, so each member's two paths sit together.

`ProblematicValue` and `UnknownValue` keep their combined block: their two cases
each exercise both symbols together, so only the path level applies.

## The four class files

`CodecRegistry`, `FabricLink`, `BaseFabricInstance` and `BaseFabricPrimitive`
gain `instance members` and `static members`. `isInstance()` is static on both
base classes and is grouped accordingly; `[EXAMPLE_METHOD]` is an instance
method and is grouped accordingly. The cross-member themes those files use —
"registration guards", "frozen instances", "inheritance", "deep-freeze
protocol" — stay where they are, which is what the guide provides for.

## Two things found on the way

`schema-type.test.ts` covers two functions from two packages
(`schemaTypeOfFabricPrimitive` from `data-model`, `isFabricPrimitiveSchemaType`
from `api`), with the top-level block named after only one of them. Its
top-level block now takes the file's own subject, and each function gets a block
beneath it.

`message-quoting.test.ts` opened `describe("message quoting")` where the guide
gives the file's base name — the same miss, and the last of its kind in the
package.

Thirty-four `describe()` titles were a single backticked token, which the guide
writes bare — and five of those this change had just introduced, so the sweep
came with it rather than after it.

## How that is checked

The descriptions move and change here, so the invariant is the test **body**.
The multiset of `it()` bodies is identical to `main` — 987 of them, compared per
file. Deeper nesting makes `deno fmt` re-wrap (a line break moves, a split call
gains a trailing comma), so the comparison normalizes exactly those two away;
with a control that changes one assertion string, the check fails as it should.

Of 1867 descriptions, none now fails to read as a verb phrase completing "it".
Before #6203, 83 did.

## Gates

`deno task check`, `deno lint`, `deno fmt --check`, `deno task check-docs`,
`deno task check-no-waitfor`, and the `data-model` suite (51 passed, 0 failed)
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQJkaKMWPLBQRDEbXET7Dd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



