### PR TITLE
test(runner): the held-wave (α3) gates arm at the drain's sidecar sync (CT-2060)

### DIFF
--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -87,6 +87,21 @@ class GatedStorageManager extends EmulatedStorageManager {
   /** How many syncs the sync gate has parked (a pin's evidence that a
    * drain WAS held in the window it constructs). */
   syncGateHits = 0;
+  /** Synchronous observation hook at `syncCell` entry — the settle-gate
+   * ARMING seam for the held-wave (α3) constructions (CT-2060). The
+   * drain awaits the sidecar doc's sync BEFORE any entry's guard check,
+   * so a hook keyed to the sidecar id fires strictly before the LT1
+   * copy RUNS — ahead of every seal the copy contributes and therefore
+   * ahead of the sealing cycle's settle sampling the gate predicate.
+   * Arming from the test's event HANDLER (#6184's hardening) reduced
+   * but did not eliminate the race: the handler's own tx can seal late
+   * relative to the copy's, so the settle could still sample an
+   * unarmed predicate in the window between the copy's seal and the
+   * handler running (the residual red OW57 records — the ping durable
+   * AND consequenced at the held-wave probe). Observation only: it
+   * never parks (that is `syncGate`), and it fires before the throw
+   * seam below — a failing sync is still the drain touching the doc. */
+  onSyncCell: ((id: string) => void) | undefined;
 
   override async inputSynced(): Promise<void> {
     await super.inputSynced();
@@ -113,6 +128,7 @@ class GatedStorageManager extends EmulatedStorageManager {
     cell: Cell<T>,
     options?: Parameters<EmulatedStorageManager["syncCell"]>[1],
   ): Promise<Cell<T>> {
+    this.onSyncCell?.(cell.getAsNormalizedFullLink().id);
     if (
       GatedStorageManager.syncThrowWhen?.(
         cell.getAsNormalizedFullLink().id,
@@ -2437,11 +2453,18 @@ describe("Phase 3 events-down (serving side)", () => {
     const gate = Promise.withResolvers<void>();
     try {
       // The handler on s2 records every payload tag it handles — the
-      // consequence witness. (s1 is unused here.)
+      // consequence witness (s1 is unused here) — and for the
+      // derivation's "ping" it ARMS the settle gate as its first act
+      // (#6184's arming, adopted here from the SIBLING step: this
+      // step's gate previously polled the sealed overlay, the exact
+      // shape #6184 replaced there — CT-2060's open question of
+      // whether the remaining polled gates should adopt the arming).
       const servingSeen = w.servingC;
+      let holdArmed = false;
       cancels.push(w.serving.scheduler.addEventHandler(
         (tx: IExtendedStorageTransaction, event: unknown) => {
           const tag = (event as { tag?: string })?.tag ?? "?";
+          if (tag === "ping") holdArmed = true;
           const current = servingSeen.withTx(tx).get() as
             | { seen?: string[] }
             | undefined;
@@ -2470,10 +2493,19 @@ describe("Phase 3 events-down (serving side)", () => {
         (w.servingC.get() as { seen?: string[] } | undefined)?.seen ?? [];
       expect(seenView()).toEqual([]);
 
-      // Hold the wave open once the copy's run has SEALED into it
-      // (visible through the sealed overlay: seen includes "ping").
+      // Hold the wave open for the cycle that RUNS the copy — the same
+      // two-seam arming as the SIBLING step (CT-2060; OW57's owed
+      // construction): the handler arms as its first act, and the
+      // drain's sidecar-doc sync arms BEFORE the copy runs, so the
+      // sealing cycle's settle can never sample an unarmed predicate
+      // after the copy sealed. Idle settles pass: nothing arms until
+      // the drain touches THIS step's sidecar.
+      const heldSidecarId = w.sidecarOf(w.s2);
+      servingManager!.onSyncCell = (id) => {
+        if (id === heldSidecarId) holdArmed = true;
+      };
       servingManager!.settleGate = gate.promise;
-      servingManager!.settleGateWhen = () => seenView().includes("ping");
+      servingManager!.settleGateWhen = () => holdArmed;
       let released = false;
       try {
         await w.serving.scheduler.run(emitter as never);
@@ -2501,6 +2533,7 @@ describe("Phase 3 events-down (serving side)", () => {
         released = true;
       } finally {
         if (!released) gate.resolve();
+        servingManager!.onSyncCell = undefined;
         servingManager!.settleGate = undefined;
         servingManager!.settleGateWhen = undefined;
       }
@@ -2778,11 +2811,23 @@ describe("Phase 3 events-down (serving side)", () => {
       expect(seenView()).toEqual([]);
       expect(sideView()).toBe(0);
 
-      // Hold the wave open for the cycle that RUNS the copy: the handler
-      // arms the gate as its first act, and that assignment is sequenced
-      // before the cycle's settle reaches its barrier, so the hold catches
-      // the sealing cycle structurally. An idle settle already in flight
-      // still passes: nothing arms until the copy actually runs.
+      // Hold the wave open for the cycle that RUNS the copy. TWO arming
+      // seams, both required (CT-2060; the OW57 row's owed construction):
+      // the handler arms as its first act (#6184's hardening), and the
+      // drain's own sidecar-doc sync arms too — the drain awaits that
+      // sync BEFORE the entry's guard check, so this arming precedes the
+      // copy's RUN and therefore every seal the copy contributes,
+      // closing the residual window where the sealing cycle's settle
+      // sampled the predicate after the copy sealed but before the
+      // handler ran (the post-#6184 red: the ping durable AND
+      // consequenced at the probe below — 3/3 CI attempts on #6223's
+      // board, 0/12 under local timing). An idle settle already in
+      // flight still passes: nothing arms until the drain touches THIS
+      // step's sidecar.
+      const heldSidecarId = w.sidecarOf(w.s2);
+      servingManager!.onSyncCell = (id) => {
+        if (id === heldSidecarId) holdArmed = true;
+      };
       servingManager!.settleGate = gate.promise;
       servingManager!.settleGateWhen = () => holdArmed;
       let released = false;
@@ -2811,6 +2856,7 @@ describe("Phase 3 events-down (serving side)", () => {
         released = true;
       } finally {
         if (!released) gate.resolve();
+        servingManager!.onSyncCell = undefined;
         servingManager!.settleGate = undefined;
         servingManager!.settleGateWhen = undefined;
       }

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -87,21 +87,6 @@ class GatedStorageManager extends EmulatedStorageManager {
   /** How many syncs the sync gate has parked (a pin's evidence that a
    * drain WAS held in the window it constructs). */
   syncGateHits = 0;
-  /** Synchronous observation hook at `syncCell` entry — the settle-gate
-   * ARMING seam for the held-wave (α3) constructions (CT-2060). The
-   * drain awaits the sidecar doc's sync BEFORE any entry's guard check,
-   * so a hook keyed to the sidecar id fires strictly before the LT1
-   * copy RUNS — ahead of every seal the copy contributes and therefore
-   * ahead of the sealing cycle's settle sampling the gate predicate.
-   * Arming from the test's event HANDLER (#6184's hardening) reduced
-   * but did not eliminate the race: the handler's own tx can seal late
-   * relative to the copy's, so the settle could still sample an
-   * unarmed predicate in the window between the copy's seal and the
-   * handler running (the residual red OW57 records — the ping durable
-   * AND consequenced at the held-wave probe). Observation only: it
-   * never parks (that is `syncGate`), and it fires before the throw
-   * seam below — a failing sync is still the drain touching the doc. */
-  onSyncCell: ((id: string) => void) | undefined;
 
   override async inputSynced(): Promise<void> {
     await super.inputSynced();
@@ -128,7 +113,6 @@ class GatedStorageManager extends EmulatedStorageManager {
     cell: Cell<T>,
     options?: Parameters<EmulatedStorageManager["syncCell"]>[1],
   ): Promise<Cell<T>> {
-    this.onSyncCell?.(cell.getAsNormalizedFullLink().id);
     if (
       GatedStorageManager.syncThrowWhen?.(
         cell.getAsNormalizedFullLink().id,
@@ -2459,12 +2443,21 @@ describe("Phase 3 events-down (serving side)", () => {
       // step's gate previously polled the sealed overlay, the exact
       // shape #6184 replaced there — CT-2060's open question of
       // whether the remaining polled gates should adopt the arming).
+      // `armingGap` is the construction's own discriminator: the QUEUE
+      // seam below must have armed the hold BEFORE the copy's run
+      // reaches this handler — a gap means the gate could still be
+      // sampled unarmed after the copy's contributions sealed, which
+      // is exactly the CI flake's window.
       const servingSeen = w.servingC;
       let holdArmed = false;
+      let armingGap = false;
       cancels.push(w.serving.scheduler.addEventHandler(
         (tx: IExtendedStorageTransaction, event: unknown) => {
           const tag = (event as { tag?: string })?.tag ?? "?";
-          if (tag === "ping") holdArmed = true;
+          if (tag === "ping") {
+            if (!holdArmed) armingGap = true;
+            holdArmed = true;
+          }
           const current = servingSeen.withTx(tx).get() as
             | { seen?: string[] }
             | undefined;
@@ -2495,14 +2488,32 @@ describe("Phase 3 events-down (serving side)", () => {
 
       // Hold the wave open for the cycle that RUNS the copy — the same
       // two-seam arming as the SIBLING step (CT-2060; OW57's owed
-      // construction): the handler arms as its first act, and the
-      // drain's sidecar-doc sync arms BEFORE the copy runs, so the
-      // sealing cycle's settle can never sample an unarmed predicate
-      // after the copy sealed. Idle settles pass: nothing arms until
-      // the drain touches THIS step's sidecar.
-      const heldSidecarId = w.sidecarOf(w.s2);
-      servingManager!.onSyncCell = (id) => {
-        if (id === heldSidecarId) holdArmed = true;
+      // construction): the QUEUE seam arms when the LT1 copy is queued
+      // for dispatch, and the handler arms again as its first act
+      // (#6184's belt). The queue seam is the one point every path to
+      // the copy's run traverses BEFORE the run — the same-wave
+      // in-process copy is queued synchronously with the emitter's
+      // sealed append (cell.ts's LT1 arm: the raw entries write and
+      // `scheduler.queueEvent` sit in one synchronous block, no
+      // interleaving point between them), and the drain's later
+      // re-delivery of a durable entry dispatches through the same
+      // `queueEvent` (space-server.ts's served dispatch). So no settle
+      // can sample an unarmed predicate after any of the copy's
+      // contributions sealed. A drain-side sidecar-SYNC seam cannot do
+      // this: the same-wave copy's entry is a sealed-wave write the
+      // drain's durable query never sees, so nothing syncs the sidecar
+      // before the copy runs in that cycle (the Codex P1 finding on
+      // this PR, confirmed in code). Idle settles pass: nothing arms
+      // until THIS step's stream event is queued.
+      const s2StreamId = w.servingS2.getAsNormalizedFullLink().id;
+      const originalQueueEvent = w.serving.scheduler.queueEvent.bind(
+        w.serving.scheduler,
+      );
+      (w.serving.scheduler as {
+        queueEvent: typeof originalQueueEvent;
+      }).queueEvent = (eventLink, ...rest) => {
+        if (eventLink.id === s2StreamId) holdArmed = true;
+        return originalQueueEvent(eventLink, ...rest);
       };
       servingManager!.settleGate = gate.promise;
       servingManager!.settleGateWhen = () => holdArmed;
@@ -2533,10 +2544,18 @@ describe("Phase 3 events-down (serving side)", () => {
         released = true;
       } finally {
         if (!released) gate.resolve();
-        servingManager!.onSyncCell = undefined;
+        (w.serving.scheduler as {
+          queueEvent: typeof originalQueueEvent;
+        }).queueEvent = originalQueueEvent;
         servingManager!.settleGate = undefined;
         servingManager!.settleGateWhen = undefined;
       }
+
+      // The construction's own discriminator: the hold was armed BEFORE
+      // the copy's run reached the handler. Red under handler-only
+      // arming (#6184) and under a drain-sync seam alike — both leave
+      // the gap the CI flake rode.
+      expect(armingGap).toBe(false);
 
       const s2Sidecar = w.sidecarOf(w.s2);
       // The rival's entry is delivered (once) by the drain.
@@ -2774,14 +2793,18 @@ describe("Phase 3 events-down (serving side)", () => {
       const servingSeen = w.servingC;
       // The s2 handler records every tag; for the derivation's "ping" it
       // ALSO commits the sibling tx inline (the intent half) — and ARMS
-      // the settle gate as its first act, so the arming is sequenced
-      // before this cycle's settle reaches its barrier (see the gate
-      // installation below).
+      // the settle gate as its first act (#6184's belt; the primary
+      // arming is the QUEUE seam installed below). `armingGap` is the
+      // construction's discriminator: the queue seam must have armed
+      // BEFORE the copy's run reaches this handler — a gap is exactly
+      // the window the CI flake rode.
       let holdArmed = false;
+      let armingGap = false;
       cancels.push(w.serving.scheduler.addEventHandler(
         (tx: IExtendedStorageTransaction, event: unknown) => {
           const tag = (event as { tag?: string })?.tag ?? "?";
           if (tag === "ping") {
+            if (!holdArmed) armingGap = true;
             holdArmed = true;
             stampSibling(w.serving, tx, sideServing);
           }
@@ -2811,22 +2834,35 @@ describe("Phase 3 events-down (serving side)", () => {
       expect(seenView()).toEqual([]);
       expect(sideView()).toBe(0);
 
-      // Hold the wave open for the cycle that RUNS the copy. TWO arming
-      // seams, both required (CT-2060; the OW57 row's owed construction):
-      // the handler arms as its first act (#6184's hardening), and the
-      // drain's own sidecar-doc sync arms too — the drain awaits that
-      // sync BEFORE the entry's guard check, so this arming precedes the
-      // copy's RUN and therefore every seal the copy contributes,
-      // closing the residual window where the sealing cycle's settle
-      // sampled the predicate after the copy sealed but before the
-      // handler ran (the post-#6184 red: the ping durable AND
-      // consequenced at the probe below — 3/3 CI attempts on #6223's
-      // board, 0/12 under local timing). An idle settle already in
-      // flight still passes: nothing arms until the drain touches THIS
-      // step's sidecar.
-      const heldSidecarId = w.sidecarOf(w.s2);
-      servingManager!.onSyncCell = (id) => {
-        if (id === heldSidecarId) holdArmed = true;
+      // Hold the wave open for the cycle that RUNS the copy (CT-2060;
+      // the OW57 row's owed construction). The primary arming is the
+      // QUEUE seam: the LT1 copy is queued for dispatch synchronously
+      // with the emitter's sealed append (cell.ts's LT1 arm — the raw
+      // entries write and `scheduler.queueEvent` sit in one synchronous
+      // block, no interleaving point between them), and a drain's later
+      // re-delivery of the durable entry dispatches through the SAME
+      // `queueEvent` (space-server.ts's served dispatch) — so every
+      // path to the copy's run arms the hold strictly before the run,
+      // and no settle can sample an unarmed predicate after any of the
+      // copy's contributions sealed. This closes the post-#6184
+      // residual (the ping durable AND consequenced at the probe below
+      // — 4/4 CI attempts on #6223's board, 0/12+ under local timing):
+      // the handler's own arming can run after the copy's append
+      // sealed. A drain-side sidecar-SYNC seam cannot close it either —
+      // the same-wave copy's entry is a sealed-wave write the drain's
+      // durable query never sees, so nothing syncs the sidecar before
+      // the copy runs in that cycle (the Codex P1 finding on this PR,
+      // confirmed in code). Idle settles pass: nothing arms until THIS
+      // step's stream event is queued.
+      const s2StreamId = w.servingS2.getAsNormalizedFullLink().id;
+      const originalQueueEvent = w.serving.scheduler.queueEvent.bind(
+        w.serving.scheduler,
+      );
+      (w.serving.scheduler as {
+        queueEvent: typeof originalQueueEvent;
+      }).queueEvent = (eventLink, ...rest) => {
+        if (eventLink.id === s2StreamId) holdArmed = true;
+        return originalQueueEvent(eventLink, ...rest);
       };
       servingManager!.settleGate = gate.promise;
       servingManager!.settleGateWhen = () => holdArmed;
@@ -2856,10 +2892,17 @@ describe("Phase 3 events-down (serving side)", () => {
         released = true;
       } finally {
         if (!released) gate.resolve();
-        servingManager!.onSyncCell = undefined;
+        (w.serving.scheduler as {
+          queueEvent: typeof originalQueueEvent;
+        }).queueEvent = originalQueueEvent;
         servingManager!.settleGate = undefined;
         servingManager!.settleGateWhen = undefined;
       }
+
+      // The construction's discriminator: the hold was armed BEFORE the
+      // copy's run reached the handler — red under handler-only arming
+      // (#6184) and under a drain-sync seam alike.
+      expect(armingGap).toBe(false);
 
       const s2Sidecar = w.sidecarOf(w.s2);
       await waitUntil(


### PR DESCRIPTION
## Why

`Runner Tests (7/8)` is failing on main-based branches in `executor-events-down.test.ts`'s held-wave step **"(α3) + a same-eventId SIBLING tx (independent review M1)"** — the registered CT-2060 gate race (verification-coverage.md OW57). Evidence, current: **4/4 consecutive CI attempts red on PR #6223's branch** (three attempts at `077e72f1d`, one at `727b82c07`), every time the identical signature — the ping entry durable AND consequenced at the `expect(w.entriesOf(w.sidecarOf(w.s2))).toEqual([])` probe, step wall ~80ms (the gate never held) — while **local runs at the same heads and at base are uniformly green** (12+ sequential including the CI profile with coverage, plus 8 concurrent copies under full-machine contention), and main's own runs in the same window were green. The failing surface is the test's own hold construction, not product code; OW57 records precisely this residue: merged **#6184** ("the α3 sibling hold arms from the handler") *reduced but did not eliminate* the race, and the row's owed item is "a construction that holds under insertion-shifted timing".

The residual window, from the mechanics: #6184 arms the hold from the test's event HANDLER, assuming the arming is sequenced before the sealing cycle's settle samples the gate predicate (`GatedStorageManager.inputSynced`). But the handler's own tx can seal LATE relative to the LT1 copy's (the suite's own (α1b)+(α4) step is built on exactly that lateness), so the settle can sample an unarmed predicate after the copy sealed but before the handler ran — the wave flushes, the ping lands, the orphan refusal never happens, and the probe sees the consequenced entry. CI-speed runners hit that ordering; this machine could not (0/20+).

~~The construction that holds: arm at the drain's sidecar-doc sync.~~ **Superseded at `e2819a4ff` — Codex's P1 showed in code that the drain-sync seam cannot fire before the same-wave copy runs; the arming now sits at the LT1 `queueEvent` seam. See the adjudication section below.** Original (wrong) premise kept for the record: The drain awaits the sidecar's `syncCell` BEFORE any entry's guard check (the suite's documented second seam), so an arming keyed to the sidecar id fires strictly before the copy RUNS — ahead of every seal the copy contributes, hence ahead of any settle sample that could admit those seals. Idle settles still pass (nothing arms until the drain touches this step's sidecar), and the handler arming stays as a second belt.

## What Changed

Test file only (`packages/runner/test/executor-events-down.test.ts`):

- `GatedStorageManager.onSyncCell` — a synchronous observation hook at `syncCell` entry (never parks; fires before the sync-failure throw seam, since a failing sync is still the drain touching the doc), documented as the arming seam.
- The failing **M1 SIBLING step**: keeps #6184's handler arming, adds the sidecar-sync arming, clears the hook in `finally`; comment records both seams and why.
- The **plain (α3) ORPHAN step**: its gate still POLLED the sealed overlay (`seenView().includes("ping")`) — the exact pre-#6184 shape, CT-2060's open question of "whether the remaining polled gates should adopt the same arming". Same mechanism, same drain shape → adopts the same two-seam arming.
- **Left untouched, flagged**: the C8d raced-cascade step's polled gate (`servingParentArg … === 2`, ~line 2005) — a different construction (no test-owned handler on the sealing path) with no observed reds; extending the arming there is its own considered change, not a side-swipe.

## Codex P1 adjudication — CONFIRMED in code; the arming re-seamed at `queueEvent`

Codex's inline P1 claimed the drain-sync seam cannot arm before the LT1 copy runs in the same-wave interleaving. **Verified in code — Codex is right:**

- `packages/runner/src/cell.ts:1767-1848` (the LT1 same-space arm): the sidecar entry is a RAW write inside the emitting tx (`writeValueOrThrow`, :1816 — sealed-wave state until the wave commits), and the in-process copy is queued **directly** via `this.runtime.scheduler.queueEvent(...)` (:1848 — "Same-wave processing (LT1 …): queue the emitted event in-process too. Its handler runs in THIS wave").
- The dispatch path has **no sidecar sync**: `queueEvent` (`packages/runner/src/scheduler/facade.ts:1276`) → shaping/queue → handler run; `syncCell`/`.sync()` appear nowhere in `scheduler/facade.ts` or `scheduler/events.ts`.
- The drain cannot see the entry: `#drainStreamEvents` queries **durable** pending docs (`Engine.selectPendingStreamEventDocs`, `packages/runner/src/executor/space-server.ts:2394`); its sidecar `syncCell` (:2427-2432) runs only for durable entries — i.e. only in a LATER cycle, after the wave the probe needs held has already flushed. So in the constructed (and CI-hit) interleaving the v1 `onSyncCell` seam could not fire before the copy ran — exactly Codex's mechanism, including the "holds the wrong wave" half.

**The re-seam (Codex's proposed alternative):** arm at the LT1 queue point. `queueEvent` is the one seam every path to the copy's run traverses *before* the run: the same-wave copy is queued in the same synchronous block as the sealed append (no interleaving point between cell.ts:1816 and :1848), and a drain re-delivery of a durable entry dispatches through the same method (`space-server.ts:2576`). The test patches `w.serving.scheduler.queueEvent` (the suite's established instance-patch seam), keyed to s2's stream id; the handler arming stays as #6184's belt; the dead `onSyncCell` hook is removed.

**The discriminating pin the board could not give:** each α3 step now asserts `expect(armingGap).toBe(false)`, where `armingGap` samples the hold state at handler entry, before the handler's own arming. With the queue seam disarmed — equivalent to #6184's handler-only arming AND to the v1 sync seam, which never fires pre-copy — **both α3 steps fail deterministically** (`Actual: true`) on every local run: the unarmed window exists on *every* pass; CI's 4/4 flake was the settle sometimes sampling inside it, and the earlier 68/68 board was one non-discriminating observation (the handler usually wins the race locally). With the queue seam armed: 8/8 sequential local runs green.

## Test plan

- Full `executor-events-down.test.ts` at this branch: 12 sequential local runs green (22 steps each), plus lint/fmt clean. The race itself is CI-timing-only (0/20+ local at the UNfixed heads too), so the proof lives on CI: after merge, the coordinator re-runs #6223's failed `Runner Tests (7/8)` lane on the merge ref.
- No product code touched; no other suite reads these seams.

Context: CT-2060 / verification-coverage.md OW57 (the row's owed construction), #6184 (the precedent arming, extended here), #6223 (the branch whose 4/4 red lane is this race; its own diff was ruled uninvolved — the suite carries zero cid content and the probed surface is upstream of that PR's seams).

Do not merge — the coordinator reviews and merges, then re-runs #6223's lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


