### PR TITLE
feat(cli): complete slugs and projection field paths

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -375,6 +375,12 @@ The listing is bounded by the space's index, which names slugs assigned since it
 existed — so an older slug still resolves and is not offered. Nothing can
 enumerate what it was never told the name of.
 
+The slot asks for both listings, so `loadPieces` is called twice. Measured
+against a local server across cold processes, one listing takes 333–347 ms and
+both together 345–439 ms: the second rides the session the first opened, and
+its cost sits under the run-to-run noise. A combined listing would be a new API
+for no measured gain, so the two calls stay.
+
 ## The first link
 
 ### 8. `--space` has no source a caller recognizes

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -80,10 +80,10 @@ read before picking one up; this table is the roll-up.
 | 1 | Inline `--option=value` drops every live candidate | correctness | done |
 | 2 | Flags offered past a `stopEarly()` boundary | correctness | done |
 | 3 | Target resolution lags the reference grammar | correctness | done |
-| 4 | Verb flags do not complete | pattern vocabulary | shaper now, wiring after step 10 |
-| 5 | Result field paths for `get` and `wish` | pattern vocabulary | not started |
+| 4 | Verb flags do not complete | pattern vocabulary | shaper done, wiring after step 10 |
+| 5 | Result field paths for `get` and `wish` | pattern vocabulary | `get` done, `wish` refused |
 | 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
-| 7 | Slugs never complete | pattern vocabulary | not started |
+| 7 | Slugs never complete | pattern vocabulary | done |
 | 8 | `--space` has no source a caller recognizes | first link | partly settled |
 | 9 | A verb's annotation is its kind, not its prose | comprehension | not started |
 | 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | not started |
@@ -93,29 +93,27 @@ read before picking one up; this table is the roll-up.
 | 14 | `wish` targets and scopes | CLI vocabulary | not started |
 | 15 | Remaining path-shaped and enumerable values | CLI vocabulary | not started |
 | 16 | Two provider entries that can never fire | hygiene | not started |
-| 17 | The README table omits the top-level spellings | hygiene | not started |
+| 17 | The README table omits the top-level spellings | hygiene | done |
 | 18 | A live-provider test seam | mechanism | done |
 | 19 | A gate that fails when a new slot has no decision | mechanism | not started |
 
-**What can be picked up today.** Everything except one wiring change and one
-item. Items 5 and 7 are independent of each other and of the surface work. Items
-9, 10, 12, 13, 14, 15, 16 and 17 are mechanical and can be taken at any time.
+**What can be picked up today.** Items 9, 10, 12, 13, 14, 15 and 16 are
+mechanical and can be taken at any time. Item 19 is the other half of the
+mechanism item 18 landed.
 
-Item 4 splits. Turning a verb's `inputSchema` into `--kebab-case` candidates is
-a pure function of the listing, belongs beside `shapeVerbCandidates`, needs no
-fabric to test, and is the same function under either grammar. Build it now.
-Only its wiring — which slot receives it — waits, because step 10 decides
-whether a verb's fields are written before the marker or after it. The position
-offers nothing until then, which is the honest state for one whose vocabulary
-the command cannot yet name.
+Item 4's candidates are built and its wiring waits: step 10 decides whether a
+verb's fields are written before the `--` marker or after it, and the position
+offers nothing until then. That is the honest state for one whose vocabulary the
+command cannot yet name.
 
 Item 6 is the one to leave alone. Under the current grammar it needs the whole
 line read for context, since a projection precedes the verb it shapes; after
 step 10 the verb is already before the cursor and it needs nothing. Building it
 now means building the machinery that step 10 makes unnecessary.
 
-Items 8 and 11 hold open decisions and are not work yet. Item 19 is the other
-half of the mechanism item 18 landed.
+Items 8 and 11 hold open decisions and are not work yet. Item 5's `wish` half is
+closed rather than open: resolving a wish writes, so the slot cannot be
+completed from a resolution as it stands.
 
 ## What this list covers, and what it cannot
 
@@ -262,56 +260,64 @@ cf call --piece <piece> addItem -- --ti<TAB>     # before it
 ```
 
 **The candidates and their slot are separable, and only the slot waits.**
-Turning an `inputSchema` into `--kebab-case` candidates is a pure function of
-the listing. It belongs beside `shapeVerbCandidates`, is testable with no
-fabric, and is the same function whichever position the fields are written in —
-so it can be built and landed before step 10 decides.
+`shapeVerbFlagCandidates` in `lib/completion/verb-flags.ts` turns a listing
+row's `inputSchema` into the flags the parser accepts: one per declared field,
+kebab-cased, both spellings of a boolean, the value flags of a non-object input,
+and the generic ones every verb takes. `--help` is among them, because it falls
+inside the callable's section where it reaches the verb and prints that verb's
+own page.
+
+It reads `declaredVerbFlags` in `lib/exec-schema.ts`, which is the enumeration
+the verb's help page renders. Two readers of one schema is how a flag comes to
+be accepted by the parser and named by neither surface, or the reverse.
+
+The module sits beside the providers rather than inside `providers.ts` because
+reading a declared input resolves `callable.ts`, which costs about a third of a
+whole static completion — and `providers.ts` is resolved on every Tab.
 
 The wiring is what waits. `liveCandidates` dispatches on `option-value` and
-`argument` slots only, so neither position reaches a provider today, and routing
-it to the current position would teach the spelling step 10 retires while the
+`argument` slots only, so neither position reaches a provider, and routing it to
+the current position would teach the spelling step 10 retires while the
 retirement is being taught.
-
-The data needs no new request. `listPieceCallables` — the call
-`callableCandidates` already makes — returns each verb's `inputSchema`, and
-`flagNameForKey` in `lib/exec-schema.ts` is the kebab-case mapping the parser
-itself applies. A verb declaring `title` accepts `--title`, and both halves of
-that sentence are already in the process.
-
-`--help` belongs in this slot too: it falls inside the callable's section, where
-it reaches the verb and prints that verb's own page.
 
 The slot past the marker is not this one. It belongs to the read options, and
 completing it from the verb's declared result is item 6.
 
-### 5. Result field paths for `get` and `wish`
+### 5. Result field paths for `get`, and why not for `wish`
 
 `--select` takes comma-separated, dot-separated field paths into the value a
-read returns, and `--schema` accepts the same spelling. Both complete nothing.
+read returns, and `--schema` accepts the same spelling. On `cf get` and
+`cf piece get` both complete, in the projection's own grammar rather than the
+cell-path one: a list splits on `,` and a path on `.`, where `cellPathCandidates`
+walks `/`. A segment ending in `@` asks for that position's address rather than
+its value, and a bare `@` asks the read for its own, so both spellings of a
+position are offered.
 
-The grammar is its own, and is not the cell-path grammar:
-`parseSelectProjection` in `lib/cell-selection.ts` splits a list on `,` and a
-path on `.`, where `cellPathCandidates` walks `/`. A segment ending in `@`
-asks for that position's address rather than its value, and a bare `@` asks the
-read for its own — so a complete candidate set offers both spellings of a
-position.
+The vocabulary needs no request the slot does not already have: the value being
+projected is the one at the piece and path the line names, which `getCellValue`
+reads. A path below an array names a field of each element rather than an index,
+because that is what a projection does with one and an index there is refused.
+A key the concise grammar cannot carry is left out rather than offered in a form
+that does not work.
 
-For `cf get` the vocabulary needs no new request and no new reachability: the
-value being projected is the one at the piece and path already named, which
-`getCellValue` reads and `keysOf` already turns into keys. That makes this the
-cheapest high-value item on the list, and independent of item 4.
+**`wish` is refused, and the plan's own precondition is what refuses it.**
+Resolving a wish writes. `resolveWish` runs a single-node pattern in the target
+space and commits the cell it lands on, so the first Tab on a query that has not
+been resolved before adds revisions to the space — measured against a local
+server as 5 revisions, 2 commits and 4 heads for a query not seen before, where
+`piece ls`, `get` and `piece verbs` each add none. A second Tab on the same
+query adds nothing, because the cell is keyed by the query; a caller editing a
+query writes once per spelling they pass through.
 
-`cf wish` projects the resolved target the same way. A wish declares no result
-shape the way a verb declares an `outputSchema`, but a shape is not what this
-provider reads: it reads a value and takes its keys, and a wish is a read. So
-the target resolves and its keys are the candidates, the same walk `cf get`
-needs. `wish` is also the one command whose `--space` is optional, so this
-completes from an identity alone.
+That is a keystroke with a side effect, which is the bar this item said to clear
+before building it, and it is not cleared. Completing `wish --select` needs a
+resolution that reads without committing, which is a change to `resolveWish`
+rather than to completion.
 
-Confirm before building it that resolving a wish writes nothing. The profile
-ordering consults a most-recently-used list, and a Tab that reordered it would
-be a keystroke with a side effect — which is a bar completion has to clear
-whatever the candidates are worth.
+`call` and `exec` are the other two commands carrying these flags, and their
+projection names positions in a verb's result rather than in the piece's root.
+Completing them from the root would offer plausible names for a different value,
+which is item 6's subject and not this one.
 
 ### 6. Result field paths for `call` and `exec`
 
@@ -356,14 +362,18 @@ line that completes as it is typed and one that completes however it is edited.
 
 ### 7. Slugs never complete
 
-A slug is a valid `--piece` value — the alias grammar names it alongside the
-bare id — and `listSpaceSlugs` enumerates every slug a space's index records.
-Completion offers ids only. `piece set-slug` takes a slug positionally and
-completes nothing there either.
+The `--piece` slot offers every slug the space's index records, then every piece
+id. Both are values the flag takes, and the slug is the readable half of that
+vocabulary, so it leads. The annotation says which a candidate is and, where the
+slug resolves to a piece the listing named, what it points at.
 
-Offer slugs beside ids in the `--piece` slot, annotated so the two are
-distinguishable. A slug is the readable half of this vocabulary, so it belongs
-above the opaque id in the candidate order.
+`piece set-slug`'s slug positional completes the same set: naming an existing
+slug re-points it, which is the case completion helps with, and a slug being
+coined for the first time is a word nothing can offer.
+
+The listing is bounded by the space's index, which names slugs assigned since it
+existed — so an older slug still resolves and is not offered. Nothing can
+enumerate what it was never told the name of.
 
 ## The first link
 
@@ -512,11 +522,10 @@ internal. Neither entry is reachable.
 
 ### 17. The README table omits the top-level spellings
 
-The completion table in `packages/cli/README.md` lists `piece call`, `piece
-get`, and `piece set`. The top-level `cf call`, `cf get`, and `cf set` complete
-identically and are the spellings the surface leads with. The table also
-predates everything this plan adds, so it is the document to update as each item
-lands.
+The completion table in `packages/cli/README.md` names `call`, `get` and `set`,
+which are the spellings the surface leads with, and says that the `piece `
+spellings complete identically. It is the document each item updates as it
+lands, which is the obligation rather than the one edit.
 
 ## Mechanism
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -991,15 +991,16 @@ array layers deep it sits, because that is what the projection does with one.
 
 A bare `@` asks the read for its own address and is accepted wherever an element
 of the list begins — with one exception `--schema` makes: an argument _starting_
-with `@` is an `@file` path, so `--schema @` is an empty one while
-`--schema revision,@` is the suffix. `--schema` also reads `{`, `true` and
-`false` as whole-value JSON Schemas, so no field of those names is offered
-there, while `--select` takes `true` and `false` as ordinary names anywhere but
-alone. Completion does not restate any of that: it puts each prospective
-candidate back through the flag's own parser and offers what comes back as a
-field list. `cf call`'s and `cf exec`'s projections shape a verb's result rather
-than the piece's root, and are not completed from it; `cf wish`'s resolution
-writes to the space, and a Tab must not.
+with `@` is its `@file` form, so `--schema @` is an empty path while
+`--schema revision,@` is the suffix. A field named `true` or `false` is offered
+wherever it is not the whole argument: written alone it is a boolean JSON Schema
+to `--schema` and refused by `--select`, and written as `revision,true` it is an
+ordinary name to both. Completion restates none of that — it puts each
+prospective candidate back through the flag's own parser and offers what comes
+back as a field list, so the two sets cannot drift. `cf call`'s and `cf exec`'s
+projections shape a verb's result rather than the piece's root, and are not
+completed from it; `cf wish`'s resolution writes to the space, and a Tab must
+not.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -989,14 +989,17 @@ and a path on `.`, and a trailing `@` asks for a position's address rather than
 its value. A path below an array names a field of each element, however many
 array layers deep it sits, because that is what the projection does with one.
 
-`--select` alone accepts a bare `@`, which asks the read for its own address, at
-any element of the list. `--schema` reads two other things by their first
-character — `@` opens a file path, and a JSON Schema opens with `{` or is one of
-the boolean schemas `true` and `false` — so it takes no bare `@`, and no field
-named `true` or `false` is offered there because those spell a whole-value
-schema instead. `cf call`'s and `cf exec`'s projections shape a verb's result
-rather than the piece's root, and are not completed from it; `cf wish`'s
-resolution writes to the space, and a Tab must not.
+A bare `@` asks the read for its own address and is accepted wherever an element
+of the list begins — with one exception `--schema` makes: an argument _starting_
+with `@` is an `@file` path, so `--schema @` is an empty one while
+`--schema revision,@` is the suffix. `--schema` also reads `{`, `true` and
+`false` as whole-value JSON Schemas, so no field of those names is offered
+there, while `--select` takes `true` and `false` as ordinary names anywhere but
+alone. Completion does not restate any of that: it puts each prospective
+candidate back through the flag's own parser and offers what comes back as a
+field list. `cf call`'s and `cf exec`'s projections shape a verb's result rather
+than the piece's root, and are not completed from it; `cf wish`'s resolution
+writes to the space, and a Tab must not.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -985,12 +985,17 @@ such as `--log-level` — plus live values read from the fabric:
 | `--datafile`                    | any file, via the shell                        |
 
 A projection's grammar is its own and not the cell path's: a list splits on `,`
-and a path on `.`, a trailing `@` asks for a position's address rather than its
-value, and a bare `@` asks the read for its own. A path below an array names a
-field of each element, because that is what the projection does with one.
-`cf call`'s and `cf exec`'s projections shape a verb's result rather than the
-piece's root, and are not completed from it; `cf wish`'s resolution writes to
-the space, and a Tab must not.
+and a path on `.`, and a trailing `@` asks for a position's address rather than
+its value. A path below an array names a field of each element, however many
+array layers deep it sits, because that is what the projection does with one.
+
+`--select` alone accepts a bare `@`, which asks the read for its own address, at
+any element of the list. `--schema` reads two other things recognized by their
+first character — a JSON Schema opens with `{`, and `@` opens a file path — so
+it takes no bare `@` and completion offers none there. `cf call`'s and
+`cf exec`'s projections shape a verb's result rather than the piece's root, and
+are not completed from it; `cf wish`'s resolution writes to the space, and a Tab
+must not.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -990,12 +990,13 @@ its value. A path below an array names a field of each element, however many
 array layers deep it sits, because that is what the projection does with one.
 
 `--select` alone accepts a bare `@`, which asks the read for its own address, at
-any element of the list. `--schema` reads two other things recognized by their
-first character — a JSON Schema opens with `{`, and `@` opens a file path — so
-it takes no bare `@` and completion offers none there. `cf call`'s and
-`cf exec`'s projections shape a verb's result rather than the piece's root, and
-are not completed from it; `cf wish`'s resolution writes to the space, and a Tab
-must not.
+any element of the list. `--schema` reads two other things by their first
+character — `@` opens a file path, and a JSON Schema opens with `{` or is one of
+the boolean schemas `true` and `false` — so it takes no bare `@`, and no field
+named `true` or `false` is offered there because those spell a whole-value
+schema instead. `cf call`'s and `cf exec`'s projections shape a verb's result
+rather than the piece's root, and are not completed from it; `cf wish`'s
+resolution writes to the space, and a Tab must not.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -972,15 +972,25 @@ source <(cf completion bash)
 Completion covers the command tree — subcommands, flags, and enumerated values
 such as `--log-level` — plus live values read from the fabric:
 
-| Slot                            | Completes to                                |
-| ------------------------------- | ------------------------------------------- |
-| `--piece`                       | piece ids, annotated with each piece's name |
-| `cf call <callable>`            | the piece's callables, as `cf piece verbs`  |
-| `cf get`/`cf set <path>`        | cell keys, one path segment at a time       |
-| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints           |
-| `--space`                       | space DIDs of local memory-v2 stores        |
-| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell      |
-| `--datafile`                    | any file, via the shell                     |
+| Slot                            | Completes to                                   |
+| ------------------------------- | ---------------------------------------------- |
+| `--piece`                       | the space's slugs, then its piece ids          |
+| `cf call <callable>`            | the piece's callables, as `cf piece verbs`     |
+| `cf get`/`cf set <path>`        | cell keys, one path segment at a time          |
+| `cf get --select`/`--schema`    | field paths into the value, and their `@` form |
+| `piece set-slug <slug>`         | the space's slugs                              |
+| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints              |
+| `--space`                       | space DIDs of local memory-v2 stores           |
+| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell         |
+| `--datafile`                    | any file, via the shell                        |
+
+A projection's grammar is its own and not the cell path's: a list splits on `,`
+and a path on `.`, a trailing `@` asks for a position's address rather than its
+value, and a bare `@` asks the read for its own. A path below an array names a
+field of each element, because that is what the projection does with one.
+`cf call`'s and `cf exec`'s projections shape a verb's result rather than the
+piece's root, and are not completed from it; `cf wish`'s resolution writes to
+the space, and a Tab must not.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -211,17 +211,19 @@ if [ -n "$SPACE_DID" ]; then ok "the space resolves to $SPACE_DID"; else
   bad "no space DID on the child's stored link"
 fi
 
-step "2. The piece slot offers ids the same command can then read"
-# The chain's second link. An id that completes but which the dispatcher
+step "2. The piece slot offers values the same command can then read"
+# The chain's second link. A value that completes but which the dispatcher
 # cannot reach would be worse than no candidate: it teaches a caller a target
-# that does not exist. Every id offered is read back here rather than assumed.
+# that does not exist. Every one offered is read back here rather than assumed.
 PIECE_SLOT=$(complete_at "cf call $LINE_ARGS --piece ")
-check "$BOARD" "$PIECE_SLOT" "the piece slot offers the deployed board"
+check "board,$BOARD" "$(candidates_at "cf call $LINE_ARGS --piece ")" \
+  "the piece slot offers the deployed board by slug and by id"
 READABLE=0
 UNREADABLE=0
-while IFS= read -r id; do
-  [ -z "$id" ] && continue
-  if [ "$(succeeds $CF get --quiet --piece "$id" $ARGS '$NAME')" = "1" ]; then
+while IFS= read -r target; do
+  [ -z "$target" ] && continue
+  if [ "$(succeeds $CF get --quiet --piece "$target" $ARGS '$NAME')" = "1" ]
+  then
     READABLE=$((READABLE + 1))
   else
     UNREADABLE=$((UNREADABLE + 1))
@@ -229,26 +231,29 @@ while IFS= read -r id; do
 done <<EOF
 $PIECE_SLOT
 EOF
-check "0" "$UNREADABLE" "every completed piece id reads back ($READABLE checked)"
-# The annotation column is what makes an opaque id legible.
+check "0" "$UNREADABLE" "every completed --piece value reads back ($READABLE checked)"
+# The annotation column is what makes an opaque id legible, and what keeps a
+# slug from being read as one.
 check "Completion fixture" \
   "$(annotation_at "cf call $LINE_ARGS --piece " "$BOARD")" \
   "the id is annotated with the piece's name"
+check "slug for Completion fixture" \
+  "$(annotation_at "cf call $LINE_ARGS --piece " board)" \
+  "and the slug says what it is and what it points at"
 
-step "3. The slug the same slot accepts does not complete"
-check "Completion fixture" \
-  "$($CF get --quiet --piece board $ARGS '$NAME' 2>/dev/null | tr -d '"')" \
-  "the slug is a --piece value the command accepts"
-gap "cf call $LINE_ARGS --piece bo" "a slug in the --piece slot"
+step "3. The slug reaches its own positional too"
+check "board" "$(candidates_at "cf piece set-slug $LINE_ARGS ")" \
+  "piece set-slug completes the slugs it can re-point"
 
 step "4. Both spellings of an option complete the same values"
 # `--piece=<TAB>` and `--piece <TAB>` are one slot. The inline spelling is the
 # one `tokenizeLine` exists to serve, and its candidates carry the `--piece=`
 # back so the shell replaces the whole token.
-check "$BOARD" "$(complete_at "cf call $LINE_ARGS --piece ")" \
+check "board,$BOARD" "$(candidates_at "cf call $LINE_ARGS --piece ")" \
   "the spaced spelling completes"
-check "--piece=$BOARD" "$(complete_at "cf call $LINE_ARGS --piece=")" \
-  "the inline spelling completes the same value, prefix attached"
+check "--piece=board,--piece=$BOARD" \
+  "$(candidates_at "cf call $LINE_ARGS --piece=")" \
+  "the inline spelling completes the same values, prefix attached"
 # The directive half of the same slot reaches the shell either way.
 check ":cf:files *.key" "$(directives_at "cf call $LINE_ARGS --identity ")" \
   "the spaced --identity spelling emits its files directive"
@@ -331,13 +336,22 @@ check "1" "$(complete_at "cf call $LINE_ARGS --piece board --" |
   grep -c '^--invocation$')" \
   "--invocation is still offered before the callable name"
 
-step "8. The verb's own fields do not complete"
+step "8. The verb's own fields do not complete yet"
 # The position where a caller has least to go on: these names are the pattern
-# author's vocabulary, not the CLI's.
+# author's vocabulary, not the CLI's. `shapeVerbFlagCandidates` derives them
+# from the listing's `inputSchema` — the same enumeration the help page below
+# renders, so a flag the parser accepts cannot be named by one and not the
+# other. Only the slot waits: step 10 of docs/plans/cli-surface-shape.md
+# decides whether a verb's fields are written before the marker or after it.
 check "pinned,title" "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
   jq -r '.verbs[] | select(.name == "addItem") | .inputSchema.properties |
     keys | sort | join(",")')" \
   "addItem declares the fields its flags are named for"
+HELP=$($CF call --piece board $ARGS addItem --help 2>/dev/null)
+check "1" "$(printf '%s\n' "$HELP" | grep -c -- '^  --title <string>')" \
+  "and its help page names the flag each one is written as"
+check "1" "$(printf '%s\n' "$HELP" | grep -c -- '^  --pinned | --no-pinned')" \
+  "including both spellings of a boolean field"
 check "1" "$(succeeds $CF call --quiet --piece board $ARGS --invocation flags-1 \
   addItem -- --title 'Flagged item')" "and the parser accepts them as flags"
 gap "cf call $LINE_ARGS --piece board addItem -- --" \
@@ -371,15 +385,47 @@ check "1" "$(complete_at "cf get $LINE_ARGS --piece board " |
   grep -c '^addItem$')" \
   "and the cell-path slot offers it anyway"
 
-step "11. Result field paths do not complete"
+step "11. Result field paths complete in the projection's own grammar"
 # --step because the board carries a computed value and a projection reads
 # through the whole result: the same reason the verb walkthrough steps before
 # it projects.
 check "dark" "$($CF get --quiet --piece board $ARGS --step \
   --select settings.theme 2>/dev/null | jq -r '.settings.theme')" \
   "a --select field path is a projection the command reads"
-gap "cf get $LINE_ARGS --piece board --select " "--select field paths"
-gap "cf get $LINE_ARGS --piece board --schema " "--schema field paths"
+# Both spellings of a position, plus the bare suffix naming the read's own
+# address. The list splits on `,` and a path on `.` — not the `/` a cell path
+# walks — so a candidate carries back everything already typed.
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board --select " |
+  grep -cx '@')" "a bare @ names the read source's own address"
+check "settings.density,settings.density@,settings.theme,settings.theme@" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board --select settings.")" \
+  "a nested position offers its value and its address spellings"
+check "revision,settings,revision,settings@" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board --select revision,set")" \
+  "a second element carries the first one back with it"
+# An array is projected element-wise, so a segment below one names a field of
+# each element. An index there is refused by the command.
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board --select items." |
+  grep -cx 'items.label')" "a position below an array offers the element's fields"
+check "0" "$(succeeds $CF get --quiet --piece board $ARGS --step \
+  --select items.0.label)" "and an index in that position is refused"
+# `--schema` reads the same field list, and reads two other things that are
+# recognized by their first character.
+check "1" "$(complete_at "cf get $LINE_ARGS --piece board --schema set" |
+  grep -cx 'settings')" "--schema completes the same field list"
+check "" "$(complete_at "cf get $LINE_ARGS --piece board --schema @")" \
+  "and offers no field path where the word names a schema file"
+# The projection is relative to the path the line already names, the same way
+# the read is.
+check "@,density,density@,theme,theme@" \
+  "$(candidates_at "cf get $LINE_ARGS --piece board settings --select ")" \
+  "a path positional moves the projection's own root with it"
+check "dark" "$($CF get --quiet --piece board $ARGS settings --select theme \
+  2>/dev/null | jq -r '.theme')" "and the command reads it from there too"
+# A verb's result is a different vocabulary and is not this one; `cf call`'s
+# projection stays empty until the verb before it can be read.
+check "" "$(complete_at "cf call $LINE_ARGS --piece board --select ")" \
+  "a call's projection is not completed from the piece's root"
 
 step "12. A name on two cells completes against the one the dispatcher reaches"
 # The child is handed a callable named `record` in its arguments AND declares

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -446,7 +446,7 @@ function projectionFieldCandidates(
  * path while `revision,@` is the suffix — and both sets of rules live in
  * `lib/cell-selection.ts`, so they are asked rather than mirrored.
  */
-async function acceptedProjections(
+export async function acceptedProjections(
   candidates: readonly Candidate[],
   flag: "select" | "schema",
 ): Promise<Candidate[]> {

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -418,9 +418,11 @@ function projectionFieldCandidates(
       descendProjection(value, path),
       `${list}${prefix}`,
       // A path that is only the suffix names the position the read is already
-      // at, which no field path reaches. `--schema` does not accept it: a
-      // leading `@` there names a file.
-      { self: flag === "select" && atElementStart && list.length === 0 },
+      // at, which no field path reaches. It is legal as any element of the
+      // list — `revision,@` parses — so it is offered at every element start,
+      // carrying the elements already closed. `--schema` does not accept it:
+      // a leading `@` there names a file.
+      { self: flag === "select" && atElementStart },
     );
     if (candidates.length === 0) return NOTHING;
     // A field path continues with `.` or `,`, so hold the cursor in place the
@@ -471,19 +473,22 @@ export function descendProjection(
   path: readonly string[],
 ): unknown {
   let current = value;
-  for (const name of path) {
-    if (Array.isArray(current)) {
-      current = current.map((element) =>
-        element && typeof element === "object"
-          ? (element as Record<string, unknown>)[name]
-          : undefined
-      );
-      continue;
-    }
-    if (!current || typeof current !== "object") return undefined;
-    current = (current as Record<string, unknown>)[name];
-  }
+  for (const name of path) current = descendOne(current, name);
   return current;
+}
+
+/**
+ * One segment of that walk. An array is descended through however many layers
+ * it has, because a projection is element-wise at every one of them:
+ * `matrix.nested.leaf` reads through `[[{nested: {leaf}}]]`, so a walk that
+ * unwrapped a single layer would offer `nested` and then nothing.
+ */
+function descendOne(value: unknown, name: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((element) => descendOne(element, name));
+  }
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[name];
 }
 
 /**
@@ -527,7 +532,10 @@ export function shapeProjectionCandidates(
 ): Candidate[] {
   const candidates: Candidate[] = [];
   if (options.self) {
-    candidates.push({ value: "@", description: "the read source's address" });
+    candidates.push({
+      value: `${prefix}@`,
+      description: "the read source's address",
+    });
   }
   for (const key of projectionKeys(value).filter(isWritableFieldName)) {
     candidates.push({ value: `${prefix}${key}` });

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -175,16 +175,36 @@ function resolvePieceContext(line: CompletionLine): PieceConfig | null {
 }
 
 /**
- * Pieces in the line's space, as `id` with the piece's name as annotation.
+ * What the `--piece` slot accepts: every slug the space's index records, then
+ * every piece id.
  *
- * A piece that failed to load still lists — its id is exactly what an operator
- * reaches for completion to recover.
+ * Both are values the flag takes, and the slug is the readable half of that
+ * vocabulary — so it leads, and the opaque id follows.
  */
 async function pieceCandidates(line: CompletionLine): Promise<ProviderResult> {
   const config = resolveSpaceContext(line);
   if (!config) return NOTHING;
-  const { listPieces } = await import("../piece.ts");
-  return values(shapePieceCandidates(await listPieces(config)));
+  const { listPieces, listSpaceSlugs } = await import("../piece.ts");
+  const [pieces, slugs] = await Promise.all([
+    listPieces(config),
+    listSpaceSlugs(config),
+  ]);
+  return values([
+    ...shapeSlugCandidates(slugs, pieces),
+    ...shapePieceCandidates(pieces),
+  ]);
+}
+
+/** Just the slugs, for the positional that takes one and nothing else. */
+async function slugCandidates(line: CompletionLine): Promise<ProviderResult> {
+  const config = resolveSpaceContext(line);
+  if (!config) return NOTHING;
+  const { listPieces, listSpaceSlugs } = await import("../piece.ts");
+  const [pieces, slugs] = await Promise.all([
+    listPieces(config),
+    listSpaceSlugs(config),
+  ]);
+  return values(shapeSlugCandidates(slugs, pieces));
 }
 
 /** Listing shape used by `shapePieceCandidates`, structural so tests need no runtime. */
@@ -192,6 +212,12 @@ export interface PieceListingLike {
   readonly id: string;
   readonly name?: string;
   readonly patternRef?: { readonly symbol?: string } | null;
+}
+
+/** Listing shape used by `shapeSlugCandidates`, structural for the same reason. */
+export interface SlugListingLike {
+  readonly slug: string;
+  readonly piece?: string;
 }
 
 /**
@@ -207,6 +233,31 @@ export function shapePieceCandidates(
     value: piece.id,
     description: piece.name ?? piece.patternRef?.symbol ?? undefined,
   }));
+}
+
+/**
+ * Label slugs so they are not read as ids. The annotation says what the value
+ * is and, where the slug resolves to a piece the listing named, what it points
+ * at — which is the question a caller choosing between two slugs is asking.
+ *
+ * A slug whose target failed to resolve still lists: it is a name the space
+ * records and the flag accepts, and completion is not the surface that decides
+ * whether it still points anywhere.
+ */
+export function shapeSlugCandidates(
+  slugs: readonly SlugListingLike[],
+  pieces: readonly PieceListingLike[],
+): Candidate[] {
+  const named = new Map(
+    pieces.map((piece) => [piece.id, piece.name ?? piece.patternRef?.symbol]),
+  );
+  return slugs.map((entry) => {
+    const name = entry.piece ? named.get(entry.piece) : undefined;
+    return {
+      value: entry.slug,
+      description: name ? `slug for ${name}` : "slug",
+    };
+  });
 }
 
 /** Callables (handlers and streams) exposed by the line's `--piece`. */
@@ -313,6 +364,182 @@ export function splitPathPrefix(
 }
 
 /**
+ * Commands whose `--select`/`--schema` names positions in the value at the
+ * target the line already gives.
+ *
+ * `call` and `exec` shape a VERB's result instead, whose vocabulary is the
+ * verb's `outputSchema` rather than the piece's root — reading the root there
+ * would offer plausible names for a different value, which is worse than
+ * offering none. `wish` shapes what its query resolved to, and resolving a
+ * wish commits a cell to the space: a Tab must not write.
+ */
+const PROJECTION_SOURCE_COMMANDS: ReadonlySet<string> = new Set([
+  "piece get",
+  "get",
+]);
+
+/**
+ * Field paths into the value a read returns, for `--select` and `--schema`.
+ *
+ * The grammar is its own and is not the cell-path grammar: a list splits on
+ * `,` and a path on `.`, where a cell path walks `/`. A segment ending in `@`
+ * asks for that position's address rather than its value, and a bare `@` asks
+ * the read for its own — so both spellings of a position are offered.
+ *
+ * The vocabulary needs no request the slot does not already have: the value
+ * being projected is the one at the piece and path the line names, which is
+ * what `cf get` would read.
+ */
+function projectionFieldCandidates(
+  flag: "select" | "schema",
+): (line: CompletionLine) => Promise<ProviderResult> {
+  return async (line) => {
+    if (!PROJECTION_SOURCE_COMMANDS.has(line.path.join(" "))) return NOTHING;
+    // `--schema` reads a JSON Schema or an `@file` as well as this list, and
+    // both are recognized by their first character. Neither is a field path.
+    if (flag === "schema" && /^[@{]/.test(line.word)) return NOTHING;
+
+    const config = resolvePieceContext(line);
+    if (!config) return NOTHING;
+
+    const { list, path, prefix, atElementStart } = splitSelectPrefix(line.word);
+    const { getCellValue } = await import("../piece.ts");
+    const { parseCellPath } = await import("@commonfabric/runner");
+    const value = await getCellValue(
+      config,
+      [
+        ...(config.piecePath ?? []),
+        ...(line.positionals[0] ? parseCellPath(line.positionals[0]) : []),
+      ],
+      { input: line.flags.has("input") || config.pieceInput === true },
+    );
+
+    const candidates = shapeProjectionCandidates(
+      descendProjection(value, path),
+      `${list}${prefix}`,
+      // A path that is only the suffix names the position the read is already
+      // at, which no field path reaches. `--schema` does not accept it: a
+      // leading `@` there names a file.
+      { self: flag === "select" && atElementStart && list.length === 0 },
+    );
+    if (candidates.length === 0) return NOTHING;
+    // A field path continues with `.` or `,`, so hold the cursor in place the
+    // way a cell path does.
+    return { candidates, directives: [{ kind: "nospace" }] };
+  };
+}
+
+/**
+ * Split the projection word being typed into the part each candidate must
+ * carry back and the path already closed within the element being typed.
+ *
+ * `notes@,settings.the` is one closed element, then `settings.` closed within
+ * the element under the cursor: the candidates are `notes@,settings.theme` and
+ * its address spelling, because the shell replaces the whole word.
+ */
+export function splitSelectPrefix(typed: string): {
+  /** Elements already closed, trailing comma included. */
+  list: string;
+  /** Segments already closed within the element being typed. */
+  path: string[];
+  /** Those segments as written, trailing dot included. */
+  prefix: string;
+  /** Whether nothing has been typed yet in this element. */
+  atElementStart: boolean;
+} {
+  const comma = typed.lastIndexOf(",");
+  const list = comma === -1 ? "" : typed.slice(0, comma + 1);
+  const element = typed.slice(list.length);
+  const dot = element.lastIndexOf(".");
+  const prefix = dot === -1 ? "" : element.slice(0, dot + 1);
+  return {
+    list,
+    path: prefix ? prefix.slice(0, -1).split(".") : [],
+    prefix,
+    atElementStart: element.length === 0,
+  };
+}
+
+/**
+ * The value a projection path names, read the way a projection reads it: a
+ * list is element-wise across an array, so a segment below one names a field
+ * of each element rather than an index. `--select items.0.title` is refused
+ * for exactly that reason.
+ */
+export function descendProjection(
+  value: unknown,
+  path: readonly string[],
+): unknown {
+  let current = value;
+  for (const name of path) {
+    if (Array.isArray(current)) {
+      current = current.map((element) =>
+        element && typeof element === "object"
+          ? (element as Record<string, unknown>)[name]
+          : undefined
+      );
+      continue;
+    }
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[name];
+  }
+  return current;
+}
+
+/**
+ * A name a concise field path can carry. `parseConciseSegment` holds a segment
+ * to an identifier grammar, and a trailing `@` in a name would be read as the
+ * address suffix — the escape that writes one needs shell quoting to survive,
+ * so such a key is left out rather than offered in a form that does not work.
+ */
+function isWritableFieldName(name: string): boolean {
+  return /^[A-Za-z_$][A-Za-z0-9_$@-]*$/.test(name) && !name.endsWith("@");
+}
+
+/**
+ * The positions one level below a projection path: an array contributes its
+ * elements' fields rather than its indices, and a leaf contributes nothing.
+ */
+export function projectionKeys(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const seen: string[] = [];
+    for (const element of value) {
+      for (const key of projectionKeys(element)) {
+        if (!seen.includes(key)) seen.push(key);
+      }
+    }
+    return seen;
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>);
+  }
+  return [];
+}
+
+/**
+ * Both spellings of every position below `value`, each carrying `prefix` so
+ * the shell replaces the whole word.
+ */
+export function shapeProjectionCandidates(
+  value: unknown,
+  prefix: string,
+  options: { self?: boolean } = {},
+): Candidate[] {
+  const candidates: Candidate[] = [];
+  if (options.self) {
+    candidates.push({ value: "@", description: "the read source's address" });
+  }
+  for (const key of projectionKeys(value).filter(isWritableFieldName)) {
+    candidates.push({ value: `${prefix}${key}` });
+    candidates.push({
+      value: `${prefix}${key}@`,
+      description: "its address",
+    });
+  }
+  return candidates;
+}
+
+/**
  * `pieceId/path/to/field` endpoints for `cf piece link`.
  *
  * Before the `/` the candidates are piece ids; after it they are that piece's
@@ -408,6 +635,8 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   Record<string, (line: CompletionLine) => Promise<ProviderResult>>
 > = {
   piece: pieceCandidates,
+  select: projectionFieldCandidates("select"),
+  schema: projectionFieldCandidates("schema"),
   space: () => spaceCandidates(),
   "api-url": () => Promise.resolve(apiUrlCandidates()),
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
@@ -449,6 +678,9 @@ const ARGUMENT_PROVIDERS: Readonly<
   "set:path": cellPathCandidates,
   "piece link:source": linkEndpointCandidates,
   "piece link:target": linkEndpointCandidates,
+  // Naming an existing slug re-points it, which is the case completion helps
+  // with; a slug being coined for the first time is a word nothing can offer.
+  "piece set-slug:slug": slugCandidates,
   "piece new:main": patternFiles,
   "piece setsrc:main": patternFiles,
   "check:files": patternFiles,

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -414,29 +414,60 @@ function projectionFieldCandidates(
       { input: line.flags.has("input") || config.pieceInput === true },
     );
 
-    const candidates = shapeProjectionCandidates(
-      descendProjection(value, path),
-      `${list}${prefix}`,
-      // `--schema true` is a JSON Schema in its own right and `--schema false`
-      // is refused as one, so neither can name a field there however the
-      // source spells its keys. `--select` reads them as ordinary names.
-      {
-        // A path that is only the suffix names the position the read is
-        // already at, which no field path reaches. It is legal as any element
-        // of the list — `revision,@` parses — so it is offered at every
-        // element start. `--schema` does not accept it: a leading `@` there
-        // names a file.
-        self: flag === "select" && atElementStart,
-        ...(flag === "schema" && list === "" && prefix === ""
-          ? { reserved: ["true", "false"] }
-          : {}),
-      },
+    // Everything the position could name, including the bare address suffix
+    // wherever an element begins — then held to what the flag's own parser
+    // accepts. Which spellings are reserved is not a rule worth restating:
+    // `--select true` is refused while `revision,true` is a field, and
+    // `--schema @` is an empty file path while `revision,@` is the suffix.
+    // Round-tripping is what keeps the offered set and the accepted set one.
+    const candidates = await acceptedProjections(
+      shapeProjectionCandidates(
+        descendProjection(value, path),
+        `${list}${prefix}`,
+        { self: atElementStart },
+      ),
+      flag,
     );
     if (candidates.length === 0) return NOTHING;
     // A field path continues with `.` or `,`, so hold the cursor in place the
     // way a cell path does.
     return { candidates, directives: [{ kind: "nospace" }] };
   };
+}
+
+/**
+ * The candidates the flag's own parser accepts, written as the whole argument
+ * they would become.
+ *
+ * A completion is a spelling a caller may stop at, so the bar is the one every
+ * other slot here is held to: the command takes it. The two flags read the
+ * same field list and reserve different spellings around it — `--select true`
+ * is refused while `revision,true` is a field, `--schema @` is an empty file
+ * path while `revision,@` is the suffix — and both sets of rules live in
+ * `lib/cell-selection.ts`, so they are asked rather than mirrored.
+ */
+async function acceptedProjections(
+  candidates: readonly Candidate[],
+  flag: "select" | "schema",
+): Promise<Candidate[]> {
+  const { parseSelectProjection, parseSelectionProjection } = await import(
+    "../cell-selection.ts"
+  );
+  const accepted: Candidate[] = [];
+  for (const candidate of candidates) {
+    try {
+      const parsed = flag === "select"
+        ? parseSelectProjection(candidate.value)
+        : await parseSelectionProjection(candidate.value);
+      // Parsing is not enough: `--schema true` succeeds and means the boolean
+      // JSON Schema, not a field of that name. The parser reports which
+      // reading it took, and only the field-list one is what this slot offers.
+      if (parsed.kind === "concise") accepted.push(candidate);
+    } catch {
+      // A spelling this flag refuses is not a candidate for it.
+    }
+  }
+  return accepted;
 }
 
 /**
@@ -551,7 +582,7 @@ export function projectionKeys(value: unknown): string[] {
 export function shapeProjectionCandidates(
   value: unknown,
   prefix: string,
-  options: { self?: boolean; reserved?: readonly string[] } = {},
+  options: { self?: boolean } = {},
 ): Candidate[] {
   const candidates: Candidate[] = [];
   if (options.self) {
@@ -560,12 +591,7 @@ export function shapeProjectionCandidates(
       description: "the read source's address",
     });
   }
-  const reserved = new Set(options.reserved ?? []);
-  for (
-    const key of projectionKeys(value)
-      .filter(isWritableFieldName)
-      .filter((key) => !reserved.has(key))
-  ) {
+  for (const key of projectionKeys(value).filter(isWritableFieldName)) {
     candidates.push({ value: `${prefix}${key}` });
     candidates.push({
       value: `${prefix}${key}@`,

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -417,12 +417,20 @@ function projectionFieldCandidates(
     const candidates = shapeProjectionCandidates(
       descendProjection(value, path),
       `${list}${prefix}`,
-      // A path that is only the suffix names the position the read is already
-      // at, which no field path reaches. It is legal as any element of the
-      // list — `revision,@` parses — so it is offered at every element start,
-      // carrying the elements already closed. `--schema` does not accept it:
-      // a leading `@` there names a file.
-      { self: flag === "select" && atElementStart },
+      // `--schema true` is a JSON Schema in its own right and `--schema false`
+      // is refused as one, so neither can name a field there however the
+      // source spells its keys. `--select` reads them as ordinary names.
+      {
+        // A path that is only the suffix names the position the read is
+        // already at, which no field path reaches. It is legal as any element
+        // of the list — `revision,@` parses — so it is offered at every
+        // element start. `--schema` does not accept it: a leading `@` there
+        // names a file.
+        self: flag === "select" && atElementStart,
+        ...(flag === "schema" && list === "" && prefix === ""
+          ? { reserved: ["true", "false"] }
+          : {}),
+      },
     );
     if (candidates.length === 0) return NOTHING;
     // A field path continues with `.` or `,`, so hold the cursor in place the
@@ -456,10 +464,25 @@ export function splitSelectPrefix(typed: string): {
   const prefix = dot === -1 ? "" : element.slice(0, dot + 1);
   return {
     list,
-    path: prefix ? prefix.slice(0, -1).split(".") : [],
+    // A closed segment may carry the address marker — `topic@.title` marks
+    // `topic` and projects `title` — so the marker is stripped for the walk
+    // and kept in the prefix the candidate carries back. Descending a literal
+    // `topic@` would find no such property and offer nothing.
+    path: prefix ? prefix.slice(0, -1).split(".").map(segmentName) : [],
     prefix,
     atElementStart: element.length === 0,
   };
+}
+
+/**
+ * The field a written segment names: the trailing address marker is not part
+ * of it, and `\@` is an escaped `@` that is. Mirrors `parseConciseSegment`,
+ * which is what the command reads a segment with.
+ */
+function segmentName(segment: string): string {
+  const escaped = "\\@";
+  const marked = segment.endsWith("@") && !segment.endsWith(escaped);
+  return (marked ? segment.slice(0, -1) : segment).replaceAll(escaped, "@");
 }
 
 /**
@@ -528,7 +551,7 @@ export function projectionKeys(value: unknown): string[] {
 export function shapeProjectionCandidates(
   value: unknown,
   prefix: string,
-  options: { self?: boolean } = {},
+  options: { self?: boolean; reserved?: readonly string[] } = {},
 ): Candidate[] {
   const candidates: Candidate[] = [];
   if (options.self) {
@@ -537,7 +560,12 @@ export function shapeProjectionCandidates(
       description: "the read source's address",
     });
   }
-  for (const key of projectionKeys(value).filter(isWritableFieldName)) {
+  const reserved = new Set(options.reserved ?? []);
+  for (
+    const key of projectionKeys(value)
+      .filter(isWritableFieldName)
+      .filter((key) => !reserved.has(key))
+  ) {
     candidates.push({ value: `${prefix}${key}` });
     candidates.push({
       value: `${prefix}${key}@`,

--- a/packages/cli/lib/completion/verb-flags.ts
+++ b/packages/cli/lib/completion/verb-flags.ts
@@ -21,7 +21,7 @@
  */
 
 import type { JSONSchema } from "@commonfabric/api";
-import { declaredVerbFlags } from "../exec-schema.ts";
+import { type DeclaredVerbFlag, declaredVerbFlags } from "../exec-schema.ts";
 import type { Candidate } from "./static.ts";
 
 /** The half of a verb listing row these candidates are derived from. */
@@ -65,25 +65,44 @@ export function shapeVerbFlagCandidates(
     candidates.push({ value, description });
   };
 
-  for (const flag of declaredVerbFlags(verb.inputSchema)) {
-    const description = fieldDescription(flag.schema) ??
-      (flag.required ? "required" : "optional");
-    // Nothing reserves a field name, so a verb may declare `json`,
-    // `json-file` or `help` — names the command already owns as bare tokens.
-    // The parser reads the bare token as ITS meaning and never reaches the
-    // field, so the field is offered in the one spelling that does reach it.
+  const declared = declaredVerbFlags(verb.inputSchema);
+  const describe = (flag: DeclaredVerbFlag) =>
+    fieldDescription(flag.schema) ?? (flag.required ? "required" : "optional");
+  // The token each declared field owns outright, which is the lookup the
+  // parser makes first.
+  const owned = new Set(declared.map((flag) => `--${flag.name}`));
+
+  // In the parser's own order. `parseObjectInput` matches the bare `--json`
+  // and `--json-file` before anything else, then a declared field of the
+  // token's exact name, and only then reads a `no-` prefix as a negation. A
+  // candidate list in any other order names flags that do something else.
+  for (const flag of declared) {
+    // A verb may declare `json`, `json-file` or `help` — names the command
+    // owns as bare tokens. The parser reads the bare token as ITS meaning and
+    // never reaches the field, so the field is offered in the one spelling
+    // that does: a boolean carries its value, anything else stops at the `=`.
     if (RESERVED_BARE_SPELLINGS.has(flag.name)) {
-      // A boolean carries its value in the spelling; anything else is
-      // completed up to the `=` and the caller writes the value.
       add(
         flag.negatable ? `--${flag.name}=true` : `--${flag.name}=`,
-        `${description} (the declared field)`,
+        `${describe(flag)} (the declared field)`,
       );
-      if (flag.negatable) add(`--no-${flag.name}`, `${description} (false)`);
       continue;
     }
-    add(`--${flag.name}`, description);
-    if (flag.negatable) add(`--no-${flag.name}`, `${description} (false)`);
+    add(`--${flag.name}`, describe(flag));
+  }
+
+  for (const flag of declared) {
+    if (!flag.negatable) continue;
+    const negation = `--no-${flag.name}`;
+    // A field named `noActive` owns `--no-active`, and the parser finds it
+    // before it ever reads the token as a negation of `active`. Offering the
+    // negation there would annotate one field's flag with another's meaning —
+    // so the inline spelling, which no other field can own, is offered instead.
+    if (owned.has(negation)) {
+      add(`--${flag.name}=false`, `${describe(flag)} (false)`);
+      continue;
+    }
+    add(negation, `${describe(flag)} (false)`);
   }
 
   for (const generic of GENERIC_FLAGS) {

--- a/packages/cli/lib/completion/verb-flags.ts
+++ b/packages/cli/lib/completion/verb-flags.ts
@@ -1,0 +1,84 @@
+/**
+ * A verb's own fields, shaped as the flags a caller writes them with.
+ *
+ * The pattern author's vocabulary rather than the CLI's, which is what makes
+ * this the position where a caller has least to go on and completion has most
+ * to give. Everything it needs rides the listing `callableCandidates` already
+ * fetches, so filling the slot costs no request.
+ *
+ * Held here rather than beside `shapeVerbCandidates` in `providers.ts` for one
+ * reason: reading a declared input means resolving `callable.ts`, which costs
+ * about a third of a whole static completion. `providers.ts` is resolved on
+ * every Tab and this module is resolved only where a verb's flags are being
+ * offered, which is what the inline imports there buy everywhere else.
+ *
+ * Which slot receives these candidates is not settled here. Step 10 of
+ * [CLI surface shape](../../../../docs/plans/cli-surface-shape.md) decides
+ * whether a verb's fields are written before the `--` marker or after it, and
+ * routing them to today's position would teach a spelling that step retires.
+ * The candidates are the same function either way, which is why they are built
+ * ahead of it.
+ */
+
+import type { JSONSchema } from "@commonfabric/api";
+import { declaredVerbFlags } from "../exec-schema.ts";
+import type { Candidate } from "./static.ts";
+
+/** The half of a verb listing row these candidates are derived from. */
+export interface VerbFlagListingLike {
+  /** The verb's input schema, as `cf piece verbs` reports it. */
+  readonly inputSchema: JSONSchema | true;
+}
+
+/**
+ * `--help` reaches the verb's own page from inside the callable's section, so
+ * it belongs in this slot rather than among the command's flags. The other
+ * generic input flags are offered beside it because the parser accepts them
+ * for every verb, whatever it declared.
+ */
+const GENERIC_FLAGS: readonly Candidate[] = [
+  { value: "--json", description: "the whole input as JSON" },
+  { value: "--json-file", description: "the whole input from a JSON file" },
+  { value: "--help", description: "this verb's own help page" },
+];
+
+/**
+ * Every flag the verb accepts, in the order its help page lists them: its
+ * declared fields first, then the generic input flags.
+ *
+ * A boolean field is offered in both spellings — `--flag` and `--no-flag` —
+ * because both are what the parser accepts and the negated one is the half a
+ * caller is least likely to guess.
+ *
+ * The annotation is the author's own doc comment where the field carries one,
+ * falling back to whether the payload door owes the field. That is the same
+ * choice the help page makes, read from the same enumeration.
+ */
+export function shapeVerbFlagCandidates(
+  verb: VerbFlagListingLike,
+): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (const flag of declaredVerbFlags(verb.inputSchema)) {
+    const description = fieldDescription(flag.schema) ??
+      (flag.required ? "required" : "optional");
+    candidates.push({ value: `--${flag.name}`, description });
+    if (flag.negatable) {
+      candidates.push({
+        value: `--no-${flag.name}`,
+        description: `${description} (false)`,
+      });
+    }
+  }
+  return [...candidates, ...GENERIC_FLAGS];
+}
+
+/** The author's doc comment on the field, where the schema carries one. */
+function fieldDescription(schema: JSONSchema | undefined): string | undefined {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return undefined;
+  }
+  const description = (schema as { description?: unknown }).description;
+  return typeof description === "string" && description.length > 0
+    ? description.split("\n")[0]
+    : undefined;
+}

--- a/packages/cli/lib/completion/verb-flags.ts
+++ b/packages/cli/lib/completion/verb-flags.ts
@@ -59,10 +59,6 @@ export function shapeVerbFlagCandidates(
 ): Candidate[] {
   const candidates: Candidate[] = [];
   const seen = new Set<string>();
-  // Nothing reserves a field name, so a verb may declare `json`, `json-file`
-  // or `help` — the spellings the command itself owns. A declared field wins
-  // the slot and the generic flag is not repeated, because two candidates of
-  // one value are a menu entry that means two things.
   const add = (value: string, description: string) => {
     if (seen.has(value)) return;
     seen.add(value);
@@ -72,12 +68,18 @@ export function shapeVerbFlagCandidates(
   for (const flag of declaredVerbFlags(verb.inputSchema)) {
     const description = fieldDescription(flag.schema) ??
       (flag.required ? "required" : "optional");
-    // Bare `--help` opens the verb's own page whatever a field of that name
-    // says, so a declared boolean `help` is set by the two spellings that
-    // cannot be mistaken for it — which is what its help page prints too.
-    if (flag.name === "help" && flag.negatable) {
-      add("--help=true", description);
-      add("--no-help", `${description} (false)`);
+    // Nothing reserves a field name, so a verb may declare `json`,
+    // `json-file` or `help` — names the command already owns as bare tokens.
+    // The parser reads the bare token as ITS meaning and never reaches the
+    // field, so the field is offered in the one spelling that does reach it.
+    if (RESERVED_BARE_SPELLINGS.has(flag.name)) {
+      // A boolean carries its value in the spelling; anything else is
+      // completed up to the `=` and the caller writes the value.
+      add(
+        flag.negatable ? `--${flag.name}=true` : `--${flag.name}=`,
+        `${description} (the declared field)`,
+      );
+      if (flag.negatable) add(`--no-${flag.name}`, `${description} (false)`);
       continue;
     }
     add(`--${flag.name}`, description);
@@ -89,6 +91,18 @@ export function shapeVerbFlagCandidates(
   }
   return candidates;
 }
+
+/**
+ * Flag names the command consumes as bare tokens before a declared field is
+ * ever consulted: `--json` and `--json-file` select an input mode, and
+ * `--help` opens the verb's page. A field of one of those names is reachable
+ * only as `--name=value`, which those doors do not match.
+ */
+const RESERVED_BARE_SPELLINGS: ReadonlySet<string> = new Set([
+  "json",
+  "json-file",
+  "help",
+]);
 
 /** The author's doc comment on the field, where the schema carries one. */
 function fieldDescription(schema: JSONSchema | undefined): string | undefined {

--- a/packages/cli/lib/completion/verb-flags.ts
+++ b/packages/cli/lib/completion/verb-flags.ts
@@ -58,18 +58,36 @@ export function shapeVerbFlagCandidates(
   verb: VerbFlagListingLike,
 ): Candidate[] {
   const candidates: Candidate[] = [];
+  const seen = new Set<string>();
+  // Nothing reserves a field name, so a verb may declare `json`, `json-file`
+  // or `help` — the spellings the command itself owns. A declared field wins
+  // the slot and the generic flag is not repeated, because two candidates of
+  // one value are a menu entry that means two things.
+  const add = (value: string, description: string) => {
+    if (seen.has(value)) return;
+    seen.add(value);
+    candidates.push({ value, description });
+  };
+
   for (const flag of declaredVerbFlags(verb.inputSchema)) {
     const description = fieldDescription(flag.schema) ??
       (flag.required ? "required" : "optional");
-    candidates.push({ value: `--${flag.name}`, description });
-    if (flag.negatable) {
-      candidates.push({
-        value: `--no-${flag.name}`,
-        description: `${description} (false)`,
-      });
+    // Bare `--help` opens the verb's own page whatever a field of that name
+    // says, so a declared boolean `help` is set by the two spellings that
+    // cannot be mistaken for it — which is what its help page prints too.
+    if (flag.name === "help" && flag.negatable) {
+      add("--help=true", description);
+      add("--no-help", `${description} (false)`);
+      continue;
     }
+    add(`--${flag.name}`, description);
+    if (flag.negatable) add(`--no-${flag.name}`, `${description} (false)`);
   }
-  return [...candidates, ...GENERIC_FLAGS];
+
+  for (const generic of GENERIC_FLAGS) {
+    add(generic.value, generic.description ?? "");
+  }
+  return candidates;
 }
 
 /** The author's doc comment on the field, where the schema carries one. */

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -881,8 +881,10 @@ export interface DeclaredVerbFlag {
  * accepted by the parser and named by neither, or the reverse.
  */
 export function declaredVerbFlags(inputSchema: JSONSchema): DeclaredVerbFlag[] {
-  if (isSchemaLessHandlerInput(inputSchema)) return [];
-
+  // A schema-less input declares no fields, but the parser still takes the
+  // value flags for it and the usage lines still advertise them — so they are
+  // reported here, which is what keeps the parser, the help page's flag list
+  // and completion naming one vocabulary.
   const properties = objectProperties(inputSchema);
   if (!properties) {
     // A non-object input is written whole, so its flags name the value rather
@@ -891,7 +893,9 @@ export function declaredVerbFlags(inputSchema: JSONSchema): DeclaredVerbFlag[] {
       {
         name: "value",
         schema: inputSchema,
-        required: true,
+        // A declared non-object input owes a value; a schema-less one does
+        // not, because invoking it with no input at all is legal.
+        required: !isSchemaLessHandlerInput(inputSchema),
         negatable: false,
       },
       { name: "value-file", required: false, negatable: false },
@@ -916,7 +920,9 @@ function specificFlagLines(schema: JSONSchema): string[] {
   // rather than any field, and their padding is fixed rather than fitted.
   if (flags[0].key === undefined) {
     return [
-      `  ${`--value ${valuePlaceholder(schema)}`.padEnd(20)}  Required.`,
+      `  ${`--value ${valuePlaceholder(schema)}`.padEnd(20)}  ${
+        flags[0].required ? "Required." : "Optional."
+      }`,
       `  ${
         "--value-file <path>".padEnd(20)
       }  Read the value from a UTF-8 file. Use - for stdin.`,

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -852,13 +852,69 @@ function fullFlagUsage(flagName: string, schema: JSONSchema): string {
   return primaryFlagUsage(flagName, schema);
 }
 
-function specificFlagLines(schema: JSONSchema): string[] {
-  if (isSchemaLessHandlerInput(schema)) {
-    return [];
+/** One flag the schema-derived parser accepts for a verb's declared input. */
+export interface DeclaredVerbFlag {
+  /** The flag's long name, without dashes — `flagNameForKey`'s mapping. */
+  readonly name: string;
+  /** The declared field it fills; absent for a non-object input's own flags. */
+  readonly key?: string;
+  /** That field's schema, for a caller rendering a placeholder or a type. */
+  readonly schema?: JSONSchema;
+  /** Whether the payload door owes this field. */
+  readonly required: boolean;
+  /** Whether `--no-<name>` is accepted beside it. */
+  readonly negatable: boolean;
+}
+
+/**
+ * Every flag the schema-derived parser accepts for `inputSchema`, in
+ * declaration order — the order the help page lists them and the order the
+ * payload door names them in.
+ *
+ * The generic flags (`--json`, `--help`, and their `-file` forms) are not
+ * here: they are the same for every verb and belong to the command rather than
+ * to what the verb declared.
+ *
+ * The vocabulary rather than a rendering of it, so that a second surface
+ * naming these flags — shell completion is one — reads the same enumeration
+ * the help page does. Two readers of one schema is how a flag comes to be
+ * accepted by the parser and named by neither, or the reverse.
+ */
+export function declaredVerbFlags(inputSchema: JSONSchema): DeclaredVerbFlag[] {
+  if (isSchemaLessHandlerInput(inputSchema)) return [];
+
+  const properties = objectProperties(inputSchema);
+  if (!properties) {
+    // A non-object input is written whole, so its flags name the value rather
+    // than any field of one.
+    return [
+      {
+        name: "value",
+        schema: inputSchema,
+        required: true,
+        negatable: false,
+      },
+      { name: "value-file", required: false, negatable: false },
+    ];
   }
 
-  const properties = objectProperties(schema);
-  if (!properties) {
+  const required = requiredEventFieldsOwed(inputSchema);
+  return Object.entries(properties).map(([key, propertySchema]) => ({
+    name: flagNameForKey(key),
+    key,
+    schema: propertySchema,
+    required: required.has(key),
+    negatable: schemaType(propertySchema) === "boolean",
+  }));
+}
+
+function specificFlagLines(schema: JSONSchema): string[] {
+  const flags = declaredVerbFlags(schema);
+  if (flags.length === 0) return [];
+
+  // A non-object input is written whole, so its two flags name the value
+  // rather than any field, and their padding is fixed rather than fitted.
+  if (flags[0].key === undefined) {
     return [
       `  ${`--value ${valuePlaceholder(schema)}`.padEnd(20)}  Required.`,
       `  ${
@@ -867,42 +923,39 @@ function specificFlagLines(schema: JSONSchema): string[] {
     ];
   }
 
-  const required = requiredEventFieldsOwed(schema);
-  const descriptors = Object.entries(properties).map(
-    ([key, propertySchema]) => {
-      const flagName = flagNameForKey(key);
-      const parts: string[] = [];
-      if (key === "help") {
-        parts.push('Optional input field named "help".');
-      } else {
-        parts.push(required.has(key) ? "Required." : "Optional.");
-      }
-      const type = schemaType(propertySchema);
-      if (key === "help" && type === "boolean") {
-        parts.push("Boolean. Use --help=true or --no-help.");
-      } else if (type === "boolean") {
-        parts.push(
-          `Boolean. Use --${flagName} for true or --no-${flagName} for false.`,
-        );
-      }
-      const enumSummary = schemaEnumSummary(propertySchema);
-      if (enumSummary) {
-        parts.push(`Allowed: ${enumSummary}.`);
-      }
-      const defaultSummary = schemaDefaultSummary(propertySchema);
-      if (defaultSummary !== undefined) {
-        parts.push(`Default: ${defaultSummary}.`);
-      }
-      const description = schemaDescription(propertySchema);
-      if (description) {
-        parts.push(description);
-      }
-      return {
-        usage: fullFlagUsage(flagName, propertySchema),
-        detail: parts.join(" "),
-      };
-    },
-  );
+  const descriptors = flags.map((flag) => {
+    const key = flag.key!;
+    const propertySchema = flag.schema!;
+    const parts: string[] = [];
+    if (key === "help") {
+      parts.push('Optional input field named "help".');
+    } else {
+      parts.push(flag.required ? "Required." : "Optional.");
+    }
+    if (key === "help" && flag.negatable) {
+      parts.push("Boolean. Use --help=true or --no-help.");
+    } else if (flag.negatable) {
+      parts.push(
+        `Boolean. Use --${flag.name} for true or --no-${flag.name} for false.`,
+      );
+    }
+    const enumSummary = schemaEnumSummary(propertySchema);
+    if (enumSummary) {
+      parts.push(`Allowed: ${enumSummary}.`);
+    }
+    const defaultSummary = schemaDefaultSummary(propertySchema);
+    if (defaultSummary !== undefined) {
+      parts.push(`Default: ${defaultSummary}.`);
+    }
+    const description = schemaDescription(propertySchema);
+    if (description) {
+      parts.push(description);
+    }
+    return {
+      usage: fullFlagUsage(flag.name, propertySchema),
+      detail: parts.join(" "),
+    };
+  });
 
   const maxUsage = descriptors.reduce(
     (width, descriptor) => Math.max(width, descriptor.usage.length),

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -419,6 +419,28 @@ Deno.test("shaping: a projection word splits into the part carried back and the 
   });
 });
 
+Deno.test("shaping: a projection path reads through however many array layers it meets", () => {
+  // `--select matrix.nested.leaf` is valid over `[[{nested: {leaf}}]]`, so a
+  // walk that unwrapped one layer would offer `nested` and then nothing.
+  const nested = { matrix: [[{ nested: { leaf: 1 } }]] };
+  assertEquals(projectionKeys(descendProjection(nested, ["matrix"])), [
+    "nested",
+  ]);
+  assertEquals(
+    projectionKeys(descendProjection(nested, ["matrix", "nested"])),
+    ["leaf"],
+  );
+});
+
+Deno.test("shaping: the bare address suffix is offered at any element of the list", () => {
+  // `revision,@` parses: a path that is only the suffix is legal wherever an
+  // element begins, not only at the first.
+  assertEquals(
+    shapeProjectionCandidates({ a: 1 }, "revision,", { self: true })[0].value,
+    "revision,@",
+  );
+});
+
 Deno.test("shaping: a projection path reads an array element-wise", () => {
   // `--select items.title` projects each element; `--select items.0.title` is
   // refused. Offering an index would name a path the command rejects.

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertFalse } from "@std/assert";
 import { resolveCompletionLine } from "../lib/completion/line.ts";
 import {
   descendProjection,
@@ -14,6 +14,10 @@ import {
   splitPathPrefix,
   splitSelectPrefix,
 } from "../lib/completion/providers.ts";
+import {
+  parseSelectionProjection,
+  parseSelectProjection,
+} from "../lib/cell-selection.ts";
 import { tokenizeLine } from "../lib/completion/mod.ts";
 import { main } from "../commands/main.ts";
 
@@ -490,20 +494,43 @@ Deno.test("shaping: an address-marked segment keeps completing below it", () => 
   assertEquals(splitSelectPrefix("a\\@.").path, ["a@"]);
 });
 
-Deno.test("shaping: --schema is offered no field named for a whole-value schema", () => {
-  // `--schema true` IS a JSON Schema and `--schema false` is refused as one,
-  // so neither can name a field there however the source spells its keys.
-  // `--select` reads them as ordinary names.
-  const keys = { "true": 1, "false": 2, "ok": 3 };
-  assertEquals(
-    shapeProjectionCandidates(keys, "", { reserved: ["true", "false"] })
-      .map((candidate) => candidate.value),
-    ["ok", "ok@"],
-  );
-  assertEquals(
-    shapeProjectionCandidates(keys, "").map((candidate) => candidate.value),
-    ["true", "true@", "false", "false@", "ok", "ok@"],
-  );
+Deno.test("the projection grammar decides which candidates a flag can take", async () => {
+  // The boundary cases, each settled by the flag's own parser rather than by
+  // a rule restated here. A candidate that parses but comes back as something
+  // other than a field list — `--schema true` is the boolean JSON Schema — is
+  // not a candidate for this slot either.
+  const shaped = (prefix: string) =>
+    shapeProjectionCandidates({ "true": 1, "false": 2, ok: 3 }, prefix, {
+      self: true,
+    }).map((candidate) => candidate.value);
+  const accepted = async (flag: "select" | "schema", prefix: string) => {
+    const kept: string[] = [];
+    for (const value of shaped(prefix)) {
+      try {
+        const parsed = flag === "select"
+          ? parseSelectProjection(value)
+          : await parseSelectionProjection(value);
+        if (parsed.kind === "concise") kept.push(value);
+      } catch {
+        // refused by this flag
+      }
+    }
+    return kept;
+  };
+
+  // `--select` takes a bare `@` at the first element; `--schema` reads a
+  // leading `@` as a file path and so does not.
+  assert((await accepted("select", "")).includes("@"));
+  assertFalse((await accepted("schema", "")).includes("@"));
+  // After a comma neither is leading, so both take it.
+  assert((await accepted("select", "revision,")).includes("revision,@"));
+  assert((await accepted("schema", "revision,")).includes("revision,@"));
+  // `true` alone is a whole-value schema to one flag and refused by the
+  // other, and an ordinary field name to both once it is not alone.
+  assertFalse((await accepted("select", "")).includes("true"));
+  assertFalse((await accepted("schema", "")).includes("true"));
+  assert((await accepted("select", "revision,")).includes("revision,true"));
+  assert((await accepted("schema", "revision,")).includes("revision,true"));
 });
 
 Deno.test("shaping: a key the concise grammar cannot carry is not offered", () => {

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { resolveCompletionLine } from "../lib/completion/line.ts";
 import {
+  acceptedProjections,
   descendProjection,
   keysOf,
   linkEndpointPrefix,
@@ -209,6 +210,13 @@ Deno.test("live candidates: a fabric slot without context degrades to empty", as
   await withEnv({}, async () => {
     for (
       const text of [
+        // The projection guards, which answer before any fabric is reached: a
+        // call's projection is a verb's result rather than the piece's root,
+        // and a `--schema` word opening with `@` or `{` is a file or a schema.
+        "cf call --piece x --select ",
+        "cf exec /tmp/x --select ",
+        "cf get --piece x --schema @",
+        "cf get --piece x --schema {",
         "cf piece call --piece x ",
         "cf piece get --piece x ",
         "cf piece get-label --piece x ",
@@ -492,6 +500,28 @@ Deno.test("shaping: an address-marked segment keeps completing below it", () => 
   );
   // An escaped `@` is part of the name, not the marker.
   assertEquals(splitSelectPrefix("a\\@.").path, ["a@"]);
+});
+
+Deno.test("acceptedProjections keeps what the flag's own parser reads as a field list", async () => {
+  // The filter itself, driven directly: a spelling each flag refuses, one it
+  // reads as something other than a field list, and one it takes.
+  const shape = (values: string[]) => values.map((value) => ({ value }));
+  assertEquals(
+    (await acceptedProjections(
+      shape(["@", "revision,@", "ok"]),
+      "select",
+    )).map((candidate) => candidate.value),
+    ["@", "revision,@", "ok"],
+  );
+  // `--schema @` is an empty file path; `--schema true` parses, but as the
+  // boolean JSON Schema rather than a field list.
+  assertEquals(
+    (await acceptedProjections(
+      shape(["@", "true", "revision,@", "ok"]),
+      "schema",
+    )).map((candidate) => candidate.value),
+    ["revision,@", "ok"],
+  );
 });
 
 Deno.test("the projection grammar decides which candidates a flag can take", async () => {

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -477,6 +477,35 @@ Deno.test("shaping: the bare address suffix is offered only where it is asked fo
   );
 });
 
+Deno.test("shaping: an address-marked segment keeps completing below it", () => {
+  // `topic@.title` marks `topic` and projects `title`, so the walk reads the
+  // field the segment NAMES while the candidate carries the marker back.
+  assertEquals(splitSelectPrefix("topic@.").path, ["topic"]);
+  assertEquals(splitSelectPrefix("topic@.").prefix, "topic@.");
+  assertEquals(
+    projectionKeys(descendProjection({ topic: { title: 1 } }, ["topic"])),
+    ["title"],
+  );
+  // An escaped `@` is part of the name, not the marker.
+  assertEquals(splitSelectPrefix("a\\@.").path, ["a@"]);
+});
+
+Deno.test("shaping: --schema is offered no field named for a whole-value schema", () => {
+  // `--schema true` IS a JSON Schema and `--schema false` is refused as one,
+  // so neither can name a field there however the source spells its keys.
+  // `--select` reads them as ordinary names.
+  const keys = { "true": 1, "false": 2, "ok": 3 };
+  assertEquals(
+    shapeProjectionCandidates(keys, "", { reserved: ["true", "false"] })
+      .map((candidate) => candidate.value),
+    ["ok", "ok@"],
+  );
+  assertEquals(
+    shapeProjectionCandidates(keys, "").map((candidate) => candidate.value),
+    ["true", "true@", "false", "false@", "ok", "ok@"],
+  );
+});
+
 Deno.test("shaping: a key the concise grammar cannot carry is not offered", () => {
   // `parseConciseSegment` holds a segment to an identifier grammar, and a
   // trailing `@` in a name reads as the address suffix. Offering either would

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,13 +1,18 @@
 import { assert, assertEquals } from "@std/assert";
 import { resolveCompletionLine } from "../lib/completion/line.ts";
 import {
+  descendProjection,
   keysOf,
   linkEndpointPrefix,
   liveCandidates,
+  projectionKeys,
   resolveSpaceContext,
   shapePieceCandidates,
+  shapeProjectionCandidates,
+  shapeSlugCandidates,
   shapeVerbCandidates,
   splitPathPrefix,
+  splitSelectPrefix,
 } from "../lib/completion/providers.ts";
 import { tokenizeLine } from "../lib/completion/mod.ts";
 import { main } from "../commands/main.ts";
@@ -361,6 +366,103 @@ Deno.test("shaping: callables are annotated by kind", () => {
       { value: "addItem", description: "handler" },
       { value: "search", description: "tool" },
     ],
+  );
+});
+
+Deno.test("shaping: a slug is labeled apart from the ids beside it", () => {
+  // Both are `--piece` values, so a candidate list mixing them has to say
+  // which is which — and where the slug resolves to a piece the listing named,
+  // what it points at is the question a caller is actually asking.
+  assertEquals(
+    shapeSlugCandidates(
+      [
+        { slug: "board", piece: "fid1:a" },
+        { slug: "orphan", piece: "fid1:missing" },
+        { slug: "unresolved" },
+      ],
+      [{ id: "fid1:a", name: "Completion fixture" }],
+    ),
+    [
+      { value: "board", description: "slug for Completion fixture" },
+      { value: "orphan", description: "slug" },
+      { value: "unresolved", description: "slug" },
+    ],
+  );
+});
+
+Deno.test("shaping: a projection word splits into the part carried back and the path", () => {
+  // The shell replaces the whole word, so a candidate has to carry every
+  // element already closed and every segment already typed in this one.
+  assertEquals(splitSelectPrefix(""), {
+    list: "",
+    path: [],
+    prefix: "",
+    atElementStart: true,
+  });
+  assertEquals(splitSelectPrefix("settings."), {
+    list: "",
+    path: ["settings"],
+    prefix: "settings.",
+    atElementStart: false,
+  });
+  assertEquals(splitSelectPrefix("items@,settings.the"), {
+    list: "items@,",
+    path: ["settings"],
+    prefix: "settings.",
+    atElementStart: false,
+  });
+  assertEquals(splitSelectPrefix("revision,"), {
+    list: "revision,",
+    path: [],
+    prefix: "",
+    atElementStart: true,
+  });
+});
+
+Deno.test("shaping: a projection path reads an array element-wise", () => {
+  // `--select items.title` projects each element; `--select items.0.title` is
+  // refused. Offering an index would name a path the command rejects.
+  assertEquals(
+    projectionKeys(descendProjection(
+      { items: [{ title: "a" }, { title: "b", pinned: true }] },
+      ["items"],
+    )),
+    ["title", "pinned"],
+  );
+  assertEquals(projectionKeys([{ a: 1 }, { b: 2 }]), ["a", "b"]);
+  assertEquals(projectionKeys({ a: 1 }), ["a"]);
+  for (const leaf of ["text", 42, true, null, undefined]) {
+    assertEquals(projectionKeys(leaf), [], String(leaf));
+  }
+});
+
+Deno.test("shaping: both spellings of a position are offered, each carrying the prefix", () => {
+  assertEquals(
+    shapeProjectionCandidates({ theme: "dark" }, "settings."),
+    [
+      { value: "settings.theme" },
+      { value: "settings.theme@", description: "its address" },
+    ],
+  );
+});
+
+Deno.test("shaping: the bare address suffix is offered only where it is asked for", () => {
+  const withSelf = shapeProjectionCandidates({ a: 1 }, "", { self: true });
+  assertEquals(withSelf[0].value, "@");
+  assertEquals(
+    shapeProjectionCandidates({ a: 1 }, "").map((c) => c.value),
+    ["a", "a@"],
+  );
+});
+
+Deno.test("shaping: a key the concise grammar cannot carry is not offered", () => {
+  // `parseConciseSegment` holds a segment to an identifier grammar, and a
+  // trailing `@` in a name reads as the address suffix. Offering either would
+  // name a path the command refuses.
+  assertEquals(
+    shapeProjectionCandidates({ "ok": 1, "not ok": 2, "trailing@": 3 }, "")
+      .map((candidate) => candidate.value),
+    ["ok", "ok@"],
   );
 });
 

--- a/packages/cli/test/completion-verb-flags.test.ts
+++ b/packages/cli/test/completion-verb-flags.test.ts
@@ -98,6 +98,38 @@ describe("shapeVerbFlagCandidates()", () => {
     ]);
   });
 
+  it("gives a colliding negation to the field that owns the token", () => {
+    // `parseObjectInput` looks a token up as a declared field before it reads
+    // a `no-` prefix as a negation, so `--no-active` sets `noActive` and never
+    // means `active = false`. Annotating it as the negation would put one
+    // field's meaning on another field's flag.
+    const schema = {
+      type: "object",
+      properties: {
+        active: { type: "boolean" },
+        noActive: { type: "boolean" },
+      },
+    };
+    const spec = {
+      callableKind: "handler",
+      defaultVerb: "invoke",
+      inputSchema: schema,
+    } as ExecCommandSpec;
+    const candidates = shapeVerbFlagCandidates({
+      inputSchema: schema as ExecCommandSpec["inputSchema"],
+    });
+    const negation = candidates.find((c) => c.value === "--no-active");
+    expect(negation?.description).toBe("optional");
+    expect(parseExecArgs(spec, ["--no-active"]).input).toEqual({
+      noActive: true,
+    });
+    // `active = false` is still reachable, by the spelling no field can own.
+    expect(candidates.map((c) => c.value)).toContain("--active=false");
+    expect(parseExecArgs(spec, ["--active=false"]).input).toEqual({
+      active: false,
+    });
+  });
+
   it("offers one candidate per value where a field collides with a generic flag", () => {
     // Two menu entries of one value would mean two different things.
     const values = shapeVerbFlagCandidates({

--- a/packages/cli/test/completion-verb-flags.test.ts
+++ b/packages/cli/test/completion-verb-flags.test.ts
@@ -85,6 +85,34 @@ describe("shapeVerbFlagCandidates()", () => {
     ]);
   });
 
+  it("sets a declared boolean `help` by the spellings that are not the help page", () => {
+    // Bare `--help` opens the verb's own page whatever a field of that name
+    // says, so offering it as the way to set the field names a flag that does
+    // something else.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: {
+        type: "object",
+        properties: { help: { type: "boolean" } },
+      },
+    }).map((candidate) => candidate.value);
+    expect(values).toContain("--help=true");
+    expect(values).toContain("--no-help");
+    expect(values.filter((v) => v === "--help").length).toBe(1);
+  });
+
+  it("offers one candidate per value where a field collides with a generic flag", () => {
+    // Nothing reserves a field name, so a verb may declare `json`. Two menu
+    // entries of one value would mean two different things.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: {
+        type: "object",
+        properties: { json: { type: "string" }, jsonFile: { type: "string" } },
+      },
+    }).map((candidate) => candidate.value);
+    expect(values).toEqual([...new Set(values)]);
+    expect(values.filter((v) => v === "--json").length).toBe(1);
+  });
+
   it("reads fields an `allOf` contributes, which the payload door judges", () => {
     // The two doors read one schema. A field the parser accepts and this did
     // not offer would be a slot silently short of the vocabulary it claims.

--- a/packages/cli/test/completion-verb-flags.test.ts
+++ b/packages/cli/test/completion-verb-flags.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { shapeVerbFlagCandidates } from "../lib/completion/verb-flags.ts";
+
+/**
+ * The `inputSchema` of one verb, in the shape `cf piece verbs --json` reports
+ * it — a declared field with a doc comment, an optional boolean, and a
+ * required field with none. Copied from a listing rather than invented, so the
+ * candidates are shaped from what a real pattern produces.
+ */
+const ADD_ITEM = {
+  inputSchema: {
+    type: "object",
+    properties: {
+      title: { type: "string", description: "The item's display label." },
+      pinned: {
+        type: "boolean",
+        description: "Whether the item starts pinned.",
+      },
+      sortKey: { type: "number" },
+    },
+    required: ["title"],
+  },
+} as const;
+
+describe("shapeVerbFlagCandidates()", () => {
+  it("names every declared field as the flag the parser accepts", () => {
+    const values = shapeVerbFlagCandidates(ADD_ITEM).map((c) => c.value);
+    expect(values).toContain("--title");
+    expect(values).toContain("--pinned");
+  });
+
+  it("writes a camelCase field as its kebab-case flag", () => {
+    // `flagNameForKey` is the mapping the parser itself applies, so `sortKey`
+    // is reachable as `--sort-key` and as nothing else.
+    const values = shapeVerbFlagCandidates(ADD_ITEM).map((c) => c.value);
+    expect(values).toContain("--sort-key");
+    expect(values).not.toContain("--sortKey");
+  });
+
+  it("offers both spellings of a boolean field", () => {
+    const values = shapeVerbFlagCandidates(ADD_ITEM).map((c) => c.value);
+    expect(values).toContain("--pinned");
+    expect(values).toContain("--no-pinned");
+    // Only a boolean is negatable.
+    expect(values).not.toContain("--no-title");
+  });
+
+  it("annotates a field with the author's own doc comment", () => {
+    const title = shapeVerbFlagCandidates(ADD_ITEM)
+      .find((candidate) => candidate.value === "--title");
+    expect(title?.description).toBe("The item's display label.");
+  });
+
+  it("falls back to whether the field is owed where no prose was written", () => {
+    const sortKey = shapeVerbFlagCandidates(ADD_ITEM)
+      .find((candidate) => candidate.value === "--sort-key");
+    expect(sortKey?.description).toBe("optional");
+  });
+
+  it("offers the generic input flags after the declared ones", () => {
+    const values = shapeVerbFlagCandidates(ADD_ITEM).map((c) => c.value);
+    expect(values.slice(-3)).toEqual(["--json", "--json-file", "--help"]);
+  });
+
+  it("returns the generic flags alone for a verb declaring no input", () => {
+    // The schema-less shape: nothing was declared, so nothing is derived, and
+    // the flags every verb accepts are still the honest candidate set.
+    expect(shapeVerbFlagCandidates({ inputSchema: true }).map((c) => c.value))
+      .toEqual(["--json", "--json-file", "--help"]);
+  });
+
+  it("names the value flags for an input that is not an object", () => {
+    // A non-object input is written whole, so `--value` is the field-shaped
+    // flag and there are no per-field ones to derive.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: { type: "string" },
+    }).map((candidate) => candidate.value);
+    expect(values).toEqual([
+      "--value",
+      "--value-file",
+      "--json",
+      "--json-file",
+      "--help",
+    ]);
+  });
+
+  it("reads fields an `allOf` contributes, which the payload door judges", () => {
+    // The two doors read one schema. A field the parser accepts and this did
+    // not offer would be a slot silently short of the vocabulary it claims.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: {
+        allOf: [
+          { type: "object", properties: { title: { type: "string" } } },
+          { type: "object", properties: { body: { type: "string" } } },
+        ],
+      },
+    }).map((candidate) => candidate.value);
+    expect(values).toContain("--title");
+    expect(values).toContain("--body");
+  });
+});

--- a/packages/cli/test/completion-verb-flags.test.ts
+++ b/packages/cli/test/completion-verb-flags.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { shapeVerbFlagCandidates } from "../lib/completion/verb-flags.ts";
+import { type ExecCommandSpec, parseExecArgs } from "../lib/exec-schema.ts";
 
 /**
  * The `inputSchema` of one verb, in the shape `cf piece verbs --json` reports
@@ -63,11 +64,23 @@ describe("shapeVerbFlagCandidates()", () => {
     expect(values.slice(-3)).toEqual(["--json", "--json-file", "--help"]);
   });
 
-  it("returns the generic flags alone for a verb declaring no input", () => {
-    // The schema-less shape: nothing was declared, so nothing is derived, and
-    // the flags every verb accepts are still the honest candidate set.
+  it("names the value flags for a verb declaring no input", () => {
+    // A schema-less input declares no fields, but the parser takes `--value`
+    // for it and the usage lines advertise it — so the candidate set says so
+    // too. The cross-check below is what proves it rather than this list.
     expect(shapeVerbFlagCandidates({ inputSchema: true }).map((c) => c.value))
-      .toEqual(["--json", "--json-file", "--help"]);
+      .toEqual(["--value", "--value-file", "--json", "--json-file", "--help"]);
+  });
+
+  it("offers a colliding field the one spelling that reaches it", () => {
+    // `parseExecArgs` reads a bare `--json` as the generic input mode and
+    // never consults a declared field of that name, so offering the bare
+    // token would name a flag that does something else.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: { type: "object", properties: { json: { type: "string" } } },
+    }).map((candidate) => candidate.value);
+    expect(values).toContain("--json=");
+    expect(values.filter((v) => v === "--json").length).toBe(1);
   });
 
   it("names the value flags for an input that is not an object", () => {
@@ -85,6 +98,62 @@ describe("shapeVerbFlagCandidates()", () => {
     ]);
   });
 
+  it("offers one candidate per value where a field collides with a generic flag", () => {
+    // Two menu entries of one value would mean two different things.
+    const values = shapeVerbFlagCandidates({
+      inputSchema: {
+        type: "object",
+        properties: { json: { type: "string" }, jsonFile: { type: "string" } },
+      },
+    }).map((candidate) => candidate.value);
+    expect(values).toEqual([...new Set(values)]);
+  });
+
+  it("offers only candidates the schema-derived parser accepts", () => {
+    // The one assertion that cannot drift from the parser: every candidate is
+    // completed the way a caller would and put back through `parseExecArgs`.
+    // A list that agreed with itself and not with the parser is exactly the
+    // defect this slot is for.
+    const booleanNames = new Set(["pinned", "help"]);
+    const argsFor = (value: string): string[] => {
+      if (value.includes("=") || value.startsWith("--no-")) return [value];
+      if (value === "--help") return [value];
+      if (value === "--json") return [value, "{}"];
+      if (value === "--json-file" || value === "--value-file") {
+        return [value, "-"];
+      }
+      return booleanNames.has(value.replace(/^--/, ""))
+        ? [value]
+        : [value, "x"];
+    };
+    const schemas: unknown[] = [
+      true,
+      { type: "object", properties: { json: { type: "string" } } },
+      { type: "object", properties: { help: { type: "boolean" } } },
+      {
+        type: "object",
+        properties: { title: { type: "string" }, pinned: { type: "boolean" } },
+      },
+    ];
+    for (const inputSchema of schemas) {
+      const spec = {
+        callableKind: "handler",
+        defaultVerb: "invoke",
+        inputSchema,
+      } as ExecCommandSpec;
+      for (
+        const candidate of shapeVerbFlagCandidates({
+          inputSchema: inputSchema as ExecCommandSpec["inputSchema"],
+        })
+      ) {
+        expect(
+          () => parseExecArgs(spec, argsFor(candidate.value)),
+          `${candidate.value} against ${JSON.stringify(inputSchema)}`,
+        ).not.toThrow();
+      }
+    }
+  });
+
   it("sets a declared boolean `help` by the spellings that are not the help page", () => {
     // Bare `--help` opens the verb's own page whatever a field of that name
     // says, so offering it as the way to set the field names a flag that does
@@ -98,19 +167,6 @@ describe("shapeVerbFlagCandidates()", () => {
     expect(values).toContain("--help=true");
     expect(values).toContain("--no-help");
     expect(values.filter((v) => v === "--help").length).toBe(1);
-  });
-
-  it("offers one candidate per value where a field collides with a generic flag", () => {
-    // Nothing reserves a field name, so a verb may declare `json`. Two menu
-    // entries of one value would mean two different things.
-    const values = shapeVerbFlagCandidates({
-      inputSchema: {
-        type: "object",
-        properties: { json: { type: "string" }, jsonFile: { type: "string" } },
-      },
-    }).map((candidate) => candidate.value);
-    expect(values).toEqual([...new Set(values)]);
-    expect(values.filter((v) => v === "--json").length).toBe(1);
   });
 
   it("reads fields an `allOf` contributes, which the payload door judges", () => {


### PR DESCRIPTION
## Why

This is the half of the completion plan that pays for itself. Every slot here
names something a deployed pattern owns, so the alternative to completing it is
a call to `cf piece verbs` or `cf get` and a read of what comes back — a round
trip and a context switch, not just keystrokes.

Items 4 (candidates only), 5, 7 and 17 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md).
Stacked on #6250.

## What Changed

**Slugs (item 7).** `--piece` offers the space's slugs before its ids — both
are values the flag takes, and the slug is the readable half — annotated so the
two are distinguishable and so a slug says what it points at.
`piece set-slug`'s slug positional offers the slugs it can re-point.

**Projection field paths (item 5), for `cf get`.** `--select` and `--schema`
complete in the projection's own grammar rather than the cell-path one: a list
splits on `,` and a path on `.`, a trailing `@` asks for a position's address
and a bare `@` for the read's own, so both spellings of a position are offered.
A path below an array names a field of each element, because that is what a
projection does with one and an index there is refused. A key the concise
grammar cannot carry is left out rather than offered in a form that does not
work.

**A verb's flags, as candidates only (item 4).** `shapeVerbFlagCandidates`
turns a listing row's `inputSchema` into the flags the parser accepts. It is
deliberately **not wired to a slot**: step 10 of `cli-surface-shape.md` decides
whether a verb's fields are written before the `--` marker or after it, and
routing them to today's position would teach the spelling that step retires.
It reads `declaredVerbFlags`, which `specificFlagLines` now also reads — so the
verb's help page and completion cannot name different vocabularies.

## `cf wish`'s half of item 5 is not built, and the plan records why

The item said to confirm before building it that resolving a wish writes
nothing. It does not. `resolveWish` runs a single-node pattern in the target
space and commits the cell it lands on, so the first Tab on a query not resolved
before writes to the space. Measured against a local server by counting rows in
the space DB:

| | revision | commit | head |
|---|---|---|---|
| `cf piece ls` | +0 | +0 | +0 |
| `cf get` | +0 | +0 | +0 |
| `cf piece verbs` | +0 | +0 | +0 |
| `cf wish '#pieceRegistry'` (first time) | **+5** | **+2** | **+4** |
| the same query again | +0 | +0 | +0 |

A caller editing a query writes once per spelling they pass through. That is a
keystroke with a side effect, which is the bar the item set and does not clear.
Completing it needs a resolution that reads without committing, which is a
change to `resolveWish` rather than to completion.

## Test plan

- The live seam, against a local dev server: 58 passed, 0 failed, 1 gap open
  (item 4's wiring). Two of its gaps closed here.
- `deno task test` in `packages/cli` — 0 failed. New pure tests cover the slug
  labelling, the projection word split, the element-wise array walk, the
  unwritable-key filter, and the shaper (including an `allOf`-declared field,
  which the payload door judges and a naive reader would miss).
- `packages/cli/test/exec.test.ts` and `piece-describe.test.ts` cover the
  `specificFlagLines` refactor; the rendered help page is unchanged.
- `deno fmt --check`, `deno lint`, `deno task check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Review round 2

Four findings, each verified against `parseExecArgs` / `parseSelectProjection`
before anything changed.

**A declared `json` or `json-file` field was offered as the bare token**, which
the parser reads as the generic input mode — `--json hello` fails trying to
parse `hello` as JSON, while `--json=hello` sets the field. The field is offered
as `--json=`; the bare generic keeps its own entry. `help` is on the same
footing, and a boolean one is `--help=true`.

**A schema-less input reported no flags**, while the parser takes `--value` for
it. This was worse than the finding said: the help page's *usage* lines already
advertised `--value <json>` while its *Flags* section omitted them, so parser
and help disagreed before completion entered it. Reporting them from
`declaredVerbFlags` fixes both surfaces from one enumeration — and surfaced that
the flag was labelled Required there, where invoking with no input is legal.

**`topic@.` stopped the walk.** `topic@.title` marks `topic` and projects
`title`, but the walk sought a literal `topic@` property. Segments are now read
the way `parseConciseSegment` reads them, marker stripped and escapes honoured,
while the candidate carries the written form back.

**`--schema true` is a JSON Schema and `--schema false` is refused as one**, so
a source field named either is no longer offered there; `--select` still reads
them as ordinary names. The README's claim that a JSON Schema is recognized by
opening `{` is corrected to include the boolean schemas.

The suggested cross-check is now a test rather than a probe: every candidate is
completed the way a caller would and put back through `parseExecArgs`, across
four schema shapes. It is the one assertion here that cannot drift from the
parser, and writing it is what caught the boolean-`help` spelling.

**On the two `loadPieces` calls** (the improvement): the mechanism is real, but
measured across cold processes one listing takes 333–347 ms and both together
345–439 ms — the second rides the session the first opened and its cost is under
run-to-run noise. Recorded in the plan rather than answered with a new combined
listing API for no measured gain.


## Coverage

The gate named `packages/cli` +61 uncovered lines. Mapping them to their
functions, almost all are **live provider bodies** — `projectionFieldCandidates`,
the slug providers, the cell-path walk — which this plan covers with
`integration/completion-over-the-cli.sh` rather than with unit tests, and which
the coverage gate does not measure. That split is the design (item 18): a
provider that reaches a fabric and returns the wrong set is invisible to a unit
test, so the walkthrough is what exercises it.

`COVERAGE.md` says to write the test rather than take the marker, so the
writable part was written first: `acceptedProjections` — the filter deciding
which spellings each flag takes — is exported and driven directly over the
boundary cases, and the guards that answer before any fabric is reached joined
the degrade-to-empty cases. That recovered 24 lines.

The residual +37 is the part unit tests cannot reach without faking a fabric,
which would duplicate what the walkthrough already proves. Accepted on that
basis, with the coverage mechanism itself under rework.

ACCEPT_COVERAGE_DEBT: packages/cli +37 lines
