### PR TITLE
refactor(ts-transformers): walk out to a usage site through one wrapper set

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -36,7 +36,7 @@ import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import { isTransparentWrapper, unwrapExpression } from "../utils/expression.ts";
 import { getCallArgumentPosition } from "./call-arguments.ts";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
 import {
@@ -1624,13 +1624,7 @@ export function isConsumedByTerminalChainCall(
       return false;
     }
 
-    if (
-      ts.isParenthesizedExpression(parent) ||
-      ts.isAsExpression(parent) ||
-      ts.isTypeAssertionExpression(parent) ||
-      ts.isNonNullExpression(parent) ||
-      ts.isSatisfiesExpression(parent)
-    ) {
+    if (isTransparentWrapper(parent)) {
       current = parent;
       continue;
     }

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -19,7 +19,12 @@ import {
   type UnreadableCellArgument,
 } from "../core/mod.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
-import { unwrapAssertCapture, unwrapExpression } from "../utils/expression.ts";
+import {
+  isTransparentWrapper,
+  outermostTransparentWrapper,
+  unwrapAssertCapture,
+  unwrapExpression,
+} from "../utils/expression.ts";
 import { decodePath, encodePath } from "../utils/path-serialization.ts";
 import { getKnownComputedKeyPathSegment } from "../utils/reactive-keys.ts";
 import {
@@ -702,14 +707,7 @@ function isBooleanConditionUsage(expression: ts.Expression): boolean {
   const parent = expression.parent;
   if (!parent) return false;
 
-  if (
-    (ts.isParenthesizedExpression(parent) ||
-      ts.isAsExpression(parent) ||
-      ts.isTypeAssertionExpression(parent) ||
-      ts.isSatisfiesExpression(parent) ||
-      ts.isNonNullExpression(parent)) &&
-    parent.expression === expression
-  ) {
+  if (isTransparentWrapper(parent) && parent.expression === expression) {
     return isBooleanConditionUsage(parent);
   }
 
@@ -753,52 +751,8 @@ function isBooleanConditionUsage(expression: ts.Expression): boolean {
   return false;
 }
 
-function unwrapIdentifierUsageSite(node: ts.Identifier): ts.Expression {
-  let current: ts.Expression = node;
-  while (true) {
-    const parent = current.parent;
-    if (!parent) {
-      return current;
-    }
-    if (
-      (ts.isParenthesizedExpression(parent) ||
-        ts.isAsExpression(parent) ||
-        ts.isTypeAssertionExpression(parent) ||
-        ts.isSatisfiesExpression(parent) ||
-        ts.isNonNullExpression(parent)) &&
-      parent.expression === current
-    ) {
-      current = parent;
-      continue;
-    }
-    return current;
-  }
-}
-
-function unwrapExpressionUsageSite(node: ts.Expression): ts.Expression {
-  let current = node;
-  while (true) {
-    const parent = current.parent;
-    if (!parent) {
-      return current;
-    }
-    if (
-      (ts.isParenthesizedExpression(parent) ||
-        ts.isAsExpression(parent) ||
-        ts.isTypeAssertionExpression(parent) ||
-        ts.isSatisfiesExpression(parent) ||
-        ts.isNonNullExpression(parent)) &&
-      parent.expression === current
-    ) {
-      current = parent;
-      continue;
-    }
-    return current;
-  }
-}
-
 function isPassThroughIdentifierUsage(node: ts.Identifier): boolean {
-  const usage = unwrapIdentifierUsageSite(node);
+  const usage = outermostTransparentWrapper(node);
   const parent = usage.parent;
   if (!parent) return false;
 
@@ -891,14 +845,7 @@ function isOptionalAliasInitializerMemberUsage(usage: ts.Expression): boolean {
       current = parent;
       continue;
     }
-    if (
-      (ts.isParenthesizedExpression(parent) ||
-        ts.isAsExpression(parent) ||
-        ts.isTypeAssertionExpression(parent) ||
-        ts.isSatisfiesExpression(parent) ||
-        ts.isNonNullExpression(parent)) &&
-      parent.expression === current
-    ) {
+    if (isTransparentWrapper(parent) && parent.expression === current) {
       current = parent;
       continue;
     }
@@ -920,12 +867,7 @@ function getIdentityArrayLocalNameForElementUsage(
   while (current.parent) {
     const parentNode = current.parent;
     if (
-      (ts.isParenthesizedExpression(parentNode) ||
-        ts.isAsExpression(parentNode) ||
-        ts.isTypeAssertionExpression(parentNode) ||
-        ts.isSatisfiesExpression(parentNode) ||
-        ts.isNonNullExpression(parentNode)) &&
-      parentNode.expression === current
+      isTransparentWrapper(parentNode) && parentNode.expression === current
     ) {
       current = parentNode;
       continue;
@@ -2424,7 +2366,7 @@ export function analyzeFunctionCapabilities(
           const suppressOrdinaryRead = () => {
             handled.add(index);
             signatureCapabilityArgumentUses.add(
-              unwrapExpressionUsageSite(argument.expression),
+              outermostTransparentWrapper(argument.expression),
             );
           };
           if (spreadSource) {
@@ -2508,7 +2450,7 @@ export function analyzeFunctionCapabilities(
 
         handled.add(index);
         signatureCapabilityArgumentUses.add(
-          unwrapExpressionUsageSite(capabilityArgument),
+          outermostTransparentWrapper(capabilityArgument),
         );
 
         if (source.dynamic) {
@@ -2756,7 +2698,7 @@ export function analyzeFunctionCapabilities(
           const source = aliases.get(node.text);
           if (source && !isMemberRootIdentifier(node)) {
             const resolvedSource = materializeSourceRef(source);
-            const usage = unwrapIdentifierUsageSite(node);
+            const usage = outermostTransparentWrapper(node);
             const parent = usage.parent;
             if (!parent) {
               // Synthetic identifiers can temporarily be detached from parent links.
@@ -2924,7 +2866,7 @@ export function analyzeFunctionCapabilities(
             // type already supplied the capability is accounted for, same as a
             // destructured identifier; don't add a second read here.
             !signatureCapabilityArgumentUses.has(
-              unwrapExpressionUsageSite(node),
+              outermostTransparentWrapper(node),
             )
           ) {
             const ref = resolveSourceRef(node);
@@ -3136,7 +3078,7 @@ export function analyzeFunctionCapabilities(
               if (argPath.dynamic) {
                 markWildcard(receiver.root, receiver.path);
               } else {
-                const keyUsage = unwrapExpressionUsageSite(node);
+                const keyUsage = outermostTransparentWrapper(node);
                 const keyUsageParent = keyUsage.parent;
                 const isChainedIntoMemberAccess = !!(
                   keyUsageParent &&

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -666,16 +666,7 @@ function allDataFlowsAreElementBindingRoots(
 function isPassthroughContainerExpression(
   expression: ts.Expression,
 ): boolean {
-  let current = expression;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isTypeAssertionExpression(current) ||
-    ts.isSatisfiesExpression(current) ||
-    ts.isNonNullExpression(current)
-  ) {
-    current = current.expression;
-  }
+  const current = unwrapExpression(expression);
   return ts.isPropertyAccessExpression(current) ||
     ts.isElementAccessExpression(current) ||
     ts.isObjectLiteralExpression(current) ||

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -42,7 +42,10 @@
 import ts from "typescript";
 import { COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES } from "../core/commonfabric-runtime-registry.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../utils/expression.ts";
 import {
   classifyArrayMethodCallSite,
   detectCallKind,
@@ -831,7 +834,7 @@ export class PatternContextValidationTransformer
     if (ts.isFunctionDeclaration(node)) return undefined;
     let current: ts.Node = node;
     let parent = current.parent;
-    while (parent && this.transparentWrapperInner(parent) === current) {
+    while (parent && unwrapTransparentWrapperOnce(parent) === current) {
       current = parent;
       parent = current.parent;
     }
@@ -842,22 +845,6 @@ export class PatternContextValidationTransformer
       ts.isObjectLiteralExpression(parent.parent)
     ) {
       return parent;
-    }
-    return undefined;
-  }
-
-  // Expressions that wrap a value without changing it: parentheses, `as`,
-  // `satisfies`, non-null `!`, and `<T>` assertions. Returns the wrapped inner
-  // expression, or undefined when the node is not such a wrapper.
-  private transparentWrapperInner(node: ts.Node): ts.Expression | undefined {
-    if (
-      ts.isParenthesizedExpression(node) ||
-      ts.isAsExpression(node) ||
-      ts.isSatisfiesExpression(node) ||
-      ts.isNonNullExpression(node) ||
-      ts.isTypeAssertionExpression(node)
-    ) {
-      return node.expression;
     }
     return undefined;
   }

--- a/packages/ts-transformers/src/transformers/write-authorized-by-validation.ts
+++ b/packages/ts-transformers/src/transformers/write-authorized-by-validation.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { getNodeText } from "../ast/mod.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 
 export class WriteAuthorizedByValidationTransformer
   extends HelpersOnlyTransformer {
@@ -346,7 +347,7 @@ function substituteTypeNode(
 function isSupportedWriteAuthorizedByInitializer(
   initializer: ts.Expression,
 ): boolean {
-  const expression = unwrapInitializer(initializer);
+  const expression = unwrapExpression(initializer);
   return ts.isCallExpression(expression) &&
     ts.isIdentifier(expression.expression) &&
     (
@@ -354,18 +355,4 @@ function isSupportedWriteAuthorizedByInitializer(
       expression.expression.text === "module" ||
       expression.expression.text === "requireEventIntegrity"
     );
-}
-
-function unwrapInitializer(expression: ts.Expression): ts.Expression {
-  let current = expression;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isTypeAssertionExpression(current) ||
-    ts.isSatisfiesExpression(current) ||
-    ts.isNonNullExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
 }

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -7,12 +7,13 @@ import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
  * value it denotes: `(x)`, `x as T`, `<T>x`, `x satisfies T`, `x!`, and the
  * partially emitted node that carries an already-rewritten subtree.
  *
- * This is the one set the pipeline looks through, and it is read in three
- * forms so that every shape of consumer has a definition to reach for:
+ * This is the one set the pipeline looks through, and it is read in four forms
+ * so that every shape of consumer has a definition to reach for:
  * {@link isTransparentWrapper} tests a node, {@link unwrapTransparentWrapperOnce}
- * steps through a single wrapper, and {@link unwrapExpression} reaches the
- * innermost expression. A spelling added here reaches all three at once, so a
- * wrapper cannot be handled by one resolver and missed by another.
+ * steps through a single wrapper, {@link unwrapExpression} reaches the innermost
+ * expression, and {@link outermostTransparentWrapper} walks the other way, out
+ * to the expression's usage site. A spelling added here reaches all four at
+ * once, so a wrapper cannot be handled by one resolver and missed by another.
  *
  * A stripper that reads a narrower set does so deliberately, and says why at
  * its own definition.
@@ -64,6 +65,36 @@ export function unwrapExpression(expr: ts.Expression): ts.Expression {
     current = current.expression;
   }
   return current;
+}
+
+/**
+ * The outermost expression that still denotes the same value as `expr`: `expr`
+ * itself when nothing wraps it, otherwise the last transparent wrapper stacked
+ * around it.
+ *
+ * The mirror of {@link unwrapExpression}, which walks in to the innermost
+ * expression. A caller asking what an expression is *used as* wants this one,
+ * because the use sits at the outside of the stack — `f(x as T)` hands `f` the
+ * whole `x as T`, not `x`.
+ *
+ * Only a wrapper reached along the `expression` spine counts. A node standing
+ * in a wrapper's type position is not the value that wrapper wraps, so the walk
+ * stops rather than climbing past it.
+ */
+export function outermostTransparentWrapper(
+  expr: ts.Expression,
+): ts.Expression {
+  let current = expr;
+  while (true) {
+    const parent = current.parent;
+    if (
+      !parent || !isTransparentWrapper(parent) ||
+      parent.expression !== current
+    ) {
+      return current;
+    }
+    current = parent;
+  }
 }
 
 /**

--- a/packages/ts-transformers/test/utils/expression.test.ts
+++ b/packages/ts-transformers/test/utils/expression.test.ts
@@ -5,6 +5,7 @@ import ts from "typescript";
 
 import {
   isTransparentWrapper,
+  outermostTransparentWrapper,
   unwrapExpression,
   unwrapTransparentWrapperOnce,
 } from "../../src/utils/expression.ts";
@@ -24,6 +25,29 @@ const WRAPPERS: Readonly<
   "x!": (inner) => ts.factory.createNonNullExpression(inner),
   "partially emitted": (inner) =>
     ts.factory.createPartiallyEmittedExpression(inner),
+};
+
+/**
+ * Parses `code` with parent pointers set and returns the first identifier named
+ * `x`, whose enclosing wrappers each test then walks out of.
+ */
+const identifierX = (code: string): ts.Identifier => {
+  const sourceFile = ts.createSourceFile(
+    "t.ts",
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  let found: ts.Identifier | undefined;
+  const walk = (candidate: ts.Node) => {
+    if (ts.isIdentifier(candidate) && candidate.text === "x") {
+      found ??= candidate;
+    }
+    ts.forEachChild(candidate, walk);
+  };
+  walk(sourceFile);
+  if (!found) throw new Error(`no identifier \`x\` in: ${code}`);
+  return found;
 };
 
 describe("expression", () => {
@@ -61,6 +85,34 @@ describe("expression", () => {
     it("returns `undefined` for an expression that is not a wrapper", () => {
       expect(unwrapTransparentWrapperOnce(ts.factory.createNumericLiteral("1")))
         .toBe(undefined);
+    });
+  });
+
+  describe("outermostTransparentWrapper()", () => {
+    it("returns the expression itself when no wrapper encloses it", () => {
+      const x = identifierX("const a = x;");
+
+      expect(outermostTransparentWrapper(x)).toBe(x);
+    });
+
+    it("returns the outermost wrapper of an enclosing chain", () => {
+      const x = identifierX("const a = ((x as T)!);");
+      // The whole initializer is the outermost thing denoting x's value.
+      let initializer: ts.Node = x;
+      while (!ts.isVariableDeclaration(initializer.parent)) {
+        initializer = initializer.parent;
+      }
+
+      expect(ts.isParenthesizedExpression(initializer)).toBe(true);
+      expect(outermostTransparentWrapper(x)).toBe(initializer);
+    });
+
+    it("stops at a parent that is not a transparent wrapper", () => {
+      const x = identifierX("const a = (x).y;");
+      const paren = x.parent;
+
+      expect(ts.isPropertyAccessExpression(paren.parent)).toBe(true);
+      expect(outermostTransparentWrapper(x)).toBe(paren);
     });
   });
 


### PR DESCRIPTION
Follow-up to #6067, which unified the child-unwrap side of the transparent-wrapper set. This takes the nine remaining sites that were named there as "found but not done", and answers the design question that PR left open.

## The question #6067 left open

Those nine sites read the canonical set **minus** `PartiallyEmittedExpression`. But most of them are not child unwraps at all — they walk *outward* through parents, asking at each step whether the parent is a wrapper standing around the node they came from. So the question was whether a parent-walk helper joins the vocabulary, or whether those sites just call `isTransparentWrapper` inline.

The evidence settles it. `capability-analysis.ts` carried the same outward walk **twice**, under two names:

```
--- unwrapIdentifierUsageSite
+++ unwrapExpressionUsageSite
-function unwrapIdentifierUsageSite(node: ts.Identifier): ts.Expression {
-  let current: ts.Expression = node;
+function unwrapExpressionUsageSite(node: ts.Expression): ts.Expression {
+  let current = node;
   while (true) {
```

That is the entire diff between them — same body, different parameter type. A duplicated operation with two names is what a vocabulary is for, so the walk becomes the fourth form.

## The fourth form

`outermostTransparentWrapper(expr)` is the mirror of `unwrapExpression`: one reaches the innermost expression, the other the outermost wrapper around it — the expression's **usage site**. `f(x as T)` hands `f` the whole `x as T`, and a caller asking what an expression is *used as* needs that, not `x`.

| Form | Direction |
| --- | --- |
| `isTransparentWrapper(node)` | test a node |
| `unwrapTransparentWrapperOnce(node)` | one step in |
| `unwrapExpression(expr)` | all the way in |
| `outermostTransparentWrapper(expr)` | all the way out |

Only wrappers on the `expression` spine count, so the walk will not climb past a node standing in a wrapper's type position.

## Sites reconciled

- `policy/capability-analysis.ts` — the duplicate pair collapses into the shared helper across its 6 call sites; the three interleaved walks (`isBooleanConditionUsage`, `isOptionalAliasInitializerMemberUsage`, `getIdentityArrayLocalNameForElementUsage`) express the one-step spine check as `isTransparentWrapper(parent) && parent.expression === current`.
- `transformers/pattern-context-validation.ts` — the private `transparentWrapperInner` method is deleted; its single caller already compared against `current`, so it becomes `unwrapTransparentWrapperOnce(parent) === current`.
- `transformers/write-authorized-by-validation.ts` — `unwrapInitializer` deleted, uses `unwrapExpression`.
- `transformers/expression-site-lowering.ts` — the inline loop in `isPassthroughContainerExpression` becomes `unwrapExpression`.
- `ast/call-kind.ts` — the terminal-chain parent walk uses `isTransparentWrapper`. This one has no spine check, matching what was there.

## The PartiallyEmittedExpression question, measured

Reading the full set adds `PartiallyEmittedExpression` at these sites. #6067 deferred them precisely because that is a no-op only *by argument*, not by construction — so here it is measured instead.

Instrumenting the wrapper predicate to record a stack trace on every PEE sighting, then running the whole suite:

```
total sightings across 1158 tests:  5
  3  test/utils/expression.test.ts
  1  test/opaque-roots-coverage.test.ts
  1  test/ast/call-kind.test.ts
pipeline-produced sightings:        0
```

All five come from the three test files that build such nodes by hand. None come from the pipeline, which transforms authored source through `ts.transform` rather than TypeScript's emit — and `createPartiallyEmittedExpression` appears nowhere outside tests. The instrument was validated against a forced positive first, so the null is trustworthy rather than a silent no-op.

## Proof of no behavior change

- `deno task test` in `packages/ts-transformers`: **1158 passed, 0 failed**.
- `UPDATE_GOLDENS=1`: **zero golden diffs** — `git status` after the run shows only the source files edited here.
- Repo-wide `deno fmt --check`, `deno lint`, `deno task check`, plus `check-package-cycles`, `check-single-copy-deps`, `check-unused-deps`, `check-deno-pins`, `check-no-waitfor`, `check-conflict-markers`, `check-skill-facts`, `check-docs-history-index`.
- Three tests added for `outermostTransparentWrapper`, each confirmed to fail against a walk mutated to stop after one step.

## Found but not done here

A sweep for the *rest* of the wrapper spellings turns up a further tier, narrower still, that neither this PR nor #6067 covers — and two of them look like the bug class of #6050 rather than cosmetic drift:

- `transformers/opaque-get-validation.ts` and a second walk in `ast/dataflow.ts` read parens/`as`/`<T>`/`!` but **not `satisfies`** — the exact omission #6050 fixed in call classification.
- `transformers/cfc-policy-authoring.ts` declares a module-local `const unwrapExpression` that **shadows the canonical name** with a different set (no `!`).
- `transformers/builder-call-hoisting.ts`, `transformers/schema-generator.ts` read parens/`as`/`<T>`/`satisfies` without `!`, which may well be deliberate.

Those need per-site judgment about whether the omission is intentional, and the `satisfies` ones deserve a reachability check before anything is called a bug. Deliberately out of scope here, where every change is proved inert.

Refs #6067, #6050.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

