### PR TITLE
perf(shell): drop QuickJumpView's dead piece-list fetch

### DIFF
--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -1,7 +1,5 @@
 import type { DID } from "@commonfabric/identity";
 import { navigate } from "@commonfabric/navigation";
-import { PageHandle } from "@commonfabric/runtime-client";
-import { Task } from "@lit/task";
 import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
 
@@ -114,40 +112,8 @@ export class XQuickJumpView extends BaseView {
 
   private inputEl?: HTMLInputElement | null;
 
-  private _pieces = new Task(this, {
-    task: async ([rt, space]) => {
-      if (!rt || !space) return undefined;
-      await rt.synced(space);
-
-      const piecesListCell = await rt.getPiecesListCell(space);
-      await piecesListCell.sync();
-
-      const piecesList = piecesListCell.get() as any[];
-      if (!piecesList) return [];
-
-      // @TODO(runtime-worker-refactor)
-      /*
-      const handles: PageHandle[] = [];
-      for (const pieceData of piecesList) {
-        const id = isCellHandle(pieceData) ? pieceData.id() : pieceData?.$ID;
-        if (id) {
-          const piece = await rt.getPattern(id);
-          if (piece) {
-            handles.push(piece);
-          }
-        }
-      }
-      */
-      return [];
-    },
-    args: () => [this.rt, this.space],
-  });
-
   override updated(changed: Map<string, unknown>) {
     super.updated(changed);
-    if (changed.has("rt")) {
-      this._pieces.run();
-    }
     if (changed.has("visible") && this.visible) {
       // Focus input when opened
       this.updateComplete.then(() => {
@@ -168,12 +134,12 @@ export class XQuickJumpView extends BaseView {
     });
   }
 
+  // @TODO(runtime-worker-refactor): the palette lists no pieces yet. Piece
+  // handles come back with that refactor; until then nothing here fetches, so
+  // opening the palette costs nothing. `rt` and `space` stay as properties for
+  // that revival and for the parent bindings that already set them.
   private getItems(): PieceItem[] {
-    const list = this._pieces.value || [];
-    return list.map((c: PageHandle) => ({
-      id: c.id(),
-      name: c.name() ?? "Untitled Piece",
-    }));
+    return [];
   }
 
   private containsInsensitive(a: string, b: string): boolean {


### PR DESCRIPTION
The quick-jump palette's `_pieces` task booted the space's default app on every shell load — `rt.synced()` + `getPiecesListCell()` resolve the piece registry, which runs the default pattern with its full resume pre-sync — and then returned `[]` unconditionally: the handle-building body is commented out behind `@TODO(runtime-worker-refactor)`, and `getItems()` (its only consumer) mapped an always-empty list. It also ran **twice** per boot: `@lit/task` already re-runs when its `args` change, and `updated()` called `run()` again whenever `rt` changed, bypassing the args-equality dedup.

Measured on a local rig serving a clone of the production topics board: these two runs were half of the four concurrent default-app starts per page load (the other two: HeaderView's cached prefetch, which renders real names and stays, and AppView's `getSpaceRoot`, the legitimate one).

This removes the task and the manual run. `getItems()` returns the empty list the palette already rendered — user-visible behavior is unchanged — and the TODO moves there as the revival marker. `rt`/`space` stay as properties for that revival and for the parent bindings that already set them.

Companion supply-side fix (concurrent starts of one piece joining a single attempt) is in #6231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


