### PR TITLE
fix(cli): complete the target spellings and slots the commands accept

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -77,9 +77,9 @@ read before picking one up; this table is the roll-up.
 
 | # | Item | Rank | Status |
 | --- | --- | --- | --- |
-| 1 | Inline `--option=value` drops every live candidate | correctness | not started |
-| 2 | Flags offered past a `stopEarly()` boundary | correctness | not started |
-| 3 | Target resolution lags the reference grammar | correctness | not started |
+| 1 | Inline `--option=value` drops every live candidate | correctness | done |
+| 2 | Flags offered past a `stopEarly()` boundary | correctness | done |
+| 3 | Target resolution lags the reference grammar | correctness | done |
 | 4 | Verb flags do not complete | pattern vocabulary | shaper now, wiring after step 10 |
 | 5 | Result field paths for `get` and `wish` | pattern vocabulary | not started |
 | 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
@@ -98,33 +98,24 @@ read before picking one up; this table is the roll-up.
 | 19 | A gate that fails when a new slot has no decision | mechanism | not started |
 
 **What can be picked up today.** Everything except one wiring change and one
-item. Items 1, 2, 3, 5 and 7 are independent of each other and of the surface
-work, and are worth doing in that order. Items 9, 10, 12, 13, 14, 15, 16 and 17
-are mechanical and can be taken at any time.
-
-Item 2 holds under either grammar. A `cf` flag written past the verb is refused
-today and belongs to the callable after step 10, so declining to offer one there
-is correct now and stays correct. It leaves the position offering nothing until
-item 4 fills it, which is the honest state for a position whose vocabulary the
-command cannot yet name — and a great deal better than offering flags the
-command rejects.
+item. Items 5 and 7 are independent of each other and of the surface work. Items
+9, 10, 12, 13, 14, 15, 16 and 17 are mechanical and can be taken at any time.
 
 Item 4 splits. Turning a verb's `inputSchema` into `--kebab-case` candidates is
 a pure function of the listing, belongs beside `shapeVerbCandidates`, needs no
 fabric to test, and is the same function under either grammar. Build it now.
 Only its wiring — which slot receives it — waits, because step 10 decides
-whether a verb's fields are written before the marker or after it.
+whether a verb's fields are written before the marker or after it. The position
+offers nothing until then, which is the honest state for one whose vocabulary
+the command cannot yet name.
 
 Item 6 is the one to leave alone. Under the current grammar it needs the whole
 line read for context, since a projection precedes the verb it shapes; after
 step 10 the verb is already before the cursor and it needs nothing. Building it
 now means building the machinery that step 10 makes unnecessary.
 
-Items 8 and 11 hold open decisions and are not work yet. Item 18 is the
-mechanism the rest is worked against, and it landed first for that reason: it
-is the only way to see a live provider fail, and the slots the items above
-describe are asserted there as gaps so that each one closing announces itself.
-Item 19 is its other half and is still to do.
+Items 8 and 11 hold open decisions and are not work yet. Item 19 is the other
+half of the mechanism item 18 landed.
 
 ## What this list covers, and what it cannot
 
@@ -196,44 +187,27 @@ throwing. And `parseExecArgs` takes the spec first and the arguments second.
 
 ### 1. Inline `--option=value` drops every live candidate
 
-`--space=<TAB>`, `--piece=<TAB>`, and `--api-url=<TAB>` offer nothing, while the
-same options completed as `--space <TAB>` work. Enumerated values are
-unaffected: `--log-level=<TAB>` completes.
-
-`complete` in `lib/completion/mod.ts` filters candidates against the word under
-the cursor, which for this spelling is `--piece=`. `staticCandidates`
-re-attaches that prefix through `withInlinePrefix`, so its candidates survive
-the filter.
-`liveCandidates` returns bare values, so every one of them fails the prefix test
-and is dropped.
-
-The fix is to apply the inline prefix to the live half as well, which means
-`complete` carrying the slot's `inlinePrefix` across both sources rather than
-`staticCandidates` owning it alone.
+`complete` in `lib/completion/mod.ts` attaches the slot's `inlinePrefix` to
+every candidate, whichever source produced it. `staticCandidates` returns bare
+values, so one rule covers the static half and the live half alike — where the
+static half owning the prefix alone left every live candidate failing the
+prefix filter that `--piece=` is.
 
 This spelling is why `tokenizeLine` exists — bash splits its own words on `=` —
-so it is the one form the implementation is built to serve and the one that does
-not work.
+so it is the one form the implementation is built to serve.
 
-Directives are the other half of the same slot: `--identity=<TAB>` emits a files
-directive whose glob the shell applies to a word still carrying `--identity=`.
-Settle both in one change.
+The directive half of the same slot lives in the shell functions, because it is
+the shell that applies a glob. `$cur` is the whole word (`--identity=~/keys/a`)
+while readline replaces only the fragment after the last word-break character,
+so bash globs that fragment and zsh `compset -P`s the flag into `IPREFIX`.
 
 ### 2. Flags offered past a `stopEarly()` boundary
 
-After the callable name, `cf call` offers `--invocation`, `--filter`,
-`--select`, `--quiet` and the rest of its own flags. The command rejects all of
-them there: `buildCallCommand` in `commands/piece.ts` is `stopEarly()`, so the
-first positional ends option parsing and every later word belongs to the
-callable's schema-derived parser. The flags' own help text says so — each
-description ends "(before the callable name)". `cf exec` has the same shape and
-the same defect, its descriptions ending "(before the mounted file)".
-
-`resolveCompletionLine` in `lib/completion/line.ts` has no notion of the
-boundary, so `option-name` stays reachable for the whole line. Cliffy records it
-as `_stopEarly` with no accessor; either read that field or have the completion
-layer name the two commands. Reading the field keeps the property where the
-command declares it, which is the reason to prefer it.
+`resolveCompletionLine` in `lib/completion/line.ts` reads Cliffy's `_stopEarly`
+field, so past the callable name on `cf call` and past the mounted file on
+`cf exec` no option slot is reachable and a flag-shaped word does not shift the
+positional index. That keeps the property where the command declares it: a
+third command becoming `stopEarly()` needs no edit in the completion layer.
 
 This holds under either grammar. A `cf` flag past the verb is refused today, and
 after step 10 of [Naming the target](cli-surface-shape.md#naming-the-target) the
@@ -244,32 +218,27 @@ should offer.
 
 ### 3. Target resolution lags the reference grammar
 
-Three documented ways to name a target complete nothing:
+`resolvePieceContext` in `lib/completion/providers.ts` parses the target through
+`normalizeLLMFriendlyRef`, which is the function the command's own intake parses
+it with: the embedded space, the `@scope` suffix, a trailing path, and the
+`#argument` suffix that selects the arguments cell the way `--input` does. What
+that does not recognize falls through to the alias grammar
+(`parseScopedIdSegment`). Taking the word verbatim as a piece id — which this
+did — meant every documented spelling but the bare id resolved to a listing
+call that could not succeed, and so to a slot that silently offered nothing.
 
-```bash
-cf call --piece /@did:key:.../of:fid1:... <TAB>   # canonical reference
-cf call --space donuts /of:fid1:... <TAB>          # positional address
-cf get --piece fid1:...#argument <TAB>             # the arguments cell
-```
+An embedded space DID supplies the space where the line names none, the way
+`parsePieceOptions` does with the same reference. Where the line names one it
+wins, and a mismatch between the two is the command's to report.
 
-The `--url` spelling of the same target works, which is what makes this read as
-random rather than as a missing capability.
-
-`resolvePieceContext` in `lib/completion/providers.ts` takes `--piece` verbatim
-as a piece id. The canonical form is not one, so the listing call fails and the
-slot degrades to empty. `normalizeLLMFriendlyRef` is the function that already
-parses this grammar — the embedded space, the `@scope` suffix, the trailing
-path, and `#argument` — and completion is an intake seam that does not use it.
-
-The positional address is a second, independent break: it occupies positional
-index 0, so `resolveSlot` resolves the cursor to the variadic `tail` rather than
-to `callable`, and the callable provider is never consulted. Whichever way
-completion learns the address form, it has to shift the positional index the way
-the command does.
-
-`#argument` selects the arguments cell, the same selection `--input` spells as a
-flag. `cellPathCandidates` reads `--input` and not the suffix, so the two
-spellings of one selection complete differently.
+The positional address was a second, independent break: it occupied positional
+index 0, so the cursor resolved to the variadic `tail` rather than to
+`callable`. `resolveCompletionLine` now reads it out as `line.address` instead
+of counting it, which shifts the index the way `readCallTarget` and
+`readTargetPositionals` shift it. Which commands accept one is carried in
+`POSITIONAL_ADDRESS_COMMANDS`, for the reason `PRE_PARSE_GLOBALS` is carried:
+nothing on the command tree distinguishes those arguments from an ordinary
+string.
 
 ## Pattern vocabulary
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -982,13 +982,25 @@ such as `--log-level` — plus live values read from the fabric:
 | `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell      |
 | `--datafile`                    | any file, via the shell                     |
 
+An option's value completes the same whether it is written after a space or
+after `=`, and every spelling of a target reaches the same slots behind it: the
+bare id, the canonical reference (space-qualified or not, with an `@scope`
+suffix, an embedded path, or the `#argument` suffix), and a canonical reference
+written positionally in place of `--piece`.
+
+Past a `stopEarly()` boundary — after `cf call`'s callable name, after
+`cf exec`'s mounted file — nothing is offered. The CLI's own flags are refused
+there, so offering them would name something the command rejects; the words that
+do belong there are the callable's, and completing those is not yet built.
+
 Live values need an identity and an api-url. Both are read from the line being
 typed (`-i`, `-a`, `-u`) before falling back to `CF_IDENTITY`/`CF_API_URL`, so
 `cf call -s other-space --piece <TAB>` lists that space's pieces rather than the
-environment's. When neither is resolvable, or the server is unreachable,
-completion yields nothing — it never prints an error into the command line. Each
-request costs one CLI invocation plus one round trip, so value completion is as
-fast as the fabric it queries.
+environment's. A space DID embedded in a reference supplies one the line did not
+name. When nothing is resolvable, or the server is unreachable, completion
+yields nothing — it never prints an error into the command line. Each request
+costs one CLI invocation plus one round trip, so value completion is as fast as
+the fabric it queries.
 
 ### `deno task cf` and other invocations
 

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -241,46 +241,61 @@ check "Completion fixture" \
   "the slug is a --piece value the command accepts"
 gap "cf call $LINE_ARGS --piece bo" "a slug in the --piece slot"
 
-step "4. The inline spelling of an option drops every live candidate"
-# `--piece=<TAB>` and `--piece <TAB>` are the same slot. Only the second works,
-# and the first is the spelling `tokenizeLine` exists to serve.
+step "4. Both spellings of an option complete the same values"
+# `--piece=<TAB>` and `--piece <TAB>` are one slot. The inline spelling is the
+# one `tokenizeLine` exists to serve, and its candidates carry the `--piece=`
+# back so the shell replaces the whole token.
 check "$BOARD" "$(complete_at "cf call $LINE_ARGS --piece ")" \
   "the spaced spelling completes"
-gap "cf call $LINE_ARGS --piece=" "the inline --piece= spelling"
-# The directive half of the same slot: the glob reaches the shell attached to a
-# word that still carries `--identity=`, so nothing can match it.
+check "--piece=$BOARD" "$(complete_at "cf call $LINE_ARGS --piece=")" \
+  "the inline spelling completes the same value, prefix attached"
+# The directive half of the same slot reaches the shell either way.
 check ":cf:files *.key" "$(directives_at "cf call $LINE_ARGS --identity ")" \
   "the spaced --identity spelling emits its files directive"
+check ":cf:files *.key" "$(directives_at "cf call $LINE_ARGS --identity=")" \
+  "and so does the inline one"
 
-step "5. Three documented ways to name a target complete nothing"
+step "5. Every documented way to name a target reaches the same slots"
 CANONICAL="/of:$BOARD"
 QUALIFIED="/@$SPACE_DID/of:$BOARD"
+VERBS="addItem,legacyAdd,noteAll,renameItem,sweep"
 check "Completion fixture" \
   "$($CF get --quiet --piece "$CANONICAL" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
   "the canonical reference is a --piece value the command accepts"
-gap "cf call $LINE_ARGS --piece $CANONICAL " \
-  "the verb slot behind a canonical --piece reference"
+check "$VERBS" "$(candidates_at "cf call $LINE_ARGS --piece $CANONICAL ")" \
+  "and the verb slot behind it offers the same verbs"
+
 check "Completion fixture" \
   "$($CF get --quiet --piece "$QUALIFIED" $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
-  "and so is its space-qualified spelling"
-gap "cf call $LINE_ARGS --piece $QUALIFIED " \
-  "the verb slot behind a space-qualified reference"
+  "its space-qualified spelling is accepted too"
+check "$VERBS" "$(candidates_at "cf call $LINE_ARGS --piece $QUALIFIED ")" \
+  "and completes the same"
+# The embedded space is enough on its own: the DID is in the reference, so a
+# line that names no --space still resolves one.
+check "$VERBS" "$(candidates_at \
+  "cf call --api-url $API_URL --identity $CF_IDENTITY --piece $QUALIFIED ")" \
+  "and supplies the space when the line names none"
 
 check "Completion fixture" \
   "$($CF get --quiet $ARGS "$CANONICAL" '$NAME' 2>/dev/null | tr -d '"')" \
   "a positional canonical address is a target the command accepts"
-gap "cf call $LINE_ARGS $CANONICAL " \
-  "the verb slot behind a positional address"
+check "$VERBS" "$(candidates_at "cf call $LINE_ARGS $CANONICAL ")" \
+  "and the callable after it completes, index shifted the way the command shifts it"
 
 check "1" "$(succeeds $CF get --quiet --piece "$CANONICAL#argument" $ARGS)" \
   "the #argument suffix is a --piece value the command accepts"
-gap "cf get $LINE_ARGS --piece $CANONICAL#argument " \
-  "the cell path behind an #argument reference"
-# The flag spelling of the same selection does complete, which is what makes
-# the suffix read as random rather than as a missing capability.
-check "1" "$(complete_at "cf get $LINE_ARGS --piece board --input " |
-  grep -c '^settings$')" \
-  "--input, which selects the same cell, completes it"
+ARGUMENT_KEYS=$(candidates_at "cf get $LINE_ARGS --piece $CANONICAL#argument ")
+check "$ARGUMENT_KEYS" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board --input ")" \
+  "and completes the arguments cell, the same keys --input does"
+check "1" "$(printf '%s' "$ARGUMENT_KEYS" | grep -c 'settings')" \
+  "which is a key the arguments cell actually holds"
+
+# A path embedded in the reference is where the walk starts, the way
+# `mergePiecePath` puts it in front of the positional path.
+check "density,theme" \
+  "$(candidates_at "cf get $LINE_ARGS --piece $CANONICAL/settings ")" \
+  "an embedded path is what the cell-path slot completes below"
 
 step "6. The verb slot"
 check "addItem,legacyAdd,noteAll,renameItem,sweep" \
@@ -303,14 +318,18 @@ check "Add one item to the board, and report the new total." \
 check "handler" "$(annotation_at "cf call $LINE_ARGS --piece board " addItem)" \
   "and the candidate is annotated with its kind instead"
 
-step "7. Past the callable name, cf's own flags are offered and refused"
+step "7. Past the callable name, cf's own flags are not offered"
 # `piece call` is stopEarly(), so the first positional ends option parsing and
-# every later word belongs to the callable's schema-derived parser.
-check "1" "$(complete_at "cf call $LINE_ARGS --piece board addItem --" |
-  grep -c '^--invocation$')" \
-  "--invocation is offered after the callable name"
+# every later word belongs to the callable's schema-derived parser. A flag the
+# command refuses there is a candidate that teaches a caller something false.
 check "0" "$(succeeds $CF call --quiet --piece board $ARGS addItem \
-  --invocation late)" "and the command refuses it there"
+  --invocation late)" "the command refuses a cf flag after the callable name"
+check "" "$(complete_at "cf call $LINE_ARGS --piece board addItem --")" \
+  "and nothing is offered there"
+# Before the callable name the same flag is accepted and offered.
+check "1" "$(complete_at "cf call $LINE_ARGS --piece board --" |
+  grep -c '^--invocation$')" \
+  "--invocation is still offered before the callable name"
 
 step "8. The verb's own fields do not complete"
 # The position where a caller has least to go on: these names are the pattern

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -12,6 +12,9 @@
  */
 
 import type { Argument, Command, Option } from "@cliffy/command";
+// Free at completion time: walking the tree means loading the command tree,
+// which already resolves this module.
+import { matchLLMFriendlyLink } from "@commonfabric/runner/shared";
 
 /**
  * A command of any option/argument parameterization.
@@ -100,6 +103,12 @@ export interface CompletionLine {
   readonly options: ReadonlyMap<string, string>;
   /** Long names of valueless flags already on the line. */
   readonly flags: ReadonlySet<string>;
+  /**
+   * A canonical reference written in the first positional, in place of
+   * `--piece`. It does not count as a positional: the command reads it out
+   * before the rest, so `<callable>` is still the argument after it.
+   */
+  readonly address?: string;
   /** Positional words already supplied to `command`. */
   readonly positionals: readonly string[];
   /** Words after a `--` separator, excluding the separator itself. */
@@ -172,6 +181,52 @@ function realSubcommands(command: AnyCommand): AnyCommand[] {
   return command.getCommands(false).filter((child) =>
     child.getName() !== "help"
   );
+}
+
+/**
+ * Whether the command ends its own option parsing at the first positional.
+ *
+ * `cf piece call` and `cf exec` are `stopEarly()`, so every word after the
+ * callable name belongs to the callable's schema-derived parser and the CLI's
+ * own flags are refused there. Cliffy stores the property with no accessor, so
+ * it is read off the field: keeping the question where the command declares it
+ * means a third command becoming `stopEarly()` needs no edit here.
+ */
+function stopsEarly(command: AnyCommand): boolean {
+  return (command as unknown as { _stopEarly?: boolean })._stopEarly === true;
+}
+
+/**
+ * Commands whose first positional may carry a canonical reference in place of
+ * `--piece`, keyed the way the provider tables are.
+ *
+ * `readTargetPositionals` and `readCallTarget` in `commands/piece.ts` are what
+ * implement it, and nothing on the command tree distinguishes those two
+ * arguments from an ordinary one — `get` declares `[addressOrPath]` and `call`
+ * declares `<callable>`, both plain strings. Carried explicitly for the same
+ * reason `PRE_PARSE_GLOBALS` is.
+ */
+const POSITIONAL_ADDRESS_COMMANDS: ReadonlySet<string> = new Set([
+  "piece get",
+  "piece set",
+  "piece call",
+  "get",
+  "set",
+  "call",
+]);
+
+/**
+ * Whether `token` in the first positional of `path` names the target rather
+ * than filling that argument. The deciding grammar is the command's:
+ * a canonical reference begins with `/`, and neither a cell path nor a
+ * callable name ever does.
+ */
+function isPositionalAddress(
+  path: readonly string[],
+  token: string,
+): boolean {
+  return POSITIONAL_ADDRESS_COMMANDS.has(path.join(" ")) &&
+    matchLLMFriendlyLink.test(token.trim());
 }
 
 /** Resolve a subcommand by name or alias, skipping Cliffy's own `help`. */
@@ -275,6 +330,7 @@ export function resolveCompletionLine(
   const path: string[] = [];
   const options = new Map<string, string>();
   const flags = new Set<string>();
+  let address: string | undefined;
   let positionals: string[] = [];
   const passthrough: string[] = [];
   let separatorSeen = false;
@@ -288,6 +344,14 @@ export function resolveCompletionLine(
     }
     if (token === "--") {
       separatorSeen = true;
+      continue;
+    }
+
+    // Past a `stopEarly()` boundary every word belongs to the callable, so a
+    // flag-shaped one is data rather than an option. Reading it as an option
+    // would shift the positional index the argument slot depends on.
+    if (positionals.length > 0 && stopsEarly(command)) {
+      positionals.push(token);
       continue;
     }
 
@@ -355,6 +419,12 @@ export function resolveCompletionLine(
         positionals = [];
         continue;
       }
+      // A positional address replaces `--piece` rather than filling the
+      // argument, so the words after it keep the indices they would have had.
+      if (address === undefined && isPositionalAddress(path, token)) {
+        address = token;
+        continue;
+      }
     }
     positionals.push(token);
   }
@@ -376,6 +446,7 @@ export function resolveCompletionLine(
     word,
     options,
     flags,
+    ...(address !== undefined && { address }),
     positionals,
     passthrough,
   };
@@ -394,6 +465,15 @@ function resolveSlot(input: {
 
   if (separatorSeen) {
     return { kind: "passthrough", index: input.passthrough.length };
+  }
+
+  // Past a `stopEarly()` boundary the CLI's own flags are refused, so no
+  // option slot is reachable there. The position belongs to the callable's
+  // vocabulary, which the argument slot below names — and which nothing
+  // completes yet. Offering nothing is what a position whose words the command
+  // cannot name should offer; offering flags the command rejects is not.
+  if (positionals.length > 0 && stopsEarly(command)) {
+    return positionalSlot(command, positionals);
   }
 
   // `--name=<cursor>` completes the value, and candidates must be emitted with
@@ -446,16 +526,22 @@ function resolveSlot(input: {
     return { kind: "subcommand" };
   }
 
-  const args = command.getArguments();
-  if (args.length > 0) {
-    const index = Math.min(positionals.length, args.length - 1);
-    const argument = args[index];
-    // Only a variadic final argument accepts more words than it declares.
-    if (positionals.length < args.length || argument.variadic) {
-      return { kind: "argument", argument, index: positionals.length };
-    }
-  }
+  return positionalSlot(command, positionals);
+}
 
+/** The argument the next positional word fills, or `null` past the last one. */
+function positionalSlot(
+  command: AnyCommand,
+  positionals: readonly string[],
+): CompletionSlot | null {
+  const args = command.getArguments();
+  if (args.length === 0) return null;
+  const index = Math.min(positionals.length, args.length - 1);
+  const argument = args[index];
+  // Only a variadic final argument accepts more words than it declares.
+  if (positionals.length < args.length || argument.variadic) {
+    return { kind: "argument", argument, index: positionals.length };
+  }
   return null;
 }
 

--- a/packages/cli/lib/completion/mod.ts
+++ b/packages/cli/lib/completion/mod.ts
@@ -11,6 +11,7 @@
 import {
   type AnyCommand,
   type CompletionLine,
+  type CompletionSlot,
   resolveCompletionLine,
   stripInvocationPrefix,
 } from "./line.ts";
@@ -128,14 +129,32 @@ function isOwnInvocation(words: readonly string[]): boolean {
 }
 
 /**
+ * The `--name=` a slot's candidates must carry, or `undefined` when the value
+ * was written after a space.
+ */
+function inlinePrefixOf(slot: CompletionSlot | null): string | undefined {
+  if (!slot) return undefined;
+  if (slot.kind === "option-value" || slot.kind === "global-option-value") {
+    return slot.inlinePrefix;
+  }
+  return undefined;
+}
+
+/**
  * Re-attach a `--name=` prefix to values completed in inline form, so the shell
  * replaces the whole token rather than appending to it.
+ *
+ * Applied to every source of candidates rather than to one of them. The word
+ * under the cursor is `--name=…` in this spelling and candidates are filtered
+ * against it below, so a bare value cannot survive that filter — which is how
+ * a live provider's candidates came to be dropped for the one spelling
+ * `tokenizeLine` exists to serve.
  */
 function withInlinePrefix(
-  candidates: Candidate[],
+  candidates: readonly Candidate[],
   prefix: string | undefined,
 ): Candidate[] {
-  if (!prefix) return candidates;
+  if (!prefix) return [...candidates];
   return candidates.map((candidate) => ({
     ...candidate,
     value: `${prefix}${candidate.value}`,
@@ -146,6 +165,9 @@ function withInlinePrefix(
  * Static candidates for a resolved line — everything answerable without I/O.
  * Split out from `complete` so tests can assert the whole static surface
  * without a fabric, which is where most completion regressions would show.
+ *
+ * Values come back bare. `complete` attaches the inline `--name=` prefix, so
+ * that one rule covers this half and the live half alike.
  */
 export function staticCandidates(line: CompletionLine): Candidate[] {
   const slot = line.slot;
@@ -158,16 +180,12 @@ export function staticCandidates(line: CompletionLine): Candidate[] {
       return subcommandCandidates(line.command);
     case "option-name":
       return optionNameCandidates(line.command, line);
-    case "option-value": {
-      const enumerated = enumeratedOptionValues(slot.option);
-      if (!enumerated) return [];
-      return withInlinePrefix(enumerated, slot.inlinePrefix);
-    }
+    case "option-value":
+      // `null` means the option has no statically known set, which leaves the
+      // slot to a live provider.
+      return enumeratedOptionValues(slot.option) ?? [];
     case "global-option-value":
-      return withInlinePrefix(
-        preParseGlobalValues(slot.option),
-        slot.inlinePrefix,
-      );
+      return preParseGlobalValues(slot.option);
     default:
       return [];
   }
@@ -195,7 +213,10 @@ export async function complete(
   const line = resolveCompletionLine(root, words, cword);
 
   const live = await liveCandidates(line);
-  const candidates = [...staticCandidates(line), ...live.candidates];
+  const candidates = withInlinePrefix(
+    [...staticCandidates(line), ...live.candidates],
+    inlinePrefixOf(line.slot),
+  );
 
   const matching = candidates.filter((candidate) =>
     candidate.value.startsWith(line.word)

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -20,6 +20,8 @@ import type { Candidate } from "./static.ts";
 import type { CompletionLine } from "./line.ts";
 import { longName } from "./line.ts";
 import { absPath } from "../utils.ts";
+import { normalizeLLMFriendlyRef } from "../llm-friendly-ref.ts";
+import { parseScopedIdSegment } from "@commonfabric/runner/shared";
 import type { PieceConfig, SpaceConfig } from "../piece.ts";
 import ports from "@commonfabric/ports" with { type: "json" };
 
@@ -57,6 +59,7 @@ function directive(...directives: Directive[]): ProviderResult {
  */
 export function resolveSpaceContext(
   line: CompletionLine,
+  embeddedSpace?: string,
 ): SpaceConfig | null {
   const url = line.options.get("url");
   const identity = line.options.get("identity") ??
@@ -64,7 +67,11 @@ export function resolveSpaceContext(
   if (!identity) return null;
 
   let apiUrl = line.options.get("api-url") ?? Deno.env.get("CF_API_URL");
-  let space = line.options.get("space");
+  // A reference carrying a space DID supplies one the line did not name, which
+  // is what `parsePieceOptions` does with the same reference. Where the line
+  // named a space it wins, and a mismatch between the two is settled by the
+  // command rather than here: completion offers candidates, it does not judge.
+  let space = line.options.get("space") ?? embeddedSpace;
 
   if (url) {
     try {
@@ -95,16 +102,76 @@ export function resolveSpaceContext(
   }
 }
 
-/** Same as `resolveSpaceContext`, plus the `--piece` the line already names. */
+/**
+ * The target reference the line names, in whichever of the four spellings it
+ * was written: `--piece`, a positional canonical address, or the piece a
+ * `--url` carries.
+ */
+function writtenPieceRef(line: CompletionLine): string | undefined {
+  const piece = line.options.get("piece") ?? line.address;
+  if (piece) return piece;
+  const url = line.options.get("url");
+  if (!url) return undefined;
+  try {
+    return new URL(url).pathname.split("/").filter(Boolean)[1];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Same as `resolveSpaceContext`, plus the target the line already names —
+ * parsed through the same grammar the command's own intake parses it with.
+ *
+ * `normalizeLLMFriendlyRef` reads the canonical reference: the embedded space,
+ * the `@scope` suffix, an embedded path, and the `#argument` suffix that
+ * selects the arguments cell the way `--input` does. What it does not
+ * recognize falls through to the alias grammar, which is `id[@scope]`. Taking
+ * the word verbatim as a piece id — which this did — meant every documented
+ * spelling but the bare id resolved to a listing call that could not succeed,
+ * and so to a slot that silently offered nothing.
+ *
+ * A malformed reference is `null` rather than a throw: the caller is a
+ * provider, and a half-typed word is the normal state of one.
+ */
 function resolvePieceContext(line: CompletionLine): PieceConfig | null {
-  const space = resolveSpaceContext(line);
+  const written = writtenPieceRef(line);
+  if (!written) return null;
+
+  let ref;
+  try {
+    ref = normalizeLLMFriendlyRef(written, {
+      space: line.options.get("space"),
+    });
+  } catch {
+    return null;
+  }
+
+  if (!ref) {
+    let alias;
+    try {
+      alias = parseScopedIdSegment(written);
+    } catch {
+      return null;
+    }
+    const space = resolveSpaceContext(line);
+    if (!space) return null;
+    return {
+      ...space,
+      piece: alias.id,
+      ...(alias.scope && { pieceScope: alias.scope }),
+    };
+  }
+
+  const space = resolveSpaceContext(line, ref.embeddedSpace);
   if (!space) return null;
-  const piece = line.options.get("piece") ??
-    (line.options.get("url")
-      ? new URL(line.options.get("url")!).pathname.split("/").filter(Boolean)[1]
-      : undefined);
-  if (!piece) return null;
-  return { ...space, piece };
+  return {
+    ...space,
+    piece: ref.pieceId,
+    ...(ref.scope && { pieceScope: ref.scope }),
+    ...(ref.path.length > 0 && { piecePath: ref.path }),
+    ...(ref.input && { pieceInput: true }),
+  };
 }
 
 /**
@@ -181,7 +248,9 @@ async function cellPathCandidates(
 
   const { parentPath, prefix } = splitPathPrefix(line.word);
   const keys = await childKeys(config, parentPath, {
-    input: line.flags.has("input"),
+    // `#argument` on the reference and `--input` as a flag are two spellings
+    // of one selection, so both reach the arguments cell here.
+    input: line.flags.has("input") || config.pieceInput === true,
   });
   if (keys.length === 0) return NOTHING;
 
@@ -195,6 +264,10 @@ async function cellPathCandidates(
  * Keys directly under `path` on a piece's cell. An array yields its indices, an
  * object its property names, and a leaf yields nothing — which is the correct
  * signal that the path is already complete.
+ *
+ * A path embedded in the reference comes first, the way `mergePiecePath` puts
+ * it, so `--piece /of:fid1:…/items` completes `items`' keys rather than the
+ * root's.
  */
 async function childKeys(
   config: PieceConfig,
@@ -203,7 +276,10 @@ async function childKeys(
 ): Promise<string[]> {
   const { getCellValue } = await import("../piece.ts");
   const { parseCellPath } = await import("@commonfabric/runner");
-  const segments = path ? parseCellPath(path) : [];
+  const segments = [
+    ...(config.piecePath ?? []),
+    ...(path ? parseCellPath(path) : []),
+  ];
   return keysOf(await getCellValue(config, segments, options));
 }
 

--- a/packages/cli/lib/completion/script.ts
+++ b/packages/cli/lib/completion/script.ts
@@ -112,18 +112,28 @@ ${fn}() {
     return
   fi
 
+  # bash replaces only the fragment after the last word-break character, and
+  # \${cur} is the whole word — \`--identity=~/keys/a\` rather than \`~/keys/a\`.
+  # A glob applied to the whole word matches nothing, so file completion is
+  # given the fragment the shell will actually replace.
+  local frag="\${cur}"
+  if [[ "\${cur}" == *[:=]* ]]; then
+    frag="\${cur##*[:=]}"
+  fi
+
   if [[ -n "\${glob}" ]]; then
     if [[ "\${glob}" == ":dirs:" ]]; then
       while IFS= read -r reply; do COMPREPLY+=("\${reply}"); done \\
-        < <(compgen -d -- "\${cur}")
+        < <(compgen -d -- "\${frag}")
     else
       while IFS= read -r reply; do COMPREPLY+=("\${reply}"); done \\
-        < <(compgen -f -X "!\${glob}" -- "\${cur}"; compgen -d -- "\${cur}")
+        < <(compgen -f -X "!\${glob}" -- "\${frag}"; compgen -d -- "\${frag}")
     fi
   fi
 
-  # bash replaces only the fragment after the last word-break character, so
-  # trim each candidate by the same amount or the prefix is duplicated.
+  # Candidates from the CLI carry the whole word, so trim them by the same
+  # amount or the prefix is duplicated. A file candidate is already the
+  # fragment and carries no such prefix, so this leaves it alone.
   if [[ "\${cur}" == *[:=]* ]]; then
     local head="\${cur%[:=]*}"
     local i
@@ -214,6 +224,10 @@ ${fn}() {
   fi
 
   if [[ -n "\${glob}" ]]; then
+    # An inline \`--name=value\` word reaches here whole. Moving the flag and
+    # its \`=\` into IPREFIX leaves \`_path_files\` completing the path rather
+    # than looking for a file whose name begins with the flag.
+    compset -P '--[^=]#='
     if [[ "\${glob}" == ":dirs:" ]]; then
       _path_files -/
     else

--- a/packages/cli/test/completion-line.test.ts
+++ b/packages/cli/test/completion-line.test.ts
@@ -147,6 +147,69 @@ Deno.test("resolve: a pre-parse global does not disturb later resolution", () =>
   assertEquals(line.slot?.kind, "subcommand");
 });
 
+Deno.test("resolve: a stopEarly command offers no option slot past its callable", () => {
+  // `piece call` ends option parsing at the callable name, so every later word
+  // belongs to the callable's own parser. Offering `--invocation` there names a
+  // flag the command refuses.
+  const line = resolve("cf piece call --piece x addItem --");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "tail");
+});
+
+Deno.test("resolve: a flag past that boundary does not shift the positional index", () => {
+  // Read as an option, `--title x` would consume two words and put the cursor
+  // at the wrong tail position.
+  const line = resolve("cf piece call --piece x addItem --title x ");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.index, 3);
+  assertEquals(line.options.get("piece"), "x");
+});
+
+Deno.test("resolve: the boundary does not reach a command that parses to the end", () => {
+  // `piece get` is not stopEarly(), so its own flags stay reachable after the
+  // path argument.
+  const line = resolve("cf piece get --piece x items --");
+  assertEquals(line.slot?.kind, "option-name");
+});
+
+Deno.test("resolve: `--` after the callable name still opens the passthrough slot", () => {
+  const line = resolve("cf piece call --piece x addItem -- --title ");
+  assertEquals(line.slot?.kind, "passthrough");
+});
+
+Deno.test("resolve: a positional canonical address names the target, not the argument", () => {
+  // The command reads the address out before the rest, so the callable is
+  // still the argument that follows it.
+  const line = resolve("cf piece call -s team /of:fid1:abc ");
+  assertEquals(line.address, "/of:fid1:abc");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "callable");
+});
+
+Deno.test("resolve: an address in `cf get` leaves the path argument next", () => {
+  const line = resolve("cf get -s team /of:fid1:abc ");
+  assertEquals(line.address, "/of:fid1:abc");
+  assert(line.slot?.kind === "argument");
+  assertEquals(line.slot.argument.name, "addressOrPath");
+  assertEquals(line.slot.index, 0);
+});
+
+Deno.test("resolve: a cell path in the same position is not read as an address", () => {
+  // A relative cell path never begins with `/`, which is the whole of the
+  // grammar that tells the two apart.
+  const line = resolve("cf get -s team items ");
+  assertEquals(line.address, undefined);
+  assertEquals(line.positionals, ["items"]);
+});
+
+Deno.test("resolve: a command with no positional address reads the word as its argument", () => {
+  // `piece get-label` takes a path and nothing else, so a `/`-leading word is
+  // that path rather than a target.
+  const line = resolve("cf piece get-label --piece x /of:fid1:abc ");
+  assertEquals(line.address, undefined);
+  assertEquals(line.positionals, ["/of:fid1:abc"]);
+});
+
 Deno.test("stripInvocationPrefix: leaves a plain cf line alone", () => {
   assertEquals(stripInvocationPrefix(["cf", "piece"]), {
     words: ["cf", "piece"],

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -87,6 +87,21 @@ Deno.test("--log-level=<value> keeps the inline prefix on candidates", async () 
   assertEquals(await completeFor("cf --log-level=de"), ["--log-level=debug"]);
 });
 
+Deno.test("the inline prefix is attached after the candidates are gathered", () => {
+  // `staticCandidates` returns bare values and `complete` attaches the prefix,
+  // so one rule covers the static half and the live half alike. Attaching it in
+  // the static half alone is what dropped every live candidate for this
+  // spelling: the word under the cursor is `--piece=`, and a bare value cannot
+  // start with it.
+  assertEquals(staticFor("cf --log-level=de"), [
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "silent",
+  ]);
+});
+
 Deno.test("cf view --language completes its accepted names", async () => {
   assertEquals(await completeFor("cf view --language "), languageNames());
 });
@@ -223,6 +238,36 @@ Deno.test("generated scripts capture the previous deno completion before rebindi
   );
   const zsh = zshCompletionScript("cf");
   assert(zsh.indexOf("_comps[deno]") < zsh.indexOf("compdef _cf deno"));
+});
+
+Deno.test("generated bash script globs the fragment the shell replaces", () => {
+  // `$cur` is the whole word (`--identity=~/keys/a`), while readline replaces
+  // only what follows the last word-break character. A glob applied to the
+  // whole word matches no file at all, which is how `--identity=<TAB>` came to
+  // offer nothing while `--identity <TAB>` worked.
+  const code = bashCompletionScript("cf").split("\n")
+    .filter((line) => !line.trim().startsWith("#"));
+  const globbing = code.filter((line) => line.includes("compgen -f -X"));
+  assert(globbing.length > 0, "expected a glob-filtered compgen");
+  for (const line of globbing) {
+    assert(
+      line.includes('"${frag}"') && !line.includes('"${cur}"'),
+      `glob applied to the whole word: ${line}`,
+    );
+  }
+});
+
+Deno.test("generated zsh script moves an inline flag prefix out of the way", () => {
+  // zsh's `_path_files` completes against `$PREFIX`, which for `--identity=`
+  // is the whole word. `compset -P` moves the flag into `IPREFIX` so the path
+  // is what gets completed.
+  // Comments stripped first: they name both, and in the other order.
+  const code = zshCompletionScript("cf").split("\n")
+    .filter((line) => !line.trim().startsWith("#")).join("\n");
+  const compset = code.indexOf("compset -P");
+  const pathFiles = code.indexOf("_path_files");
+  assert(compset !== -1, "expected the inline prefix to be compset away");
+  assert(compset < pathFiles, "compset must precede the file completion");
 });
 
 Deno.test("generated bash script avoids bash 4 builtins", () => {

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -126,6 +126,33 @@ Deno.test("space context: a malformed --url resolves to nothing, not a throw", a
   });
 });
 
+Deno.test("space context: an embedded space supplies one the line did not name", async () => {
+  // A canonical reference carries the space DID, which is the one spelling a
+  // line can name a space with and never write `--space`.
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    const config = resolveSpaceContext(
+      lineFor("cf get --piece /@did:key:zEmbedded/of:fid1:abc "),
+      "did:key:zEmbedded",
+    );
+    assert(config);
+    assertEquals(config.space, "did:key:zEmbedded");
+  });
+});
+
+Deno.test("space context: the line's own --space wins over an embedded one", async () => {
+  // Which of the two is right is the command's judgment to make; completion
+  // offers candidates and defers, so it reads the space the caller wrote.
+  await withEnv({ identity: "/env.key", apiUrl: "http://env:9999" }, () => {
+    assertEquals(
+      resolveSpaceContext(
+        lineFor("cf get -s team --piece /@did:key:zEmbedded/of:fid1:abc "),
+        "did:key:zEmbedded",
+      )?.space,
+      "team",
+    );
+  });
+});
+
 Deno.test("live candidates: unmapped slots ask for nothing", async () => {
   // A subcommand or option-name slot is answered statically; reaching for live
   // data there would spend a fabric round trip per keystroke for no reason.


### PR DESCRIPTION
## Why

Three defects of the same kind: a slot that answered nothing, or answered with
candidates the command rejects. A slot that offers a candidate the command
refuses teaches a caller something false, which is worse than one that only
fails to help — and because completion fails by staying silent, none of the
three announced itself.

Items 1, 2 and 3 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md).
Correctness gates value there: nothing is built on a slot that is still
answering wrongly.

Stacked on #6249, whose live seam is what made these visible; five of its gap
assertions close here.

## What Changed

**1. The inline `--name=value` spelling dropped every live candidate.**
`--piece=<TAB>` offered nothing while `--piece <TAB>` worked, and this is the
spelling `tokenizeLine` exists to serve — bash splits its own words on `=`.
`complete` now attaches the slot's inline prefix to both candidate sources
rather than the static half owning it alone. The directive half is the shell's:
`$cur` is the whole word (`--identity=~/keys/a`) while readline replaces only
the fragment after the last word-break character, so bash globs that fragment
and zsh `compset -P`s the flag into `IPREFIX`.

**2. `cf`'s own flags were offered past a `stopEarly()` boundary.** After
`cf call`'s callable name and `cf exec`'s mounted file, the command rejects
them — each flag's help text says "(before the callable name)". The resolver
reads Cliffy's `_stopEarly` field, so no option slot is reachable there and a
flag-shaped word no longer shifts the positional index. Reading the field keeps
the property where the command declares it: a third `stopEarly()` command needs
no edit here. The position now offers nothing, which is the honest state for
one whose vocabulary the command cannot yet name (item 4 fills it after step 10
of `cli-surface-shape.md`).

**3. Every documented way to name a target but the bare id resolved to a
listing call that could not succeed.** `resolvePieceContext` parses through
`normalizeLLMFriendlyRef` — the same function the command's own intake uses — so
the canonical reference, its space-qualified spelling, an `@scope` suffix, an
embedded path and `#argument` all reach their slots, and the alias grammar
falls through to `parseScopedIdSegment`. An embedded space DID supplies a space
the line did not name. A positional address is read out as `line.address`
rather than counted, which shifts the index the way `readCallTarget` and
`readTargetPositionals` shift it.

## Test plan

- The live seam, against a local dev server: 48 passed, 0 failed, 4 gaps open
  (down from 9 — five closed here and are now assertions of the capability).
- `deno task test` in `packages/cli` — 0 failed. New pure tests cover the
  stopEarly boundary, the positional-address index shift, the prefix ordering,
  and the embedded-space fallback.
- The shell half was driven through a **real bash 3.2 under a pty**, since that
  is the only way to see what readline inserts: `--identity=<dir>/<TAB>` offered
  nothing before and offers the same `*.key` files as the spaced spelling after.
- `deno fmt --check`, `deno lint`, `deno task check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

