### PR TITLE
feat(piece): bulk repair — the fixer runner, its refusals, and the dry diff (stage 2, PR 1)

### DIFF
--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -154,13 +154,13 @@ mid-change is the failure this ordering exists to prevent.
 that exits zero is not a verdict: the source-update path reports success for
 a piece whose source committed but whose running instance failed to refresh.
 The instrument differs by operation: a reference operation is verified by
-the after-survey diff, while a repair is verified by re-reading the stored
+the survey-diff, while a repair is verified by re-reading the stored
 document and re-asking the fixer — a distinct read after each row's write,
 made row by row inside the same invocation, because the fixer is already in
-hand and a reference diff cannot see document work (the survey-diff refuses
-repair rows for exactly that reason). The separate command exists too: a
-dry repair over the same selection re-asks the fixer across the whole set,
-and one that comes back all-conforming is the after-pass.
+hand and the survey-diff cannot see document work, which is why it refuses
+repair rows. The whole-set after-pass is a dry run over the same selection:
+it re-asks the fixer across every piece, and one that comes back
+all-conforming is the verification an operator runs on its own.
 
 **Resume** is the precondition check again: re-running the same command
 re-derives what is outstanding, skips what landed, and stops on what moved

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -92,9 +92,10 @@ the whole collection at once and names neither the offending member nor its
 position, so finding the one bad piece among a hundred has no better method
 than bisection by hand. A survey answers it in one pass.
 
-Survey is also how the other three are judged. A survey taken before a run is
-the pre-state record the plan needs; the same survey taken afterwards is the
-verification; and the difference between them is the report of what the run
+Survey is also how the reference operations are judged. A survey taken
+before a run is the pre-state record the plan needs; the same survey taken
+afterwards is the verification; and the difference between them is the
+report of what the run
 actually did. One artifact, three uses — which is why it is built first.
 
 ## The spine
@@ -149,9 +150,14 @@ resume a re-invocation rather than a separate mode.
 not a limitation to be optimized away — a parent recomputing over children
 mid-change is the failure this ordering exists to prevent.
 
-**Verify** is a separate pass, never a side effect of applying. An apply that
-exits zero is not a verdict: the source-update path reports success for a
-piece whose source committed but whose running instance failed to refresh.
+**Verify** is a separate pass, never a side effect of applying. An apply
+that exits zero is not a verdict: the source-update path reports success for
+a piece whose source committed but whose running instance failed to refresh.
+The instrument differs by operation: a reference operation is verified by
+the after-survey diff, while a repair is verified by re-reading the stored
+document and re-asking the fixer — its own separate pass, since a reference
+diff cannot see document work, and the survey-diff refuses repair rows for
+exactly that reason.
 
 **Resume** is the precondition check again: re-running the same command
 re-derives what is outstanding, skips what landed, and stops on what moved
@@ -487,8 +493,10 @@ that looks like a complete one.
 containment result, and `retained` column — run against the live board on
 day one, it answers which pieces sit on which identity and whether anything
 registered sits outside the holder; the survey-diff, which compares a survey
-against a plan or an earlier survey and is the verification every later
-stage uses; the reference a local source produces, computed without
+against a plan or an earlier survey and is the verification every
+reference operation uses — a repair's verification is re-asking its own
+fixer, and the diff refuses repair rows rather than answering about work
+it cannot see; the reference a local source produces, computed without
 compiling; and the drill.
 
 - [x] Enumeration comes from the holder's collection, and the registry is

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -155,9 +155,12 @@ that exits zero is not a verdict: the source-update path reports success for
 a piece whose source committed but whose running instance failed to refresh.
 The instrument differs by operation: a reference operation is verified by
 the after-survey diff, while a repair is verified by re-reading the stored
-document and re-asking the fixer — its own separate pass, since a reference
-diff cannot see document work, and the survey-diff refuses repair rows for
-exactly that reason.
+document and re-asking the fixer — a distinct read after each row's write,
+made row by row inside the same invocation, because the fixer is already in
+hand and a reference diff cannot see document work (the survey-diff refuses
+repair rows for exactly that reason). The separate command exists too: a
+dry repair over the same selection re-asks the fixer across the whole set,
+and one that comes back all-conforming is the after-pass.
 
 **Resume** is the precondition check again: re-running the same command
 re-derives what is outstanding, skips what landed, and stops on what moved
@@ -549,7 +552,10 @@ it.
 means that piece needs nothing, which collapses selection, resumption, and
 verification into one mechanism:
 
-- Selection is "run the fixer, keep the pieces it would change".
+- Selection is "run the fixer over the enumerated pieces and classify":
+  the ones it would change are the work, and the ones it would not are
+  already landed — recorded as such, since a resumable artifact needs the
+  landed rows as much as the outstanding ones.
 - Resume is the same question asked again — a piece already repaired is one
   the fixer no longer changes.
 - Verification is the same question asked afterwards — a repair succeeded

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,7 +1,9 @@
 # Bulk piece operations
 
 **Status:** proposed; stage 1 — the survey library, its `cf` entry points,
-and its CI drill — is built, and every later stage is unbuilt. This is the design and build sequence for changing
+and its CI drill — is built. Stage 2's repair library — the fixer runner,
+the dry-run diff, and the refusals — is built; its `cf` entry point and
+demo act follow in a stacked change. Every later stage is unbuilt. This is the design and build sequence for changing
 many pieces in one space as one reviewable, resumable operation. Driven by
 recurring Topics board upgrades.
 
@@ -573,18 +575,18 @@ stands alone as a read-only "what would change" report; and the
 complete-document and links-intact refusals as library checks, which the
 Topics restore script hand-rolls today and should import instead.
 
-- [ ] A fixer is supplied by the caller, and adding a new kind of repair
+- [x] A fixer is supplied by the caller, and adding a new kind of repair
       requires no change to the tooling.
-- [ ] Selection, resume, and verification all derive from the fixer being a
+- [x] Selection, resume, and verification all derive from the fixer being a
       no-op, with no separately maintained predicate.
-- [ ] A dry run reports the exact per-piece document diff, and writes
+- [x] A dry run reports the exact per-piece document diff, and writes
       nothing. For a whole-document write this is a requirement, not a
       convenience.
-- [ ] A fixer that returns an incomplete document is refused rather than
+- [x] A fixer that returns an incomplete document is refused rather than
       applied, and a test proves the refusal.
-- [ ] References survive a repair that does not mention them, and a fixer
+- [x] References survive a repair that does not mention them, and a fixer
       that would rewrite one as a value is refused.
-- [ ] Re-running a completed repair writes nothing.
+- [x] Re-running a completed repair writes nothing.
 - [ ] The repair act in `packages/cli/integration/bulk-ops-demo.sh` stops
       being pending: the transcript runs a fixer live where it now shows
       the provisional spelling.
@@ -726,14 +728,13 @@ Topics rehearsal remains the place where the real pattern is exercised.
 Each is named with the stage that forces it, so none of them has to be
 settled before work starts.
 
-1. **How bulk is spelled** — *stage 3*. Whether the existing per-piece
-   commands grow a plan-file target, or bulk operations get their own group,
-   decides whether the word for "one piece" stays consistent across the
-   command surface. This interacts with
-   [CLI surface shape](cli-surface-shape.md). It is deferred on purpose: the
-   core is library code, so nothing in stage 1 waits on it, and it is settled
-   when the first write operation needs a home. Until then the survey and
-   the identity read surface wherever the thin wrapper finds cheapest.
+1. ~~**How bulk is spelled.**~~ **Resolved: the `piece` group holds every
+   piece operation, single or bulk.** The first write operation is stage 2's
+   repair, and it lands as `cf piece repair` beside `cf piece survey` and
+   `cf piece inspect`: one group, one word for "one piece", and the later
+   write stages follow the same shape. A separate bulk group would buy a
+   second home at the cost of the consistency
+   [CLI surface shape](cli-surface-shape.md) exists to protect.
 2. ~~**Where preconditions are evaluated.**~~ **Resolved: over the API, and
    stage 1 builds the read.** A piece's pattern identity is readable from a
    live deployment without running the piece — the piece inspection path
@@ -750,17 +751,18 @@ settled before work starts.
    risk from the same flag used many times. The row field keeps the record
    per row and the plan-time flag keeps the decision single; the apply reads
    only the row. See the plan encoding above.
-4. **Whether repair gets a narrow write** — *stage 2*. Two writes reach a
-   piece's stored input today. One replaces the whole document and re-runs
-   the piece against it. The other writes at a path inside the document, but
-   validates the document it lands in against the piece's schema before
-   committing — which is exactly what a document in need of repair fails, so
-   it refuses the pieces a repair exists for. That leaves "change one
-   property" as a whole-document read-modify-write per piece: a large blast
-   radius for a small change, and the same path that has been observed
-   freezing a stale schema into a live board. Either repair gets a path write
-   that can be told to skip that validation, or the design accepts the wide
-   one and says why.
+4. ~~**Whether repair gets a narrow write.**~~ **Resolved: the wide write,
+   guarded.** The fixer contract already produces a whole document, so the
+   wide write is the one that matches it, and the blast radius is held by
+   refusals rather than by narrowing: an incomplete document is refused
+   before any write, a reference either round-trips untouched or the
+   document is refused, and purity is probed on every evaluation. What made
+   the narrow write attractive — sparing untouched fields and references —
+   the guards deliver at the document level: a raw read written back whole
+   carries its sigil links intact, measured at the library seam. A narrow
+   path write remains available as a later addition if rehearsal shows the
+   wide write's cost, but it would be a new runner write primitive and is
+   not what repair waits on.
 5. ~~**How a fixer is supplied.**~~ **Resolved: a validator is a JSON
    schema; a fixer is a TypeScript module the run imports.** A module can be
    type-checked against the document shape, tested without a space, and

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -321,12 +321,9 @@ piece and pieces controllers they call — the layer that owns piece
 operations, and one from which the runner's local-program resolution is
 importable, so turning a row's source into a program belongs there too.
 There they are tested on the package's own runtime fixtures, with no command
-surface at all. Only a small wrapper in the CLI has to decide whether this is
-spelled as a subcommand of an existing group, a group of its own, or
-something else — so that decision is genuinely deferred rather than quietly
-made, and the first increment does not wait on it. A decision made when the
-first *write* operation needs a home is made with more information than one
-made now.
+surface at all. Only a small wrapper in the CLI carries the spelling, which
+decision 1 has since settled: the `piece` group holds every piece operation,
+single or bulk.
 
 **Two selectors to start, and the collection one carries the order.** A
 selector is a value handed to the survey. `{kind: "collection", holder,
@@ -520,8 +517,8 @@ compiling; and the drill.
       survey, reporting per piece moved as planned, still outstanding, or
       moved to something the plan did not ask for.
 - [x] The survey and the pin read are invocable from `cf`
-      (`cf piece survey`, `cf piece inspect --pattern-identity`),
-      provisionally spelled per decision 1.
+      (`cf piece survey`, `cf piece inspect --pattern-identity`), the
+      spelling decision 1 has since confirmed.
 - [x] The stage-1 drill runs in continuous integration, under the CLI
       integration suite's `piece-call` section.
 
@@ -608,8 +605,8 @@ a verdict, and the two stay separate invocations.
 per-piece
 timing, where the number from the first rehearsal run decides whether
 siblings may run concurrently and whether stage 5 is worth building; and the
-retarget drill. This is also the stage at which the entry point gets its
-spelling (decision 1).
+retarget drill. The entry point's spelling follows decision 1: the `piece`
+group.
 
 - [ ] A retarget of a seeded board runs to completion from a checked-in plan.
 - [ ] Preconditions are proved for every row before the first write.
@@ -733,7 +730,7 @@ settled before work starts.
    repair, and it lands as `cf piece repair` beside `cf piece survey` and
    `cf piece inspect`: one group, one word for "one piece", and the later
    write stages follow the same shape. A separate bulk group would buy a
-   second home at the cost of the consistency
+   second home at the cost of the consistency that
    [CLI surface shape](cli-surface-shape.md) exists to protect.
 2. ~~**Where preconditions are evaluated.**~~ **Resolved: over the API, and
    stage 1 builds the read.** A piece's pattern identity is readable from a

--- a/packages/piece/src/ops/bulk-diff.ts
+++ b/packages/piece/src/ops/bulk-diff.ts
@@ -12,7 +12,10 @@
  * like). Rows without an op are a pre-state record and diff to
  * `unchanged`/`changed`. Every comparison is on the full executable pointer,
  * `{identity, symbol}` — an identity alone conflates two patterns one module
- * exports.
+ * exports. A plan carrying repair rows is refused outright: a repair moves
+ * the document and not the reference, so a reference diff would answer
+ * `unchanged` about work it cannot see — re-running the fixer is that
+ * verification, and it lives with the repair.
  */
 
 import { canonicalPieceAddress, type PiecePlan } from "./bulk-plan.ts";
@@ -65,6 +68,16 @@ export interface PlanDiff {
  * otherwise silently collapse.
  */
 export function diffPlan(plan: PiecePlan, after: PiecePlan): PlanDiff {
+  const repairs = plan.rows.filter((row) => row.op?.kind === "repair");
+  if (repairs.length > 0) {
+    // A repair moves the document, not the reference, so this diff would
+    // answer `unchanged` about work it cannot see; re-running the fixer is
+    // the repair's verification, and it lives with the repair.
+    throw new Error(
+      "A reference diff cannot verify a document repair: " +
+        repairs.map((row) => row.piece).join(", ") + ".",
+    );
+  }
   if (plan.header.space !== after.header.space) {
     throw new Error(
       `Plans are from different spaces: ${plan.header.space} and ` +
@@ -93,9 +106,8 @@ export function diffPlan(plan: PiecePlan, after: PiecePlan): PlanDiff {
       patternIdentity: row.expect.patternIdentity,
       symbol: row.expect.symbol,
     };
-    // A repair op carries no target reference: it moves the document, not
-    // the pattern, and its verification is the fixer's no-op rather than a
-    // reference comparison — so a reference diff reads it as op-less.
+    // The repair arm is unreachable behind the refusal above; the check is
+    // what narrows the op union to the reference-carrying kinds.
     const target: PatternRef | undefined =
       row.op === undefined || row.op.kind === "repair"
         ? undefined

--- a/packages/piece/src/ops/bulk-diff.ts
+++ b/packages/piece/src/ops/bulk-diff.ts
@@ -93,9 +93,13 @@ export function diffPlan(plan: PiecePlan, after: PiecePlan): PlanDiff {
       patternIdentity: row.expect.patternIdentity,
       symbol: row.expect.symbol,
     };
-    const target: PatternRef | undefined = row.op === undefined
-      ? undefined
-      : { patternIdentity: row.op.patternIdentity, symbol: row.op.symbol };
+    // A repair op carries no target reference: it moves the document, not
+    // the pattern, and its verification is the fixer's no-op rather than a
+    // reference comparison — so a reference diff reads it as op-less.
+    const target: PatternRef | undefined =
+      row.op === undefined || row.op.kind === "repair"
+        ? undefined
+        : { patternIdentity: row.op.patternIdentity, symbol: row.op.symbol };
     const key = canonicalPieceAddress(row.piece);
     const seen = afterById.get(key);
     afterById.delete(key);

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -243,14 +243,30 @@ export function encodePlan(plan: PiecePlan): string {
 export function decodePlan(text: string): PiecePlan {
   const lines = text.split("\n").filter((line) => line.trim() !== "");
   if (lines.length === 0) throw new Error("Plan is empty.");
-  const header = JSON.parse(lines[0]) as unknown;
-  if (!isPlanHeader(header)) {
+  return normalizePlan({
+    header: JSON.parse(lines[0]),
+    rows: lines.slice(1).map((line) => JSON.parse(line)),
+  });
+}
+
+/**
+ * Validate an assembled plan against every invariant the codec holds, and
+ * return it with each row's piece address canonical. This is the one
+ * validator the decoder and the executors share: an in-memory plan handed
+ * straight to a run gets exactly the scrutiny a decoded file gets, so no
+ * caller can slip a shape past execution that the codec would have refused
+ * — a repair row without its document hash, a duplicate piece, an invalid
+ * row.
+ */
+export function normalizePlan(
+  plan: { header: unknown; rows: readonly unknown[] },
+): PiecePlan {
+  if (!isPlanHeader(plan.header)) {
     throw new Error(
       'Plan does not start with a "piece-plan" v1 header line.',
     );
   }
-  const rows = lines.slice(1).map((line, index) => {
-    const row = JSON.parse(line) as unknown;
+  const rows = plan.rows.map((row, index) => {
     if (!isPlanRow(row)) {
       throw new Error(`Plan row ${index + 1} is not a valid row object.`);
     }
@@ -263,7 +279,7 @@ export function decodePlan(text: string): PiecePlan {
     }
     seen.add(row.piece);
   }
-  return { header, rows };
+  return { header: plan.header, rows };
 }
 
 /**
@@ -271,10 +287,11 @@ export function decodePlan(text: string): PiecePlan {
  * becomes the reference the retarget produced, and the operation restores the
  * retained revision carrying the reference the row recorded. Nothing is
  * re-surveyed or re-supplied. A plan whose header names pieces the survey
- * could not account for is refused before any row is read. Rows without a
- * retarget op have nothing to roll
- * back and are left out; a plan with no retarget rows at all is refused,
- * because deriving an empty rollback would read as having one.
+ * could not account for is refused before any row is read. Survey-only and
+ * restore rows have nothing to roll back and are left out; a repair row is
+ * refused by name, its reversal being an inverse fixer nothing can derive;
+ * and a plan with no retarget rows at all is refused, because deriving an
+ * empty rollback would read as having one.
  *
  * A retarget row whose prior source is not retained is refused by name
  * before any rollback row is produced: a restore of an unretained source is

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -77,6 +77,14 @@ export interface PieceExpect {
    * transition appends a baseline revision, so a survey cannot read one for it.
    */
   revisionId?: string;
+  /**
+   * The hash of the piece's stored input document, recorded by a repair's
+   * dry run. It is the repair row's precondition the way the reference pair
+   * is a retarget row's: the apply refuses a row whose stored document no
+   * longer hashes to it, because a document something else moved is a stop,
+   * not an overwrite.
+   */
+  documentHash?: string;
 }
 
 /** Replace a piece's source with the program a local source closure produces. */
@@ -142,8 +150,21 @@ export interface RestoreOp {
   revisionId?: string;
 }
 
+/**
+ * Run a caller-supplied fixer over the piece's stored input document. The
+ * fixer itself is a TypeScript module the run imports, so the plan records
+ * only its name for readers and for diffing — the row's enforceable half is
+ * `expect.documentHash`, which pins the document the fixer's answer was
+ * computed from.
+ */
+export interface RepairOp {
+  kind: "repair";
+  /** The fixer's name as supplied — a module path or label; never resolved. */
+  fixer: string;
+}
+
 /** What a plan row does to its piece, absent on a survey-only row. */
-export type PieceOp = RetargetOp | RestoreOp;
+export type PieceOp = RetargetOp | RestoreOp | RepairOp;
 
 /** One piece in a plan: the piece, its precondition, and its operation. */
 export interface PiecePlanRow {
@@ -276,6 +297,16 @@ export function deriveRollbackPlan(
         "names pieces the survey did not account for.",
     );
   }
+  const repairs = plan.rows.filter((row) => row.op?.kind === "repair");
+  if (repairs.length > 0) {
+    // A repair's reversal would be the inverse fixer, which does not exist;
+    // silently dropping the rows would launder a partial rollback into a
+    // complete-looking one.
+    throw new Error(
+      "No rollback can be derived: repair rows have no derivable " +
+        "reversal — " + repairs.map((row) => row.piece).join(", ") + ".",
+    );
+  }
   const unretained = plan.rows.filter((row) =>
     row.op?.kind === "retarget" && !row.expect.retained
   );
@@ -402,10 +433,18 @@ function isPlanRow(value: unknown): value is PiecePlanRow {
     expect.patternIdentity === "" ||
     typeof expect.symbol !== "string" || expect.symbol === "" ||
     typeof expect.retained !== "boolean" ||
-    !isOptionalName(expect.revisionId)
+    !isOptionalName(expect.revisionId) ||
+    !isOptionalName(expect.documentHash)
   ) return false;
   if (value.op === undefined) return true;
   if (!isPieceOp(value.op)) return false;
+  if (value.op.kind === "repair") {
+    // A repair row's verifiable half is the document hash: without one the
+    // row cannot be resumed or verified from the artifact, so the codec
+    // requires it rather than carrying a row no run could check.
+    return typeof expect.documentHash === "string" &&
+      expect.documentHash !== "";
+  }
   // A row whose operation produces the reference the row already records is
   // unverifiable: a diff could not tell "landed" from "never ran". Such a
   // row is a no-op to drop, not an operation to carry.
@@ -415,6 +454,9 @@ function isPlanRow(value: unknown): value is PiecePlanRow {
 
 function isPieceOp(value: unknown): value is PieceOp {
   if (!isRecord(value)) return false;
+  if (value.kind === "repair") {
+    return typeof value.fixer === "string" && value.fixer !== "";
+  }
   if (
     typeof value.patternIdentity !== "string" ||
     value.patternIdentity === "" ||

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -49,10 +49,24 @@ export type Fixer = (
 
 /** One leaf-level difference between a stored document and a fixer's. */
 export interface DocumentChange {
-  /** The changed position, segments joined with `/`; `""` is the root. */
+  /**
+   * The changed position: segments joined with `/`, a segment's own `/`
+   * escaped `~1` and `~` escaped `~0` — the JSON Pointer spelling, so a
+   * key containing the separator stays unambiguous. `""` is the root.
+   */
   path: string;
   before: unknown;
   after: unknown;
+}
+
+/** One path segment, display-escaped in the JSON Pointer spelling. */
+function escapeSegment(segment: string): string {
+  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+/** Segments joined for display; `""` is the root. */
+function displayPath(segments: readonly string[]): string {
+  return segments.map(escapeSegment).join("/");
 }
 
 /**
@@ -120,32 +134,77 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Every path in `node` that holds a sigil link, in traversal order. */
+/**
+ * Every path in `node` that holds a sigil link, in traversal order. Paths
+ * are segment arrays rather than joined strings, so a key containing the
+ * display separator addresses its own slot and nobody else's.
+ */
 export function collectLinkPaths(
   node: unknown,
-  path = "",
-  found: string[] = [],
-): readonly string[] {
+  path: readonly string[] = [],
+  found: (readonly string[])[] = [],
+): readonly (readonly string[])[] {
   if (node === null || typeof node !== "object") return found;
   if (isLink(node)) {
     found.push(path);
     return found;
   }
   for (const [key, value] of Object.entries(node)) {
-    collectLinkPaths(value, path === "" ? key : `${path}/${key}`, found);
+    collectLinkPaths(value, [...path, key], found);
   }
   return found;
 }
 
-/** The value at a `/`-joined path, or `undefined` where the path breaks. */
-function valueAtPath(node: unknown, path: string): unknown {
-  if (path === "") return node;
+/** The value at a segment path, or `undefined` where the path breaks. */
+function valueAtPath(node: unknown, path: readonly string[]): unknown {
   let current: unknown = node;
-  for (const segment of path.split("/")) {
+  for (const segment of path) {
     if (current === null || typeof current !== "object") return undefined;
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
+}
+
+/**
+ * Paths the fixer's answer lost, recursively: an input object's own key
+ * absent from the answer — or present as `undefined`, which the write
+ * treats the same — wherever both sides keep a record, or an equally long
+ * array, at the same position. Recursion stops where the shapes part:
+ * replacing a container outright is an act the diff reports as a change,
+ * while omitting fields from one that survives is the fragment accident
+ * this check exists to refuse. Link nodes are the links-intact check's to
+ * judge, so they are skipped here rather than reported twice.
+ */
+function lostFields(
+  before: unknown,
+  after: unknown,
+  path: readonly string[] = [],
+  out: string[] = [],
+): readonly string[] {
+  if (isLink(before)) return out;
+  const bothRecords = isRecord(before) && isRecord(after);
+  const bothArrays = Array.isArray(before) && Array.isArray(after) &&
+    before.length === after.length;
+  if (!bothRecords && !bothArrays) return out;
+  for (const key of Object.keys(before as object)) {
+    const beforeValue = (before as Record<string, unknown>)[key];
+    if (
+      bothRecords &&
+      (!Object.hasOwn(after as object, key) ||
+        ((after as Record<string, unknown>)[key] === undefined &&
+          beforeValue !== undefined))
+    ) {
+      out.push(displayPath([...path, key]));
+      continue;
+    }
+    lostFields(
+      beforeValue,
+      (after as Record<string, unknown>)[key],
+      [...path, key],
+      out,
+    );
+  }
+  return out;
 }
 
 /**
@@ -157,14 +216,14 @@ function valueAtPath(node: unknown, path: string): unknown {
 export function documentChanges(
   before: unknown,
   after: unknown,
-  path = "",
+  path: readonly string[] = [],
   out: DocumentChange[] = [],
 ): readonly DocumentChange[] {
   if (deepEqual(before, after)) return out;
   const bothRecords = isRecord(before) && isRecord(after);
   const bothArrays = Array.isArray(before) && Array.isArray(after);
   if (!bothRecords && !bothArrays) {
-    out.push({ path, before, after });
+    out.push({ path: displayPath(path), before, after });
     return out;
   }
   const keys = new Set([
@@ -175,7 +234,7 @@ export function documentChanges(
     documentChanges(
       (before as Record<string, unknown>)[key],
       (after as Record<string, unknown>)[key],
-      path === "" ? key : `${path}/${key}`,
+      [...path, key],
       out,
     );
   }
@@ -224,10 +283,9 @@ export function evaluateFixer(
     };
   }
   // The write replaces the whole document, so a field the fixer's answer
-  // lacks would be zeroed by it — a defect, never an intent.
-  const lost = Object.keys(document).filter((key) =>
-    document[key] !== undefined && first[key] === undefined
-  );
+  // lacks would be zeroed by it — a defect, never an intent — and a nested
+  // field is as gone as a top-level one.
+  const lost = lostFields(document, first);
   if (lost.length > 0) {
     return {
       kind: "refused",
@@ -244,7 +302,7 @@ export function evaluateFixer(
       return {
         kind: "refused",
         problem: `The fixer rewrote or dropped the link at ` +
-          `${linkPath === "" ? "<root>" : linkPath}.`,
+          `${linkPath.length === 0 ? "<root>" : displayPath(linkPath)}.`,
       };
     }
   }

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -39,7 +39,7 @@ import { isLink } from "@commonfabric/runner";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 import {
-  canonicalPieceAddress,
+  normalizePlan,
   type PiecePlan,
   type PiecePlanRow,
 } from "./bulk-plan.ts";
@@ -473,6 +473,10 @@ export async function repairPieces(
     phase?: string;
     expect: PiecePlanRow["expect"];
     expectedHash?: string;
+    /** The plan row this one executes, carried into the emitted artifact
+     * for every verdict short of landed, so a stopped run's artifact can
+     * be supplied straight back. */
+    supplied?: PiecePlanRow;
   }[];
   if (options.plan === undefined) {
     executionRows = members.map((row) => ({
@@ -481,15 +485,24 @@ export async function repairPieces(
       expect: row.expect,
     }));
   } else {
-    if (options.plan.header.space !== survey.plan.header.space) {
+    // The executor holds an in-memory plan to every invariant the codec
+    // holds a decoded one to — the same validator — so a shape the codec
+    // would refuse cannot reach a write by skipping the file: a repair row
+    // without its document hash, a duplicate piece, an invalid row.
+    const plan = normalizePlan(options.plan);
+    if (options.fixerName === undefined) {
       throw new Error(
-        `The plan names space ${options.plan.header.space}; this run ` +
+        "A supplied plan needs the run's fixerName: without it the plan's " +
+          "recorded fixer cannot be held against the fixer actually run.",
+      );
+    }
+    if (plan.header.space !== survey.plan.header.space) {
+      throw new Error(
+        `The plan names space ${plan.header.space}; this run ` +
           `targets ${survey.plan.header.space}.`,
       );
     }
-    const unrunnable = options.plan.rows.filter((row) =>
-      row.op?.kind !== "repair"
-    );
+    const unrunnable = plan.rows.filter((row) => row.op?.kind !== "repair");
     if (unrunnable.length > 0) {
       throw new Error(
         "The plan carries rows with no repair operation, which cannot be " +
@@ -497,26 +510,20 @@ export async function repairPieces(
           unrunnable.map((row) => row.piece).join(", ") + ".",
       );
     }
-    if (options.fixerName !== undefined) {
-      const disagreeing = options.plan.rows.filter((row) =>
-        row.op?.kind === "repair" && row.op.fixer !== options.fixerName
+    const disagreeing = plan.rows.filter((row) =>
+      row.op?.kind === "repair" && row.op.fixer !== options.fixerName
+    );
+    if (disagreeing.length > 0) {
+      throw new Error(
+        `The plan records a different fixer than this run supplies ` +
+          `(${options.fixerName}) on: ` +
+          disagreeing.map((row) => row.piece).join(", ") + ".",
       );
-      if (disagreeing.length > 0) {
-        throw new Error(
-          `The plan records a different fixer than this run supplies ` +
-            `(${options.fixerName}) on: ` +
-            disagreeing.map((row) => row.piece).join(", ") + ".",
-        );
-      }
     }
     const surveyByPiece = new Map(members.map((row) => [row.piece, row]));
-    const planPieces = new Set(
-      options.plan.rows.map((row) => canonicalPieceAddress(row.piece)),
-    );
+    const planPieces = new Set(plan.rows.map((row) => row.piece));
     const missing = members.filter((row) => !planPieces.has(row.piece));
-    const extra = options.plan.rows.filter((row) =>
-      !surveyByPiece.has(canonicalPieceAddress(row.piece))
-    );
+    const extra = plan.rows.filter((row) => !surveyByPiece.has(row.piece));
     if (missing.length > 0 || extra.length > 0) {
       throw new Error(
         "The plan and the selection disagree" +
@@ -531,15 +538,14 @@ export async function repairPieces(
           ". A stale plan is regenerated, never reconciled silently.",
       );
     }
-    executionRows = options.plan.rows.map((planRow) => {
-      const surveyRow = surveyByPiece.get(
-        canonicalPieceAddress(planRow.piece),
-      )!;
+    executionRows = plan.rows.map((planRow) => {
+      const surveyRow = surveyByPiece.get(planRow.piece)!;
       return {
         piece: surveyRow.piece,
         ...(planRow.phase === undefined ? {} : { phase: planRow.phase }),
         expect: surveyRow.expect,
         expectedHash: planRow.expect.documentHash,
+        supplied: planRow,
       };
     });
   }
@@ -601,11 +607,43 @@ export async function repairPieces(
       ...phase,
       expect: row.expect,
     };
+    // The artifact row this piece contributes. A landed row records the
+    // hash its verdict was computed from; any other verdict carries the
+    // supplied plan row through unchanged, so a stopped run's artifact can
+    // be supplied straight back; and a fresh run's row falls back to its
+    // decision's hash when one exists, or to the pre-state record.
+    const emitRow = (
+      decision:
+        | RowDecision
+        | { kind: "read-failed"; problem: string }
+        | undefined,
+      landed: boolean,
+    ) => {
+      if (!landed && row.supplied !== undefined) {
+        planRows.push(row.supplied);
+        return;
+      }
+      if (
+        decision !== undefined && decision.kind !== "read-failed" &&
+        decision.kind !== "not-document"
+      ) {
+        planRows.push({
+          piece: row.piece,
+          ...phase,
+          expect: { ...row.expect, documentHash: decision.documentHash },
+          ...(options.fixerName === undefined ? {} : {
+            op: { kind: "repair", fixer: options.fixerName },
+          }),
+        });
+        return;
+      }
+      planRows.push(preStateRow);
+    };
     if (startBlocked) {
       // The run did not start: every row reports its preflight
       // classification, and nothing was written.
       const decision = preflight.get(row.piece);
-      planRows.push(preStateRow);
+      emitRow(decision, decision?.kind === "conforms");
       if (decision === undefined || decision.kind === "read-failed") {
         rows.push({
           piece: row.piece,
@@ -659,7 +697,7 @@ export async function repairPieces(
     }
     if (stopped) {
       rows.push({ piece: row.piece, ...phase, verdict: "unattempted" });
-      planRows.push(preStateRow);
+      emitRow(preflight.get(row.piece), false);
       continue;
     }
     const expected = row.expectedHash;
@@ -709,24 +747,10 @@ export async function repairPieces(
       } else {
         decision = decide(cell.getRaw({ lastNode: "value" }));
       }
-      if (decision.kind === "not-document" || decision.kind === "moved") {
-        planRows.push(preStateRow);
-      } else {
-        // The evaluated row, as the artifact records it: the survey's
-        // expectation plus the document hash the verdict was computed
-        // from, and the repair operation when the run has a name for it.
-        planRows.push({
-          piece: row.piece,
-          ...phase,
-          expect: {
-            ...row.expect,
-            documentHash: decision.documentHash,
-          },
-          ...(options.fixerName === undefined ? {} : {
-            op: { kind: "repair", fixer: options.fixerName },
-          }),
-        });
-      }
+      emitRow(
+        decision,
+        decision.kind === "conforms" || decision.kind === "change",
+      );
       if (decision.kind === "not-document") {
         rows.push({
           piece: row.piece,
@@ -834,7 +858,7 @@ export async function repairPieces(
         verdict: "failed",
         problem: problem + state,
       });
-      planRows.push(preStateRow);
+      emitRow(preflight.get(row.piece), false);
       stopped = options.apply === true;
     }
   }

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -72,9 +72,10 @@ export type Fixer = (
  */
 export interface DocumentChange {
   /**
-   * The position: segments joined with `/`, a segment's own `/` escaped
-   * `~1` and `~` escaped `~0` — the JSON Pointer spelling, so a key
-   * containing the separator stays unambiguous. `""` is the root.
+   * The position as a JSON Pointer: `""` is the root, and every non-root
+   * position leads with `/` — so the root and a top-level empty-string key
+   * (`"/"`) stay distinct. A segment's own `/` is escaped `~1` and `~`
+   * escaped `~0`.
    */
   path: string;
   kind: "changed" | "added" | "removed";
@@ -147,10 +148,14 @@ export interface RepairOptions {
    */
   fixerName?: string;
   /**
-   * A previously emitted plan whose document hashes are this run's
-   * preconditions: a row whose stored document no longer hashes to what
-   * the plan recorded is `moved` — something other than this plan changed
-   * it — and an apply stops on it rather than overwriting.
+   * A previously emitted plan, which then IS the execution: its rows run
+   * in its order, each row's recorded document hash is its precondition,
+   * and the plan must agree with this run — same space, same fixer name,
+   * and exactly the selection's pieces, a stale plan being regenerated
+   * rather than silently reconciled. A row whose stored document still
+   * needs the repair but no longer hashes to what the plan recorded is
+   * `moved` — something other than this plan changed it — while a row the
+   * fixer no longer changes is landed, whatever it hashes to now.
    */
   plan?: PiecePlan;
   /**
@@ -191,9 +196,9 @@ function escapeSegment(segment: string): string {
   return segment.replaceAll("~", "~0").replaceAll("/", "~1");
 }
 
-/** Segments joined for display; `""` is the root. */
+/** Segments as a JSON Pointer: `""` for the root, `/`-led otherwise. */
 function displayPath(segments: readonly string[]): string {
-  return segments.map(escapeSegment).join("/");
+  return segments.map((segment) => `/${escapeSegment(segment)}`).join("");
 }
 
 /**
@@ -421,10 +426,14 @@ type RowDecision =
  * document shape, and a holder wanting repair is a one-piece list selection
  * of its own.
  *
- * Under `apply`, each row is evaluated and written in one transaction: the
+ * Under `apply`, every row is classified first, from one read each and
+ * before anything is written — the spine's preflight — and a row that
+ * moved, refuses, or cannot be read stops the run from starting at all,
+ * with every row reporting its classification and nothing applied. The
+ * serial pass then evaluates and writes each row in one transaction: the
  * fixer answers for the document the commit sees, so a concurrent edit
  * re-runs the evaluation rather than being overwritten. A supplied plan's
- * document hash is checked in the same transaction, and a mismatch is
+ * document hash is rechecked in that same transaction, and a mismatch is
  * `moved` — a stop, not an overwrite. The written document is then read
  * back and the fixer asked again — a repair succeeded when re-running the
  * fixer over the stored result is a no-op — and a refusal, a moved row, or
@@ -453,52 +462,229 @@ export async function repairPieces(
         `the failure this refusal prevents:\n${named.join("\n")}`,
     );
   }
-  const expectedHashes = new Map<string, string>();
-  for (const row of options.plan?.rows ?? []) {
-    if (row.expect.documentHash !== undefined) {
-      expectedHashes.set(
-        canonicalPieceAddress(row.piece),
-        row.expect.documentHash,
+  const members = survey.plan.rows.filter((row) => row.phase !== HOLDER_PHASE);
+  // A supplied plan is the execution, not a hint: its rows, in its order,
+  // validated against this run before anything is read further. A plan that
+  // names a piece the selection does not hold, or misses one it does, is
+  // stale — the answer is a regenerated plan, never a run that quietly
+  // reconciles the difference.
+  let executionRows: {
+    piece: string;
+    phase?: string;
+    expect: PiecePlanRow["expect"];
+    expectedHash?: string;
+  }[];
+  if (options.plan === undefined) {
+    executionRows = members.map((row) => ({
+      piece: row.piece,
+      ...(row.phase === undefined ? {} : { phase: row.phase }),
+      expect: row.expect,
+    }));
+  } else {
+    if (options.plan.header.space !== survey.plan.header.space) {
+      throw new Error(
+        `The plan names space ${options.plan.header.space}; this run ` +
+          `targets ${survey.plan.header.space}.`,
       );
     }
+    const unrunnable = options.plan.rows.filter((row) =>
+      row.op?.kind !== "repair"
+    );
+    if (unrunnable.length > 0) {
+      throw new Error(
+        "The plan carries rows with no repair operation, which cannot be " +
+          "executed or precondition-checked: " +
+          unrunnable.map((row) => row.piece).join(", ") + ".",
+      );
+    }
+    if (options.fixerName !== undefined) {
+      const disagreeing = options.plan.rows.filter((row) =>
+        row.op?.kind === "repair" && row.op.fixer !== options.fixerName
+      );
+      if (disagreeing.length > 0) {
+        throw new Error(
+          `The plan records a different fixer than this run supplies ` +
+            `(${options.fixerName}) on: ` +
+            disagreeing.map((row) => row.piece).join(", ") + ".",
+        );
+      }
+    }
+    const surveyByPiece = new Map(members.map((row) => [row.piece, row]));
+    const planPieces = new Set(
+      options.plan.rows.map((row) => canonicalPieceAddress(row.piece)),
+    );
+    const missing = members.filter((row) => !planPieces.has(row.piece));
+    const extra = options.plan.rows.filter((row) =>
+      !surveyByPiece.has(canonicalPieceAddress(row.piece))
+    );
+    if (missing.length > 0 || extra.length > 0) {
+      throw new Error(
+        "The plan and the selection disagree" +
+          (extra.length > 0
+            ? "; the plan names pieces the selection does not hold: " +
+              extra.map((row) => row.piece).join(", ")
+            : "") +
+          (missing.length > 0
+            ? "; the selection holds pieces the plan does not name: " +
+              missing.map((row) => row.piece).join(", ")
+            : "") +
+          ". A stale plan is regenerated, never reconciled silently.",
+      );
+    }
+    executionRows = options.plan.rows.map((planRow) => {
+      const surveyRow = surveyByPiece.get(
+        canonicalPieceAddress(planRow.piece),
+      )!;
+      return {
+        piece: surveyRow.piece,
+        ...(planRow.phase === undefined ? {} : { phase: planRow.phase }),
+        expect: surveyRow.expect,
+        expectedHash: planRow.expect.documentHash,
+      };
+    });
   }
   const rows: RepairRow[] = [];
   const planRows: PiecePlanRow[] = [];
   let applied = 0;
   let stopped = false;
-  for (const surveyRow of survey.plan.rows) {
-    if (surveyRow.phase === HOLDER_PHASE) continue;
-    const phase = surveyRow.phase === undefined
-      ? {}
-      : { phase: surveyRow.phase };
+  // Preflight, before the first write: every row classified from one read,
+  // exactly as the spine documents — a row that moved, or that the fixer
+  // refuses, is found while nothing has been touched, and the run does not
+  // start. The per-row transactional recheck below still guards each write
+  // against what happens after this pass.
+  let startBlocked = false;
+  const preflight = new Map<
+    string,
+    RowDecision | { kind: "read-failed"; problem: string }
+  >();
+  if (options.apply === true) {
+    for (const row of executionRows) {
+      try {
+        const controller = await pieces.get(row.piece, false);
+        const cell = await controller.input.getCell();
+        await cell.pull();
+        const decision = ((): RowDecision => {
+          const stored = cell.getRaw({ lastNode: "value" });
+          if (!isPlainRecord(stored)) return { kind: "not-document" };
+          const documentHash = hashStringOf(stored);
+          const outcome = evaluateFixer(stored, options.fixer);
+          if (outcome.kind === "conforms") {
+            return { kind: "conforms", documentHash };
+          }
+          if (
+            row.expectedHash !== undefined && documentHash !== row.expectedHash
+          ) {
+            return { kind: "moved", documentHash };
+          }
+          if (outcome.kind === "refused") {
+            return { kind: "refused", documentHash, problem: outcome.problem };
+          }
+          return { kind: "change", documentHash, changes: outcome.changes };
+        })();
+        preflight.set(row.piece, decision);
+        if (decision.kind !== "conforms" && decision.kind !== "change") {
+          startBlocked = true;
+        }
+      } catch (error) {
+        preflight.set(row.piece, {
+          kind: "read-failed",
+          problem: error instanceof Error ? error.message : String(error),
+        });
+        startBlocked = true;
+      }
+    }
+  }
+  for (const row of executionRows) {
+    const phase = row.phase === undefined ? {} : { phase: row.phase };
     const preStateRow = {
-      piece: surveyRow.piece,
+      piece: row.piece,
       ...phase,
-      expect: surveyRow.expect,
+      expect: row.expect,
     };
+    if (startBlocked) {
+      // The run did not start: every row reports its preflight
+      // classification, and nothing was written.
+      const decision = preflight.get(row.piece);
+      planRows.push(preStateRow);
+      if (decision === undefined || decision.kind === "read-failed") {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "failed",
+          problem: (decision?.problem ??
+            "The row was never classified.") +
+            "; the run did not start, so nothing was written.",
+        });
+      } else if (decision.kind === "not-document") {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "refused",
+          problem: "The stored input is not a document.",
+        });
+      } else if (decision.kind === "moved") {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "moved",
+          documentHash: decision.documentHash,
+          problem: "The stored document no longer hashes to what the plan " +
+            "recorded: something other than this plan changed it.",
+        });
+      } else if (decision.kind === "refused") {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "refused",
+          documentHash: decision.documentHash,
+          problem: decision.problem,
+        });
+      } else if (decision.kind === "conforms") {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "conforms",
+          documentHash: decision.documentHash,
+        });
+      } else {
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "would-change",
+          documentHash: decision.documentHash,
+          changes: decision.changes,
+        });
+      }
+      continue;
+    }
     if (stopped) {
-      rows.push({ piece: surveyRow.piece, ...phase, verdict: "unattempted" });
+      rows.push({ piece: row.piece, ...phase, verdict: "unattempted" });
       planRows.push(preStateRow);
       continue;
     }
-    const expected = expectedHashes.get(surveyRow.piece);
+    const expected = row.expectedHash;
     const decide = (stored: unknown): RowDecision => {
       if (!isPlainRecord(stored)) return { kind: "not-document" };
       const documentHash = hashStringOf(stored);
+      const outcome = evaluateFixer(stored, options.fixer);
+      // Landed before moved: a document the fixer no longer changes is in
+      // the state the operation produces, whatever it hashes to now — a
+      // completed plan re-run must read as landed, not as moved. Only a
+      // document that still needs the repair and no longer matches its
+      // recorded precondition was moved by something else.
+      if (outcome.kind === "conforms") {
+        return { kind: "conforms", documentHash };
+      }
       if (expected !== undefined && documentHash !== expected) {
         return { kind: "moved", documentHash };
       }
-      const outcome = evaluateFixer(stored, options.fixer);
       if (outcome.kind === "refused") {
         return { kind: "refused", documentHash, problem: outcome.problem };
-      }
-      if (outcome.kind === "conforms") {
-        return { kind: "conforms", documentHash };
       }
       return { kind: "change", documentHash, changes: outcome.changes };
     };
     try {
-      const controller = await pieces.get(surveyRow.piece, false);
+      const controller = await pieces.get(row.piece, false);
       const cell = await controller.input.getCell();
       await cell.pull();
       // Initialized only to satisfy definite assignment: a committed edit
@@ -530,10 +716,10 @@ export async function repairPieces(
         // expectation plus the document hash the verdict was computed
         // from, and the repair operation when the run has a name for it.
         planRows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           expect: {
-            ...surveyRow.expect,
+            ...row.expect,
             documentHash: decision.documentHash,
           },
           ...(options.fixerName === undefined ? {} : {
@@ -543,7 +729,7 @@ export async function repairPieces(
       }
       if (decision.kind === "not-document") {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "refused",
           problem: "The stored input is not a document.",
@@ -553,7 +739,7 @@ export async function repairPieces(
       }
       if (decision.kind === "moved") {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "moved",
           documentHash: decision.documentHash,
@@ -565,7 +751,7 @@ export async function repairPieces(
       }
       if (decision.kind === "refused") {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "refused",
           documentHash: decision.documentHash,
@@ -576,7 +762,7 @@ export async function repairPieces(
       }
       if (decision.kind === "conforms") {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "conforms",
           documentHash: decision.documentHash,
@@ -585,7 +771,7 @@ export async function repairPieces(
       }
       if (options.apply !== true) {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "would-change",
           documentHash: decision.documentHash,
@@ -602,7 +788,7 @@ export async function repairPieces(
         : undefined;
       if (verification?.kind === "conforms") {
         rows.push({
-          piece: surveyRow.piece,
+          piece: row.piece,
           ...phase,
           verdict: "repaired",
           documentHash: decision.documentHash,
@@ -611,7 +797,7 @@ export async function repairPieces(
         continue;
       }
       rows.push({
-        piece: surveyRow.piece,
+        piece: row.piece,
         ...phase,
         verdict: "failed",
         documentHash: decision.documentHash,
@@ -630,7 +816,7 @@ export async function repairPieces(
       const problem = error instanceof Error ? error.message : String(error);
       let state = "; the piece could not be re-read, so its state is unknown";
       try {
-        const controller = await pieces.get(surveyRow.piece, false);
+        const controller = await pieces.get(row.piece, false);
         const cell = await controller.input.getCell();
         await cell.pull();
         const stored = cell.getRaw({ lastNode: "value" });
@@ -643,7 +829,7 @@ export async function repairPieces(
         // The re-read failing changes nothing: `state` already says so.
       }
       rows.push({
-        piece: surveyRow.piece,
+        piece: row.piece,
         ...phase,
         verdict: "failed",
         problem: problem + state,

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -298,19 +298,46 @@ export function documentChanges(
     out.push({ path: displayPath(path), kind: "changed", before, after });
     return out;
   }
+  if (bothArrays) {
+    // Positions, not enumerable keys: a sparse array is a valid stored
+    // value and its holes are exactly what a key walk skips, so presence
+    // here is "the position exists" (`index < length`, a hole reading
+    // `undefined`) — a lost tail is removals, a grown one additions, and
+    // two unequal arrays can never diff to nothing.
+    const length = Math.max(before.length, after.length);
+    for (let index = 0; index < length; index += 1) {
+      const at = [...path, String(index)];
+      if (index >= after.length) {
+        out.push({
+          path: displayPath(at),
+          kind: "removed",
+          before: before[index],
+        });
+        continue;
+      }
+      if (index >= before.length) {
+        out.push({ path: displayPath(at), kind: "added", after: after[index] });
+        continue;
+      }
+      documentChanges(before[index], after[index], at, out);
+    }
+    return out;
+  }
+  const beforeRecord = before as Record<string, unknown>;
+  const afterRecord = after as Record<string, unknown>;
   const keys = new Set([
-    ...Object.keys(before as object),
-    ...Object.keys(after as object),
+    ...Object.keys(beforeRecord),
+    ...Object.keys(afterRecord),
   ]);
   for (const key of keys) {
-    const hasBefore = Object.hasOwn(before as object, key);
-    const hasAfter = Object.hasOwn(after as object, key);
+    const hasBefore = Object.hasOwn(beforeRecord, key);
+    const hasAfter = Object.hasOwn(afterRecord, key);
     const at = [...path, key];
     if (hasBefore && !hasAfter) {
       out.push({
         path: displayPath(at),
         kind: "removed",
-        before: (before as Record<string, unknown>)[key],
+        before: beforeRecord[key],
       });
       continue;
     }
@@ -318,16 +345,11 @@ export function documentChanges(
       out.push({
         path: displayPath(at),
         kind: "added",
-        after: (after as Record<string, unknown>)[key],
+        after: afterRecord[key],
       });
       continue;
     }
-    documentChanges(
-      (before as Record<string, unknown>)[key],
-      (after as Record<string, unknown>)[key],
-      at,
-      out,
-    );
+    documentChanges(beforeRecord[key], afterRecord[key], at, out);
   }
   return out;
 }
@@ -455,6 +477,10 @@ type RowDecision =
   | {
     kind: "change";
     documentHash: string;
+    /** The stored document the decision was computed from — what an
+     * applied row's changes are measured against, so the write path's own
+     * additions show in the report. */
+    before: Record<string, unknown>;
     /** The evaluated answer — the exact document a write must land, so
      * the report and the write cannot describe two different evaluations
      * of a fixer that lied to the purity probe. */
@@ -496,6 +522,11 @@ export async function repairPieces(
   pieces: PiecesController,
   options: RepairOptions,
 ): Promise<RepairReport> {
+  if (options.fixerName === "") {
+    // Stamped into the artifact it would be an op the codec refuses, so a
+    // successful apply would return a plan nothing can decode or resume.
+    throw new Error("A fixerName must be nonempty when given.");
+  }
   const survey = await surveyPieces(pieces, { selector: options.selector });
   if (!survey.complete) {
     const named = [
@@ -632,6 +663,7 @@ export async function repairPieces(
     return {
       kind: "change",
       documentHash,
+      before: stored,
       document: outcome.document,
       changes: outcome.changes,
     };
@@ -875,8 +907,9 @@ export async function repairPieces(
       if (!wroteThisRow) {
         // The no-write classification did not hold on the re-read: the
         // document changed under a decision that staged nothing. Nothing
-        // was written, so the row is simply not landed — reported as the
-        // work it still is, and a re-run resumes it.
+        // was written, and the run stops — plan order is a correctness
+        // constraint, so a later row must not land while this one is
+        // outstanding. A re-run resumes from here.
         rows.push({
           piece: row.piece,
           ...phase,
@@ -885,6 +918,7 @@ export async function repairPieces(
           changes: decision.changes,
         });
         emitRow(decision, false);
+        stopped = true;
         continue;
       }
       applied += 1;
@@ -905,7 +939,11 @@ export async function repairPieces(
           ...phase,
           verdict: "repaired",
           documentHash: decision.documentHash,
-          changes: decision.changes,
+          // Measured between the stored documents, not restated from the
+          // fixer's answer: the write path hydrates schema defaults into
+          // what it stores, and an addition the report never mentioned is
+          // how a repair quietly widens.
+          changes: documentChanges(decision.before, written),
         });
         emitRow(decision, true);
         continue;

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -17,16 +17,32 @@
  * The write is the wide one — the whole input document replaced — made safe
  * by refusals rather than by narrowing: a document that lost a field the
  * fixer never mentioned is a defect, not an intent, and a reference
- * rewritten as a value or dropped is corruption either way. Raw documents
- * carry references as sigil links, which are plain data on this side of the
- * runtime, so a fixer that round-trips them untouched preserves them through
- * the write — measured, and held by the links-intact refusal rather than
- * trusted.
+ * rewritten as a value or dropped is corruption either way. The apply is
+ * transactional: the fixer is re-evaluated against the document the commit
+ * actually sees, so a concurrent edit conflicts and re-runs rather than
+ * being overwritten. A stored document is a `FabricValue` — references as
+ * sigil links, and special values such as bytes as class instances — so
+ * every copy, comparison, and hash below goes through the data-model's own
+ * primitives, and the walkers treat anything that is not a plain record or
+ * a direct array as one atomic value.
+ *
+ * The run's record is the plan artifact: each evaluated row carries the
+ * hash of the document its answer was computed from, which is the repair
+ * row's precondition the way the reference pair is a retarget row's.
  */
 
+import type { FabricValue } from "@commonfabric/api";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isLink } from "@commonfabric/runner";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isPlainObject } from "@commonfabric/utils/types";
 
+import {
+  canonicalPieceAddress,
+  type PiecePlan,
+  type PiecePlanRow,
+} from "./bulk-plan.ts";
 import {
   HOLDER_PHASE,
   type PieceSelector,
@@ -37,51 +53,50 @@ import type { PiecesController } from "./pieces-controller.ts";
 /**
  * A fixer: a pure transform from a piece's stored input document to the
  * document it should hold. It receives the raw stored document — sigil
- * links included, as plain data — and returns the complete document, never
- * a fragment. Purity is part of the contract, not a style preference: the
- * run answers selection, resume, and verification by re-asking the fixer,
- * and a fixer that reads a clock or a random source makes every one of
- * those answers wrong.
+ * links and Fabric special values included — and returns the complete
+ * document, never a fragment. Purity is part of the contract, not a style
+ * preference: the run answers selection, resume, and verification by
+ * re-asking the fixer, the transactional apply re-runs it against the
+ * document the commit sees, and a fixer that reads a clock or a random
+ * source makes every one of those answers wrong.
  */
 export type Fixer = (
   document: Readonly<Record<string, unknown>>,
 ) => Record<string, unknown>;
 
-/** One leaf-level difference between a stored document and a fixer's. */
+/**
+ * One difference between a stored document and a fixer's answer. `changed`
+ * carries both sides; `added` is a position the answer holds and the stored
+ * document does not, `removed` the reverse — presence is its own fact, not
+ * an `undefined` standing in for one.
+ */
 export interface DocumentChange {
   /**
-   * The changed position: segments joined with `/`, a segment's own `/`
-   * escaped `~1` and `~` escaped `~0` — the JSON Pointer spelling, so a
-   * key containing the separator stays unambiguous. `""` is the root.
+   * The position: segments joined with `/`, a segment's own `/` escaped
+   * `~1` and `~` escaped `~0` — the JSON Pointer spelling, so a key
+   * containing the separator stays unambiguous. `""` is the root.
    */
   path: string;
-  before: unknown;
-  after: unknown;
-}
-
-/** One path segment, display-escaped in the JSON Pointer spelling. */
-function escapeSegment(segment: string): string {
-  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
-}
-
-/** Segments joined for display; `""` is the root. */
-function displayPath(segments: readonly string[]): string {
-  return segments.map(escapeSegment).join("/");
+  kind: "changed" | "added" | "removed";
+  before?: unknown;
+  after?: unknown;
 }
 
 /**
  * One piece's outcome. `conforms` and `would-change` are the dry verdicts;
  * an apply turns `would-change` into `repaired` — or `failed`, when the
- * written document still does not satisfy the fixer, which is the write
- * path lying and never a reason to write again. `refused` is the fixer
- * breaking its contract on this piece's document, and `unattempted` names
- * the rows after an apply stopped.
+ * stored document does not satisfy the fixer after the write, or when an
+ * operational error interrupted the row. `refused` is the fixer breaking
+ * its contract on this piece's document; `moved` is a supplied plan's
+ * document-hash precondition no longer holding, which is a stop rather
+ * than an overwrite; `unattempted` names the rows after an apply stopped.
  */
 export type RepairVerdict =
   | "conforms"
   | "would-change"
   | "repaired"
   | "refused"
+  | "moved"
   | "failed"
   | "unattempted";
 
@@ -91,21 +106,33 @@ export interface RepairRow {
   /** The plan row's phase label, carried as the survey stamped it. */
   phase?: string;
   verdict: RepairVerdict;
-  /** What a refused or failed row broke; absent otherwise. */
+  /** What a refused, moved, or failed row broke; absent otherwise. */
   problem?: string;
   /** The exact changes the fixer would make (or made); absent when none. */
   changes?: readonly DocumentChange[];
+  /**
+   * The hash of the stored document this row's verdict was computed from —
+   * the precondition a plan row carries. Absent where no document was read.
+   */
+  documentHash?: string;
 }
 
 /** What one repair run found, and — under `apply` — did. */
 export interface RepairReport {
   rows: readonly RepairRow[];
+  /**
+   * The run as a plan artifact: the survey's header, and one row per
+   * evaluated piece carrying its document-hash precondition — with the
+   * repair operation stamped when the run was given a fixer name to record.
+   */
+  plan: PiecePlan;
   /** Documents written. Zero on a dry run and on a conforming re-run. */
   applied: number;
   /**
    * True when every row is `conforms` or `repaired`: nothing refused,
-   * nothing failed, nothing unattempted. A dry run is complete when
-   * nothing refused — `would-change` is its answer, not a defect.
+   * nothing moved, nothing failed, nothing unattempted. A dry run is
+   * complete when nothing refused or failed — `would-change` is its
+   * answer, not a defect.
    */
   complete: boolean;
 }
@@ -113,6 +140,19 @@ export interface RepairReport {
 export interface RepairOptions {
   selector: PieceSelector;
   fixer: Fixer;
+  /**
+   * The fixer's name as the plan should record it — a module path or a
+   * label. With one, the emitted plan's evaluated rows carry the repair
+   * operation; without, they carry only the pre-state record.
+   */
+  fixerName?: string;
+  /**
+   * A previously emitted plan whose document hashes are this run's
+   * preconditions: a row whose stored document no longer hashes to what
+   * the plan recorded is `moved` — something other than this plan changed
+   * it — and an apply stops on it rather than overwriting.
+   */
+  plan?: PiecePlan;
   /**
    * Write the documents the fixer produces. Absent, the run is the
    * dry-run report — the exact per-piece diff, and no write at all.
@@ -130,8 +170,30 @@ export type FixerOutcome =
   }
   | { kind: "refused"; problem: string };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+/**
+ * The plain-record arm of a stored document: an `Object.prototype`-rooted
+ * (or null-prototype) record. A Fabric special value — bytes, a hash, an
+ * epoch — is a class instance, holds its state privately, and answers
+ * `Object.keys` with nothing, so a walker that descended into one would
+ * read every one as empty: they are atomic values here, never containers.
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return isPlainObject(value);
+}
+
+/** Structural equality over stored values, Fabric specials included. */
+function storedEqual(a: unknown, b: unknown): boolean {
+  return valueEqual(a as FabricValue, b as FabricValue);
+}
+
+/** One path segment, display-escaped in the JSON Pointer spelling. */
+function escapeSegment(segment: string): string {
+  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+/** Segments joined for display; `""` is the root. */
+function displayPath(segments: readonly string[]): string {
+  return segments.map(escapeSegment).join("/");
 }
 
 /**
@@ -144,11 +206,11 @@ export function collectLinkPaths(
   path: readonly string[] = [],
   found: (readonly string[])[] = [],
 ): readonly (readonly string[])[] {
-  if (node === null || typeof node !== "object") return found;
   if (isLink(node)) {
     found.push(path);
     return found;
   }
+  if (!isPlainRecord(node) && !Array.isArray(node)) return found;
   for (const [key, value] of Object.entries(node)) {
     collectLinkPaths(value, [...path, key], found);
   }
@@ -159,21 +221,21 @@ export function collectLinkPaths(
 function valueAtPath(node: unknown, path: readonly string[]): unknown {
   let current: unknown = node;
   for (const segment of path) {
-    if (current === null || typeof current !== "object") return undefined;
+    if (!isPlainRecord(current) && !Array.isArray(current)) return undefined;
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
 }
 
 /**
- * Paths the fixer's answer lost, recursively: an input object's own key
+ * Paths the fixer's answer lost, recursively: an input record's own key
  * absent from the answer — or present as `undefined`, which the write
- * treats the same — wherever both sides keep a record, or an equally long
- * array, at the same position. Recursion stops where the shapes part:
+ * treats the same — wherever both sides keep a plain record, or an equally
+ * long array, at the same position. Recursion stops where the shapes part:
  * replacing a container outright is an act the diff reports as a change,
  * while omitting fields from one that survives is the fragment accident
  * this check exists to refuse. Link nodes are the links-intact check's to
- * judge, so they are skipped here rather than reported twice.
+ * judge, and a Fabric special value is one value, so neither is descended.
  */
 function lostFields(
   before: unknown,
@@ -182,7 +244,7 @@ function lostFields(
   out: string[] = [],
 ): readonly string[] {
   if (isLink(before)) return out;
-  const bothRecords = isRecord(before) && isRecord(after);
+  const bothRecords = isPlainRecord(before) && isPlainRecord(after);
   const bothArrays = Array.isArray(before) && Array.isArray(after) &&
     before.length === after.length;
   if (!bothRecords && !bothArrays) return out;
@@ -208,10 +270,11 @@ function lostFields(
 }
 
 /**
- * The leaf-level differences between two documents, as change rows. A
- * position whose two sides are both containers of the same kind recurses;
- * anything else that differs is one change at that position, so a replaced
- * array or object reads as one change rather than as its every leaf.
+ * The differences between two documents, as change rows with presence its
+ * own fact. A position whose two sides are both plain records, or both
+ * direct arrays, recurses; anything else that differs — a Fabric special
+ * value included — is one change at that position, so a replaced container
+ * reads as one change rather than as its every leaf.
  */
 export function documentChanges(
   before: unknown,
@@ -219,11 +282,11 @@ export function documentChanges(
   path: readonly string[] = [],
   out: DocumentChange[] = [],
 ): readonly DocumentChange[] {
-  if (deepEqual(before, after)) return out;
-  const bothRecords = isRecord(before) && isRecord(after);
+  if (storedEqual(before, after)) return out;
+  const bothRecords = isPlainRecord(before) && isPlainRecord(after);
   const bothArrays = Array.isArray(before) && Array.isArray(after);
   if (!bothRecords && !bothArrays) {
-    out.push({ path: displayPath(path), before, after });
+    out.push({ path: displayPath(path), kind: "changed", before, after });
     return out;
   }
   const keys = new Set([
@@ -231,10 +294,29 @@ export function documentChanges(
     ...Object.keys(after as object),
   ]);
   for (const key of keys) {
+    const hasBefore = Object.hasOwn(before as object, key);
+    const hasAfter = Object.hasOwn(after as object, key);
+    const at = [...path, key];
+    if (hasBefore && !hasAfter) {
+      out.push({
+        path: displayPath(at),
+        kind: "removed",
+        before: (before as Record<string, unknown>)[key],
+      });
+      continue;
+    }
+    if (!hasBefore && hasAfter) {
+      out.push({
+        path: displayPath(at),
+        kind: "added",
+        after: (after as Record<string, unknown>)[key],
+      });
+      continue;
+    }
     documentChanges(
       (before as Record<string, unknown>)[key],
       (after as Record<string, unknown>)[key],
-      [...path, key],
+      at,
       out,
     );
   }
@@ -244,23 +326,24 @@ export function documentChanges(
 /**
  * Run the fixer over one stored document and classify the answer. Pure —
  * no controller, no space — which is what lets a fixer's refusals be unit
- * tests and lets the Topics restore import these checks instead of
- * hand-rolling them.
- *
- * The document handed to each fixer call is a fresh deep copy, so a fixer
- * that mutates its argument corrupts neither the purity probe nor the diff
- * baseline. Raw stored documents are plain data — sigil links included —
- * which is what makes the copy, the comparisons, and the walk below sound.
+ * tests. The document handed to each fixer call is a fresh unfrozen deep
+ * copy through the data-model's own clone, so a fixer that mutates its
+ * argument corrupts neither the purity probe nor the diff baseline, and a
+ * Fabric special value arrives as itself rather than as an empty shell.
  */
 export function evaluateFixer(
   document: Readonly<Record<string, unknown>>,
   fixer: Fixer,
 ): FixerOutcome {
+  const copy = () =>
+    cloneIfNecessary(document as FabricValue, {
+      frozen: false,
+    }) as Record<string, unknown>;
   let first: unknown;
   let second: unknown;
   try {
-    first = fixer(structuredClone(document) as Record<string, unknown>);
-    second = fixer(structuredClone(document) as Record<string, unknown>);
+    first = fixer(copy());
+    second = fixer(copy());
   } catch (error) {
     return {
       kind: "refused",
@@ -269,13 +352,13 @@ export function evaluateFixer(
       }`,
     };
   }
-  if (!isRecord(first)) {
+  if (!isPlainRecord(first)) {
     return {
       kind: "refused",
       problem: "The fixer returned a value that is not a document.",
     };
   }
-  if (!deepEqual(first, second)) {
+  if (!storedEqual(first, second)) {
     return {
       kind: "refused",
       problem: "The fixer is not a pure function of the document: two runs " +
@@ -298,7 +381,7 @@ export function evaluateFixer(
   // and neither is visible in the result until much later.
   for (const linkPath of collectLinkPaths(document)) {
     const kept = valueAtPath(first, linkPath);
-    if (!deepEqual(valueAtPath(document, linkPath), kept)) {
+    if (!storedEqual(valueAtPath(document, linkPath), kept)) {
       return {
         kind: "refused",
         problem: `The fixer rewrote or dropped the link at ` +
@@ -306,13 +389,25 @@ export function evaluateFixer(
       };
     }
   }
-  if (deepEqual(document, first)) return { kind: "conforms" };
+  if (storedEqual(document, first)) return { kind: "conforms" };
   return {
     kind: "change",
     document: first,
     changes: documentChanges(document, first),
   };
 }
+
+/** What one pass over a piece's stored document decided. */
+type RowDecision =
+  | { kind: "not-document" }
+  | { kind: "moved"; documentHash: string }
+  | { kind: "conforms"; documentHash: string }
+  | {
+    kind: "change";
+    documentHash: string;
+    changes: readonly DocumentChange[];
+  }
+  | { kind: "refused"; documentHash: string; problem: string };
 
 /**
  * Iterate the fixer over a selection, serially, in survey order — dry by
@@ -326,10 +421,18 @@ export function evaluateFixer(
  * document shape, and a holder wanting repair is a one-piece list selection
  * of its own.
  *
- * Under `apply`, each written document is read back and the fixer asked
- * again — a repair succeeded when re-running the fixer over the stored
- * result is a no-op — and a refusal or a failed verification stops the run
- * with every remaining row named `unattempted`, not counted.
+ * Under `apply`, each row is evaluated and written in one transaction: the
+ * fixer answers for the document the commit sees, so a concurrent edit
+ * re-runs the evaluation rather than being overwritten. A supplied plan's
+ * document hash is checked in the same transaction, and a mismatch is
+ * `moved` — a stop, not an overwrite. The written document is then read
+ * back and the fixer asked again — a repair succeeded when re-running the
+ * fixer over the stored result is a no-op — and a refusal, a moved row, or
+ * a failure stops the run with every remaining row named `unattempted`. An
+ * operational error — an unreachable piece, a write the schema refuses —
+ * becomes that row's `failed` verdict rather than escaping with the report:
+ * the rows that landed stay reported, and the row's state is re-checked
+ * after the failure so the problem says where the piece was left.
  */
 export async function repairPieces(
   pieces: PiecesController,
@@ -350,92 +453,213 @@ export async function repairPieces(
         `the failure this refusal prevents:\n${named.join("\n")}`,
     );
   }
+  const expectedHashes = new Map<string, string>();
+  for (const row of options.plan?.rows ?? []) {
+    if (row.expect.documentHash !== undefined) {
+      expectedHashes.set(
+        canonicalPieceAddress(row.piece),
+        row.expect.documentHash,
+      );
+    }
+  }
   const rows: RepairRow[] = [];
+  const planRows: PiecePlanRow[] = [];
   let applied = 0;
   let stopped = false;
-  for (const planRow of survey.plan.rows) {
-    if (planRow.phase === HOLDER_PHASE) continue;
+  for (const surveyRow of survey.plan.rows) {
+    if (surveyRow.phase === HOLDER_PHASE) continue;
+    const phase = surveyRow.phase === undefined
+      ? {}
+      : { phase: surveyRow.phase };
+    const preStateRow = {
+      piece: surveyRow.piece,
+      ...phase,
+      expect: surveyRow.expect,
+    };
     if (stopped) {
-      rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "unattempted",
-      });
+      rows.push({ piece: surveyRow.piece, ...phase, verdict: "unattempted" });
+      planRows.push(preStateRow);
       continue;
     }
-    const controller = await pieces.get(planRow.piece, false);
-    const cell = await controller.input.getCell();
-    await cell.pull();
-    const document = cell.getRaw({ lastNode: "value" });
-    if (!isRecord(document)) {
+    const expected = expectedHashes.get(surveyRow.piece);
+    const decide = (stored: unknown): RowDecision => {
+      if (!isPlainRecord(stored)) return { kind: "not-document" };
+      const documentHash = hashStringOf(stored);
+      if (expected !== undefined && documentHash !== expected) {
+        return { kind: "moved", documentHash };
+      }
+      const outcome = evaluateFixer(stored, options.fixer);
+      if (outcome.kind === "refused") {
+        return { kind: "refused", documentHash, problem: outcome.problem };
+      }
+      if (outcome.kind === "conforms") {
+        return { kind: "conforms", documentHash };
+      }
+      return { kind: "change", documentHash, changes: outcome.changes };
+    };
+    try {
+      const controller = await pieces.get(surveyRow.piece, false);
+      const cell = await controller.input.getCell();
+      await cell.pull();
+      // Initialized only to satisfy definite assignment: a committed edit
+      // has run its closure at least once, so the committed pass always
+      // overwrites this before it is read.
+      let decision: RowDecision = { kind: "not-document" };
+      if (options.apply === true) {
+        // Evaluate-and-write in one transaction: on a commit conflict the
+        // closure re-runs against fresh state, so `decision` is whatever
+        // the committed pass decided, later passes overwriting earlier.
+        await controller.input.edit((stored) => {
+          decision = decide(stored);
+          if (decision.kind !== "change") return undefined;
+          const outcome = evaluateFixer(
+            stored as Record<string, unknown>,
+            options.fixer,
+          );
+          return outcome.kind === "change"
+            ? { value: outcome.document }
+            : undefined;
+        });
+      } else {
+        decision = decide(cell.getRaw({ lastNode: "value" }));
+      }
+      if (decision.kind === "not-document" || decision.kind === "moved") {
+        planRows.push(preStateRow);
+      } else {
+        // The evaluated row, as the artifact records it: the survey's
+        // expectation plus the document hash the verdict was computed
+        // from, and the repair operation when the run has a name for it.
+        planRows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          expect: {
+            ...surveyRow.expect,
+            documentHash: decision.documentHash,
+          },
+          ...(options.fixerName === undefined ? {} : {
+            op: { kind: "repair", fixer: options.fixerName },
+          }),
+        });
+      }
+      if (decision.kind === "not-document") {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "refused",
+          problem: "The stored input is not a document.",
+        });
+        stopped = options.apply === true;
+        continue;
+      }
+      if (decision.kind === "moved") {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "moved",
+          documentHash: decision.documentHash,
+          problem: "The stored document no longer hashes to what the plan " +
+            "recorded: something other than this plan changed it.",
+        });
+        stopped = options.apply === true;
+        continue;
+      }
+      if (decision.kind === "refused") {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "refused",
+          documentHash: decision.documentHash,
+          problem: decision.problem,
+        });
+        stopped = options.apply === true;
+        continue;
+      }
+      if (decision.kind === "conforms") {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "conforms",
+          documentHash: decision.documentHash,
+        });
+        continue;
+      }
+      if (options.apply !== true) {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "would-change",
+          documentHash: decision.documentHash,
+          changes: decision.changes,
+        });
+        continue;
+      }
+      applied += 1;
+      await pieces.synced();
+      await cell.pull();
+      const written = cell.getRaw({ lastNode: "value" });
+      const verification = isPlainRecord(written)
+        ? evaluateFixer(written, options.fixer)
+        : undefined;
+      if (verification?.kind === "conforms") {
+        rows.push({
+          piece: surveyRow.piece,
+          ...phase,
+          verdict: "repaired",
+          documentHash: decision.documentHash,
+          changes: decision.changes,
+        });
+        continue;
+      }
       rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "refused",
-        problem: "The stored input is not a document.",
+        piece: surveyRow.piece,
+        ...phase,
+        verdict: "failed",
+        documentHash: decision.documentHash,
+        problem: "The stored document does not satisfy the fixer after the " +
+          "write: the write path dropped something, or a concurrent change " +
+          "landed between the write and this read. Writing again is not " +
+          "the answer either way.",
+        changes: decision.changes,
       });
+      stopped = true;
+    } catch (error) {
+      // An operational failure — an unreachable piece, a write the schema
+      // refuses — is this row's outcome, not the report's: the rows that
+      // landed stay reported. The state check runs after the failure, so
+      // the problem says where the piece was left rather than guessing.
+      const problem = error instanceof Error ? error.message : String(error);
+      let state = "; the piece could not be re-read, so its state is unknown";
+      try {
+        const controller = await pieces.get(surveyRow.piece, false);
+        const cell = await controller.input.getCell();
+        await cell.pull();
+        const stored = cell.getRaw({ lastNode: "value" });
+        if (isPlainRecord(stored)) {
+          state = evaluateFixer(stored, options.fixer).kind === "conforms"
+            ? "; the stored document satisfies the fixer, so the row landed"
+            : "; the stored document still needs the repair";
+        }
+      } catch {
+        // The re-read failing changes nothing: `state` already says so.
+      }
+      rows.push({
+        piece: surveyRow.piece,
+        ...phase,
+        verdict: "failed",
+        problem: problem + state,
+      });
+      planRows.push(preStateRow);
       stopped = options.apply === true;
-      continue;
     }
-    const outcome = evaluateFixer(document, options.fixer);
-    if (outcome.kind === "refused") {
-      rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "refused",
-        problem: outcome.problem,
-      });
-      stopped = options.apply === true;
-      continue;
-    }
-    if (outcome.kind === "conforms") {
-      rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "conforms",
-      });
-      continue;
-    }
-    if (options.apply !== true) {
-      rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "would-change",
-        changes: outcome.changes,
-      });
-      continue;
-    }
-    await controller.input.set(outcome.document, []);
-    applied += 1;
-    await pieces.synced();
-    await cell.pull();
-    const written = cell.getRaw({ lastNode: "value" });
-    const verification = isRecord(written)
-      ? evaluateFixer(written, options.fixer)
-      : undefined;
-    if (verification?.kind === "conforms") {
-      rows.push({
-        piece: planRow.piece,
-        phase: planRow.phase,
-        verdict: "repaired",
-        changes: outcome.changes,
-      });
-      continue;
-    }
-    rows.push({
-      piece: planRow.piece,
-      phase: planRow.phase,
-      verdict: "failed",
-      problem: "The written document does not satisfy the fixer, so the " +
-        "write path and the fixer disagree; writing again would not " +
-        "converge.",
-      changes: outcome.changes,
-    });
-    stopped = true;
   }
   const complete = rows.every((row) =>
     row.verdict === "conforms" || row.verdict === "repaired" ||
     (options.apply !== true && row.verdict === "would-change")
   );
-  return { rows, applied, complete };
+  return {
+    rows,
+    plan: { header: survey.plan.header, rows: planRows },
+    applied,
+    complete,
+  };
 }

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -1,0 +1,383 @@
+/**
+ * Bulk repair: a caller-supplied fixer — a pure transform from a piece's
+ * stored input document to the document it should hold — iterated over a
+ * selection by the same spine the survey walks. The tooling owns selection,
+ * ordering, the write, the stop, and resume; the fixer owns only what the
+ * change is (docs/plans/piece-bulk-operations.md, stage 2).
+ *
+ * The fixer is its own predicate. A piece the fixer would not change needs
+ * nothing, so selection ("keep what it would change"), resume ("already
+ * repaired reads as unchanged"), and verification ("re-running over the
+ * stored result is a no-op") are one mechanism, and none of them can drift
+ * from what the fixer does because they are what the fixer does. That is
+ * why a fixer must be a pure function of the document, and why this module
+ * probes the purity it cannot prove: every evaluation runs the fixer twice
+ * and refuses an answer that differs.
+ *
+ * The write is the wide one — the whole input document replaced — made safe
+ * by refusals rather than by narrowing: a document that lost a field the
+ * fixer never mentioned is a defect, not an intent, and a reference
+ * rewritten as a value or dropped is corruption either way. Raw documents
+ * carry references as sigil links, which are plain data on this side of the
+ * runtime, so a fixer that round-trips them untouched preserves them through
+ * the write — measured, and held by the links-intact refusal rather than
+ * trusted.
+ */
+
+import { isLink } from "@commonfabric/runner";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
+
+import {
+  HOLDER_PHASE,
+  type PieceSelector,
+  surveyPieces,
+} from "./bulk-survey.ts";
+import type { PiecesController } from "./pieces-controller.ts";
+
+/**
+ * A fixer: a pure transform from a piece's stored input document to the
+ * document it should hold. It receives the raw stored document — sigil
+ * links included, as plain data — and returns the complete document, never
+ * a fragment. Purity is part of the contract, not a style preference: the
+ * run answers selection, resume, and verification by re-asking the fixer,
+ * and a fixer that reads a clock or a random source makes every one of
+ * those answers wrong.
+ */
+export type Fixer = (
+  document: Readonly<Record<string, unknown>>,
+) => Record<string, unknown>;
+
+/** One leaf-level difference between a stored document and a fixer's. */
+export interface DocumentChange {
+  /** The changed position, segments joined with `/`; `""` is the root. */
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+/**
+ * One piece's outcome. `conforms` and `would-change` are the dry verdicts;
+ * an apply turns `would-change` into `repaired` — or `failed`, when the
+ * written document still does not satisfy the fixer, which is the write
+ * path lying and never a reason to write again. `refused` is the fixer
+ * breaking its contract on this piece's document, and `unattempted` names
+ * the rows after an apply stopped.
+ */
+export type RepairVerdict =
+  | "conforms"
+  | "would-change"
+  | "repaired"
+  | "refused"
+  | "failed"
+  | "unattempted";
+
+/** One piece's row in a repair report. */
+export interface RepairRow {
+  piece: string;
+  /** The plan row's phase label, carried as the survey stamped it. */
+  phase?: string;
+  verdict: RepairVerdict;
+  /** What a refused or failed row broke; absent otherwise. */
+  problem?: string;
+  /** The exact changes the fixer would make (or made); absent when none. */
+  changes?: readonly DocumentChange[];
+}
+
+/** What one repair run found, and — under `apply` — did. */
+export interface RepairReport {
+  rows: readonly RepairRow[];
+  /** Documents written. Zero on a dry run and on a conforming re-run. */
+  applied: number;
+  /**
+   * True when every row is `conforms` or `repaired`: nothing refused,
+   * nothing failed, nothing unattempted. A dry run is complete when
+   * nothing refused — `would-change` is its answer, not a defect.
+   */
+  complete: boolean;
+}
+
+export interface RepairOptions {
+  selector: PieceSelector;
+  fixer: Fixer;
+  /**
+   * Write the documents the fixer produces. Absent, the run is the
+   * dry-run report — the exact per-piece diff, and no write at all.
+   */
+  apply?: boolean;
+}
+
+/** How one evaluation of the fixer over one document came out. */
+export type FixerOutcome =
+  | { kind: "conforms" }
+  | {
+    kind: "change";
+    document: Record<string, unknown>;
+    changes: readonly DocumentChange[];
+  }
+  | { kind: "refused"; problem: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Every path in `node` that holds a sigil link, in traversal order. */
+export function collectLinkPaths(
+  node: unknown,
+  path = "",
+  found: string[] = [],
+): readonly string[] {
+  if (node === null || typeof node !== "object") return found;
+  if (isLink(node)) {
+    found.push(path);
+    return found;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    collectLinkPaths(value, path === "" ? key : `${path}/${key}`, found);
+  }
+  return found;
+}
+
+/** The value at a `/`-joined path, or `undefined` where the path breaks. */
+function valueAtPath(node: unknown, path: string): unknown {
+  if (path === "") return node;
+  let current: unknown = node;
+  for (const segment of path.split("/")) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/**
+ * The leaf-level differences between two documents, as change rows. A
+ * position whose two sides are both containers of the same kind recurses;
+ * anything else that differs is one change at that position, so a replaced
+ * array or object reads as one change rather than as its every leaf.
+ */
+export function documentChanges(
+  before: unknown,
+  after: unknown,
+  path = "",
+  out: DocumentChange[] = [],
+): readonly DocumentChange[] {
+  if (deepEqual(before, after)) return out;
+  const bothRecords = isRecord(before) && isRecord(after);
+  const bothArrays = Array.isArray(before) && Array.isArray(after);
+  if (!bothRecords && !bothArrays) {
+    out.push({ path, before, after });
+    return out;
+  }
+  const keys = new Set([
+    ...Object.keys(before as object),
+    ...Object.keys(after as object),
+  ]);
+  for (const key of keys) {
+    documentChanges(
+      (before as Record<string, unknown>)[key],
+      (after as Record<string, unknown>)[key],
+      path === "" ? key : `${path}/${key}`,
+      out,
+    );
+  }
+  return out;
+}
+
+/**
+ * Run the fixer over one stored document and classify the answer. Pure —
+ * no controller, no space — which is what lets a fixer's refusals be unit
+ * tests and lets the Topics restore import these checks instead of
+ * hand-rolling them.
+ *
+ * The document handed to each fixer call is a fresh deep copy, so a fixer
+ * that mutates its argument corrupts neither the purity probe nor the diff
+ * baseline. Raw stored documents are plain data — sigil links included —
+ * which is what makes the copy, the comparisons, and the walk below sound.
+ */
+export function evaluateFixer(
+  document: Readonly<Record<string, unknown>>,
+  fixer: Fixer,
+): FixerOutcome {
+  let first: unknown;
+  let second: unknown;
+  try {
+    first = fixer(structuredClone(document) as Record<string, unknown>);
+    second = fixer(structuredClone(document) as Record<string, unknown>);
+  } catch (error) {
+    return {
+      kind: "refused",
+      problem: `The fixer threw: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  if (!isRecord(first)) {
+    return {
+      kind: "refused",
+      problem: "The fixer returned a value that is not a document.",
+    };
+  }
+  if (!deepEqual(first, second)) {
+    return {
+      kind: "refused",
+      problem: "The fixer is not a pure function of the document: two runs " +
+        "over one document answered differently.",
+    };
+  }
+  // The write replaces the whole document, so a field the fixer's answer
+  // lacks would be zeroed by it — a defect, never an intent.
+  const lost = Object.keys(document).filter((key) =>
+    document[key] !== undefined && first[key] === undefined
+  );
+  if (lost.length > 0) {
+    return {
+      kind: "refused",
+      problem: `The fixer returned an incomplete document: ` +
+        `${lost.join(", ")} would be lost by the write.`,
+    };
+  }
+  // A reference either round-trips untouched or the document is refused: a
+  // link rewritten as a value is corrupted and a dropped one is destroyed,
+  // and neither is visible in the result until much later.
+  for (const linkPath of collectLinkPaths(document)) {
+    const kept = valueAtPath(first, linkPath);
+    if (!deepEqual(valueAtPath(document, linkPath), kept)) {
+      return {
+        kind: "refused",
+        problem: `The fixer rewrote or dropped the link at ` +
+          `${linkPath === "" ? "<root>" : linkPath}.`,
+      };
+    }
+  }
+  if (deepEqual(document, first)) return { kind: "conforms" };
+  return {
+    kind: "change",
+    document: first,
+    changes: documentChanges(document, first),
+  };
+}
+
+/**
+ * Iterate the fixer over a selection, serially, in survey order — dry by
+ * default, writing under `apply`.
+ *
+ * Selection is the survey's: the same enumeration, and the same containment
+ * gate, so a registered in-scope piece the collection lacks stops a repair
+ * exactly the way it stops a survey — a run over a silent subset is the
+ * failure this whole design exists to prevent. On a collection selector the
+ * holder's own row is not repaired: the fixer is typed against the members'
+ * document shape, and a holder wanting repair is a one-piece list selection
+ * of its own.
+ *
+ * Under `apply`, each written document is read back and the fixer asked
+ * again — a repair succeeded when re-running the fixer over the stored
+ * result is a no-op — and a refusal or a failed verification stops the run
+ * with every remaining row named `unattempted`, not counted.
+ */
+export async function repairPieces(
+  pieces: PiecesController,
+  options: RepairOptions,
+): Promise<RepairReport> {
+  const survey = await surveyPieces(pieces, { selector: options.selector });
+  if (!survey.complete) {
+    const named = [
+      ...survey.problems.map((problem) =>
+        `unreadable: ${problem.piece} ${problem.problem}`
+      ),
+      ...survey.outside.map((outside) =>
+        `registered outside the selection: ${outside.piece}`
+      ),
+    ];
+    throw new Error(
+      `The selection is incomplete, and a repair over a silent subset is ` +
+        `the failure this refusal prevents:\n${named.join("\n")}`,
+    );
+  }
+  const rows: RepairRow[] = [];
+  let applied = 0;
+  let stopped = false;
+  for (const planRow of survey.plan.rows) {
+    if (planRow.phase === HOLDER_PHASE) continue;
+    if (stopped) {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "unattempted",
+      });
+      continue;
+    }
+    const controller = await pieces.get(planRow.piece, false);
+    const cell = await controller.input.getCell();
+    await cell.pull();
+    const document = cell.getRaw({ lastNode: "value" });
+    if (!isRecord(document)) {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "refused",
+        problem: "The stored input is not a document.",
+      });
+      stopped = options.apply === true;
+      continue;
+    }
+    const outcome = evaluateFixer(document, options.fixer);
+    if (outcome.kind === "refused") {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "refused",
+        problem: outcome.problem,
+      });
+      stopped = options.apply === true;
+      continue;
+    }
+    if (outcome.kind === "conforms") {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "conforms",
+      });
+      continue;
+    }
+    if (options.apply !== true) {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "would-change",
+        changes: outcome.changes,
+      });
+      continue;
+    }
+    await controller.input.set(outcome.document, []);
+    applied += 1;
+    await pieces.synced();
+    await cell.pull();
+    const written = cell.getRaw({ lastNode: "value" });
+    const verification = isRecord(written)
+      ? evaluateFixer(written, options.fixer)
+      : undefined;
+    if (verification?.kind === "conforms") {
+      rows.push({
+        piece: planRow.piece,
+        phase: planRow.phase,
+        verdict: "repaired",
+        changes: outcome.changes,
+      });
+      continue;
+    }
+    rows.push({
+      piece: planRow.piece,
+      phase: planRow.phase,
+      verdict: "failed",
+      problem: "The written document does not satisfy the fixer, so the " +
+        "write path and the fixer disagree; writing again would not " +
+        "converge.",
+      changes: outcome.changes,
+    });
+    stopped = true;
+  }
+  const complete = rows.every((row) =>
+    row.verdict === "conforms" || row.verdict === "repaired" ||
+    (options.apply !== true && row.verdict === "would-change")
+  );
+  return { rows, applied, complete };
+}

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -32,7 +32,10 @@
  */
 
 import type { FabricValue } from "@commonfabric/api";
-import { valueEqual } from "@commonfabric/data-model/fabric-value";
+import {
+  isValidFabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isLink } from "@commonfabric/runner";
@@ -249,27 +252,28 @@ function lostFields(
   out: string[] = [],
 ): readonly string[] {
   if (isLink(before)) return out;
-  const bothRecords = isPlainRecord(before) && isPlainRecord(after);
-  const bothArrays = Array.isArray(before) && Array.isArray(after) &&
-    before.length === after.length;
-  if (!bothRecords && !bothArrays) return out;
-  for (const key of Object.keys(before as object)) {
-    const beforeValue = (before as Record<string, unknown>)[key];
-    if (
-      bothRecords &&
-      (!Object.hasOwn(after as object, key) ||
-        ((after as Record<string, unknown>)[key] === undefined &&
-          beforeValue !== undefined))
-    ) {
-      out.push(displayPath([...path, key]));
-      continue;
+  if (isPlainRecord(before) && isPlainRecord(after)) {
+    for (const key of Object.keys(before)) {
+      const beforeValue = before[key];
+      if (
+        !Object.hasOwn(after, key) ||
+        (after[key] === undefined && beforeValue !== undefined)
+      ) {
+        out.push(displayPath([...path, key]));
+        continue;
+      }
+      lostFields(beforeValue, after[key], [...path, key], out);
     }
-    lostFields(
-      beforeValue,
-      (after as Record<string, unknown>)[key],
-      [...path, key],
-      out,
-    );
+    return out;
+  }
+  if (Array.isArray(before) && Array.isArray(after)) {
+    // An array may legitimately shrink — a dedup is a repair — but the
+    // elements that survive at overlapping positions keep their own
+    // fields, whatever happened to the length.
+    const overlap = Math.min(before.length, after.length);
+    for (let index = 0; index < overlap; index += 1) {
+      lostFields(before[index], after[index], [...path, String(index)], out);
+    }
   }
   return out;
 }
@@ -363,43 +367,66 @@ export function evaluateFixer(
       problem: "The fixer returned a value that is not a document.",
     };
   }
-  if (!storedEqual(first, second)) {
-    return {
-      kind: "refused",
-      problem: "The fixer is not a pure function of the document: two runs " +
-        "over one document answered differently.",
-    };
-  }
-  // The write replaces the whole document, so a field the fixer's answer
-  // lacks would be zeroed by it — a defect, never an intent — and a nested
-  // field is as gone as a top-level one.
-  const lost = lostFields(document, first);
-  if (lost.length > 0) {
-    return {
-      kind: "refused",
-      problem: `The fixer returned an incomplete document: ` +
-        `${lost.join(", ")} would be lost by the write.`,
-    };
-  }
-  // A reference either round-trips untouched or the document is refused: a
-  // link rewritten as a value is corrupted and a dropped one is destroyed,
-  // and neither is visible in the result until much later.
-  for (const linkPath of collectLinkPaths(document)) {
-    const kept = valueAtPath(first, linkPath);
-    if (!storedEqual(valueAtPath(document, linkPath), kept)) {
+  // The store's own admission test, over the whole answer: a function, an
+  // accessor, a class instance, an own constructor or __proto__ key — any
+  // of them deep in the answer would pass a root-only look and then fail
+  // at the write, after earlier rows had already landed. Preflight exists
+  // to find exactly that before anything is written, so the admission
+  // question is asked here, and a failure while classifying the answer is
+  // a refusal too rather than an escape.
+  try {
+    if (!isValidFabricValue(first)) {
       return {
         kind: "refused",
-        problem: `The fixer rewrote or dropped the link at ` +
-          `${linkPath.length === 0 ? "<root>" : displayPath(linkPath)}.`,
+        problem: "The fixer returned a document the store cannot hold — a " +
+          "function, an accessor, or a class instance somewhere in it.",
       };
     }
+    if (!storedEqual(first, second)) {
+      return {
+        kind: "refused",
+        problem: "The fixer is not a pure function of the document: two " +
+          "runs over one document answered differently.",
+      };
+    }
+    // The write replaces the whole document, so a field the fixer's answer
+    // lacks would be zeroed by it — a defect, never an intent — and a
+    // nested field is as gone as a top-level one.
+    const lost = lostFields(document, first);
+    if (lost.length > 0) {
+      return {
+        kind: "refused",
+        problem: `The fixer returned an incomplete document: ` +
+          `${lost.join(", ")} would be lost by the write.`,
+      };
+    }
+    // A reference either round-trips untouched or the document is refused:
+    // a link rewritten as a value is corrupted and a dropped one is
+    // destroyed, and neither is visible in the result until much later.
+    for (const linkPath of collectLinkPaths(document)) {
+      const kept = valueAtPath(first, linkPath);
+      if (!storedEqual(valueAtPath(document, linkPath), kept)) {
+        return {
+          kind: "refused",
+          problem: `The fixer rewrote or dropped the link at ` +
+            `${linkPath.length === 0 ? "<root>" : displayPath(linkPath)}.`,
+        };
+      }
+    }
+    if (storedEqual(document, first)) return { kind: "conforms" };
+    return {
+      kind: "change",
+      document: first,
+      changes: documentChanges(document, first),
+    };
+  } catch (error) {
+    return {
+      kind: "refused",
+      problem: `Classifying the fixer's answer failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
   }
-  if (storedEqual(document, first)) return { kind: "conforms" };
-  return {
-    kind: "change",
-    document: first,
-    changes: documentChanges(document, first),
-  };
 }
 
 /** What one pass over a piece's stored document decided. */
@@ -410,6 +437,10 @@ type RowDecision =
   | {
     kind: "change";
     documentHash: string;
+    /** The evaluated answer — the exact document a write must land, so
+     * the report and the write cannot describe two different evaluations
+     * of a fixer that lied to the purity probe. */
+    document: Record<string, unknown>;
     changes: readonly DocumentChange[];
   }
   | { kind: "refused"; documentHash: string; problem: string };
@@ -490,6 +521,17 @@ export async function repairPieces(
     // would refuse cannot reach a write by skipping the file: a repair row
     // without its document hash, a duplicate piece, an invalid row.
     const plan = normalizePlan(options.plan);
+    if (
+      (plan.header.problems?.length ?? 0) > 0 ||
+      (plan.header.outside?.length ?? 0) > 0
+    ) {
+      // Executing it would also launder it: the report's plan carries the
+      // fresh survey's clean header, so the incompleteness would vanish.
+      throw new Error(
+        "No repair can run from an incomplete plan: its header names " +
+          "pieces the survey did not account for.",
+      );
+    }
     if (options.fixerName === undefined) {
       throw new Error(
         "A supplied plan needs the run's fixerName: without it the plan's " +
@@ -549,6 +591,33 @@ export async function repairPieces(
       };
     });
   }
+  // The one classification both passes use, so preflight and the serial
+  // recheck cannot drift: not-document, then the fixer's own answer with
+  // landed preceding moved — a document the fixer no longer changes is in
+  // the state the operation produces, whatever it hashes to.
+  const decideFor = (
+    stored: unknown,
+    expectedHash: string | undefined,
+  ): RowDecision => {
+    if (!isPlainRecord(stored)) return { kind: "not-document" };
+    const documentHash = hashStringOf(stored);
+    const outcome = evaluateFixer(stored, options.fixer);
+    if (outcome.kind === "conforms") {
+      return { kind: "conforms", documentHash };
+    }
+    if (expectedHash !== undefined && documentHash !== expectedHash) {
+      return { kind: "moved", documentHash };
+    }
+    if (outcome.kind === "refused") {
+      return { kind: "refused", documentHash, problem: outcome.problem };
+    }
+    return {
+      kind: "change",
+      documentHash,
+      document: outcome.document,
+      changes: outcome.changes,
+    };
+  };
   const rows: RepairRow[] = [];
   const planRows: PiecePlanRow[] = [];
   let applied = 0;
@@ -569,24 +638,10 @@ export async function repairPieces(
         const controller = await pieces.get(row.piece, false);
         const cell = await controller.input.getCell();
         await cell.pull();
-        const decision = ((): RowDecision => {
-          const stored = cell.getRaw({ lastNode: "value" });
-          if (!isPlainRecord(stored)) return { kind: "not-document" };
-          const documentHash = hashStringOf(stored);
-          const outcome = evaluateFixer(stored, options.fixer);
-          if (outcome.kind === "conforms") {
-            return { kind: "conforms", documentHash };
-          }
-          if (
-            row.expectedHash !== undefined && documentHash !== row.expectedHash
-          ) {
-            return { kind: "moved", documentHash };
-          }
-          if (outcome.kind === "refused") {
-            return { kind: "refused", documentHash, problem: outcome.problem };
-          }
-          return { kind: "change", documentHash, changes: outcome.changes };
-        })();
+        const decision = decideFor(
+          cell.getRaw({ lastNode: "value" }),
+          row.expectedHash,
+        );
         preflight.set(row.piece, decision);
         if (decision.kind !== "conforms" && decision.kind !== "change") {
           startBlocked = true;
@@ -700,27 +755,6 @@ export async function repairPieces(
       emitRow(preflight.get(row.piece), false);
       continue;
     }
-    const expected = row.expectedHash;
-    const decide = (stored: unknown): RowDecision => {
-      if (!isPlainRecord(stored)) return { kind: "not-document" };
-      const documentHash = hashStringOf(stored);
-      const outcome = evaluateFixer(stored, options.fixer);
-      // Landed before moved: a document the fixer no longer changes is in
-      // the state the operation produces, whatever it hashes to now — a
-      // completed plan re-run must read as landed, not as moved. Only a
-      // document that still needs the repair and no longer matches its
-      // recorded precondition was moved by something else.
-      if (outcome.kind === "conforms") {
-        return { kind: "conforms", documentHash };
-      }
-      if (expected !== undefined && documentHash !== expected) {
-        return { kind: "moved", documentHash };
-      }
-      if (outcome.kind === "refused") {
-        return { kind: "refused", documentHash, problem: outcome.problem };
-      }
-      return { kind: "change", documentHash, changes: outcome.changes };
-    };
     try {
       const controller = await pieces.get(row.piece, false);
       const cell = await controller.input.getCell();
@@ -732,25 +766,21 @@ export async function repairPieces(
       if (options.apply === true) {
         // Evaluate-and-write in one transaction: on a commit conflict the
         // closure re-runs against fresh state, so `decision` is whatever
-        // the committed pass decided, later passes overwriting earlier.
+        // the committed pass decided, later passes overwriting earlier —
+        // and the document written is the very one that decision carries,
+        // so the report and the write cannot describe two evaluations.
         await controller.input.edit((stored) => {
-          decision = decide(stored);
-          if (decision.kind !== "change") return undefined;
-          const outcome = evaluateFixer(
-            stored as Record<string, unknown>,
-            options.fixer,
-          );
-          return outcome.kind === "change"
-            ? { value: outcome.document }
+          decision = decideFor(stored, row.expectedHash);
+          return decision.kind === "change"
+            ? { value: decision.document }
             : undefined;
         });
       } else {
-        decision = decide(cell.getRaw({ lastNode: "value" }));
+        decision = decideFor(
+          cell.getRaw({ lastNode: "value" }),
+          row.expectedHash,
+        );
       }
-      emitRow(
-        decision,
-        decision.kind === "conforms" || decision.kind === "change",
-      );
       if (decision.kind === "not-document") {
         rows.push({
           piece: row.piece,
@@ -758,6 +788,7 @@ export async function repairPieces(
           verdict: "refused",
           problem: "The stored input is not a document.",
         });
+        emitRow(decision, false);
         stopped = options.apply === true;
         continue;
       }
@@ -770,6 +801,7 @@ export async function repairPieces(
           problem: "The stored document no longer hashes to what the plan " +
             "recorded: something other than this plan changed it.",
         });
+        emitRow(decision, false);
         stopped = options.apply === true;
         continue;
       }
@@ -781,6 +813,7 @@ export async function repairPieces(
           documentHash: decision.documentHash,
           problem: decision.problem,
         });
+        emitRow(decision, false);
         stopped = options.apply === true;
         continue;
       }
@@ -791,6 +824,7 @@ export async function repairPieces(
           verdict: "conforms",
           documentHash: decision.documentHash,
         });
+        emitRow(decision, true);
         continue;
       }
       if (options.apply !== true) {
@@ -801,6 +835,7 @@ export async function repairPieces(
           documentHash: decision.documentHash,
           changes: decision.changes,
         });
+        emitRow(decision, true);
         continue;
       }
       applied += 1;
@@ -818,6 +853,7 @@ export async function repairPieces(
           documentHash: decision.documentHash,
           changes: decision.changes,
         });
+        emitRow(decision, true);
         continue;
       }
       rows.push({
@@ -831,6 +867,7 @@ export async function repairPieces(
           "the answer either way.",
         changes: decision.changes,
       });
+      emitRow(decision, false);
       stopped = true;
     } catch (error) {
       // An operational failure — an unreachable piece, a write the schema

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -348,11 +348,9 @@ export function evaluateFixer(
     cloneIfNecessary(document as FabricValue, {
       frozen: false,
     }) as Record<string, unknown>;
-  let first: unknown;
-  let second: unknown;
+  let answer: unknown;
   try {
-    first = fixer(copy());
-    second = fixer(copy());
+    answer = fixer(copy());
   } catch (error) {
     return {
       kind: "refused",
@@ -361,7 +359,7 @@ export function evaluateFixer(
       }`,
     };
   }
-  if (!isPlainRecord(first)) {
+  if (!isPlainRecord(answer)) {
     return {
       kind: "refused",
       problem: "The fixer returned a value that is not a document.",
@@ -375,11 +373,31 @@ export function evaluateFixer(
   // question is asked here, and a failure while classifying the answer is
   // a refusal too rather than an escape.
   try {
-    if (!isValidFabricValue(first)) {
+    if (!isValidFabricValue(answer)) {
       return {
         kind: "refused",
         problem: "The fixer returned a document the store cannot hold — a " +
           "function, an accessor, or a class instance somewhere in it.",
+      };
+    }
+    // Detached before the probe's second run: a fixer that returns one
+    // closure-owned object from every call would otherwise mutate its own
+    // first answer into agreement with its second, and the probe would
+    // compare an object with itself. The detached copy is also what a
+    // change decision carries, so no alias the fixer still holds can
+    // reach the write.
+    const first = cloneIfNecessary(answer as FabricValue, {
+      frozen: false,
+    }) as Record<string, unknown>;
+    let second: unknown;
+    try {
+      second = fixer(copy());
+    } catch (error) {
+      return {
+        kind: "refused",
+        problem: `The fixer threw: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       };
     }
     if (!storedEqual(first, second)) {
@@ -763,18 +781,34 @@ export async function repairPieces(
       // has run its closure at least once, so the committed pass always
       // overwrites this before it is read.
       let decision: RowDecision = { kind: "not-document" };
+      let wroteThisRow = false;
       if (options.apply === true) {
         // Evaluate-and-write in one transaction: on a commit conflict the
         // closure re-runs against fresh state, so `decision` is whatever
         // the committed pass decided, later passes overwriting earlier —
         // and the document written is the very one that decision carries,
         // so the report and the write cannot describe two evaluations.
-        await controller.input.edit((stored) => {
+        const { wrote } = await controller.input.edit((stored) => {
           decision = decideFor(stored, row.expectedHash);
           return decision.kind === "change"
             ? { value: decision.document }
             : undefined;
         });
+        wroteThisRow = wrote;
+        if (!wrote) {
+          // A no-write commit stages nothing and is not conflict-checked
+          // (see PiecePropIo.edit), so the decision is remade from a fresh
+          // read — the later verification read that contract calls for —
+          // and the re-read's answer is the row's verdict. The handle is
+          // reacquired rather than reused: a concurrent source change may
+          // have superseded the argument cell the row started from.
+          const fresh = await controller.input.getCell();
+          await fresh.pull();
+          decision = decideFor(
+            fresh.getRaw({ lastNode: "value" }),
+            row.expectedHash,
+          );
+        }
       } else {
         decision = decideFor(
           cell.getRaw({ lastNode: "value" }),
@@ -838,10 +872,30 @@ export async function repairPieces(
         emitRow(decision, true);
         continue;
       }
+      if (!wroteThisRow) {
+        // The no-write classification did not hold on the re-read: the
+        // document changed under a decision that staged nothing. Nothing
+        // was written, so the row is simply not landed — reported as the
+        // work it still is, and a re-run resumes it.
+        rows.push({
+          piece: row.piece,
+          ...phase,
+          verdict: "would-change",
+          documentHash: decision.documentHash,
+          changes: decision.changes,
+        });
+        emitRow(decision, false);
+        continue;
+      }
       applied += 1;
       await pieces.synced();
-      await cell.pull();
-      const written = cell.getRaw({ lastNode: "value" });
+      // The write target is reacquired for verification: edit() resolves
+      // the argument cell inside its own transaction precisely because a
+      // concurrent source change can supersede it, and a verification
+      // through the handle this row started from would read the old cell.
+      const verifyCell = await controller.input.getCell();
+      await verifyCell.pull();
+      const written = verifyCell.getRaw({ lastNode: "value" });
       const verification = isPlainRecord(written)
         ? evaluateFixer(written, options.fixer)
         : undefined;

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -10,6 +10,7 @@ export {
   type PiecePlanRow,
   type PlanEnumeration,
   type RegisteredOutside,
+  type RepairOp,
   type RestoreOp,
   type RetargetOp,
   type RetargetSource,

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -16,6 +16,19 @@ export {
   type SurveyProblem,
 } from "./bulk-plan.ts";
 export {
+  collectLinkPaths,
+  type DocumentChange,
+  documentChanges,
+  evaluateFixer,
+  type Fixer,
+  type FixerOutcome,
+  type RepairOptions,
+  repairPieces,
+  type RepairReport,
+  type RepairRow,
+  type RepairVerdict,
+} from "./bulk-repair.ts";
+export {
   diffPlan,
   type PatternRef,
   type PieceDiffRow,

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -2810,13 +2810,16 @@ class PiecePropIo implements PieceCellIo {
   /**
    * Compute-and-set in one transaction. `produce` receives the value stored
    * at `path`, read raw inside the transaction, and answers with the value
-   * to write — or `undefined`, which leaves the document unwritten while
-   * still committing the read, so a decision made on what was read holds
-   * against concurrent writers. On a commit conflict the whole closure
-   * re-runs against fresh state, `produce` included: what lands is always
-   * a function of the document the commit saw, never of an earlier read.
-   * `produce` must therefore be a pure function of its argument — it runs
-   * any number of times, and only its last answer is written.
+   * to write — or `undefined`, which leaves the document unwritten. On a
+   * commit conflict the whole closure re-runs against fresh state,
+   * `produce` included: what lands is always a function of the document
+   * the commit saw, never of an earlier read. `produce` must therefore be
+   * a pure function of its argument — it runs any number of times, and
+   * only its last answer is written. A no-write answer stages no
+   * operation, and a transaction holding only reads is not
+   * conflict-checked by storage: a caller whose decision not to write
+   * must hold against concurrent writers has to verify it with a later
+   * read, the way a write's caller verifies the write.
    */
   async edit(
     produce: (stored: unknown) => { value: unknown } | undefined,

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -73,6 +73,10 @@ import { compileProgram } from "./utils.ts";
 interface PieceCellIo {
   get(path?: CellPath): Promise<unknown>;
   set(value: unknown, path?: CellPath): Promise<void>;
+  edit(
+    produce: (stored: unknown) => { value: unknown } | undefined,
+    path?: CellPath,
+  ): Promise<{ wrote: boolean }>;
   getCell(): Promise<Cell<unknown>>;
 }
 
@@ -2800,10 +2804,28 @@ class PiecePropIo implements PieceCellIo {
   }
 
   async set(value: unknown, path?: CellPath) {
+    await this.edit(() => ({ value }), path);
+  }
+
+  /**
+   * Compute-and-set in one transaction. `produce` receives the value stored
+   * at `path`, read raw inside the transaction, and answers with the value
+   * to write — or `undefined`, which leaves the document unwritten while
+   * still committing the read, so a decision made on what was read holds
+   * against concurrent writers. On a commit conflict the whole closure
+   * re-runs against fresh state, `produce` included: what lands is always
+   * a function of the document the commit saw, never of an earlier read.
+   * `produce` must therefore be a pure function of its argument — it runs
+   * any number of times, and only its last answer is written.
+   */
+  async edit(
+    produce: (stored: unknown) => { value: unknown } | undefined,
+    path?: CellPath,
+  ): Promise<{ wrote: boolean }> {
     const pieces = this.#cc.pieces();
     let committedTargetCell: Cell<unknown> | undefined;
 
-    const { error } = await pieces.runtime.editWithRetry((tx) => {
+    const { ok, error } = await pieces.runtime.editWithRetry((tx) => {
       // Resolve the target from the piece metadata inside every retry. A
       // concurrent setsrc may replace the argument link/schema after this
       // write starts; reusing a cell captured before the retry would then
@@ -2825,6 +2847,10 @@ class PiecePropIo implements PieceCellIo {
 
       // Build the path with transaction context
       const txCell = targetCell.withTx(tx).key(...(path ?? []));
+
+      const decision = produce(txCell.getRaw({ lastNode: "value" }));
+      if (decision === undefined) return { wrote: false };
+      const value = decision.value;
 
       const writePath = path ?? [];
       const writeTargetDiffers = (
@@ -3298,6 +3324,7 @@ class PiecePropIo implements PieceCellIo {
         }
         setTerminalValue(value);
       }
+      return { wrote: true };
     });
     if (error) {
       if ("reason" in error && error.reason instanceof Error) {
@@ -3305,6 +3332,8 @@ class PiecePropIo implements PieceCellIo {
       }
       throw error;
     }
+    // A committed decision not to write leaves nothing to pull.
+    if (ok !== undefined && !ok.wrote) return { wrote: false };
 
     const targetCell = committedTargetCell ?? await this.#getTargetCell();
 
@@ -3314,6 +3343,7 @@ class PiecePropIo implements PieceCellIo {
       await targetCell.pull();
     }
     await pieces.synced();
+    return { wrote: true };
   }
 
   #getTargetCell(): Promise<Cell<unknown>> {

--- a/packages/piece/test/ops/bulk-diff.test.ts
+++ b/packages/piece/test/ops/bulk-diff.test.ts
@@ -48,6 +48,26 @@ function surveyRow(
 
 describe("bulk-diff", () => {
   describe("diffPlan()", () => {
+    it("refuses a plan carrying repair rows, naming them", () => {
+      const plan = {
+        header,
+        rows: [{
+          piece: "fid1:ccc",
+          expect: {
+            patternIdentity: "x",
+            symbol: "default",
+            retained: true,
+            documentHash: "9f2c",
+          },
+          op: { kind: "repair" as const, fixer: "fix-titles.ts" },
+        }],
+      };
+      expect(() => diffPlan(plan, plan)).toThrow(
+        "cannot verify a document repair",
+      );
+      expect(() => diffPlan(plan, plan)).toThrow("fid1:ccc");
+    });
+
     it("returns landed, outstanding, and moved-elsewhere for retarget rows", () => {
       const plan: PiecePlan = {
         header,

--- a/packages/piece/test/ops/bulk-plan.test.ts
+++ b/packages/piece/test/ops/bulk-plan.test.ts
@@ -138,6 +138,24 @@ describe("bulk-plan", () => {
       expect(() => decodePlan(numericPiece)).toThrow("row 1");
     });
 
+    it("refuses to derive a rollback across repair rows, naming them", () => {
+      const plan = retargetPlan();
+      const withRepair = {
+        header: plan.header,
+        rows: [{
+          piece: plan.rows[0].piece,
+          expect: { ...plan.rows[0].expect, documentHash: "9f2c" },
+          op: { kind: "repair" as const, fixer: "fix-titles.ts" },
+        }],
+      };
+      expect(() => deriveRollbackPlan(withRepair, "later")).toThrow(
+        "no derivable",
+      );
+      expect(() => deriveRollbackPlan(withRepair, "later")).toThrow(
+        plan.rows[0].piece,
+      );
+    });
+
     it("returns a derived rollback unchanged on a round-trip", () => {
       const rollback = deriveRollbackPlan(retargetPlan(), "later");
       expect(decodePlan(encodePlan(rollback))).toEqual(rollback);
@@ -218,6 +236,35 @@ describe("bulk-plan", () => {
         };
         expect(() => decodePlan(JSON.stringify(bad) + "\n")).toThrow("header");
       }
+    });
+
+    it("carries a repair row only with its document-hash precondition", () => {
+      const plan = retargetPlan();
+      const repairRow = {
+        piece: plan.rows[0].piece,
+        phase: plan.rows[0].phase,
+        expect: { ...plan.rows[0].expect, documentHash: "9f2c" },
+        op: { kind: "repair", fixer: "fix-titles.ts" },
+      };
+      const good = JSON.stringify(header) + "\n" + JSON.stringify(repairRow);
+      expect(decodePlan(good).rows[0].op).toEqual({
+        kind: "repair",
+        fixer: "fix-titles.ts",
+      });
+      const hashless = {
+        ...repairRow,
+        expect: { ...plan.rows[0].expect },
+      };
+      expect(() =>
+        decodePlan(JSON.stringify(header) + "\n" + JSON.stringify(hashless))
+      ).toThrow("row 1");
+      const nameless = {
+        ...repairRow,
+        op: { kind: "repair", fixer: "" },
+      };
+      expect(() =>
+        decodePlan(JSON.stringify(header) + "\n" + JSON.stringify(nameless))
+      ).toThrow("row 1");
     });
 
     it("throws for a restore op whose revision is not a string", () => {

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -7,6 +7,7 @@ import { createBuilder } from "@commonfabric/runner";
 
 import type { Cell as BuilderCell } from "../../../runner/src/builder/types.ts";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import {
   collectLinkPaths,
@@ -452,8 +453,10 @@ describe("bulk-repair", () => {
         { kind: "repair", fixer: "upper-seed.ts" },
         { kind: "repair", fixer: "upper-seed.ts" },
       ]);
+      // Computed independently from the stored document, so a wrong hash
+      // cannot certify itself.
       expect(report.plan.rows[0].expect.documentHash)
-        .toBe(report.rows[0].documentHash);
+        .toBe(hashStringOf(await rawInput(a)));
       expect(decodePlan(encodePlan(report.plan))).toEqual(report.plan);
     });
 
@@ -476,6 +479,7 @@ describe("bulk-repair", () => {
       const report = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
         plan: dry.plan,
         apply: true,
       });
@@ -598,6 +602,7 @@ describe("bulk-repair", () => {
       const report = await repairPieces(racing as never, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
         plan: dry.plan,
         apply: true,
       });
@@ -622,6 +627,7 @@ describe("bulk-repair", () => {
       const first = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
         plan: dry.plan,
         apply: true,
       });
@@ -633,6 +639,7 @@ describe("bulk-repair", () => {
       const again = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
         plan: dry.plan,
         apply: true,
       });
@@ -661,6 +668,7 @@ describe("bulk-repair", () => {
       const report = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
         plan: reversed,
         apply: true,
       });
@@ -674,10 +682,118 @@ describe("bulk-repair", () => {
         repairPieces(pieces, {
           selector: collectionOf(holder),
           fixer: upperSeed,
+          fixerName: "upper-seed.ts",
           plan: truncated,
           apply: true,
         }),
       ).rejects.toThrow("the selection holds pieces the plan does not name");
+    });
+
+    it("holds an in-memory plan to the codec's invariants", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      // A repair row stripped of its document hash: the codec would refuse
+      // this at decode, and the executor must refuse it the same way
+      // rather than writing unconditionally.
+      const hashless = {
+        header: dry.plan.header,
+        rows: dry.plan.rows.map((row) => ({
+          ...row,
+          expect: { ...row.expect, documentHash: undefined },
+        })),
+      };
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "upper-seed.ts",
+          plan: hashless as never,
+          apply: true,
+        }),
+      ).rejects.toThrow("row 1");
+      expect((await rawInput(a)).seed).toBe("alpha");
+
+      // A duplicated row would execute its piece twice.
+      const doubled = {
+        header: dry.plan.header,
+        rows: [dry.plan.rows[0], ...dry.plan.rows],
+      };
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "upper-seed.ts",
+          plan: doubled,
+          apply: true,
+        }),
+      ).rejects.toThrow("more than once");
+
+      // A plan without the run's fixerName cannot be held against the
+      // fixer actually run.
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          plan: dry.plan,
+          apply: true,
+        }),
+      ).rejects.toThrow("needs the run's fixerName");
+    });
+
+    it("emits an artifact a stopped run can be resumed from", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      // Move the second piece so the plan-driven apply blocks at preflight.
+      const original = (await rawInput(b)).seed;
+      await b.input.set("shifted", ["seed"]);
+      await pieces.runtime.idle();
+      const blocked = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(blocked.applied).toBe(0);
+      // Every artifact row still carries its precondition and operation —
+      // the blocked run's plan is suppliable straight back.
+      expect(
+        blocked.plan.rows.every((row) =>
+          row.op?.kind === "repair" &&
+          row.expect.documentHash !== undefined
+        ),
+      ).toBe(true);
+
+      // The operator puts the moved piece back; the blocked artifact then
+      // completes the run it recorded.
+      await b.input.set(original, ["seed"]);
+      await pieces.runtime.idle();
+      const resumed = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+        plan: blocked.plan,
+        apply: true,
+      });
+      expect(resumed.rows.map((row) => row.verdict)).toEqual([
+        "repaired",
+        "repaired",
+      ]);
+      expect(resumed.complete).toBe(true);
     });
 
     it("refuses a plan that disagrees with the run", async () => {
@@ -693,6 +809,7 @@ describe("bulk-repair", () => {
         repairPieces(pieces, {
           selector: collectionOf(holder),
           fixer: upperSeed,
+          fixerName: "upper-seed.ts",
           plan: {
             header: { ...dry.plan.header, space: "did:key:somewhere-else" },
             rows: dry.plan.rows,
@@ -723,6 +840,7 @@ describe("bulk-repair", () => {
         repairPieces(pieces, {
           selector: collectionOf(holder),
           fixer: upperSeed,
+          fixerName: "upper-seed.ts",
           plan: opless,
           apply: true,
         }),

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -6,12 +6,15 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "@commonfabric/runner";
 
 import type { Cell as BuilderCell } from "../../../runner/src/builder/types.ts";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+
 import {
   collectLinkPaths,
   documentChanges,
   evaluateFixer,
   repairPieces,
 } from "../../src/ops/bulk-repair.ts";
+import { decodePlan, encodePlan } from "../../src/ops/bulk-plan.ts";
 import type { PieceController } from "../../src/ops/piece-controller.ts";
 import { PiecesController } from "../../src/ops/pieces-controller.ts";
 import { surveyPieces } from "../../src/ops/bulk-survey.ts";
@@ -82,20 +85,42 @@ describe("bulk-repair", () => {
         { a: 2, nested: { keep: true, flip: "y" } },
       );
       expect(changes).toEqual([
-        { path: "a", before: 1, after: 2 },
-        { path: "nested/flip", before: "x", after: "y" },
+        { path: "a", kind: "changed", before: 1, after: 2 },
+        { path: "nested/flip", kind: "changed", before: "x", after: "y" },
       ]);
     });
 
     it("reports a replaced container as one change, not its every leaf", () => {
       const changes = documentChanges({ list: [1, 2, 3] }, { list: "gone" });
       expect(changes).toEqual([
-        { path: "list", before: [1, 2, 3], after: "gone" },
+        { path: "list", kind: "changed", before: [1, 2, 3], after: "gone" },
       ]);
     });
 
     it("returns no rows for equal documents", () => {
       expect(documentChanges({ a: [1] }, { a: [1] })).toEqual([]);
+    });
+
+    it("reports presence as its own fact, apart from a changed value", () => {
+      expect(documentChanges({ a: 1 }, { a: 1, b: 2 })).toEqual([
+        { path: "b", kind: "added", after: 2 },
+      ]);
+      expect(documentChanges({ a: 1, b: 2 }, { a: 1 })).toEqual([
+        { path: "b", kind: "removed", before: 2 },
+      ]);
+      expect(documentChanges({ a: undefined }, { a: 3 })).toEqual([
+        { path: "a", kind: "changed", before: undefined, after: 3 },
+      ]);
+    });
+
+    it("treats a Fabric special value as one atomic leaf", () => {
+      const before = { bytes: new FabricBytes(new Uint8Array([1])) };
+      const after = { bytes: new FabricBytes(new Uint8Array([2])) };
+      expect(documentChanges(before, before)).toEqual([]);
+      const changes = documentChanges(before, after);
+      expect(changes.length).toBe(1);
+      expect(changes[0].path).toBe("bytes");
+      expect(changes[0].kind).toBe("changed");
     });
   });
 
@@ -131,7 +156,7 @@ describe("bulk-repair", () => {
       expect(outcome).toEqual({
         kind: "change",
         document: { seed: "A", keep: 1 },
-        changes: [{ path: "seed", before: "a", after: "A" }],
+        changes: [{ path: "seed", kind: "changed", before: "a", after: "A" }],
       });
     });
 
@@ -206,7 +231,7 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("change");
       if (outcome.kind !== "change") throw new Error("expected a change");
       expect(outcome.changes).toEqual([
-        { path: "wrap", before: { a: 1, b: 2 }, after: 7 },
+        { path: "wrap", kind: "changed", before: { a: 1, b: 2 }, after: 7 },
       ]);
     });
 
@@ -266,7 +291,7 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("change");
       if (outcome.kind !== "change") throw new Error("expected a change");
       expect(outcome.changes).toEqual([
-        { path: "title", before: "t", after: "renamed" },
+        { path: "title", kind: "changed", before: "t", after: "renamed" },
       ]);
     });
 
@@ -288,6 +313,21 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("refused");
       if (outcome.kind !== "refused") throw new Error("expected a refusal");
       expect(outcome.problem).toContain("<root>");
+    });
+
+    it("carries a Fabric special value through an identity fixer untouched", () => {
+      // The failure this guards: a structural clone reads a bytes value as
+      // an empty shell, so an identity fixer would "return" a corrupted
+      // document with an empty diff and the write would destroy the value.
+      const document = { bytes: new FabricBytes(new Uint8Array([1, 2])) };
+      expect(evaluateFixer(document, (d) => ({ ...d }))).toEqual({
+        kind: "conforms",
+      });
+      const changed = evaluateFixer(document, (d) => ({
+        ...d,
+        bytes: new FabricBytes(new Uint8Array([9])),
+      }));
+      expect(changed.kind).toBe("change");
     });
 
     it("is safe against a fixer that mutates its argument", () => {
@@ -364,6 +404,7 @@ describe("bulk-repair", () => {
       const report = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
+        fixerName: "upper-seed.ts",
       });
 
       expect(report.rows).toEqual([
@@ -371,12 +412,87 @@ describe("bulk-repair", () => {
           piece: a.id,
           phase: "members",
           verdict: "would-change",
-          changes: [{ path: "seed", before: "alpha", after: "ALPHA" }],
+          documentHash: report.rows[0].documentHash,
+          changes: [
+            { path: "seed", kind: "changed", before: "alpha", after: "ALPHA" },
+          ],
         },
-        { piece: b.id, phase: "members", verdict: "conforms" },
+        {
+          piece: b.id,
+          phase: "members",
+          verdict: "conforms",
+          documentHash: report.rows[1].documentHash,
+        },
       ]);
+      expect(report.rows[0].documentHash).toBeDefined();
       expect(report.applied).toBe(0);
       expect(report.complete).toBe(true);
+      expect((await rawInput(a)).seed).toBe("alpha");
+
+      // The run's record is a plan artifact: each evaluated row carries its
+      // document-hash precondition and the named repair, and the codec
+      // round-trips it.
+      expect(report.plan.rows.map((row) => row.op)).toEqual([
+        { kind: "repair", fixer: "upper-seed.ts" },
+        { kind: "repair", fixer: "upper-seed.ts" },
+      ]);
+      expect(report.plan.rows[0].expect.documentHash)
+        .toBe(report.rows[0].documentHash);
+      expect(decodePlan(encodePlan(report.plan))).toEqual(report.plan);
+    });
+
+    it("stops an apply on a row whose document moved off its plan hash", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      // Something other than the plan changes the first piece's document.
+      await a.input.set("altered", ["seed"]);
+      await pieces.runtime.idle();
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "moved",
+        "unattempted",
+      ]);
+      expect(report.rows[0].problem).toContain(
+        "something other than this plan",
+      );
+      expect(report.applied).toBe(0);
+      expect((await rawInput(b)).seed).toBe("bravo");
+    });
+
+    it("returns a failed row, state-checked, when the write path refuses", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+
+      const report = await repairPieces(pieces, {
+        // The answer breaks the piece's own input schema, so the write path
+        // refuses it — an operational failure the report must carry rather
+        // than escape with.
+        selector: collectionOf(holder),
+        fixer: (d) => ({ ...d, seed: 7 }),
+        apply: true,
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "failed",
+        "unattempted",
+      ]);
+      expect(report.rows[0].problem).toContain("schema");
+      expect(report.rows[0].problem).toContain("still needs the repair");
+      expect(report.applied).toBe(0);
       expect((await rawInput(a)).seed).toBe("alpha");
     });
 

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -380,6 +380,33 @@ describe("bulk-repair", () => {
       expect(changed.kind).toBe("change");
     });
 
+    it("refuses a fixer that throws only on the probe's second run", () => {
+      let calls = 0;
+      const outcome = evaluateFixer({ seed: "a" }, (d) => {
+        calls += 1;
+        if (calls === 2) throw new Error("the second call dies");
+        return { ...d };
+      });
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("the second call dies");
+    });
+
+    it("catches a fixer that reuses and mutates one answer object", () => {
+      // The probe's first answer is detached before the second call, so a
+      // fixer returning one closure-owned object from every call — its
+      // second call mutating its first answer into agreement — compares
+      // its two states, not the one object with itself.
+      const shared = { n: 0 };
+      const outcome = evaluateFixer({ n: 0 }, () => {
+        shared.n += 2;
+        return shared;
+      });
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("pure function");
+    });
+
     it("is safe against a fixer that mutates its argument", () => {
       const document = { seed: "a" };
       const outcome = evaluateFixer(document, (d) => {
@@ -533,6 +560,71 @@ describe("bulk-repair", () => {
       );
       expect(report.applied).toBe(0);
       expect((await rawInput(a)).seed).toBe("ALPHA");
+    });
+
+    it("reclassifies a no-write decision from a fresh read before reporting it", async () => {
+      const a = await member("ALPHA");
+      // The piece conforms when the transaction reads it, so nothing is
+      // written and nothing is conflict-checked; a concurrent writer then
+      // changes it before the verification re-read. The row must come back
+      // as the work it now is — never as a conformity that would make the
+      // report read complete.
+      let editDone = false;
+      let mutated = false;
+      const wrapController = (controller: PieceController) =>
+        new Proxy(controller, {
+          get(c, prop, receiver) {
+            if (prop !== "input") {
+              const value = Reflect.get(c, prop, receiver);
+              return typeof value === "function" ? value.bind(c) : value;
+            }
+            const input = c.input;
+            return new Proxy(input, {
+              get(i, p, r) {
+                if (p === "edit") {
+                  return async (
+                    ...args: Parameters<typeof input.edit>
+                  ) => {
+                    const result = await input.edit(...args);
+                    editDone = true;
+                    return result;
+                  };
+                }
+                if (p === "getCell") {
+                  return async () => {
+                    if (editDone && !mutated) {
+                      mutated = true;
+                      await a.input.set("shifted", ["seed"]);
+                      await pieces.runtime.idle();
+                    }
+                    return input.getCell();
+                  };
+                }
+                const value = Reflect.get(i, p, r);
+                return typeof value === "function" ? value.bind(i) : value;
+              },
+            });
+          },
+        });
+      const racing = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return async (id: string, run?: boolean) =>
+              wrapController(await target.get(id, run));
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const report = await repairPieces(racing as never, {
+        selector: { kind: "list", pieces: [a.id] },
+        fixer: upperSeed,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.verdict)).toEqual(["would-change"]);
+      expect(report.applied).toBe(0);
+      expect(report.complete).toBe(false);
     });
 
     it("reports a preflight read failure and starts nothing", async () => {

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -654,6 +654,45 @@ describe("bulk-repair", () => {
       expect((await rawInput(b)).seed).toBe("bravo");
     });
 
+    it("says the state is unknown when the failed piece cannot be re-read", async () => {
+      const a = await member("alpha");
+      const holder = await seedHolder([a]);
+      // The connection drops between the failed write and the state check:
+      // once the fixer has run (so selection and the row's own read are
+      // done), every further load of the piece fails. The wrapper delegates
+      // everything else, bound so the controller's private state still
+      // works.
+      let armed = false;
+      const flaky = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return (id: string, run?: boolean) => {
+              if (armed && id === a.id) {
+                return Promise.reject(new Error("the connection dropped"));
+              }
+              return target.get(id, run);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const report = await repairPieces(flaky as never, {
+        selector: collectionOf(holder),
+        fixer: (d) => {
+          armed = true;
+          // The answer breaks the schema, so the write path refuses it and
+          // the state check is what runs next.
+          return { ...d, seed: 7 };
+        },
+        apply: true,
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual(["failed"]);
+      expect(report.rows[0].problem).toContain("state is unknown");
+    });
+
     it("reports every refusal on a dry run instead of stopping", async () => {
       const a = await member("alpha");
       const b = await member("bravo");

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -114,6 +114,19 @@ describe("bulk-repair", () => {
       ]);
     });
 
+    it("diffs sparse arrays by position, holes and length included", () => {
+      expect(documentChanges({ a: new Array(1) }, { a: [] })).toEqual([
+        { path: "/a/0", kind: "removed", before: undefined },
+      ]);
+      expect(documentChanges({ a: [, 1] }, { a: [2, 1] })).toEqual([
+        { path: "/a/0", kind: "changed", before: undefined, after: 2 },
+      ]);
+      expect(documentChanges({ a: [1] }, { a: [1, , 3] })).toEqual([
+        { path: "/a/1", kind: "added", after: undefined },
+        { path: "/a/2", kind: "added", after: 3 },
+      ]);
+    });
+
     it("keeps the root and a top-level empty-string key distinct", () => {
       expect(documentChanges("x", "y")).toEqual([
         { path: "", kind: "changed", before: "x", after: "y" },
@@ -563,6 +576,7 @@ describe("bulk-repair", () => {
     });
 
     it("reclassifies a no-write decision from a fresh read before reporting it", async () => {
+      const b = await member("bravo");
       const a = await member("ALPHA");
       // The piece conforms when the transaction reads it, so nothing is
       // written and nothing is conflict-checked; a concurrent writer then
@@ -618,13 +632,115 @@ describe("bulk-repair", () => {
       });
 
       const report = await repairPieces(racing as never, {
+        selector: { kind: "list", pieces: [a.id, b.id] },
+        fixer: upperSeed,
+        apply: true,
+      });
+      // The raced row stops the run: plan order is a correctness
+      // constraint, so the later row must not land while this one is
+      // outstanding.
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "would-change",
+        "unattempted",
+      ]);
+      expect(report.applied).toBe(0);
+      expect(report.complete).toBe(false);
+      expect((await rawInput(b)).seed).toBe("bravo");
+    });
+
+    it("reports what the store returned after the write, not the fixer's answer", async () => {
+      const a = await member("alpha");
+      // The write path is free to normalize what it stores — schema-default
+      // hydration is the measured case — so an applied row's changes must
+      // be read back from the store. The verification read is intercepted
+      // to answer with a field the fixer never produced, standing in for
+      // exactly that normalization.
+      let editDone = false;
+      const wrapController = (controller: PieceController) =>
+        new Proxy(controller, {
+          get(c, prop, receiver) {
+            if (prop !== "input") {
+              const value = Reflect.get(c, prop, receiver);
+              return typeof value === "function" ? value.bind(c) : value;
+            }
+            const input = c.input;
+            return new Proxy(input, {
+              get(i, p, r) {
+                if (p === "edit") {
+                  return async (
+                    ...args: Parameters<typeof input.edit>
+                  ) => {
+                    const result = await input.edit(...args);
+                    editDone = true;
+                    return result;
+                  };
+                }
+                if (p === "getCell") {
+                  return async () => {
+                    const cell = await input.getCell();
+                    if (!editDone) return cell;
+                    return new Proxy(cell, {
+                      get(target, cellProp, cellReceiver) {
+                        if (cellProp === "getRaw") {
+                          return (
+                            ...raw: Parameters<typeof cell.getRaw>
+                          ) => ({
+                            ...(cell.getRaw(...raw) as Record<
+                              string,
+                              unknown
+                            >),
+                            hydrated: "by-the-store",
+                          });
+                        }
+                        const value = Reflect.get(
+                          target,
+                          cellProp,
+                          cellReceiver,
+                        );
+                        return typeof value === "function"
+                          ? value.bind(target)
+                          : value;
+                      },
+                    });
+                  };
+                }
+                const value = Reflect.get(i, p, r);
+                return typeof value === "function" ? value.bind(i) : value;
+              },
+            });
+          },
+        });
+      const hydrating = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return async (id: string, run?: boolean) =>
+              wrapController(await target.get(id, run));
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const report = await repairPieces(hydrating as never, {
         selector: { kind: "list", pieces: [a.id] },
         fixer: upperSeed,
         apply: true,
       });
-      expect(report.rows.map((row) => row.verdict)).toEqual(["would-change"]);
-      expect(report.applied).toBe(0);
-      expect(report.complete).toBe(false);
+      expect(report.rows[0].verdict).toBe("repaired");
+      expect(report.rows[0].changes).toEqual([
+        { path: "/seed", kind: "changed", before: "alpha", after: "ALPHA" },
+        { path: "/hydrated", kind: "added", after: "by-the-store" },
+      ]);
+    });
+
+    it("refuses an empty fixer name before reading anything", async () => {
+      await expect(
+        repairPieces(pieces, {
+          selector: { kind: "list", pieces: ["fid1:never-read"] },
+          fixer: upperSeed,
+          fixerName: "",
+        }),
+      ).rejects.toThrow("must be nonempty");
     });
 
     it("reports a preflight read failure and starts nothing", async () => {

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -85,15 +85,15 @@ describe("bulk-repair", () => {
         { a: 2, nested: { keep: true, flip: "y" } },
       );
       expect(changes).toEqual([
-        { path: "a", kind: "changed", before: 1, after: 2 },
-        { path: "nested/flip", kind: "changed", before: "x", after: "y" },
+        { path: "/a", kind: "changed", before: 1, after: 2 },
+        { path: "/nested/flip", kind: "changed", before: "x", after: "y" },
       ]);
     });
 
     it("reports a replaced container as one change, not its every leaf", () => {
       const changes = documentChanges({ list: [1, 2, 3] }, { list: "gone" });
       expect(changes).toEqual([
-        { path: "list", kind: "changed", before: [1, 2, 3], after: "gone" },
+        { path: "/list", kind: "changed", before: [1, 2, 3], after: "gone" },
       ]);
     });
 
@@ -103,13 +103,22 @@ describe("bulk-repair", () => {
 
     it("reports presence as its own fact, apart from a changed value", () => {
       expect(documentChanges({ a: 1 }, { a: 1, b: 2 })).toEqual([
-        { path: "b", kind: "added", after: 2 },
+        { path: "/b", kind: "added", after: 2 },
       ]);
       expect(documentChanges({ a: 1, b: 2 }, { a: 1 })).toEqual([
-        { path: "b", kind: "removed", before: 2 },
+        { path: "/b", kind: "removed", before: 2 },
       ]);
       expect(documentChanges({ a: undefined }, { a: 3 })).toEqual([
-        { path: "a", kind: "changed", before: undefined, after: 3 },
+        { path: "/a", kind: "changed", before: undefined, after: 3 },
+      ]);
+    });
+
+    it("keeps the root and a top-level empty-string key distinct", () => {
+      expect(documentChanges("x", "y")).toEqual([
+        { path: "", kind: "changed", before: "x", after: "y" },
+      ]);
+      expect(documentChanges({ "": 1 }, { "": 2 })).toEqual([
+        { path: "/", kind: "changed", before: 1, after: 2 },
       ]);
     });
 
@@ -119,7 +128,7 @@ describe("bulk-repair", () => {
       expect(documentChanges(before, before)).toEqual([]);
       const changes = documentChanges(before, after);
       expect(changes.length).toBe(1);
-      expect(changes[0].path).toBe("bytes");
+      expect(changes[0].path).toBe("/bytes");
       expect(changes[0].kind).toBe("changed");
     });
   });
@@ -156,7 +165,9 @@ describe("bulk-repair", () => {
       expect(outcome).toEqual({
         kind: "change",
         document: { seed: "A", keep: 1 },
-        changes: [{ path: "seed", kind: "changed", before: "a", after: "A" }],
+        changes: [
+          { path: "/seed", kind: "changed", before: "a", after: "A" },
+        ],
       });
     });
 
@@ -197,7 +208,7 @@ describe("bulk-repair", () => {
       );
       expect(outcome.kind).toBe("refused");
       if (outcome.kind !== "refused") throw new Error("expected a refusal");
-      expect(outcome.problem).toContain("keep, also");
+      expect(outcome.problem).toContain("/keep, /also");
     });
 
     it("refuses a nested field the answer lost, wherever the container survived", () => {
@@ -231,7 +242,7 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("change");
       if (outcome.kind !== "change") throw new Error("expected a change");
       expect(outcome.changes).toEqual([
-        { path: "wrap", kind: "changed", before: { a: 1, b: 2 }, after: 7 },
+        { path: "/wrap", kind: "changed", before: { a: 1, b: 2 }, after: 7 },
       ]);
     });
 
@@ -291,7 +302,7 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("change");
       if (outcome.kind !== "change") throw new Error("expected a change");
       expect(outcome.changes).toEqual([
-        { path: "title", kind: "changed", before: "t", after: "renamed" },
+        { path: "/title", kind: "changed", before: "t", after: "renamed" },
       ]);
     });
 
@@ -414,7 +425,12 @@ describe("bulk-repair", () => {
           verdict: "would-change",
           documentHash: report.rows[0].documentHash,
           changes: [
-            { path: "seed", kind: "changed", before: "alpha", after: "ALPHA" },
+            {
+              path: "/seed",
+              kind: "changed",
+              before: "alpha",
+              after: "ALPHA",
+            },
           ],
         },
         {
@@ -441,8 +457,8 @@ describe("bulk-repair", () => {
       expect(decodePlan(encodePlan(report.plan))).toEqual(report.plan);
     });
 
-    it("stops an apply on a row whose document moved off its plan hash", async () => {
-      const a = await member("alpha");
+    it("preflights every row, and a moved one keeps the run from starting", async () => {
+      const a = await member("ALPHA");
       const b = await member("bravo");
       const holder = await seedHolder([a, b]);
       const dry = await repairPieces(pieces, {
@@ -451,8 +467,10 @@ describe("bulk-repair", () => {
         fixerName: "upper-seed.ts",
       });
 
-      // Something other than the plan changes the first piece's document.
-      await a.input.set("altered", ["seed"]);
+      // Something other than the plan changes the SECOND piece's document:
+      // preflight must find it before the first piece is written, so the
+      // run does not start and every row reports its classification.
+      await b.input.set("altered", ["seed"]);
       await pieces.runtime.idle();
 
       const report = await repairPieces(pieces, {
@@ -462,14 +480,253 @@ describe("bulk-repair", () => {
         apply: true,
       });
       expect(report.rows.map((row) => row.verdict)).toEqual([
+        "conforms",
         "moved",
-        "unattempted",
       ]);
-      expect(report.rows[0].problem).toContain(
+      expect(report.rows[1].problem).toContain(
         "something other than this plan",
       );
       expect(report.applied).toBe(0);
-      expect((await rawInput(b)).seed).toBe("bravo");
+      expect((await rawInput(a)).seed).toBe("ALPHA");
+    });
+
+    it("reports a preflight read failure and starts nothing", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      // The connection to the second piece drops after the survey read it:
+      // its preflight read fails, so the run must not start, and the first
+      // piece keeps its classification rather than being written.
+      let bGets = 0;
+      const flaky = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return (id: string, run?: boolean) => {
+              if (id === b.id && ++bGets >= 2) {
+                // A bare string, deliberately: failures are not all Errors,
+                // and the report must carry this one's text too.
+                return Promise.reject("the connection dropped");
+              }
+              return target.get(id, run);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const report = await repairPieces(flaky as never, {
+        selector: { kind: "list", pieces: [a.id, b.id] },
+        fixer: upperSeed,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "would-change",
+        "failed",
+      ]);
+      expect(report.rows[1].problem).toContain("the run did not start");
+      expect(report.applied).toBe(0);
+      expect((await rawInput(a)).seed).toBe("alpha");
+    });
+
+    it("classifies a non-document beside the rest when the run cannot start", async () => {
+      const scalarProgram: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern } from 'commonfabric';",
+            "export default pattern<string>((text) => ({",
+            "  [NAME]: 'Scalar',",
+            "  text,",
+            "}));",
+            "",
+          ].join("\n"),
+        }],
+      };
+      const scalar = await pieces.create(scalarProgram, {
+        input: "not a document" as never,
+      });
+      const a = await member("alpha");
+
+      const report = await repairPieces(pieces, {
+        selector: { kind: "list", pieces: [scalar.id, a.id] },
+        fixer: upperSeed,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "refused",
+        "would-change",
+      ]);
+      expect(report.rows[0].problem).toContain("not a document");
+      expect(report.applied).toBe(0);
+    });
+
+    it("stops on a move that lands between preflight and the row's transaction", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      // Preflight sees both rows clean; a concurrent writer then moves the
+      // second piece before its transaction. The wrapper performs that
+      // write when the serial pass fetches the piece — after preflight, so
+      // this is exactly the window the transactional recheck exists for.
+      let gets = 0;
+      const racing = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return async (id: string, run?: boolean) => {
+              // The survey fetches the piece once and preflight once; the
+              // serial pass's fetch is the third, and the concurrent write
+              // lands there — after preflight passed this row clean.
+              if (id === b.id && ++gets === 3) {
+                await b.input.set("shifted", ["seed"]);
+                await target.runtime.idle();
+              }
+              return target.get(id, run);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+
+      const report = await repairPieces(racing as never, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "repaired",
+        "moved",
+      ]);
+      expect(report.applied).toBe(1);
+      expect((await rawInput(b)).seed).toBe("shifted");
+    });
+
+    it("resumes a completed plan: every landed row conforms, whatever it hashes to", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      const first = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(first.rows.map((row) => row.verdict)).toEqual([
+        "repaired",
+        "repaired",
+      ]);
+
+      const again = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(again.rows.map((row) => row.verdict)).toEqual([
+        "conforms",
+        "conforms",
+      ]);
+      expect(again.applied).toBe(0);
+      expect(again.complete).toBe(true);
+    });
+
+    it("executes the supplied plan's rows exactly, in the plan's order", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      const reversed = {
+        header: dry.plan.header,
+        rows: [...dry.plan.rows].reverse(),
+      };
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        plan: reversed,
+        apply: true,
+      });
+      expect(report.rows.map((row) => row.piece)).toEqual([b.id, a.id]);
+
+      const truncated = {
+        header: dry.plan.header,
+        rows: dry.plan.rows.slice(1),
+      };
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          plan: truncated,
+          apply: true,
+        }),
+      ).rejects.toThrow("the selection holds pieces the plan does not name");
+    });
+
+    it("refuses a plan that disagrees with the run", async () => {
+      const a = await member("alpha");
+      const holder = await seedHolder([a]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          plan: {
+            header: { ...dry.plan.header, space: "did:key:somewhere-else" },
+            rows: dry.plan.rows,
+          },
+          apply: true,
+        }),
+      ).rejects.toThrow("names space");
+
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "other-fixer.ts",
+          plan: dry.plan,
+          apply: true,
+        }),
+      ).rejects.toThrow("different fixer");
+
+      const opless = {
+        header: dry.plan.header,
+        rows: dry.plan.rows.map((row) => ({
+          piece: row.piece,
+          ...(row.phase === undefined ? {} : { phase: row.phase }),
+          expect: row.expect,
+        })),
+      };
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          plan: opless,
+          apply: true,
+        }),
+      ).rejects.toThrow("no repair operation");
     });
 
     it("returns a failed row, state-checked, when the write path refuses", async () => {
@@ -568,7 +825,7 @@ describe("bulk-repair", () => {
       expect(survey.plan.rows.map((row) => row.piece)).toContain(a.id);
     });
 
-    it("stops an apply at the first refusal and names the rest unattempted", async () => {
+    it("keeps the run from starting on a preflight refusal, every row classified", async () => {
       const a = await member("alpha");
       const b = await member("bravo");
       const c = await member("charlie");
@@ -583,14 +840,19 @@ describe("bulk-repair", () => {
         apply: true,
       });
 
+      // Preflight classifies all three before anything is written, finds
+      // the refusal, and the run does not start: nothing applied, and the
+      // rows around the refusal keep their classifications rather than
+      // reading as unattempted.
       expect(report.rows.map((row) => row.verdict)).toEqual([
-        "repaired",
+        "would-change",
         "refused",
-        "unattempted",
+        "would-change",
       ]);
-      expect(report.rows[2].piece).toBe(c.id);
-      expect(report.applied).toBe(1);
+      expect(report.rows[1].problem).toContain("this one is beyond me");
+      expect(report.applied).toBe(0);
       expect(report.complete).toBe(false);
+      expect((await rawInput(a)).seed).toBe("alpha");
       expect((await rawInput(c)).seed).toBe("charlie");
     });
 

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -191,6 +191,35 @@ describe("bulk-repair", () => {
       expect(outcome.problem).toContain("not a document");
     });
 
+    it("refuses an answer the store cannot hold, wherever the defect sits", () => {
+      const fn = evaluateFixer({ seed: "a" }, (d) => ({
+        ...d,
+        wrap: { deep: () => {} },
+      }));
+      expect(fn.kind).toBe("refused");
+      if (fn.kind !== "refused") throw new Error("expected a refusal");
+      expect(fn.problem).toContain("cannot hold");
+      const ctor = evaluateFixer({ seed: "a" }, (d) => ({
+        ...d,
+        constructor: { x: 1 },
+      }));
+      expect(ctor.kind).toBe("refused");
+      if (ctor.kind !== "refused") throw new Error("expected a refusal");
+      expect(ctor.problem).toContain("cannot hold");
+    });
+
+    it("turns a classification failure into a refusal, not an escape", () => {
+      // Valid at every layer admission inspects, but too deep for the
+      // comparison machinery: the failure must become this row's refusal
+      // rather than an exception that aborts the whole evaluation.
+      let deep: Record<string, unknown> = { end: true };
+      for (let index = 0; index < 200000; index += 1) deep = { next: deep };
+      const outcome = evaluateFixer({ seed: "a" }, (d) => ({ ...d, deep }));
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("Classifying the fixer's answer");
+    });
+
     it("refuses a fixer whose two runs answer differently", () => {
       let calls = 0;
       const outcome = evaluateFixer({ seed: "a" }, (d) => {
@@ -260,6 +289,15 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("refused");
       if (outcome.kind !== "refused") throw new Error("expected a refusal");
       expect(outcome.problem).toContain("rows/0/note");
+      // The guard holds through a shrink too: a surviving element keeps
+      // its fields even when the array behind it got shorter.
+      const shrunk = evaluateFixer(
+        { rows: [{ id: 1, note: "keep" }, { id: 2 }] },
+        (d) => ({ ...d, rows: [{ id: 1 }] }),
+      );
+      expect(shrunk.kind).toBe("refused");
+      if (shrunk.kind !== "refused") throw new Error("expected a refusal");
+      expect(shrunk.problem).toContain("rows/0/note");
     });
 
     it("addresses a key containing the separator unambiguously", () => {
@@ -419,12 +457,16 @@ describe("bulk-repair", () => {
         fixerName: "upper-seed.ts",
       });
 
+      // Both hashes computed independently from the stored documents, so
+      // a wrong hash cannot certify itself.
+      const hashA = hashStringOf(await rawInput(a));
+      const hashB = hashStringOf(await rawInput(b));
       expect(report.rows).toEqual([
         {
           piece: a.id,
           phase: "members",
           verdict: "would-change",
-          documentHash: report.rows[0].documentHash,
+          documentHash: hashA,
           changes: [
             {
               path: "/seed",
@@ -438,10 +480,9 @@ describe("bulk-repair", () => {
           piece: b.id,
           phase: "members",
           verdict: "conforms",
-          documentHash: report.rows[1].documentHash,
+          documentHash: hashB,
         },
       ]);
-      expect(report.rows[0].documentHash).toBeDefined();
       expect(report.applied).toBe(0);
       expect(report.complete).toBe(true);
       expect((await rawInput(a)).seed).toBe("alpha");
@@ -665,7 +706,31 @@ describe("bulk-repair", () => {
         header: dry.plan.header,
         rows: [...dry.plan.rows].reverse(),
       };
-      const report = await repairPieces(pieces, {
+      // The proof of serial order is what the store holds mid-run, not the
+      // report's ordering: when the second-planned piece is fetched for
+      // its own write, the first-planned one has already landed.
+      let aSerialGets = 0;
+      let bSeedAtASerialFetch: unknown;
+      const observing = new Proxy(pieces, {
+        get(target, prop, receiver) {
+          if (prop === "get") {
+            return async (id: string, run?: boolean) => {
+              if (id === a.id && ++aSerialGets === 3) {
+                const cell = await (await target.get(b.id, false)).input
+                  .getCell();
+                await cell.pull();
+                bSeedAtASerialFetch =
+                  (cell.getRaw({ lastNode: "value" }) as { seed?: unknown })
+                    .seed;
+              }
+              return target.get(id, run);
+            };
+          }
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+      const report = await repairPieces(observing as never, {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
@@ -673,6 +738,7 @@ describe("bulk-repair", () => {
         apply: true,
       });
       expect(report.rows.map((row) => row.piece)).toEqual([b.id, a.id]);
+      expect(bSeedAtASerialFetch).toBe("BRAVO");
 
       const truncated = {
         header: dry.plan.header,
@@ -687,6 +753,59 @@ describe("bulk-repair", () => {
           apply: true,
         }),
       ).rejects.toThrow("the selection holds pieces the plan does not name");
+    });
+
+    it("catches an unholdable answer at preflight, before anything lands", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        // Valid for the first piece, unholdable for the second: without
+        // the admission check in preflight, the first repair would land
+        // before the second row failed at its write.
+        fixer: (d) =>
+          d.seed === "bravo"
+            ? { ...d, wrap: { deep: () => {} } } as never
+            : { ...d, seed: (d.seed as string).toUpperCase() },
+        apply: true,
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "would-change",
+        "refused",
+      ]);
+      expect(report.rows[1].problem).toContain("cannot hold");
+      expect(report.applied).toBe(0);
+      expect((await rawInput(a)).seed).toBe("alpha");
+    });
+
+    it("refuses an incomplete supplied plan instead of laundering it", async () => {
+      const a = await member("alpha");
+      const holder = await seedHolder([a]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+      });
+
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "upper-seed.ts",
+          plan: {
+            header: {
+              ...dry.plan.header,
+              problems: [{ piece: "fid1:x", problem: "unreadable" }],
+            },
+            rows: dry.plan.rows,
+          },
+          apply: true,
+        }),
+      ).rejects.toThrow("incomplete plan");
+      expect((await rawInput(a)).seed).toBe("alpha");
     });
 
     it("holds an in-memory plan to the codec's invariants", async () => {
@@ -869,6 +988,10 @@ describe("bulk-repair", () => {
       expect(report.rows[0].problem).toContain("still needs the repair");
       expect(report.applied).toBe(0);
       expect((await rawInput(a)).seed).toBe("alpha");
+      // Exactly one artifact row per piece, whatever went wrong: the
+      // emitted plan still satisfies the codec.
+      expect(() => decodePlan(encodePlan(report.plan))).not.toThrow();
+      expect(report.plan.rows.length).toBe(2);
     });
 
     it("does not repair the holder's own row on a collection selector", async () => {

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -1,0 +1,543 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createBuilder } from "@commonfabric/runner";
+
+import type { Cell as BuilderCell } from "../../../runner/src/builder/types.ts";
+import {
+  collectLinkPaths,
+  documentChanges,
+  evaluateFixer,
+  repairPieces,
+} from "../../src/ops/bulk-repair.ts";
+import type { PieceController } from "../../src/ops/piece-controller.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+import { surveyPieces } from "../../src/ops/bulk-survey.ts";
+
+const signer = await Identity.fromPassphrase("bulk repair");
+
+/** A sigil link the way a raw stored document spells one. */
+function sigil(id: string): Record<string, unknown> {
+  return { "/": { "link@1": { id, path: [] } } };
+}
+
+/** A member program whose stored input carries a `seed`. */
+function memberProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ seed?: string }>(({ seed }) => ({",
+        "  [NAME]: 'Member',",
+        "  seed,",
+        "}));",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/** A holder whose stored input carries the member collection and a title. */
+function holderProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ title?: string; members?: unknown[] }>(",
+        "  ({ title, members }) => ({",
+        "    [NAME]: 'Holder',",
+        "    title,",
+        "    members,",
+        "  }),",
+        ");",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+/** Uppercase the seed; the smallest fixer with something to do. */
+function upperSeed(
+  document: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  return {
+    ...document,
+    ...(typeof document.seed === "string"
+      ? { seed: document.seed.toUpperCase() }
+      : {}),
+  };
+}
+
+describe("bulk-repair", () => {
+  describe("documentChanges()", () => {
+    it("returns one row per changed leaf, with the exact values", () => {
+      const changes = documentChanges(
+        { a: 1, nested: { keep: true, flip: "x" } },
+        { a: 2, nested: { keep: true, flip: "y" } },
+      );
+      expect(changes).toEqual([
+        { path: "a", before: 1, after: 2 },
+        { path: "nested/flip", before: "x", after: "y" },
+      ]);
+    });
+
+    it("reports a replaced container as one change, not its every leaf", () => {
+      const changes = documentChanges({ list: [1, 2, 3] }, { list: "gone" });
+      expect(changes).toEqual([
+        { path: "list", before: [1, 2, 3], after: "gone" },
+      ]);
+    });
+
+    it("returns no rows for equal documents", () => {
+      expect(documentChanges({ a: [1] }, { a: [1] })).toEqual([]);
+    });
+  });
+
+  describe("collectLinkPaths()", () => {
+    it("finds every sigil link by path, and descends no further into one", () => {
+      const doc = {
+        title: "t",
+        members: [sigil("of:fid1:a"), sigil("of:fid1:b")],
+        wrap: { inner: sigil("of:fid1:c") },
+      };
+      expect(collectLinkPaths(doc)).toEqual([
+        "members/0",
+        "members/1",
+        "wrap/inner",
+      ]);
+    });
+  });
+
+  describe("evaluateFixer()", () => {
+    const linkedDoc = {
+      title: "t",
+      members: [sigil("of:fid1:a")],
+    };
+
+    it("classifies an unchanged answer as conforming", () => {
+      expect(evaluateFixer({ seed: "A" }, (d) => ({ ...d }))).toEqual({
+        kind: "conforms",
+      });
+    });
+
+    it("returns the changed document with its exact changes", () => {
+      const outcome = evaluateFixer({ seed: "a", keep: 1 }, upperSeed);
+      expect(outcome).toEqual({
+        kind: "change",
+        document: { seed: "A", keep: 1 },
+        changes: [{ path: "seed", before: "a", after: "A" }],
+      });
+    });
+
+    it("refuses a fixer that throws, naming the message", () => {
+      const outcome = evaluateFixer({ seed: "a" }, () => {
+        throw new Error("cannot read this shape");
+      });
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("cannot read this shape");
+    });
+
+    it("refuses an answer that is not a document", () => {
+      const outcome = evaluateFixer(
+        { seed: "a" },
+        () => [] as unknown as Record<string, unknown>,
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("not a document");
+    });
+
+    it("refuses a fixer whose two runs answer differently", () => {
+      let calls = 0;
+      const outcome = evaluateFixer({ seed: "a" }, (d) => {
+        calls += 1;
+        return { ...d, stamp: calls };
+      });
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("pure function");
+    });
+
+    it("refuses an incomplete document, naming the fields the write would lose", () => {
+      const outcome = evaluateFixer(
+        { seed: "a", keep: 1, also: 2 },
+        (d) => ({ seed: d.seed }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("keep, also");
+    });
+
+    it("refuses a fixer that rewrites a link as a value", () => {
+      const outcome = evaluateFixer(linkedDoc, (d) => ({
+        ...d,
+        members: ["of:fid1:a"],
+      }));
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("members/0");
+    });
+
+    it("refuses a fixer that drops a link", () => {
+      const outcome = evaluateFixer(linkedDoc, (d) => ({
+        ...d,
+        members: [],
+      }));
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("members/0");
+    });
+
+    it("accepts a change beside an untouched link", () => {
+      const outcome = evaluateFixer(linkedDoc, (d) => ({
+        ...d,
+        title: "renamed",
+      }));
+      expect(outcome.kind).toBe("change");
+      if (outcome.kind !== "change") throw new Error("expected a change");
+      expect(outcome.changes).toEqual([
+        { path: "title", before: "t", after: "renamed" },
+      ]);
+    });
+
+    it("refuses a fixer that replaces the container a nested link lives in", () => {
+      const outcome = evaluateFixer(
+        { wrap: { inner: sigil("of:fid1:c") } },
+        (d) => ({ ...d, wrap: "gone" }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("wrap/inner");
+    });
+
+    it("refuses to alter a document that is itself a link", () => {
+      const outcome = evaluateFixer(
+        sigil("of:fid1:whole"),
+        (d) => ({ ...d, extra: 1 }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("<root>");
+    });
+
+    it("is safe against a fixer that mutates its argument", () => {
+      const document = { seed: "a" };
+      const outcome = evaluateFixer(document, (d) => {
+        (d as Record<string, unknown>).seed = "MUTATED";
+        return d as Record<string, unknown>;
+      });
+      expect(outcome.kind).toBe("change");
+      expect(document.seed).toBe("a");
+    });
+  });
+
+  describe("repairPieces()", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let pieces: PiecesController;
+
+    beforeEach(async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      pieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `bulk-repair-${crypto.randomUUID()}`,
+        }),
+        runtime,
+      );
+      await pieces.synced();
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    async function member(seed: string): Promise<PieceController> {
+      return await pieces.create(memberProgram(), { input: { seed } });
+    }
+
+    async function seedHolder(
+      members: PieceController[],
+    ): Promise<PieceController> {
+      const holder = await pieces.create(holderProgram(), { input: {} });
+      await holder.input.set(members.map((m) => m.getCell()), ["members"]);
+      await pieces.runtime.idle();
+      return holder;
+    }
+
+    function collectionOf(holder: PieceController) {
+      return {
+        kind: "collection" as const,
+        holder: holder.id,
+        path: ["members"],
+      };
+    }
+
+    async function rawInput(
+      piece: PieceController,
+    ): Promise<Record<string, unknown>> {
+      const cell = await piece.input.getCell();
+      await cell.pull();
+      return cell.getRaw({ lastNode: "value" }) as Record<string, unknown>;
+    }
+
+    it("reports the exact per-piece diff on a dry run, and writes nothing", async () => {
+      const a = await member("alpha");
+      const b = await member("BRAVO");
+      const holder = await seedHolder([a, b]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+      });
+
+      expect(report.rows).toEqual([
+        {
+          piece: a.id,
+          phase: "members",
+          verdict: "would-change",
+          changes: [{ path: "seed", before: "alpha", after: "ALPHA" }],
+        },
+        { piece: b.id, phase: "members", verdict: "conforms" },
+      ]);
+      expect(report.applied).toBe(0);
+      expect(report.complete).toBe(true);
+      expect((await rawInput(a)).seed).toBe("alpha");
+    });
+
+    it("does not repair the holder's own row on a collection selector", async () => {
+      const a = await member("ALPHA");
+      const holder = await seedHolder([a]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        // A fixer the holder's document would fail loudly: it drops the
+        // members field, so touching the holder would refuse the run.
+        fixer: (d) => ({ ...d, seed: d.seed }),
+      });
+
+      expect(report.rows.map((row) => row.piece)).toEqual([a.id]);
+    });
+
+    it("applies serially, verifies by re-asking the fixer, and a re-run writes nothing", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+
+      const applied = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        apply: true,
+      });
+      expect(applied.rows.map((row) => row.verdict)).toEqual([
+        "repaired",
+        "repaired",
+      ]);
+      expect(applied.applied).toBe(2);
+      expect(applied.complete).toBe(true);
+      expect((await rawInput(a)).seed).toBe("ALPHA");
+      expect((await rawInput(b)).seed).toBe("BRAVO");
+
+      const again = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        apply: true,
+      });
+      expect(again.rows.map((row) => row.verdict)).toEqual([
+        "conforms",
+        "conforms",
+      ]);
+      expect(again.applied).toBe(0);
+    });
+
+    it("carries links through a repair that does not mention them", async () => {
+      const a = await member("alpha");
+      const holder = await seedHolder([a]);
+      await holder.input.set("untitled", ["title"]);
+      await pieces.runtime.idle();
+      const before = await rawInput(holder);
+
+      const report = await repairPieces(pieces, {
+        selector: { kind: "list", pieces: [holder.id] },
+        fixer: (d) => ({ ...d, title: "repaired" }),
+        apply: true,
+      });
+      expect(report.rows[0].verdict).toBe("repaired");
+
+      const after = await rawInput(holder);
+      expect(after.title).toBe("repaired");
+      expect(after.members).toEqual(before.members);
+      // The strongest proof the link survived: the collection still
+      // resolves its member through it.
+      const survey = await surveyPieces(pieces, {
+        selector: collectionOf(holder),
+      });
+      expect(survey.complete).toBe(true);
+      expect(survey.plan.rows.map((row) => row.piece)).toContain(a.id);
+    });
+
+    it("stops an apply at the first refusal and names the rest unattempted", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const c = await member("charlie");
+      const holder = await seedHolder([a, b, c]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: (d) => {
+          if (d.seed === "bravo") throw new Error("this one is beyond me");
+          return { ...d, seed: (d.seed as string).toUpperCase() };
+        },
+        apply: true,
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "repaired",
+        "refused",
+        "unattempted",
+      ]);
+      expect(report.rows[2].piece).toBe(c.id);
+      expect(report.applied).toBe(1);
+      expect(report.complete).toBe(false);
+      expect((await rawInput(c)).seed).toBe("charlie");
+    });
+
+    it("refuses a piece whose stored input is not a document", async () => {
+      // A pattern may type its whole input as a scalar, and such a piece
+      // stores one — a state a document repair must refuse, not reshape.
+      const scalarProgram: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern } from 'commonfabric';",
+            "export default pattern<string>((text) => ({",
+            "  [NAME]: 'Scalar',",
+            "  text,",
+            "}));",
+            "",
+          ].join("\n"),
+        }],
+      };
+      const a = await pieces.create(scalarProgram, {
+        input: "just a string" as never,
+      });
+
+      const report = await repairPieces(pieces, {
+        selector: { kind: "list", pieces: [a.id] },
+        fixer: upperSeed,
+      });
+
+      expect(report.rows).toEqual([
+        {
+          piece: a.id,
+          phase: "list",
+          verdict: "refused",
+          problem: "The stored input is not a document.",
+        },
+      ]);
+      expect(report.complete).toBe(false);
+    });
+
+    it("fails a pure but non-idempotent fixer at verification, and stops", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        // Pure — one document always answers one way — but its own answer
+        // never satisfies it, so the post-write verification cannot pass.
+        fixer: (d) => ({ ...d, seed: `${d.seed}X` }),
+        apply: true,
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "failed",
+        "unattempted",
+      ]);
+      expect(report.rows[0].problem).toContain("does not satisfy the fixer");
+      expect(report.applied).toBe(1);
+      expect(report.complete).toBe(false);
+      expect((await rawInput(b)).seed).toBe("bravo");
+    });
+
+    it("reports every refusal on a dry run instead of stopping", async () => {
+      const a = await member("alpha");
+      const b = await member("bravo");
+      const holder = await seedHolder([a, b]);
+
+      const report = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: () => {
+          throw new Error("refuses everything");
+        },
+      });
+
+      expect(report.rows.map((row) => row.verdict)).toEqual([
+        "refused",
+        "refused",
+      ]);
+      expect(report.complete).toBe(false);
+      expect(report.applied).toBe(0);
+    });
+
+    it("refuses to repair over an incomplete selection, naming the orphan", async () => {
+      const { commonfabric } = createBuilder();
+      const { handler, pattern } = commonfabric;
+      const addPiece = handler<
+        { piece: BuilderCell<unknown> },
+        { pieceRegistry: BuilderCell<BuilderCell<unknown>[]> }
+      >(
+        true,
+        {
+          type: "object",
+          properties: { pieceRegistry: { type: "array", asCell: ["cell"] } },
+        },
+        ({ piece }, { pieceRegistry }) => {
+          pieceRegistry.push(piece);
+        },
+      );
+      const defaultPattern = pattern<{ pieceRegistry: BuilderCell<unknown>[] }>(
+        ({ pieceRegistry }) => ({
+          pieceRegistry,
+          addPiece: addPiece({ pieceRegistry }),
+        }),
+      );
+      const home = await pieces.runPersistent(
+        defaultPattern,
+        { pieceRegistry: [] },
+        "bulk-repair-default-pattern",
+      );
+      await pieces.linkDefaultPattern(home);
+      await pieces.runtime.idle();
+      await pieces.synced();
+
+      const inBoard = await member("alpha");
+      const orphan = await member("omega");
+      await pieces.add([orphan.getCell()]);
+      const holder = await seedHolder([inBoard]);
+
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          apply: true,
+        }),
+      ).rejects.toThrow("registered outside the selection");
+      expect((await rawInput(inBoard)).seed).toBe("alpha");
+    });
+  });
+});

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -107,9 +107,9 @@ describe("bulk-repair", () => {
         wrap: { inner: sigil("of:fid1:c") },
       };
       expect(collectLinkPaths(doc)).toEqual([
-        "members/0",
-        "members/1",
-        "wrap/inner",
+        ["members", "0"],
+        ["members", "1"],
+        ["wrap", "inner"],
       ]);
     });
   });
@@ -173,6 +173,69 @@ describe("bulk-repair", () => {
       expect(outcome.kind).toBe("refused");
       if (outcome.kind !== "refused") throw new Error("expected a refusal");
       expect(outcome.problem).toContain("keep, also");
+    });
+
+    it("refuses a nested field the answer lost, wherever the container survived", () => {
+      const outcome = evaluateFixer(
+        { meta: { author: "a", stamp: "s" }, seed: "x" },
+        (d) => ({
+          ...d,
+          meta: { author: (d.meta as Record<string, unknown>).author },
+        }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("meta/stamp");
+    });
+
+    it("refuses a field returned as an explicit undefined, which the write drops", () => {
+      const outcome = evaluateFixer(
+        { seed: "a", keep: 1 },
+        (d) => ({ ...d, keep: undefined }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("keep");
+    });
+
+    it("treats a container replaced outright as a change, not a fragment", () => {
+      const outcome = evaluateFixer(
+        { wrap: { a: 1, b: 2 }, seed: "x" },
+        (d) => ({ ...d, wrap: 7 }),
+      );
+      expect(outcome.kind).toBe("change");
+      if (outcome.kind !== "change") throw new Error("expected a change");
+      expect(outcome.changes).toEqual([
+        { path: "wrap", before: { a: 1, b: 2 }, after: 7 },
+      ]);
+    });
+
+    it("lets an array shrink, and still guards an element's own fields", () => {
+      const dedup = evaluateFixer(
+        { tags: ["a", "a", "b"] },
+        (d) => ({ ...d, tags: [...new Set(d.tags as string[])] }),
+      );
+      expect(dedup.kind).toBe("change");
+      const outcome = evaluateFixer(
+        { rows: [{ id: 1, note: "n" }] },
+        (d) => ({ ...d, rows: [{ id: 1 }] }),
+      );
+      expect(outcome.kind).toBe("refused");
+      if (outcome.kind !== "refused") throw new Error("expected a refusal");
+      expect(outcome.problem).toContain("rows/0/note");
+    });
+
+    it("addresses a key containing the separator unambiguously", () => {
+      const doc = { "a/b": sigil("of:fid1:slash"), seed: "x" };
+      const kept = evaluateFixer(doc, (d) => ({ ...d, seed: "y" }));
+      expect(kept.kind).toBe("change");
+      const dropped = evaluateFixer(doc, (d) => ({
+        seed: d.seed,
+        "a/b": "gone",
+      }));
+      expect(dropped.kind).toBe("refused");
+      if (dropped.kind !== "refused") throw new Error("expected a refusal");
+      expect(dropped.problem).toContain("a~1b");
     });
 
     it("refuses a fixer that rewrites a link as a value", () => {
@@ -323,9 +386,10 @@ describe("bulk-repair", () => {
 
       const report = await repairPieces(pieces, {
         selector: collectionOf(holder),
-        // A fixer the holder's document would fail loudly: it drops the
-        // members field, so touching the holder would refuse the run.
-        fixer: (d) => ({ ...d, seed: d.seed }),
+        // A fixer the holder's document would fail loudly: it returns only
+        // the members' own field, so touching the holder would refuse the
+        // run as an incomplete document.
+        fixer: (d) => ({ seed: d.seed }),
       });
 
       expect(report.rows.map((row) => row.piece)).toEqual([a.id]);

--- a/packages/piece/test/ops/piece-controller.test.ts
+++ b/packages/piece/test/ops/piece-controller.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import type { PieceController } from "../../src/ops/piece-controller.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("piece controller edit");
+
+/** A counter document; `n` is what the overlapping edits contend for. */
+function counterProgram(): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ n?: number }>(({ n }) => ({",
+        "  [NAME]: 'Counter',",
+        "  n,",
+        "}));",
+        "",
+      ].join("\n"),
+    }],
+  };
+}
+
+describe("piece-controller", () => {
+  describe("edit()", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let pieces: PiecesController;
+    let piece: PieceController;
+
+    beforeEach(async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      pieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `controller-edit-${crypto.randomUUID()}`,
+        }),
+        runtime,
+      );
+      await pieces.synced();
+      piece = await pieces.create(counterProgram(), { input: { n: 0 } });
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    async function readN(): Promise<unknown> {
+      const cell = await piece.input.getCell();
+      await cell.pull();
+      return (cell.getRaw({ lastNode: "value" }) as { n?: unknown }).n;
+    }
+
+    it("computes each overlapping edit from the then-current document", async () => {
+      // Overlapping edits on one replica serialize rather than conflict
+      // (an immediate transaction holds the local order), so the retry
+      // path stays with editWithRetry's own contract for replica-behind
+      // conflicts; what this proves is the property repair rests on —
+      // every produce call answers for the document its commit sees, so
+      // neither of two contending updates is lost.
+      let runs = 0;
+      const bump = () =>
+        piece.input.edit((stored) => {
+          runs += 1;
+          const doc = stored as { n?: number };
+          return { value: { n: (doc.n ?? 0) + 1 } };
+        });
+      await Promise.all([bump(), bump()]);
+      expect(await readN()).toBe(2);
+      expect(runs).toBe(2);
+    });
+
+    it("returns wrote: false and writes nothing for a no-write answer", async () => {
+      const result = await piece.input.edit(() => undefined);
+      expect(result).toEqual({ wrote: false });
+      expect(await readN()).toBe(0);
+    });
+
+    it("hands produce the stored value and writes its answer", async () => {
+      let seen: unknown;
+      const result = await piece.input.edit((stored) => {
+        seen = (stored as { n?: unknown }).n;
+        return { value: { n: 7 } };
+      });
+      expect(result).toEqual({ wrote: true });
+      expect(seen).toBe(0);
+      expect(await readN()).toBe(7);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Stage 1 landed the read half of bulk piece operations (#6211, #6213, #6214): the survey, the plan artifact, and the drill. This begins stage 2 — repair by a caller-supplied fixer — which is the first write: the plan's motivating defects (a board's members needing the same particular correction) have no bulk path today beyond hand-rolled scripts. Two open decisions gated this stage and are resolved in the plan document by this change: bulk writes live in the `piece` command group (decision 1), and repair takes the wide whole-document write, made safe by refusals rather than narrowed (decision 4).

## What Changed

- `packages/piece/src/ops/bulk-repair.ts` — the engine. `evaluateFixer` is pure (unit-testable without a space): it probes purity by running the fixer twice, refuses a non-document answer, an incomplete document (recursively — a nested field is as gone as a top-level one, presence judged by own key with explicit `undefined` counting as lost), and a sigil link rewritten or dropped (deep, by segment path). Stored documents are handled as the `FabricValue`s they are: copies via `cloneIfNecessary`, comparisons via `valueEqual`, hashes via `hashStringOf`, and Fabric special values as atomic leaves. Diff paths are JSON Pointers proper.
- The spine, as the plan documents it: `repairPieces` rides the survey for selection and containment; under `apply` every row is preflighted — classified from one read before the first write, with a moved, refused, or unreadable row keeping the run from starting at all — and the serial pass then evaluates and writes each row in one transaction through the new `PiecePropIo.edit()` seam, so a concurrent edit conflicts and re-evaluates rather than being overwritten (proven by a test that lands a write between preflight and the row's transaction). Verification re-asks the fixer against the stored result. Operational failures become that row's `failed` verdict with a post-failure state check; the report always returns.
- The plan artifact models repair per the design's own spec: `expect.documentHash` is the repair row's required precondition in the codec, `RepairOp` joins the op union, `repairPieces` emits the plan it ran as, and a supplied plan **is** the execution — its rows in its order, validated against the space, fixer name, and exactly the selection's pieces. Landed classification precedes the hash check, so a completed plan re-runs as `conforms`: resume works from the artifact. `deriveRollbackPlan` refuses repair rows by name.
- `packages/piece/src/ops/piece-controller.ts` — `set()` refactored onto `edit(produce)`: the same write machinery with the value computed inside the transaction from the document the commit sees.
- `docs/plans/piece-bulk-operations.md` — decisions 1 and 4 marked resolved with reasoning; the six stage-2 checklist boxes this change lands are ticked; the stage-3 and first-increment passages stop deferring the settled spelling.
- `packages/piece/test/ops/bulk-repair.test.ts` — 47 steps covering the refusal matrix, resume, plan-driven execution, preflight, the transactional recheck race, Fabric special values, and both failure state-check endings.

## Test plan

`deno task check` green; fmt/lint clean; the full piece ops suite (141 steps) green with zero uncovered lines across every bulk source; `deno task check-docs` green on the plan edits. The `cf piece repair` entry point, the drill extension, and the demo act conversion follow in a stacked change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
