### PR TITLE
test(cli): the bulk-survey drill — a seeded board, surveyed, and the plan asserted

### DIFF
--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -521,9 +521,8 @@ compiling; and the drill.
 - [x] The survey and the pin read are invocable from `cf`
       (`cf piece survey`, `cf piece inspect --pattern-identity`),
       provisionally spelled per decision 1.
-- [ ] The stage-1 drill runs in continuous integration, under the CLI
-      integration suite's `piece-call` section. Ticked by the stacked
-      change that lands it.
+- [x] The stage-1 drill runs in continuous integration, under the CLI
+      integration suite's `piece-call` section.
 
 ### 2. Repair, by a supplied fixer
 

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,8 +1,7 @@
 # Bulk piece operations
 
-**Status:** proposed; stage 1's survey library is built and in review, its
-`cf` entry points and CI drill follow in stacked changes immediately behind
-it, and every later stage is unbuilt. This is the design and build sequence for changing
+**Status:** proposed; stage 1 — the survey library, its `cf` entry points,
+and its CI drill — is built, and every later stage is unbuilt. This is the design and build sequence for changing
 many pieces in one space as one reviewable, resumable operation. Driven by
 recurring Topics board upgrades.
 
@@ -502,7 +501,7 @@ compiling; and the drill.
 - [x] Each row records whether the source behind its recorded identity is
       still retained in the space, so a row with no rollback target is known
       before the run rather than during the incident.
-- [ ] One process handles a board-sized set, start to finish.
+- [x] One process handles a board-sized set, start to finish.
 - [x] The read reports live state on every invocation, and a test proves it:
       a read taken after a change reflects the change.
 - [x] The output is a plan — the same artifact the later stages consume —

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -60,16 +60,21 @@ if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
   bad "deploy failed"
   exit 1
 fi
+FILED=0
 for title in alpha beta gamma; do
-  $CF call -q --piece "$BOARD" $ARGS addMember "{\"title\":\"$title\"}" \
-    >/dev/null 2>&1 || bad "addMember $title failed"
+  if $CF call -q --piece "$BOARD" $ARGS addMember "{\"title\":\"$title\"}" \
+    >/dev/null 2>&1; then
+    FILED=$((FILED + 1))
+  else
+    bad "addMember $title failed"
+  fi
 done
-ok "filed alpha, beta, gamma"
+check "3" "$FILED" "filed alpha, beta, gamma"
 
 step "2. Survey the collection, stamping a retarget"
 PLAN="$WORK/plan.jsonl"
 if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
-  --retarget "items=$RETARGET_FIXTURE@drill" \
+  --retarget "items=$RETARGET_FIXTURE@drill" --main-export Member \
   --out "$PLAN" 2>"$WORK/survey.err"; then
   ok "survey exited 0 (complete)"
 else
@@ -80,10 +85,11 @@ fi
 
 step "3. The header accounts for the selection"
 HEADER_FACTS=$(head -1 "$PLAN" | jq -r \
-  '[.kind, (.v|tostring), (.enumerated.collection|tostring),
-    (.enumerated.registeredOutside|tostring)] | @tsv')
-check "$(printf 'piece-plan\t1\t3\t0')" "$HEADER_FACTS" \
-  "header: piece-plan v1, collection 3, nothing registered outside"
+  '[.kind, (.v|tostring), .selector, (.enumerated.collection|tostring),
+    (.enumerated.registeredOutside|tostring),
+    ((has("problems") or has("outside"))|tostring)] | @tsv')
+check "$(printf 'piece-plan\t1\tcollection\t3\t0\tfalse')" "$HEADER_FACTS" \
+  "header: collection of 3, nothing outside, nothing unaccounted for"
 
 step "4. Rows are members in order, then the holder"
 PHASES=$(tail -n +2 "$PLAN" | jq -rs 'map(.phase) | join(",")')
@@ -106,25 +112,33 @@ step "6. The retarget stamp pins the target identity, on member rows only"
 STAMPS=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "items") | .op)
    | [(map(.kind) | unique | join(",")), (map(.rev) | unique | join(",")),
+      (map(.symbol) | unique | join(",")),
       (map(.patternIdentity) | unique | length | tostring)] | @tsv')
-check "$(printf 'retarget\tdrill\t1')" "$STAMPS" \
-  "member rows carry one retarget target, rev label 'drill'"
-TARGET_IS_CURRENT=$(tail -n +2 "$PLAN" | jq -rs \
+check "$(printf 'retarget\tdrill\tMember\t1')" "$STAMPS" \
+  "member rows carry one retarget target, rev 'drill', export Member"
+TARGET_DIFFERS=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "items"))
-   | map(.op.patternIdentity == .expect.patternIdentity) | unique | join(",")')
-check "false" "$TARGET_IS_CURRENT" \
-  "the stamped identity differs from the one the members run"
+   | map((.op.patternIdentity != null) and
+       (.op.patternIdentity != .expect.patternIdentity))
+   | unique | join(",")')
+check "true" "$TARGET_DIFFERS" \
+  "every member row is stamped, and with a different reference"
 HOLDER_OP=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "holder") | has("op")) | join(",")')
 check "false" "$HOLDER_OP" "the holder row carries no op"
 
 step "7. The single-piece pin agrees with the holder row"
-PIN_IDENTITY=$($CF piece inspect --pattern-identity --json \
-  --piece "$BOARD" $ARGS 2>/dev/null | jq -r '.patternIdentity')
-HOLDER_IDENTITY=$(tail -n +2 "$PLAN" | jq -rs \
-  'map(select(.phase == "holder") | .expect.patternIdentity) | first')
-check "$HOLDER_IDENTITY" "$PIN_IDENTITY" \
-  "inspect --pattern-identity matches the survey's holder row"
+PIN_FACTS=$($CF piece inspect --pattern-identity --json \
+  --piece "$BOARD" $ARGS 2>/dev/null |
+  jq -r '[.patternIdentity, .symbol, (.retained|tostring)] | @tsv')
+HOLDER_FACTS=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "holder") | .expect)
+   | first | [.patternIdentity, .symbol, (.retained|tostring)] | @tsv')
+if [ -z "$PIN_FACTS" ] || [ -z "$HOLDER_FACTS" ]; then
+  bad "pin extraction came back empty"
+fi
+check "$HOLDER_FACTS" "$PIN_FACTS" \
+  "inspect's source pin matches the survey's holder row, symbol included"
 
 step "8. A change shows on the next survey (live read)"
 $CF call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
@@ -132,6 +146,32 @@ $CF call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
 AFTER=$($CF piece survey -q --piece "$BOARD" --path items $ARGS \
   2>/dev/null | head -1 | jq -r '.enumerated.collection')
 check "4" "$AFTER" "the after-survey counts the member added since"
+
+step "9. A registered in-scope orphan makes the survey refuse"
+ORPHAN=$($CF piece new --quiet --main-export Member \
+  "$SCRIPT_DIR/pattern/bulk-member.tsx" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
+if [ -n "$ORPHAN" ]; then ok "registered orphan $ORPHAN"; else
+  bad "orphan deploy failed"
+fi
+if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
+  >/dev/null 2>"$WORK/incomplete.err"; then
+  bad "survey exited 0 despite a registered in-scope orphan"
+else
+  ok "survey exited nonzero with an orphan registered"
+fi
+if grep -q "registered outside the selection" "$WORK/incomplete.err"; then
+  ok "the refusal names the orphan's standing"
+else
+  bad "the refusal does not name the orphan"
+fi
+
+step "10. A list survey claims no containment"
+LIST_FACTS=$($CF piece survey -q --list "$BOARD" $ARGS 2>/dev/null |
+  head -1 | jq -r '[.selector, (.enumerated.collection|tostring),
+    (.enumerated.registeredOutside|tostring)] | @tsv')
+check "$(printf 'list\t1\t0')" "$LIST_FACTS" \
+  "list of one row, complete despite the orphan"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# The bulk-survey drill: deploy a board whose members are created through its
+# own verb, survey it, and assert the plan — the stage-1 drill of
+# docs/plans/piece-bulk-operations.md, which finishes each stage with a CI
+# drill so "does the migration tooling still work?" stays a CI result.
+#
+# It deploys pattern/bulk-board.tsx (members from pattern/bulk-member.tsx, a
+# separate module so member and board identities differ, the way topic.tsx
+# sits beside the topics board's main.tsx) and stamps a retarget from
+# pattern/bulk-member-v2.tsx, which is never deployed: the survey computes the
+# identity the source produces without writing anything. The fixtures belong
+# to this drill alone.
+#
+# Every step names the property it asserts. A fresh space per run, no prior
+# state, no store access — the survey is API-only.
+#
+# Run standalone against any host:
+#   API_URL=http://localhost:8000 packages/cli/integration/bulk-survey-drill.sh
+#
+# CI runs it through integration.sh's `piece-call` section; the
+# `bulk-survey-drill` section is the standalone selector.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+BOARD_FIXTURE="$SCRIPT_DIR/pattern/bulk-board.tsx"
+RETARGET_FIXTURE="$SCRIPT_DIR/pattern/bulk-member-v2.tsx"
+
+# Prefer a built binary when the harness supplies one; fall back to source.
+if [ -n "${CF_BINARY:-}" ]; then
+  CF="$CF_BINARY"
+else
+  CF="deno task --quiet --cwd $REPO_ROOT cf"
+fi
+
+PASS=0
+FAIL=0
+step() { printf '\n== %s\n' "$1"; }
+ok() { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
+check() {
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
+}
+
+WORK="$(mktemp -d)"
+SPACE="${SPACE:-$(mktemp -u bulkXXXXXXXX)}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  $CF id new >"$CF_IDENTITY" 2>/dev/null
+fi
+ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+echo "API_URL=$API_URL"
+echo "SPACE=$SPACE"
+
+step "1. Deploy the board and file three members through its verb"
+BOARD=$($CF piece new --quiet "$BOARD_FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
+if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
+  bad "deploy failed"
+  exit 1
+fi
+for title in alpha beta gamma; do
+  $CF call -q --piece "$BOARD" $ARGS addMember "{\"title\":\"$title\"}" \
+    >/dev/null 2>&1 || bad "addMember $title failed"
+done
+ok "filed alpha, beta, gamma"
+
+step "2. Survey the collection, stamping a retarget"
+PLAN="$WORK/plan.jsonl"
+if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
+  --retarget "items=$RETARGET_FIXTURE@drill" \
+  --out "$PLAN" 2>"$WORK/survey.err"; then
+  ok "survey exited 0 (complete)"
+else
+  bad "survey exited nonzero"
+  sed 's/^/  | /' "$WORK/survey.err"
+  exit 1
+fi
+
+step "3. The header accounts for the selection"
+HEADER_FACTS=$(head -1 "$PLAN" | jq -r \
+  '[.kind, (.v|tostring), (.enumerated.collection|tostring),
+    (.enumerated.registeredOutside|tostring)] | @tsv')
+check "$(printf 'piece-plan\t1\t3\t0')" "$HEADER_FACTS" \
+  "header: piece-plan v1, collection 3, nothing registered outside"
+
+step "4. Rows are members in order, then the holder"
+PHASES=$(tail -n +2 "$PLAN" | jq -rs 'map(.phase) | join(",")')
+check "items,items,items,holder" "$PHASES" "phase order, holder last"
+DISTINCT_PIECES=$(tail -n +2 "$PLAN" | jq -rs 'map(.piece) | unique | length')
+check "4" "$DISTINCT_PIECES" "four distinct pieces"
+
+step "5. Members share one identity; the holder has its own"
+MEMBER_IDENTITIES=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "items") | .expect.patternIdentity) | unique | length')
+check "1" "$MEMBER_IDENTITIES" "one identity across the members"
+CROSS=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(.expect.patternIdentity) | unique | length')
+check "2" "$CROSS" "the holder's identity is not the members'"
+RETAINED=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(.expect.retained) | unique | join(",")')
+check "true" "$RETAINED" "every row's source is retained"
+
+step "6. The retarget stamp pins the target identity, on member rows only"
+STAMPS=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "items") | .op)
+   | [(map(.kind) | unique | join(",")), (map(.rev) | unique | join(",")),
+      (map(.patternIdentity) | unique | length | tostring)] | @tsv')
+check "$(printf 'retarget\tdrill\t1')" "$STAMPS" \
+  "member rows carry one retarget target, rev label 'drill'"
+TARGET_IS_CURRENT=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "items"))
+   | map(.op.patternIdentity == .expect.patternIdentity) | unique | join(",")')
+check "false" "$TARGET_IS_CURRENT" \
+  "the stamped identity differs from the one the members run"
+HOLDER_OP=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "holder") | has("op")) | join(",")')
+check "false" "$HOLDER_OP" "the holder row carries no op"
+
+step "7. The single-piece pin agrees with the holder row"
+PIN_IDENTITY=$($CF piece inspect --pattern-identity --json \
+  --piece "$BOARD" $ARGS 2>/dev/null | jq -r '.patternIdentity')
+HOLDER_IDENTITY=$(tail -n +2 "$PLAN" | jq -rs \
+  'map(select(.phase == "holder") | .expect.patternIdentity) | first')
+check "$HOLDER_IDENTITY" "$PIN_IDENTITY" \
+  "inspect --pattern-identity matches the survey's holder row"
+
+step "8. A change shows on the next survey (live read)"
+$CF call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
+  >/dev/null 2>&1 || bad "addMember delta failed"
+AFTER=$($CF piece survey -q --piece "$BOARD" --path items $ARGS \
+  2>/dev/null | head -1 | jq -r '.enumerated.collection')
+check "4" "$AFTER" "the after-survey counts the member added since"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -43,6 +43,10 @@ check() {
   if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
 }
 
+# The board-sized bar the plan's stage-1 criterion sets; 113 matches the
+# motivating Topics board.
+MEMBERS_TOTAL=113
+
 WORK="$(mktemp -d)"
 SPACE="${SPACE:-$(mktemp -u bulkXXXXXXXX)}"
 if [ -z "${CF_IDENTITY:-}" ]; then
@@ -71,7 +75,13 @@ for title in alpha beta gamma; do
 done
 check "3" "$FILED" "filed alpha, beta, gamma"
 
-step "2. Survey the collection, stamping a retarget"
+step "2. One call seeds the rest of the board-sized set"
+SEED_EXTRA=$((MEMBERS_TOTAL - 3))
+SEEDED=$($CF call -q --piece "$BOARD" $ARGS seedMembers \
+  "{\"count\":$SEED_EXTRA}" 2>/dev/null | jq -r '.result.filed // empty')
+check "$SEED_EXTRA" "$SEEDED" "one call filed the remaining $SEED_EXTRA"
+
+step "3. Survey the collection, stamping a retarget"
 PLAN="$WORK/plan.jsonl"
 if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
   --retarget "items=$RETARGET_FIXTURE@drill" --main-export Member \
@@ -83,21 +93,27 @@ else
   exit 1
 fi
 
-step "3. The header accounts for the selection"
+step "4. The header accounts for the selection"
 HEADER_FACTS=$(head -1 "$PLAN" | jq -r \
   '[.kind, (.v|tostring), .selector, (.enumerated.collection|tostring),
+    (.enumerated.registry|tostring),
     (.enumerated.registeredOutside|tostring),
     ((has("problems") or has("outside"))|tostring)] | @tsv')
-check "$(printf 'piece-plan\t1\tcollection\t3\t0\tfalse')" "$HEADER_FACTS" \
-  "header: collection of 3, nothing outside, nothing unaccounted for"
+check "$(printf 'piece-plan\t1\tcollection\t%s\t1\t0\tfalse' \
+  "$MEMBERS_TOTAL")" "$HEADER_FACTS" \
+  "header: board-sized collection, the board alone registered, nothing outside"
 
-step "4. Rows are members in order, then the holder"
-PHASES=$(tail -n +2 "$PLAN" | jq -rs 'map(.phase) | join(",")')
-check "items,items,items,holder" "$PHASES" "phase order, holder last"
+step "5. Rows are members in order, then the holder"
+MEMBER_PHASES=$(tail -n +2 "$PLAN" | jq -rs \
+  "map(.phase) | .[0:$MEMBERS_TOTAL] | unique | join(\",\")")
+check "items" "$MEMBER_PHASES" "every member row leads, phased items"
+LAST_PHASE=$(tail -n +2 "$PLAN" | jq -rs 'map(.phase) | last')
+check "holder" "$LAST_PHASE" "the holder row comes last"
 DISTINCT_PIECES=$(tail -n +2 "$PLAN" | jq -rs 'map(.piece) | unique | length')
-check "4" "$DISTINCT_PIECES" "four distinct pieces"
+check "$((MEMBERS_TOTAL + 1))" "$DISTINCT_PIECES" \
+  "one distinct piece per member, plus the holder"
 
-step "5. Members share one identity; the holder has its own"
+step "6. Members share one identity; the holder has its own"
 MEMBER_IDENTITIES=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "items") | .expect.patternIdentity) | unique | length')
 check "1" "$MEMBER_IDENTITIES" "one identity across the members"
@@ -108,7 +124,7 @@ RETAINED=$(tail -n +2 "$PLAN" | jq -rs \
   'map(.expect.retained) | unique | join(",")')
 check "true" "$RETAINED" "every row's source is retained"
 
-step "6. The retarget stamp pins the target identity, on member rows only"
+step "7. The retarget stamp pins the target identity, on member rows only"
 STAMPS=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "items") | .op)
    | [(map(.kind) | unique | join(",")), (map(.rev) | unique | join(",")),
@@ -127,7 +143,7 @@ HOLDER_OP=$(tail -n +2 "$PLAN" | jq -rs \
   'map(select(.phase == "holder") | has("op")) | join(",")')
 check "false" "$HOLDER_OP" "the holder row carries no op"
 
-step "7. The single-piece pin agrees with the holder row"
+step "8. The single-piece pin agrees with the holder row"
 PIN_FACTS=$($CF piece inspect --pattern-identity --json \
   --piece "$BOARD" $ARGS 2>/dev/null |
   jq -r '[.patternIdentity, .symbol, (.retained|tostring)] | @tsv')
@@ -140,14 +156,15 @@ fi
 check "$HOLDER_FACTS" "$PIN_FACTS" \
   "inspect's source pin matches the survey's holder row, symbol included"
 
-step "8. A change shows on the next survey (live read)"
+step "9. A change shows on the next survey (live read)"
 $CF call -q --piece "$BOARD" $ARGS addMember '{"title":"delta"}' \
   >/dev/null 2>&1 || bad "addMember delta failed"
 AFTER=$($CF piece survey -q --piece "$BOARD" --path items $ARGS \
   2>/dev/null | head -1 | jq -r '.enumerated.collection')
-check "4" "$AFTER" "the after-survey counts the member added since"
+check "$((MEMBERS_TOTAL + 1))" "$AFTER" \
+  "the after-survey counts the member added since"
 
-step "9. A registered in-scope orphan makes the survey refuse"
+step "10. A registered in-scope orphan makes the survey refuse"
 ORPHAN=$($CF piece new --quiet --main-export Member \
   "$SCRIPT_DIR/pattern/bulk-member.tsx" $ARGS 2>/dev/null |
   grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
@@ -166,7 +183,7 @@ else
   bad "the refusal does not name the orphan"
 fi
 
-step "10. A list survey claims no containment"
+step "11. A list survey claims no containment"
 LIST_FACTS=$($CF piece survey -q --list "$BOARD" $ARGS 2>/dev/null |
   head -1 | jq -r '[.selector, (.enumerated.collection|tostring),
     (.enumerated.registeredOutside|tostring)] | @tsv')

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1125,6 +1125,15 @@ looked in $root_store and $toolshed_store. Set CF_DRILL_STORE_DIR."
   echo "Successfully ran the topics restore drill for ${API_URL}."
 }
 
+# The bulk-survey drill needs no store: the survey is API-only, so unlike the
+# topics restore drill there is nothing to discover on disk.
+run_bulk_survey_drill() {
+  echo "Running the bulk-survey drill..."
+  API_URL="$API_URL" bash "$SCRIPT_DIR/bulk-survey-drill.sh" ||
+    error "The bulk-survey drill failed."
+  echo "Successfully ran the bulk-survey drill for ${API_URL}."
+}
+
 # The top-level spellings are the same commands as their `cf piece`
 # counterparts (docs/plans/cli-surface-shape.md, step 5). The unit guard
 # (test/piece-data-spellings.test.ts) proves the two mounts share one
@@ -1353,6 +1362,8 @@ case "$SECTION" in
     run_verb_session_gaps
     cf_test_step_begin topics-restore-drill
     run_topics_restore_drill
+    cf_test_step_begin bulk-survey-drill
+    run_bulk_survey_drill
     ;;
   piece-call-retry)
     cf_test_step_begin piece-call-retry
@@ -1377,6 +1388,10 @@ case "$SECTION" in
   topics-drill)
     cf_test_step_begin topics-restore-drill
     run_topics_restore_drill
+    ;;
+  bulk-survey-drill)
+    cf_test_step_begin bulk-survey-drill
+    run_bulk_survey_drill
     ;;
   *)
     error "Unknown CLI integration section: $SECTION"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -59,6 +59,19 @@ cf() {
   return $status
 }
 
+# Delegated scripts (verbs-over-the-cli, verb-session-gaps, and the drills)
+# run cf through $CF_BINARY, falling back to the checkout's deno task when it
+# is unset. Resolve and export it here once, from the same decision cf_impl
+# made, so a child tests the same artifact as the step that invoked it: the
+# external binary on PATH, or unset in local-source mode so the fallback
+# keeps parent and child on the checkout together.
+if [ -z "${CF_CLI_INTEGRATION_USE_LOCAL:-}" ] && [ -z "${CF_BINARY:-}" ]; then
+  CF_BINARY="$(type -P cf || true)"
+fi
+if [ -n "${CF_BINARY:-}" ]; then
+  export CF_BINARY
+fi
+
 PATTERN_SRC="$SCRIPT_DIR/pattern/main.tsx"
 SCHEMA_COMPATIBLE_PATTERN_SRC="$SCRIPT_DIR/pattern/schema-compatible.tsx"
 SCHEMA_INCOMPATIBLE_PATTERN_SRC="$SCRIPT_DIR/pattern/schema-incompatible.tsx"

--- a/packages/cli/integration/pattern/bulk-board.tsx
+++ b/packages/cli/integration/pattern/bulk-board.tsx
@@ -1,0 +1,57 @@
+/**
+ * Board fixture for the bulk-survey drill: a holder whose stored input
+ * carries a collection of `Member` sub-pieces, created through its own
+ * `addMember` verb — which is exactly why they are absent from the piece
+ * registry, the absence the survey's containment check exists to expose.
+ * Nothing else deploys this file: the drill owns its subject.
+ */
+
+import {
+  action,
+  type Default,
+  NAME,
+  pattern,
+  type Stream,
+  type Writable,
+} from "commonfabric";
+
+import { Member, type MemberOutput } from "./bulk-member.tsx";
+
+/** File a new member on the board. */
+interface AddMemberEvent {
+  /** One line naming the member. */
+  title: string;
+}
+
+interface AddMemberResult {
+  /** The member this call created. */
+  member: MemberOutput;
+}
+
+interface BoardInput {
+  items?: Writable<MemberOutput[] | Default<[]>>;
+}
+
+/** A board of members; the collection changes only through `addMember`. */
+interface BoardOutput {
+  [NAME]: string;
+  items: MemberOutput[];
+  /** File a new member on the board. */
+  addMember: Stream<AddMemberEvent, AddMemberResult>;
+}
+
+export default pattern<BoardInput, BoardOutput>(({ items }) => {
+  const addMember = action<AddMemberEvent, AddMemberResult>((event) => {
+    const trimmed = (event.title ?? "").trim();
+    if (!trimmed) throw new Error("addMember: title must be non-empty");
+    const member = Member({ title: trimmed });
+    items.push(member);
+    return { member };
+  });
+
+  return {
+    [NAME]: "Bulk survey board",
+    items,
+    addMember,
+  };
+});

--- a/packages/cli/integration/pattern/bulk-board.tsx
+++ b/packages/cli/integration/pattern/bulk-board.tsx
@@ -28,6 +28,17 @@ interface AddMemberResult {
   member: MemberOutput;
 }
 
+/** Seed many members in one call; the board-sized set arrives as one write. */
+interface SeedMembersEvent {
+  /** How many members to file. */
+  count: number;
+}
+
+interface SeedMembersResult {
+  /** How many members this call filed. */
+  filed: number;
+}
+
 interface BoardInput {
   items?: Writable<MemberOutput[] | Default<[]>>;
 }
@@ -38,6 +49,8 @@ interface BoardOutput {
   items: MemberOutput[];
   /** File a new member on the board. */
   addMember: Stream<AddMemberEvent, AddMemberResult>;
+  /** Seed many members in one call. */
+  seedMembers: Stream<SeedMembersEvent, SeedMembersResult>;
 }
 
 export default pattern<BoardInput, BoardOutput>(({ items }) => {
@@ -49,9 +62,23 @@ export default pattern<BoardInput, BoardOutput>(({ items }) => {
     return { member };
   });
 
+  const seedMembers = action<SeedMembersEvent, SeedMembersResult>(
+    (event) => {
+      const count = event.count ?? 0;
+      if (!Number.isSafeInteger(count) || count < 1) {
+        throw new Error("seedMembers: count must be a positive integer");
+      }
+      for (let index = 0; index < count; index += 1) {
+        items.push(Member({ title: `seed-${index}` }));
+      }
+      return { filed: count };
+    },
+  );
+
   return {
     [NAME]: "Bulk survey board",
     items,
     addMember,
+    seedMembers,
   };
 });

--- a/packages/cli/integration/pattern/bulk-member-v2.tsx
+++ b/packages/cli/integration/pattern/bulk-member-v2.tsx
@@ -1,0 +1,29 @@
+/**
+ * The "next generation" of `bulk-member.tsx`, for the bulk-survey drill. The
+ * drill never deploys it: it is the `--retarget` source whose computed
+ * identity the survey stamps onto member rows, and the assertion is that the
+ * stamp differs from the identity the members currently run. The only
+ * difference from generation one is the field a retarget would change.
+ */
+
+import { NAME, pattern, type PatternFactory } from "commonfabric";
+
+export interface MemberInput {
+  title: string;
+}
+
+export interface MemberOutput {
+  [NAME]: string;
+  title: string;
+  /** Which generation of this fixture the member runs. */
+  generation: string;
+}
+
+export const Member: PatternFactory<MemberInput, MemberOutput> = pattern<
+  MemberInput,
+  MemberOutput
+>(({ title }) => ({
+  [NAME]: title,
+  title,
+  generation: "two",
+}));

--- a/packages/cli/integration/pattern/bulk-member.tsx
+++ b/packages/cli/integration/pattern/bulk-member.tsx
@@ -1,0 +1,31 @@
+/**
+ * Member fixture for the bulk-survey drill: the "current generation" of the
+ * piece a board's collection holds. It lives in its own module so a member's
+ * pattern identity differs from the board's — the shape the survey exists to
+ * read — the way `topic.tsx` sits beside the topics board's `main.tsx`.
+ * `bulk-member-v2.tsx` is the same pattern one generation later, used only as
+ * a retarget source for the identity the plan stamps; nothing deploys it.
+ * Nothing else deploys this file either: the drill owns its subject.
+ */
+
+import { NAME, pattern, type PatternFactory } from "commonfabric";
+
+export interface MemberInput {
+  title: string;
+}
+
+export interface MemberOutput {
+  [NAME]: string;
+  title: string;
+  /** Which generation of this fixture the member runs. */
+  generation: string;
+}
+
+export const Member: PatternFactory<MemberInput, MemberOutput> = pattern<
+  MemberInput,
+  MemberOutput
+>(({ title }) => ({
+  [NAME]: title,
+  title,
+  generation: "one",
+}));


### PR DESCRIPTION
## Why

Stage 1 of [bulk piece operations](docs/plans/piece-bulk-operations.md) (#6183) is finished by a drill, per the plan's own rule: the drill is what converts the design into a standing guarantee, so "does the survey still work?" is a CI result rather than an expedition. Third of the three stage-1 PRs, after the library (#6211) and the CLI wrapper (#6213).

**Stacked on #6213** (base is its branch); rebases up the chain as its parents merge. Stacked PRs run no CI here — validated by running the drill locally (below).

## What Changed

- `packages/cli/integration/bulk-survey-drill.sh` — deploy `pattern/bulk-board.tsx`, file three members through its `addMember` verb (handler-created, so absent from the registry — the absence the containment check exists for), survey with a `--retarget items=bulk-member-v2.tsx@drill` stamp, and assert the plan with `jq`: header counts, phase order with the holder last, one identity across members vs. the holder's own, `retained` on every row, the stamped target ≠ the running identity, no op on the holder row, `inspect --pattern-identity` agreeing with the holder row, and a post-survey `addMember` showing on the next survey.
- Fixtures under `integration/pattern/`: `bulk-member.tsx` in its own module (so member/board identities differ, as `topic.tsx` sits beside topics' `main.tsx`), `bulk-member-v2.tsx` (never deployed; retarget source only), `bulk-board.tsx`. The drill owns them; nothing else deploys them.
- `integration.sh`: `run_bulk_survey_drill` (API-only — none of the topics drill's store discovery), called from the `piece-call` section, plus a `bulk-survey-drill` standalone selector. **No workflow change** — the matrix legs pass only the section name, so the drill rides the existing `core-piece-call` leg.

Two facts the drill established that the unit fixtures couldn't: a sub-piece created by a board's handler carries its defining module's identity, not the board's; and its source **is** retained (a restore target exists for handler-created members).

## Test plan

Ran locally against an isolated toolshed (fresh port, scratch store): **14/14 assertions pass** first run, well under the 60-second record budget. `cf check` compiles both deployable fixtures. `check-control-characters` clean. Test-records instrumentation is the one `cf_test_step_begin bulk-survey-drill` line — the suite already ships records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

