### PR TITLE
The startup banner names what is unusual, not everything resolved

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -66,12 +66,14 @@ than experimental-feature gates are listed in
 These flags make up the `ExperimentalOptions` interface in
 [`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). They
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
-`undefined`, which means "take the built-in default". `commitPreconditions`,
-`plainResultReceipts`, `computedCellIds` and `lazyMaterialization` default on;
-`serverExecution` resolves an unset flag to the ONE first-party default
-`SERVER_EXECUTION_DEFAULT_ENABLED` in the deployed-topology presets — `false`
-today, Phase 7 having landed flip-ready DARK (its section); the other flags in
-this category default off unless their section says otherwise.
+`undefined`, which means "take the built-in default", and what that default is
+for every flag is `EXPERIMENTAL_DEFAULTS` in the same file — one table rather
+than a list here that could drift from it. Read it there; today
+`contentAddressedSchemas`, `commitPreconditions`, `plainResultReceipts`,
+`computedCellIds` and `lazyMaterialization` are on and the rest are off.
+`serverExecution` is the one whose entry is not a literal: it is the ONE
+first-party default `SERVER_EXECUTION_DEFAULT_ENABLED`, `false` today, Phase 7
+having landed flip-ready DARK (its section).
 
 The mapping from environment variable to flag is defined once, canonically, as
 `EXPERIMENTAL_ENV_VARS` in
@@ -1402,12 +1404,26 @@ For the enforcement mode in the interactive tools, use `CF_CFC_MODE`.
 
 ## Verifying flags are working
 
-When any experimental flag is explicitly overridden, the `Runtime` constructor
-logs it on startup, for example:
+When a `Runtime` runs a flag at anything other than its built-in default, the
+constructor names it on startup, for example:
 
 ```
-Experimental flag overrides: modernCellRep=true
+Non-default experimental flags: modernCellRep=true
 ```
+
+A runtime running every default says nothing, which is what makes the line
+worth reading: it answers "is this process running something unusual?", and a
+listing of every flag it resolved would bury that answer. Two constructions
+pass flags explicitly while running nothing unusual, and neither prints — the
+deployed-topology presets, which select the fleet's own server-execution arm on
+every toolshed start and every `cf` command, and a client that adopted a stock
+deployment's whole posture ([Clients that are not built alongside their
+server](#clients-that-are-not-built-alongside-their-server)).
+
+`serverExecution` is reported only when a construction SELECTED an arm other
+than the first-party default. A flag-less runtime in a serving process inherits
+the process's arm through the ambient flag rather than choosing one, so naming
+it there would claim a decision that runtime did not make.
 
 - Server-side: look in the toolshed log.
 - Browser-side: look in the browser developer console (the message comes from
@@ -1438,12 +1454,19 @@ design docs).
 ## Implementation details
 
 The Category 1 flags are declared as the `ExperimentalOptions` interface in
-[`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts). The
-`Runtime` constructor merges the provided flags with the built-in defaults
-(`commitPreconditions`, `plainResultReceipts`, and `computedCellIds` true, the
-other Category 1 flags false), propagates each one to its ambient control point,
-and then reads the effective state back so that `runtime.experimental.*`
+[`packages/runner/src/runtime.ts`](../../packages/runner/src/runtime.ts),
+beside `EXPERIMENTAL_DEFAULTS`, the total record of what each one is worth
+unset. The `Runtime` constructor propagates the flags it was given to their
+ambient control points and reads the effective state back, then fills what is
+still unset from that table, so `runtime.experimental.*` carries every flag and
 reflects what is actually in effect.
+
+The order matters and is not free to change: an unset flag has to reach the
+ambient setters as `undefined`, which they read as "leave the process's state
+alone". Writing a default in before that point would have a flag-less
+construction stomp what a co-hosted runtime established. The startup banner
+comes last, from `nonDefaultExperimentalFlags`, which compares the resolved
+posture against that same table.
 
 First-party construction config is centralized in
 [`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts),

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -68,7 +68,8 @@ These flags make up the `ExperimentalOptions` interface in
 are passed as `new Runtime({ experimental: { ... } })`. Each flag defaults to
 `undefined`, which means "take the built-in default", and what that default is
 for every flag is `EXPERIMENTAL_DEFAULTS` in the same file — one table rather
-than a list here that could drift from it. Read it there; today
+than a list here that could drift from it, aggregating the ambient flags'
+defaults from the modules that own them. Read it there; today
 `contentAddressedSchemas`, `commitPreconditions`, `plainResultReceipts`,
 `computedCellIds` and `lazyMaterialization` are on and the rest are off.
 `serverExecution` is the one whose entry is not a literal: it is the ONE
@@ -1466,7 +1467,17 @@ ambient setters as `undefined`, which they read as "leave the process's state
 alone". Writing a default in before that point would have a flag-less
 construction stomp what a co-hosted runtime established. The startup banner
 comes last, from `nonDefaultExperimentalFlags`, which compares the resolved
-posture against that same table.
+posture against that same table — `serverExecution` excepted, and read from
+what the construction selected, so an arm inherited from the process is not
+reported as this runtime's divergence.
+
+Three entries in the table are imported from the module that owns the flag's
+ambient control point rather than written out: `MODERN_CELL_REP_DEFAULT`,
+`CONTENT_ADDRESSED_SCHEMAS_DEFAULT` and `COMMIT_PRECONDITIONS_DEFAULT`. What an
+unset runtime resolves for those is that module's own state, so a value
+restated here would say what the default is without being able to change it —
+and this table is where the change is meant to be made. The other four have no
+ambient home, so the table is their declaration.
 
 First-party construction config is centralized in
 [`packages/runner/src/runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts),

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -19,13 +19,21 @@ import type { FabricPlainObject } from "@/interface.ts";
 // Configuration flags
 //
 
+/**
+ * What the flag is worth when nothing sets it. Named because the runner's
+ * `EXPERIMENTAL_DEFAULTS` aggregates it: a table that restated the value
+ * instead would say what an unset runtime runs without being able to change
+ * it, since the runtime reads this module's state back rather than the table.
+ */
+export const MODERN_CELL_REP_DEFAULT = false;
+
 /** Module-level flag for the modern cell representation. */
-let modernCellRepEnabled = false;
+let modernCellRepEnabled: boolean = MODERN_CELL_REP_DEFAULT;
 
 /** Activates or deactivates the modern cell representation flag. */
 export function setModernCellRepConfig(enabled?: boolean): void {
   if (enabled !== undefined) {
-    modernCellRepEnabled = enabled ?? false;
+    modernCellRepEnabled = enabled;
   }
 }
 
@@ -36,7 +44,7 @@ export function getModernCellRepConfig(): boolean {
 
 /** Restores the modern cell representation flag to its default. */
 export function resetModernCellRepConfig(): void {
-  modernCellRepEnabled = false;
+  modernCellRepEnabled = MODERN_CELL_REP_DEFAULT;
 }
 
 //

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1388,7 +1388,15 @@ const memoryLiveEnvironment = new NullLiveEnvironment(
 // These ambient flags and the memory protocol flags below are catalogued, with
 // their defaults and removal paths, in docs/development/EXPERIMENTAL_OPTIONS.md.
 // Update that registry when adding or removing one.
-let commitPreconditionsEnabled = true;
+/**
+ * What `commitPreconditions` is worth when nothing sets it. Named because the
+ * runner's `EXPERIMENTAL_DEFAULTS` aggregates it rather than restating it: a
+ * restated copy could not change what an unset runtime runs, because the
+ * runtime reads this module's state back.
+ */
+export const COMMIT_PRECONDITIONS_DEFAULT = true;
+
+let commitPreconditionsEnabled: boolean = COMMIT_PRECONDITIONS_DEFAULT;
 let syncSchemaTableEnabled = true;
 let ownWriteEchoEnabled = true;
 
@@ -1482,7 +1490,7 @@ export function acquireServerExecutionEnabler(): () => void {
  * but the memory protocol needs the value during client/server handshakes.
  */
 export function setCommitPreconditionsConfig(enabled?: boolean): void {
-  commitPreconditionsEnabled = enabled ?? true;
+  commitPreconditionsEnabled = enabled ?? COMMIT_PRECONDITIONS_DEFAULT;
 }
 
 export function getCommitPreconditionsConfig(): boolean {
@@ -1490,7 +1498,7 @@ export function getCommitPreconditionsConfig(): boolean {
 }
 
 export function resetCommitPreconditionsConfig(): void {
-  commitPreconditionsEnabled = true;
+  commitPreconditionsEnabled = COMMIT_PRECONDITIONS_DEFAULT;
 }
 
 /**

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -25,6 +25,7 @@ export type {
   RuntimeOptions,
   SpaceCellContents,
 } from "./runtime.ts";
+export { EXPERIMENTAL_DEFAULTS } from "./runtime.ts";
 export {
   ADOPT_SERVER_FLAGS_ENV,
   type BrowserWorkerPresetParams,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -16,6 +16,7 @@ import {
   resolveScopeKey,
   type ScopeKey,
   type ScopeKeyIdentity,
+  SERVER_EXECUTION_DEFAULT_ENABLED,
   serverExecutionEnablerCount,
   setCommitPreconditionsConfig,
   setServerExecutionConfig,
@@ -277,6 +278,68 @@ export interface ExperimentalOptions {
    * unlike v1's SERVER_PRIMARY_EXECUTION so archived docs never alias it.
    */
   serverExecution?: boolean | undefined;
+}
+
+/**
+ * What every experimental flag is worth when nothing sets it: the value a
+ * `Runtime` resolves an unset flag to, and the baseline
+ * {@link nonDefaultExperimentalFlags} reports divergence from.
+ *
+ * Written here so it is written once. The values were previously spread
+ * across the constructor and three ambient modules, and restated in prose in
+ * `docs/development/EXPERIMENTAL_OPTIONS.md`; that copy could drift from the
+ * code without anything noticing. Typed as a total record over the flags, so
+ * a new flag does not compile until it declares what "unset" means for it.
+ *
+ * The bound on that: this table is what a flag defaults TO, not what any
+ * given process is running. Three flags reach the process through ambient
+ * control points that a co-hosted runtime can move, and the constructor reads
+ * the effective value back rather than assuming this one.
+ */
+export const EXPERIMENTAL_DEFAULTS = {
+  modernCellRep: false,
+  contentAddressedSchemas: true,
+  commitPreconditions: true,
+  plainResultReceipts: true,
+  computedCellIds: true,
+  lazyMaterialization: true,
+  systemPatternAutoUpdate: false,
+  // The ONE first-party default (server-execution v2 Phase 7): the arm the
+  // fleet runs when nobody selects one. Deliberately not the ambient
+  // zero-value `false`, which is what a flag-less construction inherits
+  // rather than what a deployment means by "default". This entry is a
+  // BASELINE only — the constructor never falls back to it, because a
+  // flag-less runtime reads the process's ambient arm instead.
+  serverExecution: SERVER_EXECUTION_DEFAULT_ENABLED,
+} as const satisfies Record<keyof ExperimentalOptions, boolean>;
+
+/**
+ * The flags a runtime runs that are not {@link EXPERIMENTAL_DEFAULTS}, as
+ * `name=value` strings, in flag order. What the startup banner reports:
+ * telling an operator what is unusual about this process is the question the
+ * banner exists to answer, and a list of everything it resolved buries that.
+ *
+ * `resolved` is the runtime's effective posture; `selected` is what its
+ * caller passed. The two differ only where an ambient control point carries
+ * a value nobody here chose, and `serverExecution` is the one flag read from
+ * `selected` for exactly that reason: a flag-less runtime in a serving
+ * process inherits the process's arm rather than choosing one, so reporting
+ * it as this runtime's divergence would be a claim about a decision it did
+ * not make.
+ */
+export function nonDefaultExperimentalFlags(
+  resolved: ExperimentalOptions,
+  selected: ExperimentalOptions,
+): string[] {
+  const flags: string[] = [];
+  for (const [flag, byDefault] of Object.entries(EXPERIMENTAL_DEFAULTS)) {
+    const key = flag as keyof ExperimentalOptions;
+    const value = key === "serverExecution" ? selected[key] : resolved[key];
+    if (value !== undefined && value !== byDefault) {
+      flags.push(`${key}=${value}`);
+    }
+  }
+  return flags;
 }
 
 /**
@@ -1205,42 +1268,8 @@ export class Runtime {
           "would silently bypass the custom provider for acting runs.",
       );
     }
-    this.experimental = {
-      modernCellRep: undefined,
-      commitPreconditions: undefined,
-      plainResultReceipts: undefined,
-      computedCellIds: undefined,
-      lazyMaterialization: undefined,
-      serverExecution: undefined,
-      ...options.experimental,
-    };
-
-    // Log any overridden experimental flags. Never on stdout: the cf CLI's
-    // machine-readable output (`cf piece ls` etc.) is consumed by scripts, and
-    // this banner made every command's stdout non-empty under a flag override.
-    // Not console.error/warn either: the cf test console enforcement fails
-    // tests on those. Direct process stderr in Deno; plain console in browser
-    // realms (no stdout contract there).
-    const overrideFlags = Object.entries(this.experimental)
-      .filter(([_, v]) => v !== undefined)
-      .map(([k, v]) => `${k}=${v}`);
-    if (overrideFlags.length > 0) {
-      const banner = `Experimental flag overrides: ${overrideFlags.join(", ")}`;
-      if (typeof Deno !== "undefined" && Deno.stderr) {
-        Deno.stderr.writeSync(new TextEncoder().encode(banner + "\n"));
-      } else {
-        console.log(banner);
-      }
-    }
-
-    // Unlike ambient flags, computedCellIds and plainResultReceipts are
-    // consumed from this Runtime instance (the builder frame and the runner's
-    // receipt-only branch respectively). Normalize their local defaults after
-    // override logging so an omitted option does not appear as an explicit
-    // `true` override.
-    this.experimental.computedCellIds ??= true;
-    this.experimental.plainResultReceipts ??= true;
-    this.experimental.lazyMaterialization ??= true;
+    const selectedExperimental = options.experimental ?? {};
+    this.experimental = { ...selectedExperimental };
 
     // Propagate experimental flags to their ambient control points, then read
     // back the effective state so `experimental.*` reflects what is actually in
@@ -1289,6 +1318,35 @@ export class Runtime {
     // flag-less construction reads the ambient state through.
     this.experimental.serverExecution = this.#explicitServerExecution ??
       getServerExecutionConfig();
+
+    // The flags with no ambient home — consumed from this instance, by the
+    // builder frame, the runner's receipt-only branch, the lift materializer
+    // and the pattern updater — take their defaults here. `??=`, because the
+    // read-backs above already resolved every other flag.
+    for (const [flag, byDefault] of Object.entries(EXPERIMENTAL_DEFAULTS)) {
+      const key = flag as keyof ExperimentalOptions;
+      this.experimental[key] ??= byDefault;
+    }
+
+    // What is unusual about this process, and nothing else: an operator reads
+    // this to check a flag took effect, and a list of everything resolved
+    // buries the answer. Never on stdout — the cf CLI's machine-readable
+    // output (`cf piece ls` etc.) is consumed by scripts, and this banner made
+    // every command's stdout non-empty. Not console.error/warn either: the cf
+    // test console enforcement fails tests on those. Direct process stderr in
+    // Deno; plain console in browser realms (no stdout contract there).
+    const nonDefault = nonDefaultExperimentalFlags(
+      this.experimental,
+      selectedExperimental,
+    );
+    if (nonDefault.length > 0) {
+      const banner = `Non-default experimental flags: ${nonDefault.join(", ")}`;
+      if (typeof Deno !== "undefined" && Deno.stderr) {
+        Deno.stderr.writeSync(new TextEncoder().encode(banner + "\n"));
+      } else {
+        console.log(banner);
+      }
+    }
     this.servingPosture = options.servingPosture === true;
     // Everything below can throw (URL parsing, host validation, engine
     // construction). The enabler claimed above is process-global state,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -288,17 +288,19 @@ export interface ExperimentalOptions {
  * `Runtime` resolves an unset flag to, and the baseline
  * {@link nonDefaultExperimentalFlags} reports divergence from.
  *
- * Written here so it is written once. The values were previously spread
- * across the constructor and three ambient modules, and restated in prose in
- * `docs/development/EXPERIMENTAL_OPTIONS.md`; that copy could drift from the
- * code without anything noticing. Typed as a total record over the flags, so
- * a new flag does not compile until it declares what "unset" means for it.
+ * The one place to look a default up. They were previously spread across the
+ * constructor and three ambient modules and restated in prose in
+ * `docs/development/EXPERIMENTAL_OPTIONS.md`, where the copy could drift from
+ * the code without anything noticing. Typed as a total record over the flags,
+ * so a new flag does not compile until it declares what "unset" means for it.
  *
- * The bound on that: this table is what a flag defaults TO, not what any
- * given process is running. The three ambient flags can be moved by a
+ * Two bounds on that. This table is what a flag defaults TO, not what any
+ * given process is running: the three ambient flags can be moved by a
  * co-hosted runtime, and the constructor reads the effective value back
- * rather than assuming this one — which is also why their entries here are
- * imported from the module that owns each default rather than written out.
+ * rather than assuming this one. And it is not the sole DECLARATION site —
+ * those three defaults belong to the module that owns each control point, and
+ * are imported rather than restated, because a copy here could state a
+ * default without being able to move it.
  */
 export const EXPERIMENTAL_DEFAULTS = {
   // Three flags reach the process through an ambient control point in a lower
@@ -331,13 +333,16 @@ export const EXPERIMENTAL_DEFAULTS = {
  * telling an operator what is unusual about this process is the question the
  * banner exists to answer, and a list of everything it resolved buries that.
  *
- * `resolved` is the runtime's effective posture; `selected` is what its
- * caller passed. The two differ only where an ambient control point carries
- * a value nobody here chose, and `serverExecution` is the one flag read from
- * `selected` for exactly that reason: a flag-less runtime in a serving
- * process inherits the process's arm rather than choosing one, so reporting
- * it as this runtime's divergence would be a claim about a decision it did
- * not make.
+ * `resolved` is the runtime's effective posture, every flag present; `selected`
+ * is what its caller passed, which omits whatever it left unset. Reading from
+ * `resolved` is what lets an ambient value a co-hosted runtime established be
+ * reported, and costs nothing for an unset flag, which resolves to its default
+ * and is suppressed either way.
+ *
+ * `serverExecution` is the one flag read from `selected` instead: a flag-less
+ * runtime in a serving process inherits the process's arm rather than choosing
+ * one, so reporting it as this runtime's divergence would be a claim about a
+ * decision it did not make.
  */
 export function nonDefaultExperimentalFlags(
   resolved: ExperimentalOptions,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1,5 +1,6 @@
 import {
   getModernCellRepConfig,
+  MODERN_CELL_REP_DEFAULT,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -9,6 +10,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   acquireServerExecutionEnabler,
+  COMMIT_PRECONDITIONS_DEFAULT,
   commitPreconditionValueHash,
   getCommitPreconditionsConfig,
   getServerExecutionConfig,
@@ -24,6 +26,7 @@ import {
 } from "@commonfabric/memory/v2";
 import { RuntimeTelemetry } from "@commonfabric/runner";
 import {
+  CONTENT_ADDRESSED_SCHEMAS_DEFAULT,
   getContentAddressedSchemasConfig,
   setContentAddressedSchemasConfig,
 } from "./schema-doc-config.ts";
@@ -292,14 +295,23 @@ export interface ExperimentalOptions {
  * a new flag does not compile until it declares what "unset" means for it.
  *
  * The bound on that: this table is what a flag defaults TO, not what any
- * given process is running. Three flags reach the process through ambient
- * control points that a co-hosted runtime can move, and the constructor reads
- * the effective value back rather than assuming this one.
+ * given process is running. The three ambient flags can be moved by a
+ * co-hosted runtime, and the constructor reads the effective value back
+ * rather than assuming this one — which is also why their entries here are
+ * imported from the module that owns each default rather than written out.
  */
 export const EXPERIMENTAL_DEFAULTS = {
-  modernCellRep: false,
-  contentAddressedSchemas: true,
-  commitPreconditions: true,
+  // Three flags reach the process through an ambient control point in a lower
+  // layer, and that module's own state is what an unset runtime resolves. The
+  // value is imported from there rather than restated here: a copy could say
+  // what the default is without being able to change it, and this table is
+  // advertised as the place to change one.
+  modernCellRep: MODERN_CELL_REP_DEFAULT,
+  contentAddressedSchemas: CONTENT_ADDRESSED_SCHEMAS_DEFAULT,
+  commitPreconditions: COMMIT_PRECONDITIONS_DEFAULT,
+  // These four have no ambient home — they are consumed from the Runtime
+  // instance — so this table IS their declaration, and changing one here
+  // changes what an unset runtime runs.
   plainResultReceipts: true,
   computedCellIds: true,
   lazyMaterialization: true,

--- a/packages/runner/src/schema-doc-config.ts
+++ b/packages/runner/src/schema-doc-config.ts
@@ -14,7 +14,15 @@
  * turning it off stops emission without un-writing anything.
  */
 
-let contentAddressedSchemas = true;
+/**
+ * What the flag is worth when nothing sets it. Named because the runner's
+ * `EXPERIMENTAL_DEFAULTS` aggregates this value rather than restating it: a
+ * restated copy could not change what an unset runtime runs, because the
+ * runtime reads this module's state back rather than that table.
+ */
+export const CONTENT_ADDRESSED_SCHEMAS_DEFAULT = true;
+
+let contentAddressedSchemas: boolean = CONTENT_ADDRESSED_SCHEMAS_DEFAULT;
 
 /**
  * Sets the flag; `undefined` keeps the current state (the built-in default
@@ -33,5 +41,5 @@ export function getContentAddressedSchemasConfig(): boolean {
 
 /** Restores the flag to its default. */
 export function resetContentAddressedSchemasConfig(): void {
-  contentAddressedSchemas = true;
+  contentAddressedSchemas = CONTENT_ADDRESSED_SCHEMAS_DEFAULT;
 }

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -22,7 +22,13 @@ import { ExecutorHost } from "../src/executor/host.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-import { Runtime } from "../src/runtime.ts";
+import {
+  EXPERIMENTAL_DEFAULTS,
+  type ExperimentalOptions,
+  nonDefaultExperimentalFlags,
+  Runtime,
+} from "../src/runtime.ts";
+import { runtimePresets } from "../src/runtime-presets.ts";
 
 const signer = await Identity.fromPassphrase("test experimental");
 
@@ -54,6 +60,7 @@ describe("ExperimentalOptions", () => {
         plainResultReceipts: false,
         computedCellIds: false,
         lazyMaterialization: false,
+        systemPatternAutoUpdate: false,
         serverExecution: false,
       });
       await runtime.dispose();
@@ -76,6 +83,7 @@ describe("ExperimentalOptions", () => {
         plainResultReceipts: true,
         computedCellIds: true,
         lazyMaterialization: true,
+        systemPatternAutoUpdate: false,
         serverExecution: false,
       });
       await runtime.dispose();
@@ -96,10 +104,147 @@ describe("ExperimentalOptions", () => {
         plainResultReceipts: true,
         computedCellIds: true,
         lazyMaterialization: true,
+        systemPatternAutoUpdate: false,
         serverExecution: false,
       });
       await runtime.dispose();
       await sm.close();
+    });
+  });
+
+  // What the startup banner reports. It exists so an operator can check that
+  // a flag took effect, and the answer to that is what is UNUSUAL about this
+  // process — a list of everything resolved buries it. Two ways that went
+  // wrong before the defaults table: the deployed presets select the fleet's
+  // own server-execution arm explicitly, and a client that is not built
+  // alongside its server adopts the deployment's whole posture explicitly, so
+  // both printed a banner on every construction while running nothing unusual.
+  describe("nonDefaultExperimentalFlags()", () => {
+    const resolved = (over: ExperimentalOptions = {}): ExperimentalOptions => ({
+      ...EXPERIMENTAL_DEFAULTS,
+      ...over,
+    });
+
+    it("returns nothing for a runtime running every default", () => {
+      expect(nonDefaultExperimentalFlags(resolved(), {})).toEqual([]);
+    });
+
+    it("names a default-off flag that is on", () => {
+      expect(nonDefaultExperimentalFlags(resolved({ modernCellRep: true }), {}))
+        .toEqual(["modernCellRep=true"]);
+    });
+
+    it("names a default-on flag that is off", () => {
+      expect(
+        nonDefaultExperimentalFlags(
+          resolved({ lazyMaterialization: false }),
+          {},
+        ),
+      ).toEqual(["lazyMaterialization=false"]);
+    });
+
+    it("names every diverging flag, in flag order", () => {
+      expect(
+        nonDefaultExperimentalFlags(
+          resolved({ modernCellRep: true, computedCellIds: false }),
+          {},
+        ),
+      ).toEqual(["modernCellRep=true", "computedCellIds=false"]);
+    });
+
+    it("says nothing of an unselected serverExecution, whatever the process resolved", () => {
+      // A flag-less runtime in a serving process inherits the process's arm
+      // rather than choosing one; reporting that as ITS divergence would be a
+      // claim about a decision it did not make.
+      expect(
+        nonDefaultExperimentalFlags(
+          resolved({ serverExecution: !EXPERIMENTAL_DEFAULTS.serverExecution }),
+          {},
+        ),
+      ).toEqual([]);
+    });
+
+    it("says nothing of a serverExecution selected at the fleet default", () => {
+      // The deployed-topology presets always pass it, so this is the case
+      // that used to print on every toolshed start and every cf command.
+      expect(
+        nonDefaultExperimentalFlags(resolved(), {
+          serverExecution: EXPERIMENTAL_DEFAULTS.serverExecution,
+        }),
+      ).toEqual([]);
+    });
+
+    it("names a serverExecution arm selected against the fleet default", () => {
+      const other = !EXPERIMENTAL_DEFAULTS.serverExecution;
+      expect(
+        nonDefaultExperimentalFlags(resolved({ serverExecution: other }), {
+          serverExecution: other,
+        }),
+      ).toEqual([`serverExecution=${other}`]);
+    });
+  });
+
+  describe("the startup banner", () => {
+    /** Runs `body` with this process's stderr captured. */
+    const captureStderr = async (
+      body: () => Promise<void>,
+    ): Promise<string> => {
+      const stderr = Deno.stderr as unknown as {
+        writeSync: (bytes: Uint8Array) => number;
+      };
+      const real = stderr.writeSync.bind(Deno.stderr);
+      let written = "";
+      stderr.writeSync = (bytes: Uint8Array) => {
+        written += new TextDecoder().decode(bytes);
+        return bytes.length;
+      };
+      try {
+        await body();
+      } finally {
+        stderr.writeSync = real;
+      }
+      return written;
+    };
+
+    const withRuntime = async (
+      experimental: ExperimentalOptions,
+      preset: "unitTest" | "productionServer",
+    ): Promise<string> => {
+      const sm = StorageManager.emulate({ as: signer });
+      const options = { apiUrl: new URL(import.meta.url), storageManager: sm };
+      const written = await captureStderr(async () => {
+        const runtime = new Runtime(
+          preset === "productionServer"
+            ? runtimePresets.productionServer({ ...options, experimental })
+            : runtimePresets.unitTest({ ...options, experimental }),
+        );
+        await runtime.dispose();
+      });
+      await sm.close();
+      return written;
+    };
+
+    it("stays quiet for a runtime running the defaults", async () => {
+      expect(await withRuntime({}, "unitTest")).toBe("");
+    });
+
+    it("stays quiet for a deployed server, which selects the fleet's own arm", async () => {
+      // `productionServer` resolves an unset serverExecution to the
+      // first-party default, so this construction passes it explicitly while
+      // running nothing unusual.
+      expect(await withRuntime({}, "productionServer")).toBe("");
+    });
+
+    it("stays quiet for a client that adopted a stock deployment's posture", async () => {
+      // What `experimentalOptionsForDeployedClient` hands a cf binary when
+      // the deployment runs defaults: every flag explicit, nothing unusual.
+      expect(await withRuntime({ ...EXPERIMENTAL_DEFAULTS }, "unitTest"))
+        .toBe("");
+    });
+
+    it("names what a runtime runs off its default", async () => {
+      expect(await withRuntime({ modernCellRep: true }, "unitTest"))
+        .toBe("Non-default experimental flags: modernCellRep=true\n");
     });
   });
 

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -112,13 +112,6 @@ describe("ExperimentalOptions", () => {
     });
   });
 
-  // What the startup banner reports. It exists so an operator can check that
-  // a flag took effect, and the answer to that is what is UNUSUAL about this
-  // process — a list of everything resolved buries it. Two ways that went
-  // wrong before the defaults table: the deployed presets select the fleet's
-  // own server-execution arm explicitly, and a client that is not built
-  // alongside its server adopts the deployment's whole posture explicitly, so
-  // both printed a banner on every construction while running nothing unusual.
   describe("EXPERIMENTAL_DEFAULTS", () => {
     it("is what a runtime with no flags set actually resolves", async () => {
       // The table is advertised as the place to change a default, so an entry
@@ -152,6 +145,13 @@ describe("ExperimentalOptions", () => {
     });
   });
 
+  // What the startup banner reports. It exists so an operator can check that
+  // a flag took effect, and the answer to that is what is UNUSUAL about this
+  // process — a list of everything resolved buries it. Two ways that went
+  // wrong before the defaults table: the deployed presets select the fleet's
+  // own server-execution arm explicitly, and a client that is not built
+  // alongside its server adopts the deployment's whole posture explicitly, so
+  // both printed a banner on every construction while running nothing unusual.
   describe("nonDefaultExperimentalFlags()", () => {
     const resolved = (over: ExperimentalOptions = {}): ExperimentalOptions => ({
       ...EXPERIMENTAL_DEFAULTS,

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -119,6 +119,39 @@ describe("ExperimentalOptions", () => {
   // own server-execution arm explicitly, and a client that is not built
   // alongside its server adopts the deployment's whole posture explicitly, so
   // both printed a banner on every construction while running nothing unusual.
+  describe("EXPERIMENTAL_DEFAULTS", () => {
+    it("is what a runtime with no flags set actually resolves", async () => {
+      // The table is advertised as the place to change a default, so an entry
+      // that only SAYS what the default is would be worse than none: three
+      // flags resolve from an ambient module's own state, and a restated copy
+      // could not move them. Those entries are imported from that module, and
+      // this is what catches one going back to a literal.
+      const sm = StorageManager.emulate({ as: signer });
+      try {
+        const runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager: sm,
+        });
+        try {
+          // `serverExecution` apart: a flag-less runtime resolves the
+          // PROCESS's arm, not the fleet default this table carries for it.
+          const { serverExecution: _resolvedArm, ...resolved } =
+            runtime.experimental;
+          const { serverExecution: _fleetDefault, ...defaults } =
+            EXPERIMENTAL_DEFAULTS;
+          expect(resolved).toEqual(defaults);
+          expect(runtime.experimental.serverExecution).toBe(
+            getServerExecutionConfig(),
+          );
+        } finally {
+          await runtime.dispose();
+        }
+      } finally {
+        await sm.close();
+      }
+    });
+  });
+
   describe("nonDefaultExperimentalFlags()", () => {
     const resolved = (over: ExperimentalOptions = {}): ExperimentalOptions => ({
       ...EXPERIMENTAL_DEFAULTS,
@@ -212,16 +245,18 @@ describe("ExperimentalOptions", () => {
     ): Promise<string> => {
       const sm = StorageManager.emulate({ as: signer });
       const options = { apiUrl: new URL(import.meta.url), storageManager: sm };
-      const written = await captureStderr(async () => {
-        const runtime = new Runtime(
-          preset === "productionServer"
-            ? runtimePresets.productionServer({ ...options, experimental })
-            : runtimePresets.unitTest({ ...options, experimental }),
-        );
-        await runtime.dispose();
-      });
-      await sm.close();
-      return written;
+      try {
+        return await captureStderr(async () => {
+          const runtime = new Runtime(
+            preset === "productionServer"
+              ? runtimePresets.productionServer({ ...options, experimental })
+              : runtimePresets.unitTest({ ...options, experimental }),
+          );
+          await runtime.dispose();
+        });
+      } finally {
+        await sm.close();
+      }
     };
 
     it("stays quiet for a runtime running the defaults", async () => {


### PR DESCRIPTION
`Experimental flag overrides: …` listed every flag whose value was not
`undefined`, which is not the question the line exists to answer. Two
constructions pass flags explicitly while running nothing unusual, and both
printed on every start:

- the deployed-topology presets select the fleet's own server-execution arm
  through `withServerExecutionDefault`, so every toolshed and every `cf` command
  printed at least `serverExecution=false` — pre-existing;
- since #6225 a client not built alongside its server adopts that deployment's
  whole resolved posture, every flag of it explicit — introduced there, and
  called out in that PR as the follow-up this is.

The banner now reports divergence from the built-in default, under a name that
says so. A runtime running the defaults says nothing:

```
Non-default experimental flags: modernCellRep=true
```

## One table for the defaults

That needed the defaults to exist as one thing. They were spread across the
constructor's `??=` lines, three ambient modules' initializers, and a prose list
in `EXPERIMENTAL_OPTIONS.md` that could drift from all of them.
`EXPERIMENTAL_DEFAULTS` in `runtime.ts` is that table, `satisfies
Record<keyof ExperimentalOptions, boolean>` so a new flag does not compile until
it declares what "unset" means for it. The constructor fills from it, and the
registry document points at it instead of keeping a second copy.

**The order did not change, and is load-bearing.** An unset flag has to reach
the ambient setters as `undefined`, which `setModernCellRepConfig` and
`setContentAddressedSchemasConfig` read as "leave the process's state alone".
Writing a default in before that point would have a flag-less construction stomp
what a co-hosted runtime established. So the defaults go in only after
propagation and read-back, and the banner comes last.

## `serverExecution`

The one flag the banner reads from what a construction **selected** rather than
what it resolved. A flag-less runtime in a serving process inherits the
process's arm through the ambient flag rather than choosing one, so naming it
there would claim a decision that runtime did not make. Its table entry is
`SERVER_EXECUTION_DEFAULT_ENABLED` rather than the ambient zero-value, and is a
banner baseline only — the constructor never falls back to it, because it has
already resolved the flag from the ambient state above.

That holds through the Phase 7 flip: afterwards a preset passing `true` stays
quiet and an explicit `false` — the rollback lever — is what prints.

## One visible consequence

`runtime.experimental` now carries `systemPatternAutoUpdate`, which nothing
resolved before. Every consumer already reads it through `!` or `=== true`, so
behavior is unchanged; a toolshed's `/api/meta` posture is now complete rather
than omitting that flag, which is the better answer for a client adopting it.

## Testing

`packages/runner/test/experimental-options.test.ts` gains two blocks:

- `nonDefaultExperimentalFlags()` — a default posture reports nothing; a
  default-off flag that is on and a default-on flag that is off are both named;
  several diverging flags come out in flag order; and the three
  `serverExecution` cases (unselected is never named whatever the process
  resolved, selected-at-the-default is not named, selected-against-the-default
  is).
- the banner end to end, with this process's stderr captured: silent for a
  defaults runtime, silent for a `productionServer` preset, silent for a client
  that adopted a stock deployment's whole posture, and naming the flag when one
  really is off default.

Mutation-checked: reading `serverExecution` from the resolved posture instead of
the selection, dropping the default comparison, changing the banner wording, and
removing a flag from the table each turn a test red (the last at compile time,
TS1360).

The three `runtime.experimental` goldens in that file grew the eighth flag,
which is the change being asserted rather than a test bent to fit.

Green locally: `deno fmt --check`, `deno lint`, `deno task check`,
`check-docs`; runner (1286 tests) and toolshed suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
