### PR TITLE
test(topics): guard addTopic's children where they are still reachable

### DIFF
--- a/packages/patterns/integration/topic-board-child-contract.test.ts
+++ b/packages/patterns/integration/topic-board-child-contract.test.ts
@@ -1,0 +1,127 @@
+/**
+ * What a caller can still observe about a topic it filed through the board,
+ * once the board demands only the fields it renders.
+ *
+ * These three properties were pattern tests until the board's `topics` demand
+ * narrowed. A pattern test can only reach a stored topic through the holder's
+ * projection, and that projection no longer carries verbs, threads, or the
+ * mention graph — so the properties stopped being observable there. They are
+ * observable here, because this is the move the design says a caller makes:
+ * survey the board, resolve the row to the topic's own address, and read or
+ * call the topic itself, where its own schema governs.
+ *
+ * Each `it()` therefore guards a property of `addTopic`'s children that nothing
+ * else can: that the child is wired to the board's mention pivot, that a body
+ * given at create is not recorded as a body update, and that the board's index
+ * row tracks the child's thread after the fact.
+ */
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { env } from "@commonfabric/integration";
+import { Identity } from "@commonfabric/identity";
+import { join } from "@std/path";
+import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
+import {
+  initializePiecesController,
+  type PieceController,
+  type PiecesController,
+} from "./pieces-controller.ts";
+import { topicAt } from "./topic-board-fixture.ts";
+
+const { API_URL, SPACE_NAME } = env;
+
+describe("topic-board-child-contract", () => {
+  let cc: PiecesController;
+  let board: PieceController;
+  let releaseBoard: (() => void) | undefined;
+
+  beforeAll(async () => {
+    const identity = await Identity.generate({ implementation: "noble" });
+    cc = await initializePiecesController({
+      space: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    await cc.ensureDefaultPattern();
+    const program = await resolveLocalProgram(
+      (resolver) => cc.runtime.harness.resolve(resolver),
+      {
+        main: join(import.meta.dirname!, "..", "topics", "main.tsx"),
+        root: join(import.meta.dirname!, ".."),
+      },
+    );
+    board = await cc.create(program, { start: true });
+    // Held live for the whole suite so each `addTopic` lands against an
+    // up-to-date list, the same reason the seeding fixture holds it.
+    releaseBoard = cc.getResult(board.getCell()).sink(() => {});
+
+    // Index 0 is filed with a body; index 1 mentions it.
+    await board.result.set(
+      {
+        title: "Cited topic",
+        body: "    indented code\nline two\n",
+        agentName: "Sol",
+      },
+      ["addTopic"],
+    );
+    await board.result.set(
+      { title: "Citing topic", agentName: "Sol" },
+      ["addTopic"],
+    );
+  });
+
+  afterAll(async () => {
+    releaseBoard?.();
+    await cc?.dispose();
+  });
+
+  it("leaves the body-update stamps unset on a topic filed with a body", async () => {
+    const cited = await topicAt(board, 0);
+    // Verbatim, because trimming would corrupt whitespace-sensitive Markdown.
+    expect(await cited.result.get(["body"])).toBe(
+      "    indented code\nline two\n",
+    );
+    // Created-with is not an update: `createdBy` covers create authorship, so
+    // the update stamps must still be untouched.
+    expect(await cited.result.get(["bodyUpdatedAt"]) ?? 0).toBe(0);
+    expect(
+      (await cited.result.get(["bodyUpdatedBy", "name"])) ?? "",
+    ).toBe("");
+  });
+
+  it("wires a filed topic to the board's pivot, so a sibling's mention becomes an inbound reference", async () => {
+    const cited = await topicAt(board, 0);
+    const citing = await topicAt(board, 1);
+
+    expect((await cited.result.get(["referencedBy"]) as unknown[]).length)
+      .toBe(0);
+
+    await citing.result.set({ topic: cited.getCell() }, ["mention"]);
+
+    // The edge exists only if `addTopic` handed this child the board's
+    // `crossrefs` pivot — which is the thing no pattern test can still see.
+    const inbound = await cited.result.get(["referencedBy"]) as {
+      title: string;
+    }[];
+    expect(inbound.length).toBe(1);
+    expect(inbound[0].title).toBe("Citing topic");
+
+    // Mentioning is not symmetric.
+    expect((await citing.result.get(["referencedBy"]) as unknown[]).length)
+      .toBe(0);
+  });
+
+  it("carries the updated comment count on the board's index row", async () => {
+    const cited = await topicAt(board, 0);
+    const before = await board.result.get(["index", 0, "commentCount"]) ?? 0;
+
+    await cited.result.set({ body: "a comment", agentName: "Sol" }, [
+      "addComment",
+    ]);
+
+    // The row is built from the topic rather than copied from it, so a row
+    // already handed out has to reflect a thread that grew afterwards.
+    expect(await board.result.get(["index", 0, "commentCount"]))
+      .toBe((before as number) + 1);
+  });
+});

--- a/packages/patterns/integration/topic-board-fixture.ts
+++ b/packages/patterns/integration/topic-board-fixture.ts
@@ -193,7 +193,7 @@ function topicBody(
  * whose rows are piece-valued and expand through each topic's view of every
  * sibling; pulling the whole result grows without bound as the board fills.
  */
-async function topicAt(
+export async function topicAt(
   board: PieceController,
   index: number,
 ): Promise<PieceController> {


### PR DESCRIPTION
## Why

Three properties of a topic filed through the board have no test that can fail when they break, and two of them are about wiring `addTopic` does silently:

- `addTopic` hands its child the board's `crossrefs` pivot, which is the only reason a topic ever shows an inbound reference. Nothing asserted it.
- A body given at create is *not* a body update, so `bodyUpdatedBy/At` must stay unset and `createdBy` alone covers create authorship.
- The board's `index` row is built from the topic rather than copied from it, so a row already handed out has to reflect a thread that grew afterwards.

These are reachable here, and only here, because this is the move the design documents for a caller: file through the board, resolve the row to the topic's own address, then read and call the topic itself, where its own schema governs.

They are also the coverage that #6143 removes from `topics.test.tsx`. That PR narrows the board's demand so a stored topic reached *through the board* no longer carries verbs, threads, or the mention graph — which is a deliberate, approved change, but it takes these three assertions with it. Landing the replacement first is the point: moving coverage out of a suite and promising to rebuild it elsewhere is how it goes missing.

This is independent of that change, and passes on `main` as it stands.

## What Changed

- `packages/patterns/integration/topic-board-child-contract.test.ts` — three tests, headless, no browser.
- `packages/patterns/integration/topic-board-fixture.ts` — `topicAt` exported rather than copied. It already did the resolving for the seeding fixture; its doc comment explains why only the `topics` key is pulled, which is the part worth not re-deriving.

## Test plan

- `deno test -A ./integration/topic-board-child-contract.test.ts` in `packages/patterns` — 3 passed, on `main` and on #6143's branch alike.
- Every assertion validated by mutation, each killing only its own test:
  - dropping `boardCrossrefs: crossrefs` from `addTopic`'s child wiring → the pivot test fails, the other two stay green;
  - stamping `bodyUpdatedAt` at create → the stamps test fails, the other two stay green.
- `deno fmt`, `deno lint` clean on both files; the fixture's own unit test still passes (15 steps).

Related: #6143 (the narrowing this protects), #6237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Coverage

ACCEPT_COVERAGE_DEBT: packages/patterns +126 lines

The debt is this PR's own test file. `topic-board-child-contract.test.ts` adds
127 lines and the gate charges 126 of them against `packages/patterns`, because
a pattern integration test does not run under the coverage instrument — the
integration jobs do not set `CF_PATTERN_COVERAGE_DIR`, so the file counts as
source that nothing covers.

The measurement therefore rises by roughly the size of any test added here,
which makes it a reading about where the instrument runs rather than about what
this change leaves untested. Accepted on that basis, and with the gate itself
due for removal.
