### PR TITLE
fix(ts-transformers): preserve authored ranges on replacement nodes

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1715,6 +1715,16 @@ for transform-time source annotation (A′, CT-1870), and the same fallback
 family §16.2's coverage spans use. Rationale, per-site table, and the probe
 rig: `packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
 
+The same source-map-range-only rule applies to semantic replacement boundaries
+outside the builder-artifact path. Pattern-body reactive-root replacements,
+lowered UI-helper elements, rebuilt JSX expression containers, rewritten
+handler attributes and initializers, nested reactive-array receiver keys, and
+module-scope `__cf_data` wrappers all carry the range of the authored node they
+replace or wrap. They deliberately do not acquire that node's text range or
+original-node identity. `test/replacement-source-map-range.test.ts` runs
+fixtures through the owning pipeline stage and content-binds every recovered
+range; it also directly pins the non-input-bound reactive-wrapper helper branch.
+
 ### 11.6 Builder source-site sidecar
 
 The hoisting stage consumes that lineage to produce `BuilderSourceSitesV1`, a

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1717,13 +1717,30 @@ rig: `packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
 
 The same source-map-range-only rule applies to semantic replacement boundaries
 outside the builder-artifact path. Pattern-body reactive-root replacements,
-lowered UI-helper elements, rebuilt JSX expression containers, rewritten
-handler attributes and initializers, nested reactive-array receiver keys, and
+lowered UI-helper elements together with the data attributes they derive from
+authored helper props, rebuilt JSX expression containers, rewritten handler
+attributes and initializers, nested reactive-array receiver keys, and
 module-scope `__cf_data` wrappers all carry the range of the authored node they
-replace or wrap. They deliberately do not acquire that node's text range or
-original-node identity. `test/replacement-source-map-range.test.ts` runs
-fixtures through the owning pipeline stage and content-binds every recovered
-range; it also directly pins the non-input-bound reactive-wrapper helper branch.
+replace or wrap. A derived data attribute anchors on the helper prop it
+replaces, not on the element carrying it. They deliberately do not acquire that
+node's text range or original-node identity.
+`test/replacement-source-map-range.test.ts` runs fixtures through the owning
+pipeline stage and content-binds every recovered range; it also directly pins
+the non-input-bound reactive-wrapper helper branch.
+
+That file closes with a corpus-wide invariant: across every fixture, no
+synthesized `JsxAttribute`, `JsxElement`, `JsxExpression`, or
+`JsxSelfClosingElement` may fail to recover an authored position. Those four
+kinds always stand for authored syntax, so a synthesized one is a replacement
+that owes a range — which makes the invariant the drift gate for stages added
+later. Expression kinds are excluded because injected schemas and hoisting
+scaffolds synthesize them with no authored counterpart.
+
+Carried ranges reach the emitted source map for replacements that survive to
+emit as themselves. The JSX-shaped replacements above are rebuilt again by
+TypeScript's own JSX transform, which runs after this pipeline and does not
+propagate emit-node data, so their ranges serve in-pipeline recovery rather
+than the emitted map.
 
 ### 11.6 Builder source-site sidecar
 

--- a/docs/specs/ts-transformer/ts_transformers_type_driven_behavior_inventory.md
+++ b/docs/specs/ts-transformer/ts_transformers_type_driven_behavior_inventory.md
@@ -96,8 +96,8 @@ These are not new policy decisions by themselves, but they preserve type informa
   Registers synthetic lift-applied parameters with unwrapped types for the same reason.
 
 - `src/transformers/pattern-body-reactive-root-lowering.ts`
-  - `registerReplacementType(...)`
-  Copies original types onto replacement nodes so downstream behavior checks still see the intended type.
+  - `registerReplacement(...)`
+  Copies original types onto replacement nodes, and the authored source-map range, so downstream behavior checks still see the intended type.
 
 - `src/transformers/expression-rewrite/rewrite-helpers.ts`
   - `createReactiveWrapperForExpression(...)`

--- a/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -340,14 +340,11 @@ inert.** The mechanisms, each observed and root-caused during implementation
 
 ## 7. Narrow vs broad — decision and pricing
 
-**Decision: narrow-first (the §5 set), broad as a separately-ticketed sweep.**
-Rationale: the narrow set is complete against direct probe evidence, every site
-has its anchor in hand, and it fully unblocks A′. Broad (every replacement node
-pipeline-wide carries lineage) dissolves the bug-class and is worth doing, but
-each site needs individual anchor-correctness judgment (see hazards, §6) — a
-wrong anchor produces wrong sourcemap spans, worse than absent ones. Contingency
-honored from the seed: fold broad in now ONLY if the sweep prices it
-nearly-free.
+**Decision: narrow-first (the §5 set), then a source-map-range-only broad
+sweep.** The narrow set is complete against direct probe evidence and fully
+unblocks A′. The first broad slice covers the replacement sites whose authored
+anchor is already in scope and unambiguous. More opaque sites remain separate: a
+wrong sourcemap anchor is worse than an absent one.
 
 **Sweep results (read-only Opus survey, 2026-07-07, on 39afdb62b; three claims
 spot-verified exactly — treat the rest as a work list to re-verify at
@@ -359,31 +356,26 @@ implementation):**
   BuilderCallHoisting and rebuilds essentially every builder call bare — it
   alone re-strips anything stages 8–12 preserve, which is why the original
   three-site diagnosis could never have been sufficient.
-- **Remaining for broad** (~15–18 sites, none A′-gating, none structurally hard
-  — an anchor is in scope at every one):
-  - `pattern-body-reactive-root-lowering.ts` key()-lowering replacements
-    (`:360`, `:853/:858`, `:895`) + destructured-binding decls
-    (`:659/:666/:682`). Natural chokepoint: `registerReplacementType` (`:124`)
-    already receives the original node and could attach lineage for all of them.
-  - `ui-helper-lowering.ts:85/:96` (lowered `<ct-…>` JSX elements).
-  - JSX container rebuilds: `jsx-expression-site-router.ts:66/:86`,
-    `expression-site-lowering.ts:572/:903`, `handler-strategy.ts:85/:90` (all
-    have `update*` drop-ins).
-  - `array-method-transform.ts:93` (receiver `key()` rewrite),
-    `module-scope-cf-data.ts:138` (wrapper, borderline additive).
-  - Caveat to carry: `ifelse.ts` when/unless helpers anchor on `condition` (left
-    operand), not the whole expression — fine for emit, worth a look when broad
-    lands.
+- **Straightforward broad slice:** `registerReplacementType` carries ranges for
+  its pattern-body replacement family; UI-helper outer elements, JSX expression
+  containers, handler attributes and initializers, nested array receiver `key()`
+  calls, and module-scope `__cf_data` wrappers carry their authored container or
+  expression range. These sites use `preserveSourceMapRange` exclusively.
+- **Remaining judgment work:** destructured-binding declarations in
+  `pattern-body-reactive-root-lowering.ts` do not retain the original binding
+  node in their intermediate representation, so they need an explicit anchor
+  design. The diagnostics replacement audit and `CFHelpers` API cleanup remain
+  independent follow-ups. The `ifelse.ts` when/unless helpers anchor on the
+  condition (left operand), not the whole logical expression; that existing
+  choice remains intentionally unchanged pending a focused sourcemap review.
 - **Excluded correctly** (sweep audit list retained in the session record):
   expression-rewrite emitters (delegate to known sites), reactive-variable-for
   (already fully preserved), type-position construction, additive schema/
   coverage/hardening/shadowing machinery, analysis-only stages.
 
-**Final call: narrow-first stands, with "narrow" = builder-path-complete (§5).**
-Broad is real but not nearly-free: it roughly doubles the diff into exactly the
-sites where anchor-judgment is subtlest (containers, key() lowering), and none
-of it gates A′. It gets its own ticket with the sweep table as the work list,
-sequenced after A′'s injection design rather than before.
+**Final call:** builder-path lineage stays complete, and the straightforward
+broad slice follows the same source-map-range-only safety rule. Opaque anchors
+remain out of scope until their source identity is represented explicitly.
 
 **CT-1869 implementers, carry §6a:** the implementation proved the per-site
 judgment is not just "is the anchor's span correct" but **"does textRange reach

--- a/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -356,8 +356,8 @@ implementation):**
   BuilderCallHoisting and rebuilds essentially every builder call bare — it
   alone re-strips anything stages 8–12 preserve, which is why the original
   three-site diagnosis could never have been sufficient.
-- **Straightforward broad slice:** `registerReplacementType` carries ranges for
-  its pattern-body replacement family; UI-helper outer elements, JSX expression
+- **Straightforward broad slice:** `registerReplacement` carries ranges for its
+  pattern-body replacement family; UI-helper outer elements, JSX expression
   containers, handler attributes and initializers, nested array receiver `key()`
   calls, and module-scope `__cf_data` wrappers carry their authored container or
   expression range. These sites use `preserveSourceMapRange` exclusively.

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -5,6 +5,7 @@ import {
   getLoweredArrayMethodName,
   getTypeAtLocationWithFallback,
   preserveLineage,
+  preserveSourceMapRange,
   registerSyntheticCallType,
   typeToTypeNodeWithRegistry,
 } from "../../ast/mod.ts";
@@ -91,13 +92,16 @@ function lowerMapReceiverMemberAccess(
     return expression;
   }
 
-  return context.factory.createCallExpression(
-    context.factory.createPropertyAccessExpression(
-      context.factory.createIdentifier(current.text),
-      context.factory.createIdentifier("key"),
+  return preserveSourceMapRange(
+    context.factory.createCallExpression(
+      context.factory.createPropertyAccessExpression(
+        context.factory.createIdentifier(current.text),
+        context.factory.createIdentifier("key"),
+      ),
+      undefined,
+      segments,
     ),
-    undefined,
-    segments,
+    expression,
   );
 }
 

--- a/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
@@ -1,6 +1,9 @@
 import ts from "typescript";
 import type { TransformationContext } from "../../core/mod.ts";
-import { isEventHandlerJsxAttribute } from "../../ast/mod.ts";
+import {
+  isEventHandlerJsxAttribute,
+  preserveSourceMapRange,
+} from "../../ast/mod.ts";
 import { CaptureCollector } from "../capture-collector.ts";
 import { unwrapArrowFunction } from "../utils/ast-helpers.ts";
 import {
@@ -71,10 +74,16 @@ export function transformHandlerJsxAttribute(
     },
   );
 
-  const newInitializer = factory.createJsxExpression(
-    initializer.dotDotDotToken,
-    finalCall,
+  const newInitializer = preserveSourceMapRange(
+    factory.createJsxExpression(
+      initializer.dotDotDotToken,
+      finalCall,
+    ),
+    initializer,
   );
 
-  return factory.createJsxAttribute(attribute.name, newInitializer);
+  return preserveSourceMapRange(
+    factory.createJsxAttribute(attribute.name, newInitializer),
+    attribute,
+  );
 }

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -4,6 +4,7 @@ import {
   isCollectionType,
   isFunctionLikeExpression,
   isSyntheticNode,
+  preserveSourceMapRange,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
@@ -553,9 +554,12 @@ export function rewritePatternOwnedExpressionSites<T extends ts.Node>(
         preferInputBoundWrappers: true,
       });
       if (rewritten) {
-        return context.factory.createJsxExpression(
-          node.dotDotDotToken,
-          rewritten,
+        return preserveSourceMapRange(
+          context.factory.createJsxExpression(
+            node.dotDotDotToken,
+            rewritten,
+          ),
+          node,
         );
       }
 
@@ -875,9 +879,12 @@ export function rewriteArrayMethodCallbackExpressionSites(
           preferInputBoundWrappers: true,
         });
         if (rewritten) {
-          return context.factory.createJsxExpression(
-            node.dotDotDotToken,
-            rewritten,
+          return preserveSourceMapRange(
+            context.factory.createJsxExpression(
+              node.dotDotDotToken,
+              rewritten,
+            ),
+            node,
           );
         }
       }

--- a/packages/ts-transformers/src/transformers/jsx-expression-site-router.ts
+++ b/packages/ts-transformers/src/transformers/jsx-expression-site-router.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
-import { visitEachChildWithJsx } from "../ast/mod.ts";
+import { preserveSourceMapRange, visitEachChildWithJsx } from "../ast/mod.ts";
 import { classifyExpressionSiteHandling } from "./expression-site-policy.ts";
 import {
   rewriteExpressionSite,
@@ -63,9 +63,12 @@ function transform(context: TransformationContext): ts.SourceFile {
           visit,
         });
         if (rewritten) {
-          return context.factory.createJsxExpression(
-            node.dotDotDotToken,
-            rewritten,
+          return preserveSourceMapRange(
+            context.factory.createJsxExpression(
+              node.dotDotDotToken,
+              rewritten,
+            ),
+            node,
           );
         }
 
@@ -83,9 +86,12 @@ function transform(context: TransformationContext): ts.SourceFile {
           visit,
         });
         if (rewritten) {
-          return context.factory.createJsxExpression(
-            node.dotDotDotToken,
-            rewritten,
+          return preserveSourceMapRange(
+            context.factory.createJsxExpression(
+              node.dotDotDotToken,
+              rewritten,
+            ),
+            node,
           );
         }
 

--- a/packages/ts-transformers/src/transformers/module-scope-cf-data.ts
+++ b/packages/ts-transformers/src/transformers/module-scope-cf-data.ts
@@ -3,6 +3,7 @@ import {
   isTrustedBuilder,
   isTrustedDataHelper,
 } from "@commonfabric/utils/sandbox-contract";
+import { preserveSourceMapRange } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 
@@ -122,10 +123,13 @@ function wrapWithCfData(
 ): ts.CallExpression {
   // The HelpersOnlyTransformer filter guarantees the helpers import is
   // present; getHelperExpr throws if that invariant is ever violated.
-  return context.factory.createCallExpression(
-    context.cfHelpers.getHelperExpr("__cf_data"),
-    undefined,
-    [expression],
+  return preserveSourceMapRange(
+    context.factory.createCallExpression(
+      context.cfHelpers.getHelperExpr("__cf_data"),
+      undefined,
+      [expression],
+    ),
+    expression,
   );
 }
 

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -124,7 +124,7 @@ function isSelfPathSegment(
 }
 
 /** Carries the source-map range and inferred type to a semantic replacement. */
-function registerReplacementType(
+function registerReplacement(
   replacement: ts.Node,
   original: ts.Node,
   context: TransformationContext,
@@ -364,7 +364,7 @@ function rewriteTrackedOpaquePatternBody(
       info.path,
       context.factory,
     );
-    registerReplacementType(expression, dataFlow.expression, context);
+    registerReplacement(expression, dataFlow.expression, context);
     return { ...dataFlow, expression };
   };
 
@@ -730,7 +730,7 @@ function rewriteTrackedOpaquePatternBody(
     if (ts.isCallExpression(node)) {
       const wrappedCellGet = maybeWrapCellGetJsxCall(node);
       if (wrappedCellGet) {
-        registerReplacementType(wrappedCellGet, node, context);
+        registerReplacement(wrappedCellGet, node, context);
         return wrappedCellGet;
       }
 
@@ -755,7 +755,7 @@ function rewriteTrackedOpaquePatternBody(
       if (isDynamicElementAccess(node)) {
         const wrappedDynamicAccess = maybeWrapDynamicJsxAccess(node);
         if (wrappedDynamicAccess) {
-          registerReplacementType(wrappedDynamicAccess, node, context);
+          registerReplacement(wrappedDynamicAccess, node, context);
           return wrappedDynamicAccess;
         }
       }
@@ -809,7 +809,7 @@ function rewriteTrackedOpaquePatternBody(
       if (!hasTrackedStaticAccess && isDynamicElementAccess(visited)) {
         const wrappedDynamicAccess = maybeWrapDynamicJsxAccess(visited);
         if (wrappedDynamicAccess) {
-          registerReplacementType(wrappedDynamicAccess, visited, context);
+          registerReplacement(wrappedDynamicAccess, visited, context);
           return wrappedDynamicAccess;
         }
       }
@@ -821,7 +821,7 @@ function rewriteTrackedOpaquePatternBody(
       if (info.dynamic) {
         const wrappedDynamicAccess = maybeWrapDynamicJsxAccess(visited);
         if (wrappedDynamicAccess) {
-          registerReplacementType(wrappedDynamicAccess, visited, context);
+          registerReplacement(wrappedDynamicAccess, visited, context);
           return wrappedDynamicAccess;
         }
 
@@ -861,7 +861,7 @@ function rewriteTrackedOpaquePatternBody(
               rewrittenReceiver,
               visited.name.text,
             );
-          registerReplacementType(rewrittenMethod, visited, context);
+          registerReplacement(rewrittenMethod, visited, context);
           return rewrittenMethod;
         }
 
@@ -897,7 +897,7 @@ function rewriteTrackedOpaquePatternBody(
           info.path,
           context.factory,
         );
-        registerReplacementType(rewritten, visited, context);
+        registerReplacement(rewritten, visited, context);
         return rewritten;
       }
     }
@@ -1154,7 +1154,7 @@ function rewriteLiftAppliedCallbackComputedKeyAccesses(
       context.factory.createIdentifier(visited.expression.text),
       context.cfHelpers.getHelperExpr(keyName),
     );
-    registerReplacementType(rewritten, visited, context);
+    registerReplacement(rewritten, visited, context);
     return rewritten;
   };
 

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -7,6 +7,7 @@ import {
   isSyntheticNode,
   isWildcardTraversalCall,
   type NormalizedDataFlow,
+  preserveSourceMapRange,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import { TransformationContext } from "../core/mod.ts";
@@ -122,11 +123,13 @@ function isSelfPathSegment(
     isCommonFabricKeyExpression(segment, context, "SELF");
 }
 
+/** Carries the source-map range and inferred type to a semantic replacement. */
 function registerReplacementType(
   replacement: ts.Node,
   original: ts.Node,
   context: TransformationContext,
 ): void {
+  preserveSourceMapRange(replacement, original);
   const typeRegistry = context.state.typeRegistry;
   const originalType = getTypeAtLocationWithFallback(
     original,

--- a/packages/ts-transformers/src/transformers/ui-helper-lowering.ts
+++ b/packages/ts-transformers/src/transformers/ui-helper-lowering.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import type { SchemaHint, TransformationContext } from "../core/mod.ts";
-import { visitEachChildWithJsx } from "../ast/mod.ts";
+import { preserveSourceMapRange, visitEachChildWithJsx } from "../ast/mod.ts";
 
 type UiHelperName = "UiAction" | "UiPromptSlot" | "UiDisclosure";
 
@@ -82,10 +82,13 @@ export function rewriteUiHelperElement(
 
   if (ts.isJsxSelfClosingElement(visited) && !hasJsxChildren(node)) {
     return {
-      node: context.factory.createJsxSelfClosingElement(
-        context.factory.createIdentifier(tagName),
-        visited.typeArguments,
-        nextAttributes,
+      node: preserveSourceMapRange(
+        context.factory.createJsxSelfClosingElement(
+          context.factory.createIdentifier(tagName),
+          visited.typeArguments,
+          nextAttributes,
+        ),
+        visited,
       ),
       hint,
     };
@@ -93,16 +96,19 @@ export function rewriteUiHelperElement(
 
   if (ts.isJsxElement(visited)) {
     return {
-      node: context.factory.createJsxElement(
-        context.factory.createJsxOpeningElement(
-          context.factory.createIdentifier(tagName),
-          visited.openingElement.typeArguments,
-          nextAttributes,
+      node: preserveSourceMapRange(
+        context.factory.createJsxElement(
+          context.factory.createJsxOpeningElement(
+            context.factory.createIdentifier(tagName),
+            visited.openingElement.typeArguments,
+            nextAttributes,
+          ),
+          visited.children,
+          context.factory.createJsxClosingElement(
+            context.factory.createIdentifier(tagName),
+          ),
         ),
-        visited.children,
-        context.factory.createJsxClosingElement(
-          context.factory.createIdentifier(tagName),
-        ),
+        visited,
       ),
       hint,
     };

--- a/packages/ts-transformers/src/transformers/ui-helper-lowering.ts
+++ b/packages/ts-transformers/src/transformers/ui-helper-lowering.ts
@@ -64,9 +64,15 @@ export function rewriteUiHelperElement(
     if (!attr || attr.initializer === undefined) {
       return [];
     }
-    return [context.factory.createJsxAttribute(
-      context.factory.createIdentifier(entry.attr),
-      createJsxAttributeInitializer(attr.initializer, context.factory),
+    // The data attribute stands at the authored helper prop's site, so it
+    // carries that prop's range; the identifier is a new name and stays
+    // synthetic.
+    return [preserveSourceMapRange(
+      context.factory.createJsxAttribute(
+        context.factory.createIdentifier(entry.attr),
+        createJsxAttributeInitializer(attr.initializer, context.factory),
+      ),
+      attr,
     )];
   });
 
@@ -174,17 +180,28 @@ function getStringLiteralAttributeValue(
   return undefined;
 }
 
+/**
+ * Rebuilds a helper prop's value for the data attribute that replaces it. Each
+ * rebuilt node stands at the authored initializer's site, so it carries that
+ * range — source-map range only, never text range or original-node identity.
+ */
 function createJsxAttributeInitializer(
   initializer: ts.JsxAttributeValue,
   factory: ts.NodeFactory,
 ): ts.JsxAttributeValue {
   if (ts.isStringLiteral(initializer)) {
-    return factory.createStringLiteral(initializer.text);
+    return preserveSourceMapRange(
+      factory.createStringLiteral(initializer.text),
+      initializer,
+    );
   }
   if (ts.isJsxExpression(initializer)) {
-    return factory.createJsxExpression(
-      initializer.dotDotDotToken,
-      initializer.expression,
+    return preserveSourceMapRange(
+      factory.createJsxExpression(
+        initializer.dotDotDotToken,
+        initializer.expression,
+      ),
+      initializer,
     );
   }
   return initializer;

--- a/packages/ts-transformers/test/replacement-source-map-range.test.ts
+++ b/packages/ts-transformers/test/replacement-source-map-range.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Verifies authored source-map ranges on synthesized replacements outside the
+ * builder-artifact path.
+ */
+
+import { assert } from "@std/assert";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import ts from "typescript";
+
+import { recoverAuthoredPosition } from "../src/ast/mod.ts";
+import {
+  CFC_TRANSFORMER_STAGE_NAMES,
+  CommonFabricTransformerPipeline,
+} from "../src/cf-pipeline.ts";
+import { TransformationContext } from "../src/core/mod.ts";
+import { createReactiveWrapperForExpression } from "../src/transformers/expression-rewrite/rewrite-helpers.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import { batchTypeCheckFixtures } from "./utils.ts";
+
+const ROUTER_FIXTURE = `import {
+  Default,
+  pattern,
+  UI,
+  UiAction,
+  UiPromptSlot,
+} from "commonfabric";
+
+interface Input {
+  visible: boolean | Default<false>;
+  count: number | Default<0>;
+}
+
+export default pattern<Input>((state) => ({
+  [UI]: (
+    <div>
+      <UiAction action="CT1869_UI">run</UiAction>
+      <UiPromptSlot surface="CT1869_SURFACE" role="composer" />
+      <span>
+        {state.visible
+          ? (() => {
+            const message = state.count + " CT1869_PRE";
+            return <b>{message}</b>;
+          })()
+          : <i>hidden</i>}
+      </span>
+    </div>
+  ),
+}));
+`;
+
+const OWNED_ROUTER_FIXTURE = `import {
+  ifElse,
+  pattern,
+  UI,
+} from "commonfabric";
+
+interface Input {
+  visible: boolean;
+  count: number;
+}
+
+export default pattern<Input>((state) => ({
+  [UI]: <span>{ifElse(state.visible, state.count + 1869, 0)}</span>,
+}));
+`;
+
+const CLOSURE_FIXTURE = `import {
+  Default,
+  pattern,
+  UI,
+} from "commonfabric";
+
+interface Input {
+  count: number | Default<0>;
+  groups: {
+    rows: Array<{ title: string }>;
+  };
+}
+
+export default pattern<Input>((state) => ({
+  [UI]: (
+    <div>
+      <button onClick={() => state.count + 1869}>run</button>
+      <ul>
+        {state.groups.rows.map((row) => (
+          <li>{row.title === "x" ? "CT1869_MAP" : row.title}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+`;
+
+const POST_CLOSURE_FIXTURE = `import {
+  pattern,
+  UI,
+} from "commonfabric";
+
+interface Input {
+  items: Array<{ ct1869Active: boolean }>;
+}
+
+export default pattern<Input>((state) => ({
+  [UI]: (
+    <span>
+      {state.items.filter((item) => item.ct1869Active).length > 0}
+    </span>
+  ),
+}));
+`;
+
+const ZERO_INPUT_FIXTURE = `import {
+  Default,
+  pattern,
+} from "commonfabric";
+
+interface Input {
+  items: string[] | Default<[]>;
+  index: number | Default<0>;
+}
+
+export default pattern<Input>((state) => {
+  const picked = state.items[state.index] + "CT1869_ZERO";
+  return { picked };
+});
+`;
+
+const PATTERN_BODY_FIXTURE = `import {
+  pattern,
+} from "commonfabric";
+
+interface Input {
+  profile: { label: string };
+}
+
+export default pattern<Input>((state) => {
+  const label = state.profile.label;
+  return { label };
+});
+`;
+
+const MODULE_DATA_FIXTURE = `import {
+  pattern,
+} from "commonfabric";
+
+const DATA = { marker: "CT1869_DATA" };
+
+export default pattern(() => ({ DATA }));
+`;
+
+interface StageTransformResult {
+  readonly original: ts.SourceFile;
+  readonly transformed: ts.SourceFile;
+}
+
+/** Runs a fixture through the named stage while preserving emit-node data. */
+async function transformThroughStage(
+  source: string,
+  fileName: string,
+  stageName: string,
+): Promise<StageTransformResult> {
+  const { program } = await batchTypeCheckFixtures(
+    { [fileName]: source },
+    { types: COMMONFABRIC_TYPES },
+  );
+  const original = program.getSourceFile(fileName);
+  assert(original, `fixture source file present: ${fileName}`);
+
+  const stageIndex = CFC_TRANSFORMER_STAGE_NAMES.indexOf(stageName);
+  assert(stageIndex >= 0, `transformer stage present: ${stageName}`);
+
+  const pipeline = new CommonFabricTransformerPipeline();
+  const factories = pipeline.toFactories(program).slice(0, stageIndex + 1);
+  const result = ts.transform(original, factories);
+  const transformed = result.transformed[0];
+  assert(transformed, `stage returned a transformed source file: ${stageName}`);
+
+  // Disposing the result can clear emit-node data that stores sourceMapRange.
+  return { original, transformed };
+}
+
+/** Collects every node in a tree that satisfies the supplied type guard. */
+function collectNodes<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T,
+): T[] {
+  const matches: T[] = [];
+  const visit = (node: ts.Node): void => {
+    if (predicate(node)) matches.push(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return matches;
+}
+
+/** Returns whether a subtree contains a node satisfying the predicate. */
+function subtreeContains(
+  root: ts.Node,
+  predicate: (node: ts.Node) => boolean,
+): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (predicate(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return found;
+}
+
+/** Selects the only node matching a structural predicate. */
+function findOnly<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T,
+  label: string,
+): T {
+  const matches = collectNodes(root, predicate);
+  expect(matches, label).toHaveLength(1);
+  return matches[0]!;
+}
+
+/** Asserts that a replacement resolves to the expected authored source. */
+function expectAuthoredText(
+  node: ts.Node,
+  original: ts.SourceFile,
+  expected: string,
+): void {
+  assert(node.pos < 0, `expected a synthesized replacement for ${expected}`);
+  const position = recoverAuthoredPosition(node);
+  assert(position, `expected authored position for ${expected}`);
+  expect(original.text.slice(position.pos, position.end)).toContain(expected);
+}
+
+function hasString(root: ts.Node, text: string): boolean {
+  return subtreeContains(
+    root,
+    (node) => ts.isStringLiteral(node) && node.text === text,
+  );
+}
+
+function hasIdentifier(root: ts.Node, text: string): boolean {
+  return subtreeContains(
+    root,
+    (node) => ts.isIdentifier(node) && node.text === text,
+  );
+}
+
+describe("replacement source-map ranges", () => {
+  it("preserves authored positions on JSX-router replacements", async () => {
+    const { original, transformed } = await transformThroughStage(
+      ROUTER_FIXTURE,
+      "/ct1869-router.tsx",
+      "JsxExpressionSiteRouterTransformer",
+    );
+
+    const uiHelper = findOnly(
+      transformed,
+      (node): node is ts.JsxElement =>
+        ts.isJsxElement(node) &&
+        ts.isIdentifier(node.openingElement.tagName) &&
+        node.openingElement.tagName.text === "ct-button",
+      "rewritten UiAction",
+    );
+    expectAuthoredText(uiHelper, original, "<UiAction");
+
+    const selfClosingUiHelper = findOnly(
+      transformed,
+      (node): node is ts.JsxSelfClosingElement =>
+        ts.isJsxSelfClosingElement(node) &&
+        ts.isIdentifier(node.tagName) && node.tagName.text === "ct-textarea",
+      "rewritten self-closing UiPromptSlot",
+    );
+    expectAuthoredText(selfClosingUiHelper, original, "<UiPromptSlot");
+
+    const sharedPre = findOnly(
+      transformed,
+      (node): node is ts.JsxExpression =>
+        ts.isJsxExpression(node) && hasString(node, " CT1869_PRE"),
+      "shared pre-closure JSX expression",
+    );
+    expectAuthoredText(
+      sharedPre,
+      original,
+      "state.visible",
+    );
+
+    const ownedResult = await transformThroughStage(
+      OWNED_ROUTER_FIXTURE,
+      "/ct1869-owned-router.tsx",
+      "JsxExpressionSiteRouterTransformer",
+    );
+    const owned = findOnly(
+      ownedResult.transformed,
+      (node): node is ts.JsxExpression =>
+        ts.isJsxExpression(node) &&
+        subtreeContains(
+          node,
+          (child) => ts.isNumericLiteral(child) && child.text === "1869",
+        ),
+      "owned pre-closure JSX expression",
+    );
+    expectAuthoredText(
+      owned,
+      ownedResult.original,
+      "ifElse(state.visible, state.count + 1869, 0)",
+    );
+  });
+
+  it("preserves authored positions on closure replacements", async () => {
+    const { original, transformed } = await transformThroughStage(
+      CLOSURE_FIXTURE,
+      "/ct1869-closure.tsx",
+      "ClosureTransformer",
+    );
+
+    const handler = findOnly(
+      transformed,
+      (node): node is ts.JsxAttribute =>
+        ts.isJsxAttribute(node) &&
+        ts.isIdentifier(node.name) && node.name.text === "onClick" &&
+        subtreeContains(
+          node,
+          (child) => ts.isNumericLiteral(child) && child.text === "1869",
+        ),
+      "rewritten handler attribute",
+    );
+    expectAuthoredText(
+      handler,
+      original,
+      "onClick={() => state.count + 1869}",
+    );
+    assert(handler.initializer && ts.isJsxExpression(handler.initializer));
+    expectAuthoredText(
+      handler.initializer,
+      original,
+      "{() => state.count + 1869}",
+    );
+
+    const receiverKey = findOnly(
+      transformed,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "key" &&
+        hasString(node, "groups") && hasString(node, "rows"),
+      "lowered array-method receiver",
+    );
+    expectAuthoredText(receiverKey, original, "state.groups.rows");
+
+    const callbackExpression = findOnly(
+      transformed,
+      (node): node is ts.JsxExpression =>
+        ts.isJsxExpression(node) && hasString(node, "CT1869_MAP") &&
+        !!node.expression &&
+        !subtreeContains(node.expression, ts.isJsxExpression),
+      "rewritten array-callback JSX expression",
+    );
+    expectAuthoredText(
+      callbackExpression,
+      original,
+      '{row.title === "x" ? "CT1869_MAP" : row.title}',
+    );
+  });
+
+  it("preserves authored positions on post-closure JSX containers", async () => {
+    const { original, transformed } = await transformThroughStage(
+      POST_CLOSURE_FIXTURE,
+      "/ct1869-post-closure.tsx",
+      "PatternOwnedExpressionSiteLoweringTransformer",
+    );
+
+    const replacement = findOnly(
+      transformed,
+      (node): node is ts.JsxExpression =>
+        ts.isJsxExpression(node) && hasIdentifier(node, "ct1869Active") &&
+        subtreeContains(
+          node,
+          (child) =>
+            ts.isBinaryExpression(child) &&
+            child.operatorToken.kind === ts.SyntaxKind.GreaterThanToken,
+        ),
+      "post-closure JSX expression",
+    );
+    expectAuthoredText(
+      replacement,
+      original,
+      "state.items.filter((item) => item.ct1869Active).length > 0",
+    );
+  });
+
+  it("preserves the authored branch on zero-input wrappers", async () => {
+    const fileName = "/ct1869-zero-input.tsx";
+    const { program } = await batchTypeCheckFixtures(
+      { [fileName]: ZERO_INPUT_FIXTURE },
+      { types: COMMONFABRIC_TYPES },
+    );
+    const original = program.getSourceFile(fileName);
+    assert(original, "zero-input fixture source file present");
+
+    let rewritten: ts.Expression | undefined;
+    const result = ts.transform(original, [
+      (tsContext) => (sourceFile) => {
+        const context = new TransformationContext({
+          program,
+          sourceFile,
+          tsContext,
+        });
+        const expression = findOnly(
+          sourceFile,
+          (node): node is ts.BinaryExpression =>
+            ts.isBinaryExpression(node) && hasString(node, "CT1869_ZERO"),
+          "dynamic pattern-body initializer",
+        );
+        const analysis = context.getDataFlowAnalyzer()(expression);
+        rewritten = createReactiveWrapperForExpression(
+          expression,
+          context.getRelevantDataFlowsFromAnalysis(analysis),
+          context,
+        );
+        return sourceFile;
+      },
+    ]);
+    assert(result.transformed[0], "zero-input probe transform completed");
+    assert(rewritten, "zero-input reactive wrapper created");
+
+    const wrapper = findOnly(
+      rewritten,
+      (node): node is ts.ArrowFunction =>
+        ts.isArrowFunction(node) && node.parameters.length === 0 &&
+        hasString(node, "CT1869_ZERO"),
+      "zero-input reactive wrapper",
+    );
+    expectAuthoredText(
+      wrapper,
+      original,
+      'state.items[state.index] + "CT1869_ZERO"',
+    );
+  });
+
+  it("preserves authored positions on pattern-body replacements", async () => {
+    const { original, transformed } = await transformThroughStage(
+      PATTERN_BODY_FIXTURE,
+      "/ct1869-pattern-body.tsx",
+      "PatternCallbackLoweringTransformer",
+    );
+
+    const replacement = findOnly(
+      transformed,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "key" &&
+        hasString(node, "profile") && hasString(node, "label"),
+      "pattern-body property replacement",
+    );
+    expectAuthoredText(replacement, original, "state.profile.label");
+  });
+
+  it("preserves authored positions on module-scope data wrappers", async () => {
+    const { original, transformed } = await transformThroughStage(
+      MODULE_DATA_FIXTURE,
+      "/ct1869-module-data.tsx",
+      "ModuleScopeCfDataTransformer",
+    );
+
+    const replacement = findOnly(
+      transformed,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "__cf_data" &&
+        hasString(node, "CT1869_DATA"),
+      "module-scope data wrapper",
+    );
+    expectAuthoredText(
+      replacement,
+      original,
+      '{ marker: "CT1869_DATA" }',
+    );
+  });
+});

--- a/packages/ts-transformers/test/replacement-source-map-range.test.ts
+++ b/packages/ts-transformers/test/replacement-source-map-range.test.ts
@@ -250,6 +250,64 @@ function hasIdentifier(root: ts.Node, text: string): boolean {
   );
 }
 
+/**
+ * JSX node kinds that always stand for authored syntax. A synthesized one is a
+ * replacement for something the author wrote, so it must be able to name where
+ * that was; a stage that rebuilds one without carrying its range is the whole
+ * bug class this file guards. Expression kinds are deliberately excluded —
+ * injected schemas and hoisting scaffolds synthesize those with no authored
+ * counterpart at all.
+ */
+const AUTHORED_JSX_KINDS: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.JsxAttribute,
+  ts.SyntaxKind.JsxElement,
+  ts.SyntaxKind.JsxExpression,
+  ts.SyntaxKind.JsxSelfClosingElement,
+]);
+
+/** Every `*.input.ts(x)` fixture path, relative to the fixture root. */
+async function collectFixturePaths(): Promise<string[]> {
+  const root = new URL("./fixtures/", import.meta.url);
+  const found: string[] = [];
+  const walk = async (dir: URL, prefix: string): Promise<void> => {
+    for await (const entry of Deno.readDir(dir)) {
+      if (entry.isDirectory) {
+        await walk(new URL(`${entry.name}/`, dir), `${prefix}${entry.name}/`);
+      } else if (
+        entry.name.endsWith(".input.tsx") || entry.name.endsWith(".input.ts")
+      ) {
+        found.push(`${prefix}${entry.name}`);
+      }
+    }
+  };
+  await walk(root, "");
+  return found.sort();
+}
+
+/** Synthesized authored-JSX nodes in `root` that cannot name an authored site. */
+function unanchoredJsxNodes(root: ts.SourceFile): string[] {
+  const printer = ts.createPrinter();
+  const unanchored: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      node.pos < 0 && AUTHORED_JSX_KINDS.has(node.kind) &&
+      !recoverAuthoredPosition(node)
+    ) {
+      let printed: string;
+      try {
+        printed = printer.printNode(ts.EmitHint.Unspecified, node, root)
+          .replace(/\s+/g, " ").slice(0, 80);
+      } catch {
+        printed = "(unprintable)";
+      }
+      unanchored.push(`${ts.SyntaxKind[node.kind]}: ${printed}`);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return unanchored;
+}
+
 describe("replacement source-map ranges", () => {
   it("preserves authored positions on JSX-router replacements", async () => {
     const { original, transformed } = await transformThroughStage(
@@ -276,6 +334,17 @@ describe("replacement source-map ranges", () => {
       "rewritten self-closing UiPromptSlot",
     );
     expectAuthoredText(selfClosingUiHelper, original, "<UiPromptSlot");
+
+    // The data attribute replaces the authored helper prop, so it anchors on
+    // that prop rather than on the element that carries it.
+    const dataAttr = findOnly(
+      transformed,
+      (node): node is ts.JsxAttribute =>
+        ts.isJsxAttribute(node) &&
+        ts.isIdentifier(node.name) && node.name.text === "data-ui-action",
+      "rewritten UiAction data attribute",
+    );
+    expectAuthoredText(dataAttr, original, 'action="CT1869_UI"');
 
     const sharedPre = findOnly(
       transformed,
@@ -482,5 +551,65 @@ describe("replacement source-map ranges", () => {
       original,
       '{ marker: "CT1869_DATA" }',
     );
+  });
+
+  // The cases above pin the sites this file knows about by name. This one is
+  // the drift gate: it makes the same guarantee over every fixture, so a NEW
+  // stage that rebuilds a JSX node without carrying its range fails here
+  // instead of waiting for someone to notice a wrong debug position. The
+  // fixtures declared above are included because the corpus reaches no
+  // UI-helper element, which would otherwise leave that family ungated.
+  it("recovers an authored position for every synthesized JSX node in the corpus", async () => {
+    const fixturePaths = await collectFixturePaths();
+    expect(fixturePaths.length, "fixture corpus is non-empty").toBeGreaterThan(
+      100,
+    );
+
+    const sources: Record<string, string> = {
+      "/inline-router.tsx": ROUTER_FIXTURE,
+      "/inline-owned-router.tsx": OWNED_ROUTER_FIXTURE,
+      "/inline-closure.tsx": CLOSURE_FIXTURE,
+      "/inline-post-closure.tsx": POST_CLOSURE_FIXTURE,
+    };
+    for (const path of fixturePaths) {
+      const url = new URL(`./fixtures/${path}`, import.meta.url);
+      sources[`/${path.replaceAll("/", "_")}`] = await Deno.readTextFile(url);
+    }
+
+    // Type-check in batches: one program per fixture would dominate runtime.
+    const names = Object.keys(sources);
+    const BATCH = 25;
+    const failures: string[] = [];
+    let checked = 0;
+    for (let index = 0; index < names.length; index += BATCH) {
+      const batch = names.slice(index, index + BATCH);
+      const files = Object.fromEntries(
+        batch.map((name) => [name, sources[name]!]),
+      );
+      const { program } = await batchTypeCheckFixtures(files, {
+        types: COMMONFABRIC_TYPES,
+      });
+      for (const name of batch) {
+        const sourceFile = program.getSourceFile(name);
+        assert(sourceFile, `fixture source file present: ${name}`);
+        const pipeline = new CommonFabricTransformerPipeline();
+        const result = ts.transform(sourceFile, pipeline.toFactories(program));
+        const transformed = result.transformed[0];
+        assert(transformed, `pipeline returned a source file: ${name}`);
+        checked++;
+        for (const unanchored of unanchoredJsxNodes(transformed)) {
+          failures.push(`${name} -> ${unanchored}`);
+        }
+      }
+    }
+
+    expect(checked, "every fixture ran through the pipeline").toBe(
+      names.length,
+    );
+    expect(
+      failures,
+      "synthesized JSX nodes with no recoverable authored position; carry the " +
+        "authored range with preserveSourceMapRange at the site that builds them",
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- carry authored source-map ranges across the semantic replacement boundaries CT-1869 identified as straightforward
- use `preserveSourceMapRange` only, never a text range or original-node identity
- add stage-specific, content-bound regression coverage plus a corpus-wide drift gate, and update the current-behavior spec and lineage handoff

## Scope

Pattern-body replacement adoption, UI-helper outer elements together with the data attributes they derive from authored helper props, JSX expression containers, handler attributes and initializers, nested reactive-array receiver `key()` calls, and module-scope `__cf_data` wrappers.

`registerReplacementType` becomes `registerReplacement`: it now carries the authored range as well as the inferred type, and the old name advertised only half the job. Nine call sites, plus the two documents that referenced the old symbol.

The UI-helper data attributes were a gap the sweep originally missed. `rewriteUiHelperElement` carried a range onto the rewritten element but not onto the `data-ui-*` attribute it derives from an authored helper prop, nor onto the initializer it rebuilds for it, so both lost their authored position. Each now anchors on the prop it replaces rather than on the element carrying it.

Intentionally deferred, all four tracked in CT-1869's own PR-2 scope:
- destructured-binding replacements without an unambiguous authored binding node in the current intermediate representation
- the diagnostics replacement audit
- `CFHelpers` lineage API cleanup
- focused review of the existing when/unless left-operand anchor

## Coverage

Six content-bound cases pin the sites by name: each asserts the node is genuinely synthesized, recovers its position through `recoverAuthoredPosition`, and matches the recovered range against the authored text. Reverting any one changed file turns the matching case red, per file and per hunk.

The seventh case is the drift gate. Across every fixture, no synthesized `JsxAttribute`, `JsxElement`, `JsxExpression`, or `JsxSelfClosingElement` may fail to recover an authored position — those four kinds always stand for authored syntax, so a synthesized one is a replacement that owes a range. It enumerates the corpus from disk at runtime, so fixtures added later are covered without anyone remembering the test exists, and it runs in about three seconds. Expression kinds stay out: injected schemas and hoisting scaffolds synthesize those with no authored counterpart at all.

That gate is what surfaced the UI-helper gap. No fixture in the corpus reaches a UI-helper element, which is why it went unseen and why the file's inline fixtures are included in the gate's source set.

The suite also directly pins the non-input-bound reactive-wrapper helper branch, which already carried its range — a characterization pin, not a fix.

## Verification

- emitted output byte-identical at every touched site, checked directly rather than inferred, including all four UI-helper forms (static string, dynamic expression, `as` override, self-closing)
- emitted source maps change for the replacements that survive to emit as themselves — pattern-body `key()` lowering, the array-method receiver, and `__cf_data`. The JSX-shaped replacements are rebuilt again by TypeScript's own JSX transform, which runs after this pipeline and does not propagate emit-node data, so their ranges serve in-pipeline recovery rather than the emitted map. Confirmed by re-emitting with `jsx: preserve`, where those maps do change.
- `deno task test` in `packages/ts-transformers` — 1,160 passed, 0 failed
- `deno fmt --check`, `deno lint`, `deno check`
- `deno task check-docs` — 566 blocks
- `deno task check-docs-history-index`

Linear: CT-1869
