### PR TITLE
feat(cli): cf piece survey, and the source pin on cf piece inspect

### DIFF
--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -518,10 +518,9 @@ compiling; and the drill.
 - [x] The survey-diff: a survey compared against a plan or an earlier
       survey, reporting per piece moved as planned, still outstanding, or
       moved to something the plan did not ask for.
-- [ ] The survey and the pin read are invocable from `cf`
+- [x] The survey and the pin read are invocable from `cf`
       (`cf piece survey`, `cf piece inspect --pattern-identity`),
-      provisionally spelled per decision 1. Ticked by the stacked change
-      that lands them.
+      provisionally spelled per decision 1.
 - [ ] The stage-1 drill runs in continuous integration, under the CLI
       integration suite's `piece-call` section. Ticked by the stacked
       change that lands it.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -129,8 +129,10 @@ a plan for the bulk operations in `docs/plans/piece-bulk-operations.md`. On a
 collection survey the registry is its cross-check: a registered piece on an
 in-scope identity that the collection lacks makes the survey exit nonzero,
 naming the piece. A `--list` survey reads exactly the pieces named and makes no
-containment claim. Read-only; the spelling is provisional until the bulk write
-operations get a home.
+containment claim; each entry takes either reference form, and a canonical
+entry's embedded space composes the way it does on `--piece` — supplying the
+space when `--space` is absent, agreeing with it otherwise. Read-only; the
+spelling is provisional until the bulk write operations get a home.
 
 `cf piece slugs` lists the space's slug index: every name assigned through
 `--slug` or `set-slug`, each resolved to the piece it names. The index records

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -118,6 +118,19 @@ positional path spelling.
 the default pattern and starts each registered piece to obtain its name and
 pattern metadata. It does not enumerate every stored piece root.
 
+`cf piece inspect --pattern-identity` prints one piece's source pin — pattern
+identity, export symbol, current source revision when the piece keeps a log, and
+whether the identity's source is retained in the space — without running the
+piece and without pulling its input, result, or link graph.
+
+`cf piece survey` reads a holder's own collection — the enumeration `piece ls`
+cannot provide — one cheap identity read per member, the holder last, and emits
+a plan for the bulk operations in `docs/plans/piece-bulk-operations.md`. The
+registry is only its cross-check: a registered piece on an in-scope identity
+that the collection lacks makes the survey exit nonzero, naming the piece.
+Read-only; the spelling is provisional until the bulk write operations get a
+home.
+
 `cf piece slugs` lists the space's slug index: every name assigned through
 `--slug` or `set-slug`, each resolved to the piece it names. The index records
 assignments made since it existed, so a slug written by an older client still
@@ -774,11 +787,12 @@ The supported output switches are:
 - `cf inspect ... --json` serializes an inspector result. `inspect html` does
   not have a JSON representation, so `html` and `--json` are mutually exclusive.
   `inspect graph --dot` and `--json` are also mutually exclusive.
-- `cf piece ls`, `piece search`, `piece inspect`, `piece view`, and
-  `piece render` use `--json` as an output switch. `piece render --watch --json`
-  writes only JSON render records to stdout; watch status goes to stderr.
-  Rendering a piece without a UI fails instead of returning an empty successful
-  JSON stream.
+- `cf piece ls`, `piece search`, `piece inspect`, `piece survey`, `piece view`,
+  and `piece render` use `--json` as an output switch. `piece survey` reserves
+  stdout for the plan it emits (or, under `--json`, the full survey result); its
+  tally and findings go to stderr. `piece render --watch --json` writes only
+  JSON render records to stdout; watch status goes to stderr. Rendering a piece
+  without a UI fails instead of returning an empty successful JSON stream.
 - `cf get` and `cf wish` always return JSON. Their `--json` options are
   accepted, documented no-ops for callers that select JSON explicitly.
 - `cf check --json` compiles without evaluating and prints one object with a

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -125,11 +125,12 @@ piece and without pulling its input, result, or link graph.
 
 `cf piece survey` reads a holder's own collection — the enumeration `piece ls`
 cannot provide — one cheap identity read per member, the holder last, and emits
-a plan for the bulk operations in `docs/plans/piece-bulk-operations.md`. The
-registry is only its cross-check: a registered piece on an in-scope identity
-that the collection lacks makes the survey exit nonzero, naming the piece.
-Read-only; the spelling is provisional until the bulk write operations get a
-home.
+a plan for the bulk operations in `docs/plans/piece-bulk-operations.md`. On a
+collection survey the registry is its cross-check: a registered piece on an
+in-scope identity that the collection lacks makes the survey exit nonzero,
+naming the piece. A `--list` survey reads exactly the pieces named and makes no
+containment claim. Read-only; the spelling is provisional until the bulk write
+operations get a home.
 
 `cf piece slugs` lists the space's slug index: every name assigned through
 `--slug` or `set-slug`, each resolved to the piece it names. The index records

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2322,6 +2322,10 @@ export const piece = targetOptions(
     { collect: true },
   )
   .option(
+    "--main-export <symbol:string>",
+    "The export every --retarget source runs, recorded as each row's symbol; the default export otherwise.",
+  )
+  .option(
     "--dangerously-allow-incompatible-schema",
     "Stamp allowIncompatible onto every retarget row. The apply honors only the row field, so the plan shows exactly which rows run with the compatibility gate open.",
   )
@@ -3204,6 +3208,9 @@ export async function surveyFromCommand(
     ...(options.datafile === undefined
       ? {}
       : { dataFilePaths: options.datafile.map((p) => absPath(p)) }),
+    ...(options.mainExport === undefined
+      ? {}
+      : { mainExport: options.mainExport }),
   };
   const retargets = (options.retarget ?? []).map((spec) => {
     const parsed = parseRetargetFlag(spec);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1,9 +1,11 @@
 import { Command, ValidationError } from "@cliffy/command";
 import { Table } from "@cliffy/table";
 import type { CellScope } from "@commonfabric/api";
-import type {
-  PatternCompatibilityReport,
-  PiecePatternRef,
+import {
+  encodePlan,
+  type PatternCompatibilityReport,
+  type PiecePatternRef,
+  type PieceSelector,
 } from "@commonfabric/piece/ops";
 import ports from "@commonfabric/ports" with { type: "json" };
 import { parseCellPath, UI } from "@commonfabric/runner";
@@ -13,6 +15,7 @@ import {
 } from "@commonfabric/runner/shared";
 import { decode } from "@commonfabric/utils/encoding";
 
+import { type PhaseRetarget, readSourcePin, runSurvey } from "../lib/bulk.ts";
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
 import type {
   InvocationIdentity,
@@ -2264,27 +2267,74 @@ export const piece = targetOptions(
     "--summary",
     "Show a compact summary: scalars only, arrays/objects replaced with type descriptors, $-prefixed internal keys omitted",
   )
-  .action(async (options) => {
-    const pieceConfig = parsePieceOptions(options);
-
-    const pieceData = await inspectPiece(pieceConfig);
-
-    const displayData = options.summary
-      ? {
-        ...pieceData,
-        source: summarizeForDisplay(pieceData.source),
-        result: summarizeForDisplay(pieceData.result),
-      }
-      : pieceData;
-
-    if (options.json) {
-      // In JSON mode, use render with JSON output
-      render(displayData, { json: true });
-      return;
-    }
-
-    render(renderPieceInspection(pieceData, options.summary === true));
-  })
+  .option(
+    "--pattern-identity",
+    "Print only the piece's source pin — pattern identity, export symbol, current source revision, and whether the identity's source is retained — without pulling the input, result, or link graph",
+    { conflicts: ["summary"] },
+  )
+  .action(inspectPieceFromCommand)
+  /* piece survey */
+  .command(
+    "survey",
+    "Survey a holder's collection into a plan: one cheap read per piece, cross-checked against the piece registry. Read-only. Provisional spelling — the bulk entry point may move when the write operations get a home (docs/plans/piece-bulk-operations.md, decision 1).",
+  )
+  .usage(pieceUsage)
+  .example(
+    cliText(
+      `cf piece survey ${EX_ID} ${EX_COMP_PIECE} --path topics --out plan.jsonl`,
+    ),
+    "Survey the holder's topics collection into plan.jsonl.",
+  )
+  .option(
+    "-c,--piece <piece:string>",
+    "The holder piece whose collection is surveyed.",
+  )
+  .option(
+    "--path <path:string>",
+    "Path to the collection inside the holder's document; segments joined with '/'.",
+  )
+  .option(
+    "--side <side:string>",
+    "Which document holds the collection: input (the default) or result.",
+  )
+  .option(
+    "--list <piece:string>",
+    "Survey this piece instead of a collection. Repeatable.",
+    { collect: true, conflicts: ["piece", "path", "side"] },
+  )
+  .option(
+    "--retarget <spec:string>",
+    "Stamp a retarget onto one phase's rows, as <phase>=<main.tsx>[@rev]. A collection's members carry the path's last segment as their phase; the holder carries 'holder'. Repeatable.",
+    { collect: true },
+  )
+  .option(
+    "--root <path:string>",
+    "Root directory for every --retarget source.",
+  )
+  .option(
+    "--test <path:string>",
+    "Attach a test source file to every --retarget source. Repeatable.",
+    { collect: true },
+  )
+  .option(
+    "--datafile <path:string>",
+    "Attach a data file to every --retarget source. Repeatable.",
+    { collect: true },
+  )
+  .option(
+    "--dangerously-allow-incompatible-schema",
+    "Stamp allowIncompatible onto every retarget row. The apply honors only the row field, so the plan shows exactly which rows run with the compatibility gate open.",
+  )
+  .option(
+    "--validator <path:string>",
+    "A JSON-schema file each piece's result is read under; pieces that fail it are named on stderr.",
+  )
+  .option("--out <file:string>", "Write the plan to a file instead of stdout.")
+  .option(
+    "--json",
+    "Write the full survey result as JSON to stdout instead of the plan.",
+  )
+  .action(surveyFromCommand)
   /* piece view */
   .command("view", "Display the rendered view for a piece")
   .usage(pieceUsage)
@@ -3010,6 +3060,203 @@ export async function listPiecesFromCommand(
     parseSpaceOptions(options),
   );
   (deps.renderPieceSummaries ?? renderPieceSummaries)(pieces, !!options.json);
+}
+
+export interface PieceInspectCommandDependencies {
+  inspectPiece?: typeof inspectPiece;
+  readSourcePin?: typeof readSourcePin;
+  render?: typeof render;
+  printError?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function inspectPieceFromCommand(
+  options: PieceCLIOptions & { summary?: boolean; patternIdentity?: boolean },
+  deps: PieceInspectCommandDependencies = {},
+): Promise<void> {
+  const pieceConfig = parsePieceOptions(options);
+  const print = deps.render ?? render;
+  if (options.patternIdentity) {
+    const pin = await (deps.readSourcePin ?? readSourcePin)(pieceConfig);
+    if (pin === undefined) {
+      exitWithDataError(
+        { message: `Piece ${pieceConfig.piece} carries no pattern identity.` },
+        deps,
+      );
+    }
+    if (options.json) {
+      print(pin, { json: true });
+      return;
+    }
+    print(
+      [
+        `piece:    ${pin.piece}`,
+        `identity: ${pin.patternIdentity}`,
+        `symbol:   ${pin.symbol}`,
+        ...(pin.revisionId === undefined
+          ? []
+          : [`revision: ${pin.revisionId}`]),
+        `retained: ${pin.retained}`,
+      ].join("\n"),
+    );
+    return;
+  }
+  const pieceData = await (deps.inspectPiece ?? inspectPiece)(pieceConfig);
+  const displayData = options.summary
+    ? {
+      ...pieceData,
+      source: summarizeForDisplay(pieceData.source),
+      result: summarizeForDisplay(pieceData.result),
+    }
+    : pieceData;
+  if (options.json) {
+    print(displayData, { json: true });
+    return;
+  }
+  print(renderPieceInspection(pieceData, options.summary === true));
+}
+
+/**
+ * Parse one `--retarget` flag: `<phase>=<main>[@rev]`. The `@rev` label is
+ * recorded for readers and for diffing plans, never enforced — the identity
+ * computed from the source is the pin.
+ */
+export function parseRetargetFlag(spec: string): PhaseRetarget {
+  const eq = spec.indexOf("=");
+  if (eq <= 0 || eq === spec.length - 1) {
+    throw new ValidationError(
+      `--retarget takes <phase>=<main>[@rev], got "${spec}".`,
+      { exitCode: 1 },
+    );
+  }
+  const phase = spec.slice(0, eq);
+  const rest = spec.slice(eq + 1);
+  const at = rest.lastIndexOf("@");
+  const main = at > 0 ? rest.slice(0, at) : rest;
+  const rev = at > 0 ? rest.slice(at + 1) : undefined;
+  return {
+    phase,
+    source: { main: absPath(main) },
+    ...(rev === undefined || rev === "" ? {} : { rev }),
+  };
+}
+
+export interface SurveyCLIOptions extends PieceCLIOptions {
+  path?: string;
+  side?: string;
+  list?: string[];
+  retarget?: string[];
+  validator?: string;
+  out?: string;
+}
+
+export interface SurveyCommandDependencies {
+  runSurvey?: typeof runSurvey;
+  render?: typeof render;
+  writeTextFile?: typeof Deno.writeTextFile;
+  printError?: (message: string) => void;
+  printHint?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function surveyFromCommand(
+  options: SurveyCLIOptions,
+  deps: SurveyCommandDependencies = {},
+): Promise<void> {
+  let selector: PieceSelector;
+  let spaceConfig;
+  if (options.list !== undefined && options.list.length > 0) {
+    spaceConfig = parseSpaceOptions(options);
+    selector = { kind: "list", pieces: options.list };
+  } else {
+    const pieceConfig = parsePieceOptions(options);
+    spaceConfig = pieceConfig;
+    const path = (options.path ?? "").split("/").filter((s) => s !== "");
+    if (path.length === 0) {
+      throw new ValidationError(
+        "--path names the collection to survey; use --list to survey pieces directly.",
+        { exitCode: 1 },
+      );
+    }
+    if (
+      options.side !== undefined && options.side !== "input" &&
+      options.side !== "result"
+    ) {
+      throw new ValidationError(
+        `--side takes input or result, got "${options.side}".`,
+        { exitCode: 1 },
+      );
+    }
+    selector = {
+      kind: "collection",
+      holder: pieceConfig.piece,
+      path,
+      ...(options.side === undefined
+        ? {}
+        : { side: options.side as "input" | "result" }),
+    };
+  }
+  const shared = {
+    ...(options.root === undefined ? {} : { root: absPath(options.root) }),
+    ...(options.test === undefined
+      ? {}
+      : { testPaths: options.test.map((p) => absPath(p)) }),
+    ...(options.datafile === undefined
+      ? {}
+      : { dataFilePaths: options.datafile.map((p) => absPath(p)) }),
+  };
+  const retargets = (options.retarget ?? []).map((spec) => {
+    const parsed = parseRetargetFlag(spec);
+    return { ...parsed, source: { ...parsed.source, ...shared } };
+  });
+
+  const result = await (deps.runSurvey ?? runSurvey)(spaceConfig, {
+    selector,
+    ...(retargets.length === 0 ? {} : { retargets }),
+    ...(options.dangerouslyAllowIncompatibleSchema
+      ? { allowIncompatible: true }
+      : {}),
+    ...(options.validator === undefined
+      ? {}
+      : { validatorPath: absPath(options.validator) }),
+  });
+
+  const print = deps.render ?? render;
+  const printHint = deps.printHint ?? hint;
+  if (options.json) {
+    print(result, { json: true });
+  } else {
+    const plan = encodePlan(result.plan);
+    if (options.out !== undefined) {
+      await (deps.writeTextFile ?? Deno.writeTextFile)(options.out, plan);
+      printHint(`Wrote ${result.plan.rows.length} plan rows to ${options.out}`);
+    } else {
+      print(plan.trimEnd());
+    }
+  }
+  for (const entry of result.tally) {
+    printHint(`${entry.phase}: ${entry.count} on ${entry.patternIdentity}`);
+  }
+  for (const failure of result.validatorFailures) {
+    printHint(`validator: ${failure.piece} ${failure.problem}`);
+  }
+  if (!result.complete) {
+    exitWithDataError(
+      {
+        message: [
+          "Survey is incomplete; a write stage must refuse this plan.",
+          ...result.problems.map(
+            (problem) => `  unreadable: ${problem.piece} ${problem.problem}`,
+          ),
+          ...result.outside.map(
+            (outside) =>
+              `  registered outside the selection: ${outside.piece} on ${outside.patternIdentity}`,
+          ),
+        ].join("\n"),
+      },
+      deps,
+    );
+  }
 }
 
 export interface SlugListCommandDependencies {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3150,6 +3150,8 @@ export function parseRetargetFlag(spec: string): PhaseRetarget {
 }
 
 export interface SurveyCLIOptions extends PieceCLIOptions {
+  /** Inherited from the `piece` mount's global target options. */
+  quiet?: boolean;
   path?: string;
   side?: string;
   list?: string[];
@@ -3171,6 +3173,7 @@ export async function surveyFromCommand(
   options: SurveyCLIOptions,
   deps: SurveyCommandDependencies = {},
 ): Promise<void> {
+  setQuietMode(!!options.quiet);
   let selector: PieceSelector;
   let spaceConfig;
   if (options.list !== undefined && options.list.length > 0) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2269,14 +2269,14 @@ export const piece = targetOptions(
   )
   .option(
     "--pattern-identity",
-    "Print only the piece's source pin — pattern identity, export symbol, current source revision, and whether the identity's source is retained — without pulling the input, result, or link graph",
+    "Print the piece's source pin and nothing else — pattern identity, export symbol, current source revision, and whether the reference's source is verifiably retained — without running the piece or pulling its input, result, or link graph",
     { conflicts: ["summary"] },
   )
   .action(inspectPieceFromCommand)
   /* piece survey */
   .command(
     "survey",
-    "Survey a holder's collection into a plan: one cheap read per piece, cross-checked against the piece registry. Read-only. Provisional spelling — the bulk entry point may move when the write operations get a home (docs/plans/piece-bulk-operations.md, decision 1).",
+    "Survey a holder's collection into a plan: one cheap read per piece, cross-checked against the piece registry (a --list survey claims no containment and is not cross-checked). Read-only. Provisional spelling — the bulk entry point may move when the write operations get a home (docs/plans/piece-bulk-operations.md, decision 1).",
   )
   .usage(pieceUsage)
   .example(
@@ -2287,7 +2287,7 @@ export const piece = targetOptions(
   )
   .option(
     "-c,--piece <piece:string>",
-    "The holder piece whose collection is surveyed.",
+    `${PIECE_OPTION_HELP} The holder whose collection is surveyed.`,
   )
   .option(
     "--path <path:string>",
@@ -2337,6 +2337,7 @@ export const piece = targetOptions(
   .option(
     "--json",
     "Write the full survey result as JSON to stdout instead of the plan.",
+    { conflicts: ["out"] },
   )
   .action(surveyFromCommand)
   /* piece view */
@@ -3135,9 +3136,12 @@ export function parseRetargetFlag(spec: string): PhaseRetarget {
   }
   const phase = spec.slice(0, eq);
   const rest = spec.slice(eq + 1);
+  // Only an `@` after the last path separator is a rev label — paths with
+  // `@`-named directories (scoped packages, vendor trees) stay whole.
   const at = rest.lastIndexOf("@");
-  const main = at > 0 ? rest.slice(0, at) : rest;
-  const rev = at > 0 ? rest.slice(at + 1) : undefined;
+  const usable = at > 0 && at > rest.lastIndexOf("/");
+  const main = usable ? rest.slice(0, at) : rest;
+  const rev = usable ? rest.slice(at + 1) : undefined;
   return {
     phase,
     source: { main: absPath(main) },
@@ -3171,10 +3175,29 @@ export async function surveyFromCommand(
   let spaceConfig;
   if (options.list !== undefined && options.list.length > 0) {
     spaceConfig = parseSpaceOptions(options);
-    selector = { kind: "list", pieces: options.list };
+    const entries = options.list.map((entry) => {
+      if (entry.includes("@")) {
+        throw new ValidationError(
+          `A scoped piece cannot be surveyed; drop the @scope suffix on ` +
+            `${JSON.stringify(entry)}.`,
+          { exitCode: 1 },
+        );
+      }
+      // The canonical reference form leads with a slash; the selector takes
+      // the address itself.
+      return entry.startsWith("/") ? entry.slice(1) : entry;
+    });
+    selector = { kind: "list", pieces: entries };
   } else {
     const pieceConfig = parsePieceOptions(options);
     spaceConfig = pieceConfig;
+    if (pieceConfig.pieceScope !== undefined) {
+      throw new ValidationError(
+        "A scoped piece cannot hold the surveyed collection; drop the " +
+          "@scope suffix.",
+        { exitCode: 1 },
+      );
+    }
     const path = (options.path ?? "").split("/").filter((s) => s !== "");
     if (path.length === 0) {
       throw new ValidationError(
@@ -3242,7 +3265,10 @@ export async function surveyFromCommand(
     }
   }
   for (const entry of result.tally) {
-    printHint(`${entry.phase}: ${entry.count} on ${entry.patternIdentity}`);
+    printHint(
+      `${entry.phase}: ${entry.count} on ` +
+        `${entry.patternIdentity}#${entry.symbol}`,
+    );
   }
   for (const failure of result.validatorFailures) {
     printHint(`validator: ${failure.piece} ${failure.problem}`);
@@ -3257,7 +3283,8 @@ export async function surveyFromCommand(
           ),
           ...result.outside.map(
             (outside) =>
-              `  registered outside the selection: ${outside.piece} on ${outside.patternIdentity}`,
+              `  registered outside the selection: ${outside.piece} on ` +
+              `${outside.patternIdentity}#${outside.symbol}`,
           ),
         ].join("\n"),
       },

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -3177,19 +3177,68 @@ export async function surveyFromCommand(
   let selector: PieceSelector;
   let spaceConfig;
   if (options.list !== undefined && options.list.length > 0) {
-    spaceConfig = parseSpaceOptions(options);
+    // An entry is either the canonical reference form or the bare id. A
+    // canonical entry may embed the target space: it supplies the space when
+    // --space is absent, and otherwise the two must agree — at parse time
+    // against a DID, through validateEmbeddedSpaces against a name still to
+    // be resolved. The survey reads whole pieces, so a scope, a path, or the
+    // #argument suffix on an entry is refused rather than dropped.
+    let listSpace = options.space;
+    const embedded: string[] = [];
     const entries = options.list.map((entry) => {
-      if (entry.includes("@")) {
+      const ref = normalizeLLMFriendlyRef(entry, { space: listSpace });
+      if (ref === undefined) {
+        // The bare alias grammar reads @ as its scope marker.
+        if (entry.includes("@")) {
+          throw new ValidationError(
+            `A scoped piece cannot be surveyed; drop the @scope suffix on ` +
+              `${JSON.stringify(entry)}.`,
+            { exitCode: 1 },
+          );
+        }
+        return entry;
+      }
+      if (ref.scope !== undefined) {
         throw new ValidationError(
           `A scoped piece cannot be surveyed; drop the @scope suffix on ` +
             `${JSON.stringify(entry)}.`,
           { exitCode: 1 },
         );
       }
-      // The canonical reference form leads with a slash; the selector takes
-      // the address itself.
-      return entry.startsWith("/") ? entry.slice(1) : entry;
+      if (ref.path.length > 0) {
+        throw new ValidationError(
+          `A survey reads whole pieces; drop the path on ` +
+            `${JSON.stringify(entry)}.`,
+          { exitCode: 1 },
+        );
+      }
+      if (ref.input) {
+        throw new ValidationError(
+          `A survey reads whole pieces; drop the #argument suffix on ` +
+            `${JSON.stringify(entry)}.`,
+          { exitCode: 1 },
+        );
+      }
+      if (ref.embeddedSpace !== undefined) {
+        embedded.push(ref.embeddedSpace);
+        // A --url names the space itself; leave the deferred check to
+        // settle an entry against it rather than manufacturing a --space
+        // beside it.
+        if (listSpace === undefined && options.url === undefined) {
+          listSpace = ref.embeddedSpace;
+        }
+      }
+      return ref.pieceId;
     });
+    spaceConfig = parseSpaceOptions(
+      listSpace === options.space ? options : { ...options, space: listSpace },
+    );
+    if (embedded.length > 0) {
+      spaceConfig.embeddedSpaces = [
+        ...(spaceConfig.embeddedSpaces ?? []),
+        ...embedded,
+      ];
+    }
     selector = { kind: "list", pieces: entries };
   } else {
     const pieceConfig = parsePieceOptions(options);

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -1,0 +1,100 @@
+/**
+ * Bulk piece operations from the command line: the thin layer between the
+ * survey library in `@commonfabric/piece/ops` and the `cf piece` commands.
+ * Flag parsing and printing stay in the command module; this one loads the
+ * controller and runs the library, so it is testable without a command
+ * surface and the actions above it stay seams.
+ */
+
+import {
+  type PiecePin,
+  type PieceSelector,
+  type PlannedRetarget,
+  readPiecePin,
+  type RetargetSource,
+  surveyPieces,
+  type SurveyResult,
+} from "@commonfabric/piece/ops";
+import { localRetargetOp } from "@commonfabric/piece/ops/bulk-local";
+import type { JSONSchema } from "@commonfabric/runner";
+
+import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
+
+export interface SourcePinDependencies {
+  loadPieces?: typeof loadPieces;
+}
+
+/**
+ * Read one piece's source pin — identity, symbol, current revision when a
+ * log exists, and whether the identity's source is retained — over the API,
+ * without running the piece and without pulling its input, result, or link
+ * graph. Returns `undefined` for a piece carrying no pattern identity.
+ */
+export async function readSourcePin(
+  config: PieceConfig,
+  deps: SourcePinDependencies = {},
+): Promise<PiecePin | undefined> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  return await readPiecePin(pieces, config.piece);
+}
+
+/** One `--retarget` flag, parsed: which phase, what source, what label. */
+export interface PhaseRetarget {
+  phase: string;
+  source: RetargetSource;
+  rev?: string;
+}
+
+/** What one survey run is asked to do, parsed off the command line. */
+export interface SurveyRunRequest {
+  selector: PieceSelector;
+  retargets?: readonly PhaseRetarget[];
+  /**
+   * Stamped onto every retarget row as `op.allowIncompatible` — the plan
+   * shows which rows would run with the compatibility gate open, and the
+   * apply honors only the row field.
+   */
+  allowIncompatible?: boolean;
+  /** Path to a JSON-schema file each piece's result is read under. */
+  validatorPath?: string;
+  /** The plan header's `takenAt`; defaults to now. */
+  takenAt?: string;
+}
+
+export interface SurveyRunDependencies {
+  loadPieces?: typeof loadPieces;
+  readTextFile?: (path: string) => Promise<string>;
+}
+
+/**
+ * Run the survey: resolve each retarget's source from disk into the identity
+ * it produces — the pin the plan carries — then survey the selection and
+ * build the plan. Read-only against the space.
+ */
+export async function runSurvey(
+  config: SpaceConfig,
+  request: SurveyRunRequest,
+  deps: SurveyRunDependencies = {},
+): Promise<SurveyResult> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const operations: Record<string, PlannedRetarget> = {};
+  for (const retarget of request.retargets ?? []) {
+    const { kind: _, ...planned } = await localRetargetOp(pieces.runtime, {
+      source: retarget.source,
+      ...(retarget.rev === undefined ? {} : { rev: retarget.rev }),
+      ...(request.allowIncompatible ? { allowIncompatible: true } : {}),
+    });
+    operations[retarget.phase] = planned;
+  }
+  const validator = request.validatorPath === undefined
+    ? undefined
+    : JSON.parse(
+      await (deps.readTextFile ?? Deno.readTextFile)(request.validatorPath),
+    ) as JSONSchema;
+  return await surveyPieces(pieces, {
+    selector: request.selector,
+    ...(Object.keys(operations).length === 0 ? {} : { operations }),
+    ...(validator === undefined ? {} : { validator }),
+    ...(request.takenAt === undefined ? {} : { takenAt: request.takenAt }),
+  });
+}

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -128,17 +128,6 @@ export async function runSurvey(
     : JSON.parse(
       await (deps.readTextFile ?? Deno.readTextFile)(request.validatorPath),
     ) as JSONSchema;
-  if (
-    validator !== undefined && typeof validator !== "boolean" &&
-    (typeof validator !== "object" || validator === null ||
-      Array.isArray(validator))
-  ) {
-    // `null` is not `undefined`, and shaping by it validates nothing — a
-    // validator that cannot fail would report a clean board it never read.
-    throw new Error(
-      "The validator file must hold a JSON schema: an object or a boolean.",
-    );
-  }
   return await surveyPieces(pieces, {
     selector,
     ...(Object.keys(operations).length === 0 ? {} : { operations }),

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -1,11 +1,13 @@
 /**
  * Bulk piece operations from the command line: the thin layer between the
  * survey library in `@commonfabric/piece/ops` and the `cf piece` commands.
- * Flag parsing and printing stay in the command module; this one loads the
- * controller and runs the library, so it is testable without a command
- * surface and the actions above it stay seams.
+ * Flag parsing and printing stay in the command module; this one resolves
+ * addresses the way the other piece verbs do, loads the controller, and runs
+ * the library, so it is testable without a command surface and the actions
+ * above it stay seams.
  */
 
+import { resolvePieceAddress } from "@commonfabric/piece";
 import {
   type PiecePin,
   type PieceSelector,
@@ -22,20 +24,27 @@ import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
 
 export interface SourcePinDependencies {
   loadPieces?: typeof loadPieces;
+  resolvePieceAddress?: typeof resolvePieceAddress;
 }
 
 /**
- * Read one piece's source pin — identity, symbol, current revision when a
- * log exists, and whether the identity's source is retained — over the API,
- * without running the piece and without pulling its input, result, or link
- * graph. Returns `undefined` for a piece carrying no pattern identity.
+ * Read one piece's source pin — reference, current revision when a log
+ * exists, and whether the reference's source is verifiably retained — over
+ * the API, without running the piece and without pulling its input, result,
+ * or link graph. The address resolves the way every other piece verb
+ * resolves one (slugs included), and the piece scope is honored. Returns
+ * `undefined` for a piece carrying no pattern identity.
  */
 export async function readSourcePin(
   config: PieceConfig,
   deps: SourcePinDependencies = {},
 ): Promise<PiecePin | undefined> {
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  return await readPiecePin(pieces, config.piece);
+  const piece = await (deps.resolvePieceAddress ?? resolvePieceAddress)(
+    pieces,
+    config.piece,
+  );
+  return await readPiecePin(pieces, piece, new Map(), config.pieceScope);
 }
 
 /** One `--retarget` flag, parsed: which phase, what source, what label. */
@@ -63,21 +72,49 @@ export interface SurveyRunRequest {
 
 export interface SurveyRunDependencies {
   loadPieces?: typeof loadPieces;
+  resolvePieceAddress?: typeof resolvePieceAddress;
   readTextFile?: (path: string) => Promise<string>;
 }
 
 /**
- * Run the survey: resolve each retarget's source from disk into the identity
- * it produces — the pin the plan carries — then survey the selection and
- * build the plan. Read-only against the space.
+ * Run the survey: resolve the selector's addresses the way the other piece
+ * verbs do, resolve each retarget's source from disk into the reference it
+ * produces — the pin the plan carries — then survey the selection and build
+ * the plan. Read-only against the space. Two retargets naming one phase are
+ * refused before anything loads: the second would silently win.
  */
 export async function runSurvey(
   config: SpaceConfig,
   request: SurveyRunRequest,
   deps: SurveyRunDependencies = {},
 ): Promise<SurveyResult> {
+  const phasesSeen = new Set<string>();
+  for (const retarget of request.retargets ?? []) {
+    if (phasesSeen.has(retarget.phase)) {
+      throw new Error(
+        `Two retargets name the phase ${retarget.phase}; the second would ` +
+          `silently win.`,
+      );
+    }
+    phasesSeen.add(retarget.phase);
+  }
+
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const operations: Record<string, PlannedRetarget> = {};
+  const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
+  let selector = request.selector;
+  if (selector.kind === "collection") {
+    selector = { ...selector, holder: await resolve(pieces, selector.holder) };
+  } else {
+    const resolved: string[] = [];
+    for (const entry of selector.pieces) {
+      resolved.push(await resolve(pieces, entry));
+    }
+    selector = { kind: "list", pieces: resolved };
+  }
+
+  // A null prototype, so a phase named like an `Object.prototype` member is
+  // an own key rather than a write through the prototype chain.
+  const operations: Record<string, PlannedRetarget> = Object.create(null);
   for (const retarget of request.retargets ?? []) {
     const { kind: _, ...planned } = await localRetargetOp(pieces.runtime, {
       source: retarget.source,
@@ -91,8 +128,19 @@ export async function runSurvey(
     : JSON.parse(
       await (deps.readTextFile ?? Deno.readTextFile)(request.validatorPath),
     ) as JSONSchema;
+  if (
+    validator !== undefined && typeof validator !== "boolean" &&
+    (typeof validator !== "object" || validator === null ||
+      Array.isArray(validator))
+  ) {
+    // `null` is not `undefined`, and shaping by it validates nothing — a
+    // validator that cannot fail would report a clean board it never read.
+    throw new Error(
+      "The validator file must hold a JSON schema: an object or a boolean.",
+    );
+  }
   return await surveyPieces(pieces, {
-    selector: request.selector,
+    selector,
     ...(Object.keys(operations).length === 0 ? {} : { operations }),
     ...(validator === undefined ? {} : { validator }),
     ...(request.takenAt === undefined ? {} : { takenAt: request.takenAt }),

--- a/packages/cli/lib/json-output.ts
+++ b/packages/cli/lib/json-output.ts
@@ -83,7 +83,8 @@ export function reservesStdoutForCommandOutput(
   if (args[0] === "get" || args[0] === "call") return true;
   const subcommand = pieceSubcommand(args);
   return subcommand === "get" || subcommand === "get-label" ||
-    subcommand === "set-label" || subcommand === "call";
+    subcommand === "set-label" || subcommand === "call" ||
+    subcommand === "survey";
 }
 
 export const stderrConsoleHandler: ConsoleHandler = ({ method, args }) => ({

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -1,0 +1,286 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { PiecePlan, SurveyResult } from "@commonfabric/piece/ops";
+import { decode } from "@commonfabric/utils/encoding";
+
+import type { SurveyRunRequest } from "../lib/bulk.ts";
+import {
+  inspectPieceFromCommand,
+  parseRetargetFlag,
+  piece,
+  surveyFromCommand,
+} from "../commands/piece.ts";
+
+function captureStdout(fn: () => Promise<void>): Promise<string> {
+  let captured = "";
+  const original = Deno.stdout.writeSync;
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    captured += decode(data);
+    return data.length;
+  };
+  return fn().then(() => captured).finally(() => {
+    Deno.stdout.writeSync = original;
+  });
+}
+
+class ExitSentinel extends Error {}
+
+const OPTIONS = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  space: "home",
+  piece: "board",
+  quiet: true,
+};
+
+const PLAN: PiecePlan = {
+  header: {
+    kind: "piece-plan",
+    v: 1,
+    space: "did:key:test",
+    takenAt: "2026-08-24T00:00:00.000Z",
+    enumerated: { collection: 1, registry: 0, registeredOutside: 0 },
+  },
+  rows: [{
+    piece: "of:fid1:aaa",
+    phase: "members",
+    expect: { patternIdentity: "idA", symbol: "default", retained: true },
+  }],
+};
+
+const COMPLETE: SurveyResult = {
+  plan: PLAN,
+  tally: [
+    { phase: "members", patternIdentity: "idA", symbol: "default", count: 1 },
+  ],
+  outside: [],
+  problems: [],
+  validatorFailures: [],
+  complete: true,
+};
+
+describe("piece-survey", () => {
+  describe("parseRetargetFlag()", () => {
+    it("returns the phase, an absolute main path, and the rev label", () => {
+      const parsed = parseRetargetFlag("topics=patterns/topic.tsx@abc123");
+      expect(parsed.phase).toBe("topics");
+      expect(parsed.source.main.startsWith("/")).toBe(true);
+      expect(parsed.source.main.endsWith("/patterns/topic.tsx")).toBe(true);
+      expect(parsed.rev).toBe("abc123");
+    });
+
+    it("returns no rev when the spec carries none", () => {
+      expect(parseRetargetFlag("holder=main.tsx").rev).toBeUndefined();
+    });
+
+    it("throws for a spec without a phase or without a source", () => {
+      expect(() => parseRetargetFlag("main.tsx")).toThrow("--retarget");
+      expect(() => parseRetargetFlag("=main.tsx")).toThrow("--retarget");
+      expect(() => parseRetargetFlag("topics=")).toThrow("--retarget");
+    });
+  });
+
+  describe("surveyFromCommand()", () => {
+    it("prints the encoded plan to stdout and the tally as hints", async () => {
+      const hints: string[] = [];
+      let request: SurveyRunRequest | undefined;
+      const out = await captureStdout(() =>
+        surveyFromCommand({ ...OPTIONS, path: "topics" }, {
+          runSurvey: (_config, req) => {
+            request = req;
+            return Promise.resolve(COMPLETE);
+          },
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(out).toContain('"kind":"piece-plan"');
+      expect(out).toContain("of:fid1:aaa");
+      expect(request?.selector).toEqual({
+        kind: "collection",
+        holder: "board",
+        path: ["topics"],
+      });
+      expect(hints).toEqual(["members: 1 on idA"]);
+    });
+
+    it("writes the plan to --out instead of stdout", async () => {
+      let written: { path: string; text: string } | undefined;
+      const hints: string[] = [];
+      const out = await captureStdout(() =>
+        surveyFromCommand({ ...OPTIONS, path: "topics", out: "plan.jsonl" }, {
+          runSurvey: () => Promise.resolve(COMPLETE),
+          writeTextFile: (path, text) => {
+            written = { path: String(path), text: String(text) };
+            return Promise.resolve();
+          },
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(out).toBe("");
+      expect(written?.path).toBe("plan.jsonl");
+      expect(written?.text.endsWith("\n")).toBe(true);
+      expect(hints[0]).toBe("Wrote 1 plan rows to plan.jsonl");
+    });
+
+    it("prints the whole survey result under --json", async () => {
+      const out = await captureStdout(() =>
+        surveyFromCommand({ ...OPTIONS, path: "topics", json: true }, {
+          runSurvey: () => Promise.resolve(COMPLETE),
+          printHint: () => {},
+        })
+      );
+      expect(JSON.parse(out).complete).toBe(true);
+    });
+
+    it("surveys a list selector without a holder", async () => {
+      let request: SurveyRunRequest | undefined;
+      await captureStdout(() =>
+        surveyFromCommand(
+          { ...OPTIONS, piece: undefined, list: ["of:fid1:x"] },
+          {
+            runSurvey: (_config, req) => {
+              request = req;
+              return Promise.resolve(COMPLETE);
+            },
+            printHint: () => {},
+          },
+        )
+      );
+      expect(request?.selector).toEqual({
+        kind: "list",
+        pieces: ["of:fid1:x"],
+      });
+    });
+
+    it("passes the retargets, the override, and the validator through", async () => {
+      let request: SurveyRunRequest | undefined;
+      await captureStdout(() =>
+        surveyFromCommand(
+          {
+            ...OPTIONS,
+            path: "topics",
+            retarget: ["topics=topic.tsx@r1"],
+            root: "patterns",
+            dangerouslyAllowIncompatibleSchema: true,
+            validator: "demand.json",
+          },
+          {
+            runSurvey: (_config, req) => {
+              request = req;
+              return Promise.resolve(COMPLETE);
+            },
+            printHint: () => {},
+          },
+        )
+      );
+      expect(request?.retargets?.[0].phase).toBe("topics");
+      expect(request?.retargets?.[0].source.root?.endsWith("/patterns"))
+        .toBe(true);
+      expect(request?.allowIncompatible).toBe(true);
+      expect(request?.validatorPath?.endsWith("/demand.json")).toBe(true);
+    });
+
+    it("throws for a collection survey without --path", async () => {
+      await expect(
+        surveyFromCommand({ ...OPTIONS }, {
+          runSurvey: () => Promise.resolve(COMPLETE),
+        }),
+      ).rejects.toThrow("--path");
+    });
+
+    it("exits 1 for an incomplete survey, naming what the plan lacks", async () => {
+      const incomplete: SurveyResult = {
+        ...COMPLETE,
+        outside: [{
+          piece: "of:fid1:orphan",
+          patternIdentity: "idA",
+          symbol: "default",
+        }],
+        complete: false,
+      };
+      let exitCode: number | undefined;
+      const errors: string[] = [];
+      await expect(
+        captureStdout(() =>
+          surveyFromCommand({ ...OPTIONS, path: "topics" }, {
+            runSurvey: () => Promise.resolve(incomplete),
+            printHint: () => {},
+            printError: (message) => {
+              errors.push(message);
+            },
+            exit: (code) => {
+              exitCode = code;
+              throw new ExitSentinel();
+            },
+          })
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain("of:fid1:orphan");
+    });
+
+    it("is the action the piece command registers for survey", () => {
+      const registered = piece.getCommand("survey") as unknown as {
+        actionHandler: unknown;
+      };
+      expect(registered.actionHandler).toBe(surveyFromCommand);
+    });
+  });
+
+  describe("inspectPieceFromCommand()", () => {
+    const PIN = {
+      piece: "of:fid1:aaa",
+      patternIdentity: "idA",
+      symbol: "default",
+      revisionId: "rev-1",
+      retained: true,
+    };
+
+    it("prints the source pin as JSON under --pattern-identity --json", async () => {
+      const out = await captureStdout(() =>
+        inspectPieceFromCommand(
+          { ...OPTIONS, patternIdentity: true, json: true },
+          { readSourcePin: () => Promise.resolve(PIN) },
+        )
+      );
+      expect(JSON.parse(out)).toEqual(PIN);
+    });
+
+    it("prints the pin's fields as lines under --pattern-identity", async () => {
+      const out = await captureStdout(() =>
+        inspectPieceFromCommand({ ...OPTIONS, patternIdentity: true }, {
+          readSourcePin: () => Promise.resolve(PIN),
+        })
+      );
+      expect(out).toContain("identity: idA");
+      expect(out).toContain("revision: rev-1");
+      expect(out).toContain("retained: true");
+    });
+
+    it("exits 1 under --pattern-identity for a piece with no identity", async () => {
+      let exitCode: number | undefined;
+      await expect(
+        inspectPieceFromCommand({ ...OPTIONS, patternIdentity: true }, {
+          readSourcePin: () => Promise.resolve(undefined),
+          printError: () => {},
+          exit: (code) => {
+            exitCode = code;
+            throw new ExitSentinel();
+          },
+        }),
+      ).rejects.toThrow(ExitSentinel);
+      expect(exitCode).toBe(1);
+    });
+
+    it("is the action the piece command registers for inspect", () => {
+      const registered = piece.getCommand("inspect") as unknown as {
+        actionHandler: unknown;
+      };
+      expect(registered.actionHandler).toBe(inspectPieceFromCommand);
+    });
+  });
+});

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -165,6 +165,7 @@ describe("piece-survey", () => {
             path: "topics",
             retarget: ["topics=topic.tsx@r1"],
             root: "patterns",
+            mainExport: "Other",
             dangerouslyAllowIncompatibleSchema: true,
             validator: "demand.json",
           },
@@ -180,6 +181,7 @@ describe("piece-survey", () => {
       expect(request?.retargets?.[0].phase).toBe("topics");
       expect(request?.retargets?.[0].source.root?.endsWith("/patterns"))
         .toBe(true);
+      expect(request?.retargets?.[0].source.mainExport).toBe("Other");
       expect(request?.allowIncompatible).toBe(true);
       expect(request?.validatorPath?.endsWith("/demand.json")).toBe(true);
     });

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 import type { PiecePlan, SurveyResult } from "@commonfabric/piece/ops";
 import { decode } from "@commonfabric/utils/encoding";
 
-import type { SurveyRunRequest } from "../lib/bulk.ts";
+import { runSurvey, type SurveyRunRequest } from "../lib/bulk.ts";
 import {
   inspectPieceFromCommand,
   parseRetargetFlag,
@@ -39,6 +39,7 @@ const PLAN: PiecePlan = {
     v: 1,
     space: "did:key:test",
     takenAt: "2026-08-24T00:00:00.000Z",
+    selector: "collection" as const,
     enumerated: { collection: 1, registry: 0, registeredOutside: 0 },
   },
   rows: [{
@@ -78,6 +79,15 @@ describe("piece-survey", () => {
       expect(() => parseRetargetFlag("=main.tsx")).toThrow("--retarget");
       expect(() => parseRetargetFlag("topics=")).toThrow("--retarget");
     });
+
+    it("keeps an @-named directory whole and takes only a trailing rev", () => {
+      const scoped = parseRetargetFlag("topics=/repo/@scope/member.tsx");
+      expect(scoped.source.main).toBe("/repo/@scope/member.tsx");
+      expect(scoped.rev).toBeUndefined();
+      const both = parseRetargetFlag("topics=/repo/@scope/member.tsx@v2");
+      expect(both.source.main).toBe("/repo/@scope/member.tsx");
+      expect(both.rev).toBe("v2");
+    });
   });
 
   describe("surveyFromCommand()", () => {
@@ -102,7 +112,7 @@ describe("piece-survey", () => {
         holder: "board",
         path: ["topics"],
       });
-      expect(hints).toEqual(["members: 1 on idA"]);
+      expect(hints).toEqual(["members: 1 on idA#default"]);
     });
 
     it("writes the plan to --out instead of stdout", async () => {
@@ -186,6 +196,41 @@ describe("piece-survey", () => {
       expect(request?.validatorPath?.endsWith("/demand.json")).toBe(true);
     });
 
+    it("throws for a scoped holder or a scoped list entry", async () => {
+      await expect(
+        surveyFromCommand(
+          { ...OPTIONS, piece: "board@user", path: "topics" },
+          { runSurvey: () => Promise.resolve(COMPLETE) },
+        ),
+      ).rejects.toThrow("scope");
+      await expect(
+        surveyFromCommand(
+          { ...OPTIONS, piece: undefined, list: ["fid1:x@user"] },
+          { runSurvey: () => Promise.resolve(COMPLETE) },
+        ),
+      ).rejects.toThrow("scope");
+    });
+
+    it("strips the canonical form's leading slash from a list entry", async () => {
+      let request: SurveyRunRequest | undefined;
+      await captureStdout(() =>
+        surveyFromCommand(
+          { ...OPTIONS, piece: undefined, list: ["/of:fid1:x"] },
+          {
+            runSurvey: (_config, req) => {
+              request = req;
+              return Promise.resolve(COMPLETE);
+            },
+            printHint: () => {},
+          },
+        )
+      );
+      expect(request?.selector).toEqual({
+        kind: "list",
+        pieces: ["of:fid1:x"],
+      });
+    });
+
     it("throws for a collection survey without --path", async () => {
       await expect(
         surveyFromCommand({ ...OPTIONS }, {
@@ -225,11 +270,29 @@ describe("piece-survey", () => {
       expect(errors.join("\n")).toContain("of:fid1:orphan");
     });
 
-    it("is the action the piece command registers for survey", () => {
+    it("routes cf piece survey to surveyFromCommand", () => {
       const registered = piece.getCommand("survey") as unknown as {
         actionHandler: unknown;
       };
       expect(registered.actionHandler).toBe(surveyFromCommand);
+    });
+  });
+
+  describe("runSurvey()", () => {
+    it("refuses two retargets naming one phase before loading anything", async () => {
+      await expect(
+        runSurvey({} as never, {
+          selector: { kind: "list", pieces: ["fid1:x"] },
+          retargets: [
+            { phase: "items", source: { main: "a.tsx" } },
+            { phase: "items", source: { main: "b.tsx" } },
+          ],
+        }, {
+          loadPieces: () => {
+            throw new Error("must not load");
+          },
+        }),
+      ).rejects.toThrow("name the phase items");
     });
   });
 
@@ -278,7 +341,7 @@ describe("piece-survey", () => {
       expect(exitCode).toBe(1);
     });
 
-    it("is the action the piece command registers for inspect", () => {
+    it("routes cf piece inspect to inspectPieceFromCommand", () => {
       const registered = piece.getCommand("inspect") as unknown as {
         actionHandler: unknown;
       };

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -1,13 +1,19 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { PiecePlan, SurveyResult } from "@commonfabric/piece/ops";
 import { decode } from "@commonfabric/utils/encoding";
+
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PiecesController } from "@commonfabric/piece/ops";
 
 import { runSurvey, type SurveyRunRequest } from "../lib/bulk.ts";
 import {
   inspectPieceFromCommand,
   parseRetargetFlag,
   piece,
+  setQuietMode,
   surveyFromCommand,
 } from "../commands/piece.ts";
 
@@ -24,6 +30,8 @@ function captureStdout(fn: () => Promise<void>): Promise<string> {
 }
 
 class ExitSentinel extends Error {}
+
+const signer = await Identity.fromPassphrase("cli bulk survey");
 
 const OPTIONS = {
   apiUrl: "http://localhost:8000",
@@ -61,6 +69,9 @@ const COMPLETE: SurveyResult = {
 };
 
 describe("piece-survey", () => {
+  // The fixtures pass `quiet`, and the action applies it globally.
+  afterEach(() => setQuietMode(false));
+
   describe("parseRetargetFlag()", () => {
     it("returns the phase, an absolute main path, and the rev label", () => {
       const parsed = parseRetargetFlag("topics=patterns/topic.tsx@abc123");
@@ -113,6 +124,31 @@ describe("piece-survey", () => {
         path: ["topics"],
       });
       expect(hints).toEqual(["members: 1 on idA#default"]);
+    });
+
+    it("honors the inherited --quiet by silencing hints that otherwise print", async () => {
+      const seen: string[] = [];
+      const originalError = console.error;
+      console.error = (...parts: unknown[]) => {
+        seen.push(parts.join(" "));
+      };
+      try {
+        const run = (quiet: boolean) =>
+          surveyFromCommand(
+            { ...OPTIONS, path: "topics", out: "plan.jsonl", quiet },
+            {
+              runSurvey: () => Promise.resolve(COMPLETE),
+              writeTextFile: () => Promise.resolve(),
+            },
+          );
+        await run(false);
+        expect(seen.join("\n")).toContain("members: 1 on idA#default");
+        seen.length = 0;
+        await run(true);
+        expect(seen).toEqual([]);
+      } finally {
+        console.error = originalError;
+      }
     });
 
     it("writes the plan to --out instead of stdout", async () => {
@@ -279,6 +315,94 @@ describe("piece-survey", () => {
   });
 
   describe("runSurvey()", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let pieces: PiecesController;
+
+    beforeEach(async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      pieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `cli-bulk-survey-${crypto.randomUUID()}`,
+        }),
+        runtime,
+      );
+      await pieces.synced();
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /** The smallest surveyable member; `version` names the generation. */
+    function memberProgram(version: string): RuntimeProgram {
+      return {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern } from 'commonfabric';",
+            "export default pattern<{ seed?: string }>(() => ({",
+            "  [NAME]: 'Member',",
+            `  version: ${JSON.stringify(version)},`,
+            "}));",
+            "",
+          ].join("\n"),
+        }],
+      };
+    }
+
+    it("resolves a list selector and surveys it end to end", async () => {
+      const member = await pieces.create(memberProgram("one"), { input: {} });
+      const resolved: string[] = [];
+      const survey = await runSurvey({} as never, {
+        selector: { kind: "list", pieces: [member.id] },
+        validatorPath: "/demand.json",
+      }, {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceAddress: (_pieces, token) => {
+          resolved.push(token);
+          return Promise.resolve(token);
+        },
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            type: "object",
+            properties: { version: { type: "string" } },
+            required: ["version"],
+          })),
+      });
+      expect(resolved).toEqual([member.id]);
+      expect(survey.complete).toBe(true);
+      expect(survey.plan.rows.length).toBe(1);
+      expect(survey.plan.rows[0].expect.retained).toBe(true);
+      expect(survey.validatorFailures).toEqual([]);
+    });
+
+    it("resolves the collection holder the way the other piece verbs do", async () => {
+      const member = await pieces.create(memberProgram("one"), { input: {} });
+      await expect(
+        runSurvey({} as never, {
+          selector: {
+            kind: "collection",
+            holder: "board-slug",
+            path: ["members"],
+          },
+        }, {
+          loadPieces: () => Promise.resolve(pieces),
+          // The slug resolves to a real piece whose input holds no
+          // collection at the path, so the refusal names the absence —
+          // proof the resolved holder, not the slug text, was read.
+          resolvePieceAddress: () => Promise.resolve(member.id),
+        }),
+      ).rejects.toThrow("stores no collection at members");
+    });
+
     it("refuses two retargets naming one phase before loading anything", async () => {
       await expect(
         runSurvey({} as never, {

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -8,7 +8,11 @@ import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PiecesController } from "@commonfabric/piece/ops";
 
-import { runSurvey, type SurveyRunRequest } from "../lib/bulk.ts";
+import {
+  readSourcePin,
+  runSurvey,
+  type SurveyRunRequest,
+} from "../lib/bulk.ts";
 import {
   inspectPieceFromCommand,
   parseRetargetFlag,
@@ -124,6 +128,33 @@ describe("piece-survey", () => {
         path: ["topics"],
       });
       expect(hints).toEqual(["members: 1 on idA#default"]);
+    });
+
+    it("refuses a --side that is neither input nor result", async () => {
+      await expect(
+        surveyFromCommand({ ...OPTIONS, path: "topics", side: "bogus" }, {
+          runSurvey: () => Promise.resolve(COMPLETE),
+        }),
+      ).rejects.toThrow('--side takes input or result, got "bogus"');
+    });
+
+    it("names each validator failure as a hint", async () => {
+      const hints: string[] = [];
+      await captureStdout(() =>
+        surveyFromCommand({ ...OPTIONS, path: "topics" }, {
+          runSurvey: () =>
+            Promise.resolve({
+              ...COMPLETE,
+              validatorFailures: [
+                { piece: "of:fid1:aaa", problem: "missing version" },
+              ],
+            }),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(hints).toContain("validator: of:fid1:aaa missing version");
     });
 
     it("honors the inherited --quiet by silencing hints that otherwise print", async () => {
@@ -403,6 +434,47 @@ describe("piece-survey", () => {
       ).rejects.toThrow("stores no collection at members");
     });
 
+    it("reads a created piece's source pin over the controller", async () => {
+      const member = await pieces.create(memberProgram("one"), { input: {} });
+      const pin = await readSourcePin({ piece: member.id } as never, {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+      });
+      expect(pin?.symbol).toBe("default");
+      expect(pin?.retained).toBe(true);
+      expect(pin?.patternIdentity).toBeDefined();
+    });
+
+    it("stamps a resolved retarget onto the rows carrying its phase", async () => {
+      const member = await pieces.create(memberProgram("one"), { input: {} });
+      const dir = await Deno.makeTempDir({ prefix: "cli-bulk-retarget" });
+      try {
+        await Deno.writeTextFile(
+          `${dir}/main.tsx`,
+          memberProgram("two").files[0].contents,
+        );
+        const survey = await runSurvey({} as never, {
+          selector: { kind: "list", pieces: [member.id] },
+          retargets: [
+            { phase: "list", source: { main: `${dir}/main.tsx` }, rev: "r1" },
+          ],
+          allowIncompatible: true,
+        }, {
+          loadPieces: () => Promise.resolve(pieces),
+          resolvePieceAddress: (_pieces, token) => Promise.resolve(token),
+        });
+        const op = survey.plan.rows[0].op;
+        if (op?.kind !== "retarget") {
+          throw new Error("expected a retarget op on the list row");
+        }
+        expect(op.rev).toBe("r1");
+        expect(op.allowIncompatible).toBe(true);
+        expect(op.patternIdentity).toBeDefined();
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
     it("refuses two retargets naming one phase before loading anything", async () => {
       await expect(
         runSurvey({} as never, {
@@ -428,6 +500,35 @@ describe("piece-survey", () => {
       revisionId: "rev-1",
       retained: true,
     };
+
+    it("summarizes and prints the general inspection in both output modes", async () => {
+      const pieceData = {
+        id: "p1",
+        name: "Board",
+        patternRef: undefined,
+        source: { a: 1 },
+        result: { b: 2 },
+        cachedResultFields: [],
+        readingFrom: [],
+        readBy: [],
+      } as never;
+      const rendered: Array<{ value: unknown; json: boolean | undefined }> = [];
+      const render = (value: unknown, config?: { json?: boolean }) => {
+        rendered.push({ value, json: config?.json });
+      };
+      const deps = {
+        inspectPiece: () => Promise.resolve(pieceData),
+        render,
+      };
+      await inspectPieceFromCommand(
+        { ...OPTIONS, summary: true, json: true },
+        deps,
+      );
+      expect(rendered[0].json).toBe(true);
+      expect(rendered[0].value).toMatchObject({ id: "p1" });
+      await inspectPieceFromCommand({ ...OPTIONS }, deps);
+      expect(String(rendered[1].value)).toContain("=== Piece: p1 ===");
+    });
 
     it("prints the source pin as JSON under --pattern-identity --json", async () => {
       const out = await captureStdout(() =>

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -37,6 +37,13 @@ class ExitSentinel extends Error {}
 
 const signer = await Identity.fromPassphrase("cli bulk survey");
 
+// The 43-character handle length clears the canonical parser's threshold
+// below which an id reads as a human name and is refused.
+const HANDLE = "baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+const SPACE_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const OTHER_SPACE_DID =
+  "did:key:z6MkrZ1r5XBFZjBU34qyD8fueMbMRkKw17BZaq2ivKFjnz2z";
+
 const OPTIONS = {
   apiUrl: "http://localhost:8000",
   identity: "/tmp/test-identity.pem",
@@ -282,7 +289,7 @@ describe("piece-survey", () => {
       let request: SurveyRunRequest | undefined;
       await captureStdout(() =>
         surveyFromCommand(
-          { ...OPTIONS, piece: undefined, list: ["/of:fid1:x"] },
+          { ...OPTIONS, piece: undefined, list: [`/of:fid1:${HANDLE}`] },
           {
             runSurvey: (_config, req) => {
               request = req;
@@ -294,8 +301,117 @@ describe("piece-survey", () => {
       );
       expect(request?.selector).toEqual({
         kind: "list",
-        pieces: ["of:fid1:x"],
+        pieces: [`of:fid1:${HANDLE}`],
       });
+    });
+
+    it("folds a list entry's embedded space into the command's target", async () => {
+      const withEmbedded = `/@${SPACE_DID}/of:fid1:${HANDLE}`;
+      let config: { space?: string; embeddedSpaces?: string[] } | undefined;
+      let request: SurveyRunRequest | undefined;
+      const deps = {
+        runSurvey: (
+          cfg: { space?: string; embeddedSpaces?: string[] },
+          req: SurveyRunRequest,
+        ) => {
+          config = cfg;
+          request = req;
+          return Promise.resolve(COMPLETE);
+        },
+        printHint: () => {},
+      };
+      // No --space: the embedded DID supplies it.
+      await captureStdout(() =>
+        surveyFromCommand(
+          {
+            ...OPTIONS,
+            space: undefined,
+            piece: undefined,
+            list: [
+              withEmbedded,
+            ],
+          },
+          deps as never,
+        )
+      );
+      expect(config?.space).toBe(SPACE_DID);
+      expect(config?.embeddedSpaces).toEqual([SPACE_DID]);
+      expect(request?.selector).toEqual({
+        kind: "list",
+        pieces: [`of:fid1:${HANDLE}`],
+      });
+      // A matching --space DID: agreed at parse time, nothing deferred.
+      await captureStdout(() =>
+        surveyFromCommand(
+          {
+            ...OPTIONS,
+            space: SPACE_DID,
+            piece: undefined,
+            list: [
+              withEmbedded,
+            ],
+          },
+          deps as never,
+        )
+      );
+      expect(config?.space).toBe(SPACE_DID);
+      expect(config?.embeddedSpaces).toBeUndefined();
+      // A --space name: the comparison defers to the session open.
+      await captureStdout(() =>
+        surveyFromCommand(
+          { ...OPTIONS, piece: undefined, list: [withEmbedded] },
+          deps as never,
+        )
+      );
+      expect(config?.space).toBe("home");
+      expect(config?.embeddedSpaces).toEqual([SPACE_DID]);
+    });
+
+    it("refuses a list entry whose embedded space contradicts the target", async () => {
+      await expect(
+        surveyFromCommand(
+          {
+            ...OPTIONS,
+            space: OTHER_SPACE_DID,
+            piece: undefined,
+            list: [`/@${SPACE_DID}/of:fid1:${HANDLE}`],
+          },
+          { runSurvey: () => Promise.resolve(COMPLETE) },
+        ),
+      ).rejects.toThrow("names space");
+      // Two entries embedding different spaces cannot be one survey: the
+      // first entry's space becomes the target the second is parsed against.
+      await expect(
+        surveyFromCommand(
+          {
+            ...OPTIONS,
+            space: undefined,
+            piece: undefined,
+            list: [
+              `/@${SPACE_DID}/of:fid1:${HANDLE}`,
+              `/@${OTHER_SPACE_DID}/of:fid1:${HANDLE}`,
+            ],
+          },
+          { runSurvey: () => Promise.resolve(COMPLETE) },
+        ),
+      ).rejects.toThrow("names space");
+    });
+
+    it("refuses a list entry carrying a path, a scope, or #argument", async () => {
+      for (
+        const [entry, message] of [
+          [`/of:fid1:${HANDLE}/topics/0`, "drop the path"],
+          [`/of:fid1:${HANDLE}@user`, "@scope suffix"],
+          [`/of:fid1:${HANDLE}#argument`, "#argument suffix"],
+        ]
+      ) {
+        await expect(
+          surveyFromCommand(
+            { ...OPTIONS, piece: undefined, list: [entry] },
+            { runSurvey: () => Promise.resolve(COMPLETE) },
+          ),
+        ).rejects.toThrow(message);
+      }
     });
 
     it("throws for a collection survey without --path", async () => {

--- a/packages/piece/src/ops/bulk-survey.ts
+++ b/packages/piece/src/ops/bulk-survey.ts
@@ -237,6 +237,20 @@ export async function surveyPieces(
   const retainedByIdentity = new Map<string, boolean>();
   const rows: PiecePlanRow[] = [];
   const problems: SurveyProblem[] = [];
+  const validator = options.validator as unknown;
+  if (
+    validator !== undefined && typeof validator !== "boolean" &&
+    (typeof validator !== "object" || validator === null ||
+      Array.isArray(validator))
+  ) {
+    // The type admits only a schema, but the value usually arrives from a
+    // caller-parsed file. `null` is not `undefined`, and shaping by it
+    // validates nothing — a validator that cannot fail would report a clean
+    // board it never read.
+    throw new Error(
+      "A validator must be a JSON schema: an object or a boolean.",
+    );
+  }
   const validatorFailures: SurveyProblem[] = [];
 
   for (const { piece, phase } of selected) {

--- a/packages/piece/test/ops/bulk-survey.test.ts
+++ b/packages/piece/test/ops/bulk-survey.test.ts
@@ -545,6 +545,18 @@ describe("bulk-survey", () => {
         .toEqual([holder.id]);
     });
 
+    it("throws for a validator that is not a schema", async () => {
+      const a = await pieces.create(generationProgram("a"), { input: {} });
+      for (const validator of [null, [], "x", 7]) {
+        await expect(
+          surveyPieces(pieces, {
+            selector: { kind: "list", pieces: [a.id] },
+            validator: validator as never,
+          }),
+        ).rejects.toThrow("an object or a boolean");
+      }
+    });
+
     it("accepts a cell handle exactly where the validator declares asCell", async () => {
       const a = await pieces.create(generationProgram("a"), { input: {} });
 


### PR DESCRIPTION
## Why

Stage 1's survey library (#6211) has no way to be invoked. This is the second of the three stage-1 PRs from [bulk piece operations](docs/plans/piece-bulk-operations.md) (#6183): the thin CLI wrapper, spelled provisionally — decision 1 (how bulk is spelled) stays deferred to stage 3, and both help texts say so.

**Stacked on #6211** (base is its branch); it rebases onto `main` and leaves draft when #6211 merges. Per the repo's CI gating, a stacked PR runs no CI — the suites ran locally (below).

## What Changed

- **`cf piece survey`** — holder + `--path` (collection selector; members then holder, children-first built in) or repeated `--list`; per-phase `--retarget <phase>=<main>[@rev]` with shared `--root/--test/--datafile` (identity computed from the source is the pin; `rev` a label); `--dangerously-allow-incompatible-schema` stamps the per-row field; `--validator <schema.json>`; plan to stdout or `--out`; tally and findings on stderr; **exits 1 when the survey is incomplete**, naming what the plan lacks. `survey` reserves stdout for machine output (json-output allowlist).
- **`cf piece inspect --pattern-identity`** — the cheap source-pin read (identity, symbol, revision, retained; never runs the piece, pulls nothing else). Named so because `--identity` is the global keyfile option. The inspect action moves to the FromCommand seam (`inspectPieceFromCommand`), making both modes unit-testable.
- `packages/cli/lib/bulk.ts` — `readSourcePin` / `runSurvey` over the library; `readPiecePin` joins the `@commonfabric/piece/ops` barrel.
- README: piece-discovery section gains both commands; the `--json` output-switch list gains `survey`.

## Test plan

`packages/cli/test/piece-survey.test.ts` (18 steps, green): `parseRetargetFlag` forms and refusals; plan to stdout with tally hints; `--out`; `--json`; list selector; retarget/override/validator pass-through; **exit-1 on incomplete, naming the orphan**; pin JSON/human/missing; and registration pins asserting `survey`/`inspect` dispatch to these actions. Full `packages/cli` suite green locally; `deno task check`, repo `fmt --check`, `lint`, `check-skill-facts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
