### PR TITLE
test(ts-transformers): say why the sidecar suite pins a rejected spelling

### DIFF
--- a/packages/ts-transformers/test/builder-source-sites.test.ts
+++ b/packages/ts-transformers/test/builder-source-sites.test.ts
@@ -88,6 +88,15 @@ describe("builder-source-sites", () => {
         ),
         bindingName: "onDeclared",
       });
+      // Reaching a callback through a property access is a compile error —
+      // the module verifier cannot follow it, so the module is refused at
+      // load, and stage 7 says so
+      // (`transformers/indirect-builder-callback-validation.test.ts` pins that
+      // diagnostic). Recording is independent of that rejection and is pinned
+      // here anyway: this is the only coverage of the anchor-less fallback,
+      // where no callback anchor is recoverable and the site comes from the
+      // builder call itself. Read it as coverage of that fallback, never as a
+      // spelling a pattern may use.
       expect(sidecar?.sites.propertyHandler).toEqual({
         ...locationOf("handler(callbacks.onProperty)"),
         bindingName: "propertyHandler",


### PR DESCRIPTION
Comment only — no code change, no behavior change.

`builder-source-sites.test.ts` fixtures `const propertyHandler = handler(callbacks.onProperty)` and asserts a recorded sidecar site for it. That spelling is a compile error: stage 7 rejects a callback the module verifier cannot follow, and the module would be refused at load. Probed against main, the same compile produces both at once:

```
severity: error
type:     builder-callback:indirect-reference
message:  "…which the module verifier cannot follow — the module would be refused at load."
```

```
sites: { propertyHandler: { line: 8, col: 24, bindingName: "propertyHandler" } }
```

Recording and validation are independent stages, so a site is recorded for an artifact that will be rejected. The suite passes because it never reads `getDiagnostics()` — which is fine, but it leaves the fixture reading as though property access were a supported spelling.

The assertion does earn its place: it is the only coverage of the anchor-less fallback, where no callback anchor is recoverable and the site is taken from the builder call itself. I checked — no other test in `ts-transformers` or `runner` exercises that path. So the comment says what the assertion is for, and points at `transformers/indirect-builder-callback-validation.test.ts` where the diagnostic itself is pinned.

Worth considering as a follow-up: asserting the diagnostic *in this suite* would pin the coexistence mechanically rather than in prose. Left out here to keep this to the comment.

### Validation

Pinned `deno 2.9.4`: ts-transformers 1164 tests / 832 steps, 0 failed. `deno task check` clean across all package groups; `fmt --check` 5013 files; `lint` 4922 files.

*(authored by Claude Opus 5, on behalf of Gideon)*


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

