### PR TITLE
docs(lunch-poll): point the live-pieces block at the deployed profile-identity piece

### DIFF
--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -42,8 +42,19 @@ answering, re-establish it (see "Recovering the piece") and update this block.
 
 ### `estuary` — the stately instance, holding the real poll
 
-`estuary.saga-castor.ts.net` carries the team's **populated** poll — real
-participants, options and votes. Treat its state as production data.
+`estuary.saga-castor.ts.net` carries the team's poll as two pieces while the
+identity rollout is in progress. The **current** poll runs the profile-cell
+identity source (fresh piece, joined by creating or picking a profile):
+
+```
+space:  team-lunch
+piece:  fid1:gi7f-G8Z353Q_f_yLs_T3kB7A06TZjUmhf-M59bqvrE
+url:    https://estuary.saga-castor.ts.net/team-lunch/fid1:gi7f-G8Z353Q_f_yLs_T3kB7A06TZjUmhf-M59bqvrE
+```
+
+The **legacy name-keyed** poll still holds the accumulated participants, options
+and votes, and is Option B's migration source. Treat its state as production
+data.
 
 ```
 space:  team-lunch
@@ -104,7 +115,7 @@ on it before running it against a shared space.
 ```bash
 export CF_API_URL=https://estuary.saga-castor.ts.net/   # the populated poll; rapids.saga-castor.ts.net to iterate; http://localhost:8000 for local dev
 export CF_IDENTITY=./your-identity.key
-PIECE=fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4   # estuary
+PIECE=fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4   # estuary legacy populated poll (the current piece is in "The live pieces")
 SPACE=team-lunch
 
 # Keep this complete set on every source deployment in this guide.

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -113,9 +113,10 @@ on it before running it against a shared space.
 ## Environment setup
 
 ```bash
-export CF_API_URL=https://estuary.saga-castor.ts.net/   # the populated poll; rapids.saga-castor.ts.net to iterate; http://localhost:8000 for local dev
+export CF_API_URL=https://estuary.saga-castor.ts.net/   # estuary; rapids.saga-castor.ts.net to iterate; http://localhost:8000 for local dev
 export CF_IDENTITY=./your-identity.key
-PIECE=fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4   # estuary legacy populated poll (the current piece is in "The live pieces")
+PIECE=fid1:gi7f-G8Z353Q_f_yLs_T3kB7A06TZjUmhf-M59bqvrE   # estuary current poll — every operation in this guide targets it
+LEGACY_PIECE=fid1:S2MlU76VbKBRTtFt_hgPyi9MB04ti9yKN08G2IJJUW4   # populated name-keyed poll; Option B's migration SOURCE only
 SPACE=team-lunch
 
 # Keep this complete set on every source deployment in this guide.
@@ -254,14 +255,15 @@ the input interface casually against a piece you care about.
 ## Option B — migrate the populated name-keyed poll to a fresh piece
 
 Use this for the profile-cell identity rollout, or to get your **own** instance
-seeded with the current data without touching the shared poll:
+seeded with the team's accumulated data without touching the shared poll:
 
 ```bash
-# 1. Create your own empty piece (note the new ID it prints).
-MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
-  --root packages/patterns \
-  "${LUNCH_POLL_TEST_ARGS[@]}" \
-  -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+# 1. Pick the copy TARGET. The team rollout copies into the current piece:
+MINE="$PIECE"
+# To seed your OWN instance instead, mint a fresh piece as the target:
+#   MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
+#     --root packages/patterns "${LUNCH_POLL_TEST_ARGS[@]}" \
+#     -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
 
 # 2. Resolve your piece's argument document. This is the cell the copy writes
 #    into; `cf set --input` cannot do it (see the note below).
@@ -270,12 +272,12 @@ ARG=$(deno task cf get --piece "$MINE" -s "$SPACE" --input --select '@' -q \
 
 # 3. Copy each PerSpace field except the visit log and the host seat.
 for field in question users options votes; do
-  deno task cf get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
+  deno task cf get --piece "$LEGACY_PIECE" -s "$SPACE" "$field" --input -q \
     | deno task cf set -s "$SPACE" "$ARG/$field" -q
 done
 
 # 4. Copy the visit log, deleting the predecessor's roster links (see below).
-deno task cf get --piece "$PIECE" -s "$SPACE" visits --input -q \
+deno task cf get --piece "$LEGACY_PIECE" -s "$SPACE" visits --input -q \
   | deno eval '
       const v = JSON.parse(await new Response(Deno.stdin.readable).text());
       for (const e of v) {


### PR DESCRIPTION
The deploy guide's own rule: after a `piece new`, update the live-pieces block. The profile-identity fresh piece (#5744's required rollout shape) is now live on estuary — `team-lunch/fid1:gi7f-G8Z353Q_f_yLs_T3kB7A06TZjUmhf-M59bqvrE`, deployed 2026-08-24 with this guide's own smoke test run against a scratch space first (joinAs verdict, host-gated addOption/logVisit, render probe), from a CLI checkout matched to estuary's running commit.

The block now lists the current piece and the legacy name-keyed poll side by side: the legacy piece keeps its accumulated state as Option B's migration source (migration deliberately held until estuary's host build includes the merge — its current shell predates `cf-profile-badge`'s `fallback-name`, so migrated legacy rows would render "Unknown profile" until then). The env block's `PIECE` comment now says which piece it names, so Option B's source semantics are unchanged.

<sub>Written by Claude (Fable 5) on @mathpirate's behalf.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

