### PR TITLE
fix(data-model): a container's read is part of converting the subvalue it yields

### DIFF
--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -263,21 +263,17 @@ class DebugConverter {
     // `Object.keys()` yields are used as they come.
     const byName = result as unknown as Record<string, FabricValue>;
 
-    // Only the indices actually present are visited, which costs a sparse
-    // array its element count and not its `length`, and leaves its holes as
-    // holes.
     result.length = value.length;
     for (const key of Object.keys(value)) {
       if (!isArrayIndexPropertyName(key)) {
-        // A named property, which an array's rendering doesn't carry.
+        // It's a named property. Intentionally skipped as part of conforming to
+        // `FabricValue`.
         continue;
       }
+
       try {
         byName[key] = this.#convertSubvalue(value[key], depth + 1);
       } catch (e) {
-        // The element read is inside the `try` along with its conversion, so
-        // that an element whose read throws costs just its own index instead
-        // of every element of the array.
         byName[key] = DebugConverter.#makeErrorResult(e);
       }
     }
@@ -331,9 +327,6 @@ class DebugConverter {
       try {
         result[resultKey] = this.#convertSubvalue(value[key], depth + 1);
       } catch (e) {
-        // The property read is inside the `try` along with its conversion, so
-        // that a property whose getter throws costs just itself instead of
-        // every property of the object.
         result[resultKey] = DebugConverter.#makeErrorResult(e);
       }
     }

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -1,5 +1,6 @@
 /** Debugging-ish helpers for `FabricValue`s. */
 
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
@@ -256,10 +257,32 @@ class DebugConverter {
   /**
    * Converts an array, which is known to be at the indicated nesting depth.
    */
-  #convertArray(value: any[], depth: number): FabricValue {
-    return value.map((item, _index): FabricValue =>
-      this.#convertSubvalue(item, depth + 1)
-    );
+  #convertArray(value: any, depth: number): FabricValue {
+    const result: FabricValue[] = [];
+    // An array is indexable by property name directly, so the index names
+    // `Object.keys()` yields are used as they come.
+    const byName = result as unknown as Record<string, FabricValue>;
+
+    // Only the indices actually present are visited, which costs a sparse
+    // array its element count and not its `length`, and leaves its holes as
+    // holes.
+    result.length = value.length;
+    for (const key of Object.keys(value)) {
+      if (!isArrayIndexPropertyName(key)) {
+        // A named property, which an array's rendering doesn't carry.
+        continue;
+      }
+      try {
+        byName[key] = this.#convertSubvalue(value[key], depth + 1);
+      } catch (e) {
+        // The element read is inside the `try` along with its conversion, so
+        // that an element whose read throws costs just its own index instead
+        // of every element of the array.
+        byName[key] = DebugConverter.#makeErrorResult(e);
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -299,14 +322,23 @@ class DebugConverter {
    * Converts a plain object, which is known to be at the indicated nesting depth.
    */
   #convertPlainObject(value: any, depth: number): FabricValue {
-    const mapper = ([key, value]: [string, any]): [string, FabricValue] => {
-      if (isUnsafeObjectKey(key) || (key[0] === "/")) {
-        key = `/${key}`;
+    const result: Record<string, FabricValue> = {};
+
+    for (const key of Object.keys(value)) {
+      const resultKey = (isUnsafeObjectKey(key) || (key[0] === "/"))
+        ? `/${key}`
+        : key;
+      try {
+        result[resultKey] = this.#convertSubvalue(value[key], depth + 1);
+      } catch (e) {
+        // The property read is inside the `try` along with its conversion, so
+        // that a property whose getter throws costs just itself instead of
+        // every property of the object.
+        result[resultKey] = DebugConverter.#makeErrorResult(e);
       }
-      return [key, this.#convertSubvalue(value, depth + 1)];
-    };
-    const converted = Object.entries(value).map(mapper);
-    return Object.fromEntries(converted);
+    }
+
+    return result;
   }
 
   /**

--- a/packages/data-model/test/value-debug-structured.test.ts
+++ b/packages/data-model/test/value-debug-structured.test.ts
@@ -165,6 +165,36 @@ describe("toStructuredDebugValue()", () => {
       expect(result[2]).toEqual({ "/Map": "/..." });
     });
 
+    it("returns a sparse array without visiting the indices it has no element at", () => {
+      // A very sparse array has to cost its element count and not its
+      // `length`, which is what visiting only the keys it has buys.
+      const probed: string[] = [];
+      const target: unknown[] = [];
+      target.length = 1000;
+      target[0] = 1;
+      target[999] = new Map();
+      const counted = new Proxy(target, {
+        has(t, key) {
+          probed.push(String(key));
+          return Reflect.has(t, key);
+        },
+      });
+
+      const result = toStructuredDebugValue(counted) as unknown[];
+      expect(result.length).toBe(1000);
+      expect(Object.keys(result)).toEqual(["0", "999"]);
+      expect(result[999]).toEqual({ "/Map": "/..." });
+      expect(probed).toEqual([]);
+    });
+
+    it("returns an array without the named properties hung on it", () => {
+      const value: unknown[] = [1, new Map()];
+      (value as unknown as Record<string, unknown>).extra = new Map();
+      const result = toStructuredDebugValue(value) as unknown[];
+      expect(Object.keys(result)).toEqual(["0", "1"]);
+      expect(result[1]).toEqual({ "/Map": "/..." });
+    });
+
     it("returns a null-prototype object as an ordinary plain object", () => {
       // Were it treated as a general instance instead, the result would carry
       // a class-name tag rather than the object's own keys.
@@ -410,7 +440,7 @@ describe("toStructuredDebugValue()", () => {
         },
       };
       expect(toStructuredDebugValue(value))
-        .toEqual({ "/unconvertible": "getter blew up" });
+        .toEqual({ boom: { "/unconvertible": "getter blew up" } });
     });
 
     it("returns the failure in place, leaving siblings converted", () => {
@@ -425,14 +455,46 @@ describe("toStructuredDebugValue()", () => {
       };
       expect(toStructuredDebugValue(value)).toEqual({
         before: "kept",
-        bad: { "/unconvertible": "getter blew up" },
+        bad: { boom: { "/unconvertible": "getter blew up" } },
         after: [1, 2],
       });
     });
 
+    it("returns the failure at the property whose read threw", () => {
+      // The read of a property is part of converting it, so a getter that
+      // throws costs its own property and no other.
+      const value = {
+        before: "kept",
+        get boom(): number {
+          throw new Error("getter blew up");
+        },
+        after: 2,
+      };
+      expect(toStructuredDebugValue(value)).toEqual({
+        before: "kept",
+        boom: { "/unconvertible": "getter blew up" },
+        after: 2,
+      });
+    });
+
+    it("returns the failure at the element whose read threw", () => {
+      const value: unknown[] = [1, 3];
+      Object.defineProperty(value, 1, {
+        enumerable: true,
+        configurable: true,
+        get(): never {
+          throw new Error("element read failed");
+        },
+      });
+      expect(toStructuredDebugValue(value)).toEqual([
+        1,
+        { "/unconvertible": "element read failed" },
+      ]);
+    });
+
     it("returns the failure in place for a throwing proxy trap", () => {
-      // The traps differ in where they are reached from, so each has to be
-      // caught close enough to the value to cost only that value.
+      // These traps are reached before any single property is, so each costs
+      // the whole proxy. The `get` trap, reached per-property, is below.
       const traps: ProxyHandler<object>[] = [
         {
           getPrototypeOf() {
@@ -441,11 +503,6 @@ describe("toStructuredDebugValue()", () => {
         },
         {
           ownKeys() {
-            throw new Error("nope");
-          },
-        },
-        {
-          get() {
             throw new Error("nope");
           },
         },
@@ -459,6 +516,22 @@ describe("toStructuredDebugValue()", () => {
           z: 2,
         });
       }
+    });
+
+    it("returns the failure per key for a throwing `get` trap", () => {
+      const bad = new Proxy({ k: 1, j: 2 }, {
+        get() {
+          throw new Error("nope");
+        },
+      });
+      expect(toStructuredDebugValue({ a: 1, bad, z: 2 })).toEqual({
+        a: 1,
+        bad: {
+          k: { "/unconvertible": "nope" },
+          j: { "/unconvertible": "nope" },
+        },
+        z: 2,
+      });
     });
 
     it("returns the failure in place for a non-callable `toString`", () => {
@@ -481,9 +554,11 @@ describe("toStructuredDebugValue()", () => {
             throw thrown;
           },
         };
-        return (toStructuredDebugValue(value) as Record<string, unknown>)[
-          "/unconvertible"
-        ];
+        const result = toStructuredDebugValue(value) as Record<
+          string,
+          Record<string, unknown>
+        >;
+        return result.boom!["/unconvertible"];
       }
 
       it("returns an `Error`'s message, subclasses included", () => {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`toStructuredDebugValue()` promises that a subvalue it cannot convert costs only
itself. A container's own *read* of that subvalue sat outside the guard, so the
promise held for a subvalue that throws on conversion and not for one that
throws on being read at all. Measured on `main`:

| input | before | after |
|---|---|---|
| `{ safe: "value", get boom() { throw Error("nope") } }` | `{ "/unconvertible": "nope" }` | `{ safe: "value", boom: { "/unconvertible": "nope" } }` |
| `{ a: 1, bad: new Proxy({k:1,j:2}, {get(){throw}}), z: 2 }` | `bad: { "/unconvertible": "nope" }` | `bad: { k: {…}, j: {…} }` |
| an array element whose getter throws | whole array lost | that index only |

One getter took every sibling with it, and a dump of a value that is
misbehaving is exactly the dump that must still arrive. Both container walks now
read inside the same `try` that converts.

The traps reached before any single property is — `getPrototypeOf` and `ownKeys`
— still cost the whole value, since there is no key to charge them to.

## The array walk

While reworking it, the walk moved from the index range to the keys the array
actually has, which is a cost it was already paying through
`Array.prototype.map()`. A 100,000,000-length array holding three elements:

| walk | elapsed |
|---|---|
| `Array.prototype.map()` (before) | 1149.5ms |
| `0..length` with an `in` check | 1303.3ms |
| `Object.keys()` (after) | 0.0ms |

Holes stay holes as they did, and the named properties an array can carry are
dropped as they were; both are pinned by tests.

## Tests

Four new cases, and three existing ones re-pinned to the finer granularity —
they were asserting the coarse behavior this fixes. Every mechanism was ablated
and goes red on exactly the tests that should notice it:

| ablation | tests red |
|---|---|
| plain-object read unguarded | 10 |
| array read unguarded | 1 |
| array walks every index | 1 |
| array carries named properties | 1 |

`deno fmt --check`, `deno lint`, `deno task check` and the `data-model` suite
(52 passed, 2819 steps) are all green.

## Why now

This is a prerequisite for replacing `sanitizeForPostMessage()` in
`runtime-client` with a `toStructuredDebugValue()` call. That walk guards each
property read individually, so the swap would otherwise regress the console
path — one bad getter in a logged object would lose every other field of it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

