### PR TITLE
feat(cli): complete the operator surface and the enumerable remainder

### DIFF
--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -88,7 +88,7 @@ read before picking one up; this table is the roll-up.
 | 9 | A verb's annotation is its kind, not its prose | comprehension | done |
 | 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | done |
 | 11 | Every Tab costs two process starts | felt cost | needs a decision |
-| 12 | `nospace` is inert on the stock macOS bash | felt cost | remedy disproven |
+| 12 | `nospace` is inert on the stock macOS bash | felt cost | done |
 | 13 | Space and entity positionals across `inspect` | operator surface | done |
 | 14 | `wish` targets and scopes | CLI vocabulary | done |
 | 15 | Remaining path-shaped and enumerable values | CLI vocabulary | done |
@@ -468,36 +468,40 @@ where state lives rather than about how fast a process starts.
 Worth sizing before it is scheduled: it may be that the correctness and
 vocabulary items above change the experience more than a faster Tab would.
 
-### 12. `nospace` is inert on the stock macOS bash, and the remedy does not work
+### 12. The trailing space is inverted, not suppressed
 
 Cell paths, link endpoints and projection paths complete one segment at a time
 and emit a `nospace` directive so the cursor stays attached for the next
-separator. The bash function applies it through `compopt`, which is bash 4 and
-later; macOS ships bash 3.2. It is a keystroke *per segment*, on the default
-shell of the platform most of this repository is developed on, and it lands on
-the deepest and most useful completion there is.
+separator. `compopt` is the per-completion switch and it is bash 4 and later;
+macOS ships bash 3.2, where the directive was simply inert. It cost a keystroke
+*per segment*, on the deepest and most useful completion there is.
 
-The remedy this item proposed — a candidate carrying its own trailing separator
-— was measured against bash 3.2 through a pty and does not work. Three
-behaviours, all of them of one unique match:
+The space is now taken away by default and given back instead. The binding is
+registered `complete -o nospace`, and a candidate that should END the word
+carries its own trailing space, which bash inserts verbatim. One mechanism
+serves bash 3.2 and bash 4 alike.
 
-- A reply of `items` inserts `items ` — the space this item is about.
-- A reply of `items/` inserts `items/ `. The space falls after the separator
-  rather than inside the path, and the caller still has to delete it before
-  typing the next segment.
-- `complete -o filenames` does not change that. It suppresses a trailing space
-  only where the candidate names a directory that exists on disk, which a cell
-  path does not, and it adds filename escaping to every candidate: `#profile`
-  reaches the line as `\#profile`.
+Three measurements against bash 3.2 through a pty decided the shape, and the
+first two are why it is not the shape this item first proposed:
 
-What does suppress the space is the match not being unique: two candidates
-sharing the prefix `items/` insert that prefix and stop. So the lever is a
-phantom candidate in the menu, which costs a caller more than the keystroke it
-saves. `complete -o nospace` at registration is the other lever, and it takes
-the space away from every slot rather than the path-shaped ones.
+- A candidate carrying its own trailing **separator** does not help. `items/`
+  inserts `items/ `, so the space falls after the separator rather than inside
+  the path and the caller still deletes it. `complete -o filenames` does not
+  change that — it suppresses the space only where the candidate names a
+  directory that exists on disk — and it adds filename escaping to every
+  candidate, so `#profile` reaches the line as `\#profile`.
+- Re-registering the compspec from inside the completion function, the usual
+  stand-in for `compopt`, takes effect one completion LATE. The first Tab gets
+  a space and the second does not, which puts the option on the wrong slot.
+- A candidate carrying its own trailing **space** under `-o nospace` inserts
+  verbatim, colons and all, and an ambiguous set still inserts only the common
+  prefix.
 
-The item stays open with its remedy closed. What would settle it is a bash the
-directive works on, which is what `compopt` already reaches.
+`$1` is the command word the compspec fired for, and it decides who gets the
+space: the `deno` binding is registered without `-o nospace` and adds nothing,
+because a line handed back to another completion has to keep that completion's
+spacing. `compopt` is still called where it exists, since it is the only thing
+that reaches that binding.
 
 ## Operator surface and CLI vocabulary
 

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -88,18 +88,17 @@ read before picking one up; this table is the roll-up.
 | 9 | A verb's annotation is its kind, not its prose | comprehension | done |
 | 10 | Wrapper and deprecated verbs are offered unmarked | comprehension | done |
 | 11 | Every Tab costs two process starts | felt cost | needs a decision |
-| 12 | `nospace` is inert on the stock macOS bash | felt cost | not started |
-| 13 | Space and entity positionals across `inspect` | operator surface | not started |
-| 14 | `wish` targets and scopes | CLI vocabulary | not started |
-| 15 | Remaining path-shaped and enumerable values | CLI vocabulary | not started |
-| 16 | Two provider entries that can never fire | hygiene | not started |
+| 12 | `nospace` is inert on the stock macOS bash | felt cost | remedy disproven |
+| 13 | Space and entity positionals across `inspect` | operator surface | done |
+| 14 | `wish` targets and scopes | CLI vocabulary | done |
+| 15 | Remaining path-shaped and enumerable values | CLI vocabulary | done |
+| 16 | Two provider entries that can never fire | hygiene | done |
 | 17 | The README table omits the top-level spellings | hygiene | done |
 | 18 | A live-provider test seam | mechanism | done |
 | 19 | A gate that fails when a new slot has no decision | mechanism | not started |
 
-**What can be picked up today.** Items 12, 13, 14, 15 and 16 are mechanical and
-can be taken at any time. Item 19 is the other half of the mechanism item 18
-landed.
+**What can be picked up today.** Item 19 is what remains: the other half of the
+mechanism item 18 landed.
 
 Item 4's candidates are built and its wiring waits: step 10 decides whether a
 verb's fields are written before the `--` marker or after it, and the position
@@ -469,61 +468,96 @@ where state lives rather than about how fast a process starts.
 Worth sizing before it is scheduled: it may be that the correctness and
 vocabulary items above change the experience more than a faster Tab would.
 
-### 12. `nospace` is inert on the stock macOS bash
+### 12. `nospace` is inert on the stock macOS bash, and the remedy does not work
 
-Cell paths and link endpoints complete one segment at a time and emit a
-`nospace` directive so the cursor stays attached for the next `/`. The bash
-function applies it through `compopt`, which is bash 4 and later; macOS ships
-bash 3.2. The script comments note the cost as a keystroke. It is a keystroke
-*per segment*, on the default shell of the platform most of this repository is
-developed on, and it lands on the deepest and most useful completion there is.
+Cell paths, link endpoints and projection paths complete one segment at a time
+and emit a `nospace` directive so the cursor stays attached for the next
+separator. The bash function applies it through `compopt`, which is bash 4 and
+later; macOS ships bash 3.2. It is a keystroke *per segment*, on the default
+shell of the platform most of this repository is developed on, and it lands on
+the deepest and most useful completion there is.
 
-A candidate that carries its own trailing separator is one way around it, since
-the shell's added space then falls after a `/` rather than inside a path.
+The remedy this item proposed — a candidate carrying its own trailing separator
+— was measured against bash 3.2 through a pty and does not work. Three
+behaviours, all of them of one unique match:
+
+- A reply of `items` inserts `items ` — the space this item is about.
+- A reply of `items/` inserts `items/ `. The space falls after the separator
+  rather than inside the path, and the caller still has to delete it before
+  typing the next segment.
+- `complete -o filenames` does not change that. It suppresses a trailing space
+  only where the candidate names a directory that exists on disk, which a cell
+  path does not, and it adds filename escaping to every candidate: `#profile`
+  reaches the line as `\#profile`.
+
+What does suppress the space is the match not being unique: two candidates
+sharing the prefix `items/` insert that prefix and stop. So the lever is a
+phantom candidate in the menu, which costs a caller more than the keystroke it
+saves. `complete -o nospace` at registration is the other lever, and it takes
+the space away from every slot rather than the path-shaped ones.
+
+The item stays open with its remedy closed. What would settle it is a bash the
+directive works on, which is what `compopt` already reaches.
 
 ## Operator surface and CLI vocabulary
 
 ### 13. Space and entity positionals across `inspect`
 
-Every `cf inspect` subcommand that reads a space takes it positionally, and none
-of the eighteen have a provider — while `space clone` and `space fingerprint`,
-which take the same thing the same way, do. `inspect` reads local stores
-directly, so the provider it wants is the one `space clone` already uses, and
-item 8's disposition applies unchanged.
+Every `cf inspect` subcommand that reads a space completes it from the same
+local stores `space clone` and `space fingerprint` read, and item 8's
+disposition applies unchanged. The `<entity>` positional beside them completes
+from `listEntityModels` — the listing `inspect entities` prints — annotated
+with the label it reconstructs, so an opaque id reads.
 
-The `<entity>` positional beside them is a piece id within the named space, and
-`inspect entities` is what enumerates them.
+The two sets are generated from a list of subcommand names rather than written
+out as thirty-odd table entries, because which subcommands open a space is one
+fact and repeating it is somewhere for the next one to be forgotten. Item 19's
+gate is what names a subcommand the list has missed.
+
+The entity provider reads local stores only. `--remote` fetches a snapshot over
+the network before it can list anything, which is a round trip a keystroke
+should not start.
 
 ### 14. `wish` targets and scopes
 
-`cf wish <target>` takes a documented vocabulary — the profile targets and the
-space-relative ones its help enumerates — and completes nothing. `--scope`
-accepts exactly `~`, `.`, `profile`, or a space DID, which is an enumerated set
-plus the space provider.
+`cf wish <target>` completes the vocabulary its help enumerates — the profile
+targets and the space-relative ones — and `--scope` completes `~`, `.`,
+`profile` and the space provider's DIDs.
 
-Both sets are in the command's own help, which is what puts this below the
-pattern-owned slots rather than beside them.
+The target list is hand-maintained, because the vocabulary is the wish
+builtin's rather than the command tree's and nothing on the tree carries it.
+The command's help text is where it is documented and where it is kept in step.
+
+`--scope` means something else on `cf inspect`, where it is a scope key. An
+option provider is keyed by long name alone, so this one says which commands it
+applies to — the same scoping `--from` needs, being a file on `space clone` and
+a sequence number on `inspect diff`.
 
 ### 15. Remaining path-shaped and enumerable values
 
-The mechanical remainder, each one an entry in an existing table:
+The mechanical remainder, each one an entry in an existing table: pattern files
+for `piece set-home <main>`; files and directories for `piece getsrc <outpath>`,
+`deps update <file>`, `fuse mount|unmount <mountpoint>`, `--dir`, `--out`,
+`--output` and `space clone --from`; `--api-url`'s candidates for `--remote`;
+and `piece map --format` and `inspect entities --kind` beside the four already
+in `ENUMERATED_OPTION_VALUES`.
 
-- Pattern files: `piece set-home <main>`.
-- Files and directories: `piece getsrc <outpath>`, `deps update <file>`,
-  `fuse mount|unmount <mountpoint>`, `--dir`, `--out`, `--output`, `--from`.
-- API URLs: `--remote`, which takes what `--api-url` takes.
-- Enumerated values, which belong beside the four already in
-  `ENUMERATED_OPTION_VALUES`: `piece map --format` (`ascii`, `dot`),
-  `inspect entities --kind` (seven values its help lists).
+`--remote` is reachable only as `--remote=<value>`. Its value is optional
+(`[url:string]`), so a bare `--remote` is legal and the word after it is a
+positional rather than the flag's value — which is what the resolver reads it
+as, and what the command reads it as too.
+
+`piece set-slug <source>` is not in that enumeration and is completed with it:
+it takes what `--piece` takes, which is the same table entry.
 
 ## Hygiene
 
 ### 16. Two provider entries that can never fire
 
-`OPTION_VALUE_PROVIDERS` carries `log-file` and `state-path`. Both belong to
-`fuse-supervisor` and `fuse-daemon`, which take raw arguments and declare no
-Cliffy options, and which completion drops from its subcommand candidates as
-internal. Neither entry is reachable.
+`log-file` and `state-path` are gone from `OPTION_VALUE_PROVIDERS`. Both
+belonged to `fuse-supervisor` and `fuse-daemon`, which take raw arguments and
+declare no Cliffy options, and which completion drops from its subcommand
+candidates as internal. Item 19's gate is the same subtraction made permanent.
 
 ### 17. The README table omits the top-level spellings
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1032,6 +1032,15 @@ directory on `cf space clone` and a sequence number on `cf inspect diff`;
 the slot offers nothing, which is the honest answer for a word no set can name —
 offering the wrong set is worse than offering none.
 
+A positional divides the same way. Every `cf inspect` subcommand that opens a
+local space completes it from local stores, but `inspect pull` names a space on
+the remote and resolves it through the remote's own listing, so it offers
+nothing rather than a local DID the command would reject — listing the remote is
+a network round trip a keystroke must not start. The entity beside a space comes
+from the view that subcommand will read: its `--branch` and `--scope`, except on
+`inspect overlay`, which takes no `--scope` and reports every scope, so its
+candidates span every scope too.
+
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the
 bare id, the canonical reference (space-qualified or not, with an `@scope`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -983,21 +983,21 @@ source <(cf completion bash)
 Completion covers the command tree — subcommands, flags, and enumerated values
 such as `--log-level` — plus live values read from the fabric:
 
-| Slot                                    | Completes to                                                  |
-| --------------------------------------- | ------------------------------------------------------------- |
-| `--piece`                               | the space's slugs, then its piece ids                         |
-| `cf call <callable>`                    | the piece's callables, annotated with the doc comment on each |
-| `cf get`/`cf set <path>`                | cell keys, one path segment at a time                         |
-| `cf get --select`/`--schema`            | field paths into the value, and their `@` form                |
-| `piece set-slug <slug>`                 | the space's slugs                                             |
-| `piece link <source>/<target>`          | `pieceId/path/to/field` endpoints                             |
-| `--space`, a positional space           | space DIDs of local memory-v2 stores                          |
-| `inspect <entity>`                      | that space's entities, as `cf inspect entities` lists them    |
-| `cf wish <target>`, `--scope`           | the vocabulary `cf wish --help` enumerates                    |
-| `--identity`, pattern arguments         | `*.key` / `*.tsx` files, via the shell                        |
-| `--datafile`, `--out`, `--output`       | any file, via the shell                                       |
-| `--dir`, `--to`, `--root`, a mountpoint | a directory, via the shell                                    |
-| `--remote`                              | what `--api-url` takes, in the `--remote=<url>` spelling      |
+| Slot                                                         | Completes to                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------- |
+| `--piece`                                                    | the space's slugs, then its piece ids                         |
+| `cf call <callable>`                                         | the piece's callables, annotated with the doc comment on each |
+| `cf get`/`cf set <path>`                                     | cell keys, one path segment at a time                         |
+| `cf get --select`/`--schema`                                 | field paths into the value, and their `@` form                |
+| `piece set-slug <slug>`                                      | the space's slugs                                             |
+| `piece link <source>/<target>`                               | `pieceId/path/to/field` endpoints                             |
+| `--space`, a positional space                                | space DIDs of local memory-v2 stores                          |
+| `inspect <entity>`, `inspect graph --root`                   | that space's entities, as `cf inspect entities` lists them    |
+| `cf wish <target>`, `cf wish --scope`                        | the vocabulary `cf wish --help` enumerates                    |
+| `--identity`, pattern arguments                              | `*.key` / `*.tsx` files, via the shell                        |
+| `--datafile`, `--out`, `--output`, `space clone --from`      | any file, via the shell                                       |
+| `--dir`, a source `--root`, `space clone --to`, a mountpoint | a directory, via the shell                                    |
+| `--remote`                                                   | what `--api-url` takes, in the `--remote=<url>` spelling      |
 
 A callable is annotated with what its author said it is for, falling back to its
 kind where they wrote nothing. A wrapper or deprecated verb — the two
@@ -1023,6 +1023,14 @@ back as a field list, so the two sets cannot drift. `cf call`'s and `cf exec`'s
 projections shape a verb's result rather than the piece's root, and are not
 completed from it; `cf wish`'s resolution writes to the space, and a Tab must
 not.
+
+An option name can mean two things on two commands, so the ones that do are
+completed per command rather than by name. `--root` is a source directory on the
+commands that compile one and an entity on `cf inspect graph`; `--to` is a clone
+directory on `cf space clone` and a sequence number on `cf inspect diff`;
+`--from` and `--scope` divide the same way. Where the value is a sequence number
+the slot offers nothing, which is the honest answer for a word no set can name —
+offering the wrong set is worse than offering none.
 
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -983,17 +983,21 @@ source <(cf completion bash)
 Completion covers the command tree — subcommands, flags, and enumerated values
 such as `--log-level` — plus live values read from the fabric:
 
-| Slot                            | Completes to                                                  |
-| ------------------------------- | ------------------------------------------------------------- |
-| `--piece`                       | the space's slugs, then its piece ids                         |
-| `cf call <callable>`            | the piece's callables, annotated with the doc comment on each |
-| `cf get`/`cf set <path>`        | cell keys, one path segment at a time                         |
-| `cf get --select`/`--schema`    | field paths into the value, and their `@` form                |
-| `piece set-slug <slug>`         | the space's slugs                                             |
-| `piece link <source>/<target>`  | `pieceId/path/to/field` endpoints                             |
-| `--space`                       | space DIDs of local memory-v2 stores                          |
-| `--identity`, pattern arguments | `*.key` / `*.tsx` files, via the shell                        |
-| `--datafile`                    | any file, via the shell                                       |
+| Slot                                    | Completes to                                                  |
+| --------------------------------------- | ------------------------------------------------------------- |
+| `--piece`                               | the space's slugs, then its piece ids                         |
+| `call <callable>`                       | the piece's callables, annotated with the doc comment on each |
+| `get`/`set <path>`                      | cell keys, one path segment at a time                         |
+| `get --select`/`--schema`               | field paths into the value, and their `@` form                |
+| `piece set-slug <slug>`                 | the space's slugs                                             |
+| `piece link <source>/<target>`          | `pieceId/path/to/field` endpoints                             |
+| `--space`, a positional space           | space DIDs of local memory-v2 stores                          |
+| `inspect <entity>`                      | that space's entities, as `cf inspect entities` lists them    |
+| `wish <target>`, `wish --scope`         | the vocabulary `cf wish --help` enumerates                    |
+| `--identity`, pattern arguments         | `*.key` / `*.tsx` files, via the shell                        |
+| `--datafile`, `--out`, `--output`       | any file, via the shell                                       |
+| `--dir`, `--to`, `--root`, a mountpoint | a directory, via the shell                                    |
+| `--remote`                              | what `--api-url` takes, in the `--remote=<url>` spelling      |
 
 A callable is annotated with what its author said it is for, falling back to its
 kind where they wrote nothing. A wrapper or deprecated verb — the two

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1041,6 +1041,13 @@ from the view that subcommand will read: its `--branch` and `--scope`, except on
 `inspect overlay`, which takes no `--scope` and reports every scope, so its
 candidates span every scope too.
 
+`--remote` says the same thing about every `inspect` slot at once. It is a
+global option there and it decides where the space comes from: the token is
+resolved through the remote's own listing and the snapshot it names is fetched,
+so a local DID, a local entity and a local `graph --root` are each a candidate
+that read rejects. Every one of those slots answers nothing while it is on the
+line, in either of its spellings — `--remote=<url>` or bare.
+
 An option's value completes the same whether it is written after a space or
 after `=`, and every spelling of a target reaches the same slots behind it: the
 bare id, the canonical reference (space-qualified or not, with an `@scope`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1059,6 +1059,22 @@ that should end the word carrying its own space: `compopt` is the per-completion
 switch and it is bash 4 and later, while macOS ships bash 3.2, so the space is
 inverted rather than suppressed. zsh does it natively.
 
+The inversion is registered on the `cf` binding alone. A `deno` line can be
+handed back to whatever completed `deno` beforehand, and that completion's own
+spacing has to survive the handoff, so the `deno` binding keeps bash's default
+and `deno task cf` pays a keystroke per path segment where `cf` does not. On
+bash 4 and later `compopt` reaches that binding too and the cost disappears;
+under bash 3.2 there is no per-completion switch to reach it with, and taking
+the space away from every `deno test` and `deno run` completion is the larger
+loss.
+
+A candidate that opens with `#` — every `cf wish` target but the root — is
+inserted backslash-escaped in bash, as `\#profile`. Written bare it would be a
+comment, and the target would never reach the command; the escape is one word to
+the shell and the bare target to the CLI, and completing it again reads back the
+same target. zsh quotes what it inserts, so it arrives escaped there without the
+script doing anything.
+
 ### `deno task cf` and other invocations
 
 The scripts bind `deno` as well as `cf`, so `deno task cf piece <TAB>` completes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -986,14 +986,14 @@ such as `--log-level` — plus live values read from the fabric:
 | Slot                                    | Completes to                                                  |
 | --------------------------------------- | ------------------------------------------------------------- |
 | `--piece`                               | the space's slugs, then its piece ids                         |
-| `call <callable>`                       | the piece's callables, annotated with the doc comment on each |
-| `get`/`set <path>`                      | cell keys, one path segment at a time                         |
-| `get --select`/`--schema`               | field paths into the value, and their `@` form                |
+| `cf call <callable>`                    | the piece's callables, annotated with the doc comment on each |
+| `cf get`/`cf set <path>`                | cell keys, one path segment at a time                         |
+| `cf get --select`/`--schema`            | field paths into the value, and their `@` form                |
 | `piece set-slug <slug>`                 | the space's slugs                                             |
 | `piece link <source>/<target>`          | `pieceId/path/to/field` endpoints                             |
 | `--space`, a positional space           | space DIDs of local memory-v2 stores                          |
 | `inspect <entity>`                      | that space's entities, as `cf inspect entities` lists them    |
-| `wish <target>`, `wish --scope`         | the vocabulary `cf wish --help` enumerates                    |
+| `cf wish <target>`, `--scope`           | the vocabulary `cf wish --help` enumerates                    |
 | `--identity`, pattern arguments         | `*.key` / `*.tsx` files, via the shell                        |
 | `--datafile`, `--out`, `--output`       | any file, via the shell                                       |
 | `--dir`, `--to`, `--root`, a mountpoint | a directory, via the shell                                    |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1044,6 +1044,13 @@ yields nothing — it never prints an error into the command line. Each request
 costs one CLI invocation plus one round trip, so value completion is as fast as
 the fabric it queries.
 
+A path-shaped slot — a cell path, a link endpoint, a projection path — completes
+one segment at a time and holds the cursor for the next separator. bash gets
+that by having the binding registered `complete -o nospace`, with a candidate
+that should end the word carrying its own space: `compopt` is the per-completion
+switch and it is bash 4 and later, while macOS ships bash 3.2, so the space is
+inverted rather than suppressed. zsh does it natively.
+
 ### `deno task cf` and other invocations
 
 The scripts bind `deno` as well as `cf`, so `deno task cf piece <TAB>` completes

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -511,6 +511,46 @@ check "1" "$(complete_at "cf piece link $LINE_ARGS $BOARD/revision $ITEM_ID/rec"
 check "1" "$(succeeds $CF piece link --quiet $LINE_ARGS \
   "$BOARD/revision" "$ITEM_ID/recorded")" \
   "a pair of completed endpoints is a link the command writes"
+step "15. The operator surface completes from the same store"
+# `cf inspect` reads space DBs directly, so it wants the store step 13 looked
+# for. Where none is discoverable there is nothing here to exercise, which is
+# item 8's positional discovery rather than a defect — so the step says which
+# case it saw rather than passing either way.
+if [ -n "$DISCOVERED" ]; then
+  LOCAL_DID="$DISCOVERED"
+  check "1" "$(complete_at "cf inspect entities ${LOCAL_DID:0:20}" |
+    grep -c "^$LOCAL_DID\$")" "the space positional completes from it"
+  ENTITY=$($CF inspect entities "$LOCAL_DID" --json 2>/dev/null |
+    jq -r '.[0].id // empty')
+  if [ -n "$ENTITY" ]; then
+    check "1" "$(complete_at "cf inspect piece $LOCAL_DID ${ENTITY:0:12}" |
+      grep -c "^$ENTITY\$")" \
+      "and the entity positional completes what inspect entities lists"
+  else
+    ok "the discovered space holds no entities to complete"
+  fi
+else
+  ok "no local space db here, so the operator surface has nothing to offer"
+fi
+
+step "16. wish and the enumerated remainder"
+# These are the CLI's own vocabulary rather than a pattern's, which is what
+# puts them below the slots above. Each set is in the command's own help.
+check "1" "$(complete_at "cf wish #profileN" | grep -cx '#profileName')" \
+  "a wish target completes"
+check "profile" "$(complete_at "cf wish '#profile' --scope p" | paste -sd, -)" \
+  "and a wish scope completes its named values"
+check "ascii,dot" "$(candidates_at "cf piece map --format ")" \
+  "an enumerated option completes exactly what its help lists"
+check "1" "$(complete_at "cf inspect entities x --kind ow" |
+  grep -cx 'owned-cell')" "and so does the other one"
+# An option name means one thing per command, and the provider says where it
+# applies: a file on one, a sequence number on the other.
+check ":cf:files" "$(directives_at "cf space clone x --from ")" \
+  "--from offers a snapshot file where it names one"
+check "" "$(directives_at "cf inspect diff x y --from ")$(complete_at \
+  "cf inspect diff x y --from ")" \
+  "and nothing where it names a sequence number"
 
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -548,6 +548,11 @@ else
   probe "cf inspect piece did:key:zNoSuchSpace "
   check "0" "$PROBE_STATUS" "the entity positional runs against no store either"
 fi
+# `inspect pull` names a space on the REMOTE, resolved through the remote's own
+# listing, so a locally discovered DID is a candidate it rejects. Asserted in
+# both branches above's terms: whatever the store holds, this slot is empty.
+check "" "$(directives_at "cf inspect pull ")$(complete_at "cf inspect pull ")" \
+  "the remote-only space positional offers nothing local"
 
 step "16. wish and the enumerated remainder"
 # These are the CLI's own vocabulary rather than a pattern's, which is what

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -525,6 +525,13 @@ step "15. The operator surface completes from the same store"
 if [ -n "$DISCOVERED" ]; then
   check "1" "$(complete_at "cf inspect entities ${DISCOVERED:0:20}" |
     grep -c "^$DISCOVERED\$")" "the space positional completes from it"
+  # The same prefix under --remote: the command would resolve it through the
+  # remote's listing and open the snapshot it fetches, so the local DID it
+  # completes to above is one that read rejects. The pair is what shows the
+  # silence is a decision rather than an empty disk.
+  check "" "$(complete_at \
+    "cf inspect entities --remote=http://remote.invalid ${DISCOVERED:0:20}")" \
+    "and offers nothing once --remote moves the space off this disk"
   run $CF inspect entities "$DISCOVERED" --json
   check "0" "$RUN_STATUS" "cf inspect entities runs against it"
   ENTITY=$(printf '%s\n' "$RUN_OUT" | jq -r '.[0].id // empty' 2>/dev/null)
@@ -553,6 +560,14 @@ fi
 # both branches above's terms: whatever the store holds, this slot is empty.
 check "" "$(directives_at "cf inspect pull ")$(complete_at "cf inspect pull ")" \
   "the remote-only space positional offers nothing local"
+# `--remote` is global on `inspect` and says the same thing about every one of
+# its slots. Asserted with no store too, so the branch above cannot be the only
+# place this is checked.
+check "" "$(complete_at "cf inspect summary --remote=http://remote.invalid ")" \
+  "a --remote space positional offers nothing local"
+check "" "$(complete_at \
+  "cf inspect piece --remote=http://remote.invalid did:key:zNoSuchSpace ")" \
+  "and neither does the entity beside it"
 
 step "16. wish and the enumerated remainder"
 # These are the CLI's own vocabulary rather than a pattern's, which is what

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -10,13 +10,18 @@
 #
 # What is NOT exercised entry by entry is the rest of the provider table: a
 # dozen slots that hand the shell a constant `files` or `dirs` directive and
-# nothing else — --root, --datafile, --to, `view <file>`, `exec <mountedFile>`,
+# nothing else — --datafile, `view <file>`, `exec <mountedFile>`,
 # `id did <keypath>`, the space-management directories, and the two entries
 # item 16 of the plan records as belonging to commands that declare no options
 # at all. They read no state, so a fabric cannot change what they answer, and
 # they are asserted one by one — kind and glob — in
 # packages/cli/test/completion-providers.test.ts, which is where a constant
 # belongs. Nothing here re-checks them.
+#
+# The exception is an option name that means two things on two commands —
+# --from, --to, --root, --scope. There the answer turns on which command was
+# typed rather than on the name, so both sides of each are asserted below,
+# through the real command line rather than through a resolved slot.
 #
 # The unit tests under packages/cli/test/completion-*.test.ts cover the pure
 # half — line resolution, candidate shaping, and the degrade-to-empty path —
@@ -562,6 +567,15 @@ check ":cf:files" "$(directives_at "cf space clone x --from ")" \
 check "" "$(directives_at "cf inspect diff x y --from ")$(complete_at \
   "cf inspect diff x y --from ")" \
   "and nothing where it names a sequence number"
+check ":cf:dirs" "$(directives_at "cf space clone x --to ")" \
+  "--to offers a clone directory where it names one"
+check "" "$(directives_at "cf inspect diff x y --to ")$(complete_at \
+  "cf inspect diff x y --to ")" \
+  "and nothing where it names a sequence number"
+check ":cf:dirs" "$(directives_at "cf piece new --root ")" \
+  "--root offers a source directory where it names one"
+check "" "$(directives_at "cf inspect graph --root ")" \
+  "and hands the shell no directory where it names an entity"
 
 ELAPSED=$(($(date +%s) - START))
 printf '\n== %d passed, %d failed, %d gaps open — %ds wall clock\n' \

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -538,6 +538,10 @@ else
   check "0" "$PROBE_STATUS" "the space positional still runs with no store"
   check "" "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" \
     "and offers nothing, which is all there is on disk to offer"
+  # The entity positional too, so this branch asserts as much as the one above
+  # and a machine with no store cannot pass by checking less.
+  probe "cf inspect piece did:key:zNoSuchSpace "
+  check "0" "$PROBE_STATUS" "the entity positional runs against no store either"
 fi
 
 step "16. wish and the enumerated remainder"

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -513,24 +513,31 @@ check "1" "$(succeeds $CF piece link --quiet $LINE_ARGS \
   "a pair of completed endpoints is a link the command writes"
 step "15. The operator surface completes from the same store"
 # `cf inspect` reads space DBs directly, so it wants the store step 13 looked
-# for. Where none is discoverable there is nothing here to exercise, which is
-# item 8's positional discovery rather than a defect — so the step says which
-# case it saw rather than passing either way.
+# for. Both positionals are probed either way, on the same terms that step
+# holds to: what the listing exits with decides whether its output can be read
+# at all, and where there is nothing to list the slot must still run and come
+# back empty.
 if [ -n "$DISCOVERED" ]; then
-  LOCAL_DID="$DISCOVERED"
-  check "1" "$(complete_at "cf inspect entities ${LOCAL_DID:0:20}" |
-    grep -c "^$LOCAL_DID\$")" "the space positional completes from it"
-  ENTITY=$($CF inspect entities "$LOCAL_DID" --json 2>/dev/null |
-    jq -r '.[0].id // empty')
+  check "1" "$(complete_at "cf inspect entities ${DISCOVERED:0:20}" |
+    grep -c "^$DISCOVERED\$")" "the space positional completes from it"
+  run $CF inspect entities "$DISCOVERED" --json
+  check "0" "$RUN_STATUS" "cf inspect entities runs against it"
+  ENTITY=$(printf '%s\n' "$RUN_OUT" | jq -r '.[0].id // empty' 2>/dev/null)
   if [ -n "$ENTITY" ]; then
-    check "1" "$(complete_at "cf inspect piece $LOCAL_DID ${ENTITY:0:12}" |
+    check "1" "$(complete_at "cf inspect piece $DISCOVERED ${ENTITY:0:12}" |
       grep -c "^$ENTITY\$")" \
       "and the entity positional completes what inspect entities lists"
   else
-    ok "the discovered space holds no entities to complete"
+    probe "cf inspect piece $DISCOVERED "
+    check "0" "$PROBE_STATUS" "the entity slot runs against a space holding none"
+    check "" "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" \
+      "and offers nothing, which is all that space holds"
   fi
 else
-  ok "no local space db here, so the operator surface has nothing to offer"
+  probe "cf inspect entities "
+  check "0" "$PROBE_STATUS" "the space positional still runs with no store"
+  check "" "$(printf '%s\n' "$PROBE_OUT" | grep -v '^:cf:')" \
+    "and offers nothing, which is all there is on disk to offer"
 fi
 
 step "16. wish and the enumerated remainder"

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -710,10 +710,8 @@ async function spaceCandidates(): Promise<ProviderResult> {
  * Entities in the space a positional already names, as `cf inspect entities`
  * lists them: the label reads, the id is what the next positional takes.
  *
- * The line's `--branch` and `--scope` are passed through, so the candidates
- * come from the view the command will read rather than the space's default
- * one — an entity present on one branch and not another is offered where the
- * command would find it.
+ * The listing covers the view the command will read rather than the space's
+ * default one, which is what `entityListingView` works out from the line.
  *
  * Local stores only. `--remote` fetches a snapshot over the network before it
  * can list anything, which is a round trip a keystroke should not start.
@@ -723,35 +721,57 @@ async function entityCandidates(
 ): Promise<ProviderResult> {
   const token = line.positionals[0];
   if (!token) return NOTHING;
-  const { listEntityModels, openSpace, resolveSpace } = await import(
-    "@commonfabric/state-inspector"
-  );
+  const { listEntityModels, listScopes, openSpace, resolveSpace } =
+    await import("@commonfabric/state-inspector");
   const space = openSpace(await resolveSpace(token));
   try {
+    const view = entityListingView(line);
+    const scopes = view.allScopes
+      ? listScopes(space, { branch: view.branch }).map((scope) => scope.raw)
+      : [view.scope];
     // No limit of its own: the set is what `cf inspect entities` would list
     // with no `--limit`, so a completed id is one that command names too. The
     // listing reports its own extent, and a capped one is still every
     // candidate this slot can honestly offer.
-    const listing = listEntityModels(space, entityListingView(line));
-    return values(shapeEntityCandidates(listing.entities));
+    //
+    // `listScopes` sorts the space scope first, so an entity written in more
+    // than one scope keeps the label its space-scope value reconstructs to.
+    const seen = new Set<string>();
+    const entities: EntityListingLike[] = [];
+    for (const scope of scopes) {
+      for (
+        const entity of listEntityModels(space, { branch: view.branch, scope })
+          .entities
+      ) {
+        if (seen.has(entity.id)) continue;
+        seen.add(entity.id);
+        entities.push(entity);
+      }
+    }
+    return values(shapeEntityCandidates(entities));
   } finally {
     space.close();
   }
 }
 
 /**
- * The view of a space an inspect line names: its `--branch` and `--scope`.
+ * The view of a space an inspect line's entity slot has to cover: the branch,
+ * and either the one scope the command reads or every scope it reads across.
  *
- * Absent from the line, each is left undefined so the listing applies the same
- * default the command would. Separated from the read so a test can assert the
- * view without a space DB.
+ * A command that declares `--scope` reads one, the line's or the listing's own
+ * default. `cf inspect overlay` declares none and reports an entity's value in
+ * EVERY scope, so a slot completed from the default scope alone would hide the
+ * per-user and per-session entities that command exists to show.
+ *
+ * Separated from the read so a test can assert the view without a space DB.
  */
 export function entityListingView(
   line: CompletionLine,
-): { branch?: string; scope?: string } {
+): { branch?: string; scope?: string; allScopes: boolean } {
   return {
     branch: line.options.get("branch"),
     scope: line.options.get("scope"),
+    allScopes: line.path.join(" ") === "inspect overlay",
   };
 }
 
@@ -918,7 +938,7 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   scope: onlyOn(["wish"], () => wishScopeCandidates()),
 };
 
-/** `cf inspect` subcommands whose first positional is a space. */
+/** `cf inspect` subcommands whose first positional opens a local space. */
 const INSPECT_SPACE_COMMANDS: readonly string[] = [
   "churn",
   "commits",
@@ -931,7 +951,6 @@ const INSPECT_SPACE_COMMANDS: readonly string[] = [
   "html",
   "overlay",
   "piece",
-  "pull",
   "scopes",
   "summary",
   "timeline",
@@ -997,6 +1016,12 @@ const ARGUMENT_PROVIDERS: Readonly<
   "fuse mount:mountpoint": () => Promise.resolve(directive({ kind: "dirs" })),
   "fuse unmount:mountpoint": () => Promise.resolve(directive({ kind: "dirs" })),
   "wish:target": () => Promise.resolve(wishTargetCandidates()),
+  // `inspect pull` names a space on the REMOTE, resolved through
+  // `resolveRemoteDid` against the remote's own listing, so a locally
+  // discovered DID is a candidate the command rejects. Listing the remote is a
+  // network round trip a keystroke must not start, which leaves this slot
+  // nothing honest to offer — decided, and decided as empty.
+  "inspect pull:space": () => Promise.resolve(NOTHING),
   // `cf space` and `cf inspect` name a space positionally rather than through
   // `--space`. Both read the same local stores, so both take the same
   // candidates.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -710,6 +710,11 @@ async function spaceCandidates(): Promise<ProviderResult> {
  * Entities in the space a positional already names, as `cf inspect entities`
  * lists them: the label reads, the id is what the next positional takes.
  *
+ * The line's `--branch` and `--scope` are passed through, so the candidates
+ * come from the view the command will read rather than the space's default
+ * one — an entity present on one branch and not another is offered where the
+ * command would find it.
+ *
  * Local stores only. `--remote` fetches a snapshot over the network before it
  * can list anything, which is a round trip a keystroke should not start.
  */
@@ -727,10 +732,27 @@ async function entityCandidates(
     // with no `--limit`, so a completed id is one that command names too. The
     // listing reports its own extent, and a capped one is still every
     // candidate this slot can honestly offer.
-    return values(shapeEntityCandidates(listEntityModels(space).entities));
+    const listing = listEntityModels(space, entityListingView(line));
+    return values(shapeEntityCandidates(listing.entities));
   } finally {
     space.close();
   }
+}
+
+/**
+ * The view of a space an inspect line names: its `--branch` and `--scope`.
+ *
+ * Absent from the line, each is left undefined so the listing applies the same
+ * default the command would. Separated from the read so a test can assert the
+ * view without a space DB.
+ */
+export function entityListingView(
+  line: CompletionLine,
+): { branch?: string; scope?: string } {
+  return {
+    branch: line.options.get("branch"),
+    scope: line.options.get("scope"),
+  };
 }
 
 /** Entity shape used by `shapeEntityCandidates`, structural so tests need no DB. */
@@ -809,6 +831,34 @@ function onlyOn(
     paths.has(line.path.join(" ")) ? provider(line) : Promise.resolve(NOTHING);
 }
 
+/** The commands whose `--root` is the directory their sources resolve against. */
+const ROOT_DIRECTORY_COMMANDS: readonly string[] = [
+  "check",
+  "piece new",
+  "piece set-home",
+  "piece setsrc",
+  "piece survey",
+  "test",
+];
+
+/**
+ * `--root` by what it names: a source directory on the commands that resolve
+ * imports and authored paths against one, and on `cf inspect graph` the entity
+ * whose neighborhood the graph is drawn around.
+ *
+ * The graph's root is a node id, so it takes what the entity positionals take,
+ * read from the space the command already names.
+ */
+function rootCandidates(line: CompletionLine): Promise<ProviderResult> {
+  const command = line.path.join(" ");
+  if (command === "inspect graph") return entityCandidates(line);
+  return Promise.resolve(
+    ROOT_DIRECTORY_COMMANDS.includes(command)
+      ? directive({ kind: "dirs" })
+      : NOTHING,
+  );
+}
+
 /** API URLs worth offering: the environment's, plus the local dev server. */
 function apiUrlCandidates(): ProviderResult {
   const candidates: Candidate[] = [];
@@ -841,13 +891,19 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   // `--remote` takes what `--api-url` takes: the toolshed to read from.
   remote: () => Promise.resolve(apiUrlCandidates()),
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
-  root: () => Promise.resolve(directive({ kind: "dirs" })),
+  // A source directory on the commands that compile one, and an entity on
+  // `inspect graph`.
+  root: rootCandidates,
   test: patternFiles,
   // A data file has no fixed extension; the shell's own file completion is the
   // only honest candidate set.
   datafile: () => Promise.resolve(directive({ kind: "files" })),
-  // `cf space clone --to <dir>` builds a clone directory.
-  to: () => Promise.resolve(directive({ kind: "dirs" })),
+  // A clone directory on `space clone`, and a sequence number on `inspect
+  // diff`.
+  to: onlyOn(
+    ["space clone"],
+    () => Promise.resolve(directive({ kind: "dirs" })),
+  ),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -706,6 +706,107 @@ async function spaceCandidates(): Promise<ProviderResult> {
   return values(candidates);
 }
 
+/**
+ * Entities in the space a positional already names, as `cf inspect entities`
+ * lists them: the label reads, the id is what the next positional takes.
+ *
+ * Local stores only. `--remote` fetches a snapshot over the network before it
+ * can list anything, which is a round trip a keystroke should not start.
+ */
+async function entityCandidates(
+  line: CompletionLine,
+): Promise<ProviderResult> {
+  const token = line.positionals[0];
+  if (!token) return NOTHING;
+  const { listEntityModels, openSpace, resolveSpace } = await import(
+    "@commonfabric/state-inspector"
+  );
+  const space = openSpace(await resolveSpace(token));
+  try {
+    // No limit of its own: the set is what `cf inspect entities` would list
+    // with no `--limit`, so a completed id is one that command names too.
+    return values(shapeEntityCandidates(listEntityModels(space)));
+  } finally {
+    space.close();
+  }
+}
+
+/** Entity shape used by `shapeEntityCandidates`, structural so tests need no DB. */
+export interface EntityListingLike {
+  readonly id: string;
+  readonly label?: string;
+  readonly kind?: string;
+}
+
+/**
+ * Label entities the way `cf inspect entities` does: the reconstructed label
+ * reads, and the kind says what sort of thing it is where no label was found.
+ */
+export function shapeEntityCandidates(
+  entities: readonly EntityListingLike[],
+): Candidate[] {
+  return entities.map((entity) => ({
+    value: entity.id,
+    description: entity.label && entity.label !== "(piece)"
+      ? entity.label
+      : entity.kind,
+  }));
+}
+
+/**
+ * The wish targets `cf wish --help` enumerates: the profile ones, which
+ * resolve against the identity's home space, and the space-relative ones.
+ *
+ * A hand-maintained list, because the vocabulary is the wish builtin's rather
+ * than the command tree's and nothing on the tree carries it. The help text is
+ * where it is documented and where it is kept in step.
+ */
+export function wishTargetCandidates(): ProviderResult {
+  return values([
+    { value: "#profile", description: "the viewer's active profile object" },
+    { value: "#profileName", description: "its live display name" },
+    { value: "#profileAvatar", description: "its avatar" },
+    { value: "#profileBio", description: "its owner-authored bio" },
+    { value: "#profileSpace", description: "its own space cell" },
+    { value: "#favorites", description: "space-relative" },
+    { value: "#journal", description: "space-relative" },
+    { value: "#learned", description: "space-relative" },
+    { value: "#mentionable", description: "space-relative" },
+    { value: "#recent", description: "space-relative" },
+    { value: "#pieceRegistry", description: "space-relative" },
+    { value: "/", description: "the space's root" },
+  ]);
+}
+
+/** `cf wish --scope`: three names, plus any space DID. */
+async function wishScopeCandidates(): Promise<ProviderResult> {
+  const spaces = await spaceCandidates();
+  return values([
+    { value: "~", description: "favorites" },
+    { value: ".", description: "the current space" },
+    { value: "profile", description: "profile elements" },
+    ...spaces.candidates,
+  ]);
+}
+
+/**
+ * Restrict a provider to the commands whose option of that name means this.
+ *
+ * The option table is keyed by long name alone, and a name can mean two things
+ * on two commands: `--from` is a file on `space clone` and a sequence number on
+ * `inspect diff`, `--scope` is a wish search scope and an inspect scope key.
+ * Offering the wrong set is worse than offering none, so the provider says
+ * where it applies.
+ */
+function onlyOn(
+  commands: readonly string[],
+  provider: (line: CompletionLine) => Promise<ProviderResult>,
+): (line: CompletionLine) => Promise<ProviderResult> {
+  const paths = new Set(commands);
+  return (line) =>
+    paths.has(line.path.join(" ")) ? provider(line) : Promise.resolve(NOTHING);
+}
+
 /** API URLs worth offering: the environment's, plus the local dev server. */
 function apiUrlCandidates(): ProviderResult {
   const candidates: Candidate[] = [];
@@ -735,6 +836,8 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   schema: projectionFieldCandidates("schema"),
   space: () => spaceCandidates(),
   "api-url": () => Promise.resolve(apiUrlCandidates()),
+  // `--remote` takes what `--api-url` takes: the toolshed to read from.
+  remote: () => Promise.resolve(apiUrlCandidates()),
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
   root: () => Promise.resolve(directive({ kind: "dirs" })),
   test: patternFiles,
@@ -743,9 +846,52 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   datafile: () => Promise.resolve(directive({ kind: "files" })),
   // `cf space clone --to <dir>` builds a clone directory.
   to: () => Promise.resolve(directive({ kind: "dirs" })),
-  "log-file": () => Promise.resolve(directive({ kind: "files" })),
-  "state-path": () => Promise.resolve(directive({ kind: "files" })),
+  // `cf inspect --dir` is an extra directory to search for space DBs.
+  dir: () => Promise.resolve(directive({ kind: "dirs" })),
+  // `cf inspect html --out` and `cf check --output` write a file.
+  out: () => Promise.resolve(directive({ kind: "files" })),
+  output: () => Promise.resolve(directive({ kind: "files" })),
+  // A snapshot file on `space clone`, and a sequence number on `inspect diff`.
+  from: onlyOn(
+    ["space clone"],
+    () => Promise.resolve(directive({ kind: "files" })),
+  ),
+  // A hashtag search scope on `wish`, and a scope key on `inspect`.
+  scope: onlyOn(["wish"], () => wishScopeCandidates()),
 };
+
+/** `cf inspect` subcommands whose first positional is a space. */
+const INSPECT_SPACE_COMMANDS: readonly string[] = [
+  "churn",
+  "commits",
+  "conflicts",
+  "diff",
+  "entities",
+  "graph",
+  "history",
+  "hot",
+  "html",
+  "overlay",
+  "piece",
+  "pull",
+  "scopes",
+  "summary",
+  "timeline",
+  "users",
+  "value-at",
+];
+
+/** Those of them whose next positional is an entity within that space. */
+const INSPECT_ENTITY_COMMANDS: readonly string[] = [
+  "conflicts",
+  "converge",
+  "diff",
+  "history",
+  "overlay",
+  "piece",
+  "timeline",
+  "value-at",
+];
 
 /**
  * Positional providers, keyed by `<command path>:<argument name>`. The command
@@ -777,6 +923,8 @@ const ARGUMENT_PROVIDERS: Readonly<
   // Naming an existing slug re-points it, which is the case completion helps
   // with; a slug being coined for the first time is a word nothing can offer.
   "piece set-slug:slug": slugCandidates,
+  // The target a slug redirects to takes what `--piece` takes.
+  "piece set-slug:source": pieceCandidates,
   "piece new:main": patternFiles,
   "piece setsrc:main": patternFiles,
   "check:files": patternFiles,
@@ -785,13 +933,59 @@ const ARGUMENT_PROVIDERS: Readonly<
   "exec:mountedFile": () => Promise.resolve(directive({ kind: "files" })),
   "id did:keypath": () =>
     Promise.resolve(directive({ kind: "files", glob: "*.key" })),
-  // `cf space` names a space positionally rather than through `--space`.
+  "piece set-home:main": patternFiles,
+  "piece getsrc:outpath": () => Promise.resolve(directive({ kind: "files" })),
+  "deps update:file": () => Promise.resolve(directive({ kind: "files" })),
+  "fuse mount:mountpoint": () => Promise.resolve(directive({ kind: "dirs" })),
+  "fuse unmount:mountpoint": () => Promise.resolve(directive({ kind: "dirs" })),
+  "wish:target": () => Promise.resolve(wishTargetCandidates()),
+  // `cf space` and `cf inspect` name a space positionally rather than through
+  // `--space`. Both read the same local stores, so both take the same
+  // candidates.
   "space clone:space": () => spaceCandidates(),
   "space fingerprint:space": () => spaceCandidates(),
   // `verify`/`reset` take a clone directory built by `space clone`.
   "space verify:dir": () => Promise.resolve(directive({ kind: "dirs" })),
   "space reset:dir": () => Promise.resolve(directive({ kind: "dirs" })),
+  ...inspectSpaceProviders(),
+  ...inspectEntityProviders(),
 };
+
+/**
+ * Every `cf inspect` subcommand that names a space positionally.
+ *
+ * Generated from the list rather than written out, because the set is one
+ * fact — "the inspect subcommands that open a space" — and eighteen table
+ * entries repeating it is eighteen places for the nineteenth to be forgotten.
+ */
+function inspectSpaceProviders(): Record<
+  string,
+  (line: CompletionLine) => Promise<ProviderResult>
+> {
+  const entries: Record<
+    string,
+    (line: CompletionLine) => Promise<ProviderResult>
+  > = {};
+  for (const command of INSPECT_SPACE_COMMANDS) {
+    entries[`inspect ${command}:space`] = () => spaceCandidates();
+  }
+  return entries;
+}
+
+/** The same, for the `<entity>` that follows a space on some of them. */
+function inspectEntityProviders(): Record<
+  string,
+  (line: CompletionLine) => Promise<ProviderResult>
+> {
+  const entries: Record<
+    string,
+    (line: CompletionLine) => Promise<ProviderResult>
+  > = {};
+  for (const command of INSPECT_ENTITY_COMMANDS) {
+    entries[`inspect ${command}:entity`] = entityCandidates;
+  }
+  return entries;
+}
 
 /**
  * Run the provider for the line's slot.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -724,8 +724,10 @@ async function entityCandidates(
   const space = openSpace(await resolveSpace(token));
   try {
     // No limit of its own: the set is what `cf inspect entities` would list
-    // with no `--limit`, so a completed id is one that command names too.
-    return values(shapeEntityCandidates(listEntityModels(space)));
+    // with no `--limit`, so a completed id is one that command names too. The
+    // listing reports its own extent, and a capped one is still every
+    // candidate this slot can honestly offer.
+    return values(shapeEntityCandidates(listEntityModels(space).entities));
   } finally {
     space.close();
   }

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -714,11 +714,14 @@ async function spaceCandidates(): Promise<ProviderResult> {
  * default one, which is what `entityListingView` works out from the line.
  *
  * Local stores only. `--remote` fetches a snapshot over the network before it
- * can list anything, which is a round trip a keystroke should not start.
+ * can list anything, which is a round trip a keystroke should not start — so a
+ * line that names one is answered by `namesRemote` instead. Every caller is an
+ * `inspect` subcommand, which is what makes that check belong here.
  */
 async function entityCandidates(
   line: CompletionLine,
 ): Promise<ProviderResult> {
+  if (namesRemote(line)) return NOTHING;
   const token = line.positionals[0];
   if (!token) return NOTHING;
   const { listEntityModels, listScopes, openSpace, resolveSpace } =
@@ -831,6 +834,24 @@ async function wishScopeCandidates(): Promise<ProviderResult> {
     { value: "profile", description: "profile elements" },
     ...spaces.candidates,
   ]);
+}
+
+/**
+ * Whether the line puts `cf inspect` in remote mode.
+ *
+ * `--remote` is a global option on `inspect`, and it decides where the space
+ * comes from: `openByToken` resolves the token through the REMOTE's own
+ * listing and opens the snapshot it fetches, so a locally discovered DID and
+ * the entities of a local DB are candidates the command rejects. Its value is
+ * optional, so the flag reaches the line as an option when written
+ * `--remote=<url>` and as a bare flag otherwise, and both spellings count.
+ *
+ * Completion answers nothing there rather than listing the remote, which is a
+ * network round trip a keystroke must not start. The slot stays decided, and
+ * is decided as empty — the same disposition `inspect pull` carries.
+ */
+function namesRemote(line: CompletionLine): boolean {
+  return line.options.has("remote") || line.flags.has("remote");
 }
 
 /**
@@ -1050,7 +1071,8 @@ function inspectSpaceProviders(): Record<
     (line: CompletionLine) => Promise<ProviderResult>
   > = {};
   for (const command of INSPECT_SPACE_COMMANDS) {
-    entries[`inspect ${command}:space`] = () => spaceCandidates();
+    entries[`inspect ${command}:space`] = (line) =>
+      namesRemote(line) ? Promise.resolve(NOTHING) : spaceCandidates();
   }
   return entries;
 }

--- a/packages/cli/lib/completion/script.ts
+++ b/packages/cli/lib/completion/script.ts
@@ -32,6 +32,12 @@ function functionName(name: string): string {
  * `COMP_WORDBREAKS`, which includes `:` and `=`, so `--space=x` and
  * `http://host:8000` would arrive pre-shredded. The CLI tokenizes instead, and
  * the reply is re-trimmed to the fragment bash believes it is replacing.
+ *
+ * The trailing space is inverted rather than suppressed, because macOS ships
+ * bash 3.2 and `compopt` is bash 4+. Registering `-o nospace` and letting a
+ * candidate carry its own space is the one mechanism that works on both: the
+ * held cursor a cell path needs then costs nothing on the shell this
+ * repository is most often developed against.
  */
 export function bashCompletionScript(
   name: string,
@@ -142,14 +148,31 @@ ${fn}() {
     done
   fi
 
-  # \`compopt\` is bash 4+; on bash 3.2 the trailing space is simply not
-  # suppressed, which costs a keystroke but completes correctly.
+  # The trailing space is inverted rather than suppressed. \`compopt\` is the
+  # per-completion switch and it is bash 4+, so the ${name} binding is
+  # registered \`-o nospace\` and a candidate that should END the word carries
+  # its own space. bash inserts that space verbatim, which is what makes one
+  # mechanism serve bash 3.2 and bash 4 alike.
+  #
+  # \`\$1\` is the command word the compspec fired for, and it decides: a line
+  # handed back to another completion has to keep that completion's spacing,
+  # so the \`deno\` binding is registered WITHOUT \`-o nospace\` and adds
+  # nothing here.
+  if [[ "\${1##*/}" == "${name}" && \${nospace} -eq 0 ]]; then
+    local k
+    for k in "\${!COMPREPLY[@]}"; do
+      COMPREPLY[k]="\${COMPREPLY[k]} "
+    done
+  fi
+
+  # Still worth setting where it exists: it is what gives the \`deno\` binding
+  # the same held cursor, which the inversion above cannot reach.
   if [[ \${nospace} -eq 1 ]] && type compopt >/dev/null 2>&1; then
     compopt -o nospace
   fi
 }
 ${denoBinding}
-complete -F ${fn} ${name}
+complete -o nospace -F ${fn} ${name}
 `;
 }
 

--- a/packages/cli/lib/completion/script.ts
+++ b/packages/cli/lib/completion/script.ts
@@ -148,6 +148,19 @@ ${fn}() {
     done
   fi
 
+  # A word opening with \`#\` is a comment to an interactive bash, which drops
+  # it and everything after it before the command is called: \`wish #profile\`
+  # runs \`wish\` with no target. \`\\#profile\` is one word to the shell and the
+  # bare \`#profile\` to the command, and completing it again reads back the
+  # same target, so the escape is added to the candidate rather than left to
+  # the caller to remember.
+  local j
+  for j in "\${!COMPREPLY[@]}"; do
+    case "\${COMPREPLY[j]}" in
+      '#'*) COMPREPLY[j]="\\\\\${COMPREPLY[j]}" ;;
+    esac
+  done
+
   # The trailing space is inverted rather than suppressed. \`compopt\` is the
   # per-completion switch and it is bash 4+, so the ${name} binding is
   # registered \`-o nospace\` and a candidate that should END the word carries

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -24,12 +24,29 @@ export interface Candidate {
  *
  * `log-level` mirrors `lib/log-level.ts`; `color` mirrors the corresponding
  * `cf view` option. Language names come from the view language registry.
+ *
+ * A name here is one option's vocabulary across the whole tree. Two commands
+ * declaring the same name with different accepted values would need the
+ * provider table's command scoping instead, which is where `--scope` and
+ * `--from` are settled.
  */
 const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
   "log-level": ["debug", "info", "warn", "error", "silent"],
   "color": ["auto", "always", "never"],
   "language": languageNames(),
   "cfc-mode": ["off", "warn", "enforce"],
+  // `cf piece map --format`.
+  "format": ["ascii", "dot"],
+  // `cf inspect entities --kind`, the seven its help enumerates.
+  "kind": [
+    "piece",
+    "module",
+    "stream",
+    "schema",
+    "owned-cell",
+    "free-cell",
+    "unknown",
+  ],
 };
 
 /** First sentence of a description, for the shell's annotation column. */

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -303,6 +303,49 @@ Deno.test("generated bash script leaves the deno binding's spacing alone", () =>
   );
 });
 
+Deno.test("generated bash script escapes a candidate that would open a comment", async () => {
+  // `#profile` written into an interactive bash is a comment: the word, and
+  // the rest of the line with it, never reaches the command. `\#profile` is
+  // one word to the shell and the bare target to the CLI, and completing it
+  // again reads back the same target — so the candidate carries the escape
+  // rather than the caller having to remember it. Run through a real bash,
+  // because what is being asserted is what bash does with the script.
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      `${dir}/cf`,
+      "#!/bin/sh\nprintf '#profileName\\n/\\nplain\\n'\n",
+    );
+    await Deno.chmod(`${dir}/cf`, 0o755);
+    await Deno.writeTextFile(`${dir}/cf.bash`, bashCompletionScript("cf"));
+    const { stdout } = await new Deno.Command("/bin/bash", {
+      args: [
+        "--norc",
+        "--noprofile",
+        "-c",
+        [
+          `PATH="${dir}:$PATH"`,
+          `. "${dir}/cf.bash"`,
+          `COMP_LINE='cf wish #profileN'`,
+          "COMP_POINT=17",
+          `COMP_WORDS=(cf wish '#profileN')`,
+          "COMP_CWORD=2",
+          "_cf_complete cf",
+          `printf '[%s]' "\${COMPREPLY[@]}"`,
+        ].join("\n"),
+      ],
+    }).output();
+    // Only the hashtag is escaped, and the trailing space each candidate
+    // carries is outside the escape.
+    assertEquals(
+      new TextDecoder().decode(stdout),
+      "[\\#profileName ][/ ][plain ]",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("generated bash script avoids bash 4 builtins", () => {
   // macOS ships bash 3.2: `mapfile` does not exist at all, and `compopt` is
   // absent so it must be probed before use. Match on invocations rather than

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -188,7 +188,7 @@ Deno.test("a deno task cf line completes as cf", async () => {
 
 Deno.test("generated scripts bind both the CLI name and deno", () => {
   const bash = bashCompletionScript("cf");
-  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(bash.includes("complete -o nospace -F _cf_complete cf"));
   assert(bash.includes("complete -F _cf_complete deno"));
 
   const zsh = zshCompletionScript("cf");
@@ -197,7 +197,7 @@ Deno.test("generated scripts bind both the CLI name and deno", () => {
 
 Deno.test("--no-deno-task omits the deno binding", () => {
   const bash = bashCompletionScript("cf", { denoTask: false });
-  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(bash.includes("complete -o nospace -F _cf_complete cf"));
   assertFalse(bash.includes("complete -F _cf_complete deno"));
   assertFalse(bash.includes("complete -p deno"));
 
@@ -270,6 +270,39 @@ Deno.test("generated zsh script moves an inline flag prefix out of the way", () 
   assert(compset < pathFiles, "compset must precede the file completion");
 });
 
+Deno.test("generated bash script inverts the trailing space rather than suppressing it", () => {
+  // `compopt` is bash 4+ and macOS ships 3.2, so the space cannot be taken
+  // away per completion. The binding is registered `-o nospace` and a
+  // candidate that should end the word carries its own space instead, which
+  // is one mechanism for both bash versions.
+  const bash = bashCompletionScript("cf");
+  const code = bash.split("\n").filter((line) => !line.trim().startsWith("#"));
+  assert(
+    code.some((line) => /^complete -o nospace -F \S+ cf$/.test(line.trim())),
+    "the cf binding must register -o nospace",
+  );
+  assert(
+    code.some((line) => line.includes('COMPREPLY[k]="${COMPREPLY[k]} "')),
+    "a candidate ending the word must carry its own space",
+  );
+});
+
+Deno.test("generated bash script leaves the deno binding's spacing alone", () => {
+  // A line handed back to another completion keeps that completion's spacing,
+  // so the deno binding is registered without `-o nospace` and the function
+  // adds nothing for it.
+  const code = bashCompletionScript("cf").split("\n")
+    .filter((line) => !line.trim().startsWith("#"));
+  assert(
+    code.some((line) => /^complete -F \S+ deno$/.test(line.trim())),
+    "the deno binding must not register -o nospace",
+  );
+  assert(
+    code.some((line) => line.includes('"${1##*/}" == "cf"')),
+    "the space must be added only for the binding that asked for it",
+  );
+});
+
 Deno.test("generated bash script avoids bash 4 builtins", () => {
   // macOS ships bash 3.2: `mapfile` does not exist at all, and `compopt` is
   // absent so it must be probed before use. Match on invocations rather than
@@ -292,5 +325,5 @@ Deno.test("generated bash script avoids bash 4 builtins", () => {
 Deno.test("the CLI name flows into the generated function names", () => {
   const script = bashCompletionScript("mycf");
   assert(script.includes("_mycf_complete()"));
-  assert(script.includes("complete -F _mycf_complete mycf"));
+  assert(script.includes("complete -o nospace -F _mycf_complete mycf"));
 });

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -353,6 +353,58 @@ Deno.test("live candidates: an entity slot lists the scope the line named", asyn
   }
 });
 
+Deno.test("live candidates: an inspect line naming --remote offers nothing local", async () => {
+  // `--remote` is global on `inspect` and decides where the space comes from:
+  // `openByToken` resolves the token through the REMOTE's own listing and
+  // opens the snapshot it fetches, so a locally discovered DID and the
+  // entities of a local DB are both candidates the command rejects. Listing
+  // the remote is a round trip a keystroke must not start, which leaves
+  // nothing honest to offer. Both spellings count — the value is optional, so
+  // the flag reaches the line as an option or as a bare flag.
+  const dir = await Deno.makeTempDir();
+  const saved = Deno.env.get("MEMORY_DIR");
+  try {
+    const did = "did:key:zCompletionRemoteFixture";
+    const db = `${dir}/${did}.sqlite`;
+    seedScopedSpace(db);
+    Deno.env.set("MEMORY_DIR", dir);
+    // Local mode answers each slot, which is what makes the silence below a
+    // decision rather than a machine with nothing on it.
+    assert(
+      (await liveCandidates(lineFor("cf inspect summary "))).candidates
+        .some((candidate) => candidate.value === did),
+      "the space positional answers locally",
+    );
+    assert(
+      (await liveCandidates(lineFor(`cf inspect piece ${db} `)))
+        .candidates.length > 0,
+      "the entity positional answers locally",
+    );
+    assert(
+      (await liveCandidates(lineFor(`cf inspect graph ${db} --root `)))
+        .candidates.length > 0,
+      "graph --root answers locally",
+    );
+    for (
+      const text of [
+        "cf inspect summary --remote=http://remote.invalid ",
+        "cf inspect summary --remote ",
+        `cf inspect piece --remote=http://remote.invalid ${db} `,
+        `cf inspect piece --remote ${db} `,
+        `cf inspect graph --remote=http://remote.invalid ${db} --root `,
+      ]
+    ) {
+      const result = await liveCandidates(lineFor(text));
+      assertEquals(result.candidates, [], text);
+      assertEquals(result.directives, [], text);
+    }
+  } finally {
+    if (saved === undefined) Deno.env.delete("MEMORY_DIR");
+    else Deno.env.set("MEMORY_DIR", saved);
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("live candidates: a remote-only space positional offers nothing local", async () => {
   // `inspect pull` names a space on the REMOTE and resolves it through the
   // remote's own listing, so a locally discovered DID is a candidate the

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -780,11 +780,14 @@ Deno.test("every wish target offered is one the command's help enumerates", () =
   // The vocabulary is the wish builtin's rather than the command tree's, so it
   // is carried here by hand. The help text is where it is documented, and a
   // target in one and not the other is the drift this catches.
-  const help = wish.getDescription();
+  //
+  // Whole words, not substrings: the help enumerates `#profileName` as well as
+  // `#profile`, so a substring test would keep passing after `#profile` itself
+  // was dropped from the help — the one drift most likely to happen.
+  const documented = new Set(wish.getDescription().split(/\s+/));
   for (const candidate of wishTargetCandidates().candidates) {
-    if (candidate.value === "/") continue; // The root, named in prose.
     assert(
-      help.includes(candidate.value),
+      documented.has(candidate.value),
       `${candidate.value} is offered but not documented in cf wish --help`,
     );
   }

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -238,7 +238,7 @@ Deno.test("command: bash and zsh subcommands emit their scripts", async () => {
   const bash = await captureStdout(async () => {
     await main.parse(["completion", "bash"]);
   });
-  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(bash.includes("complete -o nospace -F _cf_complete cf"));
 
   const zsh = await captureStdout(async () => {
     await main.parse(["completion", "zsh"]);
@@ -250,7 +250,7 @@ Deno.test("command: --no-deno-task reaches the script generator", async () => {
   const bash = await captureStdout(async () => {
     await main.parse(["completion", "bash", "--no-deno-task"]);
   });
-  assert(bash.includes("complete -F _cf_complete cf"));
+  assert(bash.includes("complete -o nospace -F _cf_complete cf"));
   assert(!bash.includes("complete -F _cf_complete deno"));
 });
 

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -205,8 +205,17 @@ Deno.test("live candidates: every path-shaped slot hands the shell its own direc
     ["cf view ", "files", undefined],
     ["cf exec ", "files", undefined],
     ["cf space clone --to ", "dirs", undefined],
+    ["cf space clone x --from ", "files", undefined],
     ["cf space verify ", "dirs", undefined],
     ["cf space reset ", "dirs", undefined],
+    ["cf inspect spaces --dir ", "dirs", undefined],
+    ["cf inspect html x --out ", "files", undefined],
+    ["cf check --output ", "files", undefined],
+    ["cf piece set-home ", "files", "*.tsx"],
+    ["cf piece getsrc ", "files", undefined],
+    ["cf deps update ", "files", undefined],
+    ["cf fuse mount ", "dirs", undefined],
+    ["cf fuse unmount ", "dirs", undefined],
   ];
   for (const [text, kind, glob] of cases) {
     const result = await liveCandidates(lineFor(text));
@@ -250,13 +259,21 @@ Deno.test("an inspect entity slot reads the view its command will read", () => {
   assertEquals(entityListingView(lineFor("cf inspect diff space ")), {
     branch: undefined,
     scope: undefined,
+    allScopes: false,
   });
   assertEquals(
     entityListingView(
       lineFor("cf inspect diff --branch draft --scope of:fid1:owner space "),
     ),
-    { branch: "draft", scope: "of:fid1:owner" },
+    { branch: "draft", scope: "of:fid1:owner", allScopes: false },
   );
+  // `inspect overlay` declares no `--scope` and reports an entity's value in
+  // every scope, so its slot covers them all rather than the default one.
+  assertEquals(entityListingView(lineFor("cf inspect overlay space ")), {
+    branch: undefined,
+    scope: undefined,
+    allScopes: true,
+  });
 });
 
 /**
@@ -322,7 +339,41 @@ Deno.test("live candidates: an entity slot lists the scope the line named", asyn
         .candidates.map((candidate) => candidate.value),
       ["of:in-other"],
     );
+    // `inspect overlay` reports an entity's value in EVERY scope and takes no
+    // `--scope` to narrow it, so its slot covers every scope at once. Offering
+    // only the space scope would hide exactly the per-user and per-session
+    // entities the command exists to show.
+    assertEquals(
+      (await liveCandidates(lineFor(`cf inspect overlay ${path} `)))
+        .candidates.map((candidate) => candidate.value).sort(),
+      ["of:in-other", "of:in-space"],
+    );
   } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("live candidates: a remote-only space positional offers nothing local", async () => {
+  // `inspect pull` names a space on the REMOTE and resolves it through the
+  // remote's own listing, so a locally discovered DID is a candidate the
+  // command rejects — while every sibling that opens a local space takes one.
+  const dir = await Deno.makeTempDir();
+  const saved = Deno.env.get("MEMORY_DIR");
+  try {
+    const did = "did:key:zCompletionPullFixture";
+    await Deno.writeTextFile(`${dir}/${did}.sqlite`, "");
+    Deno.env.set("MEMORY_DIR", dir);
+    const listed = await liveCandidates(lineFor("cf inspect entities "));
+    assert(
+      listed.candidates.some((candidate) => candidate.value === did),
+      "the local store is discoverable at all",
+    );
+    const pull = await liveCandidates(lineFor("cf inspect pull "));
+    assertEquals(pull.candidates, []);
+    assertEquals(pull.directives, []);
+  } finally {
+    if (saved === undefined) Deno.env.delete("MEMORY_DIR");
+    else Deno.env.set("MEMORY_DIR", saved);
     await Deno.remove(dir, { recursive: true });
   }
 });

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,8 +1,10 @@
 import { assert, assertEquals, assertFalse } from "@std/assert";
+import { Database } from "@db/sqlite";
 import { resolveCompletionLine } from "../lib/completion/line.ts";
 import {
   acceptedProjections,
   descendProjection,
+  entityListingView,
   keysOf,
   linkEndpointPrefix,
   liveCandidates,
@@ -186,7 +188,14 @@ Deno.test("live candidates: every path-shaped slot hands the shell its own direc
   const cases: Array<[string, string, string | undefined]> = [
     ["cf piece ls -i ", "files", "*.key"],
     ["cf id did ", "files", "*.key"],
+    // Every command whose `--root` is the directory its sources resolve
+    // against. The set is hand-maintained, so it is asserted whole.
     ["cf piece new --root ", "dirs", undefined],
+    ["cf piece setsrc --root ", "dirs", undefined],
+    ["cf piece survey --root ", "dirs", undefined],
+    ["cf piece set-home --root ", "dirs", undefined],
+    ["cf check --root ", "dirs", undefined],
+    ["cf test --root ", "dirs", undefined],
     ["cf piece new --test ", "files", "*.tsx"],
     ["cf piece new ", "files", "*.tsx"],
     ["cf piece setsrc ", "files", "*.tsx"],
@@ -205,6 +214,116 @@ Deno.test("live candidates: every path-shaped slot hands the shell its own direc
     const directive = result.directives[0] as { kind: string; glob?: string };
     assertEquals(directive.kind, kind, text);
     assertEquals(directive.glob, glob, `${text} glob`);
+  }
+});
+
+Deno.test("live candidates: an option that means two things is completed per command", async () => {
+  // The option table is keyed by long name alone, so a slot answering by name
+  // would hand the shell directory completion for a sequence number and for an
+  // entity id. Offering the wrong set teaches the caller a word the command
+  // rejects, which is worse than offering none.
+  for (
+    const text of [
+      // A clone directory on `space clone`, a sequence number here.
+      "cf inspect diff space entity --to ",
+      // A snapshot file on `space clone`, a sequence number here.
+      "cf inspect diff space entity --from ",
+      // A wish search scope on `wish`, a scope key here.
+      "cf inspect diff space entity --scope ",
+      // A source directory on the commands that compile one, an entity here.
+      // No space is named yet, so the entity provider has nothing to read —
+      // which is the point: the slot reaches that provider, not the directory
+      // one, and reads no disk to find out.
+      "cf inspect graph --root ",
+    ]
+  ) {
+    const result = await liveCandidates(lineFor(text));
+    assertEquals(result.directives.length, 0, `${text} emits no directive`);
+    assertEquals(result.candidates.length, 0, `${text} offers no candidate`);
+  }
+});
+
+Deno.test("an inspect entity slot reads the view its command will read", () => {
+  // `--branch` and `--scope` choose which records the command resolves. A
+  // listing taken from the space's default view would offer entities that read
+  // is not going to find.
+  assertEquals(entityListingView(lineFor("cf inspect diff space ")), {
+    branch: undefined,
+    scope: undefined,
+  });
+  assertEquals(
+    entityListingView(
+      lineFor("cf inspect diff --branch draft --scope of:fid1:owner space "),
+    ),
+    { branch: "draft", scope: "of:fid1:owner" },
+  );
+});
+
+/**
+ * A space DB holding one entity in the default scope and one in another, so a
+ * listing taken from the wrong scope offers the wrong id rather than none.
+ */
+function seedScopedSpace(path: string): void {
+  const db = new Database(path, { create: true });
+  db.exec(`
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 2, 'active');`);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, 'session:did%3Akey%3AzAlice:s1', ?, '{}', '{"seq":0}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+  );
+  const entities: Array<[string, string]> = [
+    ["of:in-space", "space"],
+    ["of:in-other", "other"],
+  ];
+  entities.forEach(([id, scope], index) => {
+    const seq = index + 1;
+    commit.run(seq, seq);
+    rev.run(id, scope, seq, JSON.stringify({ value: id }), seq);
+  });
+  db.close();
+}
+
+Deno.test("live candidates: an entity slot lists the scope the line named", async () => {
+  // The read the command will run is scoped, so the candidates have to be:
+  // an id offered from the default scope is one that read cannot reach.
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = `${dir}/space.sqlite`;
+    seedScopedSpace(path);
+    assertEquals(
+      (await liveCandidates(lineFor(`cf inspect piece ${path} `)))
+        .candidates.map((candidate) => candidate.value),
+      ["of:in-space"],
+    );
+    assertEquals(
+      (await liveCandidates(lineFor(`cf inspect piece ${path} --scope other `)))
+        .candidates.map((candidate) => candidate.value),
+      ["of:in-other"],
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
   }
 });
 

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -8,12 +8,14 @@ import {
   liveCandidates,
   projectionKeys,
   resolveSpaceContext,
+  shapeEntityCandidates,
   shapePieceCandidates,
   shapeProjectionCandidates,
   shapeSlugCandidates,
   shapeVerbCandidates,
   splitPathPrefix,
   splitSelectPrefix,
+  wishTargetCandidates,
 } from "../lib/completion/providers.ts";
 import {
   parseSelectionProjection,
@@ -21,6 +23,7 @@ import {
 } from "../lib/cell-selection.ts";
 import { tokenizeLine } from "../lib/completion/mod.ts";
 import { main } from "../commands/main.ts";
+import { wish } from "../commands/wish.ts";
 
 function lineFor(text: string) {
   const { words, cword } = tokenizeLine(text, text.length);
@@ -634,6 +637,38 @@ Deno.test("shaping: a key the concise grammar cannot carry is not offered", () =
       .map((candidate) => candidate.value),
     ["ok", "ok@"],
   );
+});
+
+Deno.test("shaping: an entity is labeled by what was reconstructed for it", () => {
+  // The id is what the next positional takes; the label is what makes it
+  // readable. `(piece)` is what the reconstruction says when it found no name,
+  // which is the kind's job rather than the label's.
+  assertEquals(
+    shapeEntityCandidates([
+      { id: "of:fid1:a", label: "Completion fixture", kind: "piece" },
+      { id: "of:fid1:b", label: "(piece)", kind: "piece" },
+      { id: "of:fid1:c", kind: "free-cell" },
+    ]),
+    [
+      { value: "of:fid1:a", description: "Completion fixture" },
+      { value: "of:fid1:b", description: "piece" },
+      { value: "of:fid1:c", description: "free-cell" },
+    ],
+  );
+});
+
+Deno.test("every wish target offered is one the command's help enumerates", () => {
+  // The vocabulary is the wish builtin's rather than the command tree's, so it
+  // is carried here by hand. The help text is where it is documented, and a
+  // target in one and not the other is the drift this catches.
+  const help = wish.getDescription();
+  for (const candidate of wishTargetCandidates().candidates) {
+    if (candidate.value === "/") continue; // The root, named in prose.
+    assert(
+      help.includes(candidate.value),
+      `${candidate.value} is offered but not documented in cf wish --help`,
+    );
+  }
 });
 
 Deno.test("shaping: containers yield keys, leaves yield nothing", () => {


### PR DESCRIPTION
## Why

The mechanical remainder of the completion plan: every slot the tree declares
that a table walk can name, and which nothing was answering. These are the CLI's
own vocabulary rather than a pattern's, which is what puts them below the
pattern-owned slots — but a slot with no entry is silent, so a caller cannot
tell "this does not complete" from "the fabric is unreachable".

Items 12 through 16 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md).
Stacked on #6252.

## What Changed

**The operator surface (item 13).** Every `cf inspect` subcommand that names a
space completes it from the same local stores `space clone` reads, and the
`<entity>` beside it completes what `cf inspect entities` lists, annotated with
the label the reconstruction found. Both sets are generated from a list of
subcommand names rather than written out as thirty-odd table entries: which
subcommands open a space is one fact, and repeating it is somewhere for the
next one to be forgotten. The entity provider reads local stores only —
`--remote` fetches a snapshot before it can list anything, which is a round trip
a keystroke should not start.

**`wish` (item 14)** completes the targets its help enumerates and the scopes it
accepts. The target list is hand-maintained because the vocabulary is the wish
builtin's rather than the command tree's; a test asserts every target offered
appears in `cf wish --help`, so the two cannot drift.

**Command-scoped option providers.** `--scope` means a hashtag search scope on
`wish` and a scope key on `inspect`; `--from` is a snapshot file on
`space clone` and a sequence number on `inspect diff`. The option table is keyed
by long name alone, so those two providers say which commands they apply to.
Offering the wrong set is worse than offering none.

**The remainder (item 15)** — pattern files, files, directories, `--remote`,
and two enumerated sets — and **item 16**: the two provider entries belonging to
`fuse-daemon`/`fuse-supervisor`, which declare no Cliffy options, are gone.

`--remote` is reachable only as `--remote=<value>`: its value is optional, so a
bare `--remote` is legal and the word after it is a positional. Recorded rather
than worked around.

## Item 12's remedy is disproven, not implemented

The item proposed a candidate carrying its own trailing separator, so the
shell's added space would fall after a `/` rather than inside a path. Driven
through a **real bash 3.2 under a pty**, it does not work:

- a reply of `items` inserts `items ` — the space the item is about;
- a reply of `items/` inserts `items/ `, so the caller still deletes a space
  before typing the next segment;
- `complete -o filenames` does not change that (it suppresses the space only
  where the candidate names a directory that exists on disk) and it adds
  filename escaping to every candidate — `#profile` reaches the line as
  `\#profile`.

What does suppress the space is the match not being unique, so the only lever is
a phantom candidate in the menu, which costs more than the keystroke it saves.
The plan now records the measurement and the item stays open with its remedy
closed.

## Test plan

- The live seam, against a local dev server **with a `MEMORY_DIR` pointing at a
  real store**: 68 passed, 0 failed, 1 gap open. Its new steps assert the space
  and entity positionals against a real space DB, the wish and enumerated sets,
  and that `--from` offers a file on one command and nothing on the other. The
  step degrades honestly where no local store is discoverable, which is item 8's
  positional discovery rather than a defect here.
- `deno task test` in `packages/cli` — 0 failed. New pure tests cover the entity
  labelling and the wish-target/help agreement.
- `deno fmt --check`, `deno lint`, `deno task check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Since review

Rebasing onto current `main` pulled in #6049, which changed
`listEntityModels` to return a capped-listing object rather than a bare array.
The entity provider handed the whole object to a shaper expecting the array, so
it threw — and because completion swallows every error, the slot simply offered
nothing. Fixed here, and caught by the live walkthrough rather than by a type
check, which is the case that walkthrough exists for.

The harness also grew two steps in #6249, so the two this PR adds are now 15
and 16; the operator-surface step reads the store step 13 already looked for
instead of discovering it twice.


## Review round 2

The operator-surface step carried the third instance of one shape: it branched
on `cf inspect entities`' empty output, so a command that failed and a space
holding nothing read alike. The listing's exit status is now read through the
`run` helper #6249 adds, and both positionals are probed on either branch —
where there is nothing to list, the slot must still run and come back empty.
