### PR TITLE
feat(repo): gate a CLI slot nobody decided about completing

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -189,6 +189,12 @@ jobs:
           deno task run-recorded gate repo check-local-program --
           deno task check-local-program
 
+      - name: 🚧 Guard against a CLI slot nobody decided about completing
+        timeout-minutes: *work-timeout
+        run: >-
+          deno task run-recorded gate repo check-completion-slots --
+          deno task check-completion-slots
+
       - name: 🔎 Check generated commonfabric/cfc types are up to date
         timeout-minutes: *work-timeout
         working-directory: packages/static

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,11 @@ Each of these gates fails CI on its own, and none of them run as part of
   dependency declarations across the workspace
 - `deno task check-package-cycles` — two packages that import each other, the
   part of "Dependencies run downward" above that a machine can settle
+- `deno task check-completion-slots` — a `cf` option or positional nobody
+  decided about completing. Shell completion's values come from two
+  hand-maintained tables, and a slot missing from both is silent: it offers
+  nothing, exactly as an unreachable fabric does. Give it candidates, or record
+  in the task why it has none
 - `deno task check-local-program` — a program built from local files by hand
   rather than through `resolveLocalProgram`, which silently drops any data files
   the caller attached

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -64,6 +64,10 @@
     "check-test-aliases": "deno run --allow-read --allow-run=git ./tasks/check-test-aliases.ts",
     "check-skill-facts": "deno run --allow-read --allow-run=git ./tasks/check-skill-facts.ts",
     "check-verb-session-sync": "deno run --allow-read ./tasks/check-verb-session-sync.ts",
+    // Building the CLI's command tree is what this walks, and mounting it
+    // resolves the whole CLI — including the SQLite library `cf inspect`
+    // opens spaces with, which is why this needs --allow-ffi.
+    "check-completion-slots": "deno run --allow-read --allow-env --allow-sys --allow-ffi ./tasks/check-completion-slots.ts",
     "check-tripwires": "deno run --allow-read ./tasks/check-tripwires.ts",
     // Reports the docs/ link graph; --allow-write serves its --out flag.
     "docs-links": "deno run --allow-read --allow-write ./scripts/docs-links.ts",

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -590,9 +590,11 @@ lands, which is the obligation rather than the one edit.
 `packages/cli/integration/completion-over-the-cli.sh` is where every provider
 that reads state is exercised — the four that reach a fabric, the one that
 reads local stores, the one that reads the environment, and the pattern-file
-glob. The rest of the table hands the shell a constant directive that a fabric
-cannot change, and those are asserted one by one — kind and glob — in
-`test/completion-providers.test.ts`. Item 19 adds the other half: whether a
+glob — at one of the slots it answers. The rest of the table hands the shell a
+constant directive that a fabric cannot change, and those are asserted one by
+one — kind and glob — in `test/completion-providers.test.ts`, over a set that
+file derives from the tree rather than remembers: a slot handing the shell a
+directive that no case pins fails there. Item 19 adds the other half: whether a
 slot has an entry at all.
 
 `--space` is the one whose candidates depend on the machine, since it reads

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -81,7 +81,7 @@ read before picking one up; this table is the roll-up.
 | 2 | Flags offered past a `stopEarly()` boundary | correctness | done |
 | 3 | Target resolution lags the reference grammar | correctness | done |
 | 4 | Verb flags do not complete | pattern vocabulary | shaper done, wiring after step 10 |
-| 5 | Result field paths for `get` and `wish` | pattern vocabulary | `get` done, `wish` refused |
+| 5 | Result field paths for `get` and `wish` | pattern vocabulary | `get` done, `wish` declined |
 | 6 | Result field paths for `call` and `exec` | pattern vocabulary | needs step 10 |
 | 7 | Slugs never complete | pattern vocabulary | done |
 | 8 | `--space` has no source a caller recognizes | first link | partly settled |
@@ -97,11 +97,18 @@ read before picking one up; this table is the roll-up.
 | 18 | A live-provider test seam | mechanism | done |
 | 19 | A gate that fails when a new slot has no decision | mechanism | done |
 
-**What can be picked up today.** Nothing on this list. What is left is held
-rather than open: item 4's wiring waits on step 10 of
-[CLI surface shape](cli-surface-shape.md), item 6 waits on the same step, items
-8 and 11 hold decisions, item 12's remedy is disproven, and item 5's `wish`
-half needs a wish resolution that does not write.
+**What can be picked up today.** Nothing on this list. What is left is held or
+settled rather than open: item 4's wiring waits on step 10 of
+[CLI surface shape](cli-surface-shape.md) and item 6 waits on the same step;
+items 8 and 11 hold decisions; and item 5's `wish` half is declined, because
+resolving a wish writes.
+
+One defect this list does not enumerate is open and unranked: the cell-path slot
+offers a piece's callables, which `cf get` refuses and redirects to `cf call`.
+It is asserted in `completion-over-the-cli.sh` as what happens today. Telling a
+callable from a value at a path needs the verbs listing, which that provider
+does not fetch — so it is a round trip rather than a filter, and that is the
+decision it waits on.
 
 Item 4's candidates are built and its wiring waits: step 10 decides whether a
 verb's fields are written before the `--` marker or after it, and the position
@@ -313,9 +320,11 @@ query adds nothing, because the cell is keyed by the query; a caller editing a
 query writes once per spelling they pass through.
 
 That is a keystroke with a side effect, which is the bar this item said to clear
-before building it, and it is not cleared. Completing `wish --select` needs a
-resolution that reads without committing, which is a change to `resolveWish`
-rather than to completion.
+before building it. **It is not cleared, and that is decided rather than
+deferred: a durable write per distinct query is not acceptable at a keystroke.**
+The slot stays empty. Completing it would need a resolution that reads without
+committing — a change to `resolveWish`, and a question for whoever owns the
+wish builtin rather than for this plan.
 
 `call` and `exec` are the other two commands carrying these flags, and their
 projection names positions in a verb's result rather than in the piece's root.

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -95,10 +95,13 @@ read before picking one up; this table is the roll-up.
 | 16 | Two provider entries that can never fire | hygiene | done |
 | 17 | The README table omits the top-level spellings | hygiene | done |
 | 18 | A live-provider test seam | mechanism | done |
-| 19 | A gate that fails when a new slot has no decision | mechanism | not started |
+| 19 | A gate that fails when a new slot has no decision | mechanism | done |
 
-**What can be picked up today.** Item 19 is what remains: the other half of the
-mechanism item 18 landed.
+**What can be picked up today.** Nothing on this list. What is left is held
+rather than open: item 4's wiring waits on step 10 of
+[CLI surface shape](cli-surface-shape.md), item 6 waits on the same step, items
+8 and 11 hold decisions, item 12's remedy is disproven, and item 5's `wish`
+half needs a wish resolution that does not write.
 
 Item 4's candidates are built and its wiring waits: step 10 decides whether a
 verb's fields are written before the `--` marker or after it, and the position
@@ -120,13 +123,14 @@ Two of the four ways completion can be wrong are enumerated here exhaustively,
 and two are not. Knowing which is which is the difference between working the
 list and trusting it.
 
-**Enumerated exhaustively.** A slot with no provider entry: the keys of both
-provider tables are derivable from the same command tree the resolver walks, so
-walking the tree and subtracting the tables names every one. That is items 13
-to 16, and item 19 is the same walk made permanent.
+**Enumerated exhaustively, and now gated.** A slot with no provider entry: the
+keys of both provider tables are derivable from the same command tree the
+resolver walks, so walking the tree and subtracting the tables names every one.
+That is items 13 to 16, and `deno task check-completion-slots` is the same walk
+made permanent.
 
-**Enumerated exhaustively.** A provider entry with no slot: the same
-subtraction run the other way. That is item 16.
+**Enumerated exhaustively, and now gated.** A provider entry with no slot: the
+same subtraction run the other way. That is item 16, and the same gate.
 
 **Not enumerated.** A provider that returns the *wrong set* rather than an
 empty one. This is invisible at the prompt — plausible candidates look like
@@ -622,17 +626,21 @@ It is asserted there as what happens today.
 
 ### 19. A gate that fails when a new slot has no decision
 
-Completion falling behind the command surface is the mechanism this whole plan
-is a list of instances of. The tables are keyed by option long name and by
-`<command path>:<argument name>`, and both keys are derivable from the tree that
-`resolveCompletionLine` already walks, so the drift is machine-detectable: walk
-the tree, and name every value-taking option and every positional with no
-provider entry and no enumerated set.
+`deno task check-completion-slots` walks the same tree `resolveCompletionLine`
+walks and subtracts the two provider tables from it, in three directions:
 
-The check cannot decide that a slot *should* complete — plenty should not. It
-can require that every slot has been decided about, which is what an allowlist
-of deliberate omissions records. That turns the next command's completion from
-something remembered into something the gate asks for.
+- A slot with no provider, no enumerated set, and no allowlist entry.
+- A provider entry matching no slot — item 16's subtraction, made permanent.
+- An allowlist entry matching no slot, so the record of a decision cannot
+  outlive the thing it was about.
 
-Item 16 is what the same walk finds in the other direction, so both fall out of
-one implementation.
+It cannot decide that a slot *should* complete, and does not try. It requires
+that every slot has been decided about, and the allowlist is where a decision
+not to complete one is written down with its reason — what the candidates would
+have been, and why there are none.
+
+Its first run named thirty-six options and no positionals. Three of them turned
+out to be path-shaped and got directives rather than an allowance
+(`--pattern-coverage-dir`, `--timing-measures-out`, `--cfc-writeback-state`);
+the rest are counts, timestamps, pasted identifiers, coined words, and
+expressions with their own grammar.

--- a/docs/plans/cli-completion-coverage.md
+++ b/docs/plans/cli-completion-coverage.md
@@ -640,8 +640,17 @@ walks and subtracts the two provider tables from it, in three directions:
 
 - A slot with no provider, no enumerated set, and no allowlist entry.
 - A provider entry matching no slot — item 16's subtraction, made permanent.
-- An allowlist entry matching no slot, so the record of a decision cannot
+- An allowlist entry that decides no slot, so the record of a decision cannot
   outlive the thing it was about.
+
+A slot is one option on one command, not one option name. The scoped providers
+carry the commands they answer on, and the gate asks about each command the
+name is declared on separately: a `--from` answered on `space clone` says
+nothing about the `--from` on `inspect diff`, and reading the key alone would
+report the second as decided when what it offers is silence. The allowlist
+takes the same two shapes — a bare long name where nothing provides the option
+anywhere, and `<command path>:<long name>` for the commands where an option
+that is provided elsewhere means something else.
 
 It cannot decide that a slot *should* complete, and does not try. It requires
 that every slot has been decided about, and the allowlist is where a decision
@@ -653,3 +662,11 @@ out to be path-shaped and got directives rather than an allowance
 (`--pattern-coverage-dir`, `--timing-measures-out`, `--cfc-writeback-state`);
 the rest are counts, timestamps, pasted identifiers, coined words, and
 expressions with their own grammar.
+
+Asking per command named twenty more. One took candidates — `piece repair
+--list` names a piece, exactly as the `--list` on `piece survey` does. The rest
+are recorded: the two sequence numbers `inspect diff` spells `--from` and
+`--to`; the raw scope keys nine `inspect` subcommands take, which are read out
+of the data being inspected the way `--session` already is; and the eight
+projections that shape something other than the value at a target, which are
+items 6 and 5's `wish` half rather than an omission.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1150,7 +1150,9 @@ memory-v2 stores, or the environment — is exercised by
 what a Tab offers at each slot of the chain. The remaining table entries hand
 the shell a constant `files` or `dirs` directive, which a fabric cannot change:
 those are asserted one by one, kind and glob, in
-`test/completion-providers.test.ts`.
+`test/completion-providers.test.ts`; `deno task check-completion-slots` is what
+catches an entry naming a slot that does not exist, or a slot with no entry at
+all.
 
 That split is not tidiness: a provider that reaches a fabric and comes back with
 the wrong set is invisible to a unit test and invisible at the prompt, because

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1148,13 +1148,19 @@ The tests divide the same way. `test/completion-*.test.ts` cover everything
 answerable without a fabric — line resolution, candidate shaping, and the
 degrade-to-empty path. Every provider that reads state — a fabric, the local
 memory-v2 stores, or the environment — is exercised by
-`integration/completion-over-the-cli.sh`, which deploys a fixture and asserts
-what a Tab offers at each slot of the chain. The remaining table entries hand
-the shell a constant `files` or `dirs` directive, which a fabric cannot change:
-those are asserted one by one, kind and glob, in
-`test/completion-providers.test.ts`; `deno task check-completion-slots` is what
-catches an entry naming a slot that does not exist, or a slot with no entry at
-all.
+`integration/completion-over-the-cli.sh` at one of the slots it answers: it
+deploys a fixture and asserts what a Tab offers at each slot of the chain. Two
+slots sharing a provider are covered by that one step, since `piece survey`'s
+and `piece repair`'s `--list` take exactly what `--piece` takes. Which slots a
+provider is keyed to is the other question, and
+`deno task check-completion-slots` is what asks it, per command.
+
+The remaining table entries hand the shell a constant `files` or `dirs`
+directive, which a fabric cannot change: those are asserted one by one, kind and
+glob, in `test/completion-providers.test.ts`. The set that has to be asserted is
+derived there rather than remembered — every slot the tree declares is probed
+with no fabric configured, and one that hands the shell a directive no case pins
+fails the test.
 
 That split is not tidiness: a provider that reaches a fabric and comes back with
 the wrong set is invisible to a unit test and invisible at the prompt, because

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1139,8 +1139,10 @@ stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
 behind that tree. It walks the same commands and names every value-taking option
 and every positional with no provider, no enumerated set, and no recorded reason
 for having none — and the same subtraction the other way, so a provider entry
-matching no slot fails too. It cannot decide that a slot should complete; it
-requires that somebody decided.
+matching no slot fails too. It asks per command rather than per option name,
+since a provider scoped to one command answers nothing on the others declaring
+the same flag. It cannot decide that a slot should complete; it requires that
+somebody decided.
 
 The tests divide the same way. `test/completion-*.test.ts` cover everything
 answerable without a fabric — line resolution, candidate shaping, and the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1160,7 +1160,9 @@ directive, which a fabric cannot change: those are asserted one by one, kind and
 glob, in `test/completion-providers.test.ts`. The set that has to be asserted is
 derived there rather than remembered — every slot the tree declares is probed
 with no fabric configured, and one that hands the shell a directive no case pins
-fails the test.
+fails the test. A case pins one command where the provider says it answers per
+command, and every command at once where it does not — the same distinction the
+slot gate draws, and a provider held to it by a test of its own.
 
 That split is not tidiness: a provider that reaches a fabric and comes back with
 the wrong set is invisible to a unit test and invisible at the prompt, because

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1135,6 +1135,13 @@ Two facts cannot be read off that tree and are carried explicitly in
 stripped from `argv` before Cliffy parses, in `lib/log-level.ts` and
 `lib/color-mode.ts`), and the provider table binding slots to live data.
 
+`deno task check-completion-slots` is what keeps the provider table from falling
+behind that tree. It walks the same commands and names every value-taking option
+and every positional with no provider, no enumerated set, and no recorded reason
+for having none — and the same subtraction the other way, so a provider entry
+matching no slot fails too. It cannot decide that a slot should complete; it
+requires that somebody decided.
+
 The tests divide the same way. `test/completion-*.test.ts` cover everything
 answerable without a fabric — line resolution, candidate shaping, and the
 degrade-to-empty path. Every provider that reads state — a fabric, the local

--- a/packages/cli/integration/completion-over-the-cli.sh
+++ b/packages/cli/integration/completion-over-the-cli.sh
@@ -16,7 +16,8 @@
 # at all. They read no state, so a fabric cannot change what they answer, and
 # they are asserted one by one — kind and glob — in
 # packages/cli/test/completion-providers.test.ts, which is where a constant
-# belongs. Nothing here re-checks them.
+# belongs. Nothing here re-checks them, and `deno task check-completion-slots`
+# is what catches a slot with no entry at all.
 #
 # The exception is an option name that means two things on two commands —
 # --from, --to, --root, --scope. There the answer turns on which command was

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -547,3 +547,55 @@ function positionalSlot(
 
 /** Exported for `providers.ts`, which keys context lookups by long name. */
 export { longName, takesValue };
+
+/** One positional a command tree declares, and where it sits. */
+export interface DeclaredPositional {
+  /** `<command path>:<argument name>`, the key its provider carries. */
+  readonly key: string;
+  /** The command path, or `<root>` for the root command's own. */
+  readonly where: string;
+  /** Its place in that command's argument order, so a line can reach it. */
+  readonly index: number;
+}
+
+/** Every value-taking option and every positional a command tree declares. */
+export interface DeclaredSlots {
+  /** Option long name -> the command paths declaring it. */
+  readonly options: ReadonlyMap<string, readonly string[]>;
+  readonly positionals: readonly DeclaredPositional[];
+}
+
+/**
+ * Every slot the tree offers a value at, walked the way `resolveCompletionLine`
+ * walks it: `realSubcommands` decides which children are commands, and
+ * `takesValue` decides which options have a value to complete.
+ *
+ * Both keys the provider tables use fall out of this walk, which is what lets
+ * a check subtract the tables from the tree — in either direction — rather
+ * than remembering what was added.
+ */
+export function declaredSlots(root: AnyCommand): DeclaredSlots {
+  const options = new Map<string, string[]>();
+  const positionals: DeclaredPositional[] = [];
+  const walk = (command: AnyCommand, path: readonly string[]): void => {
+    const where = path.join(" ") || "<root>";
+    for (const option of command.getOptions(false)) {
+      if (!takesValue(option)) continue;
+      const seen = options.get(longName(option)) ?? [];
+      if (!seen.includes(where)) seen.push(where);
+      options.set(longName(option), seen);
+    }
+    command.getArguments().forEach((argument: Argument, index: number) => {
+      positionals.push({
+        key: `${path.join(" ")}:${argument.name}`,
+        where,
+        index,
+      });
+    });
+    for (const child of realSubcommands(command)) {
+      walk(child, [...path, child.getName()]);
+    }
+  };
+  walk(root, []);
+  return { options, positionals };
+}

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -563,6 +563,16 @@ export interface DeclaredSlots {
   /** Option long name -> the command paths declaring it. */
   readonly options: ReadonlyMap<string, readonly string[]>;
   readonly positionals: readonly DeclaredPositional[];
+  /**
+   * The option slots whose value may be omitted, as
+   * `<command path>:--<long name>`.
+   *
+   * Such an option never swallows the next word, so the cursor after
+   * `--name ` is on a positional and only `--name=` reaches the option's own
+   * value. Anything walking these slots to drive a line has to spell them that
+   * way or it drives a different slot.
+   */
+  readonly optionalValues: ReadonlySet<string>;
 }
 
 /**
@@ -577,6 +587,7 @@ export interface DeclaredSlots {
 export function declaredSlots(root: AnyCommand): DeclaredSlots {
   const options = new Map<string, string[]>();
   const positionals: DeclaredPositional[] = [];
+  const optionalValues = new Set<string>();
   const walk = (command: AnyCommand, path: readonly string[]): void => {
     const where = path.join(" ") || "<root>";
     for (const option of command.getOptions(false)) {
@@ -584,6 +595,9 @@ export function declaredSlots(root: AnyCommand): DeclaredSlots {
       const seen = options.get(longName(option)) ?? [];
       if (!seen.includes(where)) seen.push(where);
       options.set(longName(option), seen);
+      if (valueIsOptional(option)) {
+        optionalValues.add(`${where}:--${longName(option)}`);
+      }
     }
     command.getArguments().forEach((argument: Argument, index: number) => {
       positionals.push({
@@ -597,5 +611,5 @@ export function declaredSlots(root: AnyCommand): DeclaredSlots {
     }
   };
   walk(root, []);
-  return { options, positionals };
+  return { options, positionals, optionalValues };
 }

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -407,10 +407,10 @@ export function splitPathPrefix(
  * offering none. `wish` shapes what its query resolved to, and resolving a
  * wish commits a cell to the space: a Tab must not write.
  */
-const PROJECTION_SOURCE_COMMANDS: ReadonlySet<string> = new Set([
+const PROJECTION_SOURCE_COMMANDS: readonly string[] = [
   "piece get",
   "get",
-]);
+];
 
 /**
  * Field paths into the value a read returns, for `--select` and `--schema`.
@@ -428,7 +428,6 @@ function projectionFieldCandidates(
   flag: "select" | "schema",
 ): (line: CompletionLine) => Promise<ProviderResult> {
   return async (line) => {
-    if (!PROJECTION_SOURCE_COMMANDS.has(line.path.join(" "))) return NOTHING;
     // `--schema` reads a JSON Schema or an `@file` as well as this list, and
     // both are recognized by their first character. Neither is a field path.
     if (flag === "schema" && /^[@{]/.test(line.word)) return NOTHING;
@@ -855,6 +854,18 @@ function namesRemote(line: CompletionLine): boolean {
 }
 
 /**
+ * An option's provider, and the command paths it answers on.
+ *
+ * `commands` is absent on a provider that answers wherever the option is
+ * declared, and carries the paths of one restricted by {@link onlyOn}. The
+ * gate reads it: a key alone says which option was decided about, and only the
+ * paths say on which commands.
+ */
+export type OptionProvider =
+  & ((line: CompletionLine) => Promise<ProviderResult>)
+  & { readonly commands?: readonly string[] };
+
+/**
  * Restrict a provider to the commands whose option of that name means this.
  *
  * The option table is keyed by long name alone, and a name can mean two things
@@ -866,10 +877,11 @@ function namesRemote(line: CompletionLine): boolean {
 function onlyOn(
   commands: readonly string[],
   provider: (line: CompletionLine) => Promise<ProviderResult>,
-): (line: CompletionLine) => Promise<ProviderResult> {
+): OptionProvider {
   const paths = new Set(commands);
-  return (line) =>
+  const scoped = (line: CompletionLine) =>
     paths.has(line.path.join(" ")) ? provider(line) : Promise.resolve(NOTHING);
+  return Object.assign(scoped, { commands });
 }
 
 /** The commands whose `--root` is the directory their sources resolve against. */
@@ -882,6 +894,12 @@ const ROOT_DIRECTORY_COMMANDS: readonly string[] = [
   "test",
 ];
 
+/** Every command whose `--root` this table answers, in both meanings. */
+const ROOT_COMMANDS: readonly string[] = [
+  ...ROOT_DIRECTORY_COMMANDS,
+  "inspect graph",
+];
+
 /**
  * `--root` by what it names: a source directory on the commands that resolve
  * imports and authored paths against one, and on `cf inspect graph` the entity
@@ -891,13 +909,9 @@ const ROOT_DIRECTORY_COMMANDS: readonly string[] = [
  * read from the space the command already names.
  */
 function rootCandidates(line: CompletionLine): Promise<ProviderResult> {
-  const command = line.path.join(" ");
-  if (command === "inspect graph") return entityCandidates(line);
-  return Promise.resolve(
-    ROOT_DIRECTORY_COMMANDS.includes(command)
-      ? directive({ kind: "dirs" })
-      : NOTHING,
-  );
+  return line.path.join(" ") === "inspect graph"
+    ? entityCandidates(line)
+    : Promise.resolve(directive({ kind: "dirs" }));
 }
 
 /** API URLs worth offering: the environment's, plus the local dev server. */
@@ -921,12 +935,16 @@ function patternFiles(): Promise<ProviderResult> {
  * Option values by long name. A name absent here falls through to the shell's
  * own file completion only when the option is path-shaped.
  */
-const OPTION_VALUE_PROVIDERS: Readonly<
-  Record<string, (line: CompletionLine) => Promise<ProviderResult>>
-> = {
+const OPTION_VALUE_PROVIDERS: Readonly<Record<string, OptionProvider>> = {
   piece: pieceCandidates,
-  select: projectionFieldCandidates("select"),
-  schema: projectionFieldCandidates("schema"),
+  select: onlyOn(
+    PROJECTION_SOURCE_COMMANDS,
+    projectionFieldCandidates("select"),
+  ),
+  schema: onlyOn(
+    PROJECTION_SOURCE_COMMANDS,
+    projectionFieldCandidates("schema"),
+  ),
   space: () => spaceCandidates(),
   "api-url": () => Promise.resolve(apiUrlCandidates()),
   // `--remote` takes what `--api-url` takes: the toolshed to read from.
@@ -934,7 +952,7 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   identity: () => Promise.resolve(directive({ kind: "files", glob: "*.key" })),
   // A source directory on the commands that compile one, and an entity on
   // `inspect graph`.
-  root: rootCandidates,
+  root: onlyOn(ROOT_COMMANDS, rootCandidates),
   test: patternFiles,
   // A data file has no fixed extension; the shell's own file completion is the
   // only honest candidate set.
@@ -945,10 +963,10 @@ const OPTION_VALUE_PROVIDERS: Readonly<
     ["space clone"],
     () => Promise.resolve(directive({ kind: "dirs" })),
   ),
-  // `cf piece survey --list` names a piece to survey instead of a collection,
-  // so it takes what `--piece` takes. Scoped, because a `--list` elsewhere
-  // would mean something else entirely.
-  list: onlyOn(["piece survey"], pieceCandidates),
+  // `--list` names a piece to survey or repair instead of a collection, so it
+  // takes what `--piece` takes. Scoped, because a `--list` elsewhere would
+  // mean something else entirely.
+  list: onlyOn(["piece survey", "piece repair"], pieceCandidates),
   // `cf piece survey --validator` reads a JSON-schema file.
   validator: () => Promise.resolve(directive({ kind: "files" })),
   // `cf piece repair --fixer` names a TypeScript module whose default export
@@ -1108,20 +1126,29 @@ function inspectEntityProviders(): Record<
 }
 
 /**
- * The keys of both provider tables.
+ * What both provider tables answer, as command paths.
  *
  * For the gate that asks whether every slot has been decided about. Both keys
  * are derivable from the same command tree `resolveCompletionLine` walks, so
  * the drift between the tree and these tables is machine-detectable — in both
  * directions, since an entry matching no slot is the same subtraction run the
  * other way.
+ *
+ * An option maps to the command paths its provider answers on, or to `null`
+ * where it answers on every command declaring it. A scoped provider answers
+ * nothing off its paths, so a key alone would report those commands as decided
+ * when what they get is silence.
  */
 export function completionProviderKeys(): {
-  readonly options: ReadonlySet<string>;
+  readonly options: ReadonlyMap<string, readonly string[] | null>;
   readonly arguments: ReadonlySet<string>;
 } {
+  const options = new Map<string, readonly string[] | null>();
+  for (const [name, provider] of Object.entries(OPTION_VALUE_PROVIDERS)) {
+    options.set(name, provider.commands ?? null);
+  }
   return {
-    options: new Set(Object.keys(OPTION_VALUE_PROVIDERS)),
+    options,
     arguments: new Set(Object.keys(ARGUMENT_PROVIDERS)),
   };
 }

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -945,6 +945,12 @@ const OPTION_VALUE_PROVIDERS: Readonly<
     ["space clone"],
     () => Promise.resolve(directive({ kind: "dirs" })),
   ),
+  // `cf piece survey --list` names a piece to survey instead of a collection,
+  // so it takes what `--piece` takes. Scoped, because a `--list` elsewhere
+  // would mean something else entirely.
+  list: onlyOn(["piece survey"], pieceCandidates),
+  // `cf piece survey --validator` reads a JSON-schema file.
+  validator: () => Promise.resolve(directive({ kind: "files" })),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -951,6 +951,10 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   list: onlyOn(["piece survey"], pieceCandidates),
   // `cf piece survey --validator` reads a JSON-schema file.
   validator: () => Promise.resolve(directive({ kind: "files" })),
+  // `cf piece repair --fixer` names a TypeScript module whose default export
+  // is the transform; `--plan` reads the rows a survey wrote.
+  fixer: () => Promise.resolve(directive({ kind: "files", glob: "*.ts" })),
+  plan: () => Promise.resolve(directive({ kind: "files" })),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -950,6 +950,11 @@ const OPTION_VALUE_PROVIDERS: Readonly<
   // `cf inspect html --out` and `cf check --output` write a file.
   out: () => Promise.resolve(directive({ kind: "files" })),
   output: () => Promise.resolve(directive({ kind: "files" })),
+  // The remaining path-shaped values: two artifacts `cf test` writes, and the
+  // state file `cf fuse mount` passes to its child.
+  "pattern-coverage-dir": () => Promise.resolve(directive({ kind: "dirs" })),
+  "timing-measures-out": () => Promise.resolve(directive({ kind: "files" })),
+  "cfc-writeback-state": () => Promise.resolve(directive({ kind: "files" })),
   // A snapshot file on `space clone`, and a sequence number on `inspect diff`.
   from: onlyOn(
     ["space clone"],
@@ -1090,6 +1095,25 @@ function inspectEntityProviders(): Record<
     entries[`inspect ${command}:entity`] = entityCandidates;
   }
   return entries;
+}
+
+/**
+ * The keys of both provider tables.
+ *
+ * For the gate that asks whether every slot has been decided about. Both keys
+ * are derivable from the same command tree `resolveCompletionLine` walks, so
+ * the drift between the tree and these tables is machine-detectable — in both
+ * directions, since an entry matching no slot is the same subtraction run the
+ * other way.
+ */
+export function completionProviderKeys(): {
+  readonly options: ReadonlySet<string>;
+  readonly arguments: ReadonlySet<string>;
+} {
+  return {
+    options: new Set(Object.keys(OPTION_VALUE_PROVIDERS)),
+    arguments: new Set(Object.keys(ARGUMENT_PROVIDERS)),
+  };
 }
 
 /**

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -120,6 +120,16 @@ export function preParseGlobalValues(global: PreParseGlobal): Candidate[] {
 }
 
 /**
+ * The option long names carrying a statically known value set.
+ *
+ * For the gate that asks whether every slot has been decided about: an option
+ * answered from this table needs no provider entry.
+ */
+export function enumeratedOptionNames(): ReadonlySet<string> {
+  return new Set(Object.keys(ENUMERATED_OPTION_VALUES));
+}
+
+/**
  * Values for an option whose accepted set is known statically. Returns `null`
  * when the option has no such set, which tells the caller to try a live
  * provider instead.

--- a/packages/cli/lib/completion/static.ts
+++ b/packages/cli/lib/completion/static.ts
@@ -37,6 +37,8 @@ const ENUMERATED_OPTION_VALUES: Readonly<Record<string, readonly string[]>> = {
   "cfc-mode": ["off", "warn", "enforce"],
   // `cf piece map --format`.
   "format": ["ascii", "dot"],
+  // `cf piece survey --side`: which document holds the collection.
+  "side": ["input", "result"],
   // `cf inspect entities --kind`, the seven its help enumerates.
   "kind": [
     "piece",

--- a/packages/cli/test/completion-line.test.ts
+++ b/packages/cli/test/completion-line.test.ts
@@ -330,3 +330,20 @@ Deno.test("declaredSlots skips the help Cliffy propagates to every command", () 
     ["piece call:callable", "piece call:tail"],
   );
 });
+
+Deno.test("declaredSlots names the option slots whose value may be omitted", () => {
+  // An option written `[value]` is legal as a bare flag, so it never swallows
+  // the word after it: the cursor there is on a positional, and `--name=` is
+  // the only spelling that reaches the option's own value. Anything driving a
+  // line at these slots has to know which they are.
+  const tree = new Command()
+    .name("cf")
+    .command(
+      "go",
+      new Command()
+        .description("somewhere")
+        .option("--maybe [url:string]", "a value that may be omitted")
+        .option("--must <dir:string>", "a value the flag requires"),
+    );
+  assertEquals([...declaredSlots(tree).optionalValues], ["go:--maybe"]);
+});

--- a/packages/cli/test/completion-line.test.ts
+++ b/packages/cli/test/completion-line.test.ts
@@ -1,10 +1,31 @@
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { Command } from "@cliffy/command";
 import {
+  declaredSlots,
   resolveCompletionLine,
   stripInvocationPrefix,
 } from "../lib/completion/line.ts";
 import { tokenizeLine } from "../lib/completion/mod.ts";
 import { main } from "../commands/main.ts";
+
+/**
+ * A small tree in the shape the CLI's own is: nested commands, each with its
+ * own options and positionals.
+ */
+function fixtureTree() {
+  return new Command()
+    .name("cf")
+    .option("--space <space:string>", "a space")
+    .option("--quiet", "no value, so not a slot")
+    .command("piece", new Command().description("piece things"))
+    .command(
+      "get",
+      new Command()
+        .description("read")
+        .option("--select <fields:string>", "a projection")
+        .arguments("<path:string>"),
+    );
+}
 
 /** Resolve the line the way the shell would, from a raw buffer. */
 function resolve(line: string, point = line.length) {
@@ -275,4 +296,37 @@ Deno.test("resolve: a deno task cf line resolves like a cf line", () => {
   assert(line.slot?.kind === "argument");
   assertEquals(line.slot.argument.name, "callable");
   assertEquals(line.options.get("piece"), "x");
+});
+
+Deno.test("declaredSlots names a value-taking option by long name and command", () => {
+  const { options } = declaredSlots(fixtureTree());
+  assertEquals(options.get("space"), ["<root>"]);
+  assertEquals(options.get("select"), ["get"]);
+});
+
+Deno.test("declaredSlots returns no entry for an option that takes no value", () => {
+  // A flag has nothing to complete, so it is not a slot.
+  assertFalse(declaredSlots(fixtureTree()).options.has("quiet"));
+});
+
+Deno.test("declaredSlots keys a positional by command path, name and order", () => {
+  assertEquals(declaredSlots(fixtureTree()).positionals, [
+    { key: "get:path", where: "get", index: 0 },
+  ]);
+});
+
+Deno.test("declaredSlots skips the help Cliffy propagates to every command", () => {
+  // `help` reaches every descendant as a global, and its own arguments are
+  // nobody's slot: taking them at face value would put a `command` positional
+  // on every leaf of the tree.
+  const slots = declaredSlots(main);
+  assertFalse(
+    slots.positionals.some((slot) => slot.key.endsWith("help:command")),
+  );
+  assertEquals(
+    slots.positionals.filter((slot) => slot.where === "piece call").map((s) =>
+      s.key
+    ),
+    ["piece call:callable", "piece call:tail"],
+  );
 });

--- a/packages/cli/test/completion-output.test.ts
+++ b/packages/cli/test/completion-output.test.ts
@@ -4,7 +4,11 @@ import {
   staticCandidates,
   tokenizeLine,
 } from "../lib/completion/mod.ts";
-import { resolveCompletionLine } from "../lib/completion/line.ts";
+import {
+  declaredSlots,
+  resolveCompletionLine,
+} from "../lib/completion/line.ts";
+import { enumeratedOptionNames } from "../lib/completion/static.ts";
 import {
   bashCompletionScript,
   zshCompletionScript,
@@ -369,4 +373,20 @@ Deno.test("the CLI name flows into the generated function names", () => {
   const script = bashCompletionScript("mycf");
   assert(script.includes("_mycf_complete()"));
   assert(script.includes("complete -o nospace -F _mycf_complete mycf"));
+});
+
+Deno.test("every enumerated option name answers at each slot that declares it", () => {
+  // `enumeratedOptionNames` is what the slot gate subtracts from the command
+  // tree, so a name it reports has to answer at the prompt too — otherwise the
+  // gate reads a slot as decided while the slot offers nothing. `--log-level`
+  // is stripped before Cliffy parses and so declares no slot on the tree; it
+  // answers at the root, where the pre-parse globals are read.
+  const declared = declaredSlots(main).options;
+  for (const name of enumeratedOptionNames()) {
+    for (const where of declared.get(name) ?? ["<root>"]) {
+      const path = where === "<root>" ? "" : `${where} `;
+      const values = staticFor(`cf ${path}--${name} `);
+      assert(values.length > 0, `--${name} offers nothing on ${where}`);
+    }
+  }
 });

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -234,14 +234,29 @@ const DIRECTIVE_CASES: Array<[string, string, string | undefined]> = [
   ["cf fuse mount --cfc-writeback-state ", "files", undefined],
 ];
 
-/** The provider-table key the slot under the cursor reads its answer from. */
+/** The commands each option provider answers on, or `null` for every one. */
+const PROVIDER_SCOPES = completionProviderKeys().options;
+
+/**
+ * What a case has to name to pin this slot, keyed the way its provider varies.
+ *
+ * A positional provider is keyed by command path already, so one case pins one
+ * command. An option provider that names the commands it answers on can answer
+ * differently on each, so each of those is pinned on its own — which is what
+ * `--from` and `--to` need, being a file and a directory on `space clone` and
+ * sequence numbers on `inspect diff`. One that names no commands answers the
+ * same wherever its option is declared, and the test below holds it to that,
+ * so a single case covers every command at once.
+ */
 function providerKeyOf(line: CompletionLine): string | null {
   const slot = line.slot;
-  if (slot?.kind === "option-value") return `--${longName(slot.option)}`;
-  if (slot?.kind === "argument") {
-    return `${line.path.join(" ")}:${slot.argument.name}`;
-  }
-  return null;
+  const where = line.path.join(" ") || "<root>";
+  if (slot?.kind === "argument") return `${where}:${slot.argument.name}`;
+  if (slot?.kind !== "option-value") return null;
+  const name = longName(slot.option);
+  return (PROVIDER_SCOPES.get(name) ?? null) === null
+    ? `--${name}`
+    : `${where}:--${name}`;
 }
 
 /**
@@ -265,14 +280,18 @@ function shellHandoff(
     : null;
 }
 
-/** A line that puts the cursor on each slot the command tree declares. */
-function probeLines(): Array<{ text: string; key: string }> {
+/**
+ * A line that puts the cursor on each slot the command tree declares. Only the
+ * text: the key comes from the resolved line, so `providerKeyOf` is the one
+ * place that says what a case has to name.
+ */
+function probeLines(): string[] {
   const slots = declaredSlots(main);
-  const probes: Array<{ text: string; key: string }> = [];
+  const probes: string[] = [];
   for (const [name, paths] of slots.options) {
     for (const where of paths) {
       const path = where === "<root>" ? "" : `${where} `;
-      probes.push({ text: `cf ${path}--${name} `, key: `--${name}` });
+      probes.push(`cf ${path}--${name} `);
     }
   }
   for (const slot of slots.positionals) {
@@ -281,9 +300,15 @@ function probeLines(): Array<{ text: string; key: string }> {
     const filled = Array.from({ length: slot.index }, (_, i) => `x${i} `).join(
       "",
     );
-    probes.push({ text: `cf ${path}${filled}`, key: slot.key });
+    probes.push(`cf ${path}${filled}`);
   }
   return probes;
+}
+
+/** How a slot answered, as a line of the report the tests below print. */
+function handoffLabel(directive: Directive): string {
+  const glob = (directive as { glob?: string }).glob;
+  return glob ? `${directive.kind} ${glob}` : directive.kind;
 }
 
 Deno.test("live candidates: every path-shaped slot hands the shell its own directive", async () => {
@@ -332,19 +357,63 @@ Deno.test("live candidates: no slot hands the shell a directive the cases miss",
   // when four providers were added with no case. So the set is asked of the
   // code: every slot the tree declares is probed with no fabric configured,
   // and a shell handoff no case pins fails here rather than going unnoticed.
+  //
+  // The probe is keyed the way the provider varies, which is why a case on one
+  // command does not vouch for a scoped provider's other commands. An
+  // unscoped provider is vouched for by one case and held to answering the
+  // same everywhere by the test below.
   const covered = new Set(
     DIRECTIVE_CASES.map(([text]) => providerKeyOf(lineFor(text))),
   );
   const missing: string[] = [];
   await withEnv({}, async () => {
-    for (const probe of probeLines()) {
-      const handoff = shellHandoff(await liveCandidates(lineFor(probe.text)));
+    for (const text of probeLines()) {
+      const line = lineFor(text);
+      const handoff = shellHandoff(await liveCandidates(line));
       if (!handoff) continue;
-      if (covered.has(probe.key)) continue;
-      missing.push(`${probe.text.trim()} hands over ${handoff.kind}`);
+      const key = providerKeyOf(line);
+      if (key !== null && covered.has(key)) continue;
+      missing.push(`${text.trim()} hands over ${handoffLabel(handoff)}`);
     }
   });
   assertEquals(missing, []);
+});
+
+Deno.test("live candidates: an unscoped option provider answers the same everywhere", async () => {
+  // What makes one case cover every command declaring the option. A provider
+  // that names no commands is a function of the line rather than of the path,
+  // so a different answer on two commands means it is scoped in fact and not
+  // in the table — the state `--root`, `--select` and `--schema` were in
+  // before they said where they applied, and the state a single case cannot
+  // pin.
+  const answers = new Map<string, Map<string, string[]>>();
+  await withEnv({}, async () => {
+    for (const [name, paths] of declaredSlots(main).options) {
+      if ((PROVIDER_SCOPES.get(name) ?? null) !== null) continue;
+      const byAnswer = new Map<string, string[]>();
+      for (const where of paths) {
+        const path = where === "<root>" ? "" : `${where} `;
+        const result = await liveCandidates(lineFor(`cf ${path}--${name} `));
+        const handoff = shellHandoff(result);
+        const answer = handoff
+          ? handoffLabel(handoff)
+          : result.candidates.length > 0
+          ? "candidates"
+          : "nothing";
+        byAnswer.set(answer, [...(byAnswer.get(answer) ?? []), where]);
+      }
+      if (byAnswer.size > 1) answers.set(name, byAnswer);
+    }
+  });
+  assertEquals(
+    [...answers].map(([name, byAnswer]) =>
+      `--${name}: ${
+        [...byAnswer].map(([answer, where]) => `${answer} on ${where[0]}`)
+          .join(", ")
+      }`
+    ),
+    [],
+  );
 });
 
 Deno.test("live candidates: an option that means two things is completed per command", async () => {

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -216,6 +216,8 @@ Deno.test("live candidates: every path-shaped slot hands the shell its own direc
     ["cf deps update ", "files", undefined],
     ["cf fuse mount ", "dirs", undefined],
     ["cf fuse unmount ", "dirs", undefined],
+    ["cf piece repair --fixer ", "files", "*.ts"],
+    ["cf piece repair --plan ", "files", undefined],
   ];
   for (const [text, kind, glob] of cases) {
     const result = await liveCandidates(lineFor(text));

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -281,6 +281,25 @@ function shellHandoff(
 }
 
 /**
+ * The spelling that puts the cursor on an option's own value.
+ *
+ * An option whose value may be omitted never swallows the next word, so after
+ * `--remote ` the cursor is on a positional and the slot being probed would be
+ * somebody else's. `--remote=` is the spelling that reaches it, and the
+ * declaration is what says which of the two an option needs.
+ */
+function optionProbeLine(
+  name: string,
+  where: string,
+  optionalValues: ReadonlySet<string>,
+): string {
+  const path = where === "<root>" ? "" : `${where} `;
+  return optionalValues.has(`${where}:--${name}`)
+    ? `cf ${path}--${name}=`
+    : `cf ${path}--${name} `;
+}
+
+/**
  * A line that puts the cursor on each slot the command tree declares. Only the
  * text: the key comes from the resolved line, so `providerKeyOf` is the one
  * place that says what a case has to name.
@@ -290,8 +309,7 @@ function probeLines(): string[] {
   const probes: string[] = [];
   for (const [name, paths] of slots.options) {
     for (const where of paths) {
-      const path = where === "<root>" ? "" : `${where} `;
-      probes.push(`cf ${path}--${name} `);
+      probes.push(optionProbeLine(name, where, slots.optionalValues));
     }
   }
   for (const slot of slots.positionals) {
@@ -351,6 +369,38 @@ Deno.test("provider keys report which commands each option provider answers on",
   assertFalse(positionals.has("callable"));
 });
 
+Deno.test("live candidates: every probe reaches the slot it was built for", () => {
+  // What both nets below rest on. A probe that lands on a neighbouring slot
+  // tests that neighbour and reports nothing about the slot it named, so the
+  // net would pass over a whole class of options while looking exhaustive —
+  // which is what the spaced spelling did to every optional-valued option,
+  // whose flag does not swallow the word after it.
+  const slots = declaredSlots(main);
+  const wrong: string[] = [];
+  for (const [name, paths] of slots.options) {
+    for (const where of paths) {
+      const text = optionProbeLine(name, where, slots.optionalValues);
+      const line = lineFor(text);
+      const reached = line.slot?.kind === "option-value" &&
+        longName(line.slot.option) === name &&
+        (line.path.join(" ") || "<root>") === where;
+      if (!reached) wrong.push(`${text.trim()} misses ${where}:--${name}`);
+    }
+  }
+  for (const slot of slots.positionals) {
+    const path = slot.where === "<root>" ? "" : `${slot.where} `;
+    const filled = Array.from({ length: slot.index }, (_, i) => `x${i} `).join(
+      "",
+    );
+    const text = `cf ${path}${filled}`;
+    const line = lineFor(text);
+    const reached = line.slot?.kind === "argument" &&
+      `${line.path.join(" ")}:${line.slot.argument.name}` === slot.key;
+    if (!reached) wrong.push(`${text.trim()} misses ${slot.key}`);
+  }
+  assertEquals(wrong, []);
+});
+
 Deno.test("live candidates: no slot hands the shell a directive the cases miss", async () => {
   // The case table above is hand-maintained, and a hand-maintained table falls
   // behind the thing it describes without saying so — which is what it did
@@ -387,13 +437,15 @@ Deno.test("live candidates: an unscoped option provider answers the same everywh
   // before they said where they applied, and the state a single case cannot
   // pin.
   const answers = new Map<string, Map<string, string[]>>();
+  const slots = declaredSlots(main);
   await withEnv({}, async () => {
-    for (const [name, paths] of declaredSlots(main).options) {
+    for (const [name, paths] of slots.options) {
       if ((PROVIDER_SCOPES.get(name) ?? null) !== null) continue;
       const byAnswer = new Map<string, string[]>();
       for (const where of paths) {
-        const path = where === "<root>" ? "" : `${where} `;
-        const result = await liveCandidates(lineFor(`cf ${path}--${name} `));
+        const result = await liveCandidates(
+          lineFor(optionProbeLine(name, where, slots.optionalValues)),
+        );
         const handoff = shellHandoff(result);
         const answer = handoff
           ? handoffLabel(handoff)

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -1,8 +1,15 @@
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { Database } from "@db/sqlite";
-import { resolveCompletionLine } from "../lib/completion/line.ts";
+import {
+  type CompletionLine,
+  declaredSlots,
+  longName,
+  resolveCompletionLine,
+} from "../lib/completion/line.ts";
+import type { Directive } from "../lib/completion/providers.ts";
 import {
   acceptedProjections,
+  completionProviderKeys,
   descendProjection,
   entityListingView,
   keysOf,
@@ -178,54 +185,166 @@ Deno.test("live candidates: unmapped slots ask for nothing", async () => {
   }
 });
 
+/**
+ * Every slot whose whole answer is a shell handoff, and the directive it must
+ * hand over. The kind and the glob are the assertion: a wrong glob is the
+ * "wrong set" defect in its quietest form, since the slot still answers, with
+ * the wrong files, and nothing upstream can tell.
+ *
+ * Hand-written, because what each slot SHOULD hand over is not derivable from
+ * the code that hands it over. Which slots belong here is derivable, and is
+ * derived below rather than remembered.
+ */
+const DIRECTIVE_CASES: Array<[string, string, string | undefined]> = [
+  ["cf piece ls -i ", "files", "*.key"],
+  ["cf id did ", "files", "*.key"],
+  // Every command whose `--root` is the directory its sources resolve
+  // against. The set is hand-maintained, so it is asserted whole.
+  ["cf piece new --root ", "dirs", undefined],
+  ["cf piece setsrc --root ", "dirs", undefined],
+  ["cf piece survey --root ", "dirs", undefined],
+  ["cf piece set-home --root ", "dirs", undefined],
+  ["cf check --root ", "dirs", undefined],
+  ["cf test --root ", "dirs", undefined],
+  ["cf piece new --test ", "files", "*.tsx"],
+  ["cf piece new ", "files", "*.tsx"],
+  ["cf piece setsrc ", "files", "*.tsx"],
+  ["cf check ", "files", "*.tsx"],
+  ["cf test ", "files", "*.tsx"],
+  ["cf piece new --datafile ", "files", undefined],
+  ["cf view ", "files", undefined],
+  ["cf exec ", "files", undefined],
+  ["cf space clone --to ", "dirs", undefined],
+  ["cf space clone x --from ", "files", undefined],
+  ["cf space verify ", "dirs", undefined],
+  ["cf space reset ", "dirs", undefined],
+  ["cf inspect spaces --dir ", "dirs", undefined],
+  ["cf inspect html x --out ", "files", undefined],
+  ["cf check --output ", "files", undefined],
+  ["cf piece set-home ", "files", "*.tsx"],
+  ["cf piece getsrc ", "files", undefined],
+  ["cf deps update ", "files", undefined],
+  ["cf fuse mount ", "dirs", undefined],
+  ["cf fuse unmount ", "dirs", undefined],
+  ["cf piece repair --fixer ", "files", "*.ts"],
+  ["cf piece repair --plan ", "files", undefined],
+  ["cf piece survey --validator ", "files", undefined],
+  ["cf test --pattern-coverage-dir ", "dirs", undefined],
+  ["cf test --timing-measures-out ", "files", undefined],
+  ["cf fuse mount --cfc-writeback-state ", "files", undefined],
+];
+
+/** The provider-table key the slot under the cursor reads its answer from. */
+function providerKeyOf(line: CompletionLine): string | null {
+  const slot = line.slot;
+  if (slot?.kind === "option-value") return `--${longName(slot.option)}`;
+  if (slot?.kind === "argument") {
+    return `${line.path.join(" ")}:${slot.argument.name}`;
+  }
+  return null;
+}
+
+/**
+ * Whether the answer is a shell handoff and nothing else: one `files` or
+ * `dirs` directive, no candidates. That is the half a fabric cannot change,
+ * and so the half a unit test can pin.
+ *
+ * A `nospace` directive is not one. It accompanies live candidates to hold the
+ * cursor mid-path, so what it comes with is exactly what a fabric changes, and
+ * `completion-over-the-cli.sh` is where those slots are judged.
+ */
+function shellHandoff(
+  result: { candidates: readonly unknown[]; directives: readonly Directive[] },
+): Directive | null {
+  if (result.candidates.length > 0 || result.directives.length !== 1) {
+    return null;
+  }
+  const directive = result.directives[0];
+  return directive.kind === "files" || directive.kind === "dirs"
+    ? directive
+    : null;
+}
+
+/** A line that puts the cursor on each slot the command tree declares. */
+function probeLines(): Array<{ text: string; key: string }> {
+  const slots = declaredSlots(main);
+  const probes: Array<{ text: string; key: string }> = [];
+  for (const [name, paths] of slots.options) {
+    for (const where of paths) {
+      const path = where === "<root>" ? "" : `${where} `;
+      probes.push({ text: `cf ${path}--${name} `, key: `--${name}` });
+    }
+  }
+  for (const slot of slots.positionals) {
+    const path = slot.where === "<root>" ? "" : `${slot.where} `;
+    // Earlier positionals have to be filled for the cursor to reach this one.
+    const filled = Array.from({ length: slot.index }, (_, i) => `x${i} `).join(
+      "",
+    );
+    probes.push({ text: `cf ${path}${filled}`, key: slot.key });
+  }
+  return probes;
+}
+
 Deno.test("live candidates: every path-shaped slot hands the shell its own directive", async () => {
-  // One entry per reachable directive in the provider tables, asserting the
-  // glob as well as the kind. A wrong glob is the "wrong set" defect in its
-  // quietest form: the slot still answers, with the wrong files, and nothing
-  // upstream can tell. These read no state, so this is where they belong —
-  // the integration walkthrough covers the providers that reach a fabric and
-  // deliberately does not re-check these.
-  const cases: Array<[string, string, string | undefined]> = [
-    ["cf piece ls -i ", "files", "*.key"],
-    ["cf id did ", "files", "*.key"],
-    // Every command whose `--root` is the directory its sources resolve
-    // against. The set is hand-maintained, so it is asserted whole.
-    ["cf piece new --root ", "dirs", undefined],
-    ["cf piece setsrc --root ", "dirs", undefined],
-    ["cf piece survey --root ", "dirs", undefined],
-    ["cf piece set-home --root ", "dirs", undefined],
-    ["cf check --root ", "dirs", undefined],
-    ["cf test --root ", "dirs", undefined],
-    ["cf piece new --test ", "files", "*.tsx"],
-    ["cf piece new ", "files", "*.tsx"],
-    ["cf piece setsrc ", "files", "*.tsx"],
-    ["cf check ", "files", "*.tsx"],
-    ["cf test ", "files", "*.tsx"],
-    ["cf piece new --datafile ", "files", undefined],
-    ["cf view ", "files", undefined],
-    ["cf exec ", "files", undefined],
-    ["cf space clone --to ", "dirs", undefined],
-    ["cf space clone x --from ", "files", undefined],
-    ["cf space verify ", "dirs", undefined],
-    ["cf space reset ", "dirs", undefined],
-    ["cf inspect spaces --dir ", "dirs", undefined],
-    ["cf inspect html x --out ", "files", undefined],
-    ["cf check --output ", "files", undefined],
-    ["cf piece set-home ", "files", "*.tsx"],
-    ["cf piece getsrc ", "files", undefined],
-    ["cf deps update ", "files", undefined],
-    ["cf fuse mount ", "dirs", undefined],
-    ["cf fuse unmount ", "dirs", undefined],
-    ["cf piece repair --fixer ", "files", "*.ts"],
-    ["cf piece repair --plan ", "files", undefined],
-  ];
-  for (const [text, kind, glob] of cases) {
+  // These read no state, so this is where they belong — the integration
+  // walkthrough covers the providers that reach a fabric and deliberately does
+  // not re-check these.
+  for (const [text, kind, glob] of DIRECTIVE_CASES) {
     const result = await liveCandidates(lineFor(text));
     assertEquals(result.directives.length, 1, `${text} emits one directive`);
     const directive = result.directives[0] as { kind: string; glob?: string };
     assertEquals(directive.kind, kind, text);
     assertEquals(directive.glob, glob, `${text} glob`);
   }
+});
+
+Deno.test("provider keys report which commands each option provider answers on", () => {
+  // What the slot gate subtracts from the command tree. An option keyed here
+  // with no commands answers wherever it is declared; one keyed with commands
+  // answers on those and is silent everywhere else, which is the difference
+  // between a slot that was decided about and one that only looks decided.
+  const { options, arguments: positionals } = completionProviderKeys();
+  assertEquals(options.get("piece"), null);
+  assertEquals(options.get("from"), ["space clone"]);
+  assertEquals(options.get("to"), ["space clone"]);
+  assertEquals(options.get("scope"), ["wish"]);
+  assertEquals(options.get("list"), ["piece survey", "piece repair"]);
+  assertEquals(options.get("select"), ["piece get", "get"]);
+  assertEquals(options.get("root"), [
+    "check",
+    "piece new",
+    "piece set-home",
+    "piece setsrc",
+    "piece survey",
+    "test",
+    "inspect graph",
+  ]);
+  // A positional entry is keyed by command path already, so it carries no
+  // command list of its own.
+  assert(positionals.has("piece call:callable"));
+  assertFalse(positionals.has("callable"));
+});
+
+Deno.test("live candidates: no slot hands the shell a directive the cases miss", async () => {
+  // The case table above is hand-maintained, and a hand-maintained table falls
+  // behind the thing it describes without saying so — which is what it did
+  // when four providers were added with no case. So the set is asked of the
+  // code: every slot the tree declares is probed with no fabric configured,
+  // and a shell handoff no case pins fails here rather than going unnoticed.
+  const covered = new Set(
+    DIRECTIVE_CASES.map(([text]) => providerKeyOf(lineFor(text))),
+  );
+  const missing: string[] = [];
+  await withEnv({}, async () => {
+    for (const probe of probeLines()) {
+      const handoff = shellHandoff(await liveCandidates(lineFor(probe.text)));
+      if (!handoff) continue;
+      if (covered.has(probe.key)) continue;
+      missing.push(`${probe.text.trim()} hands over ${handoff.kind}`);
+    }
+  });
+  assertEquals(missing, []);
 });
 
 Deno.test("live candidates: an option that means two things is completed per command", async () => {

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -28,21 +28,47 @@ function fixtureTree() {
     );
 }
 
-/** The report for `fixtureTree()`, told about `known`. */
+/**
+ * One option name meaning two things on two commands, as `--from` does: a
+ * snapshot file on `space clone` and a sequence number on `inspect diff`.
+ */
+function twoMeaningsTree() {
+  return new Command()
+    .name("cf")
+    .command(
+      "clone",
+      new Command().description("copy a space")
+        .option("--from <file:string>", "a snapshot file"),
+    )
+    .command(
+      "diff",
+      new Command().description("compare two revisions")
+        .option("--from <n:number>", "a sequence number"),
+    );
+}
+
+/** The report for a tree, told about `known`. */
 function reportFor(known: {
-  providerOptions?: string[];
+  /** Option name -> the commands its provider answers on, `null` for all. */
+  providerOptions?: Record<string, readonly string[] | null>;
   providerArguments?: string[];
   enumerated?: string[];
   allowedOptions?: string[];
   allowedPositionals?: string[];
-}): SlotReport {
-  return reportSlots(collectSlots(fixtureTree()), {
-    providerOptions: new Set(known.providerOptions ?? []),
+  // deno-lint-ignore no-explicit-any
+}, tree: Command<any> = fixtureTree()): SlotReport {
+  return reportSlots(collectSlots(tree), {
+    providerOptions: new Map(Object.entries(known.providerOptions ?? {})),
     providerArguments: new Set(known.providerArguments ?? []),
     enumerated: new Set(known.enumerated ?? []),
     allowedOptions: new Set(known.allowedOptions ?? []),
     allowedPositionals: new Set(known.allowedPositionals ?? []),
   });
+}
+
+/** `providerOptions` for names whose provider answers on every command. */
+function everywhere(...names: string[]): Record<string, null> {
+  return Object.fromEntries(names.map((name) => [name, null]));
 }
 
 describe("check-completion-slots", () => {
@@ -76,23 +102,57 @@ describe("check-completion-slots", () => {
 
     it("returns no finding for an option a provider answers", () => {
       expect(
-        reportFor({ providerOptions: ["space", "select"] }).undecidedOptions,
+        reportFor({ providerOptions: everywhere("space", "select") })
+          .undecidedOptions,
       )
         .toEqual([]);
     });
 
     it("returns no finding for an option an enumerated set answers", () => {
       expect(
-        reportFor({ providerOptions: ["space"], enumerated: ["select"] })
+        reportFor({
+          providerOptions: everywhere("space"),
+          enumerated: ["select"],
+        })
           .undecidedOptions,
       ).toEqual([]);
     });
 
     it("returns no finding for an option the allowlist records a reason for", () => {
       expect(
-        reportFor({ providerOptions: ["space"], allowedOptions: ["select"] })
+        reportFor({
+          providerOptions: everywhere("space"),
+          allowedOptions: ["select"],
+        })
           .undecidedOptions,
       ).toEqual([]);
+    });
+
+    it("names the commands a scoped provider does not answer on", () => {
+      // A provider restricted to one command answers nothing on the other, so
+      // the slot there is as silent as one with no entry at all.
+      expect(
+        reportFor({ providerOptions: { from: ["clone"] } }, twoMeaningsTree())
+          .undecidedOptions,
+      ).toEqual(["--from  (diff)"]);
+    });
+
+    it("takes no bare allowance for an option a provider answers somewhere", () => {
+      // `--from` has candidates on `clone`, so a bare allowance saying it has
+      // none is false wherever it is read; the other command needs its own.
+      const bare = reportFor(
+        { providerOptions: { from: ["clone"] }, allowedOptions: ["from"] },
+        twoMeaningsTree(),
+      );
+      expect(bare.undecidedOptions).toEqual(["--from  (diff)"]);
+      expect(bare.staleAllowlist).toEqual(["--from"]);
+
+      const scoped = reportFor(
+        { providerOptions: { from: ["clone"] }, allowedOptions: ["diff:from"] },
+        twoMeaningsTree(),
+      );
+      expect(scoped.undecidedOptions).toEqual([]);
+      expect(scoped.staleAllowlist).toEqual([]);
     });
 
     it("names a positional with no provider and no allowance", () => {
@@ -111,24 +171,49 @@ describe("check-completion-slots", () => {
       // The same subtraction the other way: this is what found `log-file` and
       // `state-path`, which belonged to commands declaring no Cliffy options.
       expect(
-        reportFor({ providerOptions: ["log-file"], providerArguments: ["x:y"] })
+        reportFor({
+          providerOptions: everywhere("log-file"),
+          providerArguments: ["x:y"],
+        })
           .unreachableProviders,
       ).toEqual(["--log-file", "x:y"]);
     });
 
-    it("names an allowlist entry that matches no slot on the tree", () => {
+    it("names a command a scoped provider claims and the tree does not", () => {
+      // A scope naming a command that never declared the option is the same
+      // dead entry, one level down.
+      expect(
+        reportFor(
+          { providerOptions: { from: ["clone", "pull"] } },
+          twoMeaningsTree(),
+        ).unreachableProviders,
+      ).toEqual(["--from  (pull)"]);
+    });
+
+    it("names an allowlist entry that decides no slot", () => {
       // A decision cannot outlive the thing it was about.
       expect(
         reportFor({ allowedOptions: ["gone"], allowedPositionals: ["gone:x"] })
           .staleAllowlist,
       ).toEqual(["--gone", "gone:x"]);
     });
+
+    it("names an allowance for a slot a provider already answers", () => {
+      // Two records of one decision, disagreeing: the provider offers
+      // candidates the allowance says are not there.
+      expect(
+        reportFor({
+          providerOptions: everywhere("select"),
+          allowedOptions: ["get:select"],
+        }).staleAllowlist,
+      ).toEqual(["--select  (get)"]);
+    });
   });
 
   describe("describeFailures()", () => {
     it("returns nothing when the report is empty", () => {
       expect(describeFailures(reportFor({
-        providerOptions: ["space", "select"],
+        providerOptions: everywhere("space", "select"),
         providerArguments: ["get:path"],
       }))).toEqual([]);
     });
@@ -148,8 +233,10 @@ describe("check-completion-slots", () => {
     });
 
     it("records a reason for every allowance, so none is a bare exemption", () => {
+      // Trimmed, because a blank reason and a spaces-only one exempt a slot
+      // just as silently.
       for (const [key, reason] of [...NO_CANDIDATES, ...NO_OPTION_CANDIDATES]) {
-        expect(reason.length, `${key} has no reason`).toBeGreaterThan(0);
+        expect(reason.trim().length, `${key} has no reason`).toBeGreaterThan(0);
       }
     });
   });

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Command } from "@cliffy/command";
+import { declaredSlots } from "../packages/cli/lib/completion/line.ts";
 import {
-  collectSlots,
   describeFailures,
   main,
   NO_CANDIDATES,
@@ -57,7 +57,7 @@ function reportFor(known: {
   allowedPositionals?: string[];
   // deno-lint-ignore no-explicit-any
 }, tree: Command<any> = fixtureTree()): SlotReport {
-  return reportSlots(collectSlots(tree), {
+  return reportSlots(declaredSlots(tree), {
     providerOptions: new Map(Object.entries(known.providerOptions ?? {})),
     providerArguments: new Set(known.providerArguments ?? []),
     enumerated: new Set(known.enumerated ?? []),
@@ -66,31 +66,46 @@ function reportFor(known: {
   });
 }
 
+/**
+ * A tree whose slots the real provider tables have never heard of, which is
+ * what a command looks like the day it lands.
+ */
+function unknownTree() {
+  return new Command()
+    .name("cf")
+    .command(
+      "fixture",
+      new Command()
+        .description("a command no provider table names")
+        .option("--fixture-flag <value:string>", "a value nothing provides")
+        .arguments("<fixtureArg:string>"),
+    );
+}
+
+/** Run `body` with console output captured, as the other task tests do. */
+function captureConsole(
+  body: () => number,
+): { code: number; out: string; err: string } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args) => out.push(args.map(String).join(" "));
+  console.error = (...args) => err.push(args.map(String).join(" "));
+  try {
+    return { code: body(), out: out.join("\n"), err: err.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}
+
 /** `providerOptions` for names whose provider answers on every command. */
 function everywhere(...names: string[]): Record<string, null> {
   return Object.fromEntries(names.map((name) => [name, null]));
 }
 
 describe("check-completion-slots", () => {
-  describe("collectSlots()", () => {
-    it("names a value-taking option by its long name and where it was found", () => {
-      const { options } = collectSlots(fixtureTree());
-      expect(options.get("space")).toEqual(["<root>"]);
-      expect(options.get("select")).toEqual(["get"]);
-    });
-
-    it("returns no entry for an option that takes no value", () => {
-      // A flag has nothing to complete, so it is not a slot.
-      expect(collectSlots(fixtureTree()).options.has("quiet")).toBe(false);
-    });
-
-    it("keys a positional by its command path and argument name", () => {
-      expect(collectSlots(fixtureTree()).positionals).toEqual([
-        { key: "get:path", where: "get" },
-      ]);
-    });
-  });
-
   describe("reportSlots()", () => {
     it("names an option with no provider, no enumerated set and no allowance", () => {
       const report = reportFor({});
@@ -223,6 +238,20 @@ describe("check-completion-slots", () => {
       expect(text).toContain("NO_OPTION_CANDIDATES");
       expect(text).toContain("NO_CANDIDATES");
     });
+
+    it("names the entry to delete when one reaches nothing", () => {
+      // The subtraction run the other way has its own paragraph, and it has to
+      // name the dead entry: the fix is to delete that line, not to add a slot.
+      const text = describeFailures(reportFor({
+        providerOptions: everywhere("space", "select", "log-file"),
+        providerArguments: ["get:path"],
+        allowedOptions: ["gone"],
+      })).join("\n");
+      expect(text).toContain("provider entr(ies) match no slot");
+      expect(text).toContain("--log-file");
+      expect(text).toContain("allowlist entr(ies) decide no slot");
+      expect(text).toContain("--gone");
+    });
   });
 
   describe("main()", () => {
@@ -230,6 +259,30 @@ describe("check-completion-slots", () => {
       // The gate itself. Every slot the CLI declares is answered by a provider,
       // by an enumerated set, or by an allowlist entry carrying its reason.
       expect(main()).toBe(0);
+    });
+
+    it("fails a slot no table names, printing the finding and the remedy", () => {
+      const { code, err } = captureConsole(() => main([], unknownTree()));
+      expect(code).toBe(1);
+      expect(err).toContain("--fixture-flag  (fixture)");
+      expect(err).toContain("fixture:fixtureArg");
+      expect(err).toContain("Either give the slot candidates");
+      // Nothing the tables name is on this tree, so the subtraction the other
+      // way reports every entry at once.
+      expect(err).toContain("provider entr(ies) match no slot");
+    });
+
+    it("lists the undecided slots and succeeds when asked for the list", () => {
+      // `--list` is the working view: it answers what is undecided without
+      // failing, so the list can be read while it is worked through.
+      const { code, out } = captureConsole(() =>
+        main(["--list"], unknownTree())
+      );
+      expect(code).toBe(0);
+      expect(out).toContain("Undecided options:");
+      expect(out).toContain("--fixture-flag  (fixture)");
+      expect(out).toContain("Undecided positionals:");
+      expect(out).toContain("fixture:fixtureArg");
     });
 
     it("records a reason for every allowance, so none is a bare exemption", () => {

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Command } from "@cliffy/command";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import { declaredSlots } from "../packages/cli/lib/completion/line.ts";
 import {
   describeFailures,
@@ -98,6 +100,33 @@ function captureConsole(
     console.log = origLog;
     console.error = origError;
   }
+}
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** Run the gate the way its task does, and return what the process reported. */
+async function runAsProgram(
+  ...args: string[]
+): Promise<{ code: number; out: string }> {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    args: (lockPath) => [
+      "run",
+      "--config",
+      join(REPO_ROOT, "deno.jsonc"),
+      "--lock",
+      lockPath,
+      // The permissions deno.jsonc grants the task, so a run that needs more
+      // than the task allows fails here rather than in CI.
+      "--allow-read",
+      "--allow-env",
+      "--allow-sys",
+      "--allow-ffi",
+      join(REPO_ROOT, "tasks/check-completion-slots.ts"),
+      ...args,
+    ],
+  });
+  return { code: output.code, out: new TextDecoder().decode(output.stdout) };
 }
 
 /** `providerOptions` for names whose provider answers on every command. */
@@ -291,6 +320,26 @@ describe("check-completion-slots", () => {
       for (const [key, reason] of [...NO_CANDIDATES, ...NO_OPTION_CANDIDATES]) {
         expect(reason.trim().length, `${key} has no reason`).toBeGreaterThan(0);
       }
+    });
+  });
+
+  describe("as the task runs it", () => {
+    // Calling main() above would still pass if the entry point never ran it,
+    // or if the permissions the task declares were too narrow to walk the
+    // tree. This is the promise the CI job makes: the command exits 0, having
+    // done the work.
+    it("exits 0 reporting the slots it walked", async () => {
+      const { code, out } = await runAsProgram();
+      expect(code).toBe(0);
+      expect(out).toContain("Completion slots OK");
+      expect(out).toMatch(/\d+ option slot\(s\) over \d+ name\(s\)/);
+    });
+
+    it("exits 0 listing what is undecided when asked for the list", async () => {
+      const { code, out } = await runAsProgram("--list");
+      expect(code).toBe(0);
+      expect(out).toContain("Undecided options:");
+      expect(out).toContain("Undecided positionals:");
     });
   });
 });

--- a/tasks/check-completion-slots.test.ts
+++ b/tasks/check-completion-slots.test.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Command } from "@cliffy/command";
+import {
+  collectSlots,
+  describeFailures,
+  main,
+  NO_CANDIDATES,
+  NO_OPTION_CANDIDATES,
+  reportSlots,
+  type SlotReport,
+} from "./check-completion-slots.ts";
+
+/** A small tree in the shape the CLI's own is: nested commands, each with its
+ * own options and positionals. */
+function fixtureTree() {
+  return new Command()
+    .name("cf")
+    .option("--space <space:string>", "a space")
+    .option("--quiet", "no value, so not a slot")
+    .command("piece", new Command().description("piece things"))
+    .command(
+      "get",
+      new Command()
+        .description("read")
+        .option("--select <fields:string>", "a projection")
+        .arguments("<path:string>"),
+    );
+}
+
+/** The report for `fixtureTree()`, told about `known`. */
+function reportFor(known: {
+  providerOptions?: string[];
+  providerArguments?: string[];
+  enumerated?: string[];
+  allowedOptions?: string[];
+  allowedPositionals?: string[];
+}): SlotReport {
+  return reportSlots(collectSlots(fixtureTree()), {
+    providerOptions: new Set(known.providerOptions ?? []),
+    providerArguments: new Set(known.providerArguments ?? []),
+    enumerated: new Set(known.enumerated ?? []),
+    allowedOptions: new Set(known.allowedOptions ?? []),
+    allowedPositionals: new Set(known.allowedPositionals ?? []),
+  });
+}
+
+describe("check-completion-slots", () => {
+  describe("collectSlots()", () => {
+    it("names a value-taking option by its long name and where it was found", () => {
+      const { options } = collectSlots(fixtureTree());
+      expect(options.get("space")).toEqual(["<root>"]);
+      expect(options.get("select")).toEqual(["get"]);
+    });
+
+    it("returns no entry for an option that takes no value", () => {
+      // A flag has nothing to complete, so it is not a slot.
+      expect(collectSlots(fixtureTree()).options.has("quiet")).toBe(false);
+    });
+
+    it("keys a positional by its command path and argument name", () => {
+      expect(collectSlots(fixtureTree()).positionals).toEqual([
+        { key: "get:path", where: "get" },
+      ]);
+    });
+  });
+
+  describe("reportSlots()", () => {
+    it("names an option with no provider, no enumerated set and no allowance", () => {
+      const report = reportFor({});
+      expect(report.undecidedOptions).toEqual([
+        "--select  (get)",
+        "--space  (<root>)",
+      ]);
+    });
+
+    it("returns no finding for an option a provider answers", () => {
+      expect(
+        reportFor({ providerOptions: ["space", "select"] }).undecidedOptions,
+      )
+        .toEqual([]);
+    });
+
+    it("returns no finding for an option an enumerated set answers", () => {
+      expect(
+        reportFor({ providerOptions: ["space"], enumerated: ["select"] })
+          .undecidedOptions,
+      ).toEqual([]);
+    });
+
+    it("returns no finding for an option the allowlist records a reason for", () => {
+      expect(
+        reportFor({ providerOptions: ["space"], allowedOptions: ["select"] })
+          .undecidedOptions,
+      ).toEqual([]);
+    });
+
+    it("names a positional with no provider and no allowance", () => {
+      expect(reportFor({}).undecidedPositionals).toEqual(["get:path"]);
+      expect(
+        reportFor({ providerArguments: ["get:path"] }).undecidedPositionals,
+      )
+        .toEqual([]);
+      expect(
+        reportFor({ allowedPositionals: ["get:path"] }).undecidedPositionals,
+      )
+        .toEqual([]);
+    });
+
+    it("names a provider entry that matches no slot on the tree", () => {
+      // The same subtraction the other way: this is what found `log-file` and
+      // `state-path`, which belonged to commands declaring no Cliffy options.
+      expect(
+        reportFor({ providerOptions: ["log-file"], providerArguments: ["x:y"] })
+          .unreachableProviders,
+      ).toEqual(["--log-file", "x:y"]);
+    });
+
+    it("names an allowlist entry that matches no slot on the tree", () => {
+      // A decision cannot outlive the thing it was about.
+      expect(
+        reportFor({ allowedOptions: ["gone"], allowedPositionals: ["gone:x"] })
+          .staleAllowlist,
+      ).toEqual(["--gone", "gone:x"]);
+    });
+  });
+
+  describe("describeFailures()", () => {
+    it("returns nothing when the report is empty", () => {
+      expect(describeFailures(reportFor({
+        providerOptions: ["space", "select"],
+        providerArguments: ["get:path"],
+      }))).toEqual([]);
+    });
+
+    it("names the table to edit for each kind of finding", () => {
+      const text = describeFailures(reportFor({})).join("\n");
+      expect(text).toContain("NO_OPTION_CANDIDATES");
+      expect(text).toContain("NO_CANDIDATES");
+    });
+  });
+
+  describe("main()", () => {
+    it("returns 0 for the CLI's own command tree", () => {
+      // The gate itself. Every slot the CLI declares is answered by a provider,
+      // by an enumerated set, or by an allowlist entry carrying its reason.
+      expect(main()).toBe(0);
+    });
+
+    it("records a reason for every allowance, so none is a bare exemption", () => {
+      for (const [key, reason] of [...NO_CANDIDATES, ...NO_OPTION_CANDIDATES]) {
+        expect(reason.length, `${key} has no reason`).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env -S deno run --allow-read --allow-env --allow-sys --allow-ffi
+/**
+ * Fails when a slot the CLI accepts has not been decided about for completion.
+ *
+ * Completion trails the command surface, and it does so silently. The resolver
+ * walks the live Cliffy tree, so a new subcommand or flag becomes completable
+ * the moment it is registered; its VALUES do not, because they come from two
+ * hand-maintained tables. A command reaching the tree with no entry in either
+ * is indistinguishable at the prompt from one whose fabric is unreachable —
+ * both offer nothing — so the drift never announces itself.
+ *
+ * Both provider keys are derivable from the same tree the resolver walks: an
+ * option's long name, and `<command path>:<argument name>`. So the drift is
+ * machine-detectable, in three directions:
+ *
+ * - A slot with no provider, no enumerated set, and no allowlist entry.
+ * - A provider entry matching no slot on the tree — the same subtraction run
+ *   the other way, which is what found `log-file` and `state-path` belonging
+ *   to commands that declare no Cliffy options at all.
+ * - An allowlist entry matching no slot, so the record of a decision cannot
+ *   outlive the thing it was about.
+ *
+ * What this cannot decide is whether a slot SHOULD complete — plenty should
+ * not. What it requires is that every slot has been decided about, which is
+ * what the allowlists record. That turns the next command's completion from
+ * something remembered into something the gate asks for.
+ *
+ * Usage: deno task check-completion-slots
+ *        deno task check-completion-slots --list   # every undecided slot
+ */
+
+import type { Command } from "@cliffy/command";
+import { main as cliRoot } from "../packages/cli/commands/main.ts";
+import { enumeratedOptionNames } from "../packages/cli/lib/completion/static.ts";
+import { completionProviderKeys } from "../packages/cli/lib/completion/providers.ts";
+
+/**
+ * Positionals deliberately left without candidates, each with the reason.
+ *
+ * A reason here answers one question: what would the candidates BE? A value a
+ * caller pastes from elsewhere, a word they are coining, or a number has no set
+ * to draw from, and offering a wrong one is worse than offering none.
+ */
+export const NO_CANDIDATES = new Map<string, string>([
+  // Values a caller brings from outside the CLI.
+  ["acl set:did", "a DID being granted access; nothing here enumerates them"],
+  ["acl remove:did", "the same DID, and the same absence of a source"],
+  ["inspect identity:did", "a DID to look up, pasted from elsewhere"],
+  ["id derive:passphrase", "a secret; a candidate list is the wrong place"],
+  ["id from-mnemonic:mnemonic", "the same"],
+  ["ingest revoke:id", "an ingest key id, held by whoever minted it"],
+  ["ingest rotate:id", "the same"],
+  // Words the caller is coining or composing.
+  ["acl set:capability", "a capability string, composed rather than chosen"],
+  ["piece search:query", "a search query"],
+  // Words that belong to a callable rather than to the CLI. Item 4 of
+  // docs/plans/cli-completion-coverage.md builds the candidates; which slot
+  // receives them waits on step 10 of docs/plans/cli-surface-shape.md.
+  ["call:tail", "the callable's own vocabulary"],
+  ["piece call:tail", "the same"],
+  ["exec:tail", "the same"],
+]);
+
+/**
+ * Options deliberately left without candidates, keyed by long name.
+ *
+ * The same question, answered per option rather than per slot: an entry here is
+ * a value with no set to draw from, or one whose set would cost more to derive
+ * than the keystrokes it saves.
+ */
+export const NO_OPTION_CANDIDATES = new Map<string, string>([
+  // Numbers, durations and bounds. Nothing enumerates a count.
+  ["limit", "a row count"],
+  ["depth", "a graph depth"],
+  ["seq", "a revision sequence number"],
+  ["top", "a result count"],
+  ["bucket", "a time bucket size"],
+  ["since", "a timestamp"],
+  ["until", "a timestamp"],
+  ["ttl-days", "a lifetime in days"],
+  ["timeout", "a timeout in milliseconds"],
+  ["attrcache-timeout", "a timeout in seconds, passed to the FUSE child"],
+  ["stats-action-limit", "a count"],
+  ["stats-threshold", "a threshold"],
+  ["storage-stats-limit", "a count"],
+  ["wait", "a patience in seconds"],
+  // Identifiers the caller brings from outside, or coins.
+  ["did", "a DID, pasted from elsewhere"],
+  ["as", "a DID whose view to approximate, pasted from elsewhere"],
+  ["slug", "a slug being coined for the first time"],
+  ["invocation", "the caller's own word for one call"],
+  ["invocation-session", "an unguessable session string"],
+  ["install-id", "the caller's own installation identifier"],
+  ["cause-prefix", "a prefix the caller chooses"],
+  ["name", "a name the caller chooses"],
+  ["session", "a session id, read out of the data being inspected"],
+  ["branch", "a branch name; the default is the empty one"],
+  ["cfc-xattr-namespace", "a namespace the caller chooses"],
+  // Expressions and lists with their own grammar.
+  ["filter", "a jq-inspired predicate expression"],
+  ["path", "a cell path relative to a target the flag does not name"],
+  ["path-json", "the same path written as a JSON array"],
+  ["spaces", "a comma-separated list of the tokens --space takes"],
+  ["stats-include", "a comma-separated list of timing categories"],
+  ["import", "an import specifier"],
+  // Values naming something outside the fabric.
+  ["url", "a browser URL; its parts complete as --api-url, --space, --piece"],
+  ["app-url", "a shell origin, which is not the api-url --api-url names"],
+  ["repository", "a source repository URL"],
+  [
+    "main-export",
+    "an export name inside a pattern file, which needs the file compiled",
+  ],
+  ["filename", "a display name for what `cf view` is rendering"],
+]);
+
+/** One positional the tree declares, and where it was found. */
+export interface PositionalSlot {
+  readonly key: string;
+  readonly where: string;
+}
+
+/** Every value-taking option and every positional a command tree declares. */
+export interface DeclaredSlots {
+  /** Option long name -> the command paths declaring it. */
+  readonly options: Map<string, string[]>;
+  readonly positionals: PositionalSlot[];
+}
+
+/** What the check found, in the three directions it looks. */
+export interface SlotReport {
+  /** Options with no provider, no enumerated set, and no allowlist entry. */
+  readonly undecidedOptions: string[];
+  /** Positionals with no provider and no allowlist entry. */
+  readonly undecidedPositionals: string[];
+  /** Provider entries matching no slot on the tree. */
+  readonly unreachableProviders: string[];
+  /** Allowlist entries matching no slot on the tree. */
+  readonly staleAllowlist: string[];
+}
+
+/** Long name of an option, without leading dashes. */
+function longName(option: { flags: string[] }): string {
+  const long = option.flags.find((flag) => flag.startsWith("--"));
+  return (long ?? option.flags[0] ?? "").replace(/^-+/, "");
+}
+
+/**
+ * Walk a command tree the way `resolveCompletionLine` walks it: Cliffy's
+ * generated `help` is skipped, because it is propagated to every descendant
+ * and is nobody's slot.
+ */
+export function collectSlots(
+  // deno-lint-ignore no-explicit-any
+  root: Command<any>,
+): DeclaredSlots {
+  const options = new Map<string, string[]>();
+  const positionals: PositionalSlot[] = [];
+  // deno-lint-ignore no-explicit-any
+  const walk = (command: Command<any>, path: readonly string[]): void => {
+    const where = path.join(" ") || "<root>";
+    for (const option of command.getOptions(false)) {
+      if ((option.args?.length ?? 0) === 0) continue;
+      const name = longName(option);
+      const seen = options.get(name) ?? [];
+      if (!seen.includes(where)) seen.push(where);
+      options.set(name, seen);
+    }
+    for (const argument of command.getArguments()) {
+      positionals.push({ key: `${path.join(" ")}:${argument.name}`, where });
+    }
+    for (const child of command.getCommands(false)) {
+      if (child.getName() === "help") continue;
+      walk(child, [...path, child.getName()]);
+    }
+  };
+  walk(root, []);
+  return { options, positionals };
+}
+
+/** Subtract what completion decides about from what the tree declares. */
+export function reportSlots(
+  declared: DeclaredSlots,
+  known: {
+    readonly providerOptions: ReadonlySet<string>;
+    readonly providerArguments: ReadonlySet<string>;
+    readonly enumerated: ReadonlySet<string>;
+    readonly allowedOptions: ReadonlySet<string>;
+    readonly allowedPositionals: ReadonlySet<string>;
+  },
+): SlotReport {
+  const undecidedOptions: string[] = [];
+  for (const [name, where] of [...declared.options].sort()) {
+    if (known.providerOptions.has(name)) continue;
+    if (known.enumerated.has(name)) continue;
+    if (known.allowedOptions.has(name)) continue;
+    undecidedOptions.push(`--${name}  (${where.join(", ")})`);
+  }
+
+  const undecidedPositionals: string[] = [];
+  for (
+    const slot of [...declared.positionals].sort((a, b) =>
+      a.key.localeCompare(b.key)
+    )
+  ) {
+    if (known.providerArguments.has(slot.key)) continue;
+    if (known.allowedPositionals.has(slot.key)) continue;
+    undecidedPositionals.push(slot.key);
+  }
+
+  const positionalKeys = new Set(
+    declared.positionals.map((slot) => slot.key),
+  );
+  const unreachableProviders: string[] = [];
+  for (const name of known.providerOptions) {
+    if (!declared.options.has(name)) unreachableProviders.push(`--${name}`);
+  }
+  for (const key of known.providerArguments) {
+    if (!positionalKeys.has(key)) unreachableProviders.push(key);
+  }
+
+  const staleAllowlist: string[] = [];
+  for (const key of known.allowedPositionals) {
+    if (!positionalKeys.has(key)) staleAllowlist.push(key);
+  }
+  for (const name of known.allowedOptions) {
+    if (!declared.options.has(name)) staleAllowlist.push(`--${name}`);
+  }
+
+  return {
+    undecidedOptions,
+    undecidedPositionals,
+    unreachableProviders: unreachableProviders.sort(),
+    staleAllowlist: staleAllowlist.sort(),
+  };
+}
+
+/** The failures a report describes, one paragraph each. */
+export function describeFailures(report: SlotReport): string[] {
+  const failures: string[] = [];
+  const block = (lines: readonly string[]) =>
+    lines.map((line) => `  ${line}`).join("\n");
+  if (report.undecidedOptions.length > 0) {
+    failures.push(
+      `${report.undecidedOptions.length} value-taking option(s) have no ` +
+        `provider, no enumerated set, and no entry in NO_OPTION_CANDIDATES:\n` +
+        block(report.undecidedOptions),
+    );
+  }
+  if (report.undecidedPositionals.length > 0) {
+    failures.push(
+      `${report.undecidedPositionals.length} positional(s) have no provider ` +
+        `and no entry in NO_CANDIDATES:\n` +
+        block(report.undecidedPositionals),
+    );
+  }
+  if (report.unreachableProviders.length > 0) {
+    failures.push(
+      `${report.unreachableProviders.length} provider entr(ies) match no slot ` +
+        `on the command tree:\n` + block(report.unreachableProviders),
+    );
+  }
+  if (report.staleAllowlist.length > 0) {
+    failures.push(
+      `${report.staleAllowlist.length} allowlist entr(ies) match no slot:\n` +
+        block(report.staleAllowlist),
+    );
+  }
+  return failures;
+}
+
+/** Run the check against the real CLI tree. Returns the process exit code. */
+export function main(args: readonly string[] = []): number {
+  const declared = collectSlots(cliRoot);
+  const providers = completionProviderKeys();
+  const report = reportSlots(declared, {
+    providerOptions: providers.options,
+    providerArguments: providers.arguments,
+    enumerated: enumeratedOptionNames(),
+    allowedOptions: new Set(NO_OPTION_CANDIDATES.keys()),
+    allowedPositionals: new Set(NO_CANDIDATES.keys()),
+  });
+
+  if (args.includes("--list")) {
+    console.log("Undecided options:");
+    for (const line of report.undecidedOptions) console.log(`  ${line}`);
+    console.log("Undecided positionals:");
+    for (const line of report.undecidedPositionals) console.log(`  ${line}`);
+    return 0;
+  }
+
+  const failures = describeFailures(report);
+  if (failures.length > 0) {
+    console.error("Completion slot check failed.\n");
+    console.error(failures.join("\n\n"));
+    console.error(
+      "\nEither give the slot candidates in packages/cli/lib/completion/, or " +
+        "record why it has none in tasks/check-completion-slots.ts.",
+    );
+    return 1;
+  }
+
+  console.log(
+    `Completion slots OK (${declared.options.size} option name(s), ` +
+      `${declared.positionals.length} positional(s)).`,
+  );
+  return 0;
+}
+
+if (import.meta.main) Deno.exit(main(Deno.args));

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -35,8 +35,12 @@
  *        deno task check-completion-slots --list   # every undecided slot
  */
 
-import type { Command } from "@cliffy/command";
 import { main as cliRoot } from "../packages/cli/commands/main.ts";
+import {
+  type AnyCommand,
+  type DeclaredSlots,
+  declaredSlots,
+} from "../packages/cli/lib/completion/line.ts";
 import { enumeratedOptionNames } from "../packages/cli/lib/completion/static.ts";
 import { completionProviderKeys } from "../packages/cli/lib/completion/providers.ts";
 
@@ -161,19 +165,6 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
   ["wish:schema", "the same"],
 ]);
 
-/** One positional the tree declares, and where it was found. */
-export interface PositionalSlot {
-  readonly key: string;
-  readonly where: string;
-}
-
-/** Every value-taking option and every positional a command tree declares. */
-export interface DeclaredSlots {
-  /** Option long name -> the command paths declaring it. */
-  readonly options: Map<string, string[]>;
-  readonly positionals: PositionalSlot[];
-}
-
 /** What the check found, in the three directions it looks. */
 export interface SlotReport {
   /**
@@ -187,45 +178,6 @@ export interface SlotReport {
   readonly unreachableProviders: string[];
   /** Allowlist entries that decide no slot on the tree. */
   readonly staleAllowlist: string[];
-}
-
-/** Long name of an option, without leading dashes. */
-function longName(option: { flags: string[] }): string {
-  const long = option.flags.find((flag) => flag.startsWith("--"));
-  return (long ?? option.flags[0] ?? "").replace(/^-+/, "");
-}
-
-/**
- * Walk a command tree the way `resolveCompletionLine` walks it: Cliffy's
- * generated `help` is skipped, because it is propagated to every descendant
- * and is nobody's slot.
- */
-export function collectSlots(
-  // deno-lint-ignore no-explicit-any
-  root: Command<any>,
-): DeclaredSlots {
-  const options = new Map<string, string[]>();
-  const positionals: PositionalSlot[] = [];
-  // deno-lint-ignore no-explicit-any
-  const walk = (command: Command<any>, path: readonly string[]): void => {
-    const where = path.join(" ") || "<root>";
-    for (const option of command.getOptions(false)) {
-      if ((option.args?.length ?? 0) === 0) continue;
-      const name = longName(option);
-      const seen = options.get(name) ?? [];
-      if (!seen.includes(where)) seen.push(where);
-      options.set(name, seen);
-    }
-    for (const argument of command.getArguments()) {
-      positionals.push({ key: `${path.join(" ")}:${argument.name}`, where });
-    }
-    for (const child of command.getCommands(false)) {
-      if (child.getName() === "help") continue;
-      walk(child, [...path, child.getName()]);
-    }
-  };
-  walk(root, []);
-  return { options, positionals };
 }
 
 /** An option slot as a failure line reads it: the flag, and where it is. */
@@ -371,9 +323,15 @@ export function describeFailures(report: SlotReport): string[] {
   return failures;
 }
 
-/** Run the check against the real CLI tree. Returns the process exit code. */
-export function main(args: readonly string[] = []): number {
-  const declared = collectSlots(cliRoot);
+/**
+ * Run the check against a command tree — the CLI's own unless another is given
+ * — and return the process exit code.
+ */
+export function main(
+  args: readonly string[] = [],
+  root: AnyCommand = cliRoot,
+): number {
+  const declared = declaredSlots(root);
   const providers = completionProviderKeys();
   const report = reportSlots(declared, {
     providerOptions: providers.options,

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -103,6 +103,10 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
   ["spaces", "a comma-separated list of the tokens --space takes"],
   ["stats-include", "a comma-separated list of timing categories"],
   ["import", "an import specifier"],
+  [
+    "retarget",
+    "a `<phase>=<main.tsx>[@rev]` spec, composed rather than chosen",
+  ],
   // Values naming something outside the fabric.
   ["url", "a browser URL; its parts complete as --api-url, --space, --piece"],
   ["app-url", "a shell origin, which is not the api-url --api-url names"],

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -9,16 +9,22 @@
  * is indistinguishable at the prompt from one whose fabric is unreachable —
  * both offer nothing — so the drift never announces itself.
  *
- * Both provider keys are derivable from the same tree the resolver walks: an
- * option's long name, and `<command path>:<argument name>`. So the drift is
+ * Both provider tables answer in command paths, and both are derivable from
+ * the same tree the resolver walks: a positional entry is keyed by
+ * `<command path>:<argument name>`, and an option entry carries the commands
+ * its provider answers on wherever it answers on some of them. So the drift is
  * machine-detectable, in three directions:
  *
  * - A slot with no provider, no enumerated set, and no allowlist entry.
  * - A provider entry matching no slot on the tree — the same subtraction run
  *   the other way, which is what found `log-file` and `state-path` belonging
  *   to commands that declare no Cliffy options at all.
- * - An allowlist entry matching no slot, so the record of a decision cannot
- *   outlive the thing it was about.
+ * - An allowlist entry that decides no slot, so the record of a decision
+ *   cannot outlive the thing it was about.
+ *
+ * A slot is one option ON one command, not one option name: `--from` is a
+ * snapshot file on `space clone` and a sequence number on `inspect diff`, and
+ * a provider for the first says nothing about the second.
  *
  * What this cannot decide is whether a slot SHOULD complete — plenty should
  * not. What it requires is that every slot has been decided about, which is
@@ -62,11 +68,16 @@ export const NO_CANDIDATES = new Map<string, string>([
 ]);
 
 /**
- * Options deliberately left without candidates, keyed by long name.
+ * Options deliberately left without candidates.
  *
- * The same question, answered per option rather than per slot: an entry here is
- * a value with no set to draw from, or one whose set would cost more to derive
- * than the keystrokes it saves.
+ * The same question, answered per option: an entry here is a value with no set
+ * to draw from, or one whose set would cost more to derive than the keystrokes
+ * it saves.
+ *
+ * A bare long name decides the option wherever it is declared, and is honest
+ * only where nothing provides it anywhere. An option a provider answers on one
+ * command means something else on the rest, so those are decided one at a time
+ * under `<command path>:<long name>`.
  */
 export const NO_OPTION_CANDIDATES = new Map<string, string>([
   // Numbers, durations and bounds. Nothing enumerates a count.
@@ -116,6 +127,38 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
     "an export name inside a pattern file, which needs the file compiled",
   ],
   ["filename", "a display name for what `cf view` is rendering"],
+  // The commands where an option a provider answers elsewhere means something
+  // else. `--from` and `--to` bound a range of commits here, where on
+  // `space clone` they name a snapshot file and a destination directory.
+  ["inspect diff:from", "a revision sequence number"],
+  ["inspect diff:to", "the same"],
+  // A raw scope key: `space`, `user:<did>`, or `session:<did>:<uuid>`, read
+  // out of the data being inspected — the disposition `--session`, which
+  // names the last of those parts, already carries. `inspect converge` reads
+  // across spaces, so it has no single store to read them from at all.
+  ["inspect conflicts:scope", "a stored scope key, read out of the data"],
+  ["inspect converge:scope", "the same, across every space compared"],
+  ["inspect diff:scope", "the same"],
+  ["inspect graph:scope", "the same"],
+  ["inspect history:scope", "the same"],
+  ["inspect html:scope", "the same"],
+  ["inspect piece:scope", "the same"],
+  ["inspect timeline:scope", "the same"],
+  ["inspect value-at:scope", "the same"],
+  // A projection into a VERB's result rather than into the value at a target,
+  // so its vocabulary is the verb's `outputSchema`. Item 6 of
+  // docs/plans/cli-completion-coverage.md builds it, and waits on step 10 of
+  // docs/plans/cli-surface-shape.md for the verb to precede the cursor.
+  ["call:select", "the verb's own result shape"],
+  ["call:schema", "the same"],
+  ["piece call:select", "the same"],
+  ["piece call:schema", "the same"],
+  ["exec:select", "the same"],
+  ["exec:schema", "the same"],
+  // `wish` projects what its query resolved to, and resolving a wish commits a
+  // cell to the space: a Tab must not write. Item 5's `wish` half, declined.
+  ["wish:select", "a resolution a Tab must not make"],
+  ["wish:schema", "the same"],
 ]);
 
 /** One positional the tree declares, and where it was found. */
@@ -133,13 +176,16 @@ export interface DeclaredSlots {
 
 /** What the check found, in the three directions it looks. */
 export interface SlotReport {
-  /** Options with no provider, no enumerated set, and no allowlist entry. */
+  /**
+   * Option slots — one option on one command — with no provider, no
+   * enumerated set, and no allowlist entry.
+   */
   readonly undecidedOptions: string[];
   /** Positionals with no provider and no allowlist entry. */
   readonly undecidedPositionals: string[];
   /** Provider entries matching no slot on the tree. */
   readonly unreachableProviders: string[];
-  /** Allowlist entries matching no slot on the tree. */
+  /** Allowlist entries that decide no slot on the tree. */
   readonly staleAllowlist: string[];
 }
 
@@ -182,23 +228,63 @@ export function collectSlots(
   return { options, positionals };
 }
 
+/** An option slot as a failure line reads it: the flag, and where it is. */
+function optionSlotLabel(name: string, where: string): string {
+  return `--${name}  (${where})`;
+}
+
+/** An option allowance as a failure line reads it, in either key form. */
+function allowanceLabel(key: string): string {
+  const cut = key.indexOf(":");
+  return cut === -1
+    ? `--${key}`
+    : optionSlotLabel(key.slice(cut + 1), key.slice(0, cut));
+}
+
 /** Subtract what completion decides about from what the tree declares. */
 export function reportSlots(
   declared: DeclaredSlots,
   known: {
-    readonly providerOptions: ReadonlySet<string>;
+    /**
+     * Option long name -> the command paths its provider answers on, or `null`
+     * where it answers on every command declaring the option.
+     */
+    readonly providerOptions: ReadonlyMap<string, readonly string[] | null>;
     readonly providerArguments: ReadonlySet<string>;
     readonly enumerated: ReadonlySet<string>;
     readonly allowedOptions: ReadonlySet<string>;
     readonly allowedPositionals: ReadonlySet<string>;
   },
 ): SlotReport {
+  // Every allowance that turned out to answer a slot. What is left over is a
+  // decision about something that is no longer there to decide.
+  const spent = new Set<string>();
+
   const undecidedOptions: string[] = [];
-  for (const [name, where] of [...declared.options].sort()) {
-    if (known.providerOptions.has(name)) continue;
-    if (known.enumerated.has(name)) continue;
-    if (known.allowedOptions.has(name)) continue;
-    undecidedOptions.push(`--${name}  (${where.join(", ")})`);
+  for (const [name, paths] of [...declared.options].sort()) {
+    const provided = known.providerOptions.get(name);
+    for (const where of [...paths].sort()) {
+      if (
+        provided !== undefined &&
+        (provided === null || provided.includes(where))
+      ) {
+        continue;
+      }
+      if (known.enumerated.has(name)) continue;
+      const scoped = `${where}:${name}`;
+      if (known.allowedOptions.has(scoped)) {
+        spent.add(scoped);
+        continue;
+      }
+      // A bare name decides the option across the whole tree, which is only
+      // honest where nothing provides it anywhere: an option a provider
+      // answers on one command has to be decided per command on the rest.
+      if (provided === undefined && known.allowedOptions.has(name)) {
+        spent.add(name);
+        continue;
+      }
+      undecidedOptions.push(optionSlotLabel(name, where));
+    }
   }
 
   const undecidedPositionals: string[] = [];
@@ -208,7 +294,10 @@ export function reportSlots(
     )
   ) {
     if (known.providerArguments.has(slot.key)) continue;
-    if (known.allowedPositionals.has(slot.key)) continue;
+    if (known.allowedPositionals.has(slot.key)) {
+      spent.add(slot.key);
+      continue;
+    }
     undecidedPositionals.push(slot.key);
   }
 
@@ -216,8 +305,17 @@ export function reportSlots(
     declared.positionals.map((slot) => slot.key),
   );
   const unreachableProviders: string[] = [];
-  for (const name of known.providerOptions) {
-    if (!declared.options.has(name)) unreachableProviders.push(`--${name}`);
+  for (const [name, paths] of known.providerOptions) {
+    const declaredOn = declared.options.get(name);
+    if (!declaredOn) {
+      unreachableProviders.push(`--${name}`);
+      continue;
+    }
+    for (const path of paths ?? []) {
+      if (!declaredOn.includes(path)) {
+        unreachableProviders.push(optionSlotLabel(name, path));
+      }
+    }
   }
   for (const key of known.providerArguments) {
     if (!positionalKeys.has(key)) unreachableProviders.push(key);
@@ -225,10 +323,10 @@ export function reportSlots(
 
   const staleAllowlist: string[] = [];
   for (const key of known.allowedPositionals) {
-    if (!positionalKeys.has(key)) staleAllowlist.push(key);
+    if (!spent.has(key)) staleAllowlist.push(key);
   }
-  for (const name of known.allowedOptions) {
-    if (!declared.options.has(name)) staleAllowlist.push(`--${name}`);
+  for (const key of known.allowedOptions) {
+    if (!spent.has(key)) staleAllowlist.push(allowanceLabel(key));
   }
 
   return {
@@ -246,7 +344,7 @@ export function describeFailures(report: SlotReport): string[] {
     lines.map((line) => `  ${line}`).join("\n");
   if (report.undecidedOptions.length > 0) {
     failures.push(
-      `${report.undecidedOptions.length} value-taking option(s) have no ` +
+      `${report.undecidedOptions.length} value-taking option slot(s) have no ` +
         `provider, no enumerated set, and no entry in NO_OPTION_CANDIDATES:\n` +
         block(report.undecidedOptions),
     );
@@ -266,7 +364,7 @@ export function describeFailures(report: SlotReport): string[] {
   }
   if (report.staleAllowlist.length > 0) {
     failures.push(
-      `${report.staleAllowlist.length} allowlist entr(ies) match no slot:\n` +
+      `${report.staleAllowlist.length} allowlist entr(ies) decide no slot:\n` +
         block(report.staleAllowlist),
     );
   }
@@ -299,14 +397,19 @@ export function main(args: readonly string[] = []): number {
     console.error(failures.join("\n\n"));
     console.error(
       "\nEither give the slot candidates in packages/cli/lib/completion/, or " +
-        "record why it has none in tasks/check-completion-slots.ts.",
+        "record why it has none in tasks/check-completion-slots.ts — under " +
+        "`<command path>:<name>` where the option means something else " +
+        "elsewhere.",
     );
     return 1;
   }
 
+  let optionSlots = 0;
+  for (const paths of declared.options.values()) optionSlots += paths.length;
   console.log(
-    `Completion slots OK (${declared.options.size} option name(s), ` +
-      `${declared.positionals.length} positional(s)).`,
+    `Completion slots OK (${optionSlots} option slot(s) over ` +
+      `${declared.options.size} name(s), ${declared.positionals.length} ` +
+      `positional(s)).`,
   );
   return 0;
 }


### PR DESCRIPTION
## Why

Completion falling behind the command surface is the mechanism the whole
completion plan is a list of instances of. The resolver walks the live Cliffy
tree, so a new subcommand or flag becomes completable the moment it is
registered — its **values** do not, because they come from two hand-maintained
tables. A command reaching the tree with no entry in either is indistinguishable
at the prompt from one whose fabric is unreachable: both offer nothing.

Both provider keys are derivable from the same tree the resolver walks, so the
drift is machine-detectable. This makes it so, and turns the next command's
completion from something remembered into something the gate asks for.

Item 19 of
[`docs/plans/cli-completion-coverage.md`](https://github.com/commontoolsinc/labs/blob/main/docs/plans/cli-completion-coverage.md),
which completes the mechanism #6249 started. Stacked on #6253.

## What Changed

`deno task check-completion-slots` subtracts the provider tables from the
command tree in three directions:

- a slot with no provider, no enumerated set, and no recorded reason;
- a provider entry matching no slot — item 16's subtraction, made permanent;
- an allowlist entry matching no slot, so the record of a decision cannot
  outlive the thing it was about.

It cannot decide that a slot *should* complete, and does not try. It requires
that somebody decided, and the allowlist is where a decision not to complete one
is written down with what the candidates would have been and why there are none.
A test asserts every allowance carries a reason, so none is a bare exemption.

Its first run named thirty-six options and no positionals. Three turned out to
be path-shaped and got directives rather than an allowance
(`--pattern-coverage-dir`, `--timing-measures-out`, `--cfc-writeback-state`);
the rest are counts, timestamps, pasted identifiers, coined words, and
expressions with their own grammar.

Wired into CI beside the other repo gates, listed in `AGENTS.md`'s
"Automated gates", and described in the CLI README's completion implementation
section.

## Test plan

- `deno task check-completion-slots` — "Completion slots OK (60 option name(s),
  70 positional(s))".
- `deno task test` in `tasks` — 624 passed, 0 failed, including the 18 new
  steps. They drive the report against a small synthetic Cliffy tree, so each
  direction is exercised with a slot that is genuinely missing rather than by
  asserting the real tree is clean; a separate step asserts `main()` returns 0
  for the real tree.
- `deno task check` (which covers `tasks/`), `deno fmt --check`, `deno lint`,
  `deno task check-unused-deps`, `check-single-copy-deps`, `check-deno-pins`,
  `check-package-cycles`, `check-skill-facts`.
- `tasks/ci-workflow.test.ts` and `ci-step-phases.test.ts` for the new CI step's
  shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Since review

The gate's first run against current `main` named four options on
`cf piece survey`, a command that landed after this plan's slot walk was
written — which is precisely the drift it exists to catch. They are decided
rather than allowlisted wholesale: `--side` is an enumerated pair, `--list`
takes what `--piece` takes (scoped to that command, since the name would mean
something else anywhere else), `--validator` reads a schema file, and
`--retarget` composes a spec no candidate set can offer.
