### PR TITLE
docs(runner): getRaw's documented default matches the one it uses

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -177,8 +177,8 @@ export type RawCellReadOptions = IReadOptions & {
   /**
    * Controls whether `getRaw()` follows a final link at the cell's target.
    *
-   * Defaults to `"value"`, which preserves the historical raw-read behavior:
-   * resolve links on the way to the target, but return a final link as data.
+   * Defaults to `"top"`: links on the way to the target are resolved, and a
+   * final link is returned as data rather than followed.
    */
   lastNode?: LastNode;
 };


### PR DESCRIPTION
## What

`RawCellReadOptions.lastNode` documents its default as `"value"`. `getRawUntyped` destructures `lastNode = "top"`.

## Why the implementation is the one that's right

Two signals agree with `"top"` and only the one sentence disagrees:

- The behavior the same sentence goes on to describe — *resolve links on the way to the target, but return a final link as data* — is what `"top"` does. `resolveLink`'s own contract spells this out: `lastNode` "controls whether to follow links on the last path segment. By default all links are followed, but if `lastNode` is `LastNode.WriteRedirect` only write redirects are followed and if `lastNode` is `LastNode.Top` no" links are (`link-resolution.ts`).
- The doc comment in `.exec()` names the same default: "getRaw's default `"top"` would stop at the link object and miss `id`." That comment is the reason `.exec()` passes `lastNode: "value"` explicitly.

So the fix is the value name, not the description.

## Why it's worth a commit on its own

The default decides whether `getRaw()` on a cell returns the link at that position or the value behind it. Anyone reasoning about what a raw read reaches — a handle read, an opaque or otherwise restricted cell, a debug renderer — reads this doc comment first and would conclude the final link is followed by default, which is the opposite of what happens.

The replaced clause ("preserves the historical raw-read behavior") also described the code against a previous version of itself, which `docs/development/code-comment-style.md` rules out under "Not the code's own past".

## Checks

- `deno fmt --check` — clean (4689 files)
- `deno lint` — clean (4628 files)
- `deno check packages/runner/src/cell.ts` — clean
- `deno test packages/runner/test/cell-core.test.ts test/readable-cell-capability.test.ts` — 8 passed, 0 failed

Comment-only change; no behavior is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

