### PR TITLE
A --select path the source cannot hold is refused, not answered with {}

### DIFF
--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -207,18 +207,18 @@ implement, a link that has not synced.
 
 Two cases keep the older reading, and `{}` covers a typo in both. A JSON
 `--schema` names a shape of its own rather than the source's fields and is held
-to no vocabulary at all. And a field list meets positions the source schema
+to no vocabulary at all. And a field list visits positions the source schema
 settles nothing about — an open `additionalProperties`, a `patternProperties`
 map that names a pattern, a disjunction, an untyped source, a position that
-only may hold an array, a reference site declaring fields of its own, a name
-several `allOf` members declare — where no refusal is available. Read a `{}`
-from either against `cf piece describe` rather than as an answer about the
-data.
+only may hold an array, a tuple-shaped one, a reference site declaring fields
+of its own, a name several `allOf` members declare — where no refusal is
+available. Read a `{}` from either against `cf piece describe` rather than as a
+fact about the data.
 
-One of those positions goes further. A field declared ONLY through an `allOf`
+One of those positions goes further. A field declared only through an `allOf`
 member is named by the schema and refused by nothing, and no spelling on this
-surface returns it: a field list answers `{}`, a JSON `--schema` naming it
-answers `{}`, and `cf piece describe` does not list it among the fields. So
+surface returns it: a field list returns `{}`, a JSON `--schema` naming it
+returns `{}`, and `cf piece describe` does not list it among the fields. So
 `{}` there is neither absence nor a typo, and nothing the CLI offers separates
 it from either — the pattern's own source is what settles it.
 

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -196,6 +196,18 @@ absent optional source, or a wish run under `--allow-empty`, which prints `null`
 and exits 0 where it would otherwise error — and no caller can tell them apart
 from the output. Read it as "no value here", never as proof of no matches.
 
+**An empty projection is a field holding nothing, not a field that is not
+there.** A `--select`/`--schema` field list is held to the source's own
+vocabulary, so a name the schema proves cannot be there — one the position
+neither declares nor admits, one below a scalar, one below a verb — is refused
+before the read, naming the position and what it declares. What comes back as
+`{}` is therefore a position that could have held a value and does not: an
+optional field nobody has written, an interface an item does not implement, a
+link that has not synced. Where the source schema settles nothing — a position
+carrying `additionalProperties`, a disjunction, an untyped source — no refusal
+is available and `{}` still covers a typo as well, so read one there against
+`cf piece describe` rather than as an answer about the data.
+
 **An unregistered piece is not a missing piece.** Covered above, and repeated
 here because it is the failure that reads most like a definitive answer: `ls`
 and `search` returning nothing is consistent with a space full of pieces whose

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -215,11 +215,12 @@ several `allOf` members declare — where no refusal is available. Read a `{}`
 from either against `cf piece describe` rather than as an answer about the
 data.
 
-One of those positions goes further: a field declared ONLY through `allOf`
-members is named by the schema and still comes back `{}`, because the read does
-not reach a conjunction member's properties. There, `{}` is neither absence nor
-a typo — it is a field the read cannot deliver, and `cf piece describe` is what
-tells the three apart.
+One of those positions goes further. A field declared ONLY through an `allOf`
+member is named by the schema and refused by nothing, and no spelling on this
+surface returns it: a field list answers `{}`, a JSON `--schema` naming it
+answers `{}`, and `cf piece describe` does not list it among the fields. So
+`{}` there is neither absence nor a typo, and nothing the CLI offers separates
+it from either — the pattern's own source is what settles it.
 
 **An unregistered piece is not a missing piece.** Covered above, and repeated
 here because it is the failure that reads most like a definitive answer: `ls`

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -209,10 +209,11 @@ Two cases keep the older reading, and `{}` covers a typo in both. A JSON
 `--schema` names a shape of its own rather than the source's fields and is held
 to no vocabulary at all. And a field list meets positions the source schema
 settles nothing about — an open `additionalProperties`, a `patternProperties`
-map that names a pattern, a disjunction, an untyped source, a reference site
-declaring fields of its own, a name several `allOf` members declare — where no
-refusal is available. Read a `{}` from either against `cf piece describe`
-rather than as an answer about the data.
+map that names a pattern, a disjunction, an untyped source, a position that
+only may hold an array, a reference site declaring fields of its own, a name
+several `allOf` members declare — where no refusal is available. Read a `{}`
+from either against `cf piece describe` rather than as an answer about the
+data.
 
 One of those positions goes further: a field declared ONLY through `allOf`
 members is named by the schema and still comes back `{}`, because the read does

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -209,9 +209,16 @@ Two cases keep the older reading, and `{}` covers a typo in both. A JSON
 `--schema` names a shape of its own rather than the source's fields and is held
 to no vocabulary at all. And a field list meets positions the source schema
 settles nothing about — an open `additionalProperties`, a `patternProperties`
-map, a disjunction, an untyped source — where no refusal is available. Read a
-`{}` from either against `cf piece describe` rather than as an answer about the
-data.
+map that names a pattern, a disjunction, an untyped source, a reference site
+declaring fields of its own, a name several `allOf` members declare — where no
+refusal is available. Read a `{}` from either against `cf piece describe`
+rather than as an answer about the data.
+
+One of those positions goes further: a field declared ONLY through `allOf`
+members is named by the schema and still comes back `{}`, because the read does
+not reach a conjunction member's properties. There, `{}` is neither absence nor
+a typo — it is a field the read cannot deliver, and `cf piece describe` is what
+tells the three apart.
 
 **An unregistered piece is not a missing piece.** Covered above, and repeated
 here because it is the failure that reads most like a definitive answer: `ls`

--- a/docs/common/verbs/agents-over-the-cli.md
+++ b/docs/common/verbs/agents-over-the-cli.md
@@ -196,17 +196,22 @@ absent optional source, or a wish run under `--allow-empty`, which prints `null`
 and exits 0 where it would otherwise error — and no caller can tell them apart
 from the output. Read it as "no value here", never as proof of no matches.
 
-**An empty projection is a field holding nothing, not a field that is not
-there.** A `--select`/`--schema` field list is held to the source's own
-vocabulary, so a name the schema proves cannot be there — one the position
+**An empty projection from a field list is a field holding nothing, not a field
+that is not there.** A `--select`/`--schema` field list is held to the source's
+own vocabulary, so a name the schema proves cannot be there — one the position
 neither declares nor admits, one below a scalar, one below a verb — is refused
-before the read, naming the position and what it declares. What comes back as
-`{}` is therefore a position that could have held a value and does not: an
-optional field nobody has written, an interface an item does not implement, a
-link that has not synced. Where the source schema settles nothing — a position
-carrying `additionalProperties`, a disjunction, an untyped source — no refusal
-is available and `{}` still covers a typo as well, so read one there against
-`cf piece describe` rather than as an answer about the data.
+before the read, naming the position and what it declares. What that spelling
+returns as `{}` is therefore a position that could have held a value and does
+not: an optional field nobody has written, an interface an item does not
+implement, a link that has not synced.
+
+Two cases keep the older reading, and `{}` covers a typo in both. A JSON
+`--schema` names a shape of its own rather than the source's fields and is held
+to no vocabulary at all. And a field list meets positions the source schema
+settles nothing about — an open `additionalProperties`, a `patternProperties`
+map, a disjunction, an untyped source — where no refusal is available. Read a
+`{}` from either against `cf piece describe` rather than as an answer about the
+data.
 
 **An unregistered piece is not a missing piece.** Covered above, and repeated
 here because it is the failure that reads most like a definitive answer: `ls`

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -231,8 +231,8 @@ projection leaves every surviving path where it was; it does not compose with
 declared result proves cannot be there — one the position neither declares nor
 admits, one below a scalar, one below a verb — is refused before the read and
 names the vocabulary that position takes. A name it declares that simply holds
-nothing answers with nothing, which is the answer an optional field is entitled
-to. Where the result carries no declared shape, nothing holds the list and
+nothing returns nothing, which is what an optional field is entitled to. Where
+the result carries no declared shape, nothing holds the list and
 every name is read as written. A JSON `--schema` states a shape of its own and
 is held to none of this.
 

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -227,6 +227,14 @@ refuses all three flags. `--show-links` composes with a projection, because a
 projection leaves every surviving path where it was; it does not compose with
 `--filter`, which moves the positions a link names.
 
+**A field list is held to what the verb's result declares.** A name the
+declared result proves cannot be there — one the position neither declares nor
+admits, one below a scalar, one below a verb — is refused before the read and
+names the vocabulary that position takes. A name it declares that simply holds
+nothing answers with nothing, which is the answer an optional field is entitled
+to. Where a verb declares no result there is nothing to hold the list to, and
+every name is read as written.
+
 **A verb reached through a filesystem mount is the same call.** `cf exec` takes
 the three flags too, written before the mounted file, since everything after it
 belongs to the callable's own schema-derived interface. It settles the handling

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -232,8 +232,9 @@ declared result proves cannot be there — one the position neither declares nor
 admits, one below a scalar, one below a verb — is refused before the read and
 names the vocabulary that position takes. A name it declares that simply holds
 nothing answers with nothing, which is the answer an optional field is entitled
-to. Where a verb declares no result there is nothing to hold the list to, and
-every name is read as written.
+to. Where the result carries no declared shape, nothing holds the list and
+every name is read as written. A JSON `--schema` states a shape of its own and
+is held to none of this.
 
 **A verb reached through a filesystem mount is the same call.** `cf exec` takes
 the three flags too, written before the mounted file, since everything after it

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -142,10 +142,12 @@ position, the vocabulary that position declares, and — where the vocabulary ha
 a name close enough — the one the path is a typo of, the wording every other
 misspelled name gets (`packages/cli/lib/refusal.ts`). Everything the
 schema leaves open passes: an open `additionalProperties`, a `patternProperties`
-map, a disjunction, an untyped position, a reference that does not resolve, a
-reference site declaring fields of its own, and a name several `allOf` members
-declare. Refusing there would take away a read that works, and the
-direction to be wrong in is the permissive one. The full form is held to none
+map that names a pattern, a disjunction, an untyped position, a reference site
+declaring fields of its own, and a name several `allOf` members declare. A
+reference that does not resolve passes the gate as well, though the read behind
+it then reports the reference rather than answering. Refusing at any of them
+would take away a read that works, and the direction to be wrong in is the
+permissive one. The full form is held to none
 of it, since a JSON Schema states a shape of its own rather than naming the
 source's fields — which leaves it the spelling for reading a position the
 source does not declare.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -132,23 +132,23 @@ caller cannot do is introduce its own. A disjunction has no single answer to
 caller's behalf.
 
 **A field list names positions of the source, so the source's schema decides
-whether a name can be there at all.** A projection that matches nothing is a
-real answer — an optional field is absent, a link has not synced — so a read
-cannot refuse on absence. What it can refuse on is a path no value could ever
-appear at, which the schema settles before the read runs: a field a position
-neither declares nor admits, a field named below a scalar, a field named below
+whether a name can be there at all.** A projection that matches nothing
+returns a real result — an optional field is absent, a link has not synced — so
+a read cannot refuse on absence. What it can refuse on is a path no value
+could ever appear at, which the schema settles before the read runs: a field a
+position neither declares nor admits, a field named below a scalar, one below
 a verb, which dispatches rather than holding a value. The refusal names the
 position, the vocabulary that position declares, and — where the vocabulary has
 a name close enough — the one the path is a typo of, the wording every other
 misspelled name gets (`packages/cli/lib/refusal.ts`). Everything the
 schema leaves open passes: an open `additionalProperties`, a `patternProperties`
 map that names a pattern, a disjunction, an untyped position, a position that
-only MAY hold an array rather than proving it, a reference site declaring
-fields of its own, and a name several `allOf` members declare. A
-reference that does not resolve passes the gate as well, though the read behind
-it then reports the reference rather than answering. Refusing at any of them
-would take away a read that works, and the direction to be wrong in is the
-permissive one. The full form is held to none
+only may hold an array rather than proving it, a tuple-shaped array, a
+reference site declaring fields of its own, and a name several `allOf` members
+declare. A reference that does not resolve passes the gate as well, though the
+read behind it then reports the reference rather than returning a value.
+Refusing at any of them would take away a read that works, and the direction to
+be wrong in is the permissive one. The full form is held to none
 of it, since a JSON Schema states a shape of its own rather than naming the
 source's fields — which leaves it the spelling for reading a position the
 source does not declare.

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -131,6 +131,23 @@ caller cannot do is introduce its own. A disjunction has no single answer to
 "return this subtree," so honoring one would mean picking a branch on the
 caller's behalf.
 
+**A field list names positions of the source, so the source's schema decides
+whether a name can be there at all.** A projection that matches nothing is a
+real answer — an optional field is absent, a link has not synced — so a read
+cannot refuse on absence. What it can refuse on is a path no value could ever
+appear at, which the schema settles before the read runs: a field a position
+neither declares nor admits, a field named below a scalar, a field named below
+a verb, which dispatches rather than holding a value. The refusal names the
+position, the vocabulary that position declares, and the declared name the path
+is one edit from — the wording every other misspelled name gets
+(`packages/cli/lib/refusal.ts`). Everything the schema leaves open passes:
+`additionalProperties`, a disjunction, an untyped position, a reference that
+does not resolve. Refusing there would take away a read that works, and the
+direction to be wrong in is the permissive one. The full form is held to none
+of it, since a JSON Schema states a shape of its own rather than naming the
+source's fields — which leaves it the spelling for reading a position the
+source does not declare.
+
 ### Saying which positions are addresses
 
 Everything above selects *values*. A shape also needs to say "at this position,

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -138,11 +138,13 @@ cannot refuse on absence. What it can refuse on is a path no value could ever
 appear at, which the schema settles before the read runs: a field a position
 neither declares nor admits, a field named below a scalar, a field named below
 a verb, which dispatches rather than holding a value. The refusal names the
-position, the vocabulary that position declares, and the declared name the path
-is one edit from — the wording every other misspelled name gets
-(`packages/cli/lib/refusal.ts`). Everything the schema leaves open passes:
-`additionalProperties`, a disjunction, an untyped position, a reference that
-does not resolve. Refusing there would take away a read that works, and the
+position, the vocabulary that position declares, and — where the vocabulary has
+a name close enough — the one the path is a typo of, the wording every other
+misspelled name gets (`packages/cli/lib/refusal.ts`). Everything the
+schema leaves open passes: an open `additionalProperties`, a `patternProperties`
+map, a disjunction, an untyped position, a reference that does not resolve, a
+reference site declaring fields of its own, and a name several `allOf` members
+declare. Refusing there would take away a read that works, and the
 direction to be wrong in is the permissive one. The full form is held to none
 of it, since a JSON Schema states a shape of its own rather than naming the
 source's fields — which leaves it the spelling for reading a position the

--- a/docs/plans/shaped-reads-and-verb-results.md
+++ b/docs/plans/shaped-reads-and-verb-results.md
@@ -142,8 +142,9 @@ position, the vocabulary that position declares, and — where the vocabulary ha
 a name close enough — the one the path is a typo of, the wording every other
 misspelled name gets (`packages/cli/lib/refusal.ts`). Everything the
 schema leaves open passes: an open `additionalProperties`, a `patternProperties`
-map that names a pattern, a disjunction, an untyped position, a reference site
-declaring fields of its own, and a name several `allOf` members declare. A
+map that names a pattern, a disjunction, an untyped position, a position that
+only MAY hold an array rather than proving it, a reference site declaring
+fields of its own, and a name several `allOf` members declare. A
 reference that does not resolve passes the gate as well, though the read behind
 it then reports the reference rather than answering. Refusing at any of them
 would take away a read that works, and the direction to be wrong in is the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -397,10 +397,12 @@ verb, which dispatches rather than holding a value. A field that is merely
 ABSENT is a different fact and still answers with nothing at exit 0 — an
 optional field nobody has written, an interface an item does not implement, a
 link that has not synced. The refusal therefore fires only where the schema
-settles the question. These all read as they always did: an open
-`additionalProperties`, a `patternProperties` map, a disjunction, an untyped
-position, a reference that does not resolve, a reference site that declares
-fields of its own, and a name several `allOf` members declare. A JSON `--schema`
+settles the question, and a position it does not settle reads as it always did:
+an open `additionalProperties`, a `patternProperties` map that names a pattern,
+a disjunction, an untyped position, a reference site that declares fields of its
+own, and a name several `allOf` members declare. A reference that does not
+resolve is passed over as well, and what the caller then reads is the read's own
+report of the reference rather than anything about the field. A JSON `--schema`
 states a shape of its own rather than naming the source's fields and is not held
 to the source's vocabulary, which is the spelling for reading a position the
 source does not declare.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -390,18 +390,20 @@ projected null.
 **A field list names positions of the source, so the source's schema decides
 whether a name can be there at all.** A path the schema proves nothing can
 appear at is refused before the read, naming the position, the vocabulary that
-position declares, and the declared name the path is one edit from. Three shapes
-are proven: a field a position neither declares nor admits, a field named below
-a scalar, and a field named below a verb, which dispatches rather than holding a
-value. A field that is merely ABSENT is a different fact and still answers with
-nothing at exit 0 — an optional field nobody has written, an interface an item
-does not implement, a link that has not synced. The refusal therefore fires only
-where the schema settles the question: a position carrying
-`additionalProperties`, a disjunction, an untyped position, and a reference that
-does not resolve all read as they always did. A JSON `--schema` states a shape
-of its own rather than naming the source's fields and is not held to the
-source's vocabulary, which is the spelling for reading a position the source
-does not declare.
+position declares, and — where the vocabulary holds a name close enough — the
+one the path is a typo of. Three shapes are proven: a field a position neither
+declares nor admits, a field named below a scalar, and a field named below a
+verb, which dispatches rather than holding a value. A field that is merely
+ABSENT is a different fact and still answers with nothing at exit 0 — an
+optional field nobody has written, an interface an item does not implement, a
+link that has not synced. The refusal therefore fires only where the schema
+settles the question. These all read as they always did: an open
+`additionalProperties`, a `patternProperties` map, a disjunction, an untyped
+position, a reference that does not resolve, a reference site that declares
+fields of its own, and a name several `allOf` members declare. A JSON `--schema`
+states a shape of its own rather than naming the source's fields and is not held
+to the source's vocabulary, which is the spelling for reading a position the
+source does not declare.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -394,13 +394,14 @@ position declares, and — where the vocabulary holds a name close enough — th
 one the path is a typo of. Three shapes are proven: a field a position neither
 declares nor admits, a field named below a scalar, and a field named below a
 verb, which dispatches rather than holding a value. A field that is merely
-ABSENT is a different fact and still answers with nothing at exit 0 — an
-optional field nobody has written, an interface an item does not implement, a
-link that has not synced. The refusal therefore fires only where the schema
-settles the question, and a position it does not settle reads as it always did:
-an open `additionalProperties`, a `patternProperties` map that names a pattern,
-a disjunction, an untyped position, a position that only MAY hold an array
+absent is a different fact and still returns nothing at exit 0 — an optional
+field nobody has written, an interface an item does not implement, a link that
+has not synced. The refusal therefore fires only where the schema settles the
+question, and a position it does not settle reads as it always did: an open
+`additionalProperties`, a `patternProperties` map that names a pattern, a
+disjunction, an untyped position, a position that only may hold an array
 (untyped beside an `items`, or typed as both an array and an object), a
+tuple-shaped array, whose `prefixItems` give its elements no one vocabulary, a
 reference site that declares fields of its own, and a name several `allOf`
 members declare. A reference that does not resolve is passed over as well, and
 what the caller then reads is the read's own report of the reference rather than

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -388,26 +388,29 @@ source remains the ordinary successful `null` CLI response, as does a valid
 projected null.
 
 **A field list names positions of the source, so the source's schema decides
-whether a name can be there at all.** A path the schema proves nothing can
-appear at is refused before the read, naming the position, the vocabulary that
-position declares, and — where the vocabulary holds a name close enough — the
-one the path is a typo of. Three shapes are proven: a field a position neither
-declares nor admits, a field named below a scalar, and a field named below a
-verb, which dispatches rather than holding a value. A field that is merely
-absent is a different fact and still returns nothing at exit 0 — an optional
-field nobody has written, an interface an item does not implement, a link that
-has not synced. The refusal therefore fires only where the schema settles the
-question, and a position it does not settle reads as it always did: an open
-`additionalProperties`, a `patternProperties` map that names a pattern, a
-disjunction, an untyped position, a position that only may hold an array
-(untyped beside an `items`, or typed as both an array and an object), a
-tuple-shaped array, whose `prefixItems` give its elements no one vocabulary, a
-reference site that declares fields of its own, and a name several `allOf`
-members declare. A reference that does not resolve is passed over as well, and
-what the caller then reads is the read's own report of the reference rather than
-anything about the field. A JSON `--schema` states a shape of its own rather
-than naming the source's fields and is not held to the source's vocabulary,
-which is the spelling for reading a position the source does not declare.
+whether a name can be there at all.** A position states its vocabulary by
+carrying a `properties` map, so one declaring no fields (`properties: {}`)
+refuses every name while a position with no map declares nothing and refuses
+none. A path the schema proves nothing can appear at is refused before the read,
+naming the position, the vocabulary that position declares, and — where the
+vocabulary holds a name close enough — the one the path is a typo of. Three
+shapes are proven: a field a position neither declares nor admits, a field named
+below a scalar, and a field named below a verb, which dispatches rather than
+holding a value. A field that is merely absent is a different fact and still
+returns nothing at exit 0 — an optional field nobody has written, an interface
+an item does not implement, a link that has not synced. The refusal therefore
+fires only where the schema settles the question, and a position it does not
+settle reads as it always did: an open `additionalProperties`, a
+`patternProperties` map that names a pattern, a disjunction, an untyped
+position, a position that only may hold an array (untyped beside an `items`, or
+typed as both an array and an object), a tuple-shaped array, whose `prefixItems`
+give its elements no one vocabulary, a reference site that declares fields of
+its own, and a name several `allOf` members declare. A reference that does not
+resolve is passed over as well, and what the caller then reads is the read's own
+report of the reference rather than anything about the field. A JSON `--schema`
+states a shape of its own rather than naming the source's fields and is not held
+to the source's vocabulary, which is the spelling for reading a position the
+source does not declare.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -387,6 +387,22 @@ exits nonzero and states that the failure is not JSON `null`. An absent optional
 source remains the ordinary successful `null` CLI response, as does a valid
 projected null.
 
+**A field list names positions of the source, so the source's schema decides
+whether a name can be there at all.** A path the schema proves nothing can
+appear at is refused before the read, naming the position, the vocabulary that
+position declares, and the declared name the path is one edit from. Three shapes
+are proven: a field a position neither declares nor admits, a field named below
+a scalar, and a field named below a verb, which dispatches rather than holding a
+value. A field that is merely ABSENT is a different fact and still answers with
+nothing at exit 0 — an optional field nobody has written, an interface an item
+does not implement, a link that has not synced. The refusal therefore fires only
+where the schema settles the question: a position carrying
+`additionalProperties`, a disjunction, an untyped position, and a reference that
+does not resolve all read as they always did. A JSON `--schema` states a shape
+of its own rather than naming the source's fields and is not held to the
+source's vocabulary, which is the spelling for reading a position the source
+does not declare.
+
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern
 constructs its first storage read from the union of predicate-observed and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -399,13 +399,14 @@ optional field nobody has written, an interface an item does not implement, a
 link that has not synced. The refusal therefore fires only where the schema
 settles the question, and a position it does not settle reads as it always did:
 an open `additionalProperties`, a `patternProperties` map that names a pattern,
-a disjunction, an untyped position, a reference site that declares fields of its
-own, and a name several `allOf` members declare. A reference that does not
-resolve is passed over as well, and what the caller then reads is the read's own
-report of the reference rather than anything about the field. A JSON `--schema`
-states a shape of its own rather than naming the source's fields and is not held
-to the source's vocabulary, which is the spelling for reading a position the
-source does not declare.
+a disjunction, an untyped position, a position that only MAY hold an array
+(untyped beside an `items`, or typed as both an array and an object), a
+reference site that declares fields of its own, and a name several `allOf`
+members declare. A reference that does not resolve is passed over as well, and
+what the caller then reads is the read's own report of the reference rather than
+anything about the field. A JSON `--schema` states a shape of its own rather
+than naming the source's fields and is not held to the source's vocabulary,
+which is the spelling for reading a position the source does not declare.
 
 Both transforms run as a short-lived computed pattern in the caller's session.
 When the declared source schema fixes the root container shape, the pattern

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -26,8 +26,14 @@ import {
   isInstance,
   isObjectNotArray,
   isObjectOrArray,
-  type ReadonlyRecord,
 } from "@commonfabric/utils/types";
+import {
+  declaredFieldNames,
+  declaredFieldsAt,
+  isSchemaObject,
+  schemaIsArrayShaped,
+  schemaIsObjectShaped,
+} from "./declared-fields.ts";
 
 import {
   type CallableKind,
@@ -337,12 +343,6 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
-function isSchemaObject(
-  schema: JSONSchema | undefined,
-): schema is ReadonlyRecord {
-  return isObjectNotArray(schema);
-}
-
 /**
  * A verb invocation rejected before dispatch because the supplied payload does
  * not satisfy the verb's declared event schema.
@@ -396,172 +396,12 @@ export function normalizeAbsentVerbPayload(
   return {};
 }
 
-/**
- * Whether a resolved event schema describes an object payload — directly, or
- * as an `allOf` conjunction with an object-schema branch (a conjunction that
- * includes an object schema IS an object schema, no branch choice involved).
- * `anyOf`/`oneOf` roots deliberately return false: normalizing `{}` there
- * would pick among alternatives on the caller's behalf, the combinator
- * boundary the D5 rule records (refuse or normalize only on proof) — the
- * plan's D5 bullet names disjunctive roots out of scope.
- */
-export function schemaIsObjectShaped(
-  target: JSONSchema,
-  root: JSONSchema,
-): boolean {
-  if (!isSchemaObject(target)) return false;
-  if (target.type === "object" || isSchemaObject(target.properties)) {
-    return true;
-  }
-  if (Array.isArray(target.allOf)) {
-    return target.allOf.some((branch) => {
-      const resolved = localRefTarget(branch, root);
-      return isSchemaObject(resolved) &&
-        (resolved.type === "object" || isSchemaObject(resolved.properties));
-    });
-  }
-  return false;
-}
-
 /** A field a payload carries at a position whose schema does not declare it,
  * with what that position does declare. */
 interface UndeclaredEventField {
   key: string;
   position: string;
   declared: string[];
-}
-
-/** One property map an object-shaped position reaches, with the local-ref
- * scope the schemas inside it resolve against. */
-interface DeclaredFieldSource {
-  properties: Record<string, JSONSchema>;
-  root: JSONSchema;
-}
-
-/** What a position declares, and whether anything there honors a field none of
- * its maps name. */
-interface DeclaredFields {
-  sources: DeclaredFieldSource[];
-  honorsUndeclared: boolean;
-  /** Every name any reached member marks required. A conjunction constrains
-   * one value from all its members at once, so a name any of them requires is
-   * required of the payload. A DISJUNCTION contributes none — a payload
-   * satisfies one branch, so no branch's requirement binds it, and the walk
-   * stops at one rather than reading its members. */
-  required: Set<string>;
-}
-
-/**
- * Every property map an object-shaped position reaches, and whether it honors a
- * field none of them name.
- *
- * A conjunction constrains one value from several members at once, so the
- * fields it declares are the UNION across its members: a payload satisfying an
- * `allOf` satisfies every member, and a field one member names is a field the
- * position names. Taking the union is also the safe direction — the cost of
- * missing a member is refusing a field that was declared, and the cost of an
- * extra member is accepting one that would have been dropped.
- *
- * A disjunction anywhere inside makes the whole position honor everything: a
- * branch a payload was meant for may name a field the others do not, and
- * choosing among branches is the caller's, not this gate's.
- *
- * `followed` breaks reference cycles, and it records the REFERENCE rather than
- * the schema it resolved to — the same key `localRefTarget` cycles on, and the
- * only one that works here: resolution hands back a fresh view of a definition
- * each time, so a recursive `$ref` reaches an object this walk has never seen
- * and descends forever. A member is skipped once its reference has been
- * followed in the scope it was written in; a definition contributes its fields
- * once, and a schema naming itself terminates.
- */
-function declaredFieldsAt(
-  node: Record<string, unknown>,
-  root: JSONSchema,
-  into: DeclaredFields = {
-    sources: [],
-    honorsUndeclared: false,
-    required: new Set<string>(),
-  },
-  followed: Map<JSONSchema, Set<string>> = new Map(),
-): DeclaredFields {
-  if (isSchemaObject(node.properties as JSONSchema)) {
-    into.sources.push({
-      properties: node.properties as Record<string, JSONSchema>,
-      root,
-    });
-  }
-  // `false` is the one value that does NOT honor undeclared fields — it is
-  // the schema saying no extra field is permitted. Reading mere presence as
-  // permission inverts the strictest spelling into the most permissive one,
-  // and the field is then dropped by the runtime and the call reported
-  // settled, which is the silent loss this refusal exists to prevent.
-  if (
-    node.additionalProperties !== undefined &&
-    node.additionalProperties !== false
-  ) {
-    into.honorsUndeclared = true;
-  }
-  if (Array.isArray(node.required)) {
-    for (const name of node.required as unknown[]) {
-      if (typeof name === "string") into.required.add(name);
-    }
-  }
-  if (!Array.isArray(node.allOf)) return into;
-  for (const member of node.allOf as JSONSchema[]) {
-    const memberRoot = cfcSchemaChildRoot(member, root);
-    if (isSchemaObject(member) && typeof member.$ref === "string") {
-      let inScope = followed.get(memberRoot);
-      if (inScope?.has(member.$ref)) continue;
-      if (inScope === undefined) {
-        inScope = new Set();
-        followed.set(memberRoot, inScope);
-      }
-      inScope.add(member.$ref);
-    }
-    const resolved = localRefTarget(member, memberRoot);
-    if (!isSchemaObject(resolved)) continue;
-    if (resolved.anyOf !== undefined || resolved.oneOf !== undefined) {
-      into.honorsUndeclared = true;
-      continue;
-    }
-    declaredFieldsAt(
-      resolved,
-      cfcSchemaChildRoot(resolved, memberRoot),
-      into,
-      followed,
-    );
-  }
-  return into;
-}
-
-/** The vocabulary a refusal names: every field the position's maps declare, in
- * the order they were reached, each named once. */
-function declaredFieldNames(sources: DeclaredFieldSource[]): string[] {
-  const names: string[] = [];
-  for (const source of sources) {
-    for (const key of Object.keys(source.properties)) {
-      if (!names.includes(key)) names.push(key);
-    }
-  }
-  return names;
-}
-
-/**
- * Whether a position describes the array a payload holds there.
- *
- * The array counterpart of {@link schemaIsObjectShaped}, and it answers the
- * question the same way: a stated `type` says so, and otherwise the container
- * keyword being present does. An untyped position naming `items` is an array
- * to everything except schema traversal's own descent, which requires the
- * stated type and empties the position without it — the same asymmetry the
- * object side has, one container over.
- */
-function schemaIsArrayShaped(node: Record<string, unknown>): boolean {
-  const declaredType = node.type;
-  if (declaredType === "array") return true;
-  if (Array.isArray(declaredType)) return declaredType.includes("array");
-  if (declaredType !== undefined) return false;
-  return node.items !== undefined || node.prefixItems !== undefined;
 }
 
 /**

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1858,12 +1858,17 @@ function firstUnheldSelectionField(
   // of its elements — the traversal `alignConciseProjectionMask` applies to
   // the mask beside this.
   //
-  // Crossed only where the position must hold an array, which is the question
-  // {@link sourceProvesContainer} exists to settle. A position that merely may
-  // hold one — untyped beside an `items`, or a union naming both containers —
-  // settles neither depth: the name belongs to an element where the value is
-  // an array and to the position itself where it is not, and judging it at one
-  // of them refuses a read that works at the other.
+  // One rule governs the crossing: an array is crossed only where the source
+  // gives its elements ONE schema, since that schema is then the vocabulary of
+  // every element and of nothing else. The three ways a source falls short of
+  // that are checked below and each is passed over. A position that merely may
+  // hold an array — untyped beside an `items`, or a union naming both
+  // containers — settles neither depth: the name belongs to an element where
+  // the value is an array and to the position itself where it is not, and
+  // judging it at one of them refuses a read that works at the other. A tuple
+  // gives each index its own schema. And a draft-07 tuple writes that list as
+  // `items` itself, which is not a schema at all and stops the walk one level
+  // down, where a list of schemas is not a schema object.
   if (sourceProvesContainer("array", target, targetRoot)) {
     // A tuple declares a different shape per index, so its elements have no
     // one vocabulary: `items` describes the positions past the prefix and says

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1843,6 +1843,11 @@ function firstUnheldSelectionField(
   // interface declares what it names.
   const target = resolveCfcSchemaRefs(source, scopeRoot);
   if (!isSchemaObject(target)) return undefined;
+  // The marker is read again on what the reference names, since a definition
+  // can carry it as readily as the site naming one.
+  if (carriesStreamMarker(target)) {
+    return { key: Object.keys(named)[0], position, holds: { stream: true } };
+  }
   if (target.anyOf !== undefined || target.oneOf !== undefined) {
     return undefined;
   }
@@ -1878,8 +1883,16 @@ function firstUnheldSelectionField(
   }
 
   // A pattern-matched name is declared without being named, so a position
-  // carrying one has a vocabulary no list of keys states.
-  if (target.patternProperties !== undefined) return undefined;
+  // carrying one has a vocabulary no list of keys states. An empty map names
+  // no pattern and so admits nothing, which leaves the declared names the
+  // whole vocabulary.
+  const patterns = target.patternProperties;
+  if (
+    patterns !== undefined &&
+    !(isObjectNotArray(patterns) && Object.keys(patterns).length === 0)
+  ) {
+    return undefined;
+  }
   const declared = declaredFieldsAt(target, targetRoot);
   // A position with no property map states no vocabulary, and answers with
   // whatever the value holds there.

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1795,9 +1795,9 @@ interface UnheldSelectionField {
  * The first field a concise list names that the source schema proves cannot be
  * there — a typo, or a name the source has since stopped declaring.
  *
- * A projection that matches nothing legitimately answers nothing: an optional
- * field is absent, a link that has not synced is unresolvable, and both are
- * real answers a read must be able to give. What this separates out is the
+ * A projection that matches nothing legitimately returns nothing: an optional
+ * field is absent, a link that has not synced is unresolvable, and a read has
+ * to be able to return both. What this separates out is the
  * case where no value could ever appear at the path, which the schema settles
  * before the read runs and which is never anything but a mistake.
  *
@@ -1829,7 +1829,7 @@ function firstUnheldSelectionField(
   }
   // A reference site that declares fields of its own is passed over. The
   // site's keywords and the definition's are two accounts of one position, and
-  // a read answers from both — it reads whatever is stored at a name neither
+  // a read draws on both — it returns whatever is stored at a name neither
   // account declares — so which of them governs a name is not a question this
   // gate settles.
   if (
@@ -1858,13 +1858,23 @@ function firstUnheldSelectionField(
   // of its elements — the traversal `alignConciseProjectionMask` applies to
   // the mask beside this.
   //
-  // Crossed only where the position MUST hold an array, which is the question
-  // {@link sourceProvesContainer} exists to answer. A position that merely may
+  // Crossed only where the position must hold an array, which is the question
+  // {@link sourceProvesContainer} exists to settle. A position that merely may
   // hold one — untyped beside an `items`, or a union naming both containers —
   // settles neither depth: the name belongs to an element where the value is
   // an array and to the position itself where it is not, and judging it at one
   // of them refuses a read that works at the other.
   if (sourceProvesContainer("array", target, targetRoot)) {
+    // A tuple declares a different shape per index, so its elements have no
+    // one vocabulary: `items` describes the positions past the prefix and says
+    // nothing about the prefix itself. An empty list declares no position and
+    // leaves `items` describing every element.
+    const prefix = target.prefixItems;
+    if (
+      prefix !== undefined && !(Array.isArray(prefix) && prefix.length === 0)
+    ) {
+      return undefined;
+    }
     return firstUnheldSelectionField(
       sourceItemSchema(target),
       targetRoot,
@@ -1897,7 +1907,7 @@ function firstUnheldSelectionField(
     return undefined;
   }
   const declared = declaredFieldsAt(target, targetRoot);
-  // A position with no property map states no vocabulary, and answers with
+  // A position with no property map states no vocabulary, and returns
   // whatever the value holds there.
   if (declared.sources.length === 0) return undefined;
   const declaringSources = (key: string) =>
@@ -2505,8 +2515,8 @@ function resolveProjection(
   if (projection === undefined) return undefined;
   if (projection.kind === "concise") {
     // A field list names positions of the source, so the source is what says
-    // whether a name can be there at all. A path it cannot hold answers
-    // nothing however the read is run, and answering nothing is what a read
+    // whether a name can be there at all. A path it cannot hold returns
+    // nothing however the read is run, and returning nothing is what a read
     // legitimately does for a field that is merely absent — so the two are
     // separated here, before the read, where the schema still distinguishes
     // them.

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -23,11 +23,19 @@ import {
   cfcSchemaChildRoot,
   isEmbeddedCfcSchemaRef,
   resolveCfcSchemaRef,
+  resolveCfcSchemaRefs,
 } from "@commonfabric/runner/cfc/schema-refs";
 import { ANNOTATION_KEYS } from "@commonfabric/piece/schema-compatibility";
 import { createLLMFriendlyLink } from "@commonfabric/runner/shared";
 import { isObjectNotArray, isObjectOrArray } from "@commonfabric/utils/types";
 import { runtimeErrorLog } from "./callable.ts";
+import {
+  declaredFieldNames,
+  declaredFieldsAt,
+  isSchemaObject,
+  schemaIsArrayShaped,
+  schemaIsObjectShaped,
+} from "./declared-fields.ts";
 import { nearestName } from "./refusal.ts";
 
 type PredicateComparisonOperator = "==" | "!=" | "<" | "<=" | ">" | ">=";
@@ -1191,6 +1199,14 @@ export async function parseCellSelectionOptions(options: {
 }
 
 /**
+ * Whether a schema position is marked a stream, which is a dispatch surface
+ * rather than a value: nothing is stored at it to read or to address.
+ */
+function carriesStreamMarker(schema: { readonly asCell?: unknown }): boolean {
+  return Array.isArray(schema.asCell) && schema.asCell.includes("stream");
+}
+
+/**
  * The `source` a derived projection records, in place of the text a caller
  * would have typed. It reaches the derived read's cause, so it is a fixed
  * string rather than a rendering of the schema: two calls that derive the same
@@ -1254,9 +1270,7 @@ function derivePosition(
   // A stream carries no value: it renders as the empty object and reading it
   // says nothing. `asCell` otherwise says how a position is held rather than
   // what shape it has, and the shape beside it is what decides the cut.
-  if (Array.isArray(schema.asCell) && schema.asCell.includes("stream")) {
-    return DERIVED_DROPPED;
-  }
+  if (carriesStreamMarker(schema)) return DERIVED_DROPPED;
 
   if (typeof schema.$ref === "string") {
     const ref = schema.$ref;
@@ -1752,6 +1766,197 @@ function alignConciseMarkers(
       }),
     ),
   };
+}
+
+/**
+ * A field a concise list names at a position the source cannot hold it at,
+ * with what that position holds instead.
+ */
+interface UnheldSelectionField {
+  key: string;
+  /**
+   * The position the field was named at, spelled the way this boundary spells
+   * a projection position everywhere else: `<root>` for the read's own source,
+   * `.name` for a property, `[]` for the elements of an array a field list
+   * crosses.
+   */
+  position: string;
+  /**
+   * What the position does hold: the field names it declares, the types it
+   * states where it declares no fields, or the stream it is.
+   */
+  holds:
+    | { fields: string[] }
+    | { types: string[] }
+    | { stream: true };
+}
+
+/**
+ * The first field a concise list names that the source schema proves cannot be
+ * there — a typo, or a name the source has since stopped declaring.
+ *
+ * A projection that matches nothing legitimately answers nothing: an optional
+ * field is absent, a link that has not synced is unresolvable, and both are
+ * real answers a read must be able to give. What this separates out is the
+ * case where no value could ever appear at the path, which the schema settles
+ * before the read runs and which is never anything but a mistake.
+ *
+ * The walk is the caller's field list, which is finite, consulting the source
+ * schema beside it — so a source that names itself terminates on the list
+ * rather than on a cycle guard. Every position where the schema stops proving
+ * what sits under it fails open, each one marked below: a refusal costs a
+ * retype, while a read wrongly refused cannot be taken at all. That is the
+ * direction the call door's gate over a payload's fields fails in too
+ * (`firstUndeclaredEventField`, callable.ts).
+ */
+function firstUnheldSelectionField(
+  source: JSONSchema | undefined,
+  root: JSONSchema,
+  projection: JSONSchema,
+  position: string,
+): UnheldSelectionField | undefined {
+  if (typeof projection === "boolean") return undefined;
+  const named = projection.properties;
+  if (!isObjectNotArray(named)) return undefined;
+  if (!isSchemaObject(source)) return undefined;
+  // A stream is a dispatch surface rather than a value, so nothing is stored
+  // at it for a field path to reach. The marker is read before the reference
+  // beside it is followed, because that is where a verb carries it:
+  // `{asCell: ["stream"], $ref: "#/$defs/AddEvent"}` puts the event's fields
+  // in the definition and the marker at the site naming it.
+  if (carriesStreamMarker(source)) {
+    return { key: Object.keys(named)[0], position, holds: { stream: true } };
+  }
+  // A reference site that declares fields of its own is passed over. The
+  // site's keywords and the definition's are two accounts of one position, and
+  // a read answers from both — it reads whatever is stored at a name neither
+  // account declares — so which of them governs a name is not a question this
+  // gate settles.
+  if (
+    typeof source.$ref === "string" &&
+    (isObjectNotArray(source.properties) || source.allOf !== undefined)
+  ) {
+    return undefined;
+  }
+  const scopeRoot = cfcSchemaChildRoot(source, root);
+  // A reference is followed the way the validator follows it, so a named
+  // interface declares what it names.
+  const target = resolveCfcSchemaRefs(source, scopeRoot);
+  if (!isSchemaObject(target)) return undefined;
+  if (target.anyOf !== undefined || target.oneOf !== undefined) {
+    return undefined;
+  }
+  const targetRoot = cfcSchemaChildRoot(target, scopeRoot);
+
+  // A field list names a field wherever the value holds one rather than at a
+  // fixed depth, so an array position is crossed and the same names are asked
+  // of its elements — the traversal `alignConciseProjectionMask` applies to
+  // the mask beside this.
+  if (schemaIsArrayShaped(target)) {
+    if (schemaIsObjectShaped(target, targetRoot)) return undefined;
+    return firstUnheldSelectionField(
+      sourceItemSchema(target),
+      targetRoot,
+      projection,
+      `${position}[]`,
+    );
+  }
+
+  if (!schemaIsObjectShaped(target, targetRoot)) {
+    const types = schemaTypes(target);
+    // A stated scalar type is the position saying what it holds, and a string
+    // has no fields to name. Every other reading of the position — no type at
+    // all, a union admitting a container, a conjunction whose members state
+    // the type between them — leaves the shape open, and an open position
+    // holds whatever was stored there.
+    if (
+      types.length === 0 || types.includes("object") || types.includes("array")
+    ) {
+      return undefined;
+    }
+    return { key: Object.keys(named)[0], position, holds: { types } };
+  }
+
+  // A pattern-matched name is declared without being named, so a position
+  // carrying one has a vocabulary no list of keys states.
+  if (target.patternProperties !== undefined) return undefined;
+  const declared = declaredFieldsAt(target, targetRoot);
+  // A position with no property map states no vocabulary, and answers with
+  // whatever the value holds there.
+  if (declared.sources.length === 0) return undefined;
+  const declaringSources = (key: string) =>
+    declared.sources.filter((source) => Object.hasOwn(source.properties, key));
+  if (!declared.honorsUndeclared) {
+    for (const key of Object.keys(named)) {
+      if (declaringSources(key).length === 0) {
+        return {
+          key,
+          position,
+          holds: { fields: declaredFieldNames(declared.sources) },
+        };
+      }
+    }
+  }
+  for (const [key, child] of Object.entries(named)) {
+    const matches = declaringSources(key);
+    // A name several conjunction members declare is passed over one level
+    // down: the walk cannot say which member's schema governs beneath it.
+    if (matches.length > 1) continue;
+    const found = firstUnheldSelectionField(
+      matches.length === 1
+        ? matches[0].properties[key]
+        : target.additionalProperties as JSONSchema | undefined,
+      matches.length === 1 ? matches[0].root : targetRoot,
+      child as JSONSchema,
+      `${position}.${key}`,
+    );
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/** The names a refusal lists, quoted, in the order the source declares them. */
+function quotedNames(names: readonly string[]): string {
+  return names.map((name) => `"${name}"`).join(", ");
+}
+
+/**
+ * The refusal a field the source cannot hold earns.
+ *
+ * The caller is handed what the reader knew before it read anything: the name
+ * they wrote, the position it was named at, what that position holds instead,
+ * and the declared name they are one edit from. No read-side surface prints
+ * the schema a read runs against, so the vocabulary is the whole remediation.
+ */
+function unheldSelectionFieldError(
+  flag: ProjectionFlag,
+  found: UnheldSelectionField,
+): CellSelectionError {
+  const opening = `Invalid ${flag} at ${found.position}: "${found.key}" is ` +
+    "not a field the source holds. ";
+  if ("stream" in found.holds) {
+    return new CellSelectionError(
+      opening +
+        `${found.position} is a verb, which dispatches rather than holding ` +
+        "a value to select from",
+    );
+  }
+  if ("types" in found.holds) {
+    return new CellSelectionError(
+      opening +
+        `${found.position} holds ${
+          quotedNames(found.holds.types)
+        }, which has no fields`,
+    );
+  }
+  const nearest = nearestName(found.key, found.holds.fields);
+  return new CellSelectionError(
+    opening +
+      (nearest === undefined ? "" : `Did you mean "${nearest}"? `) +
+      (found.holds.fields.length === 0
+        ? `${found.position} declares no fields at all`
+        : `${found.position} declares ${quotedNames(found.holds.fields)}`),
+  );
 }
 
 function projectValue(
@@ -2283,6 +2488,21 @@ function resolveProjection(
 ): ResolvedProjection | undefined {
   if (projection === undefined) return undefined;
   if (projection.kind === "concise") {
+    // A field list names positions of the source, so the source is what says
+    // whether a name can be there at all. A path it cannot hold answers
+    // nothing however the read is run, and answering nothing is what a read
+    // legitimately does for a field that is merely absent — so the two are
+    // separated here, before the read, where the schema still distinguishes
+    // them.
+    const unheld = firstUnheldSelectionField(
+      sourceSchema,
+      sourceSchema ?? true,
+      projection.schema,
+      "<root>",
+    );
+    if (unheld !== undefined) {
+      throw unheldSelectionFieldError(projection.flag, unheld);
+    }
     const projectsArrayItems = sourceIsArray;
     const source = projectsArrayItems
       ? schemaAtArrayItem(sourceSchema)

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -1857,8 +1857,14 @@ function firstUnheldSelectionField(
   // fixed depth, so an array position is crossed and the same names are asked
   // of its elements — the traversal `alignConciseProjectionMask` applies to
   // the mask beside this.
-  if (schemaIsArrayShaped(target)) {
-    if (schemaIsObjectShaped(target, targetRoot)) return undefined;
+  //
+  // Crossed only where the position MUST hold an array, which is the question
+  // {@link sourceProvesContainer} exists to answer. A position that merely may
+  // hold one — untyped beside an `items`, or a union naming both containers —
+  // settles neither depth: the name belongs to an element where the value is
+  // an array and to the position itself where it is not, and judging it at one
+  // of them refuses a read that works at the other.
+  if (sourceProvesContainer("array", target, targetRoot)) {
     return firstUnheldSelectionField(
       sourceItemSchema(target),
       targetRoot,
@@ -1866,19 +1872,16 @@ function firstUnheldSelectionField(
       `${position}[]`,
     );
   }
+  if (schemaIsArrayShaped(target)) return undefined;
 
   if (!schemaIsObjectShaped(target, targetRoot)) {
     const types = schemaTypes(target);
     // A stated scalar type is the position saying what it holds, and a string
     // has no fields to name. Every other reading of the position — no type at
-    // all, a union admitting a container, a conjunction whose members state
-    // the type between them — leaves the shape open, and an open position
-    // holds whatever was stored there.
-    if (
-      types.length === 0 || types.includes("object") || types.includes("array")
-    ) {
-      return undefined;
-    }
+    // all, a union admitting an object, a conjunction whose members state the
+    // type between them — leaves the shape open, and an open position holds
+    // whatever was stored there.
+    if (types.length === 0 || types.includes("object")) return undefined;
     return { key: Object.keys(named)[0], position, holds: { types } };
   }
 

--- a/packages/cli/lib/declared-fields.ts
+++ b/packages/cli/lib/declared-fields.ts
@@ -1,0 +1,190 @@
+/**
+ * What a schema position declares, read the way the runtime reads it.
+ *
+ * Two doors ask this question of two different schemas. The call door asks a
+ * verb's event schema which fields a payload may carry; the read door asks a
+ * source cell's schema which fields a `--select` path may name. A name neither
+ * declares is the same mistake either way, so both are answered here rather
+ * than twice — the vocabulary a refusal prints, and the rule deciding whether
+ * a position judges undeclared names at all, are one implementation.
+ *
+ * Every answer here fails open: where the schema stops proving what sits under
+ * a position, the position declares nothing and judges nothing. A refusal
+ * spends nothing and can be retried, while a wrongly refused call cannot be
+ * made and a wrongly refused read cannot be taken.
+ */
+
+import type { JSONSchema } from "@commonfabric/api";
+import { cfcSchemaChildRoot } from "@commonfabric/runner/cfc/schema-refs";
+import { localRefTarget } from "@commonfabric/runner/cfc/schema-sanitization";
+import {
+  isObjectNotArray,
+  type ReadonlyRecord,
+} from "@commonfabric/utils/types";
+
+/** Whether `schema` is a schema object rather than a boolean or absent. */
+export function isSchemaObject(
+  schema: JSONSchema | undefined,
+): schema is ReadonlyRecord {
+  return isObjectNotArray(schema);
+}
+
+/**
+ * Whether a resolved schema position describes an object — directly, or as an
+ * `allOf` conjunction with an object-schema branch (a conjunction that
+ * includes an object schema IS an object schema, no branch choice involved).
+ * `anyOf`/`oneOf` roots deliberately return false: reading one as an object
+ * would pick among alternatives on the caller's behalf, and a position is
+ * judged only on proof.
+ */
+export function schemaIsObjectShaped(
+  target: JSONSchema,
+  root: JSONSchema,
+): boolean {
+  if (!isSchemaObject(target)) return false;
+  if (target.type === "object" || isSchemaObject(target.properties)) {
+    return true;
+  }
+  if (Array.isArray(target.allOf)) {
+    return target.allOf.some((branch) => {
+      const resolved = localRefTarget(branch, root);
+      return isSchemaObject(resolved) &&
+        (resolved.type === "object" || isSchemaObject(resolved.properties));
+    });
+  }
+  return false;
+}
+
+/**
+ * Whether a position describes an array.
+ *
+ * The array counterpart of {@link schemaIsObjectShaped}, and it answers the
+ * question the same way: a stated `type` says so, and otherwise the container
+ * keyword being present does. An untyped position naming `items` is an array
+ * to everything except schema traversal's own descent, which requires the
+ * stated type and empties the position without it — the same asymmetry the
+ * object side has, one container over.
+ */
+export function schemaIsArrayShaped(node: Record<string, unknown>): boolean {
+  const declaredType = node.type;
+  if (declaredType === "array") return true;
+  if (Array.isArray(declaredType)) return declaredType.includes("array");
+  if (declaredType !== undefined) return false;
+  return node.items !== undefined || node.prefixItems !== undefined;
+}
+
+/** One property map an object-shaped position reaches, with the local-ref
+ * scope the schemas inside it resolve against. */
+export interface DeclaredFieldSource {
+  properties: Record<string, JSONSchema>;
+  root: JSONSchema;
+}
+
+/** What a position declares, and whether anything there honors a field none of
+ * its maps name. */
+export interface DeclaredFields {
+  sources: DeclaredFieldSource[];
+  honorsUndeclared: boolean;
+  /** Every name any reached member marks required. A conjunction constrains
+   * one value from all its members at once, so a name any of them requires is
+   * required of the value. A DISJUNCTION contributes none — a value satisfies
+   * one branch, so no branch's requirement binds it, and the walk
+   * stops at one rather than reading its members. */
+  required: Set<string>;
+}
+
+/**
+ * Every property map an object-shaped position reaches, and whether it honors a
+ * field none of them name.
+ *
+ * A conjunction constrains one value from several members at once, so the
+ * fields it declares are the UNION across its members: a value satisfying an
+ * `allOf` satisfies every member, and a field one member names is a field the
+ * position names. Taking the union is also the safe direction — the cost of
+ * missing a member is refusing a field that was declared, and the cost of an
+ * extra member is accepting one that would have been dropped.
+ *
+ * A disjunction anywhere inside makes the whole position honor everything: a
+ * branch the value was meant for may name a field the others do not, and
+ * choosing among branches is the caller's, not this reader's.
+ *
+ * `followed` breaks reference cycles, and it records the REFERENCE rather than
+ * the schema it resolved to — the same key `localRefTarget` cycles on, and the
+ * only one that works here: resolution hands back a fresh view of a definition
+ * each time, so a recursive `$ref` reaches an object this walk has never seen
+ * and descends forever. A member is skipped once its reference has been
+ * followed in the scope it was written in; a definition contributes its fields
+ * once, and a schema naming itself terminates.
+ */
+export function declaredFieldsAt(
+  node: Record<string, unknown>,
+  root: JSONSchema,
+  into: DeclaredFields = {
+    sources: [],
+    honorsUndeclared: false,
+    required: new Set<string>(),
+  },
+  followed: Map<JSONSchema, Set<string>> = new Map(),
+): DeclaredFields {
+  if (isSchemaObject(node.properties as JSONSchema)) {
+    into.sources.push({
+      properties: node.properties as Record<string, JSONSchema>,
+      root,
+    });
+  }
+  // `false` is the one value that does NOT honor undeclared fields — it is
+  // the schema saying no extra field is permitted. Reading mere presence as
+  // permission inverts the strictest spelling into the most permissive one,
+  // and the name is then dropped by the runtime — a field a call never
+  // delivers, a path a read never answers — which is the silent loss the
+  // refusals built on this exist to prevent.
+  if (
+    node.additionalProperties !== undefined &&
+    node.additionalProperties !== false
+  ) {
+    into.honorsUndeclared = true;
+  }
+  if (Array.isArray(node.required)) {
+    for (const name of node.required as unknown[]) {
+      if (typeof name === "string") into.required.add(name);
+    }
+  }
+  if (!Array.isArray(node.allOf)) return into;
+  for (const member of node.allOf as JSONSchema[]) {
+    const memberRoot = cfcSchemaChildRoot(member, root);
+    if (isSchemaObject(member) && typeof member.$ref === "string") {
+      let inScope = followed.get(memberRoot);
+      if (inScope?.has(member.$ref)) continue;
+      if (inScope === undefined) {
+        inScope = new Set();
+        followed.set(memberRoot, inScope);
+      }
+      inScope.add(member.$ref);
+    }
+    const resolved = localRefTarget(member, memberRoot);
+    if (!isSchemaObject(resolved)) continue;
+    if (resolved.anyOf !== undefined || resolved.oneOf !== undefined) {
+      into.honorsUndeclared = true;
+      continue;
+    }
+    declaredFieldsAt(
+      resolved,
+      cfcSchemaChildRoot(resolved, memberRoot),
+      into,
+      followed,
+    );
+  }
+  return into;
+}
+
+/** The vocabulary a refusal names: every field the position's maps declare, in
+ * the order they were reached, each named once. */
+export function declaredFieldNames(sources: DeclaredFieldSource[]): string[] {
+  const names: string[] = [];
+  for (const source of sources) {
+    for (const key of Object.keys(source.properties)) {
+      if (!names.includes(key)) names.push(key);
+    }
+  }
+  return names;
+}

--- a/packages/cli/lib/declared-fields.ts
+++ b/packages/cli/lib/declared-fields.ts
@@ -104,9 +104,10 @@ export interface DeclaredFields {
  * missing a member is refusing a field that was declared, and the cost of an
  * extra member is accepting one that would have been dropped.
  *
- * A disjunction anywhere inside makes the whole position honor everything: a
- * branch the value was meant for may name a field the others do not, and
- * choosing among branches is the caller's, not this reader's.
+ * A disjunction makes the whole position honor everything, whether it sits at
+ * the position or inside a conjunction member: a branch the value was meant
+ * for may name a field the others do not, and choosing among branches is the
+ * caller's, not this reader's.
  *
  * `followed` breaks reference cycles, and it records the REFERENCE rather than
  * the schema it resolved to — the same key `localRefTarget` cycles on, and the
@@ -148,6 +149,12 @@ export function declaredFieldsAt(
     for (const name of node.required as unknown[]) {
       if (typeof name === "string") into.required.add(name);
     }
+  }
+  // A disjunction AT the position, read here rather than left to each caller
+  // to guard: a branch the value was meant for may name a field the others do
+  // not, and this reader is the one that says whether a position judges.
+  if (node.anyOf !== undefined || node.oneOf !== undefined) {
+    into.honorsUndeclared = true;
   }
   if (!Array.isArray(node.allOf)) return into;
   for (const member of node.allOf as JSONSchema[]) {

--- a/packages/cli/lib/declared-fields.ts
+++ b/packages/cli/lib/declared-fields.ts
@@ -4,12 +4,12 @@
  * Two doors ask this question of two different schemas. The call door asks a
  * verb's event schema which fields a payload may carry; the read door asks a
  * source cell's schema which fields a `--select` path may name. A name neither
- * declares is the same mistake either way, so both are answered here rather
+ * declares is the same mistake either way, so both are settled here rather
  * than twice — the vocabulary a refusal prints, and the rule deciding whether
  * a position judges undeclared names at all, are one implementation.
  *
- * Every answer here fails open: where the schema stops proving what sits under
- * a position, the position declares nothing and judges nothing. A refusal
+ * Every reading here fails open: where the schema stops proving what sits
+ * under a position, the position declares nothing and judges nothing. A refusal
  * spends nothing and can be retried, while a wrongly refused call cannot be
  * made and a wrongly refused read cannot be taken.
  */
@@ -58,7 +58,7 @@ export function schemaIsObjectShaped(
 /**
  * Whether a position describes an array.
  *
- * The array counterpart of {@link schemaIsObjectShaped}, and it answers the
+ * The array counterpart of {@link schemaIsObjectShaped}, and it settles the
  * question the same way: a stated `type` says so, and otherwise the container
  * keyword being present does. An untyped position naming `items` is an array
  * to everything except schema traversal's own descent, which requires the
@@ -136,7 +136,7 @@ export function declaredFieldsAt(
   // the schema saying no extra field is permitted. Reading mere presence as
   // permission inverts the strictest spelling into the most permissive one,
   // and the name is then dropped by the runtime — a field a call never
-  // delivers, a path a read never answers — which is the silent loss the
+  // delivers, a path a read never returns — which is the silent loss the
   // refusals built on this exist to prevent.
   if (
     node.additionalProperties !== undefined &&

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -46,10 +46,10 @@ import {
   executeResolvedCallable,
   normalizeAbsentVerbPayload,
   runtimeErrorLog,
-  schemaIsObjectShaped,
   verbInputSchemaError,
   VerbInputValidationError,
 } from "../lib/callable.ts";
+import { schemaIsObjectShaped } from "../lib/declared-fields.ts";
 import {
   type CellSelection,
   CellSelectionError,

--- a/packages/cli/test/piece-get-transform.test.ts
+++ b/packages/cli/test/piece-get-transform.test.ts
@@ -1010,11 +1010,13 @@ describe("cf piece get transforms", () => {
         projection: await parseSelectionProjection("id"),
       }),
     ).toEqual({ id: 1 });
-    expect(
-      await deriveSelectedValue(runtime, space, source, {
+    await expect(
+      deriveSelectedValue(runtime, space, source, {
         projection: await parseSelectionProjection("missing"),
       }),
-    ).toEqual({});
+    ).rejects.toThrow(
+      'Invalid --schema at <root>: "missing" is not a field the source holds',
+    );
     expect(
       await deriveSelectedValue(runtime, space, source, {
         projection: await parseSelectionProjection(JSON.stringify({

--- a/packages/cli/test/select-unheld-field.test.ts
+++ b/packages/cli/test/select-unheld-field.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Pins the refusal a `--select`/`--schema` field list gets when it names a
+ * field the source schema proves cannot be there: which positions it fires at,
+ * the wording a caller reads, and — in equal measure — the positions it passes
+ * over, each asserted as the read still answering.
+ *
+ * The gate is `firstUnheldSelectionField` (../lib/cell-selection.ts), reached
+ * through `deriveSelectedValue`, which is the path every read flag takes. The
+ * root case is driven against a COMPILED, RUN pattern, because the schema a
+ * piece is read through is one the transformer emits and a hand-built schema
+ * could only assert back what this file assumed. The shapes the transformer
+ * does not emit — an open position, a disjunction, a union of scalars — are
+ * written out, since a caller meets them through `handler` schemas and
+ * hand-written cells.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { type Cell, type JSONSchema, Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { getResultCellWithSourceSchema } from "../../runner/src/piece-helpers.ts";
+import {
+  deriveSelectedValue,
+  parseSelectionProjection,
+  parseSelectProjection,
+} from "../lib/cell-selection.ts";
+
+/**
+ * A pattern whose result type names a scalar, a computed number, an array and
+ * a verb — the four positions a field list can be pointed at, as the
+ * transformer spells them. The verb reaches the result schema as
+ * `{asCell: ["stream"], $ref: "#/$defs/AddEvent"}`, which is the shape the
+ * stream check has to see through the reference beside it.
+ */
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      'import { action, cell, computed, pattern, Stream } from "commonfabric";',
+      "",
+      "interface AddEvent { title: string; }",
+      "",
+      "interface Item { title: string; done: boolean; }",
+      "",
+      "interface Out {",
+      "  label: string;",
+      "  count: number;",
+      "  items: Item[];",
+      "  add: Stream<AddEvent>;",
+      "}",
+      "",
+      "export default pattern<Record<string, never>, Out>(() => {",
+      "  const items = cell<Item[]>([{ title: 'First', done: false }]);",
+      "  const label = cell('untitled');",
+      "  const add = action((event: AddEvent) => {",
+      "    items.push({ title: event.title, done: false });",
+      "  });",
+      "  return {",
+      "    label,",
+      "    count: computed(() => items.get().length),",
+      "    items,",
+      "    add,",
+      "  };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const signer = await Identity.fromPassphrase("cf-select-unheld-field");
+const space = signer.did();
+
+describe("select-unheld-field", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /** The result cell of a live piece, read through the schema the pattern
+   * declares — the one narrowing `cf` applies before any command sees it. */
+  const livePieceResult = async (id: string): Promise<Cell<unknown>> => {
+    const compiled = await runtime.patternManager.compilePattern(
+      PROGRAM as never,
+      { space },
+    );
+    const tx = runtime.edit();
+    const root = runtime.run(
+      tx,
+      compiled,
+      {},
+      runtime.getCell(space, id, undefined, tx),
+    );
+    runtime.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await root.pull();
+    return getResultCellWithSourceSchema(root);
+  };
+
+  /** A cell holding `value` under `schema`, which is the source a hand-written
+   * shape is read through. */
+  const sourceCell = async (
+    id: string,
+    schema: JSONSchema,
+    value: unknown,
+  ): Promise<Cell<unknown>> => {
+    const tx = runtime.edit();
+    const cell = runtime.getCell(space, id, schema, tx);
+    cell.set(value as never);
+    expect((await tx.commit()).ok).toBeDefined();
+    return cell;
+  };
+
+  const selected = (source: Cell<unknown>, select: string) =>
+    deriveSelectedValue(runtime, space, source, {
+      projection: parseSelectProjection(select),
+    });
+
+  it("refuses a misspelled field, naming the near miss and the whole vocabulary", async () => {
+    const source = await livePieceResult("unheld-root");
+    await expect(selected(source, "labl")).rejects.toThrow(
+      'Invalid --select at <root>: "labl" is not a field the source holds. ' +
+        'Did you mean "label"? <root> declares "label", "count", "items", "add"',
+    );
+    // A misspelling asked for an address is the same misspelling.
+    await expect(selected(source, "labl@")).rejects.toThrow(
+      'Invalid --select at <root>: "labl" is not a field the source holds',
+    );
+  });
+
+  it("refuses a dotted path at the first segment the source cannot hold", async () => {
+    const source = await livePieceResult("unheld-dotted");
+    await expect(selected(source, "add.v1")).rejects.toThrow(
+      'Invalid --select at <root>.add: "v1" is not a field the source holds',
+    );
+    await expect(selected(source, "bump.v1")).rejects.toThrow(
+      'Invalid --select at <root>: "bump" is not a field the source holds',
+    );
+  });
+
+  it("refuses a field named below a scalar, naming the type the position holds", async () => {
+    const source = await livePieceResult("unheld-scalar");
+    await expect(selected(source, "label.first")).rejects.toThrow(
+      'Invalid --select at <root>.label: "first" is not a field the source ' +
+        'holds. <root>.label holds "string", which has no fields',
+    );
+  });
+
+  it("refuses a field named below a verb, which holds no value to select from", async () => {
+    const source = await livePieceResult("unheld-stream");
+    await expect(selected(source, "add.title")).rejects.toThrow(
+      'Invalid --select at <root>.add: "title" is not a field the source ' +
+        "holds. <root>.add is a verb, which dispatches rather than holding a " +
+        "value to select from",
+    );
+  });
+
+  it("crosses an array to name the position an element field was named at", async () => {
+    const source = await livePieceResult("unheld-element");
+    await expect(selected(source, "items.titel")).rejects.toThrow(
+      'Invalid --select at <root>.items[]: "titel" is not a field the source ' +
+        'holds. Did you mean "title"? <root>.items[] declares "title", "done"',
+    );
+    expect(await selected(source, "items.title")).toEqual({
+      items: [{ title: "First" }],
+    });
+  });
+
+  it("reads every field the piece does declare, and the address of one asked for it", async () => {
+    const source = await livePieceResult("unheld-declared");
+    expect(await selected(source, "label,count")).toEqual({
+      label: "untitled",
+      count: 1,
+    });
+    // A marked position names a field without descending into it, so nothing
+    // below it is judged — and `@` alone names the read's own source, which is
+    // above every field.
+    expect(await selected(source, "add@")).toMatchObject({
+      add: { $link: expect.any(String) },
+    });
+    expect(await selected(source, "@")).toMatchObject({
+      $link: expect.any(String),
+    });
+  });
+
+  it("reads a field the source declares nothing about, at a position that admits one", async () => {
+    const source = await sourceCell(
+      "unheld-open",
+      {
+        type: "object",
+        properties: { title: { type: "string" } },
+        additionalProperties: true,
+      },
+      { title: "First", extra: "kept" },
+    );
+    expect(await selected(source, "extra")).toEqual({ extra: "kept" });
+  });
+
+  it("reads a field named at a position with no property map at all", async () => {
+    const source = await sourceCell(
+      "unheld-untyped",
+      { type: "object" },
+      { title: "First" },
+    );
+    expect(await selected(source, "title")).toEqual({ title: "First" });
+  });
+
+  it("refuses a field named at a position that declares an empty field map", async () => {
+    const source = await sourceCell(
+      "unheld-empty-map",
+      {
+        type: "object",
+        properties: { holder: { type: "object", properties: {} } },
+      },
+      { holder: {} },
+    );
+    await expect(selected(source, "holder.title")).rejects.toThrow(
+      'Invalid --select at <root>.holder: "title" is not a field the source ' +
+        "holds. <root>.holder declares no fields at all",
+    );
+  });
+
+  it("reads a field named across an array whose element shape is left open", async () => {
+    const source = await sourceCell(
+      "unheld-open-array",
+      {
+        type: "object",
+        properties: { items: { type: "array" } },
+      },
+      { items: [{ title: "First", other: "dropped" }] },
+    );
+    expect(await selected(source, "items.title")).toEqual({
+      items: [{ title: "First" }],
+    });
+  });
+
+  it("reads a field named at a position that matches names by pattern", async () => {
+    const source = await sourceCell(
+      "unheld-pattern-properties",
+      {
+        type: "object",
+        properties: { title: { type: "string" } },
+        patternProperties: { "^x-": { type: "string" } },
+      },
+      { title: "First", "x-trace": "kept" },
+    );
+    expect(await selected(source, "x-trace")).toEqual({ "x-trace": "kept" });
+  });
+
+  it("reads a field named under a disjunction, whose branches need not agree", async () => {
+    const source = await sourceCell(
+      "unheld-disjunction",
+      {
+        type: "object",
+        properties: {
+          holder: {
+            anyOf: [
+              { type: "object", properties: { title: { type: "string" } } },
+              { type: "object", properties: { name: { type: "string" } } },
+            ],
+          },
+        },
+      },
+      { holder: { name: "Ada" } },
+    );
+    expect(await selected(source, "holder.name")).toEqual({
+      holder: { name: "Ada" },
+    });
+  });
+
+  it("reads a field named under a union that admits an object", async () => {
+    const source = await sourceCell(
+      "unheld-union",
+      {
+        type: "object",
+        properties: { holder: { type: ["object", "null"] } },
+      },
+      { holder: { name: "Ada" } },
+    );
+    expect(await selected(source, "holder.name")).toEqual({
+      holder: { name: "Ada" },
+    });
+  });
+
+  it("refuses a field named under a union of scalars, which admits no object", async () => {
+    const source = await sourceCell(
+      "unheld-scalar-union",
+      {
+        type: "object",
+        properties: { title: { type: ["string", "null"] } },
+      },
+      { title: null },
+    );
+    await expect(selected(source, "title.first")).rejects.toThrow(
+      'Invalid --select at <root>.title: "first" is not a field the source ' +
+        'holds. <root>.title holds "string", "null", which has no fields',
+    );
+  });
+
+  it("names a conjunction member's field in the vocabulary, and lets one through", async () => {
+    const source = await sourceCell(
+      "unheld-conjunction",
+      {
+        type: "object",
+        properties: { title: { type: "string" } },
+        allOf: [{
+          type: "object",
+          properties: { subtitle: { type: "string" } },
+        }],
+      },
+      { title: "First", subtitle: "Second" },
+    );
+    // A conjunction constrains one value from every member at once, so a field
+    // any member declares is a field the position declares.
+    await expect(selected(source, "subtitle")).resolves.toBeDefined();
+    await expect(selected(source, "subtitel")).rejects.toThrow(
+      'Did you mean "subtitle"? <root> declares "title", "subtitle"',
+    );
+  });
+
+  it("reads a field a referenced definition declares, and refuses one it does not", async () => {
+    const source = await sourceCell(
+      "unheld-reference",
+      {
+        type: "object",
+        properties: { holder: { $ref: "#/$defs/Holder" } },
+        $defs: {
+          Holder: {
+            type: "object",
+            properties: { title: { type: "string" } },
+          },
+        },
+      },
+      { holder: { title: "First" } },
+    );
+    expect(await selected(source, "holder.title")).toEqual({
+      holder: { title: "First" },
+    });
+    await expect(selected(source, "holder.titel")).rejects.toThrow(
+      'Invalid --select at <root>.holder: "titel" is not a field the source ' +
+        'holds. Did you mean "title"? <root>.holder declares "title"',
+    );
+  });
+
+  it("reads a field named at a reference site that declares fields of its own", async () => {
+    const source = await sourceCell(
+      "unheld-reference-site",
+      {
+        type: "object",
+        properties: {
+          holder: {
+            $ref: "#/$defs/Holder",
+            properties: { extra: { type: "string" } },
+          },
+        },
+        $defs: {
+          Holder: {
+            type: "object",
+            properties: { title: { type: "string" } },
+          },
+        },
+      },
+      { holder: { title: "First", extra: "beside" } },
+    );
+    // The read answers from both accounts of the position, so neither is the
+    // vocabulary a refusal could name.
+    expect(await selected(source, "holder.title")).toEqual({
+      holder: { title: "First" },
+    });
+    expect(await selected(source, "holder.extra")).toEqual({
+      holder: { extra: "beside" },
+    });
+  });
+
+  it("reads a field a JSON `--schema` names, which states a shape rather than naming the source's", async () => {
+    const source = await sourceCell(
+      "unheld-json-schema",
+      {
+        type: "object",
+        properties: { title: { type: "string" } },
+      },
+      { title: "First" },
+    );
+    await expect(
+      deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection("extra"),
+      }),
+    ).rejects.toThrow(
+      'Invalid --schema at <root>: "extra" is not a field the source holds',
+    );
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"type":"object","properties":{"title":true}}',
+        ),
+      }),
+    ).toEqual({ title: "First" });
+  });
+});

--- a/packages/cli/test/select-unheld-field.test.ts
+++ b/packages/cli/test/select-unheld-field.test.ts
@@ -268,6 +268,39 @@ describe("select-unheld-field", () => {
     });
   });
 
+  it("reads a field named at an untyped position beside an `items` schema", async () => {
+    const source = await sourceCell(
+      "unheld-untyped-items",
+      { items: { type: "object", properties: { title: { type: "string" } } } },
+      { extra: "kept" },
+    );
+    // The position may hold an array and holds an object, so the name belongs
+    // to the position itself rather than to an element, and the element
+    // schema's vocabulary says nothing about it. The empty answer is the
+    // concise read applying its field mask, not a refusal — the JSON spelling
+    // of the same request reaches the value.
+    expect(await selected(source, "extra")).toEqual({});
+    expect(
+      await deriveSelectedValue(runtime, space, source, {
+        projection: await parseSelectionProjection(
+          '{"type":"object","properties":{"extra":true}}',
+        ),
+      }),
+    ).toEqual({ extra: "kept" });
+  });
+
+  it("reads a field named at a position typed as both an array and an object", async () => {
+    const source = await sourceCell(
+      "unheld-array-or-object",
+      {
+        type: ["array", "object"],
+        items: { type: "object", properties: { title: { type: "string" } } },
+      },
+      { extra: "kept" },
+    );
+    expect(await selected(source, "extra")).toEqual({ extra: "kept" });
+  });
+
   it("reads a field named at a position that matches names by pattern", async () => {
     const source = await sourceCell(
       "unheld-pattern-properties",

--- a/packages/cli/test/select-unheld-field.test.ts
+++ b/packages/cli/test/select-unheld-field.test.ts
@@ -166,6 +166,29 @@ describe("select-unheld-field", () => {
     );
   });
 
+  it("refuses a field named below a verb a referenced definition carries", async () => {
+    const source = await sourceCell(
+      "unheld-referenced-stream",
+      {
+        type: "object",
+        properties: { add: { $ref: "#/$defs/Add" } },
+        $defs: {
+          Add: {
+            asCell: ["stream"],
+            type: "object",
+            properties: { title: { type: "string" } },
+          },
+        },
+      },
+      {},
+    );
+    await expect(selected(source, "add.title")).rejects.toThrow(
+      'Invalid --select at <root>.add: "title" is not a field the source ' +
+        "holds. <root>.add is a verb, which dispatches rather than holding a " +
+        "value to select from",
+    );
+  });
+
   it("crosses an array to name the position an element field was named at", async () => {
     const source = await livePieceResult("unheld-element");
     await expect(selected(source, "items.titel")).rejects.toThrow(
@@ -308,7 +331,7 @@ describe("select-unheld-field", () => {
     );
   });
 
-  it("names a conjunction member's field in the vocabulary, and lets one through", async () => {
+  it("returns the empty projection for a field only a conjunction member declares", async () => {
     const source = await sourceCell(
       "unheld-conjunction",
       {
@@ -322,8 +345,11 @@ describe("select-unheld-field", () => {
       { title: "First", subtitle: "Second" },
     );
     // A conjunction constrains one value from every member at once, so a field
-    // any member declares is a field the position declares.
-    await expect(selected(source, "subtitle")).resolves.toBeDefined();
+    // any member declares is a field the position declares, and the gate lets
+    // it through. What comes back is empty because the read's own traversal
+    // does not reach a conjunction member's properties, which is a fact about
+    // the read rather than about the gate.
+    expect(await selected(source, "subtitle")).toEqual({});
     await expect(selected(source, "subtitel")).rejects.toThrow(
       'Did you mean "subtitle"? <root> declares "title", "subtitle"',
     );
@@ -381,6 +407,43 @@ describe("select-unheld-field", () => {
     expect(await selected(source, "holder.extra")).toEqual({
       holder: { extra: "beside" },
     });
+  });
+
+  it("names no unheld field where the source's own reference does not resolve", async () => {
+    const source = await sourceCell(
+      "unheld-unresolved-reference",
+      {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          holder: { $ref: "#/$defs/Missing" },
+        },
+      },
+      { title: "First" },
+    );
+    // The position is passed over rather than refused, so what the caller
+    // reads is the source schema's own problem, named as that.
+    await expect(selected(source, "holder.title")).rejects.toThrow(
+      "Could not resolve source schema reference for --select",
+    );
+  });
+
+  it("reads a field two accounts of one position both declare", async () => {
+    const source = await sourceCell(
+      "unheld-twice-declared",
+      {
+        type: "object",
+        properties: { title: { type: "string" } },
+        allOf: [{
+          type: "object",
+          properties: { title: { type: "string" } },
+        }],
+      },
+      { title: "First" },
+    );
+    // Which account governs what sits below `title` is unsettled, so nothing
+    // below it is judged.
+    expect(await selected(source, "title.first")).toEqual({ title: "First" });
   });
 
   it("reads a field a JSON `--schema` names, which states a shape rather than naming the source's", async () => {

--- a/packages/cli/test/select-unheld-field.test.ts
+++ b/packages/cli/test/select-unheld-field.test.ts
@@ -2,7 +2,7 @@
  * Pins the refusal a `--select`/`--schema` field list gets when it names a
  * field the source schema proves cannot be there: which positions it fires at,
  * the wording a caller reads, and — in equal measure — the positions it passes
- * over, each asserted as the read still answering.
+ * over, each asserted as the read still returning a value.
  *
  * The gate is `firstUnheldSelectionField` (../lib/cell-selection.ts), reached
  * through `deriveSelectedValue`, which is the path every read flag takes. The
@@ -10,7 +10,7 @@
  * piece is read through is one the transformer emits and a hand-built schema
  * could only assert back what this file assumed. The shapes the transformer
  * does not emit — an open position, a disjunction, a union of scalars — are
- * written out, since a caller meets them through `handler` schemas and
+ * written out, since a caller reaches them through `handler` schemas and
  * hand-written cells.
  */
 
@@ -268,6 +268,25 @@ describe("select-unheld-field", () => {
     });
   });
 
+  it("reads a field only a tuple's prefix element declares", async () => {
+    const source = await sourceCell(
+      "unheld-tuple",
+      {
+        type: "array",
+        prefixItems: [{
+          type: "object",
+          properties: { title: { type: "string" } },
+        }],
+        items: { type: "object", properties: { count: { type: "number" } } },
+      },
+      [{ title: "First" }, { count: 2 }],
+    );
+    // `items` describes the elements past the prefix, so it is the vocabulary
+    // of some elements rather than of all of them.
+    expect(await selected(source, "title")).toEqual([{ title: "First" }, {}]);
+    expect(await selected(source, "count")).toEqual([{}, { count: 2 }]);
+  });
+
   it("reads a field named at an untyped position beside an `items` schema", async () => {
     const source = await sourceCell(
       "unheld-untyped-items",
@@ -276,7 +295,7 @@ describe("select-unheld-field", () => {
     );
     // The position may hold an array and holds an object, so the name belongs
     // to the position itself rather than to an element, and the element
-    // schema's vocabulary says nothing about it. The empty answer is the
+    // schema's vocabulary says nothing about it. The empty result is the
     // concise read applying its field mask, not a refusal — the JSON spelling
     // of the same request reaches the value.
     expect(await selected(source, "extra")).toEqual({});
@@ -432,7 +451,7 @@ describe("select-unheld-field", () => {
       },
       { holder: { title: "First", extra: "beside" } },
     );
-    // The read answers from both accounts of the position, so neither is the
+    // The read draws on both accounts of the position, so neither is the
     // vocabulary a refusal could name.
     expect(await selected(source, "holder.title")).toEqual({
       holder: { title: "First" },

--- a/packages/cli/test/select-unheld-field.test.ts
+++ b/packages/cli/test/select-unheld-field.test.ts
@@ -287,6 +287,24 @@ describe("select-unheld-field", () => {
     expect(await selected(source, "count")).toEqual([{}, { count: 2 }]);
   });
 
+  it("reads a field named across an array whose `items` is a list of schemas", async () => {
+    const source = await sourceCell(
+      "unheld-draft-07-tuple",
+      {
+        type: "array",
+        items: [
+          { type: "object", properties: { title: { type: "string" } } },
+          { type: "object", properties: { count: { type: "number" } } },
+        ],
+      } as never,
+      [{ title: "First" }, { count: 2 }],
+    );
+    // A list of schemas is not a schema, so it states no element vocabulary
+    // for the walk to judge a name against — including a name no element
+    // declares.
+    expect(await selected(source, "nope")).toEqual([{}, {}]);
+  });
+
   it("reads a field named at an untyped position beside an `items` schema", async () => {
     const source = await sourceCell(
       "unheld-untyped-items",

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -327,6 +327,17 @@ emitted address composes into the next command unchanged, without being
 reassembled. Neither spelling composes with `--filter`. See
 `packages/cli/README.md` for the exact syntax and supported schema subset.
 
+A field list is held to the source's own vocabulary. A path the schema proves
+nothing can appear at — a field the position neither declares nor admits, a
+field named below a scalar, a field named below a verb — is refused before the
+read, naming the position, what it declares, and the declared name the path is
+one edit from. A field that is merely absent still answers with nothing at exit
+0, so `{}` reads as "nothing here" rather than "you may have mistyped". Where
+the source schema settles nothing — a position carrying `additionalProperties`,
+a disjunction, an untyped position, an unresolvable reference — no refusal is
+available. A JSON `--schema` states a shape of its own rather than naming the
+source's fields, and is not held to that vocabulary.
+
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.
 They shape the result of the call — a handler's `result` inside the Invocation

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -327,13 +327,16 @@ emitted address composes into the next command unchanged, without being
 reassembled. Neither spelling composes with `--filter`. See
 `packages/cli/README.md` for the exact syntax and supported schema subset.
 
-A field list is held to the source's own vocabulary. A path the schema proves
-nothing can appear at — a field the position neither declares nor admits, a
-field named below a scalar, a field named below a verb — is refused before the
-read, naming the position, what it declares, and, where one is close enough, the
-declared name the path is a typo of. A field that is merely absent still returns
-nothing at exit 0, so a `{}` from a field list reads as "nothing here" rather
-than "you may have mistyped". Where the source schema settles nothing — an open
+A field list is held to the source's own vocabulary, and a position states that
+vocabulary by carrying a `properties` map: one declaring no fields
+(`properties: {}`) refuses every name, while a position with no map at all
+declares nothing and refuses none. A path the schema proves nothing can appear
+at — a field the position neither declares nor admits, a field named below a
+scalar, a field named below a verb — is refused before the read, naming the
+position, what it declares, and, where one is close enough, the declared name
+the path is a typo of. A field that is merely absent still returns nothing at
+exit 0, so a `{}` from a field list reads as "nothing here" rather than "you may
+have mistyped". Where the source schema settles nothing — an open
 `additionalProperties`, a `patternProperties` map that names a pattern, a
 disjunction, an untyped position, a position that only may hold an array, a
 tuple-shaped array, a reference site declaring fields of its own, a name several

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -330,13 +330,14 @@ reassembled. Neither spelling composes with `--filter`. See
 A field list is held to the source's own vocabulary. A path the schema proves
 nothing can appear at — a field the position neither declares nor admits, a
 field named below a scalar, a field named below a verb — is refused before the
-read, naming the position, what it declares, and the declared name the path is
-one edit from. A field that is merely absent still answers with nothing at exit
-0, so `{}` reads as "nothing here" rather than "you may have mistyped". Where
-the source schema settles nothing — a position carrying `additionalProperties`,
-a disjunction, an untyped position, an unresolvable reference — no refusal is
-available. A JSON `--schema` states a shape of its own rather than naming the
-source's fields, and is not held to that vocabulary.
+read, naming the position, what it declares, and, where one is close enough, the
+declared name the path is a typo of. A field that is merely absent still answers
+with nothing at exit 0, so a `{}` from a field list reads as "nothing here"
+rather than "you may have mistyped". Where the source schema settles nothing —
+an open `additionalProperties`, a `patternProperties` map, a disjunction, an
+untyped position, an unresolvable reference — no refusal is available. A JSON
+`--schema` states a shape of its own rather than naming the source's fields, and
+is not held to that vocabulary.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -331,16 +331,16 @@ A field list is held to the source's own vocabulary. A path the schema proves
 nothing can appear at — a field the position neither declares nor admits, a
 field named below a scalar, a field named below a verb — is refused before the
 read, naming the position, what it declares, and, where one is close enough, the
-declared name the path is a typo of. A field that is merely absent still answers
-with nothing at exit 0, so a `{}` from a field list reads as "nothing here"
-rather than "you may have mistyped". Where the source schema settles nothing —
-an open `additionalProperties`, a `patternProperties` map that names a pattern,
-a disjunction, an untyped position, a position that only may hold an array, a
-reference site declaring fields of its own, a name several `allOf` members
-declare — no refusal is available. An unresolvable reference is passed over too,
-and the read reports the reference itself. A JSON `--schema` states a shape of
-its own rather than naming the source's fields, and is not held to that
-vocabulary.
+declared name the path is a typo of. A field that is merely absent still returns
+nothing at exit 0, so a `{}` from a field list reads as "nothing here" rather
+than "you may have mistyped". Where the source schema settles nothing — an open
+`additionalProperties`, a `patternProperties` map that names a pattern, a
+disjunction, an untyped position, a position that only may hold an array, a
+tuple-shaped array, a reference site declaring fields of its own, a name several
+`allOf` members declare — no refusal is available. An unresolvable reference is
+passed over too, and the read reports the reference itself. A JSON `--schema`
+states a shape of its own rather than naming the source's fields, and is not
+held to that vocabulary.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -335,11 +335,12 @@ declared name the path is a typo of. A field that is merely absent still answers
 with nothing at exit 0, so a `{}` from a field list reads as "nothing here"
 rather than "you may have mistyped". Where the source schema settles nothing —
 an open `additionalProperties`, a `patternProperties` map that names a pattern,
-a disjunction, an untyped position, a reference site declaring fields of its
-own, a name several `allOf` members declare — no refusal is available. An
-unresolvable reference is passed over too, and the read reports the reference
-itself. A JSON `--schema` states a shape of its own rather than naming the
-source's fields, and is not held to that vocabulary.
+a disjunction, an untyped position, a position that only may hold an array, a
+reference site declaring fields of its own, a name several `allOf` members
+declare — no refusal is available. An unresolvable reference is passed over too,
+and the read reports the reference itself. A JSON `--schema` states a shape of
+its own rather than naming the source's fields, and is not held to that
+vocabulary.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -334,10 +334,12 @@ read, naming the position, what it declares, and, where one is close enough, the
 declared name the path is a typo of. A field that is merely absent still answers
 with nothing at exit 0, so a `{}` from a field list reads as "nothing here"
 rather than "you may have mistyped". Where the source schema settles nothing —
-an open `additionalProperties`, a `patternProperties` map, a disjunction, an
-untyped position, an unresolvable reference — no refusal is available. A JSON
-`--schema` states a shape of its own rather than naming the source's fields, and
-is not held to that vocabulary.
+an open `additionalProperties`, a `patternProperties` map that names a pattern,
+a disjunction, an untyped position, a reference site declaring fields of its
+own, a name several `allOf` members declare — no refusal is available. An
+unresolvable reference is passed over too, and the read reports the reference
+itself. A JSON `--schema` states a shape of its own rather than naming the
+source's fields, and is not held to that vocabulary.
 
 `piece call` takes the same three flags, before the callable name, with the same
 grammar, the same `--select`/`--schema` conflict, and the same error messages.


### PR DESCRIPTION
## Why

Closes #5684.

`cf get --select bmup` answered `{}` at exit 0 — the same answer a field that
is merely absent gives. A typo and an empty optional were one outcome, so an
agent that mistyped a field concluded the data was absent and acted on it.

The issue's sharp case is a dotted name: `--select bump.v1` splits on the dot,
asks for a nested `v1` inside `bump`, matches nothing, and returns `{}` — while
`cf call "bump.v1"` dispatches fine, so the read and call surfaces disagreed
about one name with no diagnostic between them.

The rule that separates the two cases is available before the read runs, and it
is the rule the call door already applies to a payload's fields: **absence by
instance is data; absence by schema is a refusal.** That matters more as
optional nested interfaces become the way a holder deals with items at mixed
generations — `--filter '.printable == null'` makes legitimate absence the
common case, and `{}` covering both stops being tolerable.

Two silent wrong answers turned up beside the reported one, both fixed here:
`--select label.first` against a string `label` returned `{"label":"untitled"}`
— the parent whole, not what was asked for — and `--select add.title` against a
verb returned a raw link envelope.

## What Changed

`firstUnheldSelectionField` (`packages/cli/lib/cell-selection.ts`) walks the
caller's field list against the source schema before the read and refuses three
proven shapes: a field a position neither declares nor admits, a field named
below a scalar, and a field named below a verb. The refusal names the position,
the vocabulary that position declares, and — where the vocabulary has one close
enough — the declared name the path is a typo of, in the wording `refusal.ts`
already gives a misspelled projection key, payload field, or flag:

```
$ cf get --quiet --piece <piece> --select bmup
Invalid --select at <root>: "bmup" is not a field the source holds.
Did you mean "bump-v1"? <root> declares "title", "bump-v1"
```

Every position the schema does not settle is passed over and reads exactly as
before: an open `additionalProperties`, a `patternProperties` map that names a
pattern, a disjunction, an untyped position, a position that only MAY hold an
array, a reference site that declares fields of its own, and a name several
`allOf` members declare. A refusal costs a retype; a read wrongly refused
cannot be taken at all, so every uncertain position fails open. An array is
crossed only where `sourceProvesContainer` proves the position holds one —
"may it be" is the wrong question for a field list, which crosses arrays
implicitly, so a name means one thing at the element and another at the
position itself. A JSON `--schema` states a shape of its own rather than naming
the source's fields and is held to none of this, which leaves it the spelling
for reading a position the source does not declare.

The vocabulary reader the call door built for payload fields — `declaredFieldsAt`,
`schemaIsObjectShaped` and their neighbours — moves out of `callable.ts` into
`declared-fields.ts`, so both doors answer "what does this position declare"
from one implementation instead of drifting into two.

Docs updated in the same change: `packages/cli/README.md` (the syntax
reference), `skills/cf/SKILL.md`, `docs/common/verbs/over-the-cli.md`,
`docs/common/verbs/agents-over-the-cli.md` ("What a negative answer is worth",
which is where the old `{}` belonged), and
`docs/plans/shaped-reads-and-verb-results.md`.

## Test plan

- `packages/cli/test/select-unheld-field.test.ts` — 23 cases, driven through
  `deriveSelectedValue`. The refusals are asserted against a compiled, run
  pattern, so they are pinned to the schema the transformer actually emits; the
  fail-open positions are asserted as the read still ANSWERING, which is the
  assertion that fails if a branch starts failing closed.
- `packages/cli/test/piece-get-transform.test.ts` — the one assertion pinning
  `--schema missing` → `{}` now pins the refusal.
- `deno task check`, `deno fmt --check`, `deno lint`, `deno task check-docs`,
  `check-skill-facts`, `check-no-waitfor`, `check-package-cycles`, and
  `deno task test` in `packages/cli` (176 files, 0 failed).
- `cell-selection.ts` and `declared-fields.ts` are both at 100% line coverage,
  measured with `DENO_COVERAGE_DIR` over the whole package suite.

## Known gaps

- `--filter` paths get no such check. A mistyped predicate path still filters
  everything out silently, and the same walk would answer it.
- A field declared only through an `allOf` member is unreachable on this
  surface: the gate passes it, a field list answers `{}`, a JSON `--schema`
  naming it answers `{}`, and `cf piece describe` does not list it. Left alone
  here; the doc says so rather than implying the CLI can tell it apart.
- Measured while checking the above, and **not** touched: an unprojected read
  through `{type: "object", properties: {title}, allOf: [{type: "object",
  properties: {subtitle}}]}` returns `{"subtitle": "Second"}` and drops
  `title`. The conjunction member's property map wins and the position's own is
  lost. That is runner traversal behavior, not the CLI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)