### PR TITLE
test(data-model): title the indented-debug block for the function it tests

### DIFF
--- a/packages/data-model/test/value-debug-indented.test.ts
+++ b/packages/data-model/test/value-debug-indented.test.ts
@@ -13,7 +13,7 @@ import { expect } from "@std/expect";
 import { toCompactDebugString, toIndentedDebugString } from "@/value-debug.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 
-describe("toIndentedDebugString (direct wrapper coverage)", () => {
+describe("toIndentedDebugString()", () => {
   it("returns a non-empty string for a plain nested object", () => {
     const result = toIndentedDebugString({ a: 1, nested: { b: 2 } });
     expect(typeof result).toBe("string");


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`value-debug-indented.test.ts` opened
`describe("toIndentedDebugString (direct wrapper coverage)")` — a name with a
note appended, where the top-level rule in
[`unit-test-coding-style.md`](../blob/main/docs/development/unit-test-coding-style.md)
asks for the subject alone.

The file tests one export. `toCompactDebugString` appears exactly once, as the
operand a single assertion compares against ("applies indentation that the
compact form omits"), never as a subject. So the block takes that function's
name: `describe("toIndentedDebugString()")`.

## Why the parenthetical is dropped rather than nested

It describes every test in the file, so it has no sibling to distinguish itself
from. A block that wraps the whole file and contrasts with nothing adds a level
to the run transcript without telling a reader which group failed, which is the
job the guide gives a `describe()` title.

What it was reaching for is already stated, at length and more precisely, in the
file's own doc comment — that the wrapper is a one-line forward to a
module-private renderer, and is exercised directly here so it is covered
independently of whichever larger suite happens to reach it indirectly. That is
the right home for it: it is a fact about why the file exists, not a grouping
within it.

## Scope

One line. The suite is unchanged at 51 passed / 2747 steps, `deno fmt --check`
and `deno lint` pass.

This leaves `codec-realm/index.test.ts` as the only `data-model` test file whose
top-level title is neither its file's base name nor a single export it covers.
That one is deliberate: the file tests what the barrel re-exports — four names,
asserted as a public surface — so its subject is the module, and a bare `index`
would say nothing in a run transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQJkaKMWPLBQRDEbXET7Dd


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

