### PR TITLE
fix(ts-transformers): a `satisfies` no longer hides an opaque `.get()`

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -303,8 +303,9 @@ On call `receiver.get()` (no args):
     - a **`pattern` / `render` callback parameter** (including via destructured
       binding elements), or
     - a local variable whose initializer is a **reactive-origin call** (after
-      stripping non-null/parenthesized/cast wrappers and property/element-access
-      tails), as defined by `isReactiveOriginCall` / the runtime registry (§5):
+      stripping the transparent wrapper set — parentheses, `as`, `<T>`,
+      `satisfies`, `!` — and property/element-access tails), as defined by
+      `isReactiveOriginCall` / the runtime registry (§5):
       reactive-origin builders (`pattern`, `computed`, `lift`, `handler`,
       `action`, `render`), the lift-applied shape, `ifElse` / `when` / `unless`,
       cell factories / `Cell.for`, `wish`, `generateObject`, `generateText`, and

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -9,7 +9,10 @@ import {
 import { isFunctionLikeExpression } from "./function-predicates.ts";
 import { symbolDeclaresCommonFabricDefault } from "../core/common-fabric-symbols.ts";
 import { isBrandedCellType } from "../transformers/cell-type.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../utils/expression.ts";
 import { isSafeIdentifierText } from "../utils/identifiers.ts";
 import {
   detectCallKind,
@@ -664,13 +667,9 @@ export function createDataFlowAnalyzer(
           current = current.expression;
           continue;
         }
-        if (
-          ts.isParenthesizedExpression(current) ||
-          ts.isAsExpression(current) ||
-          ts.isTypeAssertionExpression(current) ||
-          ts.isNonNullExpression(current)
-        ) {
-          current = current.expression;
+        const unwrapped = unwrapTransparentWrapperOnce(current);
+        if (unwrapped) {
+          current = unwrapped;
           continue;
         }
         if (ts.isCallExpression(current)) {

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -15,6 +15,7 @@ import ts from "typescript";
 import { detectCallKind, isReactiveOriginCall } from "../ast/call-kind.ts";
 import { getNodeText } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import { unwrapTransparentWrapperOnce } from "../utils/expression.ts";
 
 export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -198,13 +199,9 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   ): boolean {
     let current: ts.Expression = expr;
     while (true) {
-      if (
-        ts.isNonNullExpression(current) ||
-        ts.isParenthesizedExpression(current) ||
-        ts.isAsExpression(current) ||
-        ts.isTypeAssertionExpression(current)
-      ) {
-        current = current.expression;
+      const unwrapped = unwrapTransparentWrapperOnce(current);
+      if (unwrapped) {
+        current = unwrapped;
         continue;
       }
       if (

--- a/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
+++ b/packages/ts-transformers/test/opaque-get-validation-coverage.test.ts
@@ -108,6 +108,44 @@ Deno.test(
   },
 );
 
+// isReactiveInitializer reads the shared transparent-wrapper set, so every
+// spelling that wraps the origin call without changing it reaches the same
+// diagnostic. `satisfies` is the spelling most easily left out of a
+// hand-written wrapper list, so it is pinned here alongside its neighbours.
+Deno.test(
+  "opaque-get flags .get() on a local initialized through each wrapper spelling",
+  async () => {
+    const initializers = [
+      "computed(() => count * 2)",
+      "(computed(() => count * 2))",
+      "computed(() => count * 2)!",
+      "computed(() => count * 2) as never",
+      "computed(() => count * 2) satisfies unknown",
+      "(computed(() => count * 2) satisfies unknown)",
+    ];
+
+    for (const initializer of initializers) {
+      const source = `      import { computed, pattern } from "commonfabric";
+
+      export default pattern<{ count: number }>(({ count }) => {
+        const doubled = ${initializer};
+        const bad = doubled.get();
+        return { bad };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getOpaqueGetErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        1,
+        `expected one opaque-get error for initializer: ${initializer}`,
+      );
+    }
+  },
+);
+
 // isReactiveExpression binding-element branch: a value destructured out of a
 // local whose initializer is a reactive-origin call is still reactive, so
 // .get() on the destructured binding is flagged.


### PR DESCRIPTION
Named as a suspect in #6242's "found but not done". Two walks read the transparent-wrapper set minus `satisfies` — the exact omission #6050 fixed in call classification. One of them turns out to be a **live false negative in validation**; the other is latent. This PR separates those two claims with evidence rather than treating them alike.

## The live one

`isReactiveInitializer` (`opaque-get-validation.ts`) decides whether a local holds a reactive value, and so whether `.get()` on it draws `opaque-get:invalid-call`. It stripped parentheses, `as`, `<T>`, and `!` — but not `satisfies`. Probing every spelling of the same program:

```
bare                  errors=1
parenthesized         errors=1
non-null              errors=1
as-cast               errors=1
SATISFIES             errors=0     <-- diagnostic silently suppressed
satisfies in parens    errors=0
```

So `const doubled = computed(() => count * 2) satisfies unknown;` followed by `doubled.get()` compiled clean, while every other way of writing the same thing was correctly rejected. That is ordinary pattern-authoring syntax, not an exotic shape.

After the fix, all six report `errors=1`.

## The latent one

`findRootIdentifier` (`ast/dataflow.ts`) carried the same omission, but nothing reaches it with a `satisfies`. Its branch is gated on `isSynthetic(expression)`, and instrumenting the bail it would take records **one** bail across the entire suite — on an `ObjectLiteralExpression`, not a `satisfies`. The instrument was validated by that single hit, so the null is trustworthy rather than a silent no-op.

Corrected as drift, not as a defect. The distinction is in the commit message so it is not lost later.

## What changed

Both walks now step through the shared set via `unwrapTransparentWrapperOnce`, so a spelling added to that set reaches them too — which is the point of the vocabulary #6067 and #6242 built.

## Evidence the fix is safe

A validation change that reports *more* needs to show it does not over-report:

- **Negative probe** — `Writable<T>.get()` stays legal in every spelling (`bare`, `satisfies`, `as`-cast all report `errors=0`). The fix only reaches initializers that were already reactive-origin calls.
- **`deno task cfcheck`** — the authoritative pattern type-check passes over **all 421 pattern files**, exit 0, no `opaque-get` diagnostic. `satisfies` does appear in 29 pattern files, so this was worth running rather than assuming.
- **`UPDATE_GOLDENS=1`** — zero golden diffs, consistent with the bug being reachable by authoring but unused in the fixture corpus.
- Full suite **1159 passed, 0 failed**; repo-wide `deno fmt --check`, `deno lint`, `deno task check`, and the `check-*` gates including `check-docs` and `check-baselines-append-only`.

## Test

`opaque-get-validation-coverage.test.ts` gains a case that pins all six wrapper spellings to the same outcome, so the next omission fails a test instead of silencing a diagnostic. Confirmed to fail against the pre-fix wrapper list.

## Spec

`ts_transformers_current_behavior_spec.md` §"On call `receiver.get()`" described the old list as "non-null/parenthesized/cast wrappers". Updated to name the transparent wrapper set, per the package's rule that a transformer behavior change is a spec change. `spec-sync.test.ts` and `check-docs` pass.

## Still open from #6242

`cfc-policy-authoring.ts` declares a module-local `const unwrapExpression` that shadows the canonical name with a different set (no `!`). Left alone here — that one is a naming hazard rather than a `satisfies` omission, and changing its set needs its own reachability work.

Refs #6242, #6067, #6050.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

