### PR TITLE
fix(runner): defer validation of argument slots behind unreadable links at any depth

### DIFF
--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -707,7 +707,7 @@ export function unwrapOneLevelAndBindToDoc<T extends FabricExecValue>(
       // Copy lazily, as the array branch does: allocate only once a value
       // actually converts to something else, so the shared path — the common
       // one, and the majority of nodes — allocates nothing at all. (Compare
-      // `overlayUnresolvedLinkPlaceholders()` in `runner.ts`, the same idiom.)
+      // `overlayUnreadableLinkPlaceholders()` in `runner.ts`, the same idiom.)
       let converted: Record<string, FabricExecValue> | undefined;
       for (const key of Object.keys(binding)) {
         const value = binding[key];

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1082,52 +1082,41 @@ function closedWorldEventRejection(
     `never ignored): ${failure}`;
 }
 
-/** How {@link readStoredLinkChainRaw} answered for one stored link. */
-export type StoredLinkChainReading =
-  // A doc on the chain is provably absent from this replica (or a read
-  // failed outright): nothing about the value is knowable here.
-  | { unreadable: true }
-  // The chain was walked over present docs. `value` may be `undefined` —
-  // a genuinely stored absence, which the caller judges strictly — or the
-  // raw tree at the endpoint, with `base` naming the doc it lives in.
-  | { unreadable?: undefined; value: unknown; base: NormalizedFullLink };
-
 const READ_NON_RECURSIVE: IReadOptions = { nonRecursive: true };
 
 /**
- * Follow one stored link — and any links it chains through — over RAW doc
- * bytes via `tx`, distinguishing "a doc this replica cannot serve" from "a
- * value that is genuinely absent in a doc it can". The distinction rides the
- * transaction's own contract: every read here goes under the doc's "value"
- * segment, so an absent DOCUMENT fails with `NotFoundError` naming the
- * document (empty error path), while a present doc's missing slot reads as
- * a successful `undefined`.
+ * Resolve one stored link — and any links it chains through — to the RAW
+ * value tree at its endpoint, reading doc bytes through `tx`. `value` is
+ * `undefined` whenever no readable tree is there: an absent doc, a doc
+ * record holding no value (what a meta-only write leaves behind), a path the
+ * present tree does not hold, a chain that cycles. The caller draws no
+ * distinction among those — this walk exists to mirror the structure the
+ * materialization resolved, not to judge absences, and which of them a raw
+ * read is looking at is not knowable here (a slot a pattern materializes
+ * lazily reads exactly like one that never synced; the pattern-vintage gate
+ * holds real stores of both).
  *
  * Steps hop by hop rather than calling link-resolution's resolver because
- * the caller needs every intermediate doc's raw tree, not the chain's
- * endpoint — and because a raw read of a path that crosses a mid-doc link
- * would descend into the link sigil's own JSON, so path segments are walked
- * in memory and links met along the way are followed by recursion.
+ * the caller needs the endpoint's raw tree to recurse into, and because a
+ * raw read of a path that crosses a mid-doc link would descend into the
+ * link sigil's own JSON — so path segments are walked in memory and links
+ * met along the way are followed.
  *
- * `chain` carries the link addresses of the CURRENT descent only
- * (backtracked by the caller), so a genuine cycle terminates as "read
- * nothing new" while the same doc reached from sibling slots is walked at
- * every position.
+ * `chain` carries the link addresses of the CURRENT descent; every key this
+ * walk adds is removed on the way out, whichever exit is taken — sibling
+ * slots routinely share targets (one profile linked from `profiles`, `mru`,
+ * and `defaultProfile` at once), and a leftover key would misread the
+ * second sibling as a cycle. The repeat-address guard is the walk's
+ * termination backstop, and the reason it is exported: the staging
+ * materialization happens to throw on the cyclic shapes reachable today
+ * before any walk runs, so only a direct test can exercise termination.
  */
 export function readStoredLinkChainRaw(
   tx: IExtendedStorageTransaction,
   startLink: NormalizedFullLink,
   chain: Set<string>,
-): StoredLinkChainReading {
-  // Every key this walk adds is removed on the way out, whichever exit is
-  // taken: the chain must describe the caller's descent, not this walk's —
-  // sibling slots routinely share targets (one profile linked from
-  // `profiles`, `mru`, and `defaultProfile` at once), and a leftover key
-  // would misread the second sibling as a cycle.
+): { value: unknown; base: NormalizedFullLink } {
   const added: string[] = [];
-  // Follow a link met at `rest` segments from the end of the current path.
-  // A repeat address is a stored cycle — a dead end the docs genuinely hold,
-  // reported as a judged absence, never as unreadable.
   const follow = (
     value: CellLink,
     base: NormalizedFullLink,
@@ -1154,10 +1143,8 @@ export function readStoredLinkChainRaw(
         },
         READ_NON_RECURSIVE,
       );
-      if (error !== undefined) {
-        // An absent document — and any read failure this walk cannot
-        // classify — is an unreadable target, never a judged value.
-        return { unreadable: true };
+      if (error !== undefined || ok.value === undefined) {
+        return { value: undefined, base: link };
       }
       let value: unknown = ok.value;
       const path = [...link.path] as string[];
@@ -1170,8 +1157,6 @@ export function readStoredLinkChainRaw(
           break;
         }
         if (!isObjectOrArray(value)) {
-          // Reading through a primitive (or a stored absence): the doc is
-          // present and simply does not hold this path.
           return { value: undefined, base: link };
         }
         value = (value as Record<string, unknown>)[path.shift()!];
@@ -1193,15 +1178,18 @@ export function readStoredLinkChainRaw(
 
 /**
  * Rebuild `materialized` so every slot whose STORED value routes through a
- * link chain that dead-ends at a doc this replica cannot serve carries
- * {@link UNRESOLVED_LINK_PLACEHOLDER} instead of `undefined`. Slots that DID
- * materialize keep their materialized value (and full strict validation),
- * and so does a genuinely stored absence — a present doc holding `undefined`
- * (or nothing) at the slot — so a doc that really holds nothing still fails
- * a required check. Deferral is for what this context cannot read, never for
- * what it read and judged; a deferred slot's check still happens, at
- * instantiation-time reactive reads (the same verdict link-resolution's
- * `pendingHopDoc` renders for lazy reads).
+ * link and materialized to `undefined` carries
+ * {@link UNRESOLVED_LINK_PLACEHOLDER} instead. Behind a link, an absence
+ * defers, whatever produced it: the value is owned elsewhere, and "not
+ * replicated here yet" reads identically to "not materialized yet" — the
+ * pattern-vintage gate holds real stores where the same missing slot is
+ * each of those. A slot that materialized to a VALUE is never touched, so a
+ * readable wrong-typed value still refuses; and an `undefined` stored
+ * literally in the argument doc itself — no link involved — still judges,
+ * so a doc that plainly holds nothing keeps failing a required check. A
+ * deferred slot's schema check still happens, at instantiation-time
+ * reactive reads (the same verdict link-resolution's `pendingHopDoc`
+ * renders for lazy reads).
  *
  * The walk mirrors the materialization it repairs: from the argument doc's
  * raw bytes, following every link — across docs and spaces, to any depth —
@@ -1221,29 +1209,21 @@ function overlayUnreadableLinkPlaceholders(
   chain: Set<string>,
 ): unknown {
   if (isCellLink(raw)) {
+    if (materialized === undefined) return UNRESOLVED_LINK_PLACEHOLDER;
     const link = parseLink(raw, base);
     const key = JSON.stringify([link.space, link.id, link.scope, link.path]);
     if (chain.has(key)) return materialized;
     chain.add(key);
     const reading = readStoredLinkChainRaw(tx, link, chain);
-    let result: unknown;
-    if (reading.unreadable === true) {
-      result = materialized === undefined
-        ? UNRESOLVED_LINK_PLACEHOLDER
-        : materialized;
-    } else if (reading.value === undefined) {
-      // Present doc, genuinely absent value: keep the materialized
-      // `undefined` and let validation judge it.
-      result = materialized;
-    } else {
-      result = overlayUnreadableLinkPlaceholders(
+    const result = reading.value === undefined
+      ? materialized
+      : overlayUnreadableLinkPlaceholders(
         tx,
         reading.base,
         reading.value,
         materialized,
         chain,
       );
-    }
     chain.delete(key);
     return result;
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -56,6 +56,7 @@ import { refuseFabricInstance } from "./fabric-special-object.ts";
 import { resolveLink } from "./link-resolution.ts";
 import {
   areNormalizedLinksSame,
+  type CellLink,
   createSigilLinkFromParsedLink,
   getDerivedInternalCell,
   getDerivedInternalCellLink,
@@ -104,6 +105,7 @@ import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
 import type {
   DID,
   IExtendedStorageTransaction,
+  IReadOptions,
   IStorageSubscription,
   MemorySpace,
   URI,
@@ -1080,43 +1082,138 @@ function closedWorldEventRejection(
     `never ignored): ${failure}`;
 }
 
+/** How {@link readStoredLinkChainRaw} answered for one stored link. */
+export type StoredLinkChainReading =
+  // A doc on the chain is provably absent from this replica (or a read
+  // failed outright): nothing about the value is knowable here.
+  | { unreadable: true }
+  // The chain was walked over present docs. `value` may be `undefined` —
+  // a genuinely stored absence, which the caller judges strictly — or the
+  // raw tree at the endpoint, with `base` naming the doc it lives in.
+  | { unreadable?: undefined; value: unknown; base: NormalizedFullLink };
+
+const READ_NON_RECURSIVE: IReadOptions = { nonRecursive: true };
+
 /**
- * Rebuild `materialized` so every slot whose STORED value routes through a
- * link that cannot be read in this transaction carries
- * {@link UNRESOLVED_LINK_PLACEHOLDER} instead of `undefined`. Slots that DID
- * materialize keep their materialized value (and full strict validation);
- * a literal `undefined` stored where no link is involved also keeps it, so a
- * doc that genuinely holds nothing still fails a required check.
+ * Follow one stored link — and any links it chains through — over RAW doc
+ * bytes via `tx`, distinguishing "a doc this replica cannot serve" from "a
+ * value that is genuinely absent in a doc it can". The distinction rides the
+ * transaction's own contract: every read here goes under the doc's "value"
+ * segment, so an absent DOCUMENT fails with `NotFoundError` naming the
+ * document (empty error path), while a present doc's missing slot reads as
+ * a successful `undefined`.
  *
- * The walk mirrors the materialization it repairs: it starts from the
- * argument doc's raw bytes and follows every link — across docs and spaces,
- * to any depth — reading each target's RAW value through `tx`. It steps hop
- * by hop rather than calling link-resolution's resolver because it needs
- * every INTERMEDIATE doc's raw tree to recurse into, not the chain's
- * endpoint. A link chain that dead-ends at a doc the local replica cannot
- * serve is exactly the case the placeholder exists for: the slot has a
- * value, this context just cannot read it yet (the same verdict
- * link-resolution's `pendingHopDoc` renders for lazy reads). The fleet incident this generalizes from: a profile's
- * `name` cell stores a link to its seed value's doc, cold-start sync
- * delivers the cell doc but not the seed doc, and the one-hop overlay this
- * walk replaced could not see past the first resolution — so every home
- * bricked with `profiles: 0: name: value does not match type string` on the
- * first pattern-identity move after the profile was written.
+ * Steps hop by hop rather than calling link-resolution's resolver because
+ * the caller needs every intermediate doc's raw tree, not the chain's
+ * endpoint — and because a raw read of a path that crosses a mid-doc link
+ * would descend into the link sigil's own JSON, so path segments are walked
+ * in memory and links met along the way are followed by recursion.
  *
  * `chain` carries the link addresses of the CURRENT descent only
- * (backtracked on return), so a doc reachable from two sibling slots — one
- * profile linked from `profiles`, `mru`, and `defaultProfile` at once — is
- * repaired at every position, while a genuine cycle terminates.
+ * (backtracked by the caller), so a genuine cycle terminates as "read
+ * nothing new" while the same doc reached from sibling slots is walked at
+ * every position.
+ */
+export function readStoredLinkChainRaw(
+  tx: IExtendedStorageTransaction,
+  startLink: NormalizedFullLink,
+  chain: Set<string>,
+): StoredLinkChainReading {
+  // Every key this walk adds is removed on the way out, whichever exit is
+  // taken: the chain must describe the caller's descent, not this walk's —
+  // sibling slots routinely share targets (one profile linked from
+  // `profiles`, `mru`, and `defaultProfile` at once), and a leftover key
+  // would misread the second sibling as a cycle.
+  const added: string[] = [];
+  // Follow a link met at `rest` segments from the end of the current path.
+  // A repeat address is a stored cycle — a dead end the docs genuinely hold,
+  // reported as a judged absence, never as unreadable.
+  const follow = (
+    value: CellLink,
+    base: NormalizedFullLink,
+    rest: string[],
+  ) => {
+    const next = parseLink(value, base);
+    const path = [...next.path, ...rest];
+    const key = JSON.stringify([next.space, next.id, next.scope, path]);
+    if (chain.has(key)) return undefined;
+    chain.add(key);
+    added.push(key);
+    return { ...next, path };
+  };
+  try {
+    let link = startLink;
+    while (true) {
+      const { ok, error } = tx.read(
+        {
+          space: link.space,
+          id: link.id,
+          scope: link.scope,
+          type: "application/json",
+          path: ["value"],
+        },
+        READ_NON_RECURSIVE,
+      );
+      if (error !== undefined) {
+        // An absent document — and any read failure this walk cannot
+        // classify — is an unreadable target, never a judged value.
+        return { unreadable: true };
+      }
+      let value: unknown = ok.value;
+      const path = [...link.path] as string[];
+      let followed: NormalizedFullLink | undefined;
+      while (path.length > 0) {
+        if (isCellLink(value)) {
+          // A link met mid-path: the rest of the path applies at its target.
+          followed = follow(value, link, path);
+          if (followed === undefined) return { value: undefined, base: link };
+          break;
+        }
+        if (!isObjectOrArray(value)) {
+          // Reading through a primitive (or a stored absence): the doc is
+          // present and simply does not hold this path.
+          return { value: undefined, base: link };
+        }
+        value = (value as Record<string, unknown>)[path.shift()!];
+      }
+      if (followed === undefined && isCellLink(value)) {
+        followed = follow(value, link, []);
+        if (followed === undefined) return { value: undefined, base: link };
+      }
+      if (followed !== undefined) {
+        link = followed;
+        continue;
+      }
+      return { value, base: link };
+    }
+  } finally {
+    for (const key of added) chain.delete(key);
+  }
+}
+
+/**
+ * Rebuild `materialized` so every slot whose STORED value routes through a
+ * link chain that dead-ends at a doc this replica cannot serve carries
+ * {@link UNRESOLVED_LINK_PLACEHOLDER} instead of `undefined`. Slots that DID
+ * materialize keep their materialized value (and full strict validation),
+ * and so does a genuinely stored absence — a present doc holding `undefined`
+ * (or nothing) at the slot — so a doc that really holds nothing still fails
+ * a required check. Deferral is for what this context cannot read, never for
+ * what it read and judged; a deferred slot's check still happens, at
+ * instantiation-time reactive reads (the same verdict link-resolution's
+ * `pendingHopDoc` renders for lazy reads).
  *
- * The error direction is deferral, never false refusal. A raw read cannot
- * distinguish every "absent because unreplicated" from "absent in a readable
- * doc" — a link whose in-doc path crosses another link is the corner — so a
- * slot that is undefined on BOTH sides defers. A deferred slot's check still
- * happens, at instantiation-time reads; a slot the materialization DID
- * produce a value for is never touched at all.
+ * The walk mirrors the materialization it repairs: from the argument doc's
+ * raw bytes, following every link — across docs and spaces, to any depth —
+ * via {@link readStoredLinkChainRaw}. The fleet incident this generalizes
+ * from: a profile's `name` cell stores a link to its seed value's doc,
+ * cold-start sync delivers the cell doc but not the seed doc, and the
+ * one-hop overlay this walk replaced could not see past the first
+ * resolution — so every home bricked with `profiles: 0: name: value does
+ * not match type string` on the first pattern-identity move after the
+ * profile was written.
  */
 function overlayUnreadableLinkPlaceholders(
-  runtime: Runtime,
   tx: IExtendedStorageTransaction,
   base: NormalizedFullLink,
   raw: unknown,
@@ -1125,37 +1222,35 @@ function overlayUnreadableLinkPlaceholders(
 ): unknown {
   if (isCellLink(raw)) {
     const link = parseLink(raw, base);
-    if (link === undefined || link.space === undefined) return materialized;
-    const key = JSON.stringify([link.space, link.id, link.path]);
+    const key = JSON.stringify([link.space, link.id, link.scope, link.path]);
     if (chain.has(key)) return materialized;
-    const targetRaw = runtime.getCellFromLink(
-      link as NormalizedFullLink,
-      undefined,
-      tx,
-    ).getRaw({ meta: ignoreReadForScheduling });
-    if (targetRaw === undefined) {
-      return materialized === undefined
+    chain.add(key);
+    const reading = readStoredLinkChainRaw(tx, link, chain);
+    let result: unknown;
+    if (reading.unreadable === true) {
+      result = materialized === undefined
         ? UNRESOLVED_LINK_PLACEHOLDER
         : materialized;
+    } else if (reading.value === undefined) {
+      // Present doc, genuinely absent value: keep the materialized
+      // `undefined` and let validation judge it.
+      result = materialized;
+    } else {
+      result = overlayUnreadableLinkPlaceholders(
+        tx,
+        reading.base,
+        reading.value,
+        materialized,
+        chain,
+      );
     }
-    chain.add(key);
-    const result = overlayUnreadableLinkPlaceholders(
-      runtime,
-      tx,
-      link as NormalizedFullLink,
-      targetRaw,
-      materialized,
-      chain,
-    );
     chain.delete(key);
     return result;
   }
-  if (Array.isArray(raw)) {
-    if (!Array.isArray(materialized)) return materialized;
+  if (Array.isArray(raw) && Array.isArray(materialized)) {
     let result: unknown[] | undefined;
     for (let i = 0; i < raw.length; i++) {
       const child = overlayUnreadableLinkPlaceholders(
-        runtime,
         tx,
         base,
         raw[i],
@@ -1173,7 +1268,6 @@ function overlayUnreadableLinkPlaceholders(
     let result: Record<string, unknown> | undefined;
     for (const [key, rawChild] of Object.entries(raw)) {
       const child = overlayUnreadableLinkPlaceholders(
-        runtime,
         tx,
         base,
         rawChild,
@@ -1732,7 +1826,6 @@ export class Runner {
       validationFailure = validateSchemaValue(
         argumentSchema,
         overlayUnreadableLinkPlaceholders(
-          this.runtime,
           tx,
           argumentLink,
           argumentCell.withTx(tx).getRaw({ meta: ignoreReadForScheduling }),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -918,12 +918,13 @@ type RunnerRunOptions = {
   parentPieceRootId?: string;
 };
 
-// Placeholder standing in for an argument slot whose stored raw value is a
-// link that cannot be dereferenced in the current transaction (target doc
-// absent or not yet synced). Validation accepts it anywhere: the slot HAS a
-// value — we just cannot read it right now — so its schema check is deferred
-// to instantiation-time reactive reads, exactly like the running pattern's
-// own reads of the same slot. See applySetupState's pattern-change branch.
+// Placeholder standing in for an argument slot whose stored value routes
+// through a link that cannot be dereferenced in the current transaction
+// (target doc absent or not yet synced), at ANY depth of the stored graph.
+// Validation accepts it anywhere: the slot HAS a value — we just cannot read
+// it right now — so its schema check is deferred to instantiation-time
+// reactive reads, exactly like the running pattern's own reads of the same
+// slot. See validateArgument.
 const UNRESOLVED_LINK_PLACEHOLDER = Object.freeze({
   "unresolved cell link": true,
 });
@@ -1080,26 +1081,87 @@ function closedWorldEventRejection(
 }
 
 /**
- * Rebuild `materialized` so every slot whose counterpart in `raw` is a link
- * that materialized to nothing carries {@link UNRESOLVED_LINK_PLACEHOLDER}
- * instead of being absent/undefined. Slots that DID materialize keep their
- * materialized value (and full strict validation); everything else is
- * returned unchanged.
+ * Rebuild `materialized` so every slot whose STORED value routes through a
+ * link that cannot be read in this transaction carries
+ * {@link UNRESOLVED_LINK_PLACEHOLDER} instead of `undefined`. Slots that DID
+ * materialize keep their materialized value (and full strict validation);
+ * a literal `undefined` stored where no link is involved also keeps it, so a
+ * doc that genuinely holds nothing still fails a required check.
+ *
+ * The walk mirrors the materialization it repairs: it starts from the
+ * argument doc's raw bytes and follows every link — across docs and spaces,
+ * to any depth — reading each target's RAW value through `tx`. It steps hop
+ * by hop rather than calling link-resolution's resolver because it needs
+ * every INTERMEDIATE doc's raw tree to recurse into, not the chain's
+ * endpoint. A link chain that dead-ends at a doc the local replica cannot
+ * serve is exactly the case the placeholder exists for: the slot has a
+ * value, this context just cannot read it yet (the same verdict
+ * link-resolution's `pendingHopDoc` renders for lazy reads). The fleet incident this generalizes from: a profile's
+ * `name` cell stores a link to its seed value's doc, cold-start sync
+ * delivers the cell doc but not the seed doc, and the one-hop overlay this
+ * walk replaced could not see past the first resolution — so every home
+ * bricked with `profiles: 0: name: value does not match type string` on the
+ * first pattern-identity move after the profile was written.
+ *
+ * `chain` carries the link addresses of the CURRENT descent only
+ * (backtracked on return), so a doc reachable from two sibling slots — one
+ * profile linked from `profiles`, `mru`, and `defaultProfile` at once — is
+ * repaired at every position, while a genuine cycle terminates.
+ *
+ * The error direction is deferral, never false refusal. A raw read cannot
+ * distinguish every "absent because unreplicated" from "absent in a readable
+ * doc" — a link whose in-doc path crosses another link is the corner — so a
+ * slot that is undefined on BOTH sides defers. A deferred slot's check still
+ * happens, at instantiation-time reads; a slot the materialization DID
+ * produce a value for is never touched at all.
  */
-function overlayUnresolvedLinkPlaceholders(
-  materialized: unknown,
+function overlayUnreadableLinkPlaceholders(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  base: NormalizedFullLink,
   raw: unknown,
+  materialized: unknown,
+  chain: Set<string>,
 ): unknown {
   if (isCellLink(raw)) {
-    return materialized === undefined
-      ? UNRESOLVED_LINK_PLACEHOLDER
-      : materialized;
+    const link = parseLink(raw, base);
+    if (link === undefined || link.space === undefined) return materialized;
+    const key = JSON.stringify([link.space, link.id, link.path]);
+    if (chain.has(key)) return materialized;
+    const targetRaw = runtime.getCellFromLink(
+      link as NormalizedFullLink,
+      undefined,
+      tx,
+    ).getRaw({ meta: ignoreReadForScheduling });
+    if (targetRaw === undefined) {
+      return materialized === undefined
+        ? UNRESOLVED_LINK_PLACEHOLDER
+        : materialized;
+    }
+    chain.add(key);
+    const result = overlayUnreadableLinkPlaceholders(
+      runtime,
+      tx,
+      link as NormalizedFullLink,
+      targetRaw,
+      materialized,
+      chain,
+    );
+    chain.delete(key);
+    return result;
   }
   if (Array.isArray(raw)) {
     if (!Array.isArray(materialized)) return materialized;
     let result: unknown[] | undefined;
     for (let i = 0; i < raw.length; i++) {
-      const child = overlayUnresolvedLinkPlaceholders(materialized[i], raw[i]);
+      const child = overlayUnreadableLinkPlaceholders(
+        runtime,
+        tx,
+        base,
+        raw[i],
+        materialized[i],
+        chain,
+      );
       if (child !== materialized[i]) {
         result ??= materialized.slice();
         result[i] = child;
@@ -1110,9 +1172,13 @@ function overlayUnresolvedLinkPlaceholders(
   if (isObjectOrArray(raw) && isObjectOrArray(materialized)) {
     let result: Record<string, unknown> | undefined;
     for (const [key, rawChild] of Object.entries(raw)) {
-      const child = overlayUnresolvedLinkPlaceholders(
-        (materialized as Record<string, unknown>)[key],
+      const child = overlayUnreadableLinkPlaceholders(
+        runtime,
+        tx,
+        base,
         rawChild,
+        (materialized as Record<string, unknown>)[key],
+        chain,
       );
       if (child !== (materialized as Record<string, unknown>)[key]) {
         result ??= { ...(materialized as Record<string, unknown>) };
@@ -1588,19 +1654,13 @@ export class Runner {
   }
 
   /** Stage an argument write, materialize aliases in the same transaction, and
-   * reject the transaction unless the resulting value satisfies its schema.
-   * `unresolvedLinkRaw` (the staged pre-materialization value) makes slots
-   * whose raw value is a link that cannot currently be dereferenced validate
-   * as opaque instead of as their unreadable materialization — pass it only
-   * when re-staging a STORED argument (pattern hot-swap), never for a
-   * caller-supplied value. */
+   * reject the transaction unless the resulting value satisfies its schema. */
   private updateAndValidateArgument<T>(
     tx: IExtendedStorageTransaction,
     argumentLink: NormalizedFullLink,
     argument: T,
     argumentSchema: JSONSchema,
     defaults: FabricValue,
-    options: { unresolvedLinkRaw?: unknown } = {},
   ): void {
     this.updateArgument(tx, argumentLink, argument, argumentSchema);
     this.validateArgument(
@@ -1608,7 +1668,6 @@ export class Runner {
       argumentLink,
       argumentSchema,
       defaults,
-      options,
     );
   }
 
@@ -1617,7 +1676,6 @@ export class Runner {
     argumentLink: NormalizedFullLink,
     argumentSchema: JSONSchema,
     defaults: FabricValue,
-    options: { unresolvedLinkRaw?: unknown } = {},
   ): void {
     const argumentCell = this.runtime.getCellFromLink(
       argumentLink,
@@ -1626,40 +1684,65 @@ export class Runner {
     );
     const materializedArgument = argumentCell.asSchema(undefined).withTx(tx)
       .get();
-    let validationArgument: unknown = mergeSchemaDefaults(
+    const validationArgument: unknown = mergeSchemaDefaults(
       materializedArgument,
       defaults,
       argumentSchema,
       { mergeMaterializedLinks: true },
     );
-    if (options.unresolvedLinkRaw !== undefined) {
-      validationArgument = overlayUnresolvedLinkPlaceholders(
-        validationArgument,
-        options.unresolvedLinkRaw,
-      );
-    }
-    const validationFailure = validateSchemaValue(
+    const validationOptions = {
+      acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink,
+      // An OPTIONAL key holding `undefined` carries no data, and a handler
+      // mints one without meaning to: `comments.push({ author, ... })` with
+      // no author in hand writes the key, and the codec stores that presence.
+      // Measuring it here asks whether `undefined` satisfies the property's
+      // declared type, which nothing ordinary answers yes to — and THIS
+      // refusal is permanent, because the same identity refuses identically
+      // (see `isStoredArgumentSchemaRefusal`). A pattern would be unable to
+      // update documents it wrote itself. Measured on `topics/topic.tsx`
+      // (`author`) and `lunch-poll/main.tsx` (`imageUrl`).
+      //
+      // Scoped to THIS caller rather than made the validator's rule: writing
+      // `undefined` where a number is declared is still a mistake worth
+      // rejecting at a result write, while the caller can still see it.
+      optionalUndefinedIsAbsent: true,
+    };
+    let validationFailure = validateSchemaValue(
       argumentSchema,
       validationArgument,
       argumentSchema,
-      {
-        acceptOpaqueValue: acceptsOpaqueCellOrUnresolvedLink,
-        // An OPTIONAL key holding `undefined` carries no data, and a handler
-        // mints one without meaning to: `comments.push({ author, ... })` with
-        // no author in hand writes the key, and the codec stores that presence.
-        // Measuring it here asks whether `undefined` satisfies the property's
-        // declared type, which nothing ordinary answers yes to — and THIS
-        // refusal is permanent, because the same identity refuses identically
-        // (see `isStoredArgumentSchemaRefusal`). A pattern would be unable to
-        // update documents it wrote itself. Measured on `topics/topic.tsx`
-        // (`author`) and `lunch-poll/main.tsx` (`imageUrl`).
-        //
-        // Scoped to THIS caller rather than made the validator's rule: writing
-        // `undefined` where a number is declared is still a mistake worth
-        // rejecting at a result write, while the caller can still see it.
-        optionalUndefinedIsAbsent: true,
-      },
+      validationOptions,
     );
+    if (validationFailure !== undefined) {
+      // Judge only what this context can actually read. The materialization
+      // above resolves the staged doc's whole link graph through this
+      // transaction, and a link chain that dead-ends at a doc the local
+      // replica cannot serve materializes as `undefined` — indistinguishable
+      // from a stored mistake, though the stored bytes are fine and every
+      // OTHER context may read them. Validating that `undefined` bricks the
+      // piece permanently (same identity, same refusal — see
+      // `isStoredArgumentSchemaRefusal`), so such slots validate as opaque
+      // and their schema check is deferred to instantiation-time reactive
+      // reads, which sync what they need. Supplied and re-staged arguments
+      // alike: a caller vouches for the value it stages, but which link
+      // targets happen to be replicated HERE was never part of that value.
+      // The overlay only ever turns `undefined` into an accepted opaque, so
+      // running it on failure alone changes no verdict — it spares the
+      // happy path a second walk of the stored graph.
+      validationFailure = validateSchemaValue(
+        argumentSchema,
+        overlayUnreadableLinkPlaceholders(
+          this.runtime,
+          tx,
+          argumentLink,
+          argumentCell.withTx(tx).getRaw({ meta: ignoreReadForScheduling }),
+          validationArgument,
+          new Set(),
+        ),
+        argumentSchema,
+        validationOptions,
+      );
+    }
     if (validationFailure !== undefined) {
       throw new Error(
         `${STORED_ARGUMENT_SCHEMA_REFUSAL}: ${validationFailure}`,
@@ -1675,9 +1758,8 @@ export class Runner {
    * Mirrors the re-stage branch's deferrals deliberately, so the two paths
    * cannot disagree about what counts as valid: an argument doc that reads
    * nothing right now is skipped (CT-1917 — a nested piece's argument lives in
-   * its host's doc, and "not synced" is not "invalid"), and the staged raw is
-   * passed so a slot holding an unreadable link validates as opaque rather than
-   * as its missing materialization.
+   * its host's doc, and "not synced" is not "invalid"), and validateArgument
+   * itself defers any slot whose stored link chain cannot be read right now.
    */
   private validateStoredArgument<R>(
     tx: IExtendedStorageTransaction,
@@ -1695,13 +1777,6 @@ export class Runner {
       argumentLink,
       pattern.argumentSchema,
       defaults,
-      {
-        unresolvedLinkRaw: mergeSchemaDefaults(
-          stored,
-          defaults,
-          pattern.argumentSchema,
-        ),
-      },
     );
   }
 
@@ -2031,25 +2106,23 @@ export class Runner {
         );
 
         // Stage the exact Fabric-layer representation before validating it.
-        // The untyped materialization below resolves ordinary sigil links
+        // The untyped materialization inside resolves ordinary sigil links
         // through this same transaction without dropping fields that fail the
         // candidate schema. A thrown validation error aborts the transaction,
         // so neither this write nor the schema retarget can become durable on
-        // failure. When no argument was supplied (a pattern hot-swap re-using
-        // the stored value), a slot holding a link whose target cannot be
-        // read RIGHT NOW must not fail validation — the staged raw is passed
-        // so such slots validate as opaque instead of as their (unreadable)
-        // materialization. A supplied argument keeps strict validation:
-        // callers stage exactly the value they were given. (At least one of
-        // `argument`/`previousArgument` is defined here — the skip branch
-        // above owns the both-undefined case — so the merge yields a value.)
+        // failure. A slot whose staged link chain cannot be read RIGHT NOW
+        // validates as opaque rather than as its unreadable materialization —
+        // supplied and re-staged arguments alike, because which link targets
+        // this replica holds is a fact about the moment, not about the value
+        // the caller staged. (At least one of `argument`/`previousArgument`
+        // is defined here — the skip branch above owns the both-undefined
+        // case — so the merge yields a value.)
         this.updateAndValidateArgument(
           tx,
           argumentLink,
           nextArgument,
           pattern.argumentSchema,
           defaults,
-          argument === undefined ? { unresolvedLinkRaw: nextArgument } : {},
         );
         argumentUpdated = true;
       }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -102,13 +102,14 @@ import { forEachSubschema } from "./schema-walk.ts";
 import { rendererVDOMSchema } from "./schemas.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
 import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
-import type {
-  DID,
-  IExtendedStorageTransaction,
-  IReadOptions,
-  IStorageSubscription,
-  MemorySpace,
-  URI,
+import {
+  type DID,
+  type IExtendedStorageTransaction,
+  type IReadOptions,
+  type IStorageSubscription,
+  type MemorySpace,
+  toThrowable,
+  type URI,
 } from "./storage/interface.ts";
 import {
   machineryRead,
@@ -1143,7 +1144,18 @@ export function readStoredLinkChainRaw(
         },
         READ_NON_RECURSIVE,
       );
-      if (error !== undefined || ok.value === undefined) {
+      if (error !== undefined) {
+        // The same line readOrThrow draws: an absent document or a path
+        // through a primitive reads as no value here, and every other
+        // failure — a dead transaction, malformed storage — surfaces.
+        if (
+          error.name !== "NotFoundError" && error.name !== "TypeMismatchError"
+        ) {
+          throw toThrowable(error);
+        }
+        return { value: undefined, base: link };
+      }
+      if (ok.value === undefined) {
         return { value: undefined, base: link };
       }
       let value: unknown = ok.value;

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -83,6 +83,23 @@ const typedCount = (marker: string): RuntimeProgram =>
     "",
   ].join("\n"));
 
+/**
+ * A candidate that types a NESTED object: `row.name` is required, so a `row`
+ * that materializes without it refuses. The nested-cold cases stand on this —
+ * the argument doc's own slot (`row`) resolves fine, and only a hop past it
+ * dead-ends.
+ */
+const typedRow = (marker: string): RuntimeProgram =>
+  programOf([
+    "import { pattern } from 'commonfabric';",
+    "interface Row { name: string; other?: string }",
+    "interface Args { row?: Row; [key: string]: any }",
+    "export default pattern<Args, { marker: string }>(() => {",
+    `  return { marker: ${JSON.stringify(marker)} };`,
+    "});",
+    "",
+  ].join("\n"));
+
 describe("pattern update validates the stored argument", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let rt: Runtime;
@@ -879,6 +896,80 @@ describe("pattern update validates the stored argument", () => {
     ).toBeUndefined();
     await cell.pull();
     expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("rolls forward when the unreadable link sits BEHIND a readable hop", async () => {
+    // The 2026-08-21 fleet incident, in miniature. A profile's `name` cell
+    // stores a LINK to the doc holding its seed value, cold-start sync
+    // delivers the cell doc but not the seed doc, and the home pattern's
+    // first identity move in months re-validated every home's `profiles`
+    // argument over that half-replicated graph: `profiles: 0: name: value
+    // does not match type string`, permanently, fleet-wide. The one-hop case
+    // above never covers this: the argument doc's OWN slot resolves fine
+    // (`row` materializes as an object), and the dead end is a hop further
+    // down, where an overlay that only reads the argument doc's raw cannot
+    // see it. The deferral has to follow the stored link graph as deep as the
+    // materialization it repairs.
+    const absent = rt.getCell<string>(space, "nested-cold-target");
+    const row = rt.getCell<Record<string, unknown>>(space, "nested-cold-row");
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      row.withTx(tx).asSchema(undefined as never).set(
+        { name: absent, other: "fine" } as never,
+      );
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      { row },
+      "nested-cold-link",
+    );
+
+    const { error } = await rollForward(cell, typedRow("v2"));
+
+    expect(
+      error,
+      "a slot whose stored value routes through an unreadable link one hop " +
+        "past the argument doc was treated as invalid — the shape that " +
+        "bricked every home space on 2026-08-21",
+    ).toBeUndefined();
+    await cell.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("still refuses a READABLE wrong-typed value behind the same hop", async () => {
+    // The differential that pins where the deferral ends: identical nesting,
+    // identical candidate, but the value behind the hop is present and simply
+    // wrong. Deferral is for what this context cannot read, never for what it
+    // read and found invalid — widen it to any nested `undefined`-adjacent
+    // shape and the gate stops gating.
+    const row = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-wrong-type-row",
+    );
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      row.withTx(tx).asSchema(undefined as never).set(
+        { name: 7, other: "fine" } as never,
+      );
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      { row },
+      "nested-wrong-type-link",
+    );
+
+    const { error, thrown } = await rollForward(cell, typedRow("v2"));
+
+    expect(
+      error,
+      "a readable nested value of the wrong type slipped past validation — " +
+        "the unreadable-link deferral is leaking onto values that were read " +
+        "and judged",
+    ).toContain("updated arguments do not match the candidate schema");
+    expect(error).toContain("name: value does not match type string");
+    expect(isStoredArgumentSchemaRefusal(thrown)).toBe(true);
   });
 
   it("leaves a same-version setup alone over an argument its OWN schema rejects", async () => {

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -10,6 +10,7 @@ import {
   isStoredArgumentSchemaRefusal,
   STORED_ARGUMENT_SCHEMA_REFUSAL,
 } from "../src/index.ts";
+import { readStoredLinkChainRaw } from "../src/runner.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { getMetaLink } from "../src/link-utils.ts";
@@ -899,22 +900,28 @@ describe("pattern update validates the stored argument", () => {
   });
 
   it("rolls forward when the unreadable link sits BEHIND a readable hop", async () => {
-    // The 2026-08-21 fleet incident, in miniature. A profile's `name` cell
-    // stores a LINK to the doc holding its seed value, cold-start sync
-    // delivers the cell doc but not the seed doc, and the home pattern's
-    // first identity move in months re-validated every home's `profiles`
-    // argument over that half-replicated graph: `profiles: 0: name: value
-    // does not match type string`, permanently, fleet-wide. The one-hop case
-    // above never covers this: the argument doc's OWN slot resolves fine
-    // (`row` materializes as an object), and the dead end is a hop further
-    // down, where an overlay that only reads the argument doc's raw cannot
-    // see it. The deferral has to follow the stored link graph as deep as the
-    // materialization it repairs.
+    // The 2026-08-21 fleet incident, in miniature and to its full depth. A
+    // profile's `name` cell stores a LINK to the doc holding its seed value
+    // — a chain, not a slot: the row doc's `name` holds a link to a cell doc
+    // whose whole content is another link, and only THAT target is missing
+    // (cold-start sync delivers the cell doc but not the seed doc). The home
+    // pattern's first identity move in months re-validated every home's
+    // `profiles` argument over that half-replicated graph: `profiles: 0:
+    // name: value does not match type string`, permanently, fleet-wide. The
+    // one-hop case above never covers this: the argument doc's OWN slot
+    // resolves fine (`row` materializes as an object), and the dead end is
+    // hops further down, where an overlay that only reads the argument doc's
+    // raw cannot see it. The deferral has to follow the stored link graph as
+    // deep as the materialization it repairs. The row's `loop` slot links
+    // back to the row doc itself, pinning that a repeated address along one
+    // descent terminates instead of recursing forever.
     const absent = rt.getCell<string>(space, "nested-cold-target");
+    const mid = rt.getCell<string>(space, "nested-cold-mid");
     const row = rt.getCell<Record<string, unknown>>(space, "nested-cold-row");
     const { error: writeError } = await rt.editWithRetry((tx) => {
+      mid.withTx(tx).asSchema(undefined as never).set(absent as never);
       row.withTx(tx).asSchema(undefined as never).set(
-        { name: absent, other: "fine" } as never,
+        { name: mid, other: "fine", loop: row } as never,
       );
     });
     expect(writeError?.message).toBeUndefined();
@@ -929,12 +936,168 @@ describe("pattern update validates the stored argument", () => {
 
     expect(
       error,
-      "a slot whose stored value routes through an unreadable link one hop " +
+      "a slot whose stored value routes through an unreadable link chain " +
         "past the argument doc was treated as invalid — the shape that " +
         "bricked every home space on 2026-08-21",
     ).toBeUndefined();
     await cell.pull();
     expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("defers a link whose path crosses another link mid-doc", async () => {
+    // A link may address a path inside its target, and the target doc may
+    // hold ANOTHER link partway along that path. A raw read of the full path
+    // would descend into the mid-doc link sigil's own JSON and report a
+    // false absence, so the walk steps segments itself and follows the link
+    // it meets — here to a doc the replica cannot serve, which is the
+    // unreadable case: defer, and the update proceeds.
+    const absent = rt.getCell<Record<string, unknown>>(
+      space,
+      "mid-path-cold-target",
+    );
+    const wrap = rt.getCell<Record<string, unknown>>(space, "mid-path-wrap");
+    const row = rt.getCell<Record<string, unknown>>(space, "mid-path-row");
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      wrap.withTx(tx).asSchema(undefined as never).set(
+        { wrap: absent } as never,
+      );
+      row.withTx(tx).asSchema(undefined as never).set(
+        { name: wrap.key("wrap").key("inner"), other: "fine" } as never,
+      );
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      { row },
+      "mid-path-cold-link",
+    );
+
+    const { error } = await rollForward(cell, typedRow("v2"));
+
+    expect(
+      error,
+      "a linked path crossing a mid-doc link into an absent doc was judged " +
+        "as a plain absence instead of deferred as unreadable",
+    ).toBeUndefined();
+    await cell.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
+  });
+
+  it("fails loudly on a stored link CYCLE rather than deferring it", async () => {
+    // Two docs each holding only a link to the other: every doc on the
+    // chain is present and readable, so nothing is unreadable — the chain
+    // just never produces a value. The staging materialization refuses to
+    // resolve such a chain (link resolution throws on the cycle), so the
+    // update fails loudly before any deferral question arises. What this
+    // pins is the boundary: a cycle must never ride the unreadable-link
+    // deferral through to a committed update. The walk's own repeat-address
+    // guard — the backstop that keeps it terminating if a cyclic graph ever
+    // reaches it — is exercised directly below.
+    const cycleA = rt.getCell<unknown>(space, "cycle-a");
+    const cycleB = rt.getCell<unknown>(space, "cycle-b");
+    const row = rt.getCell<Record<string, unknown>>(space, "cycle-row");
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      cycleA.withTx(tx).asSchema(undefined as never).set(cycleB as never);
+      cycleB.withTx(tx).asSchema(undefined as never).set(cycleA as never);
+      row.withTx(tx).asSchema(undefined as never).set(
+        { name: cycleA, other: "fine" } as never,
+      );
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      { row },
+      "cycle-link",
+    );
+
+    const { error } = await rollForward(cell, typedRow("v2"));
+
+    expect(
+      error,
+      "a stored link cycle slipped through a pattern update silently",
+    ).toContain("cycle");
+    await cell.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v1");
+  });
+
+  it("terminates the raw walk on a cyclic stored graph", async () => {
+    // Direct exercise of readStoredLinkChainRaw's repeat-address guard: the
+    // staging materialization happens to throw on root-link cycles before
+    // the walk runs today, but the walk must terminate on its own — it
+    // follows raw bytes, and an infinite loop here would hang setup on
+    // whatever cyclic shape some other resolution vintage tolerates. A
+    // cycle reads as a judged absence (a dead end the docs genuinely hold),
+    // never as unreadable.
+    const cycleA = rt.getCell<unknown>(space, "walk-cycle-a");
+    const cycleB = rt.getCell<unknown>(space, "walk-cycle-b");
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      cycleA.withTx(tx).asSchema(undefined as never).set(cycleB as never);
+      cycleB.withTx(tx).asSchema(undefined as never).set(cycleA as never);
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+
+    const tx = rt.edit();
+    try {
+      const reading = readStoredLinkChainRaw(
+        tx,
+        cycleA.getAsNormalizedFullLink(),
+        new Set(),
+      );
+      expect(reading.unreadable).toBeUndefined();
+      expect((reading as { value: unknown }).value).toBeUndefined();
+    } finally {
+      await tx.commit();
+    }
+  });
+
+  it("still refuses a PRESENT doc's genuinely absent value behind the hop", async () => {
+    // The other side of the unreadable/absent line, pinned so the deep
+    // deferral cannot widen into it: here every doc on the chain is present
+    // and readable — the linked slot just holds nothing. That is a judged
+    // absence, not an unreadable one, and a required field over it must
+    // refuse exactly as a plain missing value would.
+    const present = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-absent-slot-target",
+    );
+    const row = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-absent-slot-row",
+    );
+    const { error: writeError } = await rt.editWithRetry((tx) => {
+      present.withTx(tx).asSchema(undefined as never).set(
+        { unrelated: true } as never,
+      );
+      row.withTx(tx).asSchema(undefined as never).set(
+        {
+          // Two segments, so the walk reads THROUGH the primitive stored at
+          // `unrelated` — the same judged absence as a missing slot.
+          name: present.key("unrelated").key("deeper"),
+          other: "fine",
+        } as never,
+      );
+    });
+    expect(writeError?.message).toBeUndefined();
+    await rt.idle();
+    const { cell } = await setupVintage(
+      openArgument("v1"),
+      { row },
+      "nested-absent-slot-link",
+    );
+
+    const { error, thrown } = await rollForward(cell, typedRow("v2"));
+
+    expect(
+      error,
+      "a required slot whose link lands on a readable doc that genuinely " +
+        "holds nothing slipped past validation — the unreadable-link " +
+        "deferral is leaking onto judged absences",
+    ).toContain("updated arguments do not match the candidate schema");
+    expect(error).toContain("name:");
+    expect(isStoredArgumentSchemaRefusal(thrown)).toBe(true);
   });
 
   it("still refuses a READABLE wrong-typed value behind the same hop", async () => {

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -93,7 +93,10 @@ const typedCount = (marker: string): RuntimeProgram =>
 const typedRow = (marker: string): RuntimeProgram =>
   programOf([
     "import { pattern } from 'commonfabric';",
-    "interface Row { name: string; other?: string }",
+    // Open like the argument object above it: the row fixtures carry slots
+    // the candidate never declares (a chained alias, a self-link), the way
+    // stored docs of another vintage routinely do.
+    "interface Row { name: string; other?: string; [key: string]: any }",
     "interface Args { row?: Row; [key: string]: any }",
     "export default pattern<Args, { marker: string }>(() => {",
     `  return { marker: ${JSON.stringify(marker)} };`,
@@ -1059,10 +1062,14 @@ describe("pattern update validates the stored argument", () => {
     const cycleA = rt.getCell<unknown>(space, "walk-cycle-a");
     const cycleB = rt.getCell<unknown>(space, "walk-cycle-b");
     const prim = rt.getCell<Record<string, unknown>>(space, "walk-primitive");
+    const metaOnly = rt.getCell<unknown>(space, "walk-meta-only");
     const { error: writeError } = await rt.editWithRetry((tx) => {
       cycleA.withTx(tx).asSchema(undefined as never).set(cycleB as never);
       cycleB.withTx(tx).asSchema(undefined as never).set(cycleA as never);
       prim.withTx(tx).asSchema(undefined as never).set({ p: true } as never);
+      // A doc record a meta-only write leaves behind: present, no value —
+      // the stamped-but-unmaterialized state real vintages hold.
+      metaOnly.withTx(tx).setMetaRaw("slug", "walk-meta-only");
     });
     expect(writeError?.message).toBeUndefined();
     await rt.idle();
@@ -1099,9 +1106,23 @@ describe("pattern update validates the stored argument", () => {
           new Set(),
         ).value,
       ).toBeUndefined();
+      expect(
+        readStoredLinkChainRaw(
+          tx,
+          metaOnly.getAsNormalizedFullLink(),
+          new Set(),
+        ).value,
+      ).toBeUndefined();
     } finally {
       await tx.commit();
     }
+
+    // Anything other than an absence surfaces instead of reading as a dead
+    // end — the same line readOrThrow draws. A committed transaction is the
+    // reachable member of that class.
+    expect(() =>
+      readStoredLinkChainRaw(tx, cycleA.getAsNormalizedFullLink(), new Set())
+    ).toThrow();
   });
 
   it("defers a PRESENT doc's absent value behind the hop", async () => {

--- a/packages/runner/test/pattern-update-argument-validation.test.ts
+++ b/packages/runner/test/pattern-update-argument-validation.test.ts
@@ -917,11 +917,38 @@ describe("pattern update validates the stored argument", () => {
     // descent terminates instead of recursing forever.
     const absent = rt.getCell<string>(space, "nested-cold-target");
     const mid = rt.getCell<string>(space, "nested-cold-mid");
+    const fine = rt.getCell<string>(space, "nested-cold-fine");
+    const fineHop = rt.getCell<string>(space, "nested-cold-fine-hop");
+    const inner = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-cold-inner",
+    );
+    const wrap = rt.getCell<Record<string, unknown>>(
+      space,
+      "nested-cold-wrap",
+    );
     const row = rt.getCell<Record<string, unknown>>(space, "nested-cold-row");
     const { error: writeError } = await rt.editWithRetry((tx) => {
       mid.withTx(tx).asSchema(undefined as never).set(absent as never);
+      fine.withTx(tx).asSchema(undefined as never).set("fine" as never);
+      fineHop.withTx(tx).asSchema(undefined as never).set(fine as never);
+      inner.withTx(tx).asSchema(undefined as never).set(
+        { inner: "annotation" } as never,
+      );
+      wrap.withTx(tx).asSchema(undefined as never).set(
+        { wrap: inner } as never,
+      );
       row.withTx(tx).asSchema(undefined as never).set(
-        { name: mid, other: "fine", loop: row } as never,
+        {
+          name: mid,
+          // A chain and a mid-path link that RESOLVE, beside the one that
+          // does not: the walk mirrors these to their values and leaves
+          // them untouched while `name` alone defers.
+          other: fineHop,
+          // The note's path crosses the link stored at `wrap` mid-doc.
+          note: wrap.key("wrap").key("inner"),
+          loop: row,
+        } as never,
       );
     });
     expect(writeError?.message).toBeUndefined();
@@ -1028,13 +1055,14 @@ describe("pattern update validates the stored argument", () => {
     // the walk runs today, but the walk must terminate on its own — it
     // follows raw bytes, and an infinite loop here would hang setup on
     // whatever cyclic shape some other resolution vintage tolerates. A
-    // cycle reads as a judged absence (a dead end the docs genuinely hold),
-    // never as unreadable.
+    // cycle resolves to no readable tree, like every other dead end.
     const cycleA = rt.getCell<unknown>(space, "walk-cycle-a");
     const cycleB = rt.getCell<unknown>(space, "walk-cycle-b");
+    const prim = rt.getCell<Record<string, unknown>>(space, "walk-primitive");
     const { error: writeError } = await rt.editWithRetry((tx) => {
       cycleA.withTx(tx).asSchema(undefined as never).set(cycleB as never);
       cycleB.withTx(tx).asSchema(undefined as never).set(cycleA as never);
+      prim.withTx(tx).asSchema(undefined as never).set({ p: true } as never);
     });
     expect(writeError?.message).toBeUndefined();
     await rt.idle();
@@ -1046,19 +1074,45 @@ describe("pattern update validates the stored argument", () => {
         cycleA.getAsNormalizedFullLink(),
         new Set(),
       );
-      expect(reading.unreadable).toBeUndefined();
-      expect((reading as { value: unknown }).value).toBeUndefined();
+      expect(reading.value).toBeUndefined();
+      // The other no-tree dead ends, exercised at the same seam: a doc the
+      // store has never held, and a path that reads through a primitive.
+      const absent = rt.getCell<unknown>(space, "walk-absent-target");
+      expect(
+        readStoredLinkChainRaw(
+          tx,
+          absent.getAsNormalizedFullLink(),
+          new Set(),
+        ).value,
+      ).toBeUndefined();
+      expect(
+        readStoredLinkChainRaw(
+          tx,
+          absent.key("beyond").getAsNormalizedFullLink(),
+          new Set(),
+        ).value,
+      ).toBeUndefined();
+      expect(
+        readStoredLinkChainRaw(
+          tx,
+          prim.key("p").key("deeper").getAsNormalizedFullLink(),
+          new Set(),
+        ).value,
+      ).toBeUndefined();
     } finally {
       await tx.commit();
     }
   });
 
-  it("still refuses a PRESENT doc's genuinely absent value behind the hop", async () => {
-    // The other side of the unreadable/absent line, pinned so the deep
-    // deferral cannot widen into it: here every doc on the chain is present
-    // and readable — the linked slot just holds nothing. That is a judged
-    // absence, not an unreadable one, and a required field over it must
-    // refuse exactly as a plain missing value would.
+  it("defers a PRESENT doc's absent value behind the hop", async () => {
+    // Behind a link, an absence defers whatever produced it. This exact
+    // shape argues why: the pattern-vintage stores hold pieces whose
+    // `profiles` argument links a path the target doc does not hold YET —
+    // the slot materializes lazily, on the first profile created — and a
+    // validator that judged "present doc, absent path" as invalid refused
+    // every update over them. Absence at rest is indistinguishable from
+    // absence-so-far, so the slot's check belongs to instantiation-time
+    // reads, which see the write when it comes.
     const present = rt.getCell<Record<string, unknown>>(
       space,
       "nested-absent-slot-target",
@@ -1088,16 +1142,16 @@ describe("pattern update validates the stored argument", () => {
       "nested-absent-slot-link",
     );
 
-    const { error, thrown } = await rollForward(cell, typedRow("v2"));
+    const { error } = await rollForward(cell, typedRow("v2"));
 
     expect(
       error,
-      "a required slot whose link lands on a readable doc that genuinely " +
-        "holds nothing slipped past validation — the unreadable-link " +
-        "deferral is leaking onto judged absences",
-    ).toContain("updated arguments do not match the candidate schema");
-    expect(error).toContain("name:");
-    expect(isStoredArgumentSchemaRefusal(thrown)).toBe(true);
+      "a slot whose link lands on a path its target does not hold yet was " +
+        "treated as invalid — the lazily-materialized-slot shape the " +
+        "pattern-vintage stores hold",
+    ).toBeUndefined();
+    await cell.pull();
+    expect((cell.getAsQueryResult() as { marker: string }).marker).toBe("v2");
   });
 
   it("still refuses a READABLE wrong-typed value behind the same hop", async () => {


### PR DESCRIPTION
Root cause and fix for the 2026-08-21 estuary outage: every home space failed cold start with

    updated arguments do not match the candidate schema:
      profiles: 0: name: value does not match type string

and the deploy had to be rolled back to a667cf56a, where estuary is still pinned. This is what has been blocking every estuary deploy since.

## Root cause

Three facts compose, none of them wrong-sounding alone:

1. **An argument-derived seed stores as a link, one hop further than a static seed.** `profile-home.tsx` seeds `name` with `trimInitialName(initialName)` — a derived value — so the name cell's doc stores a LINK to the doc holding the resolved seed. `avatar`'s static `""` stores inline. Measured on production: Gideon's `name` chain is `result → of:ME467FIh… (a link) → of:o2k4BQ7J… ("Gideon")`, while `avatar` terminates in one hop. Every profile created through the trusted create surface has this shape — which is why the fleet bricked on exactly `name` and nothing else.

2. **The cold-start sync closure delivers hop 1 but never hop 2.** At validation time the worker's replica held the name cell doc and every literal sibling, and did not hold the seed doc (instrumented locally; deterministic across reloads). The validating read is a one-shot synchronous materialization inside the setup transaction — no convergence rounds, no load kicks — so the dead end materializes as `undefined`.

3. **Setup validation confused "cannot read right now" with "invalid".** The existing deferral (`UNRESOLVED_LINK_PLACEHOLDER`, the CT-1917 line) only walked the argument doc's own raw — blind past the first resolution — and only ran for re-staged arguments, while a sub-piece re-instantiated by its host's setup (ProfilePicker, whose argument is `profiles`/`defaultProfile`/`mru`) arrives on the supplied-argument branch, which had no deferral at all.

So the first `home.tsx` identity move since profiles were written (#6019 — the change itself was irrelevant) re-ran home's setup on cold start, the picker's argument re-validated over the half-replicated graph, `name` materialized `undefined` against a required `string`, and the refusal is permanent by design: the same identity refuses identically, and the roll-forward heal no-ops because the official pattern is already the pinned one. The stored data was never wrong — the same docs read back `"Gideon"` through any converging read path.

## Fix

`validateArgument` now defers exactly what this context cannot read, at any depth, on both branches. `overlayUnreadableLinkPlaceholders` walks the STORED link graph the way the materialization it repairs does — raw reads through the transaction, following links across docs and spaces, cycle-guarded — and substitutes the placeholder wherever a chain dead-ends at a doc the replica cannot serve and the materialization came back `undefined`. A readable value of the wrong type still refuses: deferral is for what could not be read, never for what was read and judged. The deferred slot's schema check lands where it always belonged — instantiation-time reactive reads, which sync what they need (the same verdict link-resolution's `pendingHopDoc` renders for lazy reads, per the OW51 ruling).

Since the overlay can only turn `undefined` into an accepted opaque, it runs only after a first validation failure; the happy path pays nothing.

## Verification

- **The incident's exact shape, end to end**: a home + profile created through the real create surface on a local server at the rolled-back pin (a667cf56a), then cold-loaded under current main, bricks byte-for-byte without this change — same message, same failed heal — and with it swaps cleanly to the current identity, profile and name intact, and reads back `"Repro User"` post-swap with `Pattern Ref` at the new identity.
- **Regression tests** in `pattern-update-argument-validation.test.ts`: the nested-cold case ("the unreadable link sits BEHIND a readable hop") fails with the outage signature without the fix; the differential ("still refuses a READABLE wrong-typed value behind the same hop") pins that strictness survives.
- Full `runner` and `piece` suites green; `deno task check`, `deno fmt --check`, `deno lint` clean.

## Deploy note

Estuary stays pinned at a667cf56a until this is in the deployed build; with it, every bricked-class home swaps cleanly on its next cold load — no data surgery. (Post-#6210 the server ensures the space root itself; its replica is complete, so it may well perform the swap before any browser does. The fix makes both contexts safe.)

## Where the review arc landed (2026-08-25)

The rule, sharpened by four review rounds and one lesson the pattern-vintage gate taught the hard way: **behind a link, an absence defers — whatever produced it.** An early review round tried judging "present doc, absent path" strictly; the vintage stores refused it (a `profiles` argument routinely links a path its target doc does not hold *yet* — the slot materializes lazily on first use, indistinguishable at rest from not-yet-synced). What stays judged: a value actually read (a wrong-typed value refuses), and a literal `undefined` stored in the argument doc itself with no link involved.

**Companion: #6245** takes the other fork of the contract — setup validation *converges before it judges, then judges strictly* (a never-pulled target postpones the update instead of passing it; a confirmed absence behind a required slot refuses). That is the destination; it needs patterns-side schema-honesty companions and more runway. This PR is the intermediate that unblocks estuary deploys now, per area-owner review.

Follow-ups deliberately not in this PR: the cold-start closure excluding second-hop targets at scalar schema positions (the sync-side defect #6245's line of work owns); whether setup should store argument-derived seeds as resolved literals rather than a link to the derivation's doc (write-side hardening; the fleet's existing docs need this fix regardless); the heal message attributing a sub-piece's refusal to the root pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


