### PR TITLE
docs(cli): shell completion coverage, and how a command names its target

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -103,3 +103,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
   do one job under two names. Separate from the read-layer plan because it
   renames rather than adds, so its risk is what breaks for a caller who already
   learned the current spelling.
+- [Shell completion coverage](cli-completion-coverage.md) sequences the work
+  that makes `cf completion` answer correctly across the surface it claims and
+  reach the verb surface it does not: the slots that offer a wrong candidate,
+  the verb flags and result shapes that offer none, the source `--space` needs
+  before any of it is reachable by name, and the gate that keeps completion
+  from falling behind the command tree again.

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -1,0 +1,507 @@
+# Shell completion coverage — implementation plan
+
+`cf completion` answers a Tab with candidates for the slot under the cursor.
+This plan sequences the work that makes it answer correctly across the surface
+it already claims, and extends it to the pattern-owned vocabulary it does not
+yet reach.
+
+The design is unchanged and is not restated here.
+[`packages/cli/README.md`](../../packages/cli/README.md#shell-completion) is
+the reference for what completion covers and how it is installed;
+[Verbs over the CLI](../common/verbs/over-the-cli.md) is the caller-facing
+surface most of this plan serves. Read those for reasoning; read this for
+order.
+
+## Why
+
+Completion is the one part of the CLI that fails by staying silent. Every
+provider failure degrades to an empty candidate list on purpose, because a
+completion request runs between two keystrokes and must never paste a stack
+trace into the command line. That is the right disposition and it is also why
+a defect here does not announce itself: a slot that resolves nothing and a slot
+that has no provider are the same experience at the prompt.
+
+Three consequences follow, and they are what this plan is for.
+
+**Completion trails the command surface.** The resolver walks the live Cliffy
+tree, so a new subcommand or flag becomes completable the moment it is
+registered. The *values* do not: they come from two hand-maintained tables in
+`lib/completion/providers.ts`, and a new command reaching the tree with no
+entry in either is indistinguishable at the prompt from one whose fabric is
+unreachable.
+
+**The chain has a weak first link.** Reaching a piece, a verb, or a cell path
+needs a space, `--space` is required on every command that reads one, and
+`--space` completes to space DIDs discovered from local stores — while the
+value a caller types is a space name. A name derives its DID one way, so a
+discovered DID can never produce the name that made it.
+
+**Nothing exercises a live provider.** The unit tests cover the pure shaping
+functions and assert that a slot with no fabric context degrades to empty.
+Every path that reaches a fabric is unverified, and the defects below sit
+exactly where no live exercise runs.
+
+## How this list is ranked
+
+Two axes, because either one alone gets the order wrong.
+
+**Correctness gates value.** A slot that offers a candidate the command
+rejects, or that hides candidates it holds, is worse than a slot that offers
+nothing: the first teaches a caller something false, the second only fails to
+help. Those defects are also the smallest edits here. They go first, cheapest
+first, and nothing is built on a slot that is still answering wrongly.
+
+**After that, rank by whose vocabulary it is.** Completion earns its keep where
+the words are not the CLI's own. A flag name, an enumerated value, and a
+subcommand are each one `--help` away, so completing them saves keystrokes. A
+piece id, a verb name, a verb's flags, a cell path, and the field paths of a
+verb's result are none of them derivable from the CLI — they belong to a
+deployed pattern, and the only other way to learn one is to make a call and read
+what comes back. Completing those saves a round trip and a context switch, which
+is a different order of saving.
+
+Frequency multiplies it. The slots on the call path — name a piece, name a verb,
+fill its event, shape its result — are hit on nearly every command; `inspect`'s
+positionals are hit by an operator during an investigation.
+
+So: correctness first, then pattern-owned vocabulary on the call path, then
+everything a caller could have read out of `--help` anyway. The rank column
+records which of those an item is, and the table is in working order.
+
+## State
+
+Where every item stands. The sections below carry the detail and are what to
+read before picking one up; this table is the roll-up.
+
+| # | Item | Rank | Status |
+| --- | --- | --- | --- |
+| 1 | Inline `--option=value` drops every live candidate | correctness | not started |
+| 2 | Flags offered past a `stopEarly()` boundary | correctness | not started |
+| 3 | Target resolution lags the reference grammar | correctness | not started |
+| 4 | Verb flags do not complete (with item 2) | pattern vocabulary | not started |
+| 5 | Result field paths for `get` and `wish` | pattern vocabulary | not started |
+| 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
+| 7 | Slugs never complete | pattern vocabulary | not started |
+| 8 | `--space` has no source a caller recognizes | first link | needs a decision |
+| 9 | A verb's annotation is its kind, not its prose | comprehension | not started |
+| 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | not started |
+| 11 | Every Tab costs two process starts | felt cost | needs a decision |
+| 12 | `nospace` is inert on the stock macOS bash | felt cost | not started |
+| 13 | Space and entity positionals across `inspect` | operator surface | not started |
+| 14 | `wish` targets and scopes | CLI vocabulary | not started |
+| 15 | Remaining path-shaped and enumerable values | CLI vocabulary | not started |
+| 16 | Two provider entries that can never fire | hygiene | not started |
+| 17 | The README table omits the top-level spellings | hygiene | not started |
+| 18 | A live-provider test seam | mechanism | not started |
+| 19 | A gate that fails when a new slot has no decision | mechanism | not started |
+
+Items 1 to 7 are worth doing in that order. The first three are corrections and
+are small, and items 4 to 6 read from listings those corrections have to be
+answering correctly first. Everything from 8 down can be picked up
+independently.
+
+## What this list covers, and what it cannot
+
+Two of the four ways completion can be wrong are enumerated here exhaustively,
+and two are not. Knowing which is which is the difference between working the
+list and trusting it.
+
+**Enumerated exhaustively.** A slot with no provider entry: the keys of both
+provider tables are derivable from the same command tree the resolver walks, so
+walking the tree and subtracting the tables names every one. That is items 13
+to 16, and item 19 is the same walk made permanent.
+
+**Enumerated exhaustively.** A provider entry with no slot: the same
+subtraction run the other way. That is item 16.
+
+**Not enumerated.** A provider that returns the *wrong set* rather than an
+empty one. This is invisible at the prompt — plausible candidates look like
+correct ones — and there is no mechanical test for it. Item 2 is one instance,
+found by reading a flag's help text rather than by any method that would find
+the next one. The open questions of this kind are listed under item 18, because
+a live seam is what turns them from questions into assertions.
+
+**Not enumerated.** Defects in the installed shell functions rather than in the
+callback they invoke. The bash function has been driven directly and agrees
+with the callback on the cases tried, including reproducing item 1 end to end.
+zsh's `_describe` rendering, the colon escaping that piece ids and DIDs need,
+and the `deno` binding are untested.
+
+## Correctness
+
+### 1. Inline `--option=value` drops every live candidate
+
+`--space=<TAB>`, `--piece=<TAB>`, and `--api-url=<TAB>` offer nothing, while the
+same options completed as `--space <TAB>` work. Enumerated values are
+unaffected: `--log-level=<TAB>` completes.
+
+`complete` in `lib/completion/mod.ts` filters candidates against the word under
+the cursor, which for this spelling is `--piece=`. `staticCandidates`
+re-attaches that prefix through `withInlinePrefix`, so its candidates survive
+the filter.
+`liveCandidates` returns bare values, so every one of them fails the prefix test
+and is dropped.
+
+The fix is to apply the inline prefix to the live half as well, which means
+`complete` carrying the slot's `inlinePrefix` across both sources rather than
+`staticCandidates` owning it alone.
+
+This spelling is why `tokenizeLine` exists — bash splits its own words on `=` —
+so it is the one form the implementation is built to serve and the one that does
+not work.
+
+Directives are the other half of the same slot: `--identity=<TAB>` emits a files
+directive whose glob the shell applies to a word still carrying `--identity=`.
+Settle both in one change.
+
+### 2. Flags offered past a `stopEarly()` boundary
+
+After the callable name, `cf call` offers `--invocation`, `--filter`,
+`--select`, `--quiet` and the rest of its own flags. The command rejects all of
+them there: `buildCallCommand` in `commands/piece.ts` is `stopEarly()`, so the
+first positional ends option parsing and every later word belongs to the
+callable's schema-derived parser. The flags' own help text says so — each
+description ends "(before the callable name)". `cf exec` has the same shape and
+the same defect, its descriptions ending "(before the mounted file)".
+
+`resolveCompletionLine` in `lib/completion/line.ts` has no notion of the
+boundary, so `option-name` stays reachable for the whole line. Cliffy records it
+as `_stopEarly` with no accessor; either read that field or have the completion
+layer name the two commands. Reading the field keeps the property where the
+command declares it, which is the reason to prefer it.
+
+Past the boundary the slot is the callable's, so this and item 4 are one edit:
+recognizing the boundary is what routes the slot to the verb's own fields, and
+recognizing it without routing the slot leaves the position offering nothing.
+[Naming the target](cli-surface-shape.md#naming-the-target) decides where the
+boundary sits — under it the verb opens the callable's section and `--` closes
+it, so the position after the verb is the callable's and the position after the
+marker is the read step's.
+
+### 3. Target resolution lags the reference grammar
+
+Three documented ways to name a target complete nothing:
+
+```bash
+cf call --piece /@did:key:.../of:fid1:... <TAB>   # canonical reference
+cf call --space donuts /of:fid1:... <TAB>          # positional address
+cf get --piece fid1:...#argument <TAB>             # the arguments cell
+```
+
+The `--url` spelling of the same target works, which is what makes this read as
+random rather than as a missing capability.
+
+`resolvePieceContext` in `lib/completion/providers.ts` takes `--piece` verbatim
+as a piece id. The canonical form is not one, so the listing call fails and the
+slot degrades to empty. `normalizeLLMFriendlyRef` is the function that already
+parses this grammar — the embedded space, the `@scope` suffix, the trailing
+path, and `#argument` — and completion is an intake seam that does not use it.
+
+The positional address is a second, independent break: it occupies positional
+index 0, so `resolveSlot` resolves the cursor to the variadic `tail` rather than
+to `callable`, and the callable provider is never consulted. Whichever way
+completion learns the address form, it has to shift the positional index the way
+the command does.
+
+`#argument` selects the arguments cell, the same selection `--input` spells as a
+flag. `cellPathCandidates` reads `--input` and not the suffix, so the two
+spellings of one selection complete differently.
+
+## Pattern vocabulary
+
+This is the half of the list that pays for itself. Every slot in this section
+names something a deployed pattern owns, so the alternative to completing it is
+a call to `cf piece verbs` or `cf get` and a read of what comes back.
+
+### 4. Verb flags do not complete
+
+`cf call --piece <piece> addItem -- --<TAB>` offers nothing, and neither does
+the equivalent under `cf exec`. This is the position where a caller most needs
+help, because the vocabulary is the pattern author's rather than the CLI's.
+
+Two edits stand between the current behavior and candidates:
+
+- `liveCandidates` dispatches on `option-value` and `argument` slots only, so
+  the `passthrough` slot — every word after `--` — reaches no provider at all.
+- `call:tail`, `piece call:tail`, and `exec:tail` have no `ARGUMENT_PROVIDERS`
+  entries, so the words before a `--` reach none either.
+
+The data needs no new request. `listPieceCallables` — the call
+`callableCandidates` already makes — returns each verb's `inputSchema`, and
+`flagNameForKey` in `lib/exec-schema.ts` is the kebab-case mapping the parser
+itself applies. A verb declaring `title` accepts `--title`, and both halves of
+that sentence are already in the process.
+
+The same slot should offer `--help`, which the callable's parser accepts and
+which is the documented way to read one verb's interface.
+
+### 5. Result field paths for `get` and `wish`
+
+`--select` takes comma-separated, dot-separated field paths into the value a
+read returns, and `--schema` accepts the same spelling. Both complete nothing.
+
+The grammar is its own, and is not the cell-path grammar:
+`parseSelectProjection` in `lib/cell-selection.ts` splits a list on `,` and a
+path on `.`, where `cellPathCandidates` walks `/`. A segment ending in `@`
+asks for that position's address rather than its value, and a bare `@` asks the
+read for its own — so a complete candidate set offers both spellings of a
+position.
+
+For `cf get` the vocabulary needs no new request and no new reachability: the
+value being projected is the one at the piece and path already named, which
+`getCellValue` reads and `keysOf` already turns into keys. That makes this the
+cheapest high-value item on the list, and independent of item 4.
+
+`cf wish` projects the resolved target the same way. A wish declares no result
+shape the way a verb declares an `outputSchema`, but a shape is not what this
+provider reads: it reads a value and takes its keys, and a wish is a read. So
+the target resolves and its keys are the candidates, the same walk `cf get`
+needs. `wish` is also the one command whose `--space` is optional, so this
+completes from an identity alone.
+
+Confirm before building it that resolving a wish writes nothing. The profile
+ordering consults a most-recently-used list, and a Tab that reordered it would
+be a keystroke with a side effect — which is a bar completion has to clear
+whatever the candidates are worth.
+
+### 6. Result field paths for `call` and `exec`
+
+The same flags on a call shape the verb's result, whose vocabulary is the verb's
+`outputSchema` — carried by the same listing item 4 reads.
+
+This one is not really a completion item, and the surface work dissolves most
+of it. `stopEarly()` requires a projection before the callable name today, and a
+caller who writes it after gets one of three outcomes with no rule connecting
+them:
+
+```text
+call <verb> --select item.title '{...}'   Use a single inline JSON argument or
+                                          "--" before schema-derived flags.
+call <verb> -- --title x --select y       "--select" at <event> is not a field
+                                          this verb declares.
+call <verb> --json '{...}'                works
+```
+
+The first message names a rule the caller did not break: they passed a single
+inline JSON argument, and `--select` is not a schema-derived flag. It is what
+`--invocation` and `--show-links` say too. The second is a good message about
+the wrong subject. The third succeeds, because `--json` is a token the
+callable's parser accepts — so the surface is not "a `cf` flag never works after
+the verb", it is "some do", which is not a rule anyone can infer from using it.
+
+[Naming the target](cli-surface-shape.md#naming-the-target) settles this: the
+verb opens the callable's section and `--` closes it, so a projection is written
+after the marker and therefore always after the verb. That ordering is what this
+item was waiting on, and it arrives with the verb already on the line ahead of
+the cursor — so the candidates come from the `outputSchema` the listing in item
+4 already carries, read from the words before the cursor like every other slot.
+
+What survives is one improvement completion wants on its own account.
+`resolveCompletionLine` derives two different things from `words.slice(1,
+cursor)` — which slot the cursor is in, and which piece and verb the line names
+— and only the first needs the prefix. Resolving the slot from the prefix while
+gathering context from the whole line is what makes mid-line editing complete
+against the position being edited rather than against the end of the line. It is
+no longer load-bearing for this item, and it is still the difference between a
+line that completes as it is typed and one that completes however it is edited.
+
+### 7. Slugs never complete
+
+A slug is a valid `--piece` value — the alias grammar names it alongside the
+bare id — and `listSpaceSlugs` enumerates every slug a space's index records.
+Completion offers ids only. `piece set-slug` takes a slug positionally and
+completes nothing there either.
+
+Offer slugs beside ids in the `--piece` slot, annotated so the two are
+distinguishable. A slug is the readable half of this vocabulary, so it belongs
+above the opaque id in the candidate order.
+
+## The first link
+
+### 8. `--space` has no source a caller recognizes
+
+`--space` takes a space name or a DID, is required on every command that reads a
+space, and has no environment fallback. Completion offers DIDs discovered from
+local memory-v2 stores. A name derives its DID one way, so the discovered DID is
+never the name that produced it, and a caller who works in names gets candidates
+they cannot use.
+
+Discovery is also positional: `candidateRoots` walks up from the working
+directory looking for a store, so completion offers spaces in a checkout that
+holds one and nothing in a worktree that does not — while both talk to the same
+server.
+
+Three sources exist, and choosing among them is a decision this plan does not
+make:
+
+- **The identity's home space.** Always derivable from `--identity` alone, with
+  no server and no local store. One candidate, always correct, and the one a
+  profile target resolves against.
+- **Local stores, made independent of the working directory.** Keeps today's
+  candidates and stops them depending on where the caller stands. Still DIDs.
+- **A record of spaces this CLI has opened.** The only source that can hold a
+  name, because it can record the name at the moment a session resolves it. New
+  state on disk, and the question of when an entry expires.
+
+The third is the one that answers the complaint; it is also the only one that
+adds a durable artifact, which is why it is a decision rather than a task.
+
+## Comprehension
+
+### 9. A verb's annotation is its kind, not its prose
+
+`shapeVerbCandidates` annotates every candidate with `handler` or `tool`. The
+listing row carries `description` — the doc comment the author wrote on the
+property, the same sentence the verb's help page opens with. The annotation
+column is where that sentence belongs; the kind is a two-value fact that rarely
+decides anything at the prompt.
+
+Fall back to the kind where a verb carries no prose, so a candidate is never
+unannotated.
+
+### 10. Wrapper and deprecated verbs are offered unmarked
+
+`cf piece verbs` hides `tier: "wrapper"` and `deprecated` rows unless `--all`,
+and prints a note saying how many it held back. `shapeVerbCandidates` maps the
+full array, so completion offers what the listing hides, and offers it looking
+like everything else.
+
+Both are callable, so offering them is defensible and hiding them is defensible.
+What is not defensible is the two surfaces disagreeing silently. Marking them in
+the annotation column is the cheapest way to agree — it keeps a name reachable
+while saying what it is.
+
+## Felt cost
+
+A completion that arrives late is experienced as one that did not arrive. These
+two items are what a caller feels on slots that are otherwise working.
+
+### 11. Every Tab costs two process starts
+
+`bin/cf` runs `launcher.ts`, which spawns a second Deno process for the CLI, and
+both start on every Tab. Measured against a local server from a warm checkout: a
+purely static completion — subcommand names, no I/O at all — settles in about
+0.34s, and a completion that reaches the fabric takes 0.44s to 1.2s. This agrees
+with the figure `packages/cli/README.md` already records for the source path
+against the compiled binary.
+
+The compiled binary is declined for a reason that has nothing to do with
+completion: nothing invalidates it, so a stale one rejects newer flags and skews
+against an updated server. That reasoning is sound and this item does not
+reopen it.
+
+What has not been considered is whether the cost has to be paid per keystroke at
+all. The static half of the surface needs no fabric and no piece listing, and
+the live half re-reads the same listing on every Tab of the same line. Both are
+shapes a cache or a resident process could serve, and both are decisions about
+where state lives rather than about how fast a process starts.
+
+Worth sizing before it is scheduled: it may be that the correctness and
+vocabulary items above change the experience more than a faster Tab would.
+
+### 12. `nospace` is inert on the stock macOS bash
+
+Cell paths and link endpoints complete one segment at a time and emit a
+`nospace` directive so the cursor stays attached for the next `/`. The bash
+function applies it through `compopt`, which is bash 4 and later; macOS ships
+bash 3.2. The script comments note the cost as a keystroke. It is a keystroke
+*per segment*, on the default shell of the platform most of this repository is
+developed on, and it lands on the deepest and most useful completion there is.
+
+A candidate that carries its own trailing separator is one way around it, since
+the shell's added space then falls after a `/` rather than inside a path.
+
+## Operator surface and CLI vocabulary
+
+### 13. Space and entity positionals across `inspect`
+
+Every `cf inspect` subcommand that reads a space takes it positionally, and none
+of the eighteen have a provider — while `space clone` and `space fingerprint`,
+which take the same thing the same way, do. `inspect` reads local stores
+directly, so the provider it wants is the one `space clone` already uses, and
+item 8's disposition applies unchanged.
+
+The `<entity>` positional beside them is a piece id within the named space, and
+`inspect entities` is what enumerates them.
+
+### 14. `wish` targets and scopes
+
+`cf wish <target>` takes a documented vocabulary — the profile targets and the
+space-relative ones its help enumerates — and completes nothing. `--scope`
+accepts exactly `~`, `.`, `profile`, or a space DID, which is an enumerated set
+plus the space provider.
+
+Both sets are in the command's own help, which is what puts this below the
+pattern-owned slots rather than beside them.
+
+### 15. Remaining path-shaped and enumerable values
+
+The mechanical remainder, each one an entry in an existing table:
+
+- Pattern files: `piece set-home <main>`.
+- Files and directories: `piece getsrc <outpath>`, `deps update <file>`,
+  `fuse mount|unmount <mountpoint>`, `--dir`, `--out`, `--output`, `--from`.
+- API URLs: `--remote`, which takes what `--api-url` takes.
+- Enumerated values, which belong beside the four already in
+  `ENUMERATED_OPTION_VALUES`: `piece map --format` (`ascii`, `dot`),
+  `inspect entities --kind` (seven values its help lists).
+
+## Hygiene
+
+### 16. Two provider entries that can never fire
+
+`OPTION_VALUE_PROVIDERS` carries `log-file` and `state-path`. Both belong to
+`fuse-supervisor` and `fuse-daemon`, which take raw arguments and declare no
+Cliffy options, and which completion drops from its subcommand candidates as
+internal. Neither entry is reachable.
+
+### 17. The README table omits the top-level spellings
+
+The completion table in `packages/cli/README.md` lists `piece call`, `piece
+get`, and `piece set`. The top-level `cf call`, `cf get`, and `cf set` complete
+identically and are the spellings the surface leads with. The table also
+predates everything this plan adds, so it is the document to update as each item
+lands.
+
+## Mechanism
+
+### 18. A live-provider test seam
+
+No test drives a provider against a fabric. `completion-providers.test.ts`
+covers the shaping functions and the degrade-to-empty path; the integration
+scripts under `packages/cli/integration/` do not mention completion.
+
+Every correctness defect above is a shape no live exercise runs. A script
+alongside `verbs-over-the-cli.sh` — deploy a fixture, then assert what a Tab
+offers at each slot of the chain — is the coverage that would have caught them,
+and it composes with the existing harness rather than needing a new one.
+`verb-session-gaps.sh` is the precedent for asserting a gap so that it fails
+loudly the day it closes.
+
+It is also the only way to settle the questions no table walk can reach, which
+are the ones to write first:
+
+- Whether `cellPathCandidates` should stop at a `$link` boundary or follow it,
+  and which it does.
+- Whether the `--piece` listing and the dispatcher agree about scope, so that
+  every completed id is one the same command can then read.
+- Whether a verb stored on both the input and result cells completes against the
+  cell the dispatcher will reach it on, which is the shadowing rule the verbs
+  listing states.
+
+### 19. A gate that fails when a new slot has no decision
+
+Completion falling behind the command surface is the mechanism this whole plan
+is a list of instances of. The tables are keyed by option long name and by
+`<command path>:<argument name>`, and both keys are derivable from the tree that
+`resolveCompletionLine` already walks, so the drift is machine-detectable: walk
+the tree, and name every value-taking option and every positional with no
+provider entry and no enumerated set.
+
+The check cannot decide that a slot *should* complete — plenty should not. It
+can require that every slot has been decided about, which is what an allowlist
+of deliberate omissions records. That turns the next command's completion from
+something remembered into something the gate asks for.
+
+Item 16 is what the same walk finds in the other direction, so both fall out of
+one implementation.

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -78,7 +78,7 @@ read before picking one up; this table is the roll-up.
 | 1 | Inline `--option=value` drops every live candidate | correctness | not started |
 | 2 | Flags offered past a `stopEarly()` boundary | correctness | not started |
 | 3 | Target resolution lags the reference grammar | correctness | not started |
-| 4 | Verb flags do not complete (with item 2) | pattern vocabulary | not started |
+| 4 | Verb flags do not complete (with item 2) | pattern vocabulary | needs step 10 |
 | 5 | Result field paths for `get` and `wish` | pattern vocabulary | not started |
 | 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
 | 7 | Slugs never complete | pattern vocabulary | not started |
@@ -215,16 +215,30 @@ a call to `cf piece verbs` or `cf get` and a read of what comes back.
 
 ### 4. Verb flags do not complete
 
-`cf call --piece <piece> addItem -- --<TAB>` offers nothing, and neither does
-the equivalent under `cf exec`. This is the position where a caller most needs
-help, because the vocabulary is the pattern author's rather than the CLI's.
+A verb's own fields are the pattern author's vocabulary rather than the CLI's,
+so this is the position where a caller has least to go on and completion has
+most to give. Nothing is offered there.
 
-Two edits stand between the current behavior and candidates:
+Where "there" is depends on step 10. Today the fields are written after `--`;
+afterwards the verb opens the callable's section and they are written directly
+after the verb, with `--` closing that section and opening the read step's:
 
-- `liveCandidates` dispatches on `option-value` and `argument` slots only, so
-  the `passthrough` slot — every word after `--` — reaches no provider at all.
-- `call:tail`, `piece call:tail`, and `exec:tail` have no `ARGUMENT_PROVIDERS`
-  entries, so the words before a `--` reach none either.
+```text
+cf call --piece <piece> addItem --ti<TAB>        # after step 10
+cf call --piece <piece> addItem -- --ti<TAB>     # before it
+```
+
+**Build this against the settled grammar, not the current one.** The two
+positions are different slots, so completing the current one means completing it
+again later, and it would teach the spelling that step 10 retires while the
+retirement is being taught. If it lands first for some other reason, it is
+transitional and says so.
+
+`liveCandidates` dispatches on `option-value` and `argument` slots only, so
+neither position reaches a provider today. After step 10 the slot to route is
+the one following the verb, which is the same boundary item 2 has to recognize —
+the two are one edit, and recognizing the boundary without routing the slot
+leaves the position offering nothing.
 
 The data needs no new request. `listPieceCallables` — the call
 `callableCandidates` already makes — returns each verb's `inputSchema`, and
@@ -232,8 +246,11 @@ The data needs no new request. `listPieceCallables` — the call
 itself applies. A verb declaring `title` accepts `--title`, and both halves of
 that sentence are already in the process.
 
-The same slot should offer `--help`, which the callable's parser accepts and
-which is the documented way to read one verb's interface.
+`--help` belongs in this slot too: it falls inside the callable's section, where
+it reaches the verb and prints that verb's own page.
+
+The slot past the marker is not this one. It belongs to the read options, and
+completing it from the verb's declared result is item 6.
 
 ### 5. Result field paths for `get` and `wish`
 

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -434,13 +434,12 @@ it should have gone:
 | a projection before the verb | a result has to be named before it can be shaped |
 | a second `--` | one boundary follows the callable's section, and it is already drawn |
 
-The corrected line is what makes this survivable without a warned window, and
-the refusal has to be reached before a reinterpretation is: a verb may declare a
-field named for a read option, so a line that would otherwise be read as a
-projection has to be recognized as the old spelling first. Every one of these is
-a spelling that worked before, so the caller reading the refusal is someone who
-learned the old one — and a message that says only what is wrong asks them to
-rediscover the grammar, while one that prints the line asks them to retype it.
+The corrected line is what makes this survivable without a warned window. Every
+one of these is a spelling that worked before, so the caller reading the refusal
+is someone who learned the old one — and a message that says only what is wrong
+asks them to rediscover the grammar, while one that prints the line asks them to
+retype it. It is also what keeps a field named for a read option from being read
+as one, which is the only case here that would otherwise pass quietly.
 The repository already answers this way where it matters: a mounted callable's
 result reports the whole command that reads it
 back rather than the address alone.
@@ -542,22 +541,21 @@ those same commands until it has landed.
     on `exec`. A projection is refused before the verb and inside the callable's
     section, and each refusal names the section the flag belongs to and prints
     the corrected line. The change takes effect at once rather than through a
-    warned window, which rests on a line carrying the old marker being refused
-    rather than reinterpreted — and that has to be built rather than assumed.
-    Nothing reserves a field name, so a verb may declare `select`, `filter` or
-    `schema`, and a line whose only fields are those parses as a projection
-    instead: the handler runs with different input and exits zero. `--help` is
-    the same shape, being the one flag that is never unknown.
+    warned window.
 
-    **So the old marker is refused, not reinterpreted.** A `--` that opens an
-    empty callable section, followed by words naming fields the verb declares,
-    is the old spelling and is answered with the corrected line. That is what
-    every old line carrying fields does, so the shape is recognizable wherever
-    it matters, and a caller writing the new grammar never produces it — fields
-    written before the marker leave the section non-empty. `--help` after an
-    empty section keeps reaching the callable, for the reason given above.
-    Both need the verb's declared fields in hand, so the split settles after
-    the schema is loaded rather than during argument handling.
+    Printing the corrected line is what carries that, and it is worth being
+    exact about which case needs it. A stray `cf` flag is refused as an unknown
+    read option and the message adds the spelling that works. A stray *field* is
+    not always refused: nothing reserves a field name, so a verb may declare
+    `select`, `filter` or `schema`, and a line whose only fields are those reads
+    as a projection instead — the handler runs with different input and exits
+    zero. Recognizing words after an empty callable section as fields the verb
+    declares is what turns that into a corrected line rather than a quiet
+    reinterpretation, and it is the same recognition the message needs anyway.
+    A caller writing the new grammar never produces the shape, since fields
+    before the marker leave the section non-empty. It needs the verb's declared
+    fields in hand, so it settles after the schema loads rather than during
+    argument handling.
 11. **`--url` decomposes** into the transport it names and the reference it
     carries, and survives as a convenience for pasting rather than as the only
     spelling that carries a whole target.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -44,10 +44,16 @@ nothing else.
 | `piece get` | reading a piece | reading a cell at a path |
 | `--input` | a mode you switch on | an address — it follows a link stored in the document to reach the arguments cell |
 | `--schema` | one input format | two — a full schema, and a concise path shorthand that is not a schema |
+| `--url` | a transport address | a target reference — host, space and piece in one token, and the only spelling that takes a space by name |
 
 The `--piece` case is not cosmetic. Believing the target had to be a piece is
 what made a verb's receipt look like it needed purpose-built read machinery,
 when it is an ordinary cell that any read already handles.
+
+**One grammar, two spellings.** `cf exec` writes a callable's arguments
+directly after the mounted file that names it. `cf call` requires `--` before
+the same words in the same position. The two commands invoke a callable the same
+way and disagree about how a caller says so.
 
 **One word, two jobs — twice.** `piece inspect` examines a running piece, while
 `cf inspect` reads the database offline and has its own `piece` subcommand.
@@ -173,6 +179,320 @@ their own is a step-7-class decision this document leaves open.
 
 `--select` and `--schema` everywhere, split per the reasons above.
 
+## Naming the target
+
+Every read and every call names a target, and it takes three words to do it: a
+space, a piece, and — for a call — a verb. How those words are spelled looks
+like decoration on the layout above. It is not: it decides whether that layout
+can be written at all.
+
+### The order is a dependency chain
+
+Each word can only be resolved once the words before it are known. A piece is
+named within a space; a verb is named on a piece; a verb's fields and the shape
+of its result are named by the verb.
+
+```text
+space  ->  piece  ->  verb  ->  verb fields  ->  result shape
+```
+
+Anything that resolves one of those — a caller reaching for the documentation, a
+tool offering candidates, a reader making sense of a line — needs every earlier
+word already in hand. So the chain is not a convention. It is the order the
+words become knowable, and a layout that contradicts it is one where a stage
+cannot be resolved from what precedes it.
+
+Read the target layout against it and every element sits in dependency order,
+`<read opts>` last because the result shape is knowable only once the verb is:
+
+```text
+cf call <addr> <verb> <payload> <read opts>
+```
+
+Two things follow, and they are the reason this section exists.
+
+**The verb cannot lead.** A layout naming the verb before the address puts it
+ahead of the words that say which piece it lives on, so nothing can resolve it —
+including the caller. The verb goes after the address, which is where the layout
+already puts it.
+
+**The read options go after the payload, and nowhere else.** They shape the
+verb's result, so they are knowable only at the end of the chain — a projection
+written before the verb names positions in a result nothing has identified yet,
+which is a shape the caller cannot check and a reader cannot follow. The layout
+above is prescriptive on this point: `<read opts>` is a position, not an
+illustration, and a projection written before the verb is refused rather than
+accepted quietly.
+
+`piece call` places them before the callable name today, because everything
+after that name belongs to the callable's own schema-derived parser. So the one
+position the layout allows is the one position the command rejects, a caller who
+writes them where the layout shows them gets an error about a rule they did not
+break, and the same three flags sit in a different place on `call` than on
+`get`. That is the layout's own constraint going unmet, and closing it is the
+work below rather than a new proposal.
+
+### What names a target today
+
+Four spellings, no two of which carry the same parts:
+
+| Spelling | Carries | Piece written as | Space written as |
+| --- | --- | --- | --- |
+| `--space` plus `--piece` | space, piece | a handle or a slug | a name or a DID |
+| `--url` | host, space, piece | a handle | a name |
+| `/@did:…/of:fid1:…` | space, piece, scope, path | a handle only | a DID only |
+| positional `/of:fid1:…` | piece, scope, path | a handle only | not carried |
+
+Two of those columns are the whole problem, and they run in opposite
+directions. The alias grammar is the one a person can write — it takes a slug,
+and a space by name. The canonical reference is the one that carries the most
+and is meant to lead, and it refuses both: a slug in that position is turned
+away with "piece references must use handles, not human names."
+
+So the form that composes is not the form anyone types, and the form anyone
+types cannot carry a space at all. Neither is a spelling a caller can learn
+once.
+
+**Terseness lives in the identifier, not in the separator.** The same piece,
+three ways:
+
+```text
+  7  tracker
+ 51  of:fid1:pOrTkvYX-…
+110  /@did:key:z6MkiAwQ…/of:fid1:pOrTkvYX-…
+```
+
+Collapsing two flags into one token saves a handful of characters. Naming the
+piece by its slug saves a hundred, and naming the space ambiently saves the
+rest. A combined token is worth having for what it composes — one word to copy,
+one word to pass on — rather than for its length, and the short spelling a
+caller wants is mostly reachable already through parts that exist.
+
+**A separator has to be one the parts cannot contain.** A handle contains a
+colon (`fid1:…`) and so does a DID (`did:key:…`), so a colon-joined
+`host:space:piece` cannot be split from either end without knowing which
+segments are allowed to contain colons — and a host carries a port, which is a
+third. `/` is contained by none of the three, which is why the canonical
+reference already joins its parts with it. Its layout is the right structure
+already: right-anchored, each level to the left a broader scope, omitted levels
+supplied by context, the same shape a container image reference has.
+
+**A host is not part of the referent.** `--url` carries one because it is a
+browser URL, and that conflates a transport with a thing being addressed: the
+same space and piece are the same space and piece whichever host serves them.
+`--api-url` already names the transport. So `--url` does not want a better
+name — it wants to decompose into the two things it is carrying, and survive as
+a documented convenience for pasting a URL out of a browser rather than as the
+only spelling that carries a whole target.
+
+### Three moves, which compose
+
+**Give the space an ambient source.** A parameter that is required everywhere
+and identical across a working session is one a caller should state once. This
+shortens the chain by a stage, so a piece resolves from a bare command, and it
+removes the most-repeated word on the surface. `wish` already reads this way.
+
+`CF_SPACE` is where it lives, beside the `CF_API_URL` and `CF_IDENTITY` the same
+builder already reads, and `--space` overrides it. It serves reads and writes
+alike, which is what every comparable tool does — a namespace, a project and a
+profile are each ambient for deletes as much as for reads.
+
+**A command that writes names the space it wrote to.** A wrong space is not an
+error: it succeeds against data nobody meant to touch, and removing a piece from
+one is indistinguishable at the prompt from removing it from another. Naming the
+space in what the command prints is a receipt rather than a prompt, so it costs
+a non-interactive caller nothing and leaves a wrong space visible the moment it
+happens. Nothing in this CLI asks a caller to confirm anything, and this does
+not introduce the first thing that does.
+
+**Let one spelling carry the whole target, in the form a person writes.** The
+canonical reference has the right structure and the wrong vocabulary; the alias
+has the right vocabulary and carries less. Closing the gap means the reference
+accepts a space by name and a piece by slug — `did:key:…` and `fid1:…` are both
+self-identifying, so neither can be mistaken for a name — and that a reference
+may be written positionally wherever `--piece` is accepted, which a slug cannot
+be today.
+
+The reference carries cells and stops there. A verb is not one, so it stays the
+word after the reference rather than a segment inside it — which is where a
+caller reads it anyway, the reference already in hand by the time they write it.
+
+That is a change to the rule that new capabilities land in the canonical form
+first and an alias never leads. The rule is right about direction and this does
+not overturn it: the canonical form still leads, and what it gains is the
+ability to say the same things the alias already says. What would break the rule
+is leaving the human vocabulary in the alias and letting the alias grow, which
+is the shape the surface has now.
+
+A reference that carries the target also collapses the chain into one word,
+where every part a later segment depends on sits to its left inside the same
+token. Resolving one is then the segment-at-a-time walk a path within a cell
+already needs, rather than a rule about the order of separate words. And it
+gives `--url` somewhere to decompose to.
+
+**Separate the three parties on the line.** A call is read by three: `cf`
+resolves the target, the callable consumes its input, and the read step shapes
+what came back. The chain says they run in that order, and the layout says they
+are written in that order. What is missing is the marker between the second and
+the third.
+
+**The verb opens the callable's section; `--` closes it.** A positional already
+marks where the callable's vocabulary begins, so no marker is written there —
+the same boundary `docker run` draws at an image name and `ssh` at a host. What
+a marker is needed for is the boundary the conventional shape does not have: the
+one where the callable's section ends and the read step's begins.
+
+```text
+cf call <target> <verb> <verb input>
+cf call <target> <verb> <verb input> -- <read opts>
+cf call <target> <verb> -- <read opts>             # a verb that takes none
+cf exec <mountedFile> <verb input> -- <read opts>
+```
+
+One marker at most, and it appears only on a call that asks for a projection.
+
+`cf exec` already reads this way — its arguments are written directly after the
+mounted file, with nothing between. `cf call` requires a marker for the same
+words in the same position, so the two commands spell one grammar two ways. This
+settles that disagreement in the direction the sibling already went, and it is
+the smaller change of the two: what the callable's section needs is not a new
+boundary at its start but a way out at its end.
+
+**This is one rule across every command that reads.** Six carry the read
+options, and they divide by whether a callable's vocabulary stands between the
+command and them. `get` and `wish` have none, so nothing separates their read
+options from the rest of the line. `call` and `exec` have one, so a marker
+closes it:
+
+```text
+cf get  <addr> [path]           --select …
+cf wish <target>                --select …
+cf call <target> <verb> <input> -- --select …
+cf exec <mountedFile> <input>   -- --select …
+```
+
+The read options come after the thing they shape in all four, and the marker
+appears exactly where something else owns flags in between. That is one rule a
+caller derives rather than two they memorize.
+
+The documentation already writes it this way wherever the grammar allows.
+Every `get` and `wish` example puts the read options last; every `call` and
+`exec` example puts them first, which is the only position those two accept.
+Nobody chose the split — the grammar imposed it — and closing it converges the
+surface rather than giving `call` a spelling of its own.
+
+**Parsing what follows the marker needs nothing new.** The tokens past it are
+the read options and only those, so they parse against a command carrying just
+those three. Value typing, the near-miss suggestion for a misspelled flag, and
+the refusal of `--schema` beside `--select` all come from the declaration that
+already exists.
+
+**The payload is verb input, whichever way it is spelled.** Inline JSON is the
+same argument as the schema-derived flags that replace it, so it sits in the
+same section, and no caller has to know which spelling of an argument changes
+where it goes.
+
+**Two reasons the closing marker earns its place**, and the second is the one
+that generalizes. A verb has to be named before a projection is written, both
+because a result cannot be shaped before it is produced and because nothing can
+offer the positions of a result it has not identified. And a projection must not
+be read where a verb's fields are read, because the two vocabularies are
+independent and either may grow a name the other already has.
+
+That second reason is why the boundary is not conditional on a collision
+existing today. A rule that admits a projection into the callable's section
+while no field shares its name is a rule that holds until an author adds one,
+and then a line that worked reaches a different reader with no edit and no
+warning. The boundary is drawn whether or not anything is currently standing on
+it.
+
+**A projection is refused before the verb**, and inside the callable's section,
+and reported rather than absorbed in both places.
+
+**`--help` reaches the callable from both spellings.** Written after the verb
+it falls inside the callable's section and prints that verb's own page, which is
+what it does today. Written as `<verb> -- --help` — the spelling the
+documentation currently teaches — it would otherwise land among the read options
+and print this command's page instead, with nothing to refuse it, since `--help`
+is the one flag that is never an unknown one. That shape has no competing
+reading: a caller wanting this command's help writes it without a verb. So it is
+given the meaning it already has, as a rule about the grammar rather than a
+window that closes.
+
+**Every way to get this wrong is answered with the line that would work.** The
+vocabularies on both sides of the boundary are known — `cf`'s flags are
+declared, and the verb's fields arrive with its input schema — so a name in the
+wrong section is recognizable as belonging to the other one. A refusal names
+which section the flag belongs to **and prints the corrected command**, rather
+than reporting that a name is unknown and leaving the caller to work out where
+it should have gone:
+
+| Written | What it should say |
+| --- | --- |
+| a `cf` flag after the verb | it is a `cf` flag, and that a projection goes past `--` |
+| a verb field before the verb | it is a field of that verb, and that fields follow the verb |
+| a projection before the verb | a result has to be named before it can be shaped |
+| a second `--` | one boundary follows the callable's section, and it is already drawn |
+
+The corrected line is what makes this survivable without a warned window.
+Every one of these is a spelling that worked before, so the caller reading the
+refusal is someone who learned the old one — and a message that says only what
+is wrong asks them to rediscover the grammar, while one that prints the line
+asks them to retype it. The repository already answers this way where it
+matters: a mounted callable's result reports the whole command that reads it
+back rather than the address alone.
+
+`undeclaredFlagError` is where the first of those belongs: it already answers an
+undeclared name with a near miss and the vocabulary the position takes, and
+already carries one special case that searches a different candidate set. A name
+that is a `cf` flag is another.
+
+The rule for `cf` is one sentence: `cf` owns the flags it declares plus the
+payload spellings it already forwards, up to the first marker. A verb declaring
+a field that collides with a `cf` flag reaches it past that marker, which is
+where every schema-derived flag already lives.
+
+The three moves are independent and each stands alone, but they point the same
+way: a caller states the space once, names the rest in one word, and writes what
+follows in the order the words become knowable.
+
+### Precedent worth not re-deriving
+
+Position deciding which entity a flag applies to is well-established.
+`ffmpeg` scopes options by their position relative to `-i` — the same flag
+before and after names an input setting and an output setting. `ld` resolves
+`-l` against the objects to its left. `git` accepts `--no-pager` before a
+subcommand and not after. The pattern is ordinary; what draws complaints in
+those tools is that the rule is invisible where it is broken, which is an
+argument about the error message rather than about the grammar.
+
+Handing everything after a boundary to a wrapped command is the most
+conventional shape on this list, and it divides on how the boundary is drawn.
+Where a positional already marks it, no marker is written: `docker run` ends its
+own options at the image name, as `ssh` does at the host and `env`, `nice`,
+`timeout` and `sudo` do at the command. Where no positional marks it, a marker
+is required and its omission is an error: `kubectl exec … -- <cmd>`,
+`npm run <script> -- <flags>`, `cargo run -- <args>`. Neither family lets a
+caller choose.
+
+A `cf` call has the positional — the verb names it — and takes the first
+family's shape for that reason. What neither family has is a section *after* the
+wrapped command's, which is the one boundary a marker is spent on here. The
+nearest precedent is `curl --next`, which separates one request's flags from the
+next's: evidence for reading a line as a sequence of sections rather than as a
+nesting.
+
+A hierarchy in one token with optional parts is equally well-trodden, and
+right-anchored optionality is its usual form: a container image reference
+(`registry/namespace/image:tag@digest`) defaults the registry and namespace when
+they are omitted, as `scp`'s `[user@]host:path` defaults the user. `kubectl`'s
+`type/name` is the same idea one level shallower.
+
+Ambient scope with a flag override is close to unanimous among tools that
+address more than one tenant: `kubectl` has a current-context namespace beside
+`--namespace`, `gcloud` a configured project beside `--project`, `aws` a profile
+from environment or configuration beside `--profile`.
+
 ## How to get there
 
 Additive, in dependency order. Nothing before 6b removes or renames anything a
@@ -202,6 +522,46 @@ than taking anything away.
 Steps 1–5 are mechanical. Step 7 needs real decisions and belongs last, because
 each pair is two working commands whose merge changes behavior rather than
 spelling.
+
+**Naming the target is a second arc, not a later step.** Steps 1 through 7
+decide what the commands are called; the work below decides how a caller writes
+what a command acts on. The two are independent except at one point — 6b removes
+the spellings 6a warned about, so nothing here starts a second deprecation on
+those same commands until it has landed.
+
+8. **Give the space an ambient source** in `CF_SPACE`, with the flag overriding
+   it, serving reads and writes alike; and every command that writes names the
+   space it wrote to.
+9. **The reference takes a space by name and a piece by slug**, and may be
+   written positionally wherever `--piece` is accepted. A slug is accepted
+   positionally today only through the flag, which is the gap this closes.
+10. **The verb opens the callable's section and `--` closes it**, on `call` and
+    on `exec`. A projection is refused before the verb and inside the callable's
+    section, and each refusal names the section the flag belongs to and prints
+    the corrected line. The change takes effect at once rather than through a
+    warned window: a line carrying the old marker puts the verb's own fields
+    where the read options are read, and an unknown read option is refused
+    loudly with the spelling that works. The corrected line is what stands in
+    for the window, so it lands with the change rather than after it. `--help`
+    is the exception, and is carried from both spellings for the reason given
+    above.
+11. **`--url` decomposes** into the transport it names and the reference it
+    carries, and survives as a convenience for pasting rather than as the only
+    spelling that carries a whole target.
+
+Steps 8, 9 and 11 add. Step 10 is the one that changes what a written line
+means, and it is the one the rest of the surface reads against — a projection
+cannot be written after the verb until it lands.
+
+The sweep is bounded and known: about thirty places in this repository teach the
+old marker, one of them the verb session walkthrough, whose commands
+`check-verb-session-sync` already holds to what its demo script runs.
+
+**The trailing form is taught throughout**, in the same pass as step 10. The
+read options go after the thing they shape on every command that has them, which
+is what `get` and `wish` already show and what `call` and `exec` gain. Their
+leading position stays legal where nothing is ambiguous; the documentation stops
+using it.
 
 **Each step carries its own documentation.** `--input`, `--piece`, and
 `piece get` appear across the tutorial, `packages/cli/README.md`, and the
@@ -254,3 +614,10 @@ preserve that.
 
 **`piece link` stays.** It writes a link with reactive-wiring meaning that a
 general value write does not express.
+
+**That the position which works everywhere today stops working.** The read
+options may precede the positional on all six commands now. Afterwards a
+projection before the verb is refused, so the one spelling a caller could carry
+between commands is the one being taken away. It is replaced by a spelling that
+works on all six, which is the trade, and it is worth stating rather than
+discovering.

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -434,12 +434,15 @@ it should have gone:
 | a projection before the verb | a result has to be named before it can be shaped |
 | a second `--` | one boundary follows the callable's section, and it is already drawn |
 
-The corrected line is what makes this survivable without a warned window.
-Every one of these is a spelling that worked before, so the caller reading the
-refusal is someone who learned the old one — and a message that says only what
-is wrong asks them to rediscover the grammar, while one that prints the line
-asks them to retype it. The repository already answers this way where it
-matters: a mounted callable's result reports the whole command that reads it
+The corrected line is what makes this survivable without a warned window, and
+the refusal has to be reached before a reinterpretation is: a verb may declare a
+field named for a read option, so a line that would otherwise be read as a
+projection has to be recognized as the old spelling first. Every one of these is
+a spelling that worked before, so the caller reading the refusal is someone who
+learned the old one — and a message that says only what is wrong asks them to
+rediscover the grammar, while one that prints the line asks them to retype it.
+The repository already answers this way where it matters: a mounted callable's
+result reports the whole command that reads it
 back rather than the address alone.
 
 `undeclaredFlagError` is where the first of those belongs: it already answers an
@@ -539,12 +542,22 @@ those same commands until it has landed.
     on `exec`. A projection is refused before the verb and inside the callable's
     section, and each refusal names the section the flag belongs to and prints
     the corrected line. The change takes effect at once rather than through a
-    warned window: a line carrying the old marker puts the verb's own fields
-    where the read options are read, and an unknown read option is refused
-    loudly with the spelling that works. The corrected line is what stands in
-    for the window, so it lands with the change rather than after it. `--help`
-    is the exception, and is carried from both spellings for the reason given
-    above.
+    warned window, which rests on a line carrying the old marker being refused
+    rather than reinterpreted — and that has to be built rather than assumed.
+    Nothing reserves a field name, so a verb may declare `select`, `filter` or
+    `schema`, and a line whose only fields are those parses as a projection
+    instead: the handler runs with different input and exits zero. `--help` is
+    the same shape, being the one flag that is never unknown.
+
+    **So the old marker is refused, not reinterpreted.** A `--` that opens an
+    empty callable section, followed by words naming fields the verb declares,
+    is the old spelling and is answered with the corrected line. That is what
+    every old line carrying fields does, so the shape is recognizable wherever
+    it matters, and a caller writing the new grammar never produces it — fields
+    written before the marker leave the section non-empty. `--help` after an
+    empty section keeps reaching the callable, for the reason given above.
+    Both need the verb's declared fields in hand, so the split settles after
+    the schema is loaded rather than during argument handling.
 11. **`--url` decomposes** into the transport it names and the reference it
     carries, and survives as a convenience for pasting rather than as the only
     spelling that carries a whole target.


### PR DESCRIPTION
## Why

Shell completion fails by staying silent. Every provider failure degrades to an
empty candidate list on purpose — a completion request runs between two
keystrokes and must never paste a stack trace into the command line — so a slot
with no provider and a slot whose fabric is unreachable are the same experience
at the prompt. Probing it against a live server turned up defects that had been
sitting in that silence.

Three of them are not completion bugs. Completion is the only consumer that has
to model the CLI's grammar *completely*, so it fails wherever the grammar is not
self-consistent, and that is what it found:

- `cf call` offers flags at positions where it rejects them, and each of those
  flags' own help text says they belong elsewhere.
- The canonical `/@did:…/of:fid1:…` reference — the portable one-token address
  the documentation teaches — is not parsed at an intake seam that takes
  `--piece`.
- A projection written in the natural place fails three different ways with no
  rule connecting them, one of which is `--json`, which succeeds.

An agent hits all three, and the third is worse for an agent than for a person:
"use a single inline JSON argument" tells it to go rewrite a JSON argument that
was already correct.

So this lands two plans rather than one. The completion plan cannot be built on
a grammar that has not settled where a projection goes.

## What Changed

**`docs/plans/cli-completion-coverage.md`** (new) — 19 items, ranked on two
axes. Correctness gates value: a slot offering a candidate the command rejects
is worse than one offering nothing. Below that, rank by whose vocabulary it is —
a flag name is one `--help` away, while a piece id, a verb name, a verb's flags
and the field paths of a result belong to a deployed pattern and cost a round
trip to learn. It also states what the list covers exhaustively (a slot with no
provider, a provider with no slot — both mechanical) and what it cannot (a
provider returning the *wrong* set, and defects in the installed shell
functions).

**`docs/plans/cli-surface-shape.md`** — a new `## Naming the target` section and
four steps. A target's words become knowable in one order — space, piece, verb,
verb fields, result shape — and every element of the layout this document
already prescribes sits in that order except the read options, which
`stopEarly()` forces to the front. The section settles: an ambient space in
`CF_SPACE` serving reads and writes alike, with writing commands naming the
space they wrote to; a reference that takes a space by name and a piece by slug,
with the verb staying the word after it; the verb opening the callable's section
and `--` closing it, which is what `cf exec` already does and `cf call` does
not; and `--url` decomposing into the transport it names and the reference it
carries.

Step 10 is the one that changes what a written line means. It switches at once
rather than through a warned window, because a stray marker puts the verb's own
fields where the read options are read and an unknown read option is refused
loudly — with the corrected line, which is what stands in for the window.
`--help` is the exception, carried from both spellings: it is the one flag that
is never unknown, so it would otherwise print the wrong page and exit zero.

## Test plan

Documentation only; no code changes.

- `deno task check-docs` — 559 blocks pass
- `deno task check-docs-history-index`, `check-conflict-markers`,
  `check-skill-facts` — pass
- `deno task docs-links --orphan` — no orphans; both plans are indexed in
  `docs/plans/README.md`

Every claim about current behavior was verified against a running server or a
hermetic parser probe rather than read off the source: the live providers were
driven through `cf completion complete` against a deployed fixture, the
command tree was walked to enumerate provider coverage, and Cliffy's handling of
repeated separators was probed directly — which is what corrected an earlier
claim that a distinct marker needs no preceding `--`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

