### PR TITLE
docs(development): a single-export test file titles its block for the export

### DIFF
--- a/docs/development/unit-test-coding-style.md
+++ b/docs/development/unit-test-coding-style.md
@@ -72,8 +72,10 @@ Use the BDD functions from `@std/testing/bdd` — `describe()`, `it()`,
 Every test file has a single top-level `describe()` call containing everything
 else. Its title is the name of the file under test without the source suffix:
 `describe("donut-weight", ...)` for `donut-weight.ts`. As a special case, when
-the source file exists only to export one class, the title names that class:
-`describe("DonutWeight", ...)`.
+the file tests only one class, function, or other export, the title names that
+export: `describe("DonutWeight", ...)` for a class, and
+`describe("eatDonut()", ...)` for a function. That is the same condition under
+which the file itself is named for the export rather than for a source file.
 
 There is one carve-out. When a file parameterizes the same test body across a
 fixed set of implementations — typically one `describe()` per implementation,
@@ -142,7 +144,8 @@ describe("DonutWeight", () => {
 ### Describing a function
 
 A top-level function gets a `describe()` of its own, holding a sequence of
-`it()`s, in the same shape as a method's block above.
+`it()`s, in the same shape as a method's block above. Where the file tests only
+that function, that block is the file's single top-level `describe()`.
 
 ### Writing the description strings
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

The top-level `describe()` rule states one special case, for a file whose source
exports only a class. A file that tests a single function is the same situation
and takes the same treatment — `describe("cloneForMutation()")` — but the rule
did not say so, leaving a reader to infer it from the class case.

Doc-only. No test changes: the guide now states the shape those files already
have.

## The condition is what the file covers, not what its source exports

The wording keys off the same condition the file naming rule a few paragraphs up
already uses. That distinction is load-bearing rather than cosmetic:
`cloneForMutation`, `cloneIfNecessary` and `shallowMutableClone` all live in
`value-clone.ts`, which has fourteen exports. A condition worded around the
source file — "when the source file exists only to export one function" — would
have excluded the three files that most need it.

## What it settles

By a census of the 51 `data-model` test files, eight have a top-level title
differing from their file's base name. This makes six of them conforming:

| file | title |
| --- | --- |
| `cloneForMutation.test.ts` | `cloneForMutation()` |
| `cloneIfNecessary.test.ts` | `cloneIfNecessary()` |
| `shallowMutableClone.test.ts` | `shallowMutableClone()` |
| `valueEqual.test.ts` | `valueEqual()` |
| `codec-common/codecOf.test.ts` | `codecOf()` |
| `codec-realm/marker.test.ts` | `markerOf()` |

The two left over are separate questions about those files rather than about
this rule. `codec-realm/index.test.ts` titles its block `codec-realm/index`,
path-qualifying because a bare `index` says nothing in a run transcript.
`value-debug-indented.test.ts` titles its block `toIndentedDebugString (direct
wrapper coverage)`, which carries a coverage note rather than a name, and the
file exercises `toCompactDebugString` as well.

## Gates

`deno task check-docs`, `deno fmt --check`, and `deno task check-skill-facts`
pass. No line in the file exceeds 80 columns, and the two edited paragraphs are
greedy-filled at that width; neither example's code span is split across a line
break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQJkaKMWPLBQRDEbXET7Dd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

