### PR TITLE
refactor(js-compiler,ts-transformers): name the sidecar site's coordinate space

### DIFF
--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -553,12 +553,13 @@ export class TypeScriptCompiler {
       const stem = outName.replace(/\.js$/, "");
       const sourceName = sourceByStem.get(stem);
       if (sourceName === undefined) continue;
+      const sourceSites = builderSourceSites?.get(sourceName);
       result.set(sourceName, {
         js: contents,
         sourceMap: parseSourceMap(writes[`${outName}.map`]),
-        ...(builderSourceSites?.get(sourceName) === undefined
+        ...(sourceSites === undefined
           ? {}
-          : { builderSourceSites: builderSourceSites.get(sourceName) }),
+          : { builderSourceSites: sourceSites }),
         ...(policyManifests?.get(sourceName)?.length
           ? { policyManifests: policyManifests.get(sourceName) }
           : {}),
@@ -680,12 +681,13 @@ export class TypeScriptCompiler {
       if (!outName.endsWith(".js")) continue;
       const sourceName = sourceByStem.get(outName.replace(/\.js$/, ""));
       if (sourceName === undefined) continue;
+      const sourceSites = builderSourceSites?.get(sourceName);
       modules.set(sourceName, {
         js: contents,
         sourceMap: parseSourceMap(writes[`${outName}.map`]),
-        ...(builderSourceSites?.get(sourceName) === undefined
+        ...(sourceSites === undefined
           ? {}
-          : { builderSourceSites: builderSourceSites.get(sourceName) }),
+          : { builderSourceSites: sourceSites }),
         ...(policyManifests?.get(sourceName)?.length
           ? { policyManifests: policyManifests.get(sourceName) }
           : {}),

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -210,7 +210,7 @@ function hoistBuilderCalls(
   context: TransformationContext,
 ): ts.SourceFile {
   const factory = context.factory;
-  const authoredSourceFile = context.program.getSourceFile(sourceFile.fileName);
+  const inputSourceFile = context.program.getSourceFile(sourceFile.fileName);
   const builderSourceSites = Object.create(null) as Record<
     string,
     BuilderSourceSite
@@ -227,8 +227,9 @@ function hoistBuilderCalls(
     ) {
       return;
     }
-    const site = resolveAuthoredSite(artifact, authoredSourceFile);
+    const site = resolveCompilerInputSite(artifact, inputSourceFile);
     if (site === undefined) return;
+    // `mapSite` is what turns compiler-input coordinates into authored ones.
     const mapped = mapSite(sourceFile.fileName, site);
     if (mapped !== undefined) builderSourceSites[symbol] = mapped;
   };
@@ -579,21 +580,26 @@ function resolveSameFileFunctionDeclaration(
     : undefined;
 }
 
-/** Resolves one artifact's authored coordinates and declaration name. */
-function resolveAuthoredSite(
+/**
+ * Resolves one artifact's position and declaration name in COMPILER-INPUT
+ * coordinates. The input carries the helper prelude the compiler injects, so
+ * these line numbers are authored only once `mapSite` has normalized them; the
+ * transformer records nothing without a mapper for exactly that reason.
+ */
+function resolveCompilerInputSite(
   artifact: BuilderArtifact,
-  authoredSourceFile: ts.SourceFile | undefined,
+  inputSourceFile: ts.SourceFile | undefined,
 ): BuilderSourceSite | undefined {
-  if (!authoredSourceFile) return undefined;
+  if (!inputSourceFile) return undefined;
   const candidates = artifact.fn
     ? [artifact.fn, artifact.call]
     : [artifact.call];
   for (const candidate of candidates) {
     const range = recoverAuthoredPosition(candidate);
     if (!range) continue;
-    const enclosing = findAuthoredNodeAt(authoredSourceFile, range.pos);
-    const start = enclosing?.node.getStart(authoredSourceFile) ?? range.pos;
-    const position = authoredSourceFile.getLineAndCharacterOfPosition(
+    const enclosing = findAuthoredNodeAt(inputSourceFile, range.pos);
+    const start = enclosing?.node.getStart(inputSourceFile) ?? range.pos;
+    const position = inputSourceFile.getLineAndCharacterOfPosition(
       start >= range.pos && start < range.end ? start : range.pos,
     );
     return {


### PR DESCRIPTION
Two readability nits noticed while reviewing #6058, deliberately left out of that PR to keep its diff to the design. No behavior change.

### `resolveAuthoredSite` did not return authored coordinates

It reads positions off `context.program.getSourceFile(...)` — the *compiler input*, which carries the one-line helper prelude the compiler injects. Those coordinates become authored only once `builderSourceSites.mapSite` has normalized them, which is exactly why the transformer records no sidecar at all when no mapper is supplied.

Renamed to `resolveCompilerInputSite`, with the `authoredSourceFile` parameter (and the local feeding it) renamed to `inputSourceFile` so the coordinate space is consistent inside the function, and a one-line note at the call site marking where `mapSite` does the conversion.

Left alone deliberately: `recoverAuthoredPosition` and `findAuthoredNodeAt` both return offsets and nodes rather than line numbers, and the node they find genuinely is authored syntax — the prelude shift only affects line numbering, so those names are accurate as they stand.

### A map lookup running twice per module

`builderSourceSites.get(sourceName)` was called once in the `=== undefined` test and again in the branch, in both `CompiledTypeScriptModule` assembly loops. Hoisted into a local.

### Validation

Pinned `deno 2.9.4`: js-compiler 15 tests / 157 steps, ts-transformers 1163 / 816, runner 1286 / 7424 — 0 failed anywhere. `deno task check` clean across all package groups; `fmt --check` 5011 files; `lint` 4920 files.

*(authored by Claude Opus 5, on behalf of Gideon)*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

