### PR TITLE
test(runner): bounded accept-and-retry for the α3 sibling step's structural window (OW57, RULED)

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6554,12 +6554,45 @@ supply; OW29/OW32/OW34 closed):
     identical signature — the ping durable AND consequenced at the
     probe (`expect(...).toEqual([])` received the consequenced ping
     entry) — on a loaded machine at `b775787b6`; five runs of plain
-    main's version at the same head were green. Owed, still: a
-    construction that holds under insertion-shifted timing (or an
-    owner call to accept-and-retry the step); until then a red of
-    THIS step with the ping already durable at the probe is this
-    race, not a product regression, and not the inserting PR's
-    defect. No lift trigger (test-harness item).
+    main's version at the same head were green. The owed
+    "construction that holds" was then DISPROVED as reachable
+    test-side: after two further arming constructions failed on the
+    identical signature (a drain-sync seam, then the queue seam
+    #6233 merged — the arming provably synchronous with the sealed
+    append), 5 identical CI observations on #6223's boards forced
+    the seam audit (PR #6223, comment 5401826757): the serving
+    cycle's ONLY `inputSynced` consultation is inside the settle
+    race (`space-server.ts` `#waveCycle` :3727), and the committing
+    tail after the settle break (watermark `tx.commit()` :3979 →
+    notice settle :3998 → wave capture :4002 → `await #sealChain`
+    :4005 → `commitWave` :4046) admits late seals with NO further
+    gate sample — an emitter interleaving into those awaits flushes
+    past an ARMED gate. The settle is a WATERMARK barrier, not an
+    admission barrier (no product defect asserted; W never claims
+    tail seqs), so no test-side held-wave construction can be sound
+    for tail-arriving work, and even a held gate only DELAYS (the
+    deadline arm commits what is sealed so far). RULED 2026-08-24
+    (owner, verbatim): "agreed with your recommendation: bounded
+    accept-and-retry for now". BUILT (the retry PR): the M1 SIBLING
+    step re-runs its FULL construction (fresh prefix, host tenure,
+    client) at most TWICE; ONLY the tagged structural signature
+    retries — the held-wave probe finding the flushed ping durable
+    (`A3StructuralWindow`) — and every other failure propagates on
+    the first attempt (verified: the title's sibling-fold mutation
+    reds attempt 1 with zero retries; the forced window retries
+    once, logs once, and propagates after attempt 2). Absorbed hits
+    log the greppable marker `a3-structural-window-retry (OW57)` —
+    the CI count is the evidence base for this row's DESTINATION: a
+    product-side seam on the committing tail (its own considered
+    change), which is what would let a held-wave construction bind
+    again. The plain (α3) ORPHAN step shares the construction class
+    and INHERITS this disposition if it ever fires the same
+    signature (durable flushed ping at its held-wave probe) — not
+    pre-wrapped: the ruling's scope is "for now", the observed
+    step. Until then a red of an (α3) step with the ping already
+    durable at the probe is this window, not a product regression,
+    and not the inserting PR's defect. No lift trigger
+    (test-harness item).
   - **OW58 — the consequence-notice resolved-error guard wedge
     (adversarial review of PR #6186, MAJOR-1 — probe-confirmed;
     minted 2026-08-21; PRE-EXISTING since Phase 3, NOT introduced by

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -2896,17 +2896,33 @@ describe("Phase 3 events-down (serving side)", () => {
         // below absorbs once; anything else fails loud, first time.
         {
           const durableAtProbe = w.entriesOf(w.sidecarOf(w.s2));
+          // The tag requires the window's WHOLE fingerprint, not the
+          // symptom alone (Cubic P1 on the retry PR): (a) the durable
+          // content is exactly the emitter's ping — nothing else ever
+          // qualifies; (b) the queue-seam arming provably ENGAGED
+          // (`holdArmed` — set synchronously with the sealed append,
+          // so a durable ping with holdArmed still false means the
+          // arming machinery itself broke: NOT the window, fails
+          // loud, first attempt). The residual — an intermittent
+          // gate-machinery regression producing exactly an
+          // armed-flush — is indistinguishable from the window at
+          // this seam BY THE AUDIT'S CONCLUSION (no admitting-path
+          // seam exists test-side), which is what the owner ruled
+          // on: it is absorbed AT MOST ONCE, logged and countable,
+          // and a deterministic regression with this signature still
+          // reds the step on the second attempt.
           if (
             durableAtProbe.length > 0 &&
+            holdArmed &&
             durableAtProbe.every((entry) =>
               (entry.payload as { tag?: string } | undefined)?.tag === "ping"
             )
           ) {
             throw new A3StructuralWindow(
               `the held-wave probe found the emitter's ping durable ` +
-                `(${durableAtProbe.length} entry/entries) — the ` +
-                `committing-tail window admitted the wave past the ` +
-                `armed settle gate`,
+                `(${durableAtProbe.length} entry/entries) with the hold ` +
+                `armed — the committing-tail window admitted the wave ` +
+                `past the armed settle gate`,
             );
           }
           expect(durableAtProbe).toEqual([]);
@@ -2960,16 +2976,20 @@ describe("Phase 3 events-down (serving side)", () => {
       expect(seen).toEqual(["rival"]);
       expect(w.engineN(sideServing)).toBe(0);
       expect(stats.events.orphanDeliveriesRefused).toBe(1);
+      // Scoped to THIS attempt's stream (Cubic P3 on the retry PR): the
+      // retry reuses the per-step server/space, so a global scan would
+      // read an absorbed attempt-1 tenure's leftovers beside this
+      // construction's — an eventId embeds its stream doc id, and each
+      // attempt's stream is prefix-fresh, so the filter is exact.
+      const s2Id = w.s2.getAsNormalizedFullLink().id;
       const consequenced = (w.engine.database.prepare(
         `SELECT consequence_of FROM "commit"
          WHERE class = 'derived' AND consequence_of IS NOT NULL`,
       ).all() as Array<{ consequence_of: string }>).flatMap((row) =>
         decodeMemoryBoundary(row.consequence_of) as unknown as string[]
-      );
+      ).filter((id) => id.includes(s2Id));
       const durableIds = new Set(
-        sidecarIdsIn(w.engine).flatMap((id) =>
-          w.entriesOf(id).map((entry) => entry.eventId)
-        ),
+        w.entriesOf(w.sidecarOf(w.s2)).map((entry) => entry.eventId),
       );
       expect(consequenced.length).toBeGreaterThanOrEqual(1);
       for (const id of consequenced) expect(durableIds.has(id)).toBe(true);

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -2767,13 +2767,22 @@ describe("Phase 3 events-down (serving side)", () => {
     }
   });
 
-  it("(α3) + a same-eventId SIBLING tx (independent review M1): the LT1 copy of a DERIVATION emitter's superseded append commits a sibling event-handler-stamped tx (the served navigateTo intent shape) inside the same wave; the orphan refusal must take the SIBLING down with the handler's contribution — neither half of an orphan lands (a navigation intent enacted for an event with zero durable entries is events.md §4's FORBIDDEN half-delivery); the refusal is counted once per EVENT (mutation: the sibling fold removed → the handler half is refused, the intent half LANDS — `side` 1)", async () => {
-    const w = await w3Setup("w3-sibling-orphan", { flushDeadlineMs: 30_000 });
+  /** Tags the ONE retryable failure of the sibling-orphan step: the
+   * held-wave probe finding the emitter's flushed "ping" durable — the
+   * structural ungated-tail window (OW57). Nothing else throws this. */
+  class A3StructuralWindow extends Error {}
+
+  /** The sibling-orphan construction, extracted whole so the bounded
+   * accept-and-retry below can re-run it FRESH (the window lottery is
+   * per-construction — a bare re-assert would just re-fail): every
+   * attempt gets its own doc/stream prefix, host tenure, and client. */
+  const runSiblingOrphanConstruction = async (prefix: string) => {
+    const w = await w3Setup(prefix, { flushDeadlineMs: 30_000 });
     const cancels: Array<() => void> = [];
     const gate = Promise.withResolvers<void>();
     const sideClient = clientRuntime.getCell<{ n?: number }>(
       space,
-      "w3-sibling-orphan-side",
+      `${prefix}-side`,
       undefined,
     );
     await sideClient.sync();
@@ -2785,7 +2794,7 @@ describe("Phase 3 events-down (serving side)", () => {
     }
     const sideServing = w.serving.getCell<{ n?: number }>(
       space,
-      "w3-sibling-orphan-side",
+      `${prefix}-side`,
       undefined,
     );
     await sideServing.sync();
@@ -2819,7 +2828,7 @@ describe("Phase 3 events-down (serving side)", () => {
       ));
       const trigger = w.serving.getCell<{ v?: number }>(
         space,
-        "w3-sibling-orphan-trigger",
+        `${prefix}-trigger`,
         undefined,
       );
       await trigger.sync();
@@ -2876,7 +2885,32 @@ describe("Phase 3 events-down (serving side)", () => {
         );
         // The wave is HELD: nothing of it has reached the store yet (the
         // sidecar holds no "ping" entry) — the rival below races it.
-        expect(w.entriesOf(w.sidecarOf(w.s2))).toEqual([]);
+        // The one shape this probe can see that is NOT a regression is
+        // the structural ungated-tail window: the serving cycle's
+        // committing tail (watermark commit → notice settle → seal-chain
+        // drain → commitWave) runs AFTER the settle's only inputSynced
+        // consultation, so an emitter interleaving into those awaits
+        // flushes past an ARMED gate (space-server.ts #waveCycle; the
+        // OW57 audit). That shape — the flushed ping durable here, and
+        // nothing else — throws the TAGGED error the bounded retry
+        // below absorbs once; anything else fails loud, first time.
+        {
+          const durableAtProbe = w.entriesOf(w.sidecarOf(w.s2));
+          if (
+            durableAtProbe.length > 0 &&
+            durableAtProbe.every((entry) =>
+              (entry.payload as { tag?: string } | undefined)?.tag === "ping"
+            )
+          ) {
+            throw new A3StructuralWindow(
+              `the held-wave probe found the emitter's ping durable ` +
+                `(${durableAtProbe.length} entry/entries) — the ` +
+                `committing-tail window admitted the wave past the ` +
+                `armed settle gate`,
+            );
+          }
+          expect(durableAtProbe).toEqual([]);
+        }
         w.s2.send({ tag: "rival" } as never);
         await clientRuntime.idle();
         await clientRuntime.storageManager.synced();
@@ -2942,6 +2976,50 @@ describe("Phase 3 events-down (serving side)", () => {
     } finally {
       gate.resolve();
       for (const cancel of cancels) cancel();
+    }
+  };
+
+  it("(α3) + a same-eventId SIBLING tx (independent review M1): the LT1 copy of a DERIVATION emitter's superseded append commits a sibling event-handler-stamped tx (the served navigateTo intent shape) inside the same wave; the orphan refusal must take the SIBLING down with the handler's contribution — neither half of an orphan lands (a navigation intent enacted for an event with zero durable entries is events.md §4's FORBIDDEN half-delivery); the refusal is counted once per EVENT (mutation: the sibling fold removed → the handler half is refused, the intent half LANDS — `side` 1) — bounded accept-and-retry on the structural window (OW57, RULED 2026-08-24)", async () => {
+    // OW57, RULED 2026-08-24 (owner, verbatim: "agreed with your
+    // recommendation: bounded accept-and-retry for now"). The audit
+    // behind the ruling (#6223's settle-gate seam audit): the serving
+    // cycle's committing tail admits seals AFTER the settle's only
+    // inputSynced consultation, so no test-side held-wave construction
+    // can be sound against an emitter that interleaves there — three
+    // arming constructions (the #6184 handler arm, a drain-sync seam,
+    // the queue seam this step keeps) failed on the identical CI
+    // signature, 5 identical observations. Bounded: TWO attempts total;
+    // ONLY the tagged structural signature retries (the held-wave probe
+    // finding the flushed ping durable — A3StructuralWindow); every
+    // other failure, the title's mutation pins included, propagates on
+    // the FIRST attempt. Each attempt re-runs the FULL construction
+    // (fresh prefix, fresh host tenure, fresh client) — the window
+    // lottery is per-construction. An absorbed hit logs the greppable
+    // marker "a3-structural-window-retry (OW57)": CI occurrences stay
+    // countable, the evidence base for the eventual tail-seam decision.
+    for (let attempt = 1;; attempt++) {
+      try {
+        await runSiblingOrphanConstruction(`w3-sibling-orphan-a${attempt}`);
+        return;
+      } catch (error) {
+        if (attempt < 2 && error instanceof A3StructuralWindow) {
+          console.warn(
+            `a3-structural-window-retry (OW57): attempt ${attempt} hit ` +
+              `the structural ungated-tail window — ${error.message}; ` +
+              `re-running the full construction (bounded: 2 attempts)`,
+          );
+          // The re-run needs the first construction torn down: the host
+          // holds the space lease and serving tenure, the client its
+          // session. (The suite's afterEach tears down only the CURRENT
+          // pair.)
+          await host?.close();
+          host = undefined;
+          await clientRuntime?.dispose();
+          await clientManager?.close();
+          continue;
+        }
+        throw error;
+      }
     }
   });
 


### PR DESCRIPTION
## Why

The "(α3) + a same-eventId SIBLING tx (independent review M1)" step in `executor-events-down.test.ts` reds on CI-speed runners with one signature — the held-wave probe's `toEqual([])` receiving the emitter's durable (often consequenced) ping — while local runs stay green. **Three arming constructions failed on that identical signature** (#6184's arm-from-the-handler; a drain-sync seam; #6233's queue seam, whose arming is provably synchronous with the sealed append), across **5 identical CI observations** on #6223's boards. That forced the settle-gate seam audit (#6223, comment 5401826757), which settled the mechanism in code:

- The serving cycle's ONLY `inputSynced` consultation — the suite's settle-gate seam — sits inside the settle race (`packages/runner/src/executor/space-server.ts` `#waveCycle` `:3727`).
- The cycle's **committing tail runs after the settle break with no further gate sample**: watermark `tx.commit()` `:3979` → notice settle `:3998` → wave capture `:4002` → `await #sealChain` `:4005` → `commitWave` `:4046`. Seals landing in those awaits join the closing wave and flush **past an armed gate**.
- The settle is a **watermark barrier, not an admission barrier** (W never claims tail seqs — no product defect asserted), and even a held gate only *delays*: the deadline arm commits what is sealed so far.

So **no test-side held-wave construction can be sound** against an emitter that interleaves into the tail. Owner ruling (2026-08-24, verbatim): *"agreed with your recommendation: bounded accept-and-retry for now"*.

## What Changed

Test file + register row only:

- The M1 step's construction is extracted whole (`runSiblingOrphanConstruction`) and re-run **fresh** per attempt — per-attempt doc/stream prefix, host tenure, and client, because the window lottery is per-construction. **Bounded: 2 attempts total.**
- **Only the tagged structural signature retries**: the held-wave probe finding the flushed ping durable (every durable entry `tag === "ping"`) throws `A3StructuralWindow`; any other durable content falls through to the plain assertion, and **every other failure propagates on the first attempt**.
- Absorbed hits log the greppable marker **`a3-structural-window-retry (OW57)`** — CI occurrences stay countable, the evidence base for the row's destination (a product-side seam on the committing tail, as its own considered change).
- The queue-seam arming + `armingGap` discriminator stay exactly as #6233 merged them — construction soundness is orthogonal to the retry.
- The plain (α3) ORPHAN step shares the construction class but is **not pre-wrapped** (the ruling's scope is "for now", the observed step); the OW57 row records that it inherits this disposition if it ever fires the same signature.
- OW57 row: RULED marker + the owner's verbatim + the audit's citations + the tail-seam destination + the inheritance note.

## Test plan

- Suite green at this tree: `executor-events-down.test.ts` 22/22 steps; fmt/lint clean.
- **Forced-window verification** (both arms disarmed in a scratch run): attempt 1 tagged, marker logged exactly once, attempt 2 re-ran the full construction fresh (the between-attempts teardown exercised — host lease + client session) and propagated `A3StructuralWindow` — the bound holds.
- **Mutation verification** (the title's own mutation — the sibling fold `eventOrphaned` neutralized in `wave.ts`, scratch run): the step reds on the **first** attempt at the `side = 0` assert with **zero** retry markers — the filter cannot absorb a real orphan-refusal regression, because it engages only on the tagged probe.

Context: OW57 / CT-2060 (the row carries the full history), #6184 (first arming), #6233 (queue seam + discriminator), #6223 (the boards that produced the 5 observations and the seam audit).

Do not merge — the coordinator reviews and merges; #6223 then takes a fresh merge-of-main to pick this up (a rerun would reuse the old snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

