### PR TITLE
feat(cli): annotate a verb candidate with what its author said it is for

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -434,8 +434,12 @@ word back to them and calls it documentation.
 `cf piece verbs` hides `tier: "wrapper"` and `deprecated` rows unless `--all`,
 and prints a note saying how many it held back. Completion offers them, because
 both are callable and a name that works should be reachable — and marks them,
-because two surfaces disagreeing silently is what is not defensible. The mark
-leads the annotation: `[deprecated] Add one item.`
+because two surfaces disagreeing silently is what is not defensible. The marks
+lead the annotation: `[deprecated] Add one item.`
+
+The two can coexist, and the listing joins them, so completion joins them the
+same way — `[wrapper,deprecated]`. Picking one would be the same disagreement
+in a narrower place.
 
 ## Felt cost
 

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -85,8 +85,8 @@ read before picking one up; this table is the roll-up.
 | 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
 | 7 | Slugs never complete | pattern vocabulary | done |
 | 8 | `--space` has no source a caller recognizes | first link | partly settled |
-| 9 | A verb's annotation is its kind, not its prose | comprehension | not started |
-| 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | not started |
+| 9 | A verb's annotation is its kind, not its prose | comprehension | done |
+| 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | done |
 | 11 | Every Tab costs two process starts | felt cost | needs a decision |
 | 12 | `nospace` is inert on the stock macOS bash | felt cost | not started |
 | 13 | Space and entity positionals across `inspect` | operator surface | not started |
@@ -97,9 +97,9 @@ read before picking one up; this table is the roll-up.
 | 18 | A live-provider test seam | mechanism | done |
 | 19 | A gate that fails when a new slot has no decision | mechanism | not started |
 
-**What can be picked up today.** Items 9, 10, 12, 13, 14, 15 and 16 are
-mechanical and can be taken at any time. Item 19 is the other half of the
-mechanism item 18 landed.
+**What can be picked up today.** Items 12, 13, 14, 15 and 16 are mechanical and
+can be taken at any time. Item 19 is the other half of the mechanism item 18
+landed.
 
 Item 4's candidates are built and its wiring waits: step 10 decides whether a
 verb's fields are written before the `--` marker or after it, and the position
@@ -419,28 +419,23 @@ reached for.
 
 ## Comprehension
 
-### 9. A verb's annotation is its kind, not its prose
+### 9. A verb's annotation is its prose, falling back to its kind
 
-`shapeVerbCandidates` annotates every candidate with `handler` or `tool`. The
-listing row carries `description` — the doc comment the author wrote on the
-property, the same sentence the verb's help page opens with. The annotation
-column is where that sentence belongs; the kind is a two-value fact that rarely
-decides anything at the prompt.
+`shapeVerbCandidates` annotates a candidate with the doc comment the author
+wrote on the property — the same sentence `cf piece verbs` prints under the row
+and the verb's help page opens with — taking its first line, which is what one
+column of one row holds. The kind is the fallback where the author documented
+nothing, so a candidate is never unannotated, and it is never derived from the
+name: a listing that restates `addItem` as "add item" reports a caller's own
+word back to them and calls it documentation.
 
-Fall back to the kind where a verb carries no prose, so a candidate is never
-unannotated.
-
-### 10. Wrapper and deprecated verbs are offered unmarked
+### 10. Wrapper and deprecated verbs are marked
 
 `cf piece verbs` hides `tier: "wrapper"` and `deprecated` rows unless `--all`,
-and prints a note saying how many it held back. `shapeVerbCandidates` maps the
-full array, so completion offers what the listing hides, and offers it looking
-like everything else.
-
-Both are callable, so offering them is defensible and hiding them is defensible.
-What is not defensible is the two surfaces disagreeing silently. Marking them in
-the annotation column is the cheapest way to agree — it keeps a name reachable
-while saying what it is.
+and prints a note saying how many it held back. Completion offers them, because
+both are callable and a name that works should be reachable — and marks them,
+because two surfaces disagreeing silently is what is not defensible. The mark
+leads the annotation: `[deprecated] Add one item.`
 
 ## Felt cost
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -983,17 +983,23 @@ source <(cf completion bash)
 Completion covers the command tree — subcommands, flags, and enumerated values
 such as `--log-level` — plus live values read from the fabric:
 
-| Slot                            | Completes to                                   |
-| ------------------------------- | ---------------------------------------------- |
-| `--piece`                       | the space's slugs, then its piece ids          |
-| `cf call <callable>`            | the piece's callables, as `cf piece verbs`     |
-| `cf get`/`cf set <path>`        | cell keys, one path segment at a time          |
-| `cf get --select`/`--schema`    | field paths into the value, and their `@` form |
-| `piece set-slug <slug>`         | the space's slugs                              |
-| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints              |
-| `--space`                       | space DIDs of local memory-v2 stores           |
-| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell         |
-| `--datafile`                    | any file, via the shell                        |
+| Slot                            | Completes to                                                  |
+| ------------------------------- | ------------------------------------------------------------- |
+| `--piece`                       | the space's slugs, then its piece ids                         |
+| `cf call <callable>`            | the piece's callables, annotated with the doc comment on each |
+| `cf get`/`cf set <path>`        | cell keys, one path segment at a time                         |
+| `cf get --select`/`--schema`    | field paths into the value, and their `@` form                |
+| `piece set-slug <slug>`         | the space's slugs                                             |
+| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints                             |
+| `--space`                       | space DIDs of local memory-v2 stores                          |
+| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell                        |
+| `--datafile`                    | any file, via the shell                                       |
+
+A callable is annotated with what its author said it is for, falling back to its
+kind where they wrote nothing. A wrapper or deprecated verb — the two
+`cf piece verbs` holds back unless `--all` — is offered with that mark leading
+its annotation, since both are callable and a name that works should be
+reachable.
 
 A projection's grammar is its own and not the cell path's: a list splits on `,`
 and a path on `.`, and a trailing `@` asks for a position's address rather than

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -997,8 +997,9 @@ such as `--log-level` — plus live values read from the fabric:
 
 A callable is annotated with what its author said it is for, falling back to its
 kind where they wrote nothing. A wrapper or deprecated verb — the two
-`cf piece verbs` holds back unless `--all` — is offered with that mark leading
-its annotation, since both are callable and a name that works should be
+`cf piece verbs` holds back unless `--all` — is offered with its marks leading
+that annotation, joined the way the listing joins them and both shown where a
+verb carries both, since either is callable and a name that works should be
 reachable.
 
 A projection's grammar is its own and not the cell path's: a list splits on `,`

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -312,16 +312,24 @@ check "addItem,noteAll,renameItem,sweep" \
     jq -r '[.verbs[] | select(.deprecated != true and .tier != "wrapper") |
       .name] | sort | join(",")')" \
   "the verbs listing shows four of them"
-check "handler" "$(annotation_at "cf call $LINE_ARGS --piece board " legacyAdd)" \
-  "the deprecated verb is offered annotated like every other"
-# The annotation column carries the kind, while the listing row carries the
-# prose the author wrote — the sentence the verb's help page opens with.
-check "Add one item to the board, and report the new total." \
-  "$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
-    jq -r '.verbs[] | select(.name == "addItem") | .description')" \
+# Both surfaces are offered the deprecated verb, and completion says so: it is
+# callable, so hiding it would put a working name out of reach, and offering it
+# unmarked is the two surfaces disagreeing silently.
+check "[deprecated] handler" \
+  "$(annotation_at "cf call $LINE_ARGS --piece board " legacyAdd)" \
+  "the verb the listing held back is offered marked"
+check "1" "$(succeeds $CF call --quiet --piece board $ARGS \
+  --invocation legacy-1 legacyAdd '{"title":"Legacy item"}')" \
+  "and it is callable, which is why it is offered at all"
+# The annotation column carries what the author said the verb is FOR, which is
+# the sentence its help page opens with.
+ADD_PROSE=$($CF piece verbs --piece board $ARGS --json 2>/dev/null |
+  jq -r '.verbs[] | select(.name == "addItem") | .description')
+check "Add one item to the board, and report the new total." "$ADD_PROSE" \
   "the listing carries addItem's prose"
-check "handler" "$(annotation_at "cf call $LINE_ARGS --piece board " addItem)" \
-  "and the candidate is annotated with its kind instead"
+check "$ADD_PROSE" \
+  "$(annotation_at "cf call $LINE_ARGS --piece board " addItem)" \
+  "and the candidate is annotated with the same sentence"
 
 step "7. Past the callable name, cf's own flags are not offered"
 # `piece call` is stopEarly(), so the first positional ends option parsing and

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -275,13 +275,45 @@ async function callableCandidates(
 export interface VerbListingLike {
   readonly name: string;
   readonly kind: string;
+  /** The author's doc comment on the verb, where the listing carries one. */
+  readonly description?: string;
+  /** A UI affordance rather than a headless verb. Hidden by `cf piece verbs`. */
+  readonly tier?: string;
+  /** `@deprecated` on the verb. Hidden by `cf piece verbs`. */
+  readonly deprecated?: boolean;
 }
 
-/** Callables annotated by kind, matching what `cf piece verbs` reports. */
+/**
+ * Callables, annotated with what the author said the verb is FOR.
+ *
+ * `cf piece verbs` prints that sentence under each row and it is the one a
+ * verb's help page opens with, so it is what the annotation column is for. The
+ * kind is a two-value fact that rarely decides anything at the prompt, and it
+ * is the fallback where the author documented nothing — never derived from the
+ * name, which would report a caller's own word back as documentation.
+ *
+ * A wrapper or deprecated verb is marked. `cf piece verbs` holds both back
+ * unless `--all` and says how many it held; completion offers them, because
+ * both are callable and a name that works should be reachable. What is not
+ * defensible is the two surfaces disagreeing silently, and the mark is the
+ * cheapest way to agree: it keeps the name reachable while saying what it is.
+ */
 export function shapeVerbCandidates(
   verbs: readonly VerbListingLike[],
 ): Candidate[] {
-  return verbs.map((verb) => ({ value: verb.name, description: verb.kind }));
+  return verbs.map((verb) => {
+    const mark = verb.tier === "wrapper"
+      ? "wrapper"
+      : verb.deprecated === true
+      ? "deprecated"
+      : undefined;
+    const said = verb.description?.split("\n")[0].trim();
+    const body = said && said.length > 0 ? said : verb.kind;
+    return {
+      value: verb.name,
+      description: mark ? `[${mark}] ${body}` : body,
+    };
+  });
 }
 
 /**

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -302,16 +302,18 @@ export function shapeVerbCandidates(
   verbs: readonly VerbListingLike[],
 ): Candidate[] {
   return verbs.map((verb) => {
-    const mark = verb.tier === "wrapper"
-      ? "wrapper"
-      : verb.deprecated === true
-      ? "deprecated"
-      : undefined;
+    // Both marks, in the order and the join `cf piece verbs` renders them
+    // with. They can coexist, and picking one would put the two surfaces back
+    // into the silent disagreement this item is about.
+    const marks = [
+      ...(verb.tier === "wrapper" ? ["wrapper"] : []),
+      ...(verb.deprecated === true ? ["deprecated"] : []),
+    ].join(",");
     const said = verb.description?.split("\n")[0].trim();
     const body = said && said.length > 0 ? said : verb.kind;
     return {
       value: verb.name,
-      description: mark ? `[${mark}] ${body}` : body,
+      description: marks ? `[${marks}] ${body}` : body,
     };
   });
 }

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -368,15 +368,59 @@ Deno.test("shaping: a piece is labeled by name, falling back to its pattern", ()
   );
 });
 
-Deno.test("shaping: callables are annotated by kind", () => {
+Deno.test("shaping: a callable is annotated with what the author said it is for", () => {
+  // The doc comment is the sentence the verb's help page opens with, and the
+  // kind is a two-value fact that rarely decides anything at the prompt. The
+  // kind is the fallback where the author documented nothing, so a candidate
+  // is never unannotated.
   assertEquals(
     shapeVerbCandidates([
-      { name: "addItem", kind: "handler" },
+      { name: "addItem", kind: "handler", description: "Add one item." },
       { name: "search", kind: "tool" },
+      { name: "wrapped", kind: "handler", description: "  " },
     ]),
     [
-      { value: "addItem", description: "handler" },
+      { value: "addItem", description: "Add one item." },
       { value: "search", description: "tool" },
+      { value: "wrapped", description: "handler" },
+    ],
+  );
+});
+
+Deno.test("shaping: a callable takes the first line of a multi-line comment", () => {
+  // The annotation is one column of one row; the rest of the comment is what
+  // the verb's own help page is for.
+  assertEquals(
+    shapeVerbCandidates([
+      {
+        name: "noteAll",
+        kind: "handler",
+        description: "Record it.\nThen some.",
+      },
+    ])[0].description,
+    "Record it.",
+  );
+});
+
+Deno.test("shaping: a verb the listing holds back is offered marked", () => {
+  // `cf piece verbs` hides both unless --all. Both are callable, so hiding
+  // them here would put a working name out of reach; the mark is what keeps
+  // the two surfaces from disagreeing silently.
+  assertEquals(
+    shapeVerbCandidates([
+      { name: "legacyAdd", kind: "handler", deprecated: true },
+      {
+        name: "openPicker",
+        kind: "handler",
+        tier: "wrapper",
+        description: "Pick.",
+      },
+      { name: "addItem", kind: "handler", deprecated: false },
+    ]),
+    [
+      { value: "legacyAdd", description: "[deprecated] handler" },
+      { value: "openPicker", description: "[wrapper] Pick." },
+      { value: "addItem", description: "handler" },
     ],
   );
 });

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -402,6 +402,24 @@ Deno.test("shaping: a callable takes the first line of a multi-line comment", ()
   );
 });
 
+Deno.test("shaping: a verb carrying both marks is offered with both", () => {
+  // The marks can coexist, and `cf piece verbs` renders them joined — so
+  // picking one would put the two surfaces back into the silent disagreement
+  // this mark exists to end.
+  assertEquals(
+    shapeVerbCandidates([
+      {
+        name: "openLegacy",
+        kind: "handler",
+        tier: "wrapper",
+        deprecated: true,
+        description: "Open it.",
+      },
+    ]),
+    [{ value: "openLegacy", description: "[wrapper,deprecated] Open it." }],
+  );
+});
+
 Deno.test("shaping: a verb the listing holds back is offered marked", () => {
   // `cf piece verbs` hides both unless --all. Both are callable, so hiding
   // them here would put a working name out of reach; the mark is what keeps


### PR DESCRIPTION
## Why

Two ways the verb slot was harder to read than it needed to be, both cheap to
fix and both about what the annotation column says.

Items 9 and 10 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md).
Stacked on #6251.

## What Changed

**The annotation is the verb's prose, not its kind.** Every candidate was
annotated `handler` or `tool` — a two-value fact that rarely decides anything at
the prompt — while the listing row already carried the doc comment the author
wrote on the property, which is the sentence `cf piece verbs` prints under the
row and the verb's help page opens with. That sentence is what the column is
for. The kind stays as the fallback where the author documented nothing, so a
candidate is never unannotated, and it is never derived from the name: a listing
that restates `addItem` as "add item" reports a caller's own word back to them
and calls it documentation.

**A wrapper or deprecated verb is marked.** `cf piece verbs` holds both back
unless `--all` and prints a note saying how many it held; completion offered
them looking like everything else. Both are callable, so offering them is right
— hiding them would put a working name out of reach. What is not defensible is
the two surfaces disagreeing silently, and the mark is the cheapest way to
agree: `[deprecated] Add one item.` keeps the name reachable while saying what
it is.

## Test plan

- The live seam, against a local dev server: 59 passed, 0 failed, 1 gap open.
  Its verb-slot step now asserts that the candidate's annotation is the same
  sentence the listing carries, and that the held-back verb is offered marked
  **and is callable** — which is why it is offered at all.
- `deno task test` in `packages/cli` — 0 failed. New pure tests cover the prose
  fallback, the first-line trim on a multi-line comment, and both marks.
- `deno fmt --check`, `deno lint`, `deno task check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

