### PR TITLE
docs(cli): make both completion plans executable from the document alone

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -127,6 +127,45 @@ with the callback on the cases tried, including reproducing item 1 end to end.
 zsh's `_describe` rendering, the colon escaping that piece ids and DIDs need,
 and the `deno` binding are untested.
 
+## Working on this
+
+Completion swallows every error on purpose, so a provider that throws, a fabric
+that is unreachable, and a slot with no provider are one experience: no
+candidates. Nothing here can be debugged by watching a shell, and a change that
+looks like it worked at the prompt has not been observed.
+
+**Drive the callback directly.** The installed shell function calls one command,
+and so should you. It takes the line and the cursor offset, and prints what the
+shell would have offered:
+
+```bash
+cf completion complete --shell zsh --line "cf call --piece x " --point 18
+```
+
+The shell functions themselves are a separate surface and are exercised by
+sourcing what `cf completion bash` prints and calling `_cf_complete` with
+`COMP_LINE`, `COMP_POINT`, `COMP_WORDS` and `COMP_CWORD` set. Reach for that
+only when the defect is in the script rather than in the candidates.
+
+**Live slots need a space, a piece, and something deployed in it.** A piece id,
+a verb name, a cell path and a result shape are all read from a running fabric,
+so a provider cannot be exercised without one: point `CF_API_URL` at a local
+server, `CF_IDENTITY` at a keyfile, deploy a fixture, and complete against it.
+An empty result from a provider proves nothing until the same target answers
+the equivalent `cf` command.
+
+**Where the tests go.** `packages/cli/test/completion-*.test.ts` hold the pure
+half — line resolution, candidate shaping, the degrade-to-empty path — and are
+the right home for anything answerable without a fabric.
+[`unit-test-coding-style.md`](../development/unit-test-coding-style.md) governs
+their shape and is worth reading first, since not every file in that directory
+follows it. Anything that needs a fabric belongs beside
+`packages/cli/integration/verbs-over-the-cli.sh`, which is item 18.
+
+**Two traps in the parsing layer.** A throwaway Cliffy command used to parse a
+token list needs `.noExit()`, or a bad flag ends the process instead of
+throwing. And `parseExecArgs` takes the spec first and the arguments second.
+
 ## Correctness
 
 ### 1. Inline `--option=value` drops every live candidate

--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -458,6 +458,38 @@ The three moves are independent and each stands alone, but they point the same
 way: a caller states the space once, names the rest in one word, and writes what
 follows in the order the words become knowable.
 
+### Alternatives, and why they are not the design
+
+Recorded so they are not proposed again by someone reading only the outcome.
+
+**The verb leading the line.** Naming the verb first would give every later word
+a verb to resolve against, which reads like the obvious fix for a projection
+that cannot find one. It puts the verb ahead of the words that say which piece
+it lives on, so nothing can resolve the *verb* — and that is the completion that
+works today and the one worth most.
+
+**A distinct marker for the second boundary.** A marker unlike `--` names its
+own place, where a repeat of `--` is positional. It also cannot be written where
+the argument parser is still parsing: a word shaped like a flag is refused
+there, including one the command has declared. So the spelling that would make
+it convenient — reaching the read step with no callable section before it —
+costs a split of the arguments ahead of parsing, which the repeated marker never
+needs because a second `--` only ever follows a first.
+
+**Two markers, with the verb opening nothing.** Fencing the callable's section
+on both sides is symmetric and puts every vocabulary behind an explicit
+boundary. It also spends a marker on a boundary a positional already draws,
+which is the boundary `docker run`, `ssh` and `cf exec` all leave unmarked, and
+it forces an empty section on any verb that declares no input.
+
+**Admitting a projection into the callable's section when no field collides.**
+This costs a caller nothing today and holds only until an author declares a
+field of that name, at which point a line that worked reaches a different
+reader with no edit and no warning.
+
+**A colon-joined `host:space:piece`.** A handle contains a colon, a DID contains
+two, and a host carries a port, so the token cannot be split from either end.
+
 ### Precedent worth not re-deriving
 
 Position deciding which entity a flag applies to is well-established.
@@ -528,8 +560,11 @@ spelling.
 **Naming the target is a second arc, not a later step.** Steps 1 through 7
 decide what the commands are called; the work below decides how a caller writes
 what a command acts on. The two are independent except at one point — 6b removes
-the spellings 6a warned about, so nothing here starts a second deprecation on
-those same commands until it has landed.
+the spellings 6a warned about, so nothing here changes those same commands until
+it has landed. `PIECE_DATA_SPELLING_END_DATE` in
+`packages/cli/commands/piece.ts` is the date those warnings name and the one
+thing to check before starting step
+10.
 
 8. **Give the space an ambient source** in `CF_SPACE`, with the flag overriding
    it, serving reads and writes alike; and every command that writes names the
@@ -564,9 +599,11 @@ Steps 8, 9 and 11 add. Step 10 is the one that changes what a written line
 means, and it is the one the rest of the surface reads against — a projection
 cannot be written after the verb until it lands.
 
-The sweep is bounded and known: about thirty places in this repository teach the
-old marker, one of them the verb session walkthrough, whose commands
-`check-verb-session-sync` already holds to what its demo script runs.
+The sweep is bounded and enumerable: twelve files across `docs/`, `skills/`,
+`packages/cli/README.md`, and the CLI's own tests and integration scripts teach
+the old marker. Two of them are the verb session documents, whose commands
+`check-verb-session-sync` holds to what the demo script runs — so those change
+in the same commit as the script, or the gate fails.
 
 **The trailing form is taught throughout**, in the same pass as step 10. The
 read options go after the thing they shape on every command that has them, which


### PR DESCRIPTION
## Why

The two plans merged in #6227 record a design well and hand off badly. A session
pointed at them would know what is wrong and what the fix is, and would then have
to rediscover how to run a completion at all — the callback that drives one, what
a live slot needs before it can answer, and where a test for it belongs. It would
also re-propose the alternatives, because the documents carry the outcome without
the reasons the other shapes were dropped.

That is the difference between a design record and something a second session can
execute. This closes it.

## What Changed

**`cli-completion-coverage.md` gains a `## Working on this` section.** Completion
swallows every error by design, so a throwing provider, an unreachable fabric and
a slot with no provider are one experience — which means none of this is
debuggable by watching a shell. The section says to drive
`cf completion complete --shell zsh --line … --point …` directly, what a live slot
needs before it can answer anything (a space, a piece, and something deployed),
where the pure tests and the fabric-backed ones each belong, and two traps: a
throwaway Cliffy command needs `.noExit()` or a bad flag ends the process, and
`parseExecArgs` takes the spec first.

**`cli-surface-shape.md` gains `### Alternatives, and why they are not the
design`.** Five of them, each with the reason it loses: the verb leading the line
(it puts the verb ahead of the words that resolve it, killing the completion that
works today), a distinct marker for the second boundary, two markers with the verb
opening nothing, admitting a projection into the callable's section when no field
collides, and a colon-joined `host:space:piece`.

It also names `PIECE_DATA_SPELLING_END_DATE` as the one thing to check before
starting step 10, and re-scopes the sweep: twelve files teach the old marker, and
two of them are the verb session documents that `check-verb-session-sync` holds to
the demo script — so those change in the same commit as the script or the gate
fails.

## Test plan

Documentation only; no code changes.

- `deno task check-docs` — 566 blocks pass
- `deno task check-skill-facts` — 46 documents, all cited paths resolve
- `deno task check-conflict-markers`, `check-control-characters`,
  `check-docs-history-index` — pass
- `deno task docs-links --orphan` — no orphans

The sweep count and the gate's coverage were re-measured against current `main`
rather than carried over: `check-verb-session-sync` now covers
`the-verb-session.md` as well as `session-walkthrough.md`, and the earlier
"about thirty places" was a line count rather than a file count.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

