### PR TITLE
fix(runner): join concurrent starts of one piece into a single attempt

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1318,7 +1318,7 @@ export class Runner {
   // still current. Entries are removed when their attempt settles; a stale
   // entry (stop moved the doc's generation, or the epoch changed) is
   // overwritten by the fresh attempt that replaces it.
-  private inFlightStartsByDoc = new Map<string, StartAttempt>();
+  #inFlightStartsByDoc = new Map<string, StartAttempt>();
   private crossSpaceChildSpaces = new WeakMap<
     IExtendedStorageTransaction,
     MemorySpace[]
@@ -2308,7 +2308,7 @@ export class Runner {
     options: { schedulePatternUpdate?: boolean } = {},
   ): Promise<boolean> {
     const startKey = this.getDocKey(resultCell);
-    const inFlight = this.inFlightStartsByDoc.get(startKey);
+    const inFlight = this.#inFlightStartsByDoc.get(startKey);
     if (
       inFlight?.settled !== undefined && this.isStartAttemptCurrent(inFlight)
     ) {
@@ -2347,7 +2347,7 @@ export class Runner {
           this.finishStartAttempt(attempt);
         });
       attempt.settled = settled;
-      this.inFlightStartsByDoc.set(startKey, attempt);
+      this.#inFlightStartsByDoc.set(startKey, attempt);
       return settled;
     } catch (error) {
       this.finishStartAttempt(attempt);
@@ -4576,8 +4576,8 @@ export class Runner {
   private finishStartAttempt(attempt: StartAttempt): void {
     this.activeStartAttempts.delete(attempt);
     for (const key of attempt.generationsByDoc.keys()) {
-      if (this.inFlightStartsByDoc.get(key) === attempt) {
-        this.inFlightStartsByDoc.delete(key);
+      if (this.#inFlightStartsByDoc.get(key) === attempt) {
+        this.#inFlightStartsByDoc.delete(key);
       }
       const active = this.activeStartAttemptsByDoc.get(key);
       if (!active?.delete(attempt)) continue;
@@ -4662,7 +4662,7 @@ export class Runner {
     this.lifecycleEpoch++;
     // The epoch change already makes every held attempt non-current, so no
     // later start can join one; dropping the index releases the attempts too.
-    this.inFlightStartsByDoc.clear();
+    this.#inFlightStartsByDoc.clear();
     this.independentlyStartedResults.clear();
     for (const key of [...this.pendingDeferredStarts.keys()]) {
       this.cancelPendingDeferredStarts(key);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -216,6 +216,10 @@ type StartAttempt = {
   // The result this attempt resolved to, which a link start only learns by
   // following the link.
   targetKey?: `${MemorySpace}/${ScopeKey}/${URI}`;
+  // The attempt's outcome, which a concurrent start of the same doc joins
+  // instead of running a second resolution pipeline. Assigned by start() once
+  // the pipeline promise exists.
+  settled?: Promise<boolean>;
 };
 
 // The debug-name builders reuse the action's already-computed
@@ -1309,6 +1313,12 @@ export class Runner {
   // Covers the pre-resolution window where a link attempt does not know its
   // eventual target doc and therefore cannot appear in the per-doc index yet.
   private activeStartAttempts = new Set<StartAttempt>();
+  // The attempt a concurrent start() of the same doc joins, keyed by the doc
+  // the call entered through. One entry per doc: the newest attempt that is
+  // still current. Entries are removed when their attempt settles; a stale
+  // entry (stop moved the doc's generation, or the epoch changed) is
+  // overwritten by the fresh attempt that replaces it.
+  private inFlightStartsByDoc = new Map<string, StartAttempt>();
   private crossSpaceChildSpaces = new WeakMap<
     IExtendedStorageTransaction,
     MemorySpace[]
@@ -2277,12 +2287,33 @@ export class Runner {
    * running with a lifetime of its own, false when it was superseded or the
    * piece was stopped while the start resolved, or rejects with an error.
    * Runs synchronously when data is available (important for tests).
+   *
+   * Single-flight per doc: a call whose doc already carries a current
+   * in-flight attempt returns that attempt's outcome instead of running a
+   * second resolution pipeline. The dependency pre-sync is the expensive phase
+   * of a start, and concurrent callers — several views asking for the same
+   * space root during one page load, say — would otherwise each run it in
+   * full. Joining shares the outcome, rejection included, and runs under the
+   * first caller's options: a joiner's `schedulePatternUpdate` is not applied,
+   * which matches the already-running fast path, where only the attempt that
+   * instantiates schedules the update check. A call made after a stop never
+   * joins — the stop moved the doc's start generation, so the held attempt is
+   * no longer current and a fresh attempt runs. Calls entering through
+   * different docs whose links resolve to the same piece do not join either;
+   * they run separate resolutions and converge at the registration guard
+   * before instantiation.
    */
   start<T = any>(
     resultCell: Cell<T>,
     options: { schedulePatternUpdate?: boolean } = {},
   ): Promise<boolean> {
     const startKey = this.getDocKey(resultCell);
+    const inFlight = this.inFlightStartsByDoc.get(startKey);
+    if (
+      inFlight?.settled !== undefined && this.isStartAttemptCurrent(inFlight)
+    ) {
+      return inFlight.settled;
+    }
     const attempt: StartAttempt = {
       lifecycleEpoch: this.lifecycleEpoch,
       schedulePatternUpdate: options.schedulePatternUpdate ?? true,
@@ -2292,7 +2323,7 @@ export class Runner {
     this.activeStartAttempts.add(attempt);
     this.trackStartAttempt(attempt, startKey);
     try {
-      return this.doStart(resultCell, new Set(), attempt)
+      const settled = this.doStart(resultCell, new Set(), attempt)
         .then((started) => {
           // This start gives the result a lifetime of its own, so an enclosing
           // pattern releasing it later leaves it running. An attempt whose
@@ -2315,6 +2346,9 @@ export class Runner {
         .finally(() => {
           this.finishStartAttempt(attempt);
         });
+      attempt.settled = settled;
+      this.inFlightStartsByDoc.set(startKey, attempt);
+      return settled;
     } catch (error) {
       this.finishStartAttempt(attempt);
       return Promise.reject(error);
@@ -3275,7 +3309,11 @@ export class Runner {
         return await this.doStart(rootCell, seenCells, attempt);
       }
 
-      // we may already be in the midst of starting this, so don't start again
+      // Another path may have installed this piece's registration while the
+      // pre-sync was awaiting I/O. start() joins same-doc calls before they
+      // get here, so the remaining writers of this race are an identity-change
+      // restart within this same attempt and an attempt that entered through a
+      // different doc whose links resolve to this piece.
       if (this.cancels.has(this.getDocKey(rootCell))) {
         return true;
       }
@@ -4538,6 +4576,9 @@ export class Runner {
   private finishStartAttempt(attempt: StartAttempt): void {
     this.activeStartAttempts.delete(attempt);
     for (const key of attempt.generationsByDoc.keys()) {
+      if (this.inFlightStartsByDoc.get(key) === attempt) {
+        this.inFlightStartsByDoc.delete(key);
+      }
       const active = this.activeStartAttemptsByDoc.get(key);
       if (!active?.delete(attempt)) continue;
       if (active.size === 0) {
@@ -4619,6 +4660,9 @@ export class Runner {
     // storage teardown, but they can neither publish a cache nor call
     // startCore under the new epoch.
     this.lifecycleEpoch++;
+    // The epoch change already makes every held attempt non-current, so no
+    // later start can join one; dropping the index releases the attempts too.
+    this.inFlightStartsByDoc.clear();
     this.independentlyStartedResults.clear();
     for (const key of [...this.pendingDeferredStarts.keys()]) {
       this.cancelPendingDeferredStarts(key);

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -3312,8 +3312,10 @@ describe("runner utils", () => {
       (resultCell as any).synced = true;
 
       const runner = runtime.runner as any;
+      let dependencySyncRuns = 0;
       const originalSync = runner.syncCellsForRunningPattern.bind(runner);
       runner.syncCellsForRunningPattern = async (...args: any[]) => {
+        dependencySyncRuns++;
         await clock.settle();
         return originalSync(...args);
       };
@@ -3325,6 +3327,10 @@ describe("runner utils", () => {
         ]);
         expect(first).toBe(true);
         expect(second).toBe(true);
+        // The second start joins the first attempt, so the dependency
+        // pre-sync — the expensive phase concurrent starts used to repeat —
+        // runs once for the pair.
+        expect(dependencySyncRuns).toBe(1);
 
         resultCell.key("increment").send();
         await runtime.idle();

--- a/packages/runner/test/start-single-flight.test.ts
+++ b/packages/runner/test/start-single-flight.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Cell } from "../src/cell.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+// start() is single-flight per doc: concurrent calls for the same doc share
+// one resolution pipeline and its outcome, while a stop between two calls
+// separates them into distinct attempts. These tests drive the runner
+// directly through the restart path — a piece that ran, stopped, and is
+// started again — because that is the state where start() owns the whole
+// pipeline (a fresh run() instantiates without it).
+
+const signer = await Identity.fromPassphrase("start single flight");
+const space = signer.did();
+
+describe("start()", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  // A piece that ran and then stopped: durable, locally assembled, and not
+  // running — the state from which start() runs its full pipeline.
+  async function stoppedPiece(
+    name: string,
+  ): Promise<Cell<{ doubled: number }>> {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const doubler = pattern<{ source: number }>(({ source }) => ({
+      doubled: lift((value: number) => value * 2)(source),
+    }));
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{ doubled: number }>(
+      space,
+      name,
+      undefined,
+      tx,
+    );
+    runtime.run(tx, doubler, { source: 3 }, resultCell);
+    await tx.commit();
+    await runtime.idle();
+    runtime.runner.stop(resultCell);
+    return resultCell;
+  }
+
+  it("returns the in-flight attempt's outcome to a concurrent start of the same doc", async () => {
+    const resultCell = await stoppedPiece("single flight join");
+    const first = runtime.runner.start(resultCell);
+    const second = runtime.runner.start(resultCell);
+    expect(second).toBe(first);
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+    await resultCell.pull();
+    await runtime.idle();
+    expect(resultCell.key("doubled").getAsQueryResult()).toBe(6);
+  });
+
+  it("runs a fresh attempt for a start issued after a stop of the in-flight one", async () => {
+    const resultCell = await stoppedPiece("single flight stop between");
+    const doomed = runtime.runner.start(resultCell);
+    runtime.runner.stop(resultCell);
+    const fresh = runtime.runner.start(resultCell);
+    expect(fresh).not.toBe(doomed);
+    expect(await doomed).toBe(false);
+    expect(await fresh).toBe(true);
+    await resultCell.pull();
+    await runtime.idle();
+    expect(resultCell.key("doubled").getAsQueryResult()).toBe(6);
+  });
+
+  it("returns true from a start issued after the previous attempt settled", async () => {
+    const resultCell = await stoppedPiece("single flight sequential");
+    expect(await runtime.runner.start(resultCell)).toBe(true);
+    expect(await runtime.runner.start(resultCell)).toBe(true);
+  });
+
+  it("shares a rejection with the joined start", async () => {
+    const resultCell = runtime.getCell<unknown>(
+      space,
+      "single flight no data",
+    );
+    const first = runtime.runner.start(resultCell);
+    const second = runtime.runner.start(resultCell);
+    expect(second).toBe(first);
+    await expect(first).rejects.toThrow("No data at cell");
+  });
+
+  it("does not join an attempt from a previous lifecycle epoch", async () => {
+    const resultCell = await stoppedPiece("single flight epoch");
+    const previousEpoch = runtime.runner.start(resultCell);
+    runtime.runner.stopAll();
+    const currentEpoch = runtime.runner.start(resultCell);
+    expect(currentEpoch).not.toBe(previousEpoch);
+    expect(await previousEpoch).toBe(false);
+    expect(await currentEpoch).toBe(true);
+  });
+});

--- a/packages/runner/test/start-single-flight.test.ts
+++ b/packages/runner/test/start-single-flight.test.ts
@@ -61,11 +61,19 @@ describe("start()", () => {
 
   it("returns the in-flight attempt's outcome to a concurrent start of the same doc", async () => {
     const resultCell = await stoppedPiece("single flight join");
+    // Independently obtained handles for the same doc — a fresh cell from the
+    // same address, and a subpath cell into it. The join is keyed by doc, so
+    // both join the first attempt; object identity plays no part.
+    const freshHandle = runtime.getCell<{ doubled: number }>(
+      space,
+      "single flight join",
+    );
     const first = runtime.runner.start(resultCell);
-    const second = runtime.runner.start(resultCell);
-    expect(second).toBe(first);
+    const viaFreshHandle = runtime.runner.start(freshHandle);
+    const viaSubpath = runtime.runner.start(resultCell.key("doubled"));
+    expect(viaFreshHandle).toBe(first);
+    expect(viaSubpath).toBe(first);
     expect(await first).toBe(true);
-    expect(await second).toBe(true);
     await resultCell.pull();
     await runtime.idle();
     expect(resultCell.key("doubled").getAsQueryResult()).toBe(6);

--- a/packages/runner/test/start-single-flight.test.ts
+++ b/packages/runner/test/start-single-flight.test.ts
@@ -7,11 +7,14 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 // start() is single-flight per doc: concurrent calls for the same doc share
-// one resolution pipeline and its outcome, while a stop between two calls
-// separates them into distinct attempts. These tests drive the runner
-// directly through the restart path — a piece that ran, stopped, and is
-// started again — because that is the state where start() owns the whole
-// pipeline (a fresh run() instantiates without it).
+// one attempt and its outcome, while a stop between two calls separates them
+// into distinct attempts. These tests drive the runner through the restart
+// path — a piece that ran, stopped, and is started again — which exercises
+// the join, the stop and epoch boundaries, and rejection sharing. That path
+// restarts from locally assembled cells, so the cold-resume dependency
+// pre-sync stays out of frame here; that the pre-sync runs once for a
+// concurrent pair is pinned by "does not register duplicate handlers while
+// resumed dependencies sync" in runner.test.ts.
 
 const signer = await Identity.fromPassphrase("start single flight");
 const space = signer.did();

--- a/packages/runner/test/start-single-flight.test.ts
+++ b/packages/runner/test/start-single-flight.test.ts
@@ -81,10 +81,23 @@ describe("start()", () => {
     expect(resultCell.key("doubled").getAsQueryResult()).toBe(6);
   });
 
-  it("returns true from a start issued after the previous attempt settled", async () => {
+  it("retires the join entry when the attempt settles: a start after a later stop runs fresh", async () => {
     const resultCell = await stoppedPiece("single flight sequential");
+    const first = runtime.runner.start(resultCell);
+    expect(await first).toBe(true);
+    // While the piece runs, a repeat start reports true from the registration
+    // guard; whether it joined is unobservable and harmless here.
     expect(await runtime.runner.start(resultCell)).toBe(true);
-    expect(await runtime.runner.start(resultCell)).toBe(true);
+    // The distinguishing sequence: with the settled attempt's entry left in
+    // the index, this start would join its stale resolved promise and report
+    // true while the piece stayed stopped.
+    runtime.runner.stop(resultCell);
+    const afterStop = runtime.runner.start(resultCell);
+    expect(afterStop).not.toBe(first);
+    expect(await afterStop).toBe(true);
+    await resultCell.pull();
+    await runtime.idle();
+    expect(resultCell.key("doubled").getAsQueryResult()).toBe(6);
   });
 
   it("shares a rejection with the joined start", async () => {


### PR DESCRIPTION
## The defect

`Runner.start()` is documented and used as idempotent — `getPieceCell`'s call
site says "It's idempotent - no effect if already running" — but the guard
that delivers that (`cancels.has(key)` in `doStart`) only sees **completed**
starts: the registration installs when a start finishes. Concurrent starts of
the same piece all pass the guard and each run the full resolution pipeline.
The one in-flight re-check sits **after** `syncCellsForRunningPattern`, so it
protects instantiation and nothing else — the dependency pre-sync, which is
the expensive phase, runs once per caller.

Every shell page load demonstrates it. The shell issues `pattern:getSpaceRoot`
plus three `page:getAll` during boot, all of which resolve the space's default
app with `runIt=true` within the same few milliseconds. Measured on a local
rig serving a clone of the production topics board (113 topics, at the estuary
pin `a667cf56a`; the same counts reproduce on a current-main-era build whose
delta does not touch this path): the default
app's resume pre-sync ran **4×** per load, and with the board's own resume
that put `resumeArgumentLinkTargetSync` at **9,625 spans** and
`resumeCellSync` at **446** per load. With this change: **5,029** and **173**
— the two pipelines that remain are the default app's (once) and the board's
(once).

## The fix

`start()` becomes single-flight per doc: a call whose doc already carries a
current in-flight attempt returns that attempt's outcome instead of launching
a second pipeline. The join index is one map keyed by `getDocKey` (doc-level,
so subpath and root cells of one doc share an entry), the attempt carries its
settlement promise, and `finishStartAttempt` retires the entry.

Semantics, deliberately:

- **A stop still wins.** Stops move the doc's start generation, which makes
  the held attempt non-current — so a `start()` issued after a stop never
  joins the doomed attempt; it runs fresh. Joiners of a stopped attempt get
  `false`, exactly what their own attempt would have reported.
- **Epochs.** `stopAll()` bumps the lifecycle epoch and clears the index; a
  held attempt from a previous epoch fails the currency check, so a start
  after `stopAll` runs fresh.
- **Rejections are shared.** A joiner sees the first caller's failure rather
  than retrying independently. Callers with their own heal-and-retry
  (`getDefaultPattern`) retry through a fresh flight.
- **Options.** A joiner's `schedulePatternUpdate` is not applied. This matches
  the existing already-running fast path: only the attempt that instantiates
  schedules the update check, and a caller that lands after completion already
  had its flag dropped at the `cancels` guard.
- **Aliases keep today's behavior.** Two calls entering through *different*
  docs whose links resolve to the same piece do not join; they run separate
  resolutions and converge at the pre-instantiation registration guard, whose
  comment now names that remaining race.

## What this is not

This is a correctness fix, not a wall-clock fix. On the local rig the load's
wall time is CPU-bound and does not move measurably; what falls is redundant
work volume — half the pre-sync spans and the matching server-side watch
registrations per page load. The wall-clock investigation continues separately.

## Tests

`packages/runner/test/start-single-flight.test.ts`: the join (shared promise,
both resolve true, piece runs), stop-between-starts (fresh attempt, doomed
resolves false), sequential restart, shared rejection, and the epoch boundary.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

