### PR TITLE
test(cli): drive completion's live providers against a fabric

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -36,10 +36,12 @@ needs a space, `--space` is required on every command that reads one, and
 value a caller types is a space name. A name derives its DID one way, so a
 discovered DID can never produce the name that made it.
 
-**Nothing exercises a live provider.** The unit tests cover the pure shaping
-functions and assert that a slot with no fabric context degrades to empty.
-Every path that reaches a fabric is unverified, and the defects below sit
-exactly where no live exercise runs.
+**A live provider is exercised in one place only.** The unit tests cover the
+pure shaping functions and assert that a slot with no fabric context degrades
+to empty; nothing they can see distinguishes a provider that reaches a fabric
+and returns the wrong set. `completion-over-the-cli.sh` (item 18) is what does,
+and the defects below are the ones it was written to make visible — several of
+them are asserted there as gaps until the item that closes them lands.
 
 ## How this list is ranked
 
@@ -118,10 +120,11 @@ line read for context, since a projection precedes the verb it shapes; after
 step 10 the verb is already before the cursor and it needs nothing. Building it
 now means building the machinery that step 10 makes unnecessary.
 
-Items 8 and 11 hold open decisions and are not work yet. Items 18 and 19 are the
-mechanism, and are worth having early rather than last: item 18 is the only way
-to see a live provider fail, and everything above it is a shape no live exercise
-currently runs.
+Items 8 and 11 hold open decisions and are not work yet. Item 18 is the
+mechanism the rest is worked against, and it landed first for that reason: it
+is the only way to see a live provider fail, and the slots the items above
+describe are asserted there as gaps so that each one closing announces itself.
+Item 19 is its other half and is still to do.
 
 ## What this list covers, and what it cannot
 
@@ -550,8 +553,13 @@ lands.
 
 ### 18. A live-provider test seam
 
-`packages/cli/integration/completion-over-the-cli.sh` is where every provider
-that reads live state is exercised. It deploys `pattern/completion-target.tsx`,
+`packages/cli/integration/completion-over-the-cli.sh` is where every provider in
+`lib/completion/providers.ts` is exercised — those that read a fabric, the one
+that reads local stores, and the two that answer from the environment.
+`--space` is the one that cannot be held to it everywhere: it reads what is on
+disk, so a run with no store discoverable exercises it only as far as saying
+so, and that step reports which case it saw. It deploys
+`pattern/completion-target.tsx`,
 then asserts what a Tab offers at each slot of the chain, and runs in CI through
 `integration.sh`'s `piece-call` section (`completion` is the standalone
 selector). `test/completion-*.test.ts` stay the home for everything answerable

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -556,9 +556,10 @@ lands.
 `packages/cli/integration/completion-over-the-cli.sh` is where every provider
 that reads state is exercised — the four that reach a fabric, the one that
 reads local stores, the one that reads the environment, and the pattern-file
-glob. The rest of the table hands the shell a constant directive and reads
-nothing, so one probe stands for it; item 19's gate is what keeps such an entry
-from naming a slot that does not exist.
+glob. The rest of the table hands the shell a constant directive that a fabric
+cannot change, and those are asserted one by one — kind and glob — in
+`test/completion-providers.test.ts`. Item 19 adds the other half: whether a
+slot has an entry at all.
 
 `--space` is the one whose candidates depend on the machine, since it reads
 what is on disk. That step reads `cf inspect spaces`' exit status as well as

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -553,13 +553,20 @@ lands.
 
 ### 18. A live-provider test seam
 
-`packages/cli/integration/completion-over-the-cli.sh` is where every provider in
-`lib/completion/providers.ts` is exercised — those that read a fabric, the one
-that reads local stores, and the two that answer from the environment.
-`--space` is the one that cannot be held to it everywhere: it reads what is on
-disk, so a run with no store discoverable exercises it only as far as saying
-so, and that step reports which case it saw. It deploys
-`pattern/completion-target.tsx`,
+`packages/cli/integration/completion-over-the-cli.sh` is where every provider
+that reads state is exercised — the four that reach a fabric, the one that
+reads local stores, the one that reads the environment, and the pattern-file
+glob. The rest of the table hands the shell a constant directive and reads
+nothing, so one probe stands for it; item 19's gate is what keeps such an entry
+from naming a slot that does not exist.
+
+`--space` is the one whose candidates depend on the machine, since it reads
+what is on disk. That step reads `cf inspect spaces`' exit status as well as
+its output — a command that failed and a machine with no store print the same
+nothing — and probes the provider either way: with a store it must offer the
+DID, without one it must come back empty and successful.
+
+It deploys `pattern/completion-target.tsx`,
 then asserts what a Tab offers at each slot of the chain, and runs in CI through
 `integration.sh`'s `piece-call` section (`completion` is the standalone
 selector). `test/completion-*.test.ts` stay the home for everything answerable

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -92,7 +92,7 @@ read before picking one up; this table is the roll-up.
 | 15 | Remaining path-shaped and enumerable values | CLI vocabulary | not started |
 | 16 | Two provider entries that can never fire | hygiene | not started |
 | 17 | The README table omits the top-level spellings | hygiene | not started |
-| 18 | A live-provider test seam | mechanism | not started |
+| 18 | A live-provider test seam | mechanism | done |
 | 19 | A gate that fails when a new slot has no decision | mechanism | not started |
 
 **What can be picked up today.** Everything except one wiring change and one
@@ -550,27 +550,38 @@ lands.
 
 ### 18. A live-provider test seam
 
-No test drives a provider against a fabric. `completion-providers.test.ts`
-covers the shaping functions and the degrade-to-empty path; the integration
-scripts under `packages/cli/integration/` do not mention completion.
+`packages/cli/integration/completion-over-the-cli.sh` is where every provider
+that reads live state is exercised. It deploys `pattern/completion-target.tsx`,
+then asserts what a Tab offers at each slot of the chain, and runs in CI through
+`integration.sh`'s `piece-call` section (`completion` is the standalone
+selector). `test/completion-*.test.ts` stay the home for everything answerable
+without a fabric.
 
-Every correctness defect above is a shape no live exercise runs. A script
-alongside `verbs-over-the-cli.sh` — deploy a fixture, then assert what a Tab
-offers at each slot of the chain — is the coverage that would have caught them,
-and it composes with the existing harness rather than needing a new one.
-`verb-session-gaps.sh` is the precedent for asserting a gap so that it fails
-loudly the day it closes.
+Two rules the script holds to, both forced by completion's silence. A slot is
+judged only after the equivalent `cf` command has been run against the same
+target, so an empty candidate list reads as a defect rather than as an
+unreachable fabric. And a candidate is judged by whether the command accepts it.
 
-It is also the only way to settle the questions no table walk can reach, which
-are the ones to write first:
+It carries `gap` assertions, on the `verb-session-gaps.sh` precedent, for the
+slots below that answer nothing today: each fails loudly the day its slot starts
+answering. The count is printed on the script's last line rather than restated
+here.
 
-- Whether `cellPathCandidates` should stop at a `$link` boundary or follow it,
-  and which it does.
-- Whether the `--piece` listing and the dispatcher agree about scope, so that
-  every completed id is one the same command can then read.
-- Whether a verb stored on both the input and result cells completes against the
-  cell the dispatcher will reach it on, which is the shadowing rule the verbs
-  listing states.
+The three questions no table walk can reach are settled there:
+
+- `cellPathCandidates` **follows** a `$link` boundary rather than stopping at
+  it, and the path that crosses one is a path `cf get` reads.
+- Every id the `--piece` listing offers is one the same command reads back. The
+  converse does not hold and is not a defect: the listing enumerates registered
+  pieces, while a child piece is reached by the address its parent's result
+  carries.
+- A verb on both cells completes **once**, against the result cell — the same
+  one the dispatcher reaches, which is the shadowing rule the verbs listing
+  states.
+
+One defect the script found that this list did not enumerate: the cell-path slot
+offers a piece's callables, which `cf get` refuses and redirects to `cf call`.
+It is asserted there as what happens today.
 
 ### 19. A gate that fails when a new slot has no decision
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1040,9 +1040,9 @@ degrade-to-empty path. Every provider that reads state — a fabric, the local
 memory-v2 stores, or the environment — is exercised by
 `integration/completion-over-the-cli.sh`, which deploys a fixture and asserts
 what a Tab offers at each slot of the chain. The remaining table entries hand
-the shell a constant `files` or `dirs` directive and read nothing, so one probe
-stands for them; `deno task check-completion-slots` is what keeps such an entry
-from naming a slot that does not exist.
+the shell a constant `files` or `dirs` directive, which a fabric cannot change:
+those are asserted one by one, kind and glob, in
+`test/completion-providers.test.ts`.
 
 That split is not tidiness: a provider that reaches a fabric and comes back with
 the wrong set is invisible to a unit test and invisible at the prompt, because

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1036,10 +1036,13 @@ stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
 
 The tests divide the same way. `test/completion-*.test.ts` cover everything
 answerable without a fabric — line resolution, candidate shaping, and the
-degrade-to-empty path. Every provider that reads live state is exercised by
-`integration/completion-over-the-cli.sh`, which deploys a fixture and asserts
-what a Tab offers at each slot of the chain. That split is not tidiness: a
-provider that reaches a fabric and comes back with the wrong set is invisible to
-a unit test and invisible at the prompt, because failure here is silent by
-design. The script also carries `gap` assertions for slots that answer nothing
-today, so one starting to answer fails loudly rather than passing quietly.
+degrade-to-empty path. Every provider in `lib/completion/providers.ts` is
+exercised by `integration/completion-over-the-cli.sh`, which deploys a fixture
+and asserts what a Tab offers at each slot of the chain — including the two that
+answer from the environment rather than from a server, and `--space`, which
+reads what is on disk and so is exercised as far as a run has a local store to
+discover. That split is not tidiness: a provider that reaches a fabric and comes
+back with the wrong set is invisible to a unit test and invisible at the prompt,
+because failure here is silent by design. The script also carries `gap`
+assertions for slots that answer nothing today, so one starting to answer fails
+loudly rather than passing quietly.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1033,3 +1033,13 @@ Two facts cannot be read off that tree and are carried explicitly in
 `lib/completion/`: the pre-parse globals `--log-level` and `--no-color` (both
 stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
 `lib/color-mode.ts`), and the provider table binding slots to live data.
+
+The tests divide the same way. `test/completion-*.test.ts` cover everything
+answerable without a fabric — line resolution, candidate shaping, and the
+degrade-to-empty path. Every provider that reads live state is exercised by
+`integration/completion-over-the-cli.sh`, which deploys a fixture and asserts
+what a Tab offers at each slot of the chain. That split is not tidiness: a
+provider that reaches a fabric and comes back with the wrong set is invisible to
+a unit test and invisible at the prompt, because failure here is silent by
+design. The script also carries `gap` assertions for slots that answer nothing
+today, so one starting to answer fails loudly rather than passing quietly.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1036,13 +1036,16 @@ stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
 
 The tests divide the same way. `test/completion-*.test.ts` cover everything
 answerable without a fabric — line resolution, candidate shaping, and the
-degrade-to-empty path. Every provider in `lib/completion/providers.ts` is
-exercised by `integration/completion-over-the-cli.sh`, which deploys a fixture
-and asserts what a Tab offers at each slot of the chain — including the two that
-answer from the environment rather than from a server, and `--space`, which
-reads what is on disk and so is exercised as far as a run has a local store to
-discover. That split is not tidiness: a provider that reaches a fabric and comes
-back with the wrong set is invisible to a unit test and invisible at the prompt,
-because failure here is silent by design. The script also carries `gap`
-assertions for slots that answer nothing today, so one starting to answer fails
-loudly rather than passing quietly.
+degrade-to-empty path. Every provider that reads state — a fabric, the local
+memory-v2 stores, or the environment — is exercised by
+`integration/completion-over-the-cli.sh`, which deploys a fixture and asserts
+what a Tab offers at each slot of the chain. The remaining table entries hand
+the shell a constant `files` or `dirs` directive and read nothing, so one probe
+stands for them; `deno task check-completion-slots` is what keeps such an entry
+from naming a slot that does not exist.
+
+That split is not tidiness: a provider that reaches a fabric and comes back with
+the wrong set is invisible to a unit test and invisible at the prompt, because
+failure here is silent by design. The script also carries `gap` assertions for
+slots that answer nothing today, so one starting to answer fails loudly rather
+than passing quietly.

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# The completion chain against a live fabric: deploy a piece, then assert what
+# a Tab offers at each slot of space -> piece -> verb -> verb fields -> cell
+# path -> result shape.
+#
+# Every provider that reads real state is exercised here and nowhere else. The
+# unit tests under packages/cli/test/completion-*.test.ts cover the pure half —
+# line resolution, candidate shaping, and the degrade-to-empty path — and by
+# construction cannot see a provider that reaches a fabric and comes back with
+# the wrong set. Completion swallows every error on purpose, so a provider that
+# throws and a provider that has nothing to say are one experience at the
+# prompt: silence. This script is what tells them apart.
+#
+# Two rules follow from that silence, and both are held to below. A slot is
+# judged only after the equivalent `cf` command has been run against the same
+# target, so an empty candidate list is read as a defect rather than as an
+# unreachable fabric. And a candidate is judged by whether the command accepts
+# it, not by whether something came back.
+#
+# It drives `cf completion complete` directly, which is the one command the
+# installed shell function calls. The shell functions themselves are a separate
+# surface and are not exercised here.
+#
+# A step may assert a GAP rather than a capability, the way
+# `verb-session-gaps.sh` does: such a step fails loudly the day its gap closes,
+# so a slot that starts answering announces itself instead of aging into a
+# stale plan. How many are open is tallied as they run and printed on the last
+# line, so no prose here can fall out of step with the assertions below.
+#
+# Documented in docs/plans/cli-completion-coverage.md, whose item 18 this is.
+#
+# It deploys pattern/completion-target.tsx and nothing else. That fixture
+# belongs to this walkthrough alone, so a change to a pattern the product ships
+# can never break a demonstration of what a Tab offers.
+#
+# Run standalone against any host:
+#   API_URL=http://localhost:8000 packages/cli/integration/completion-over-the-cli.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+API_URL="${API_URL:-http://localhost:8000}"
+FIXTURE="$SCRIPT_DIR/pattern/completion-target.tsx"
+
+# Prefer a built binary when the harness supplies one; fall back to source.
+if [ -n "${CF_BINARY:-}" ]; then
+  CF="$CF_BINARY"
+else
+  CF="deno task --quiet --cwd $REPO_ROOT cf"
+fi
+
+PASS=0
+FAIL=0
+GAPS=0
+step() { printf '\n== %s\n' "$1"; }
+ok() { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
+check() {
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
+}
+# A gap we expect to be there. When it closes this fails loudly, which is how
+# the script tells us the slot started answering rather than quietly passing.
+gap() {
+  if [ -n "$1" ]; then
+    bad "GAP CLOSED — $2 now completes; update this script and the plan"
+  else
+    ok "gap still open: $2"
+    GAPS=$((GAPS + 1))
+  fi
+}
+# "1" when the command exits zero, "0" when it does not. What a slot offers is
+# judged against what the command accepts, so the command is run rather than
+# reasoned about.
+succeeds() {
+  if "$@" >/dev/null 2>&1; then printf '1\n'; else printf '0\n'; fi
+}
+
+SPACE="${SPACE:-$(mktemp -u compXXXXXXXX)}"
+if [ -z "${CF_IDENTITY:-}" ]; then
+  CF_IDENTITY=$(mktemp)
+  $CF id new >"$CF_IDENTITY" 2>/dev/null
+fi
+ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
+# The same three, written the way a caller types them on the line being
+# completed. Every provider resolves its fabric from the half-typed line first,
+# so a probe that carried them only in the environment would prove nothing
+# about the precedence the providers actually apply.
+LINE_ARGS="--api-url $API_URL --identity $CF_IDENTITY --space $SPACE"
+echo "API_URL=$API_URL"
+echo "SPACE=$SPACE"
+
+# A handler call needs a session its invocation ids are chosen within.
+export CF_INVOCATION_SESSION=$($CF invocation-session new 2>/dev/null)
+
+# What the shell would be offered for a line whose cursor sits at its end.
+# Directives (`:cf:…` lines) are dropped; `directives_at` is what reads those.
+complete_at() {
+  $CF completion complete --shell bash --line "$1" --point "${#1}" 2>/dev/null |
+    grep -v '^:cf:'
+}
+# The same, sorted and joined, so a candidate set compares as one string.
+candidates_at() {
+  complete_at "$1" | LC_ALL=C sort | paste -sd, -
+}
+directives_at() {
+  $CF completion complete --shell bash --line "$1" --point "${#1}" 2>/dev/null |
+    grep '^:cf:' | paste -sd, -
+}
+# zsh pairs each candidate with the annotation the shell renders beside it,
+# which is the only spelling that shows what a candidate is annotated WITH.
+# A colon inside a value is escaped in that format — every piece id carries
+# one — so the key is escaped the same way before it is matched.
+annotation_at() {
+  local key="${2//:/\\:}:"
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "$key"*) printf '%s\n' "${line#"$key"}" ;;
+    esac
+  done < <($CF completion complete --shell zsh --line "$1" \
+    --point "${#1}" 2>/dev/null)
+}
+
+START=$(date +%s)
+
+step "1. Deploy the fixture and give it a child"
+# --quiet makes the piece id stdout's only line; stderr is dropped and the
+# grep anchored so a compile warning carrying a fid1: token cannot be taken
+# for the deploy's id.
+BOARD=$($CF piece new --quiet --slug board "$FIXTURE" $ARGS 2>/dev/null |
+  grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
+if [ -n "$BOARD" ]; then ok "deployed $BOARD"; else
+  bad "deploy failed"
+  exit 1
+fi
+# The child is what a path crossing a link boundary crosses into, and what the
+# shadowed-name step calls. --show-links names the document behind /item, which
+# is the address form --piece takes back in.
+ADDED=$($CF call --quiet --show-links --piece board $ARGS --invocation add-1 \
+  addItem '{"title":"First item"}' 2>/dev/null)
+ITEM=$(echo "$ADDED" | jq -r '.links["/item"] // empty')
+if [ -n "$ITEM" ]; then ok "added a child item: $ITEM"; else
+  bad "addItem returned no address for the item it created"
+  exit 1
+fi
+# The space DID, read off a stored link rather than assumed: a space NAME
+# derives its DID one way, so nothing on the line carries it. The canonical
+# reference's space-qualified spelling needs it.
+SPACE_DID=$($CF get --quiet --piece board $ARGS items 2>/dev/null |
+  jq -r '.[0].record["/"]["link@1"].space // empty')
+if [ -n "$SPACE_DID" ]; then ok "the space resolves to $SPACE_DID"; else
+  bad "no space DID on the child's stored link"
+fi
+
+step "2. The piece slot offers ids the same command can then read"
+# The chain's second link. An id that completes but which the dispatcher
+# cannot reach would be worse than no candidate: it teaches a caller a target
+# that does not exist. Every id offered is read back here rather than assumed.
+PIECE_SLOT=$(complete_at "cf call $LINE_ARGS --piece ")
+check "$BOARD" "$PIECE_SLOT" "the piece slot offers the deployed board"
+READABLE=0
+UNREADABLE=0
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if [ "$(succeeds $CF get --quiet --piece "$id" $ARGS '$NAME')" = "1" ]; then
+    READABLE=$((READABLE + 1))
+  else
+    UNREADABLE=$((UNREADABLE + 1))
+  fi
+done <<EOF
+$PIECE_SLOT
+EOF
+check "0" "$UNREADABLE" "every completed piece id reads back ($READABLE checked)"
+# The annotation column is what makes an opaque id legible.
+check "Completion fixture" \
+  "$(annotation_at "cf call $LINE_ARGS --piece " "$BOARD")" \
+  "the id is annotated with the piece's name"
+
+step "3. The slug the same slot accepts does not complete"
+check "Completion fixture" \
+  "$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
+  "the slug is a --piece value the command accepts"
+gap "$(complete_at "cf call $LINE_ARGS --piece bo")" "a slug in the --piece slot"
+
+step "4. The inline spelling of an option drops every live candidate"
+# `--piece=<TAB>` and `--piece <TAB>` are the same slot. Only the second works,
+# and the first is the spelling `tokenizeLine` exists to serve.
+check "$BOARD" "$(complete_at "cf call $LINE_ARGS --piece ")" \
+  "the spaced spelling completes"
+gap "$(complete_at "cf call $LINE_ARGS --piece=")" \
+  "the inline --piece= spelling"
+# The directive half of the same slot: the glob reaches the shell attached to a
+# word that still carries `--identity=`, so nothing can match it.
+check ":cf:files *.key" "$(directives_at "cf call $LINE_ARGS --identity ")" \
+  "the spaced --identity spelling emits its files directive"
+
+step "5. Three documented ways to name a target complete nothing"
+CANONICAL="/of:$BOARD"
+QUALIFIED="/@$SPACE_DID/of:$BOARD"
+check "Completion fixture" \
+  "$($CF get --quiet --piece "$CANONICAL" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
+  "the canonical reference is a --piece value the command accepts"
+gap "$(complete_at "cf call $LINE_ARGS --piece $CANONICAL ")" \
+  "the verb slot behind a canonical --piece reference"
+check "Completion fixture" \
+  "$($CF get --quiet --piece "$QUALIFIED" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
+  "and so is its space-qualified spelling"
+gap "$(complete_at "cf call $LINE_ARGS --piece $QUALIFIED ")" \
+  "the verb slot behind a space-qualified reference"
+
+check "Completion fixture" \
+  "$($CF get --quiet $ARGS "$CANONICAL" '$NAME' 2>/dev/null | tr -d '"')" \
+  "a positional canonical address is a target the command accepts"
+gap "$(complete_at "cf call $LINE_ARGS $CANONICAL ")" \
+  "the verb slot behind a positional address"
+
+check "1" "$(succeeds $CF get --quiet --piece "$CANONICAL#argument" $ARGS)" \
+  "the #argument suffix is a --piece value the command accepts"
+gap "$(complete_at "cf get $LINE_ARGS --piece $CANONICAL#argument ")" \
+  "the cell path behind an #argument reference"
+# The flag spelling of the same selection does complete, which is what makes
+# the suffix read as random rather than as a missing capability.
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board --input " |
+  grep -c '^settings$')" \
+  "--input, which selects the same cell, completes it"
+
+step "6. The verb slot"
+check "addItem,legacyAdd,noteAll,renameItem,sweep" \
+  "$(candidates_at "cf call $LINE_ARGS --piece board ")" \
+  "every callable the piece exposes is offered"
+# The default listing holds back the deprecated row and says how many it held.
+check "addItem,noteAll,renameItem,sweep" \
+  "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
+    jq -r '[.verbs[] | select(.deprecated != true and .tier != "wrapper") |
+      .name] | sort | join(",")')" \
+  "the verbs listing shows four of them"
+check "handler" "$(annotation_at "cf call $LINE_ARGS --piece board " legacyAdd)" \
+  "the deprecated verb is offered annotated like every other"
+# The annotation column carries the kind, while the listing row carries the
+# prose the author wrote — the sentence the verb's help page opens with.
+check "Add one item to the board, and report the new total." \
+  "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
+    jq -r '.verbs[] | select(.name == "addItem") | .description')" \
+  "the listing carries addItem's prose"
+check "handler" "$(annotation_at "cf call $LINE_ARGS --piece board " addItem)" \
+  "and the candidate is annotated with its kind instead"
+
+step "7. Past the callable name, cf's own flags are offered and refused"
+# `piece call` is stopEarly(), so the first positional ends option parsing and
+# every later word belongs to the callable's schema-derived parser.
+check "1" "$(complete_at "cf call $LINE_ARGS --piece board addItem --" |
+  grep -c '^--invocation$')" \
+  "--invocation is offered after the callable name"
+check "0" "$(succeeds $CF call --quiet --piece board $ARGS addItem \
+  --invocation late)" "and the command refuses it there"
+
+step "8. The verb's own fields do not complete"
+# The position where a caller has least to go on: these names are the pattern
+# author's vocabulary, not the CLI's.
+check "pinned,title" "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
+  jq -r '.verbs[] | select(.name == "addItem") | .inputSchema.properties |
+    keys | sort | join(",")')" \
+  "addItem declares the fields its flags are named for"
+check "1" "$(succeeds $CF call --quiet --piece board $ARGS --invocation flags-1 \
+  addItem -- --title 'Flagged item')" "and the parser accepts them as flags"
+gap "$(complete_at "cf call $LINE_ARGS --piece board addItem -- --")" \
+  "a verb's fields after the marker"
+
+step "9. A cell path completes one segment at a time"
+check ":cf:nospace" "$(directives_at "cf get $LINE_ARGS --piece board ")" \
+  "the cursor is held for the next separator"
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board " |
+  grep -c '^settings$')" "a root key is offered"
+check "settings/density,settings/theme" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board settings/")" \
+  "a nested object offers its keys, each carrying the path already typed"
+check "cozy" "$($CF get --quiet --piece board $ARGS settings/density \
+  2>/dev/null | tr -d '"')" "and the completed path is one cf get reads"
+
+step "10. A cell path follows a \$link boundary rather than stopping at it"
+# `items/0` is a link to another document. The path walk reads through it, so
+# the child's own keys are what the slot offers.
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board items/0/" |
+  grep -c '^items/0/label$')" \
+  "the keys past the boundary are the child's own"
+check "First item" "$($CF get --quiet --piece board $ARGS items/0/label \
+  2>/dev/null | tr -d '"')" \
+  "and the path crossing the boundary is one cf get reads"
+# The same slot also offers names cf get refuses: a callable is not a value,
+# and reading one is redirected to cf call.
+check "0" "$(succeeds $CF get --quiet --piece board $ARGS addItem)" \
+  "reading a callable's name is refused"
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board " |
+  grep -c '^addItem$')" \
+  "and the cell-path slot offers it anyway"
+
+step "11. Result field paths do not complete"
+# --step because the board carries a computed value and a projection reads
+# through the whole result: the same reason the verb walkthrough steps before
+# it projects.
+check "dark" "$($CF get --quiet --piece board $ARGS --step \
+  --select settings.theme 2>/dev/null | jq -r '.settings.theme')" \
+  "a --select field path is a projection the command reads"
+gap "$(complete_at "cf get $LINE_ARGS --piece board --select ")" \
+  "--select field paths"
+gap "$(complete_at "cf get $LINE_ARGS --piece board --schema ")" \
+  "--schema field paths"
+
+step "12. A name on two cells completes against the one the dispatcher reaches"
+# The child is handed a callable named `record` in its arguments AND declares
+# one on its result. The listing states that the result shadows the input; a
+# candidate set that offered both, or the wrong one, would name a call that
+# does something else.
+check "record" "$(candidates_at "cf call $LINE_ARGS --piece ${ITEM#/of:} ")" \
+  "the shadowed name is offered exactly once"
+BOARD_REVISION=$($CF get --quiet --piece board $ARGS revision 2>/dev/null)
+check "1" "$($CF call --quiet --piece "${ITEM#/of:}" $ARGS --invocation rec-1 \
+  record '{"text":"first"}' 2>/dev/null | jq -r '.result.recorded')" \
+  "calling it reaches the result cell's callable"
+check "$BOARD_REVISION" "$($CF get --quiet --piece board $ARGS revision \
+  2>/dev/null)" \
+  "and not the one the arguments cell carries, which writes elsewhere"
+
+ELAPSED=$(($(date +%s) - START))
+printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \
+  "$PASS" "$FAIL" "$GAPS" "$ELAPSED"
+[ "$FAIL" -eq 0 ]

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -13,9 +13,10 @@
 # nothing else — --root, --datafile, --to, `view <file>`, `exec <mountedFile>`,
 # `id did <keypath>`, the space-management directories, and the two entries
 # item 16 of the plan records as belonging to commands that declare no options
-# at all. They read no state, so there is nothing here that could come back
-# wrong; --identity stands for them, and `deno task check-completion-slots` is
-# what keeps such an entry from naming a slot that does not exist.
+# at all. They read no state, so a fabric cannot change what they answer, and
+# they are asserted one by one — kind and glob — in
+# packages/cli/test/completion-providers.test.ts, which is where a constant
+# belongs. Nothing here re-checks them.
 #
 # The unit tests under packages/cli/test/completion-*.test.ts cover the pure
 # half — line resolution, candidate shaping, and the degrade-to-empty path —
@@ -401,13 +402,14 @@ DISCOVERED=$(printf '%s\n' "$RUN_OUT" | grep -oE '^did:key:[A-Za-z0-9]+' |
   head -1)
 if [ -n "$DISCOVERED" ]; then
   ok "a local space db is discoverable: $DISCOVERED"
-  check "1" "$(complete_at "cf piece ls $CONN_ARGS --space ${DISCOVERED%??????????}" |
-    grep -c "^$DISCOVERED\$")" \
-    "the --space slot offers a DID discovered on disk"
+  probe "cf piece ls $CONN_ARGS --space ${DISCOVERED%??????????}"
+  check "0" "$PROBE_STATUS" "the --space slot runs"
+  check "1" "$(printf '%s\n' "$PROBE_OUT" | grep -c "^$DISCOVERED\$")" \
+    "and offers a DID discovered on disk"
 else
   ok "no local space db is discoverable here"
   probe "cf piece ls $CONN_ARGS --space "
-  check "0" "$PROBE_STATUS" "the --space slot still runs"
+  check "0" "$PROBE_STATUS" "the --space slot runs"
   check "" "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" \
     "and offers nothing, which is all there is on disk to offer"
 fi

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -3,13 +3,21 @@
 # a Tab offers at each slot of space -> piece -> verb -> verb fields -> cell
 # path -> result shape.
 #
-# Every provider that reads real state is exercised here and nowhere else. The
-# unit tests under packages/cli/test/completion-*.test.ts cover the pure half —
-# line resolution, candidate shaping, and the degrade-to-empty path — and by
-# construction cannot see a provider that reaches a fabric and comes back with
-# the wrong set. Completion swallows every error on purpose, so a provider that
-# throws and a provider that has nothing to say are one experience at the
-# prompt: silence. This script is what tells them apart.
+# Every provider in lib/completion/providers.ts is exercised here: the ones
+# that read a fabric (pieces, callables, cell paths, link endpoints), the one
+# that reads local memory-v2 stores (--space), and the two that answer from the
+# environment (--api-url, pattern files). The unit tests under
+# packages/cli/test/completion-*.test.ts cover the pure half — line resolution,
+# candidate shaping, and the degrade-to-empty path — and by construction cannot
+# see a provider that reaches a fabric and comes back with the wrong set.
+# Completion swallows every error on purpose, so a provider that throws and a
+# provider that has nothing to say are one experience at the prompt: silence.
+# This script is what tells them apart.
+#
+# One provider cannot be held to that everywhere: --space reads what is on
+# disk, so a run with no local store discoverable exercises it only as far as
+# saying so. That step reports which case it saw rather than passing either
+# way.
 #
 # Two rules follow from that silence, and both are held to below. A slot is
 # judged only after the equivalent `cf` command has been run against the same
@@ -58,10 +66,31 @@ bad() { printf '  FAIL %s\n' "$1"; FAIL=$((FAIL + 1)); }
 check() {
   if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi
 }
-# A gap we expect to be there. When it closes this fails loudly, which is how
-# the script tells us the slot started answering rather than quietly passing.
+# Run the completion command, keeping its exit status apart from its output.
+#
+# A provider that answers nothing and a CLI that could not run both print
+# nothing, so a probe reading output alone reports a dead instrument as
+# evidence: with a `cf` that only exits nonzero, every gap below still read as
+# "gap still open". The status is what tells the two apart, and it is kept in a
+# variable rather than returned because the callers below read the output
+# through command substitution, which would run this in a subshell and lose it.
+PROBE_OUT=""
+PROBE_STATUS=0
+probe() {
+  PROBE_OUT=$($CF completion complete --shell bash --line "$1" \
+    --point "${#1}" 2>/dev/null)
+  PROBE_STATUS=$?
+}
+
+# A gap we expect to be there, named by the line that probes it. When it closes
+# this fails loudly, which is how the script tells us the slot started
+# answering rather than quietly passing — and when the command itself fails,
+# that is a third outcome rather than a gap.
 gap() {
-  if [ -n "$1" ]; then
+  probe "$1"
+  if [ "$PROBE_STATUS" -ne 0 ]; then
+    bad "completion exited $PROBE_STATUS probing $2 — no gap can be read from that"
+  elif [ -n "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" ]; then
     bad "GAP CLOSED — $2 now completes; update this script and the plan"
   else
     ok "gap still open: $2"
@@ -85,7 +114,8 @@ ARGS="--api-url=$API_URL --identity=$CF_IDENTITY --space=$SPACE"
 # completed. Every provider resolves its fabric from the half-typed line first,
 # so a probe that carried them only in the environment would prove nothing
 # about the precedence the providers actually apply.
-LINE_ARGS="--api-url $API_URL --identity $CF_IDENTITY --space $SPACE"
+CONN_ARGS="--api-url $API_URL --identity $CF_IDENTITY"
+LINE_ARGS="$CONN_ARGS --space $SPACE"
 echo "API_URL=$API_URL"
 echo "SPACE=$SPACE"
 
@@ -123,7 +153,16 @@ annotation_at() {
 
 START=$(date +%s)
 
-step "1. Deploy the fixture and give it a child"
+step "1. The completion command answers, and the fixture deploys"
+# Every probe below reads an empty candidate list as a fact about a slot, and
+# that reading holds only while the command itself runs. A static completion
+# needs no fabric and no identity, so nothing but a broken CLI can empty it —
+# which makes this the one place the instrument is checked rather than assumed.
+probe "cf piece "
+check "0" "$PROBE_STATUS" "cf completion complete exits zero"
+check "1" "$(printf '%s\n' "$PROBE_OUT" | grep -c '^verbs$')" \
+  "and a static slot answers, so an empty one below is about the slot"
+
 # --quiet makes the piece id stdout's only line; stderr is dropped and the
 # grep anchored so a compile warning carrying a fid1: token cannot be taken
 # for the deploy's id.
@@ -139,6 +178,7 @@ fi
 ADDED=$($CF call --quiet --show-links --piece board $ARGS --invocation add-1 \
   addItem '{"title":"First item"}' 2>/dev/null)
 ITEM=$(echo "$ADDED" | jq -r '.links["/item"] // empty')
+ITEM_ID=${ITEM#/of:}
 if [ -n "$ITEM" ]; then ok "added a child item: $ITEM"; else
   bad "addItem returned no address for the item it created"
   exit 1
@@ -180,15 +220,14 @@ step "3. The slug the same slot accepts does not complete"
 check "Completion fixture" \
   "$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
   "the slug is a --piece value the command accepts"
-gap "$(complete_at "cf call $LINE_ARGS --piece bo")" "a slug in the --piece slot"
+gap "cf call $LINE_ARGS --piece bo" "a slug in the --piece slot"
 
 step "4. The inline spelling of an option drops every live candidate"
 # `--piece=<TAB>` and `--piece <TAB>` are the same slot. Only the second works,
 # and the first is the spelling `tokenizeLine` exists to serve.
 check "$BOARD" "$(complete_at "cf call $LINE_ARGS --piece ")" \
   "the spaced spelling completes"
-gap "$(complete_at "cf call $LINE_ARGS --piece=")" \
-  "the inline --piece= spelling"
+gap "cf call $LINE_ARGS --piece=" "the inline --piece= spelling"
 # The directive half of the same slot: the glob reaches the shell attached to a
 # word that still carries `--identity=`, so nothing can match it.
 check ":cf:files *.key" "$(directives_at "cf call $LINE_ARGS --identity ")" \
@@ -200,23 +239,23 @@ QUALIFIED="/@$SPACE_DID/of:$BOARD"
 check "Completion fixture" \
   "$($CF get --quiet --piece "$CANONICAL" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
   "the canonical reference is a --piece value the command accepts"
-gap "$(complete_at "cf call $LINE_ARGS --piece $CANONICAL ")" \
+gap "cf call $LINE_ARGS --piece $CANONICAL " \
   "the verb slot behind a canonical --piece reference"
 check "Completion fixture" \
   "$($CF get --quiet --piece "$QUALIFIED" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
   "and so is its space-qualified spelling"
-gap "$(complete_at "cf call $LINE_ARGS --piece $QUALIFIED ")" \
+gap "cf call $LINE_ARGS --piece $QUALIFIED " \
   "the verb slot behind a space-qualified reference"
 
 check "Completion fixture" \
   "$($CF get --quiet $ARGS "$CANONICAL" '$NAME' 2>/dev/null | tr -d '"')" \
   "a positional canonical address is a target the command accepts"
-gap "$(complete_at "cf call $LINE_ARGS $CANONICAL ")" \
+gap "cf call $LINE_ARGS $CANONICAL " \
   "the verb slot behind a positional address"
 
 check "1" "$(succeeds $CF get --quiet --piece "$CANONICAL#argument" $ARGS)" \
   "the #argument suffix is a --piece value the command accepts"
-gap "$(complete_at "cf get $LINE_ARGS --piece $CANONICAL#argument ")" \
+gap "cf get $LINE_ARGS --piece $CANONICAL#argument " \
   "the cell path behind an #argument reference"
 # The flag spelling of the same selection does complete, which is what makes
 # the suffix read as random rather than as a missing capability.
@@ -263,7 +302,7 @@ check "pinned,title" "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
   "addItem declares the fields its flags are named for"
 check "1" "$(succeeds $CF call --quiet --piece board $ARGS --invocation flags-1 \
   addItem -- --title 'Flagged item')" "and the parser accepts them as flags"
-gap "$(complete_at "cf call $LINE_ARGS --piece board addItem -- --")" \
+gap "cf call $LINE_ARGS --piece board addItem -- --" \
   "a verb's fields after the marker"
 
 step "9. A cell path completes one segment at a time"
@@ -301,25 +340,71 @@ step "11. Result field paths do not complete"
 check "dark" "$($CF get --quiet --piece board $ARGS --step \
   --select settings.theme 2>/dev/null | jq -r '.settings.theme')" \
   "a --select field path is a projection the command reads"
-gap "$(complete_at "cf get $LINE_ARGS --piece board --select ")" \
-  "--select field paths"
-gap "$(complete_at "cf get $LINE_ARGS --piece board --schema ")" \
-  "--schema field paths"
+gap "cf get $LINE_ARGS --piece board --select " "--select field paths"
+gap "cf get $LINE_ARGS --piece board --schema " "--schema field paths"
 
 step "12. A name on two cells completes against the one the dispatcher reaches"
 # The child is handed a callable named `record` in its arguments AND declares
 # one on its result. The listing states that the result shadows the input; a
 # candidate set that offered both, or the wrong one, would name a call that
 # does something else.
-check "record" "$(candidates_at "cf call $LINE_ARGS --piece ${ITEM#/of:} ")" \
+check "record" "$(candidates_at "cf call $LINE_ARGS --piece $ITEM_ID ")" \
   "the shadowed name is offered exactly once"
 BOARD_REVISION=$($CF get --quiet --piece board $ARGS revision 2>/dev/null)
-check "1" "$($CF call --quiet --piece "${ITEM#/of:}" $ARGS --invocation rec-1 \
+check "1" "$($CF call --quiet --piece "$ITEM_ID" $ARGS --invocation rec-1 \
   record '{"text":"first"}' 2>/dev/null | jq -r '.result.recorded')" \
   "calling it reaches the result cell's callable"
 check "$BOARD_REVISION" "$($CF get --quiet --piece board $ARGS revision \
   2>/dev/null)" \
   "and not the one the arguments cell carries, which writes elsewhere"
+
+step "13. The slots that read something other than the fabric"
+# Two providers answer from the environment rather than from a server, so a
+# probe of them proves nothing about reachability and everything about the
+# vocabulary — which is the half that can silently go missing.
+check "1" "$(complete_at "cf piece ls $CONN_ARGS --api-url http" |
+  grep -c '^http')" "--api-url offers a URL to connect to"
+check ":cf:files *.tsx" "$(directives_at "cf piece new $LINE_ARGS --test ")" \
+  "a pattern-file slot hands the shell the glob it filters by"
+# `--space` completes from local memory-v2 stores rather than from the server,
+# so it has nothing to offer where none is discoverable — which is item 8's
+# positional discovery rather than a defect here. The step says which it saw,
+# so a run that could not exercise the provider does not read as one that did.
+DISCOVERED=$($CF inspect spaces 2>/dev/null |
+  grep -oE '^did:key:[A-Za-z0-9]+' | head -1)
+if [ -n "$DISCOVERED" ]; then
+  ok "a local space db is discoverable: $DISCOVERED"
+  check "1" "$(complete_at "cf piece ls $CONN_ARGS --space ${DISCOVERED%??????????}" |
+    grep -c "^$DISCOVERED\$")" \
+    "the --space slot offers a DID discovered on disk"
+else
+  ok "no local space db here, so --space has nothing to discover"
+fi
+
+step "14. Both halves of a link endpoint"
+# `piece link` takes `pieceId/path/to/field` twice. Before the `/` the
+# candidates are piece ids and after it they are that piece's cell keys, so one
+# slot spans two vocabularies and both are read from the fabric.
+check ":cf:nospace" "$(directives_at "cf piece link $LINE_ARGS ")" \
+  "the endpoint holds the cursor for the separator it continues with"
+check "1" "$(complete_at "cf piece link $LINE_ARGS ${BOARD%??????????}" |
+  grep -c "^$BOARD\$")" "the source offers a piece id before the separator"
+check "1" "$(complete_at "cf piece link $LINE_ARGS $BOARD/rev" |
+  grep -c "^$BOARD/revision\$")" "and that piece's keys after it"
+check "1" "$(complete_at "cf piece link $LINE_ARGS $BOARD/revision ${BOARD%??????????}" |
+  grep -c "^$BOARD\$")" "the target completes the same way"
+# The id half offers what the listing holds — registered pieces — while the key
+# half reads whichever id was typed. So the child, which the listing does not
+# name, still completes its own keys once its address is pasted in.
+check "1" "$(complete_at "cf piece link $LINE_ARGS $BOARD/revision $ITEM_ID/rec" |
+  grep -c "^$ITEM_ID/recorded\$")" \
+  "and a pasted child address completes its keys, which the listing cannot name"
+# And the pair the two slots completed is one the command accepts, which is the
+# bar every other slot here is held to. Last, because it writes: a link makes
+# the target mirror the source, so nothing above may depend on either value.
+check "1" "$(succeeds $CF piece link --quiet $LINE_ARGS \
+  "$BOARD/revision" "$ITEM_ID/recorded")" \
+  "a pair of completed endpoints is a link the command writes"
 
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -3,21 +3,26 @@
 # a Tab offers at each slot of space -> piece -> verb -> verb fields -> cell
 # path -> result shape.
 #
-# Every provider in lib/completion/providers.ts is exercised here: the ones
-# that read a fabric (pieces, callables, cell paths, link endpoints), the one
-# that reads local memory-v2 stores (--space), and the two that answer from the
-# environment (--api-url, pattern files). The unit tests under
-# packages/cli/test/completion-*.test.ts cover the pure half — line resolution,
-# candidate shaping, and the degrade-to-empty path — and by construction cannot
-# see a provider that reaches a fabric and comes back with the wrong set.
-# Completion swallows every error on purpose, so a provider that throws and a
-# provider that has nothing to say are one experience at the prompt: silence.
-# This script is what tells them apart.
+# Every provider that reads state is exercised here: the four that reach a
+# fabric (pieces, callables, cell paths, link endpoints), the one that reads
+# local memory-v2 stores (--space, and the `space` positionals sharing it), the
+# one that reads the environment (--api-url), and the pattern-file glob.
 #
-# One provider cannot be held to that everywhere: --space reads what is on
-# disk, so a run with no local store discoverable exercises it only as far as
-# saying so. That step reports which case it saw rather than passing either
-# way.
+# What is NOT exercised entry by entry is the rest of the provider table: a
+# dozen slots that hand the shell a constant `files` or `dirs` directive and
+# nothing else — --root, --datafile, --to, `view <file>`, `exec <mountedFile>`,
+# `id did <keypath>`, the space-management directories, and the two entries
+# item 16 of the plan records as belonging to commands that declare no options
+# at all. They read no state, so there is nothing here that could come back
+# wrong; --identity stands for them, and `deno task check-completion-slots` is
+# what keeps such an entry from naming a slot that does not exist.
+#
+# The unit tests under packages/cli/test/completion-*.test.ts cover the pure
+# half — line resolution, candidate shaping, and the degrade-to-empty path —
+# and by construction cannot see a provider that reaches a fabric and comes
+# back with the wrong set. Completion swallows every error on purpose, so a
+# provider that throws and a provider that has nothing to say are one
+# experience at the prompt: silence. This script is what tells them apart.
 #
 # Two rules follow from that silence, and both are held to below. A slot is
 # judged only after the equivalent `cf` command has been run against the same
@@ -80,6 +85,19 @@ probe() {
   PROBE_OUT=$($CF completion complete --shell bash --line "$1" \
     --point "${#1}" 2>/dev/null)
   PROBE_STATUS=$?
+}
+
+# The same discipline for the auxiliary commands this script branches on.
+#
+# `probe` keeps the completion command honest; every OTHER command whose empty
+# output decides a branch needs it too, or the branch reads a broken CLI as a
+# fact about the fabric. That is the same defect twice in one file, so it is
+# the shape that is fixed rather than the instance.
+RUN_OUT=""
+RUN_STATUS=0
+run() {
+  RUN_OUT=$("$@" 2>/dev/null)
+  RUN_STATUS=$?
 }
 
 # A gap we expect to be there, named by the line that probes it. When it closes
@@ -367,18 +385,31 @@ check "1" "$(complete_at "cf piece ls $CONN_ARGS --api-url http" |
 check ":cf:files *.tsx" "$(directives_at "cf piece new $LINE_ARGS --test ")" \
   "a pattern-file slot hands the shell the glob it filters by"
 # `--space` completes from local memory-v2 stores rather than from the server,
-# so it has nothing to offer where none is discoverable — which is item 8's
-# positional discovery rather than a defect here. The step says which it saw,
-# so a run that could not exercise the provider does not read as one that did.
-DISCOVERED=$($CF inspect spaces 2>/dev/null |
-  grep -oE '^did:key:[A-Za-z0-9]+' | head -1)
+# so what it can offer depends on what is on disk — which is item 8's
+# positional discovery rather than a defect here.
+#
+# Two things that follow, and the second is what a bare `if -n` gets wrong.
+# Whether a store was found is read from `cf inspect spaces`' exit status as
+# well as its output, since a command that failed and a machine with no store
+# print the same nothing. And the provider is probed in BOTH branches: with a
+# store it must offer the DID, and without one it must come back empty AND
+# successful, which is the case a skipped probe could not tell from a broken
+# CLI.
+run $CF inspect spaces
+check "0" "$RUN_STATUS" "cf inspect spaces runs, so its output can be read"
+DISCOVERED=$(printf '%s\n' "$RUN_OUT" | grep -oE '^did:key:[A-Za-z0-9]+' |
+  head -1)
 if [ -n "$DISCOVERED" ]; then
   ok "a local space db is discoverable: $DISCOVERED"
   check "1" "$(complete_at "cf piece ls $CONN_ARGS --space ${DISCOVERED%??????????}" |
     grep -c "^$DISCOVERED\$")" \
     "the --space slot offers a DID discovered on disk"
 else
-  ok "no local space db here, so --space has nothing to discover"
+  ok "no local space db is discoverable here"
+  probe "cf piece ls $CONN_ARGS --space "
+  check "0" "$PROBE_STATUS" "the --space slot still runs"
+  check "" "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" \
+    "and offers nothing, which is all there is on disk to offer"
 fi
 
 step "14. Both halves of a link endpoint"

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1086,7 +1086,8 @@ run_verb_session_gaps() {
 # two above; it deploys its own fixture and takes its own space.
 #
 # It is the only thing that drives a completion provider against real state,
-# and it reaches every provider the completion layer declares:
+# and it reaches every provider that reads any — the fabric, the local stores,
+# or the environment. Its own header draws the boundary exactly:
 # the unit tests cover the pure half, and a provider that reaches a fabric and
 # returns the WRONG set looks exactly like one that returned nothing, because
 # completion swallows every error on purpose. It also carries `gap` assertions

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1085,7 +1085,8 @@ run_verb_session_gaps() {
 # The completion chain against a live fabric. Same delegation rationale as the
 # two above; it deploys its own fixture and takes its own space.
 #
-# It is the only thing that drives a completion provider against real state:
+# It is the only thing that drives a completion provider against real state,
+# and it reaches every provider the completion layer declares:
 # the unit tests cover the pure half, and a provider that reaches a fabric and
 # returns the WRONG set looks exactly like one that returned nothing, because
 # completion swallows every error on purpose. It also carries `gap` assertions

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -1082,6 +1082,22 @@ run_verb_session_gaps() {
   echo "Successfully ran the verb-session gap harness for ${API_URL}."
 }
 
+# The completion chain against a live fabric. Same delegation rationale as the
+# two above; it deploys its own fixture and takes its own space.
+#
+# It is the only thing that drives a completion provider against real state:
+# the unit tests cover the pure half, and a provider that reaches a fabric and
+# returns the WRONG set looks exactly like one that returned nothing, because
+# completion swallows every error on purpose. It also carries `gap` assertions
+# for slots that deliberately answer nothing today, which fail the day one
+# starts answering.
+run_completion_walkthrough() {
+  echo "Running the completion walkthrough..."
+  API_URL="$API_URL" bash "$SCRIPT_DIR/completion-over-the-cli.sh" ||
+    error "The completion walkthrough failed."
+  echo "Successfully ran the completion walkthrough for ${API_URL}."
+}
+
 # The Topics content-safety drill: export a space's authored content, clobber a
 # topic the way a bad migration would, restore it, and prove the restore
 # byte-exact. docs/plans/topics-migration-rehearsal.md makes it part of every
@@ -1373,6 +1389,8 @@ case "$SECTION" in
     run_verbs_walkthrough
     cf_test_step_begin verb-session-gaps
     run_verb_session_gaps
+    cf_test_step_begin completion-walkthrough
+    run_completion_walkthrough
     cf_test_step_begin topics-restore-drill
     run_topics_restore_drill
     cf_test_step_begin bulk-survey-drill
@@ -1397,6 +1415,10 @@ case "$SECTION" in
   verb-gaps)
     cf_test_step_begin verb-session-gaps
     run_verb_session_gaps
+    ;;
+  completion)
+    cf_test_step_begin completion-walkthrough
+    run_completion_walkthrough
     ;;
   topics-drill)
     cf_test_step_begin topics-restore-drill

--- a/packages/cli/integration/pattern/completion-target.tsx
+++ b/packages/cli/integration/pattern/completion-target.tsx
@@ -1,0 +1,209 @@
+/**
+ * Fixture for the completion walkthrough (`completion-over-the-cli.sh`).
+ *
+ * It exists so the walkthrough owns its subject: the shipped patterns are used
+ * elsewhere, and a change to one of them should never break a demonstration of
+ * what a Tab offers. Nothing else deploys this file.
+ *
+ * Every element here is a slot of the completion chain — space, piece, verb,
+ * verb fields, cell path, result shape — so the walkthrough can name a
+ * candidate set rather than assert that something came back:
+ *
+ * - `settings` is a nested object, so a cell path completes more than one
+ *   segment deep.
+ * - `items` holds child pieces, so a path crossing a `$link` boundary has a
+ *   boundary to cross.
+ * - `addItem` declares two fields and a doc comment; `renameItem` declares
+ *   three; `sweep` declares none. Together they are the vocabulary a verb's
+ *   flags come from and the prose a candidate is annotated with.
+ * - `legacyAdd` is `@deprecated`, which the default verb listing holds back —
+ *   so the walkthrough can ask whether completion agrees with the listing.
+ * - `Item` carries a callable named `record` on its result cell AND is handed
+ *   one of that name in its arguments, which is the shadowing rule the verbs
+ *   listing states and the one no table walk can reach.
+ */
+
+import {
+  action,
+  computed,
+  type Default,
+  NAME,
+  pattern,
+  type Stream,
+  type Writable,
+} from "commonfabric";
+
+interface RecordEvent {
+  /** What to record against this item. */
+  text: string;
+}
+
+interface RecordResult {
+  /** The count as persisted, so a caller can confirm the write landed. */
+  recorded: number;
+}
+
+interface ItemInput {
+  label?: Writable<string | Default<"">>;
+  recorded?: Writable<number | Default<0>>;
+  /**
+   * A callable handed in by the board, so this piece's ARGUMENTS cell carries
+   * a name its result cell also carries. The two are different streams, and
+   * which one a caller reaches is the shadowing rule.
+   */
+  record?: Stream<RecordEvent, RecordResult>;
+}
+
+interface ItemOutput {
+  [NAME]: string;
+  label: string;
+  recorded: number;
+  /** Record one line against this item, and report the running count. */
+  record: Stream<RecordEvent, RecordResult>;
+}
+
+/** One item, deployed as a child of the board below. */
+export const Item = pattern<ItemInput, ItemOutput>(
+  ({ label, recorded }) => {
+    const record = action<RecordEvent, RecordResult>((event) => {
+      const text = (event.text ?? "").trim();
+      if (!text) throw new Error("record: text must be non-empty");
+      const next = (recorded.get() ?? 0) + 1;
+      recorded.set(next);
+      return { recorded: next };
+    });
+
+    return {
+      [NAME]: label,
+      label,
+      recorded,
+      record,
+    };
+  },
+);
+
+interface AddItemEvent {
+  /** The item's display label. */
+  title: string;
+  /** Whether the item starts pinned. */
+  pinned?: boolean;
+}
+
+interface AddItemResult {
+  /** The item this call created. */
+  item: ItemOutput;
+  /** How many items the board holds afterwards. */
+  total: number;
+}
+
+interface RenameItemEvent {
+  /** Which item to rename, by position. */
+  index: number;
+  /** The label to write. */
+  newTitle: string;
+  /** Leave the old label in place when it is already set. */
+  keepExisting?: boolean;
+}
+
+interface RenameItemResult {
+  /** The label as persisted. */
+  label: string;
+}
+
+/**
+ * Both fields optional so a projection may name one of them. A concise field
+ * path closes the position it names, so selecting `settings.theme` out of a
+ * schema that REQUIRES `density` reads as a required value that did not
+ * materialize — which is a fact about the projection rather than about
+ * completion, and not the one this fixture is for.
+ */
+interface BoardSettings {
+  theme?: string;
+  density?: string;
+}
+
+interface BoardInput {
+  items?: Writable<ItemOutput[] | Default<[]>>;
+  settings?: Writable<
+    BoardSettings | Default<{ theme: "dark"; density: "cozy" }>
+  >;
+  revision?: Writable<number | Default<0>>;
+}
+
+interface BoardOutput {
+  [NAME]: string;
+  items: ItemOutput[];
+  itemCount: number;
+  settings: BoardSettings;
+  revision: number;
+  /** Add one item to the board, and report the new total. */
+  addItem: Stream<AddItemEvent, AddItemResult>;
+  /** Rename the item at a position. */
+  renameItem: Stream<RenameItemEvent, RenameItemResult>;
+  /** Bump the revision and return nothing. */
+  sweep: Stream<void>;
+  /**
+   * Record against the board rather than one item. Handed to every child as
+   * its `record` argument, which is what puts a callable of that name on the
+   * child's arguments cell beside the one on its result cell.
+   */
+  noteAll: Stream<RecordEvent, RecordResult>;
+  /** @deprecated Use addItem, which reports the new total. */
+  legacyAdd: Stream<AddItemEvent>;
+}
+
+export default pattern<BoardInput, BoardOutput>(
+  ({ items, settings, revision }) => {
+    const noteAll = action<RecordEvent, RecordResult>((event) => {
+      const text = (event.text ?? "").trim();
+      if (!text) throw new Error("noteAll: text must be non-empty");
+      const next = (revision.get() ?? 0) + 1;
+      revision.set(next);
+      return { recorded: next };
+    });
+
+    const addItem = action<AddItemEvent, AddItemResult>((event) => {
+      const title = (event.title ?? "").trim();
+      if (!title) throw new Error("addItem: title must be non-empty");
+      const item = Item({ label: title, recorded: 0, record: noteAll });
+      items.push(item);
+      return { item, total: (items.get() ?? []).length };
+    });
+
+    const renameItem = action<RenameItemEvent, RenameItemResult>((event) => {
+      const list = items.get() ?? [];
+      const target = list[event.index];
+      if (!target) throw new Error("renameItem: no item at that index");
+      const label = (event.newTitle ?? "").trim();
+      if (!label) throw new Error("renameItem: newTitle must be non-empty");
+      if (event.keepExisting && (target.label ?? "").length > 0) {
+        return { label: target.label };
+      }
+      items.key(event.index).key("label").set(label);
+      return { label };
+    });
+
+    const sweep = action(() => {
+      revision.set((revision.get() ?? 0) + 1);
+    });
+
+    const legacyAdd = action<AddItemEvent>((event) => {
+      const title = (event.title ?? "").trim();
+      if (!title) throw new Error("legacyAdd: title must be non-empty");
+      items.push(Item({ label: title, recorded: 0, record: noteAll }));
+    });
+
+    return {
+      [NAME]: "Completion fixture",
+      items,
+      itemCount: computed(() => (items.get() ?? []).length),
+      settings,
+      revision,
+      addItem,
+      renameItem,
+      sweep,
+      noteAll,
+      legacyAdd,
+    };
+  },
+);

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -136,20 +136,35 @@ Deno.test("live candidates: unmapped slots ask for nothing", async () => {
   }
 });
 
-Deno.test("live candidates: path-shaped slots defer to the shell", async () => {
-  const cases: Array<[string, string]> = [
-    ["cf piece ls -i ", "files"],
-    ["cf piece new --root ", "dirs"],
-    ["cf piece new --test ", "files"],
-    ["cf piece new --datafile ", "files"],
-    ["cf check ", "files"],
-    ["cf space verify ", "dirs"],
-    ["cf space clone --to ", "dirs"],
-    ["cf id did ", "files"],
+Deno.test("live candidates: every path-shaped slot hands the shell its own directive", async () => {
+  // One entry per reachable directive in the provider tables, asserting the
+  // glob as well as the kind. A wrong glob is the "wrong set" defect in its
+  // quietest form: the slot still answers, with the wrong files, and nothing
+  // upstream can tell. These read no state, so this is where they belong —
+  // the integration walkthrough covers the providers that reach a fabric and
+  // deliberately does not re-check these.
+  const cases: Array<[string, string, string | undefined]> = [
+    ["cf piece ls -i ", "files", "*.key"],
+    ["cf id did ", "files", "*.key"],
+    ["cf piece new --root ", "dirs", undefined],
+    ["cf piece new --test ", "files", "*.tsx"],
+    ["cf piece new ", "files", "*.tsx"],
+    ["cf piece setsrc ", "files", "*.tsx"],
+    ["cf check ", "files", "*.tsx"],
+    ["cf test ", "files", "*.tsx"],
+    ["cf piece new --datafile ", "files", undefined],
+    ["cf view ", "files", undefined],
+    ["cf exec ", "files", undefined],
+    ["cf space clone --to ", "dirs", undefined],
+    ["cf space verify ", "dirs", undefined],
+    ["cf space reset ", "dirs", undefined],
   ];
-  for (const [text, kind] of cases) {
+  for (const [text, kind, glob] of cases) {
     const result = await liveCandidates(lineFor(text));
-    assertEquals(result.directives[0]?.kind, kind, text);
+    assertEquals(result.directives.length, 1, `${text} emits one directive`);
+    const directive = result.directives[0] as { kind: string; glob?: string };
+    assertEquals(directive.kind, kind, text);
+    assertEquals(directive.glob, glob, `${text} glob`);
   }
 });
 


### PR DESCRIPTION
## Why

Completion is the one part of the CLI that fails by staying silent. Every
provider failure degrades to an empty candidate list on purpose, because a
completion request runs between two keystrokes and must never paste a stack
trace into the command line. That is why nothing here announces a defect: a
slot that resolves nothing, a slot whose fabric is unreachable, and a slot with
no provider at all are one experience at the prompt.

So the existing tests could not have caught what the rest of this stack fixes.
`test/completion-*.test.ts` cover the pure shaping functions and assert that a
slot with no fabric context degrades to empty; every path that reaches a fabric
was unverified, and the defects sat exactly where no live exercise ran.

This is item 18 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md),
and it lands first on purpose: it is the only way to watch a live provider
fail, and every correctness item stacked above it is a shape nothing currently
exercises.

Targets `main`. The plan document it works against merged as #6236, and
#6250 through #6254 stack on this one.

## What Changed

- `packages/cli/integration/completion-over-the-cli.sh` — deploys a fixture,
  then asserts what a Tab offers at each slot of the chain: space → piece →
  verb → verb fields → cell path → result shape. 58 assertions, 9 of them
  `gap` assertions on the `verb-session-gaps.sh` precedent, which fail loudly
  the day their slot starts answering.
- `packages/cli/integration/pattern/completion-target.tsx` — the fixture, owned
  by this walkthrough alone. A nested object, an array of child pieces, verbs
  with declared fields and doc comments, a `@deprecated` verb, and a child
  carrying a callable name on both its result and its arguments cell.
- Wired into `integration.sh`'s `piece-call` section (so CI runs it) with
  `completion` as the standalone selector.

Two rules the script holds to, both forced by completion's silence. A slot is
judged only after the equivalent `cf` command has been run against the same
target, so an empty candidate list reads as a defect rather than as an
unreachable fabric. And a candidate is judged by whether the command accepts it.

It settles the three questions no table walk can reach:

- `cellPathCandidates` **follows** a `$link` boundary, and the path that
  crosses one is a path `cf get` reads.
- Every id the `--piece` listing offers is one the same command reads back.
- A verb on both cells completes **once**, against the result cell — the same
  one the dispatcher reaches.

It also found one defect the plan does not enumerate: the cell-path slot offers
a piece's callables, which `cf get` refuses and redirects to `cf call`. Asserted
as what happens today.

## Test plan

- `API_URL=http://localhost:8000 packages/cli/integration/completion-over-the-cli.sh`
  against a local dev server: **58 passed, 0 failed, 9 gaps open** — and the
  same 58 with `MEMORY_DIR` pointed at an empty directory, so a machine with
  no local space store cannot pass by asserting less than one with a store.
- `CF_CLI_INTEGRATION_SECTION=completion ./packages/cli/integration/integration.sh`
  — same, through the dispatcher CI uses.
- `deno task test` in `packages/cli` — 0 failed.
- In CI the script runs inside `CLI Integration Tests (core-piece-call)`,
  which is the job to read for this PR.
- `deno fmt --check`, `deno lint`, `deno task check-skill-facts`,
  `deno task check-docs`, `deno task cfcheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->






## Review rounds

Every finding so far, and what each cost. The counts above are this PR's head
alone; earlier revisions of this description quoted totals from later PRs in
the stack, which was wrong.

**The harness could report a broken CLI as evidence.** `gap` read its probe
through command substitution, so a `cf` that only exits nonzero produced
`pass=1 fail=0 gaps=1`. `gap` now runs the probe and keeps the exit status apart
from the output. The same shape then turned up twice more — in space discovery
here, and in the entity step in #6253 — so the fix is a `run` helper any step
branching on a command's emptiness reaches for, not three patches.

**A branch could pass by asserting less.** A machine with no local store skipped
the `--space` probe entirely. Both branches now assert the same three things and
the run reports 58 either way.

**"Every provider" was an overclaim, twice.** First against the whole table
(`spaceCandidates`, `linkEndpointCandidates`, `apiUrlCandidates` and
`patternFiles` were unreached — steps 13 and 14 now cover them), then against
the dozen constant-directive entries that one `--identity` probe was standing
for. Those are asserted individually now, kind and glob, in
`test/completion-providers.test.ts` — confirmed to fail against a deliberately
wrong glob rather than passing vacuously.

**A gate cited before it exists.** The coverage note named
`deno task check-completion-slots`, which arrives with item 19 in #6254. At this
head the task does not exist, so the citation is gone from here and added there.
