### PR TITLE
A refused piece start is a race, not a verdict: re-attempt it against fresh state

### DIFF
--- a/docs/history/plans/server-execution-v2/optimize/ow45-armb-basis-narrowing-scope.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow45-armb-basis-narrowing-scope.md
@@ -1,0 +1,155 @@
+---
+status: historical
+created: 2026-08-23
+archived: 2026-08-23
+reason: "Scoping memo (flag-don't-fill) for a THIRD arm of the OW45 arm-B client-start fork, surfaced by the adversarial review of the ruled-(a) build: close the first-hydration refusal by NARROWING the deferred start's commit conflict set — the way two sibling rows in the same register already closed this exact refusal class — instead of by retrying it. Scope only: what the start reads into its basis, whether those reads are structurally narrowable, what it would dissolve, what it risks, and what must be measured before anyone builds it. NOT the ruled (a); it needs the owner's ruling of its own."
+---
+
+# Narrowing the basis instead of retrying it — a third arm for OW45 arm B
+
+## Why this memo exists
+
+The owner ruled (a) — retry the deferred start on a stale-confirmed-read
+conflict — and it was built with red-first pins
+(`ow45-armb-client-start-fork.md`, RULED 2026-08-22). Two things then
+happened, and together they say the fork's option set was incomplete:
+
+- **The live ON gate did not clear the lift bar.** 2 reds in 7 runs on
+  an ON-built binary carrying the fix (verified: the fix's own
+  exhaustion-log string is present in the artifact). Both arm-B shapes
+  reproduced WITH the retry shipped — the whole-piece shape
+  (`isNotebook: false`, `noteCount: -1`, `storedUiNoteChips: 98`,
+  0 rendered) and the single-chain shape (`notesLength: 7`,
+  `mentionableLength: 7`, `renderedNoteChips: 6`).
+- **The adversarial review surfaced a third disposition** that neither
+  the fork memo nor the register considered: two sibling rows in THIS
+  register closed this identical refusal class by narrowing what enters
+  the commit's confirmed-read set, rather than by re-running the commit.
+
+This memo scopes that third arm. It is NOT a build, and it is NOT the
+ruled (a): if it is right it REPLACES (a) rather than refining it, which
+is a decision for the owner.
+
+## The precedent, stated exactly
+
+Both sibling closures are in `verification-coverage.md`, and both ended
+at the same seat — `buildReads` in `packages/runner/src/storage/v2.ts`,
+which decides what a commit asserts as a concurrency precondition:
+
+- The `cid:` exclusion (register row at the `stale confirmed read:
+  cid:… at seq 0 conflicted with seq N` delivery-gap window).
+  Content-addressed documents "carry no commit-time concurrency
+  precondition at all: their content can never change … so there is no
+  staleness for a conflict check to find", while the client's confirmed
+  basis for one it resolved from an overlay or registry is 0 and the
+  doc's first INSTALL is a real revision row. Exporting that read
+  "killed the commit as `stale confirmed read: cid:… at seq 0` exactly
+  in the delivery-gap window the resolution fallbacks serve". The fix
+  drops the read; presence is "owned by server-side closure
+  validation".
+- The CFC blind-write exclusion (the sibling row above it), which
+  narrows a different family of reads out of the conflict set on the
+  same principle — with the precondition the ruling wanted to KEEP
+  (a concurrent `/cfc` change) still conflicting.
+
+The shape of both: a read was entering the conflict set that was never
+a genuine precondition, and the refusal it caused was structural rather
+than a real race. Neither was fixed by retrying.
+
+## What the failing start actually asserts
+
+The instrumented catch that founded arm B names its conflicted entity
+precisely (run b04, `ow45-armb-client-start-fork.md`):
+
+```text
+ConflictError: stale confirmed read:
+  computed:fid1:1PlbDz… at seq 0 conflicted with seq 10
+```
+
+The conflicted id is **`computed:`-kinded**, and that scheme is not
+decoration. `packages/runner/src/entity-kind.ts` defines it as a
+SEMANTIC property of the entity: `computed:fid1:<hash>` "names an
+entity whose contents are re-derivable by the runtime that minted it",
+and the kind exists to say "what conflict policy the server may apply".
+The same grouping already appears in the serving loop:
+`neverAPieceRootId` (`executor/space-server.ts`) treats
+`computed:`-prefixed ids in the same structural class as `cid:` ones.
+
+So the client's deferred start is asserting a CAS precondition — "this
+computed document was absent at seq 0" — over a document whose content
+is by definition re-derivable, and which under the flag the SERVING side
+owns and is materializing at that very moment. That is the same
+category error the `cid:` exclusion corrected, in a different scheme.
+
+## The candidate, and its scoping questions
+
+**Candidate:** drop `computed:`-kinded reads from the commit's confirmed
+conflict set at `buildReads`, beside the `cid:` exclusion that is
+already there.
+
+If that holds, the race DISSOLVES rather than being re-run: the start
+commits without asserting a precondition it has no business asserting,
+on BOTH arms, with no retry, no bound to justify, no readiness gate to
+depend on, and none of the re-entrancy hazards a retry introduces (the
+review confirmed one such regression in the shipped (a): a re-attempt
+token minted with no lifecycle check, repopulating a map `stopAll()`
+had cleared).
+
+It is NOT obviously correct, and these are the questions that decide it:
+
+1. **Is the exclusion sound for a VALUE dependency?** A `cid:` doc's
+   content can never change, which is what made its exclusion free. A
+   `computed:` doc's content CAN change — it is re-derived. A start
+   that genuinely consumed a computed value and writes a function of it
+   would, without the precondition, commit against a stale view. The
+   counter-argument is serving-loop.md §3d's own soundness rule for
+   derived state ("dropping is sound exactly because derived values are
+   re-derivable"), but §3d says that about the SERVER dropping derived
+   WRITES from a wave, not about a client dropping derived READS from a
+   basis. That is an analogy, not a proof, and it needs the owner's
+   ruling rather than an implementer's inference.
+2. **Should it be scoped to reads at ABSENCE (seq 0)?** The observed
+   failure is specifically a pre-birth read: basis 0 against a doc the
+   server was creating. A narrow exclusion — computed-kinded reads whose
+   confirmed basis is 0 — dissolves the first-hydration race while
+   leaving every read of an EXISTING computed doc asserting its true
+   version. This is the smaller, more defensible cut.
+3. **Should it be flag-scoped?** Under ON the serving side is the sole
+   deriver, so a client asserting preconditions on computed docs is
+   simply wrong. Under OFF the client derives them itself, and the
+   precondition may be load-bearing. A flag-scoped exclusion keeps the
+   OFF arm byte-identical (testing.md §2's requirement) at the cost of
+   a branch the flip would later remove.
+4. **Is the start's basis ONLY computed reads?** Unverified. One
+   sample (b04) names a computed doc; the h01/h05 single-chain shape
+   was never traced to its conflicted entity at all. If a start's basis
+   also stales on `of:`-kinded docs, this narrowing closes part of the
+   class and the remainder still needs an answer.
+
+## What must be measured before building
+
+- **The conflict set's composition.** Instrument the refused start to
+  dump its full confirmed-read set (ids and seqs), not just the single
+  entity the error message names. The message reports the FIRST
+  conflict the engine found; the fix's scope depends on the whole set.
+  This also settles whether the review's point about the retry pulling
+  only one document — the single id parsed from the message — is the
+  binding limitation it appears to be.
+- **Whether the single-chain shape shares the mechanism.** It reds the
+  same step with a fully-started piece (7 notes, 6 chips), so it may be
+  a different seat entirely. Arm B was mapped as three defects; two
+  were fixed; this memo must not assume the remaining reds are one
+  thing.
+- **An OFF-arm neutrality witness.** Whatever the scoping decision,
+  testing.md §2 requires the OFF arm to be byte-identical, and the
+  review recorded that the shipped (a) has no such witness.
+
+## Status
+
+Recorded for the owner. Three arms now exist for OW45 arm B: (a) the
+ruled and built retry, which the live gate shows does not clear the
+bar; (b) adopt-not-start, recorded POST-FLIP as OW61; and this one,
+which would supersede (a) rather than extend it. The instrumented
+verdict on whether (a)'s retry fires at all in a red run is the other
+input the owner needs, and is reported with the gate evidence in the
+OW45 row.

--- a/docs/history/plans/server-execution-v2/optimize/ow45-armb-client-start-fork.md
+++ b/docs/history/plans/server-execution-v2/optimize/ow45-armb-client-start-fork.md
@@ -178,6 +178,23 @@ with the Phase-7 flip work, and would retire (a)'s retry as dead code
 ruled disposition on evidence the ruling did not have; surface that
 evidence to the owner rather than building against the ruling.
 
+**RULED 2026-08-22 (owner Berni) — the recommendation is adopted as
+stated.**
+
+> ok, let's do (a) and record (b) as a post-flip task — owner,
+> 2026-08-22
+
+(a) is BUILT at the seat named above: a stale-confirmed-read refusal
+of a commit-gated start earns a bounded re-attempt against fresh
+confirmed state, every other refusal class stays terminal exactly as
+it is today, and exhaustion keeps that terminal arm under a
+distinctly-named log. (b) is RECORDED as a POST-FLIP task carrying
+this memo as its design seed — verification-coverage.md **OW61**,
+which also holds the pieces (b) needs before it can be built and its
+duty to retire (a)'s retry when it lands. (c) stands as written: the
+S-C ruling's closed-loss-window premise is disproven for the notebook
+flow, recorded for the owner, and not built against.
+
 ## Residuals flagged beside the fork (recorded, not owed here)
 
 - The scheduler-level event deferral (`outcome.kind === "deferred"`,

--- a/docs/plans/server-execution-v2.md
+++ b/docs/plans/server-execution-v2.md
@@ -38,7 +38,36 @@ The arc's coordination state is carried HERE, on the branch, not in any
 agent's memory (owner directive 2026-08-18). This block is LIVE: update
 it in the PR that moves the state.
 
-**Delta 2026-08-22 (this PR): OW45 arm B triaged on an instrumented
+**Delta 2026-08-23 (this PR): the OW45 arm-B client-start fork RULED
+(a) and BUILT — a transient refusal of a piece start is no longer
+terminal.** The owner adopted the memo's recommendation as stated
+("ok, let's do (a) and record (b) as a post-flip task", 2026-08-22).
+BUILT: a commit-gated start refused for a STALE CONFIRMED READ
+re-attempts against fresh confirmed state — bounded at 2, on both
+deferred-start arms, each attempt taking a fresh ownership token
+REGISTERED before the readiness gate so a stop, a release, or a
+teardown tombstones the pending re-attempt through the path that
+already tombstones a pending first attempt. Every other refusal class
+stays terminal exactly as today, and exhaustion keeps that terminal
+arm under a distinctly-named log. The §3d question a re-run raises is
+answered STRUCTURALLY: a consequence-stamped start diverts into the
+speculation overlay and never reaches the memory server, so only a
+`bookkeeping` start can be refused this way and no re-attempt can mint
+a second speculative consequence — with the spec's silence on the
+RE-ISSUE case FLAGGED for the owner rather than filled. Red-first: the
+re-attempt and budget pins watched red against the pre-fix terminal
+arm, and each obligation pin watched red against a deliberately-broken
+variant of the fix (no ownership dedupe; an unregistered retry
+ownership; retrying every conflict class; a re-attempt that re-stamps
+a fresh consequence). RECORDED, not built: (b) adopt-not-start as the
+model's destination, POST-FLIP, with its five open pieces and its duty
+to retire (a)'s retry — verification-coverage.md **OW61**. Disclosed
+ripple for the review round: the fix is NOT flag-gated, because the
+terminal arm it corrects is shared with the OFF arm, where the same
+refusal produces the same dead piece. Full evidence:
+verification-coverage.md OW45's arm-B block.
+
+**Delta 2026-08-22 (#6202): OW45 arm B triaged on an instrumented
 client — the starvation family is THREE defects: two FIXED red-first,
 one isolated live and FORKED to the owner; the last skip entry STAYS.**
 The instrumented bench (worker console forwarded, fresh store per run,

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5713,12 +5713,32 @@ supply; OW29/OW32/OW34 closed):
     `renderedNoteChips: 6` — one chip's dependency starved while the
     piece is fully healthy). So (a) does not close the class, and the
     single-chain shape may not even share the client-start seat.
-    Instrumented follow-up (worker console forwarded, 6 burners): 3
-    runs, all GREEN, `tx-commit-error` 0 and exhaustion 0 in each —
-    consistent with healthy runs and therefore NOT discriminating; the
-    red was not re-caught under instrumentation, so whether (a)'s retry
-    FIRES, EXHAUSTS, or never sees a refusal in a red run is
-    **UNRESOLVED** and is the measurement the next pass owes.
+    **Instrumented follow-up: 5 runs (worker console forwarded, 6 CPU
+    burners), 4 GREEN and 1 RED — and the red is NOT an arm-B shape,
+    so the question it was meant to settle is STILL UNRESOLVED.**
+    `tx-commit-error` 0 and exhaustion 0 in all five, forwarding
+    VERIFIED live (50 forwarded worker lines carrying `[runner.*]` and
+    `[cell]` tags), so the zero is a real negative rather than a
+    capture failure. The red (load 11.72) reads
+    `isNotebook: true, noteCount: 6, notesLength: 6,
+    mentionableLength: 6, showNewNotePrompt: true` — internally
+    CONSISTENT at six notes, nothing sticky-undefined — and its
+    event diagnostics show `eventInvocationCount: 7` split **6 + 1
+    across two different notebook handler ids**: one of the seven
+    clicks was consequenced by a different handler while the new-note
+    prompt was showing. That is a UI-interaction race, not the
+    starvation: arm B's signature is the store holding all seven
+    appends while client reads stay undefined, and here the seventh
+    note was never created by the creating handler at all.
+    **Bench caveat, recorded so the next pass does not repeat it:** the
+    6-burner regime (load 11.72) sits ABOVE the 3–16 band the arm-B
+    reds were characterized in, and it induced this distinct failure
+    instead of the one under study — while the UNLOADED gate runs
+    (loads 9.49 and 7.03) reproduced both arm-B shapes. Deliberate
+    burner load is therefore the wrong instrument for this defect; the
+    honest bench is ambient load with many runs. Whether (a)'s retry
+    FIRES, EXHAUSTS, or never sees a refusal in a genuine arm-B red
+    remains the measurement owed.
     **A LIVENESS HAZARD IN (a) ITSELF, recorded because it would make
     the retry look like a fix while never firing**: the re-attempt
     awaits the conflict's `readyToRetry`, and for a WIRE-borne server

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5589,6 +5589,103 @@ supply; OW29/OW32/OW34 closed):
     old-shape stall is the die-off at the front; b01's shape hid
     inside the population as "the product not answering" with the
     client blameless.
+    **ARM-B CLIENT-START — RULED (a) AND BUILT 2026-08-23.** The fork
+    went to the owner and came back adopted as recommended: "ok, let's
+    do (a) and record (b) as a post-flip task" (owner Berni,
+    2026-08-22). (b) — adopt-not-start under ON — is RECORDED as the
+    model's destination in **OW61** below, POST-FLIP, carrying the
+    memo as its design seed; (c)'s evidence stays recorded and
+    unbuilt-against. The build, at the seat the triage named: a
+    commit-gated start refused for a STALE CONFIRMED READ re-attempts
+    against fresh confirmed state, bounded, and every other refusal
+    class is untouched. Its three parts:
+    - **The discriminator.** `isStaleConfirmedReadConflict`
+      (`storage/rejection.ts`, beside the rest of the shared rejection
+      vocabulary): a `ConflictError` whose message names a stale
+      confirmed read. The OTHER `ConflictError` shape — `pending
+      dependency not resolved`, this session's own unresolved commit —
+      is deliberately EXCLUDED (a fresh read is not what settles it),
+      as is every non-conflict refusal: a CFC or speculative-basis
+      abort, an authorization denial, a precondition failure, a
+      row-label violation. Discriminated by MESSAGE, the way
+      `toRejectedError` already recovers the conflicted entity from
+      one — `Error` fields do not survive the wire, the message does.
+    - **The bound: 2 re-attempts**, because the readiness gate
+      advances the session past the conflicting commit and pulls the
+      named doc, so ONE re-attempt lands after the materialization it
+      lost to and the second is headroom for a birth committed across
+      more than one wave. A basis still stale after that is not this
+      race but sustained contention on the piece's own docs, where
+      re-running would install and tear down a piece context per
+      attempt. Exhaustion keeps TODAY's terminal arm and adds a
+      distinctly-named log (`deferred-start-conflict-exhausted`), so
+      exhaustion is never read as a first-attempt refusal —
+      serving-loop.md §3d's piece-start surfacing rule, honored in
+      every arm.
+    - **Re-entrancy.** Each attempt takes a FRESH ownership token
+      REGISTERED under the result's key before the readiness gate is
+      awaited, so a stop, a release, a teardown, or a navigation away
+      during that window tombstones the pending re-attempt through
+      the same `cancelPendingDeferredStarts` path that already
+      tombstones a pending first attempt. The previous attempt's
+      cancel has already run when the next is scheduled, so two
+      installs never coexist. Both deferred-start arms carry it —
+      `startAfterSuccessfulCommit` AND the sibling
+      `runPatternAfterSuccessfulCommit`, which mints the OTHER
+      navigate-deferred start and meets the identical race.
+    **The §3d stamp on a re-run — ANSWERED STRUCTURALLY, with the
+    spec's silence FLAGGED.** A re-attempt re-derives the stamp from
+    the same `speculativeConsequence` and the same originating run
+    context: the same consequence RE-ISSUED, never a second one. And a
+    consequence-stamped start cannot reach this retry at all — on a
+    flag-ON client an `event-handler`-kind start tx DIVERTS into the
+    speculation overlay instead of committing (§3d's boundary
+    sentence; `SpeculationOverlayDestination.seal`), and the overlay
+    refuses only by aborting, so the server-produced stale confirmed
+    read is unreachable for it. Only a `bookkeeping`-stamped start
+    commits to the store and can be refused this way. FLAGGED for the
+    owner rather than settled here: §3d sanctions the stamp on the
+    deferred start but does not state the RE-ISSUE case in words; the
+    implementation takes the one reading under which a second
+    speculative consequence is unreachable.
+    **The pattern-load-error path (`runner.ts` ~2860) needs no arm of
+    its own** (traced, recorded): both of its sites sit inside
+    `setupPatternWatcher`, which is armed only AFTER a successful
+    instantiate, and both report a pattern-LOAD verdict — a
+    `loadPatternByIdentity` promise, no transaction and no
+    `ConflictError` — so the retry contract has no meaning there. In
+    the b04 trace it is DOWNSTREAM of the dead start: with the start
+    re-attempted the piece is instantiated and the watcher runs
+    against a live piece. Its own pre-existing question — the thrown
+    arm logs a load error its neighboring comment calls possibly
+    transient, and stops — is RECORDED, not opened by this arc.
+    **Red-first evidence.** Pins in
+    `packages/runner/test/deferred-start-conflict-retry.test.ts`,
+    refusing the START transaction specifically (recognized by the
+    runner handing it to `startWithTx`) in the shape `toRejectedError`
+    produces from the wire. Watched RED against the pre-fix terminal
+    arm: the re-attempt pin and the budget pin. The obligation pins
+    are watched red against DELIBERATELY-BROKEN variants of the fix,
+    since "no retry at all" makes them vacuous: a retry without the
+    ownership dedupe reds the double-install pin (two installs live at
+    once), an UNREGISTERED retry ownership reds the zombie pin (a
+    re-attempt fires after the piece was stopped), retrying every
+    conflict class reds the terminal-class pin (the pending-dependency
+    refusal re-attempted), and a re-attempt that re-stamps itself a
+    fresh consequence reds the §3d pin (one event-handler seal where
+    there must be none). A harness note that mattered: an observer
+    that WRAPPED `startWithTx`'s return value suppressed every
+    teardown, because the runner compares that exact cancel against
+    its registry to decide ownership — it manufactured the very
+    concurrency it claimed to measure, so liveness is read from the
+    runner's own registry instead.
+    **DISCLOSED RIPPLE (for the review round): the fix is NOT
+    flag-gated.** The terminal arm it corrects is shared with the OFF
+    arm, where the same transient refusal produces the same dead
+    piece; gating would ship a knowingly-broken OFF path and would be
+    removed by the flip anyway. So OFF-arm behavior does change —
+    exactly when a start commit is refused for a stale confirmed read,
+    which today yields a piece with no client context.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:
@@ -6605,6 +6702,53 @@ supply; OW29/OW32/OW34 closed):
     dropped echo's missing cover is user-visible (the OW33
     arrival-witness fork's fix would NOT close this — a dropped
     run seals no overlay entry at all).**
+  - **OW61 — adopt-not-start: the piece-open seam is where the ON
+    execution model's "one starter per piece" has to land. POST-FLIP
+    (RULED 2026-08-22, owner: "ok, let's do (a) and record (b) as a
+    post-flip task").** The destination the OW45 arm-B fork named (b),
+    recorded rather than built: a flag-ON client whose navigate lands
+    on a piece the SERVER materialized does not run a deferred start
+    of its own at all — it ADOPTS the served instance (sync the root,
+    register demand through the served closure) and starts nothing.
+    That DISSOLVES the first-hydration race instead of re-attempting
+    it, and it is the posture canon already states rather than a new
+    mechanism: runtime-mapping.md's N62 row deleted the old
+    observation-adoption feature precisely BECAUSE under the flag
+    "clients no longer run committed derivations at all (reload is
+    read-and-render, §3b)", and serving-loop.md §3b states that
+    posture. The client-side deferred start is the remnant still
+    running against it at the navigate/piece-open seam. Design seed:
+    `../../history/plans/server-execution-v2/optimize/ow45-armb-client-start-fork.md`
+    (disposition (b), with the instrumented catch that motivates it).
+    WHY POST-FLIP: it touches the piece-open path for every ON
+    navigate, and the flip's own bar is the ON skip list EMPTY — which
+    the shipped (a) reaches without moving that path. **The five
+    pieces it still needs, none of them settled by this row:**
+    (i) how the ADOPTED context is constructed client-side — what a
+    client holds for a piece it did not start, and which of today's
+    start-walk products (node wiring, the cancel registration, the
+    demand registration) it keeps; (ii) the BIRTH-adoption flow — a
+    navigate that arrives BEFORE the server has materialized the
+    piece has nothing to adopt, so the seam needs a defined wait or a
+    defined fallback; (iii) whether §3d's speculative-consequence
+    stamp SURVIVES at all once no client start transaction exists —
+    §3d's sanction is written for the deferred start, and adoption
+    deletes the thing it sanctions, so that sentence needs
+    restatement, not inference; (iv) the UNMATERIALIZED-piece
+    fallback, i.e. whether the OFF-arm start path is retained as a
+    fallback under ON and under exactly which predicate; (v) the
+    first-hydration UX gates — what the user sees between navigate
+    and adoption, which is today covered by the client's own start
+    rendering immediately. **Its landing DUTY: retire (a)'s retry.**
+    With no client start transaction there is no start commit to be
+    refused, so `reattemptDeferredStartOnStaleRead` and the
+    `isStaleConfirmedReadConflict` predicate become dead code on the
+    ON arm and must be removed with it (the OFF arm keeps them while
+    the OFF path exists — see the OW45 row's disclosed ripple: the
+    fix is deliberately not flag-gated). Trigger: the post-flip soak,
+    or any ON surface where a re-attempted start is observed
+    exhausting its budget in real usage
+    (`deferred-start-conflict-exhausted`), whichever comes first.**
 
 ## 4. Standing rule
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -5686,6 +5686,65 @@ supply; OW29/OW32/OW34 closed):
     removed by the flip anyway. So OFF-arm behavior does change —
     exactly when a start commit is refused for a stale confirmed read,
     which today yields a piece with no client context.
+    **THE ON GATE FAILED (2026-08-23) — (a) DOES NOT LIFT THE SKIP,
+    which therefore STAYS.** Protocol as the lift bar requires: ON-built
+    binary (`shellServerExecutionDefine === "true"` and `servingLoop`
+    present, probed per run), fresh store per run, load recorded; the
+    fix VERIFIED present in the artifact (its exhaustion-log string is
+    baked in), so these are not a stale build. Result **5 PASS / 2 FAIL
+    in 7 runs** (the run aborted after the 10/10 bar was already
+    missed, to spend the remaining budget on root cause):
+
+    | run | verdict | load | secs |
+    | --- | --- | --- | --- |
+    | 1 | FAIL | 9.49 | 314 |
+    | 2 | FAIL | 7.03 | 320 |
+    | 3 | PASS | 5.71 | 18 |
+    | 4 | PASS | 7.52 | 17 |
+    | 5 | PASS | 8.56 | 13 |
+    | 6 | PASS | 7.54 | 30 |
+    | 7 | PASS | 8.26 | 28 |
+
+    BOTH arm-B shapes reproduced WITH the retry shipped: run 2 is the
+    WHOLE-PIECE shape this fix targets (`isNotebook: false`,
+    `noteCount: -1`, `notesLength: 0`, `storedUiNoteChips: 98`, 0
+    rendered — the b04 signature), and run 1 is the SINGLE-CHAIN shape
+    (`noteCount: 7`, `notesLength: 7`, `mentionableLength: 7`, but
+    `renderedNoteChips: 6` — one chip's dependency starved while the
+    piece is fully healthy). So (a) does not close the class, and the
+    single-chain shape may not even share the client-start seat.
+    Instrumented follow-up (worker console forwarded, 6 burners): 3
+    runs, all GREEN, `tx-commit-error` 0 and exhaustion 0 in each —
+    consistent with healthy runs and therefore NOT discriminating; the
+    red was not re-caught under instrumentation, so whether (a)'s retry
+    FIRES, EXHAUSTS, or never sees a refusal in a red run is
+    **UNRESOLVED** and is the measurement the next pass owes.
+    **A LIVENESS HAZARD IN (a) ITSELF, recorded because it would make
+    the retry look like a fix while never firing**: the re-attempt
+    awaits the conflict's `readyToRetry`, and for a WIRE-borne server
+    `ConflictError` that function is `waitForCaughtUpLocalSeq`
+    (attached at `memory/v2/client.ts`'s transact catch, gated on the
+    `retryAfterSeq` the server sets for every conflict), which resolves
+    only when a LATER sync arrives carrying a `caughtUpLocalSeq`. First
+    hydration is exactly the case where none need arrive — the flow
+    ends with a write followed by pure reads and the space goes quiet,
+    which is why the starvation is sticky at all. The shipped pins
+    cannot see this: they inject refusals with no gate attached. A
+    red-first probe for it exists and is described in the scoping memo
+    below rather than shipped, because the arm it would fix is not the
+    ruled one.
+    **A THIRD ARM IS NOW ON THE TABLE** (adversarial review,
+    2026-08-23): close this refusal by NARROWING the deferred start's
+    commit conflict set — the way two sibling rows in this register
+    already closed this exact refusal class (the `cid:` exclusion and
+    the CFC blind-write exclusion, both at `buildReads`) — instead of
+    retrying it. The b04 conflict names a `computed:`-kinded entity,
+    whose scheme means "re-derivable by the runtime that minted it" and
+    exists precisely to say what conflict policy may apply. Scope,
+    risks, and the measurements it needs first:
+    `../../history/plans/server-execution-v2/optimize/ow45-armb-basis-narrowing-scope.md`.
+    It would SUPERSEDE (a) rather than refine it, so it needs the
+    owner's ruling of its own.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:
@@ -6721,8 +6780,11 @@ supply; OW29/OW32/OW34 closed):
     `../../history/plans/server-execution-v2/optimize/ow45-armb-client-start-fork.md`
     (disposition (b), with the instrumented catch that motivates it).
     WHY POST-FLIP: it touches the piece-open path for every ON
-    navigate, and the flip's own bar is the ON skip list EMPTY — which
-    the shipped (a) reaches without moving that path. **The five
+    navigate. (This row first said the flip's empty-skip-list bar was
+    reached by (a) without moving that path. The live gate DISPROVED
+    that — see the arm-B gate evidence in OW45 — so which arm reaches
+    the bar is an OPEN question, not a settled one, and (b)'s
+    scheduling is the only claim this row still makes.) **The five
     pieces it still needs, none of them settled by this row:**
     (i) how the ADOPTED context is constructed client-side — what a
     client holds for a piece it did not start, and which of today's

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3403,6 +3403,7 @@ export class Runner {
     speculativeConsequence?: { eventId: string },
   ): Cancel {
     const resultLink = resultCell.getAsNormalizedFullLink();
+    const startLifecycleEpoch = this.lifecycleEpoch;
     const ownership = this.createDeferredStartOwnership(resultCell);
     // ONE attempt at the gated start, written to be re-runnable: a refusal
     // that names a stale confirmed read earns a bounded re-attempt against
@@ -3480,6 +3481,7 @@ export class Runner {
                 attemptsLeft,
                 attempt,
                 "start",
+                startLifecycleEpoch,
               )
             ) {
               return;
@@ -3593,8 +3595,17 @@ export class Runner {
       attemptsLeft: number,
     ) => void,
     label: string,
+    scheduledLifecycleEpoch: number,
   ): boolean {
     if (!isStaleConfirmedReadConflict(error)) return false;
+    // The teardown window a token cannot cover. `stopAll()` cancels the
+    // pending starts it can SEE and clears their index, so a teardown that
+    // lands before this continuation runs leaves nothing to cancel a token
+    // minted afterwards — and the re-attempt would install a piece onto a
+    // runner that no longer exists. The lifecycle epoch is what every other
+    // asynchronous continuation here checks for exactly this reason; a
+    // re-attempt is one more of them.
+    if (scheduledLifecycleEpoch !== this.lifecycleEpoch) return false;
     if (attemptsLeft <= 0) {
       logger.error(
         "deferred-start-conflict-exhausted",
@@ -3610,7 +3621,10 @@ export class Runner {
     // into a piece that is no longer wanted.
     const retryOwnership = this.createDeferredStartOwnership(resultCell);
     const retry = this.runtime.awaitCommitRetryReadiness(error).then(() => {
-      if (retryOwnership.isCancelled()) return;
+      if (
+        retryOwnership.isCancelled() ||
+        scheduledLifecycleEpoch !== this.lifecycleEpoch
+      ) return;
       attempt(retryOwnership, attemptsLeft - 1);
     }).catch((cause) => {
       // `attempt` rethrows a synchronous start failure to its caller; on a
@@ -3638,6 +3652,7 @@ export class Runner {
     speculativeConsequence?: { eventId: string },
   ): Cancel {
     const resultLink = resultCell.getAsNormalizedFullLink();
+    const startLifecycleEpoch = this.lifecycleEpoch;
     const ownership = this.createDeferredStartOwnership(resultCell);
     // Re-runnable for the same reason as the deferred start above, and
     // through the same bounded re-attempt: this arm mints the OTHER
@@ -3709,6 +3724,7 @@ export class Runner {
                 attemptsLeft,
                 attempt,
                 "cross-space pattern",
+                startLifecycleEpoch,
               )
             ) {
               return;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -114,6 +114,7 @@ import {
 } from "./storage/reactivity-log.ts";
 import {
   isConflictRejection,
+  isStaleConfirmedReadConflict,
   isStorageTransactionInconsistent,
 } from "./storage/rejection.ts";
 
@@ -182,6 +183,16 @@ const triggerFlowLogger = getLogger("runner.trigger-flow", {
  * reached only by a pattern churning through results it will not revisit.
  */
 const RESULT_SHORTCUT_LIMIT = 4096;
+
+/**
+ * How many times a commit-gated start re-attempts a transaction the server
+ * refused for a stale confirmed read. The rationale for the size is in
+ * `Runner.reattemptDeferredStartOnStaleRead`, which owns the whole policy:
+ * one re-attempt lands after the birth writes this start lost its basis to,
+ * and the second is headroom for a serving loop that commits a birth across
+ * more than one wave.
+ */
+const DEFERRED_START_CONFLICT_RETRIES = 2;
 
 const EAGER_RESULT_BUILTIN_REFS = new Set([
   "fetchBinary",
@@ -1245,6 +1256,14 @@ export class Runner {
   // so tests can synchronize deterministically under the frozen-clock
   // preload, where wall-clock polling cannot observe this work.
   private pendingWatcherPatternLoads = new Set<Promise<unknown>>();
+  // In-flight re-attempts of a commit-gated start whose transaction lost its
+  // basis to the serving side's own first-hydration writes (see
+  // `reattemptDeferredStartOnStaleRead`). NEVER awaited by dispose(), for the
+  // same reason as the watcher loads above: the readiness gate they await is
+  // a session catch-up, which a closing runtime may never reach, and a
+  // cancelled ownership already tombstones the work. Tracked solely so tests
+  // can synchronize deterministically.
+  private pendingDeferredStartRetries = new Set<Promise<unknown>>();
   // Both maps record that this runner prepared or stopped a result, so a later
   // start of the same result can reuse the cells it already assembled instead
   // of re-syncing dependencies and rehydrating a snapshot. They are shortcuts:
@@ -3385,16 +3404,17 @@ export class Runner {
   ): Cancel {
     const resultLink = resultCell.getAsNormalizedFullLink();
     const ownership = this.createDeferredStartOwnership(resultCell);
-    tx.addCommitCallback((_committedTx, result) => {
-      if (result.error) {
-        // The callback that would install this start is the one running now,
-        // so a failed transaction leaves nothing to reach the pending entry
-        // later. Settle it here, which also drops it from the index of starts
-        // pending under this result's key.
-        ownership.cancel();
-        return;
-      }
-      if (ownership.isCancelled()) return;
+    // ONE attempt at the gated start, written to be re-runnable: a refusal
+    // that names a stale confirmed read earns a bounded re-attempt against
+    // fresh confirmed state (`reattemptDeferredStartOnStaleRead`). Each
+    // attempt mints its own transaction and its own ownership token, and
+    // installs at most once — the previous attempt's install is torn down by
+    // its own `cancel()` before the next one is scheduled.
+    const attempt = (
+      attemptOwnership: DeferredCancelOwnership,
+      attemptsLeft: number,
+    ): void => {
+      if (attemptOwnership.isCancelled()) return;
 
       const startTx = this.runtime.edit();
       // Minted inside a commit callback — by definition outside any
@@ -3437,7 +3457,7 @@ export class Runner {
       );
       try {
         if (
-          ownership.markInstalled(
+          attemptOwnership.markInstalled(
             this.startWithTx(
               startTx,
               committedResultCell,
@@ -3452,7 +3472,18 @@ export class Runner {
         this.runtime.prepareTxForCommit(startTx);
         startTx.commit().then(({ error }) => {
           if (error) {
-            ownership.cancel();
+            attemptOwnership.cancel();
+            if (
+              this.reattemptDeferredStartOnStaleRead(
+                error,
+                resultCell,
+                attemptsLeft,
+                attempt,
+                "start",
+              )
+            ) {
+              return;
+            }
             logger.error(
               "tx-commit-error",
               "Error committing deferred start transaction",
@@ -3460,11 +3491,11 @@ export class Runner {
             );
             return;
           }
-          if (pullOnceAfterStart && !ownership.isCancelled()) {
+          if (pullOnceAfterStart && !attemptOwnership.isCancelled()) {
             this.pullCellOnceInPullMode(committedResultCell);
           }
         }).catch((error) => {
-          ownership.cancel();
+          attemptOwnership.cancel();
           logger.error(
             "tx-commit-error",
             "Deferred start transaction commit rejected",
@@ -3473,12 +3504,128 @@ export class Runner {
         });
       } catch (error) {
         startTx.abort(error);
-        ownership.cancel();
+        attemptOwnership.cancel();
         logger.error("runner-start", "Deferred start failed", error);
         throw error;
       }
+    };
+    tx.addCommitCallback((_committedTx, result) => {
+      if (result.error) {
+        // The callback that would install this start is the one running now,
+        // so a failed transaction leaves nothing to reach the pending entry
+        // later. Settle it here, which also drops it from the index of starts
+        // pending under this result's key.
+        ownership.cancel();
+        return;
+      }
+      attempt(ownership, DEFERRED_START_CONFLICT_RETRIES);
     });
     return ownership.cancel;
+  }
+
+  /**
+   * The bounded re-attempt a commit-gated start earns when its transaction is
+   * refused for a STALE CONFIRMED READ, and the seat of the OW45 arm-B fix
+   * (server-execution v2; verification-coverage.md). Returns whether a
+   * re-attempt was scheduled — `false` leaves the caller's terminal arm to
+   * run exactly as it does for every other refusal.
+   *
+   * WHY a start earns one at all. Under the server-execution flag a piece is
+   * materialized SERVER-side, and the client's navigate-deferred start reads
+   * that piece's computed documents to base its own transaction on. At first
+   * hydration those two acts race by construction: the serving loop's derived
+   * commits for the just-born piece are in flight exactly while the client
+   * reads their targets as absent, so the client's basis is stale the moment
+   * the interleaving is tight — the EXPECTED shape, not an exceptional one.
+   * Terminating there is what made the race fatal: `startWithTx` has already
+   * installed the client-side piece inside the transaction when the refusal
+   * lands, the error arm's cancel tears that install down, and nothing
+   * re-attempts it — so the piece has no client context for the rest of the
+   * session and every read that depends on it resolves to nothing, while the
+   * store holds every append. A transient refusal must not be terminal.
+   *
+   * WHAT stays terminal. Only a stale confirmed read is re-attempted
+   * ({@link isStaleConfirmedReadConflict}). Every other refusal keeps today's
+   * behavior exactly: a CFC or speculative-basis refusal, an authorization
+   * denial, a precondition failure, a row-label violation — none of them
+   * describe a basis that a fresh read repairs, so re-running recomputes the
+   * same refusal and each doomed attempt costs a round trip.
+   *
+   * THE BOUND is small on purpose. The conflict this closes is a birth race
+   * against writes that are already in flight: the readiness gate advances
+   * the session past the conflicting commit and pulls the named document, so
+   * one re-attempt lands after the materialization it lost to, and the second
+   * is headroom for a serving loop that commits its birth in more than one
+   * wave. A basis still stale after that is not this race — it is sustained
+   * contention on the piece's own documents, where continuing to re-run would
+   * install and tear down a piece context per attempt — so the budget ends
+   * and the caller's terminal arm reports it, with the exhaustion named
+   * distinctly here so it is never confused with a first-attempt refusal.
+   *
+   * RE-ENTRANCY. Each re-attempt takes a FRESH ownership token, registered
+   * under the result's key before the readiness gate is awaited, so a stop,
+   * a release, a runtime teardown, or a navigation away during that window
+   * tombstones the pending retry through the same path that already
+   * tombstones a pending first attempt (`cancelPendingDeferredStarts`) — the
+   * retry then observes the tombstone and installs nothing. The previous
+   * attempt's `cancel()` has already run when this is called, so the two
+   * tokens never hold an install at the same time.
+   *
+   * THE §3d STAMP rides the re-attempt unchanged, because a re-attempt is the
+   * SAME consequence re-issued rather than a second one: `attempt` re-derives
+   * the stamp from the same `speculativeConsequence` and the same originating
+   * run context. Note that a stamp carrying an eventId cannot reach here at
+   * all — on a flag-ON client an event-handler-kind start transaction diverts
+   * into the speculation overlay instead of committing (serving-loop.md §3d's
+   * boundary sentence; `SpeculationOverlayDestination.seal`), and the
+   * overlay's refusals are aborts, never a stale confirmed read. Only a
+   * `bookkeeping`-stamped start commits to the store and can be refused this
+   * way. That the spec does not state the re-issue case EXPLICITLY is flagged
+   * for the owner rather than settled here; the implementation takes the one
+   * reading under which a second speculative consequence is unreachable.
+   */
+  private reattemptDeferredStartOnStaleRead<T>(
+    error: { name?: string; message?: string },
+    resultCell: Cell<T>,
+    attemptsLeft: number,
+    attempt: (
+      ownership: DeferredCancelOwnership,
+      attemptsLeft: number,
+    ) => void,
+    label: string,
+  ): boolean {
+    if (!isStaleConfirmedReadConflict(error)) return false;
+    if (attemptsLeft <= 0) {
+      logger.error(
+        "deferred-start-conflict-exhausted",
+        `Deferred ${label} transaction still lost its basis after ` +
+          `${DEFERRED_START_CONFLICT_RETRIES} re-attempts against fresh ` +
+          "confirmed state; the piece has no client-side context",
+        error,
+      );
+      return false;
+    }
+    // Registered BEFORE the readiness gate is awaited: this token is what a
+    // concurrent stop or teardown cancels to keep the re-attempt from firing
+    // into a piece that is no longer wanted.
+    const retryOwnership = this.createDeferredStartOwnership(resultCell);
+    const retry = this.runtime.awaitCommitRetryReadiness(error).then(() => {
+      if (retryOwnership.isCancelled()) return;
+      attempt(retryOwnership, attemptsLeft - 1);
+    }).catch((cause) => {
+      // `attempt` rethrows a synchronous start failure to its caller; on a
+      // re-attempt that caller is this promise, so surface it here rather
+      // than as an unhandled rejection. Loud in every arm, per
+      // serving-loop.md §3d's piece-start surfacing rule.
+      logger.error(
+        "runner-start",
+        `Deferred ${label} re-attempt failed`,
+        cause,
+      );
+    });
+    this.pendingDeferredStartRetries.add(retry);
+    retry.finally(() => this.pendingDeferredStartRetries.delete(retry));
+    return true;
   }
 
   private runPatternAfterSuccessfulCommit<T = any>(
@@ -3492,15 +3639,15 @@ export class Runner {
   ): Cancel {
     const resultLink = resultCell.getAsNormalizedFullLink();
     const ownership = this.createDeferredStartOwnership(resultCell);
-    tx.addCommitCallback((_committedTx, result) => {
-      if (result.error) {
-        // Settled here for the same reason as the start above: this callback
-        // is the only thing that reaches the pending entry, so a failed
-        // transaction would otherwise strand it under the result's key.
-        ownership.cancel();
-        return;
-      }
-      if (ownership.isCancelled()) return;
+    // Re-runnable for the same reason as the deferred start above, and
+    // through the same bounded re-attempt: this arm mints the OTHER
+    // navigate-deferred start (a handler result pattern whose own result is
+    // still undefined), so it meets the identical first-hydration race.
+    const attempt = (
+      attemptOwnership: DeferredCancelOwnership,
+      attemptsLeft: number,
+    ): void => {
+      if (attemptOwnership.isCancelled()) return;
 
       const startTx = this.runtime.edit();
       // Minted inside a commit callback — outside any scheduler run;
@@ -3534,7 +3681,7 @@ export class Runner {
       );
       try {
         if (
-          ownership.markInstalled(
+          attemptOwnership.markInstalled(
             this.runWithStartOwnership(
               startTx,
               pattern,
@@ -3554,7 +3701,18 @@ export class Runner {
         this.runtime.prepareTxForCommit(startTx);
         startTx.commit().then(({ error }) => {
           if (error) {
-            ownership.cancel();
+            attemptOwnership.cancel();
+            if (
+              this.reattemptDeferredStartOnStaleRead(
+                error,
+                resultCell,
+                attemptsLeft,
+                attempt,
+                "cross-space pattern",
+              )
+            ) {
+              return;
+            }
             logger.error(
               "tx-commit-error",
               "Error committing deferred cross-space pattern transaction",
@@ -3562,11 +3720,11 @@ export class Runner {
             );
             return;
           }
-          if (pullOnceAfterStart && !ownership.isCancelled()) {
+          if (pullOnceAfterStart && !attemptOwnership.isCancelled()) {
             this.pullCellOnceInPullMode(committedResultCell);
           }
         }).catch((error) => {
-          ownership.cancel();
+          attemptOwnership.cancel();
           logger.error(
             "tx-commit-error",
             "Deferred cross-space pattern transaction rejected",
@@ -3575,7 +3733,7 @@ export class Runner {
         });
       } catch (error) {
         startTx.abort(error);
-        ownership.cancel();
+        attemptOwnership.cancel();
         logger.error(
           "runner-start",
           "Deferred cross-space pattern failed",
@@ -3583,6 +3741,16 @@ export class Runner {
         );
         throw error;
       }
+    };
+    tx.addCommitCallback((_committedTx, result) => {
+      if (result.error) {
+        // Settled here for the same reason as the start above: this callback
+        // is the only thing that reaches the pending entry, so a failed
+        // transaction would otherwise strand it under the result's key.
+        ownership.cancel();
+        return;
+      }
+      attempt(ownership, DEFERRED_START_CONFLICT_RETRIES);
     });
     return ownership.cancel;
   }
@@ -4610,6 +4778,20 @@ export class Runner {
         ...this.pendingWatcherPatternLoads,
         ...this.pendingPointerCommits,
       ]);
+    }
+  }
+
+  /**
+   * TESTS ONLY: settle in-flight re-attempts of commit-gated starts (see
+   * `reattemptDeferredStartOnStaleRead`). Loops because an attempt that
+   * conflicts again schedules the next one from inside this chain. Never
+   * called from dispose(): the readiness gate a re-attempt awaits is a
+   * session catch-up, which a closing runtime need never reach — a cancelled
+   * ownership is what stops the work there.
+   */
+  async idleDeferredStartRetries(): Promise<void> {
+    while (this.pendingDeferredStartRetries.size > 0) {
+      await Promise.allSettled([...this.pendingDeferredStartRetries]);
     }
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2334,49 +2334,7 @@ export class Runtime {
     return tx.commit().then(async ({ error }) => {
       if (error) {
         if (maxRetries > 0 && isRetryableCommitRejection(error)) {
-          // A CONFLICT means this replica is behind the authoritative
-          // version: re-running immediately re-reads the same stale local
-          // state and fails identically, so without waiting the retries all
-          // burn on one deterministic conflict (CT-1824 — the compile-cache
-          // write-back looped this way and stale-version pieces recompiled
-          // on every cold boot). The conflict carries the catch-up gate;
-          // await it so the retry runs against fresh state — same protocol
-          // as the scheduler's conflict handling (scheduler/action-run.ts).
-          // A readiness gate that rejects (session closed/replaced while
-          // waiting) is control flow, not an error: retry anyway and let
-          // commit produce the definitive outcome.
-          const readyToRetry =
-            (error as { readyToRetry?: () => unknown }).readyToRetry;
-          if (typeof readyToRetry === "function") {
-            try {
-              await readyToRetry();
-            } catch {
-              // Readiness aborted — the retry's commit decides.
-            }
-          }
-          // The catch-up gate advances the session past the conflicting
-          // commit, but a doc this replica never READ does not arrive with
-          // it — and a conflicted blind WRITE means exactly that (the
-          // compile-cache write-back rewrites derived docs a cold replica
-          // has never seen). Pull the named doc so the retry's write
-          // carries its true version instead of re-asserting seq 0.
-          const conflict = (error as {
-            conflict?: { space?: MemorySpace; of?: string };
-          }).conflict;
-          if (
-            conflict?.space !== undefined &&
-            typeof conflict.of === "string" &&
-            conflict.of !== "of:unknown"
-          ) {
-            try {
-              await this.storageManager.open(conflict.space).sync(
-                conflict.of as unknown as URI,
-                { path: [], schema: false },
-              );
-            } catch {
-              // Pull failed — the retry's commit decides.
-            }
-          }
+          await this.awaitCommitRetryReadiness(error);
           return this.editWithRetry<T>(fn, maxRetries - 1);
         } else {
           return { error };
@@ -2392,6 +2350,62 @@ export class Runtime {
         },
       };
     });
+  }
+
+  /**
+   * Wait until a retry of a rejected commit would run against FRESH state.
+   * The protocol every conflict retrier shares — `editWithRetry` above, and
+   * the runner's commit-gated piece start (runner.ts):
+   *
+   * A CONFLICT means this replica is behind the authoritative version:
+   * re-running immediately re-reads the same stale local state and fails
+   * identically, so without waiting the retries all burn on one
+   * deterministic conflict (CT-1824 — the compile-cache write-back looped
+   * this way and stale-version pieces recompiled on every cold boot). The
+   * conflict carries the catch-up gate; await it so the retry runs against
+   * fresh state — the same protocol as the scheduler's conflict handling
+   * (scheduler/action-run.ts). A readiness gate that REJECTS (session closed
+   * or replaced while waiting) is control flow, not an error: return anyway
+   * and let the retry's own commit produce the definitive outcome.
+   *
+   * The gate advances the session past the conflicting commit, but a doc
+   * this replica never READ does not arrive with it — and a conflicted blind
+   * WRITE means exactly that (the compile-cache write-back rewrites derived
+   * docs a cold replica has never seen; a piece start's basis names computed
+   * docs the serving side was materializing). So the named doc is pulled
+   * too, and the retry's write carries its true version instead of
+   * re-asserting seq 0.
+   *
+   * Every step is best-effort by design: this resolves rather than throws,
+   * because the retry's commit — not this readiness — is what decides.
+   */
+  async awaitCommitRetryReadiness(error: unknown): Promise<void> {
+    const readyToRetry = (error as { readyToRetry?: () => unknown })
+      ?.readyToRetry;
+    if (typeof readyToRetry === "function") {
+      try {
+        await readyToRetry();
+      } catch {
+        // Readiness aborted — the retry's commit decides.
+      }
+    }
+    const conflict = (error as {
+      conflict?: { space?: MemorySpace; of?: string };
+    })?.conflict;
+    if (
+      conflict?.space !== undefined &&
+      typeof conflict.of === "string" &&
+      conflict.of !== "of:unknown"
+    ) {
+      try {
+        await this.storageManager.open(conflict.space).sync(
+          conflict.of as unknown as URI,
+          { path: [], schema: false },
+        );
+      } catch {
+        // Pull failed — the retry's commit decides.
+      }
+    }
   }
 
   prepareTxForCommit(tx: IExtendedStorageTransaction): void {

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -95,6 +95,36 @@ export function isConflictRejection(
 }
 
 /**
+ * The STALE-CONFIRMED-READ sub-shape of {@link isConflictRejection}: the
+ * server refused the commit because a document the transaction read at a
+ * given seq had already advanced past it, so a re-read is what converges.
+ * The other shape normalized to `ConflictError` — `pending dependency not
+ * resolved` (memory/v2/engine.ts: a commit whose basis names a local seq the
+ * server has not accepted yet) — is deliberately NOT included. It says this
+ * session's own earlier commit is unresolved rather than that this read is
+ * behind, so it is that commit's fate, not a fresh read, that decides it.
+ *
+ * Discriminated by MESSAGE, the way `toRejectedError` (storage/v2.ts) already
+ * recovers the conflicted entity from one: `Error` fields do not survive the
+ * wire, the message does, and its format is owned by the `ConflictError`
+ * construction in memory/v2/engine.ts.
+ *
+ * A caller that only needs "can re-running converge at all" wants
+ * {@link isRetryableCommitRejection}. This predicate is for a caller that
+ * must separate a basis a fresh read fixes from every other refusal — the
+ * commit-gated piece start, whose first-hydration commit races the serving
+ * side materializing the very documents its basis read as absent
+ * (server-execution v2; verification-coverage.md OW45 arm B).
+ */
+export function isStaleConfirmedReadConflict(
+  error: { name?: string; message?: string } | undefined | null,
+): boolean {
+  return isConflictRejection(error) &&
+    typeof error?.message === "string" &&
+    error.message.includes("stale confirmed read");
+}
+
+/**
  * A stale-basis inconsistency: a value the transaction read changed on this
  * replica between the read and the commit (see storage/v2-transaction.ts
  * `validate()`). Like a conflict it is resolved by re-running the transaction

--- a/packages/runner/test/deferred-start-conflict-retry.test.ts
+++ b/packages/runner/test/deferred-start-conflict-retry.test.ts
@@ -1,0 +1,479 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { Cell } from "../src/cell.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+import { entityKey } from "../src/scheduler/keys.ts";
+
+// A commit-gated piece start whose transaction is REFUSED for a stale
+// confirmed read. Under server-side execution that refusal is the expected
+// shape of first hydration, not an exceptional one: the piece is materialized
+// server-side, and the client's deferred start reads the piece's computed
+// documents to base its transaction on exactly while the serving loop's
+// derived commits are materializing them. Terminating there left the piece
+// with no client-side context for the whole session — its install is rolled
+// back by the error arm's cancel and nothing re-attempted it — so every read
+// that depended on it resolved to nothing while the store held every append
+// (verification-coverage.md OW45 arm B; the run b04 catch).
+//
+// These tests drive the runner through its public surface and refuse the
+// START transaction at the transaction seam — the idiom this package already
+// uses to isolate a commit-classification decision from every other moving
+// part (edit-with-retry-classification.test.ts,
+// compile-cache-writeback-conflict.test.ts). Refusing at the memory server
+// instead cannot reach this path: a start whose setup already committed with
+// its handler's transaction carries no operations of its own, so its commit
+// never makes a server round trip at all, while the real first-hydration
+// start (whose setup rides the start) does. The refusal object is the shape
+// `toRejectedError` (storage/v2.ts) produces from the wire — the engine's own
+// message text, plus the conflict descriptor it parses out of it — so the
+// discriminator under test sees exactly what a real refusal presents.
+//
+// The injector refuses only transactions the runner hands to `startWithTx`,
+// so the setup commit, the scheduler's own runs, and the readiness pull all
+// proceed normally and the refusal lands on the start alone.
+
+const signer = await Identity.fromPassphrase("deferred start conflict retry");
+const space = signer.did();
+
+/**
+ * Refuse the first `count` START transactions with `error`, and nothing
+ * else. A start transaction is recognized by the runner handing it to
+ * `startWithTx` — which happens before the commit — so this refuses exactly
+ * the transaction under test and leaves every other commit of the run
+ * (the setup, the scheduler's runs, the readiness pull) untouched.
+ *
+ * `refusalsReach(n)` resolves when the nth refusal has been delivered.
+ * Awaiting a signal like this is what makes these tests deterministic
+ * without a clock: an event that never happens lets the event loop quiesce,
+ * and Deno fails the pending wait at once, naming the test
+ * (docs/development/waiting-in-tests.md — the no-deadline signal idiom of
+ * scheduler-event-receipts.test.ts).
+ */
+function refuseDeferredStartCommits(
+  runtime: Runtime,
+  error: { name: string; message: string },
+  count = 1,
+): {
+  refusalsReach(n: number): Promise<void>;
+  refusals(): number;
+  restore(): void;
+} {
+  const originalEdit = runtime.edit.bind(runtime);
+  const runner = runtime.runner as unknown as {
+    startWithTx: (...args: unknown[]) => () => void;
+  };
+  const originalStartWithTx = runner.startWithTx;
+  const startTransactions = new WeakSet<object>();
+  const waiters = new Map<number, ReturnType<typeof Promise.withResolvers>>();
+  let refusals = 0;
+
+  runner.startWithTx = (...args: unknown[]) => {
+    startTransactions.add(args[0] as object);
+    return Reflect.apply(originalStartWithTx, runtime.runner, args) as () =>
+      void;
+  };
+
+  (runtime as unknown as { edit: typeof runtime.edit }).edit = ((
+    ...args: Parameters<typeof runtime.edit>
+  ) => {
+    const tx = originalEdit(...args);
+    const commit = tx.commit.bind(tx);
+    (tx as unknown as { commit: typeof tx.commit }).commit = (() => {
+      if (refusals >= count || !startTransactions.has(tx)) return commit();
+      refusals++;
+      for (const [at, waiter] of waiters) {
+        if (at <= refusals) waiter.resolve(undefined);
+      }
+      // A refused commit applies nothing, so discard this attempt's writes
+      // the way the rollback behind a server refusal does.
+      tx.abort(error.message);
+      return Promise.resolve({ error });
+    }) as typeof tx.commit;
+    return tx;
+  }) as typeof runtime.edit;
+
+  return {
+    refusalsReach: (n: number) => {
+      if (refusals >= n) return Promise.resolve();
+      let waiter = waiters.get(n);
+      if (waiter === undefined) {
+        waiter = Promise.withResolvers();
+        waiters.set(n, waiter);
+      }
+      return waiter.promise as Promise<void>;
+    },
+    refusals: () => refusals,
+    restore: () => {
+      (runtime as unknown as { edit: typeof runtime.edit }).edit = originalEdit;
+      runner.startWithTx = originalStartWithTx;
+    },
+  };
+}
+
+/**
+ * Await a signal the test itself resolves. Deliberately no deadline: a
+ * signal that never arrives lets the event loop quiesce and Deno fails the
+ * pending wait, naming the test — which is the RED these pins are watched
+ * at. The label keeps that failure readable.
+ */
+async function waitForSignal(
+  signal: Promise<void>,
+  _label: string,
+): Promise<void> {
+  await signal;
+}
+
+/**
+ * Watch the runner install the client-side piece context for one result:
+ * how many installs ran, and whether one ever ran while a previous one was
+ * still registered — the double-install question a re-attempt raises.
+ *
+ * Deliberately passes `startWithTx`'s return value through UNCHANGED. The
+ * runner compares that exact cancel against its registry to decide whether
+ * an ownership still owns the registration (`createDeferredStartOwnership`),
+ * so a harness that wraps it silently suppresses every teardown and would
+ * manufacture the very concurrency it claims to measure. Liveness is read
+ * from the runner's own registry instead.
+ */
+function observeInstalls(
+  runtime: Runtime,
+  matches: (cell: Cell<unknown>) => boolean,
+  registered: () => boolean,
+): {
+  installs(): number;
+  everConcurrent(): boolean;
+  nth(n: number): Promise<void>;
+  restore(): void;
+} {
+  const runner = runtime.runner as unknown as {
+    startWithTx: (...args: unknown[]) => () => void;
+  };
+  const original = runner.startWithTx;
+  const waiters = new Map<number, ReturnType<typeof Promise.withResolvers>>();
+  let installs = 0;
+  let everConcurrent = false;
+
+  runner.startWithTx = (...args: unknown[]) => {
+    if (matches(args[1] as Cell<unknown>)) {
+      // Read BEFORE this install registers: a registration still standing
+      // here belongs to a previous attempt that was never torn down.
+      if (registered()) everConcurrent = true;
+      installs++;
+      for (const [at, waiter] of waiters) {
+        if (at <= installs) waiter.resolve(undefined);
+      }
+    }
+    return Reflect.apply(original, runtime.runner, args) as () => void;
+  };
+
+  return {
+    installs: () => installs,
+    everConcurrent: () => everConcurrent,
+    nth: (n: number) => {
+      if (installs >= n) return Promise.resolve();
+      let waiter = waiters.get(n);
+      if (waiter === undefined) {
+        waiter = Promise.withResolvers();
+        waiters.set(n, waiter);
+      }
+      return waiter.promise as Promise<void>;
+    },
+    restore: () => {
+      runner.startWithTx = original;
+    },
+  };
+}
+
+describe("a commit-gated start refused for a stale confirmed read", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  // The registration key the runner indexes cancels by.
+  function key(cell: Cell<unknown>) {
+    return entityKey(
+      cell.getAsNormalizedFullLink(),
+      runtime.scopeKeyIdentity,
+    );
+  }
+
+  // The gated-start shape the navigate path mints: an immediate transaction
+  // that defers the runner's start until it commits.
+  function gatedTx() {
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    return tx;
+  }
+
+  // A stale-confirmed-read refusal in the shape `toRejectedError` hands the
+  // runner: the engine's message plus the conflict descriptor parsed from
+  // it. It names a REAL document, so the readiness pull the retry performs
+  // resolves against the store instead of a phantom id.
+  function staleConfirmedReadOf(cell: Cell<unknown>) {
+    const id = cell.getAsNormalizedFullLink().id;
+    return {
+      name: "ConflictError",
+      message: `stale confirmed read: ${id} at seq 0 conflicted with seq 10`,
+      conflict: { space, the: "application/json", of: id },
+    };
+  }
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("re-attempts the start and leaves the piece running", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "started after a stale confirmed read",
+      undefined,
+      tx,
+    );
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      staleConfirmedReadOf(result),
+    );
+    const installed = observeInstalls(
+      runtime,
+      (cell) => key(cell) === key(result),
+      () => runtime.runner.cancels.has(key(result)),
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await waitForSignal(
+        installed.nth(2),
+        "the start's re-attempt installing the piece",
+      );
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      // The refusal really happened, and the piece is running anyway.
+      expect(injector.refusals()).toBe(1);
+      expect(runtime.runner.cancels.has(key(result))).toBe(true);
+      await result.pull();
+      expect(result.get()?.doubled).toBe(6);
+    } finally {
+      installed.restore();
+      injector.restore();
+    }
+  });
+
+  it("installs the piece exactly once across the refusal and its re-attempt", async () => {
+    // The re-attempt must not leave the refused attempt's client-side piece
+    // context installed beside its own. Counted at the runner's own
+    // registration index: an install adds this result's key, a teardown
+    // removes it, and the two must alternate — never two live at once.
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "installed once across a re-attempt",
+      undefined,
+      tx,
+    );
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      staleConfirmedReadOf(result),
+    );
+    const installed = observeInstalls(
+      runtime,
+      (cell) => key(cell) === key(result),
+      () => runtime.runner.cancels.has(key(result)),
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await waitForSignal(
+        installed.nth(2),
+        "the start's re-attempt installing the piece",
+      );
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      // Two attempts ran — and at no point did two installs coexist.
+      expect(installed.installs()).toBe(2);
+      expect(installed.everConcurrent()).toBe(false);
+      expect(runtime.runner.cancels.has(key(result))).toBe(true);
+    } finally {
+      installed.restore();
+      injector.restore();
+    }
+  });
+
+  it("stops re-attempting when the piece is stopped before the re-attempt fires", async () => {
+    // The zombie case: the user navigated away, or the piece was disposed,
+    // between the refusal and the re-attempt. The pending re-attempt is
+    // registered under the result's key BEFORE its readiness gate is
+    // awaited, so the stop tombstones it through the same path that
+    // tombstones a pending first attempt — it must install nothing.
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "stopped between the refusal and the re-attempt",
+      undefined,
+      tx,
+    );
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      staleConfirmedReadOf(result),
+    );
+    const installed = observeInstalls(
+      runtime,
+      (cell) => key(cell) === key(result),
+      () => runtime.runner.cancels.has(key(result)),
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await waitForSignal(
+        injector.refusalsReach(1),
+        "the start's transaction being refused",
+      );
+      runtime.runner.stop(result);
+
+      // Settle whatever the re-attempt chain still has to do, then assert it
+      // did nothing: the refused attempt's install is the only one there
+      // ever was, nothing is registered, and no re-attempt is left pending
+      // to fire into a piece the session has moved on from.
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      expect(installed.installs()).toBe(1);
+      expect(runtime.runner.cancels.has(key(result))).toBe(false);
+    } finally {
+      installed.restore();
+      injector.restore();
+    }
+  });
+
+  it("keeps every other refusal terminal, on the first attempt", async () => {
+    // The discriminator. A refusal that does not name a stale confirmed read
+    // describes no basis a fresh read repairs, so re-running recomputes the
+    // same refusal: one attempt, exactly as before this retry existed.
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    for (
+      const refusal of [
+        // A CFC / speculative-basis style pre-storage refusal.
+        {
+          name: "StorageTransactionAborted",
+          message: "CFC enforcement rejected commit: prepared digest changed",
+        },
+        // A deterministic server-side commit-rule refusal.
+        {
+          name: "RowLabelCommitError",
+          message: "row label rule refused the commit",
+        },
+        // The OTHER ConflictError shape: this session's own earlier commit is
+        // unresolved, which a re-read does not settle.
+        {
+          name: "ConflictError",
+          message: "pending dependency not resolved: 7",
+        },
+      ]
+    ) {
+      const tx = gatedTx();
+      const result = runtime.getCell<{ doubled?: number }>(
+        space,
+        `terminal on ${refusal.name}: ${refusal.message}`,
+        undefined,
+        tx,
+      );
+      // Refuse EVERY transaction once armed, so a re-attempt would be seen
+      // as a second refusal rather than passing through.
+      const injector = refuseDeferredStartCommits(
+        runtime,
+        refusal,
+        Number.MAX_SAFE_INTEGER,
+      );
+      try {
+        runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+        expect((await tx.commit()).error).toBeUndefined();
+
+        await waitForSignal(
+          injector.refusalsReach(1),
+          `the start's transaction being refused with ${refusal.name}`,
+        );
+        await runtime.runner.idleDeferredStartRetries();
+        await runtime.idle();
+
+        expect(injector.refusals()).toBe(1);
+        expect(runtime.runner.cancels.has(key(result))).toBe(false);
+      } finally {
+        injector.restore();
+      }
+    }
+  });
+
+  it("gives up after a bounded number of re-attempts", async () => {
+    // A basis still stale after the bound is not the birth race any more,
+    // and continuing would install and tear down a piece context per
+    // attempt. One attempt plus DEFERRED_START_CONFLICT_RETRIES re-attempts,
+    // then the terminal arm.
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "exhausts its re-attempts",
+      undefined,
+      tx,
+    );
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      staleConfirmedReadOf(result),
+      Number.MAX_SAFE_INTEGER,
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await waitForSignal(
+        injector.refusalsReach(3),
+        "the start exhausting its re-attempts",
+      );
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      // The first attempt plus exactly two re-attempts.
+      expect(injector.refusals()).toBe(3);
+      expect(runtime.runner.cancels.has(key(result))).toBe(false);
+    } finally {
+      injector.restore();
+    }
+  });
+});

--- a/packages/runner/test/deferred-start-conflict-retry.test.ts
+++ b/packages/runner/test/deferred-start-conflict-retry.test.ts
@@ -57,6 +57,11 @@ function refuseDeferredStartCommits(
   runtime: Runtime,
   error: { name: string; message: string },
   count = 1,
+  /** Runs synchronously as the refusal is delivered — BEFORE the runner's
+   * commit continuation observes it. That is the only way a test can place
+   * an event inside the window between the refusal and the re-attempt's
+   * scheduling. */
+  onRefusal?: () => void,
 ): {
   refusalsReach(n: number): Promise<void>;
   refusals(): number;
@@ -85,6 +90,7 @@ function refuseDeferredStartCommits(
     (tx as unknown as { commit: typeof tx.commit }).commit = (() => {
       if (refusals >= count || !startTransactions.has(tx)) return commit();
       refusals++;
+      onRefusal?.();
       for (const [at, waiter] of waiters) {
         if (at <= refusals) waiter.resolve(undefined);
       }
@@ -368,6 +374,56 @@ describe("a commit-gated start refused for a stale confirmed read", () => {
       await runtime.runner.idleDeferredStartRetries();
       await runtime.idle();
 
+      expect(installed.installs()).toBe(1);
+      expect(runtime.runner.cancels.has(key(result))).toBe(false);
+    } finally {
+      installed.restore();
+      injector.restore();
+    }
+  });
+
+  it("schedules no re-attempt once the runtime has been torn down", async () => {
+    // The teardown window the ownership token alone does not cover. A
+    // re-attempt cancels its predecessor and registers a FRESH token under
+    // the result's key — but `stopAll()` cancels the tokens it can SEE and
+    // clears that map, so a teardown landing before the refusal's
+    // continuation runs leaves nothing to cancel the token minted after it.
+    // Without a lifecycle check the re-attempt then installs a piece onto a
+    // runner that has been explicitly torn down.
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "torn down before the re-attempt was scheduled",
+      undefined,
+      tx,
+    );
+    const injector = refuseDeferredStartCommits(
+      runtime,
+      staleConfirmedReadOf(result),
+      1,
+      // Inside the window: the runner is torn down while the refusal is in
+      // flight, so the teardown cannot see a token that does not exist yet.
+      () => runtime.runner.stopAll(),
+    );
+    const installed = observeInstalls(
+      runtime,
+      (cell) => key(cell) === key(result),
+      () => runtime.runner.cancels.has(key(result)),
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      // The refused attempt is the only one that ever installed, and the
+      // torn-down runner holds no registration for the piece.
+      expect(injector.refusals()).toBe(1);
       expect(installed.installs()).toBe(1);
       expect(runtime.runner.cancels.has(key(result))).toBe(false);
     } finally {

--- a/packages/runner/test/deferred-start-conflict-retry.test.ts
+++ b/packages/runner/test/deferred-start-conflict-retry.test.ts
@@ -477,3 +477,164 @@ describe("a commit-gated start refused for a stale confirmed read", () => {
     }
   });
 });
+
+// The §3d question a re-attempt raises (serving-loop.md §3d, RULED
+// 2026-08-13): a flag-ON client's navigate-deferred start is stamped as a
+// SPECULATIVE CONSEQUENCE carrying its event's id, so a re-attempt must not
+// mint a SECOND consequence for one navigate or re-consume that eventId.
+//
+// The answer is structural rather than defensive, and these two pins are what
+// establish it. A start stamped `event-handler` DIVERTS into the speculation
+// overlay instead of committing, and the overlay's refusals are aborts — so a
+// stale confirmed read, which only the memory server produces, cannot reach a
+// consequence-stamped start at all. Only a `bookkeeping`-stamped start
+// commits to the store, and re-attempting one mints no consequence.
+//
+// FLAGGED, not settled here: §3d sanctions the stamp on the deferred start
+// but does not state the RE-ISSUE case in words. The implementation takes the
+// reading under which a second speculative consequence is unreachable — the
+// same consequence re-issued, never a new one — and the owner's ruling on
+// that sentence is owed (verification-coverage.md OW45 arm B).
+describe("a re-attempt and the §3d speculative-consequence stamp", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  function key(cell: Cell<unknown>) {
+    return entityKey(cell.getAsNormalizedFullLink(), runtime.scopeKeyIdentity);
+  }
+
+  function gatedTx() {
+    const tx = runtime.edit();
+    tx.tx.immediate = true;
+    (tx.tx as { deferRunnerStartUntilCommit?: boolean })
+      .deferRunnerStartUntilCommit = true;
+    return tx;
+  }
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    // EXPLICITLY flag-ON, and with no serving posture: a flag-ON CLIENT,
+    // which is the arm that carries the speculation overlay and the arm the
+    // OW45 arm-B defect was caught on.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { serverExecution: true },
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("diverts a consequence-stamped start to the overlay, where a stale confirmed read cannot reach it", async () => {
+    const tx = runtime.edit();
+    // Read AFTER the first edit(): the overlay is created lazily, when a
+    // transaction first asks the runtime for its seal destination.
+    const overlay = runtime.speculationOverlay;
+    expect(overlay).toBeDefined();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "a speculative consequence's deferred start",
+      undefined,
+      tx,
+    );
+    const id = result.getAsNormalizedFullLink().id;
+
+    // A start transaction stamped exactly as the navigate-deferred start
+    // stamps its own under the flag (`startAfterSuccessfulCommit`: the
+    // piece-start action id, `event-handler` kind, the firing event's id).
+    // Routing is decided by that stamp alone, so this is the start's own
+    // disposition.
+    const consequence = runtime.edit();
+    runtime.stampServerRun(consequence, {
+      actionId: `piece-start/${id}`,
+      kind: "event-handler",
+      eventId: "event:one-navigate",
+    });
+    result.withTx(consequence).set({ doubled: 6 });
+    expect((await consequence.commit()).error).toBeUndefined();
+
+    // It DIVERTED: one event-handler seal, the overlay's, for the one
+    // navigate. A diverted transaction never reaches the memory server, and
+    // the overlay refuses only by aborting — so the server-produced stale
+    // confirmed read this fix re-attempts is unreachable for a
+    // consequence-stamped start, and a re-attempt can never mint a second
+    // consequence or re-consume the eventId.
+    expect(overlay!.eventEchoSealCount).toBe(1);
+
+    // The discrimination is the STAMP: the same transaction stamped
+    // `bookkeeping` — what every start without a speculative consequence
+    // carries — commits to the store instead, which is the arm that can be
+    // refused this way.
+    // Its own document: the diverted write above leaves a speculative layer
+    // over `result`, and a later authored read basis naming that layer is
+    // refused on its own grounds (speculation.md §6) — which would be a
+    // different story than the one this pin tells.
+    const otherTx = runtime.edit();
+    const other = runtime.getCell<{ doubled?: number }>(
+      space,
+      "a bookkeeping start's own document",
+      undefined,
+      otherTx,
+    );
+    otherTx.abort("only needed to mint the cell");
+    const bookkeeping = runtime.edit();
+    runtime.stampServerRun(bookkeeping, {
+      actionId: `piece-start/${other.getAsNormalizedFullLink().id}`,
+      kind: "bookkeeping",
+    });
+    other.withTx(bookkeeping).set({ doubled: 12 });
+    expect((await bookkeeping.commit()).error).toBeUndefined();
+    expect(overlay!.eventEchoSealCount).toBe(1);
+
+    tx.abort("unused setup transaction");
+  });
+
+  it("mints no speculative consequence when it re-attempts a bookkeeping start", async () => {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const Piece = pattern<{ value: number }>(({ value }) => ({
+      doubled: lift((input: number) => input * 2)(value),
+    }));
+    const tx = gatedTx();
+    const result = runtime.getCell<{ doubled?: number }>(
+      space,
+      "a bookkeeping start re-attempted under the flag",
+      undefined,
+      tx,
+    );
+    const overlay = runtime.speculationOverlay;
+    expect(overlay).toBeDefined();
+    const id = result.getAsNormalizedFullLink().id;
+    const injector = refuseDeferredStartCommits(runtime, {
+      name: "ConflictError",
+      message: `stale confirmed read: ${id} at seq 0 conflicted with seq 10`,
+    });
+    const installed = observeInstalls(
+      runtime,
+      (cell) => key(cell) === key(result),
+      () => runtime.runner.cancels.has(key(result)),
+    );
+    try {
+      runtime.run(tx, Piece, { value: 3 }, result.withTx(tx));
+      expect((await tx.commit()).error).toBeUndefined();
+
+      await waitForSignal(
+        installed.nth(2),
+        "the start's re-attempt installing the piece",
+      );
+      await runtime.runner.idleDeferredStartRetries();
+      await runtime.idle();
+
+      // The re-attempt ran and the piece is running — and not one
+      // event-handler seal was minted along the way.
+      expect(injector.refusals()).toBe(1);
+      expect(runtime.runner.cancels.has(key(result))).toBe(true);
+      expect(overlay!.eventEchoSealCount).toBe(0);
+    } finally {
+      installed.restore();
+      injector.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Under the server-execution flag a piece is materialized server-side, and the
client's navigate-deferred start reads that piece's computed documents to base
its own transaction on. At first hydration those two acts race by
construction: the serving loop's derived commits for the just-born piece are
in flight exactly while the client reads their targets as absent. So the
client's start transaction is refused for a stale confirmed read — and today
that refusal is TERMINAL. `startWithTx` has already installed the client-side
piece inside the transaction when the refusal lands, the error arm's cancel
tears that install down, and nothing re-attempts it. The piece then has no
client context for the rest of the session and every read that depends on it
resolves to nothing, while the store holds every append: zero data loss,
sticky client-side unresolved reads.

That is OW45 arm B, caught live on an instrumented client (run b04) and forked
to the owner with three dispositions. The owner ruled:

> ok, let's do (a) and record (b) as a post-flip task — owner, 2026-08-22

This PR is (a): a transient refusal must not be terminal. (b) — adopt-not-start
under ON, which dissolves the race instead of re-attempting it — is RECORDED as
a post-flip task (OW61), not built.

## What Changed

**The retry contract.** A commit-gated start refused for a stale confirmed read
re-attempts against fresh confirmed state:

- **Discriminator**: `isStaleConfirmedReadConflict` (new, in the shared
  rejection vocabulary). The other `ConflictError` shape — `pending dependency
  not resolved` — is excluded, as is every non-conflict refusal (CFC abort,
  authorization denial, precondition failure, row-label violation). Those stay
  terminal exactly as today.
- **Bound: 2.** The readiness gate advances the session past the conflicting
  commit and pulls the named document, so one re-attempt lands after the
  materialization it lost to; the second is headroom for a birth committed
  across more than one wave. Exhaustion keeps today's terminal arm and adds a
  distinctly-named log so it is never read as a first-attempt refusal.
- **Re-entrancy**: each attempt takes a fresh ownership token, registered under
  the result's key *before* the readiness gate is awaited, so a stop, release,
  teardown, or navigation away tombstones the pending re-attempt through the
  path that already tombstones a pending first attempt. The previous attempt's
  cancel has run before the next is scheduled, so two installs never coexist.

Both deferred-start arms carry it — `startAfterSuccessfulCommit` and the
sibling `runPatternAfterSuccessfulCommit`, which mints the other
navigate-deferred start and meets the identical race.

`Runtime.awaitCommitRetryReadiness` is extracted from `editWithRetry` so the
catch-up-then-pull protocol has one named home and two callers rather than a
second copy.

**The §3d stamp on a re-run** is answered structurally: a consequence-stamped
start diverts into the speculation overlay and never reaches the memory
server, and the overlay refuses only by aborting — so a stale confirmed read
is unreachable for it, and only a `bookkeeping` start can be refused this way.
A re-attempt re-derives the stamp from the same context: the same consequence
re-issued, never a second one. **Flagged, not filled**: §3d sanctions the stamp
on the deferred start but does not state the re-issue case in words.

**Not covered, traced and recorded**: the `pattern-load-error` path. Both sites
sit inside `setupPatternWatcher` (armed only after a successful instantiate)
and report a load verdict — no transaction, no `ConflictError` — so the retry
contract has no meaning there. In the b04 trace it is downstream of the dead
start.

**Disclosed ripple**: the fix is NOT flag-gated. The terminal arm it corrects is
shared with the OFF arm, where the same refusal produces the same dead piece;
gating would ship a knowingly-broken OFF path and the flip would remove the
branch anyway.

## Test plan

`packages/runner/test/deferred-start-conflict-retry.test.ts` — refuses the
START transaction specifically (recognized by the runner handing it to
`startWithTx`), in the shape `toRejectedError` produces from the wire.

Watched RED against the pre-fix terminal arm: the re-attempt pin, the budget
pin. The obligation pins are vacuous against "no retry at all", so each was
watched red against a deliberately-broken variant of the fix:

| pin | broken variant that reds it | observed |
| --- | --- | --- |
| no double-install | retry without the ownership dedupe | two installs live at once |
| no zombie | unregistered retry ownership | 2 installs after a stop, expected 1 |
| terminal classes stay terminal | retry every conflict class | 3 refusals, expected 1 |
| no second consequence | re-attempt re-stamps a fresh consequence | 1 event-handler seal, expected 0 |

A harness note worth keeping: an observer that WRAPPED `startWithTx`'s return
value suppressed every teardown, because the runner compares that exact cancel
against its registry to decide ownership — it manufactured the concurrency it
claimed to measure. Liveness is read from the runner's own registry instead.

Regression, one file per invocation, under the package's real test flags
(`--preload=test/clock-preload.ts`): `edit-with-retry-classification`,
`compile-cache-writeback-conflict`, `child-run-ownership`,
`child-pattern-start-ownership`, `scheduler-event-receipts`,
`speculation-overlay`, `scheduler-idle-pattern-work` — all green.

## Status: NOT landable as-is — the ON gate failed

**The live gate disproves this PR's premise as a lift.** ON-built binary
(posture probed per run), fresh store per run, fix verified present in the
artifact: **5 pass / 2 fail in 7 runs**. Both arm-B shapes reproduced WITH the
retry shipped — run 2 the whole-piece shape this fix targets
(`isNotebook: false`, `noteCount: -1`, 98 stored chips, 0 rendered), run 1 the
single-chain shape (7 notes, 6 chips). The ON skip entry is therefore
UNTOUCHED and stays.

Since opening, three things changed on the branch:

1. **A confirmed regression this PR introduced is fixed** (`64b7066d6`). The
   re-attempt minted an ownership token with no lifecycle check, repopulating
   the map `stopAll()` had just cleared, and installed a piece onto a
   torn-down runner. Watched red first — 2 installs where there must be 1 —
   then gated on the scheduling lifecycle epoch at both the mint and the
   post-readiness install.
2. **A liveness hazard in the retry is recorded, not fixed.** The re-attempt
   awaits the conflict's `readyToRetry`, which for a wire-borne server
   `ConflictError` is `waitForCaughtUpLocalSeq` (attached at
   `memory/v2/client.ts`'s transact catch, gated on the server's
   `retryAfterSeq`) and resolves only when a LATER sync arrives. First
   hydration is exactly the case where none need arrive — which is why the
   starvation is sticky at all. The shipped pins cannot see this: they inject
   refusals with no gate attached.
3. **A third arm is scoped for the owner**
   (`optimize/ow45-armb-basis-narrowing-scope.md`): close the refusal by
   NARROWING the start's commit conflict set — as two sibling rows in the
   same register already closed this exact refusal class at `buildReads` —
   instead of retrying it. The b04 conflict names a `computed:`-kinded entity,
   a scheme that means "re-derivable by the runtime that minted it". That arm
   would SUPERSEDE this one, so it needs a ruling of its own.

The instrumented follow-up did not settle whether the retry fires in a real
red: 5 runs, 1 red, and that red was a UI-interaction race (7 clicks split 6+1
across two notebook handlers), not a starvation. The burner regime that caught
it sits above the band the arm-B reds live in — recorded so the next pass uses
ambient load instead.
