### PR TITLE
feat(cli): cf piece repair — the fixer at the terminal (stage 2, PR 2)

### DIFF
--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -598,8 +598,8 @@ Topics restore script hand-rolls today and should import instead.
       that would rewrite one as a value is refused.
 - [x] Re-running a completed repair writes nothing.
 - [x] The repair act in `packages/cli/integration/bulk-ops-demo.sh` stops
-      being pending: the transcript runs a fixer live where it now shows
-      the provisional spelling.
+      being pending: the transcript runs a fixer live under the canonical
+      spelling, `cf piece repair`.
 
 ### 3. Retarget
 

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -174,8 +174,15 @@ what to do to it:
 piece         precondition                  operation
 of:fid1:aaa…  reference=PB0Gum…#default     retarget=topic.tsx@<rev>
 of:fid1:bbb…  reference=PB0Gum…#default     retarget=topic.tsx@<rev>
-of:fid1:ccc…  document-hash=9f2c…           repair=<fixer>
+of:fid1:ccc…  document-hash=9f2c…           repair=<fixer>@<closure-id>
 ```
+
+A repair row carries two pins, because it has two inputs that can drift: the
+document hash holds the piece to the state the fixer's answer was computed
+from, and the closure identity — the same no-compile identity a retarget's
+source carries — holds the fixer to the implementation that was reviewed. A
+plan whose fixer file changed after review, or whose spelling resolves to
+different code elsewhere, refuses before the module is even imported.
 
 Four properties follow from making this a file rather than a command line:
 

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,9 +1,8 @@
 # Bulk piece operations
 
-**Status:** proposed; stage 1 — the survey library, its `cf` entry points,
-and its CI drill — is built. Stage 2's repair library — the fixer runner,
-the dry-run diff, and the refusals — is built; its `cf` entry point and
-demo act follow in a stacked change. Every later stage is unbuilt. This is the design and build sequence for changing
+**Status:** proposed; stages 1 and 2 — the survey and repair libraries,
+their `cf` entry points, and their coverage in the CI drill and the demo —
+are built. Every later stage is unbuilt. This is the design and build sequence for changing
 many pieces in one space as one reviewable, resumable operation. Driven by
 recurring Topics board upgrades.
 
@@ -598,7 +597,7 @@ Topics restore script hand-rolls today and should import instead.
 - [x] References survive a repair that does not mention them, and a fixer
       that would rewrite one as a value is refused.
 - [x] Re-running a completed repair writes nothing.
-- [ ] The repair act in `packages/cli/integration/bulk-ops-demo.sh` stops
+- [x] The repair act in `packages/cli/integration/bulk-ops-demo.sh` stops
       being pending: the transcript runs a fixer live where it now shows
       the provisional spelling.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -137,6 +137,14 @@ surface work rather than read about it, `integration/bulk-ops-demo.sh` narrates
 a board-sized survey end to end against a running server, with the unbuilt write
 stages shown as pending acts.
 
+`cf piece repair` runs a caller-supplied fixer — a TypeScript module whose
+default export is a pure transform from a piece's stored input document to the
+document it should hold — over the same selection surface the survey takes. Dry
+by default, reporting the exact per-piece diff and writing nothing; under
+`--apply` it writes each row in its own transaction, and a plan from a dry run
+drives the apply row for row under its document-hash preconditions (`--plan`).
+The design is `docs/plans/piece-bulk-operations.md`, stage 2.
+
 `cf piece slugs` lists the space's slug index: every name assigned through
 `--slug` or `set-slug`, each resolved to the piece it names. The index records
 assignments made since it existed, so a slug written by an older client still

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -800,12 +800,16 @@ The supported output switches are:
 - `cf inspect ... --json` serializes an inspector result. `inspect html` does
   not have a JSON representation, so `html` and `--json` are mutually exclusive.
   `inspect graph --dot` and `--json` are also mutually exclusive.
-- `cf piece ls`, `piece search`, `piece inspect`, `piece survey`, `piece view`,
-  and `piece render` use `--json` as an output switch. `piece survey` reserves
-  stdout for the plan it emits (or, under `--json`, the full survey result); its
-  tally and findings go to stderr. `piece render --watch --json` writes only
-  JSON render records to stdout; watch status goes to stderr. Rendering a piece
-  without a UI fails instead of returning an empty successful JSON stream.
+- `cf piece ls`, `piece search`, `piece inspect`, `piece survey`,
+  `piece repair`, `piece view`, and `piece render` use `--json` as an output
+  switch. `piece survey` reserves stdout for the plan it emits (or, under
+  `--json`, the full survey result); its tally and findings go to stderr.
+  `piece repair` reserves stdout the same way — the emitted plan, or under
+  `--json` the full report in the canonical FabricValue encoding — with its
+  verdict tally and dry-run diff going to stderr. `piece render --watch --json`
+  writes only JSON render records to stdout; watch status goes to stderr.
+  Rendering a piece without a UI fails instead of returning an empty successful
+  JSON stream.
 - `cf get` and `cf wish` always return JSON. Their `--json` options are
   accepted, documented no-ops for callers that select JSON explicitly.
 - `cf check --json` compiles without evaluating and prints one object with a

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -131,11 +131,10 @@ in-scope identity that the collection lacks makes the survey exit nonzero,
 naming the piece. A `--list` survey reads exactly the pieces named and makes no
 containment claim; each entry takes either reference form, and a canonical
 entry's embedded space composes the way it does on `--piece` — supplying the
-space when `--space` is absent, agreeing with it otherwise. Read-only; the
-spelling is provisional until the bulk write operations get a home. To watch the
-surface work rather than read about it, `integration/bulk-ops-demo.sh` narrates
-a board-sized survey end to end against a running server, with the unbuilt write
-stages shown as pending acts.
+space when `--space` is absent, agreeing with it otherwise. Read-only. To watch
+the surface work rather than read about it, `integration/bulk-ops-demo.sh`
+narrates a board-sized survey and repair end to end against a running server,
+with the unbuilt write stages shown as pending acts.
 
 `cf piece repair` runs a caller-supplied fixer — a TypeScript module whose
 default export is a pure transform from a piece's stored input document to the

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -34,6 +34,10 @@ import {
   parseCellSelectionOptions,
 } from "../lib/cell-selection.ts";
 import { cliCommand, cliText } from "../lib/cli-name.ts";
+import type { FabricValue } from "@commonfabric/api";
+import { jsonFromFabricValue } from "@commonfabric/data-model/codecs";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+
 import { reservesStdoutForCommandOutput } from "../lib/json-output.ts";
 import { normalizeLLMFriendlyRef } from "../lib/llm-friendly-ref.ts";
 import { renderPiece } from "../lib/piece-render.ts";
@@ -2394,7 +2398,7 @@ export const piece = targetOptions(
   )
   .option(
     "--json",
-    "Write the full repair report as JSON to stdout instead of the plan.",
+    "Write the full repair report to stdout instead of the plan, in the canonical FabricValue JSON encoding — a diffed document may hold values plain JSON cannot carry.",
     { conflicts: ["out"] },
   )
   .action(repairFromCommand)
@@ -3450,7 +3454,10 @@ export async function repairFromCommand(
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
   if (options.json) {
-    print(report, { json: true });
+    // The canonical FabricValue encoding, not a JSON.stringify: a diffed
+    // document's values may be Fabric specials — bytes, a hash — that a
+    // plain serializer flattens into empty shells.
+    print(jsonFromFabricValue(report as unknown as FabricValue));
   } else {
     const plan = encodePlan(report.plan);
     if (options.out !== undefined) {
@@ -3468,6 +3475,32 @@ export async function repairFromCommand(
     [...tally.entries()].map(([verdict, count]) => `${verdict}: ${count}`)
       .join(" · "),
   );
+  if (options.apply !== true) {
+    // The dry run's product is the exact per-piece diff, so every changed
+    // position renders — through the data-model's own debug stringifier,
+    // which shows a Fabric special value as itself.
+    for (const row of report.rows) {
+      for (const change of row.changes ?? []) {
+        if (change.kind === "added") {
+          printHint(
+            `+ ${row.piece} ${change.path} ` +
+              toCompactDebugString(change.after),
+          );
+        } else if (change.kind === "removed") {
+          printHint(
+            `- ${row.piece} ${change.path} ` +
+              toCompactDebugString(change.before),
+          );
+        } else {
+          printHint(
+            `~ ${row.piece} ${change.path} ` +
+              `${toCompactDebugString(change.before)} -> ` +
+              toCompactDebugString(change.after),
+          );
+        }
+      }
+    }
+  }
   for (const row of report.rows) {
     if (row.problem !== undefined) {
       printHint(`${row.verdict}: ${row.piece} ${row.problem}`);

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -15,7 +15,13 @@ import {
 } from "@commonfabric/runner/shared";
 import { decode } from "@commonfabric/utils/encoding";
 
-import { type PhaseRetarget, readSourcePin, runSurvey } from "../lib/bulk.ts";
+import {
+  type PhaseRetarget,
+  readSourcePin,
+  type RepairRunRequest,
+  runRepair,
+  runSurvey,
+} from "../lib/bulk.ts";
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
 import type {
   InvocationIdentity,
@@ -2340,6 +2346,58 @@ export const piece = targetOptions(
     { conflicts: ["out"] },
   )
   .action(surveyFromCommand)
+  /* piece repair */
+  .command(
+    "repair",
+    "Run a caller-supplied fixer over the selection's stored input documents",
+  )
+  .usage(pieceUsage)
+  .example(
+    cliText(
+      `cf piece repair ${EX_ID} ${EX_COMP_PIECE} --path topics --fixer fix.ts`,
+    ),
+    "Report what the fixer would change, writing nothing.",
+  )
+  .option(
+    "-c,--piece <piece:string>",
+    `${PIECE_OPTION_HELP} The holder whose collection is repaired.`,
+  )
+  .option(
+    "--path <path:string>",
+    "Path to the collection inside the holder's document; segments joined with '/'.",
+  )
+  .option(
+    "--side <side:string>",
+    "Which document holds the collection: input (the default) or result.",
+  )
+  .option(
+    "--list <piece:string>",
+    "Repair this piece instead of a collection. Repeatable.",
+    { collect: true, conflicts: ["piece", "path", "side"] },
+  )
+  .option(
+    "--fixer <path:string>",
+    "A TypeScript module whose default export is the fixer: a pure transform from a piece's stored input document to the document it should hold.",
+    { required: true },
+  )
+  .option(
+    "--plan <file:string>",
+    "Execute this plan's rows, in its order, under its document-hash preconditions.",
+  )
+  .option(
+    "--apply",
+    "Write the documents the fixer produces. Without it the run is the dry report: the exact per-piece diff, and no write at all.",
+  )
+  .option(
+    "--out <file:string>",
+    "Write the emitted plan to a file instead of stdout.",
+  )
+  .option(
+    "--json",
+    "Write the full repair report as JSON to stdout instead of the plan.",
+    { conflicts: ["out"] },
+  )
+  .action(repairFromCommand)
   /* piece view */
   .command("view", "Display the rendered view for a piece")
   .usage(pieceUsage)
@@ -3149,12 +3207,7 @@ export function parseRetargetFlag(spec: string): PhaseRetarget {
   };
 }
 
-export interface SurveyCLIOptions extends PieceCLIOptions {
-  /** Inherited from the `piece` mount's global target options. */
-  quiet?: boolean;
-  path?: string;
-  side?: string;
-  list?: string[];
+export interface SurveyCLIOptions extends BulkSelectionOptions {
   retarget?: string[];
   validator?: string;
   out?: string;
@@ -3169,20 +3222,30 @@ export interface SurveyCommandDependencies {
   exit?: (code: number) => never;
 }
 
-export async function surveyFromCommand(
-  options: SurveyCLIOptions,
-  deps: SurveyCommandDependencies = {},
-): Promise<void> {
-  setQuietMode(!!options.quiet);
-  let selector: PieceSelector;
-  let spaceConfig;
+/** The selection surface the bulk piece commands share. */
+export interface BulkSelectionOptions extends PieceCLIOptions {
+  /** Inherited from the `piece` mount's global target options. */
+  quiet?: boolean;
+  path?: string;
+  side?: string;
+  list?: string[];
+}
+
+/**
+ * Read a bulk command's selection off its flags — one function for the
+ * survey and the repair, so the two cannot drift in what an address means
+ * or what they refuse. A `--list` entry is either the canonical reference
+ * form or the bare id; a canonical entry may embed the target space, which
+ * supplies the space when `--space` is absent and must otherwise agree —
+ * at parse time against a DID, through validateEmbeddedSpaces against a
+ * name still to be resolved. Bulk operations read whole pieces, so a
+ * scope, a path, or the #argument suffix on an entry is refused rather
+ * than dropped.
+ */
+export function readBulkSelection(
+  options: BulkSelectionOptions,
+): { selector: PieceSelector; spaceConfig: SpaceConfig } {
   if (options.list !== undefined && options.list.length > 0) {
-    // An entry is either the canonical reference form or the bare id. A
-    // canonical entry may embed the target space: it supplies the space when
-    // --space is absent, and otherwise the two must agree — at parse time
-    // against a DID, through validateEmbeddedSpaces against a name still to
-    // be resolved. The survey reads whole pieces, so a scope, a path, or the
-    // #argument suffix on an entry is refused rather than dropped.
     let listSpace = options.space;
     const embedded: string[] = [];
     const entries = options.list.map((entry) => {
@@ -3191,8 +3254,8 @@ export async function surveyFromCommand(
         // The bare alias grammar reads @ as its scope marker.
         if (entry.includes("@")) {
           throw new ValidationError(
-            `A scoped piece cannot be surveyed; drop the @scope suffix on ` +
-              `${JSON.stringify(entry)}.`,
+            `A scoped piece cannot be selected for a bulk operation; drop ` +
+              `the @scope suffix on ${JSON.stringify(entry)}.`,
             { exitCode: 1 },
           );
         }
@@ -3200,22 +3263,22 @@ export async function surveyFromCommand(
       }
       if (ref.scope !== undefined) {
         throw new ValidationError(
-          `A scoped piece cannot be surveyed; drop the @scope suffix on ` +
-            `${JSON.stringify(entry)}.`,
+          `A scoped piece cannot be selected for a bulk operation; drop ` +
+            `the @scope suffix on ${JSON.stringify(entry)}.`,
           { exitCode: 1 },
         );
       }
       if (ref.path.length > 0) {
         throw new ValidationError(
-          `A survey reads whole pieces; drop the path on ` +
+          `A bulk operation reads whole pieces; drop the path on ` +
             `${JSON.stringify(entry)}.`,
           { exitCode: 1 },
         );
       }
       if (ref.input) {
         throw new ValidationError(
-          `A survey reads whole pieces; drop the #argument suffix on ` +
-            `${JSON.stringify(entry)}.`,
+          `A bulk operation reads whole pieces; drop the #argument suffix ` +
+            `on ${JSON.stringify(entry)}.`,
           { exitCode: 1 },
         );
       }
@@ -3230,7 +3293,7 @@ export async function surveyFromCommand(
       }
       return ref.pieceId;
     });
-    spaceConfig = parseSpaceOptions(
+    const spaceConfig = parseSpaceOptions(
       listSpace === options.space ? options : { ...options, space: listSpace },
     );
     if (embedded.length > 0) {
@@ -3239,42 +3302,51 @@ export async function surveyFromCommand(
         ...embedded,
       ];
     }
-    selector = { kind: "list", pieces: entries };
-  } else {
-    const pieceConfig = parsePieceOptions(options);
-    spaceConfig = pieceConfig;
-    if (pieceConfig.pieceScope !== undefined) {
-      throw new ValidationError(
-        "A scoped piece cannot hold the surveyed collection; drop the " +
-          "@scope suffix.",
-        { exitCode: 1 },
-      );
-    }
-    const path = (options.path ?? "").split("/").filter((s) => s !== "");
-    if (path.length === 0) {
-      throw new ValidationError(
-        "--path names the collection to survey; use --list to survey pieces directly.",
-        { exitCode: 1 },
-      );
-    }
-    if (
-      options.side !== undefined && options.side !== "input" &&
-      options.side !== "result"
-    ) {
-      throw new ValidationError(
-        `--side takes input or result, got "${options.side}".`,
-        { exitCode: 1 },
-      );
-    }
-    selector = {
+    return { selector: { kind: "list", pieces: entries }, spaceConfig };
+  }
+  const pieceConfig = parsePieceOptions(options);
+  if (pieceConfig.pieceScope !== undefined) {
+    throw new ValidationError(
+      "A scoped piece cannot hold the selected collection; drop the " +
+        "@scope suffix.",
+      { exitCode: 1 },
+    );
+  }
+  const path = (options.path ?? "").split("/").filter((s) => s !== "");
+  if (path.length === 0) {
+    throw new ValidationError(
+      "--path names the collection; use --list to select pieces directly.",
+      { exitCode: 1 },
+    );
+  }
+  if (
+    options.side !== undefined && options.side !== "input" &&
+    options.side !== "result"
+  ) {
+    throw new ValidationError(
+      `--side takes input or result, got "${options.side}".`,
+      { exitCode: 1 },
+    );
+  }
+  return {
+    selector: {
       kind: "collection",
       holder: pieceConfig.piece,
       path,
       ...(options.side === undefined
         ? {}
         : { side: options.side as "input" | "result" }),
-    };
-  }
+    },
+    spaceConfig: pieceConfig,
+  };
+}
+
+export async function surveyFromCommand(
+  options: SurveyCLIOptions,
+  deps: SurveyCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const { selector, spaceConfig } = readBulkSelection(options);
   const shared = {
     ...(options.root === undefined ? {} : { root: absPath(options.root) }),
     ...(options.test === undefined
@@ -3337,6 +3409,85 @@ export async function surveyFromCommand(
             (outside) =>
               `  registered outside the selection: ${outside.piece} on ` +
               `${outside.patternIdentity}#${outside.symbol}`,
+          ),
+        ].join("\n"),
+      },
+      deps,
+    );
+  }
+}
+
+export interface RepairCLIOptions extends BulkSelectionOptions {
+  fixer: string;
+  plan?: string;
+  apply?: boolean;
+  out?: string;
+}
+
+export interface RepairCommandDependencies {
+  runRepair?: typeof runRepair;
+  render?: typeof render;
+  writeTextFile?: typeof Deno.writeTextFile;
+  printError?: (message: string) => void;
+  printHint?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+export async function repairFromCommand(
+  options: RepairCLIOptions,
+  deps: RepairCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  const { selector, spaceConfig } = readBulkSelection(options);
+  const request: RepairRunRequest = {
+    selector,
+    fixerPath: absPath(options.fixer),
+    fixerName: options.fixer,
+    ...(options.plan === undefined ? {} : { planPath: absPath(options.plan) }),
+    ...(options.apply === true ? { apply: true } : {}),
+  };
+  const report = await (deps.runRepair ?? runRepair)(spaceConfig, request);
+  const print = deps.render ?? render;
+  const printHint = deps.printHint ?? hint;
+  if (options.json) {
+    print(report, { json: true });
+  } else {
+    const plan = encodePlan(report.plan);
+    if (options.out !== undefined) {
+      await (deps.writeTextFile ?? Deno.writeTextFile)(options.out, plan);
+      printHint(`Wrote ${report.plan.rows.length} plan rows to ${options.out}`);
+    } else {
+      print(plan.trimEnd());
+    }
+  }
+  const tally = new Map<string, number>();
+  for (const row of report.rows) {
+    tally.set(row.verdict, (tally.get(row.verdict) ?? 0) + 1);
+  }
+  printHint(
+    [...tally.entries()].map(([verdict, count]) => `${verdict}: ${count}`)
+      .join(" · "),
+  );
+  for (const row of report.rows) {
+    if (row.problem !== undefined) {
+      printHint(`${row.verdict}: ${row.piece} ${row.problem}`);
+    }
+  }
+  if (!report.complete) {
+    exitWithDataError(
+      {
+        message: [
+          options.apply === true
+            ? "Repair did not complete; re-running resumes it."
+            : "Repair found rows it must refuse.",
+          // The problem rides the message, not a hint: a quiet script is
+          // the caller most in need of the why.
+          ...report.rows.filter((row) =>
+            row.verdict !== "conforms" && row.verdict !== "repaired" &&
+            (options.apply === true || row.verdict !== "would-change")
+          ).map((row) =>
+            `  ${row.verdict}: ${row.piece}` +
+            (row.problem === undefined ? "" : ` ${row.problem}`)
           ),
         ].join("\n"),
       },

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2286,7 +2286,7 @@ export const piece = targetOptions(
   /* piece survey */
   .command(
     "survey",
-    "Survey a holder's collection into a plan: one cheap read per piece, cross-checked against the piece registry (a --list survey claims no containment and is not cross-checked). Read-only. Provisional spelling — the bulk entry point may move when the write operations get a home (docs/plans/piece-bulk-operations.md, decision 1).",
+    "Survey a holder's collection into a plan: one cheap read per piece, cross-checked against the piece registry (a --list survey claims no containment and is not cross-checked). Read-only.",
   )
   .usage(pieceUsage)
   .example(

--- a/packages/cli/integration/bulk-ops-demo.sh
+++ b/packages/cli/integration/bulk-ops-demo.sh
@@ -250,7 +250,39 @@ run cf call -q -s "$SPACE" --piece board addMember '{"title":"delta"}'
 run_loud cf piece survey -s "$SPACE" --piece board --path items --out "$WORK/after.jsonl"
 run sh -c "head -1 '$WORK/after.jsonl' | jq -c .enumerated"
 
-act "7 · The refusal the survey exists to make"
+act "7 · A repair: the fixer is the work, the spine is the tooling"
+say "Stage 2, live. A fixer is a TypeScript module default-exporting a pure"
+say "transform from a piece's stored document to the document it should"
+say "hold. The tooling owns selection, ordering, the write, the stop, and"
+say "resume; the fixer owns only what the change is."
+cat > "$WORK/fix-titles.ts" <<'FIXER'
+export default (document: Readonly<Record<string, unknown>>) => ({
+  ...document,
+  ...(typeof document.title === "string"
+    ? { title: (document.title as string).toUpperCase() }
+    : {}),
+});
+FIXER
+run cat "$WORK/fix-titles.ts"
+say "Dry by default: the exact per-piece diff, and no write at all. Every"
+say "plan row records the document hash its verdict was computed from — the"
+say "repair row's precondition — and the fixer it was evaluated for."
+run_loud cf piece repair -s "$SPACE" --piece board --path items \
+  --fixer "$WORK/fix-titles.ts" --out "$WORK/repair.jsonl"
+run sh -c "sed -n 2p '$WORK/repair.jsonl' | jq '{piece, hash: .expect.documentHash, op}'"
+say "The plan drives the apply: its rows, in its order, each row checked"
+say "against its recorded hash in the same transaction that writes it."
+run_loud cf piece repair -s "$SPACE" --piece board --path items \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply \
+  --out "$WORK/applied.jsonl"
+say "Resume is the same command again: a repaired document is one the fixer"
+say "no longer changes, so a completed plan re-runs as landed and writes"
+say "nothing."
+run_loud cf piece repair -s "$SPACE" --piece board --path items \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply \
+  --out "$WORK/applied.jsonl"
+
+act "8 · The refusal the survey exists to make"
 say "Deploy a member directly, so the registry knows a piece the board's"
 say "collection does not hold. A silent subset is the failure bulk operations"
 say "die of, so the survey stops and names it rather than emitting a plan"
@@ -263,7 +295,7 @@ say "The plan the later stages consume is therefore complete by construction:"
 say "an incomplete survey refuses to produce one, and a serialized plan"
 say "carries the incompleteness so no write stage can consume it either."
 
-act "8 · A list survey claims only what it read"
+act "9 · A list survey claims only what it read"
 say "Naming pieces directly skips the containment check — and says so: the"
 say "header records the selector, so a reader of the plan knows no"
 say "containment claim was made. The orphan is still out there; this survey"
@@ -271,20 +303,14 @@ say "just never claimed otherwise."
 run_loud cf piece survey -s "$SPACE" --list board --out "$WORK/list.jsonl"
 run sh -c "head -1 '$WORK/list.jsonl' | jq -c '{selector, enumerated}'"
 
-act "9 · The rest of the mechanism, by what it waits on"
+act "10 · The rest of the mechanism, by what it waits on"
 say "The plan files this transcript produced are the input to every later"
 say "stage; nothing below needs a different artifact — the paths are the"
 say "ones written above. Each act shows the command a stage adds and what"
-say "it will print — spelled provisionally, since decision 1 of the plan"
-say "owns where bulk writes live, and prefixed » because nothing runs it."
-say "A stage that lands converts its act from PENDING to run; the plan's"
-say "checklist for that stage says so, the way stage 1's did."
-
-pending "cf piece repair -s $SPACE --plan $WORK/plan.jsonl --fixer fix-titles.ts" \
-  "stage 2: a caller-supplied fixer, iterated by the spine, dry by default" \
-"fid1:cey7Ro... title: 'seed-0' -> 'Seed 0'
-112 more member rows would change; the holder already conforms.
---apply writes the 113 in plan order"
+say "it will print — spelled provisionally per the plan, and prefixed »"
+say "because nothing runs it. A stage that lands converts its act from"
+say "PENDING to run; the plan's checklist for that stage says so, the way"
+say "stages 1 and 2 did."
 
 pending "cf piece apply -s $SPACE $WORK/retarget.jsonl" \
   "stage 3: the retarget apply — serial, precondition-checked, resumable" \

--- a/packages/cli/integration/bulk-ops-demo.sh
+++ b/packages/cli/integration/bulk-ops-demo.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Bulk piece operations as something to watch. What runs today is stage 1 of
-# docs/plans/piece-bulk-operations.md — a board of 113 members surveyed in
-# one process, the plan it emits, the retarget stamp, and the containment
-# refusal — live rather than asserted. What the later stages add appears as
+# Bulk piece operations as something to watch. What runs today is stages 1
+# and 2 of docs/plans/piece-bulk-operations.md — a board of 113 members
+# surveyed in one process, the plan it emits, the retarget stamp, the
+# containment refusal, and a repair: a fixer run dry, applied from its own
+# plan, and resumed as landed — live rather than asserted. What the later
+# stages add appears as
 # PENDING acts at the end: the eventual shape of the mechanism stays visible
 # in the transcript, and each stage's checklist in the plan carries the item
 # that converts its act from pending to run, so a landed stage cannot leave
@@ -181,7 +183,7 @@ refused() {
 # against until the stage lands. What keeps a pending act from going stale is
 # the plan document instead — each later stage's checklist carries the item
 # that converts its act here from pending to run, the same per-change tick
-# discipline stage 1 used.
+# discipline stages 1 and 2 used.
 pending() {
   printf '\n%s   » %s%s\n' "$Y" "$1" "$N"
   printf '%s     PENDING — %s%s\n' "$Y" "$2" "$N"

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -164,7 +164,59 @@ AFTER=$($CF piece survey -q --piece "$BOARD" --path items $ARGS \
 check "$((MEMBERS_TOTAL + 1))" "$AFTER" \
   "the after-survey counts the member added since"
 
-step "10. A registered in-scope orphan makes the survey refuse"
+step "10. A repair runs dry, applies from its plan, and resumes as landed"
+cat > "$WORK/fix-titles.ts" <<'FIXER'
+export default (document: Readonly<Record<string, unknown>>) => ({
+  ...document,
+  ...(typeof document.title === "string"
+    ? { title: (document.title as string).toUpperCase() }
+    : {}),
+});
+FIXER
+if $CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/fix-titles.ts" --out "$WORK/repair.jsonl" \
+  2>"$WORK/repair-dry.err"; then
+  ok "dry repair exited 0"
+else
+  bad "dry repair exited nonzero"
+  sed 's/^/  | /' "$WORK/repair-dry.err"
+fi
+DRY_OPS=$(tail -n +2 "$WORK/repair.jsonl" | jq -rs \
+  'map(.op.fixer) | unique | join(",")')
+check "$WORK/fix-titles.ts" "$DRY_OPS" \
+  "every plan row records the fixer it was evaluated for"
+APPLY_FACTS=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply --json \
+  2>"$WORK/repair-apply.err" | jq -r '[(.applied|tostring),
+    (.complete|tostring), (.rows | map(.verdict) | unique | join(","))]
+    | @tsv')
+MEMBERS_NOW=$((MEMBERS_TOTAL + 1))
+check "$(printf '%s\ttrue\trepaired' "$MEMBERS_NOW")" "$APPLY_FACTS" \
+  "the plan-driven apply repaired every member row"
+RESUME=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply --json \
+  2>/dev/null | jq -r '[(.applied|tostring), (.complete|tostring),
+    (.rows | map(.verdict) | unique | join(","))] | @tsv')
+check "$(printf '0\ttrue\tconforms')" "$RESUME" \
+  "re-running the completed plan writes nothing and reads all-landed"
+cat > "$WORK/drop-everything.ts" <<'FIXER'
+export default () => ({});
+FIXER
+if $CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/drop-everything.ts" \
+  >/dev/null 2>"$WORK/repair-refuse.err"; then
+  bad "a field-dropping fixer was accepted"
+else
+  ok "a field-dropping fixer exited nonzero"
+fi
+if grep -q "incomplete document" "$WORK/repair-refuse.err"; then
+  ok "the refusal names the incomplete document"
+else
+  bad "the refusal does not name the incomplete document"
+  sed 's/^/  | /' "$WORK/repair-refuse.err"
+fi
+
+step "11. A registered in-scope orphan makes the survey refuse"
 ORPHAN=$($CF piece new --quiet --main-export Member \
   "$SCRIPT_DIR/pattern/bulk-member.tsx" $ARGS 2>/dev/null |
   grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
@@ -183,7 +235,7 @@ else
   bad "the refusal does not name the orphan"
 fi
 
-step "11. A list survey claims no containment"
+step "12. A list survey claims no containment"
 LIST_FACTS=$($CF piece survey -q --list "$BOARD" $ARGS 2>/dev/null |
   head -1 | jq -r '[.selector, (.enumerated.collection|tostring),
     (.enumerated.registeredOutside|tostring)] | @tsv')

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# The bulk-survey drill: deploy a board whose members are created through its
-# own verb, survey it, and assert the plan — the stage-1 drill of
+# The bulk-operations drill: deploy a board whose members are created
+# through its own verb, survey it, assert the plan — and repair it: a fixer
+# run dry with every plan row recording its precondition and fixer, applied
+# from that plan, resumed as all-landed writing nothing, and a
+# field-dropping fixer refused by name. Stages 1 and 2 of
 # docs/plans/piece-bulk-operations.md, which finishes each stage with a CI
 # drill so "does the migration tooling still work?" stays a CI result.
 #

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -188,9 +188,27 @@ DRY_OPS=$(tail -n +2 "$WORK/repair.jsonl" | jq -rs \
   'map(.op.fixer) | unique | join(",")')
 check "$WORK/fix-titles.ts" "$DRY_OPS" \
   "every plan row records the fixer it was evaluated for"
+# The reviewed plan pins the fixer implementation: an edited module is a
+# different closure identity, and the apply refuses it by name.
+cp "$WORK/fix-titles.ts" "$WORK/fix-titles.reviewed.ts"
+printf '\n// edited after review\n' >> "$WORK/fix-titles.ts"
+if $CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply \
+  >/dev/null 2>"$WORK/repair-pin.err"; then
+  bad "an edited fixer ran under the reviewed plan"
+else
+  ok "an edited fixer exited nonzero under the reviewed plan"
+fi
+if grep -q "different fixer implementation" "$WORK/repair-pin.err"; then
+  ok "the refusal names the implementation pin"
+else
+  bad "the refusal does not name the implementation pin"
+  sed 's/^/  | /' "$WORK/repair-pin.err"
+fi
+mv "$WORK/fix-titles.reviewed.ts" "$WORK/fix-titles.ts"
 APPLY_FACTS=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
   --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply --json \
-  2>"$WORK/repair-apply.err" | jq -r '[(.applied|tostring),
+  2>"$WORK/repair-apply.err" | sed 's/^fvj1://' | jq -r '[(.applied|tostring),
     (.complete|tostring), (.rows | map(.verdict) | unique | join(","))]
     | @tsv')
 MEMBERS_NOW=$((MEMBERS_TOTAL + 1))
@@ -198,8 +216,9 @@ check "$(printf '%s\ttrue\trepaired' "$MEMBERS_NOW")" "$APPLY_FACTS" \
   "the plan-driven apply repaired every member row"
 RESUME=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
   --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply --json \
-  2>/dev/null | jq -r '[(.applied|tostring), (.complete|tostring),
-    (.rows | map(.verdict) | unique | join(","))] | @tsv')
+  2>/dev/null | sed 's/^fvj1://' | jq -r '[(.applied|tostring),
+    (.complete|tostring), (.rows | map(.verdict) | unique | join(","))]
+    | @tsv')
 check "$(printf '0\ttrue\tconforms')" "$RESUME" \
   "re-running the completed plan writes nothing and reads all-landed"
 cat > "$WORK/drop-everything.ts" <<'FIXER'
@@ -219,7 +238,56 @@ else
   sed 's/^/  | /' "$WORK/repair-refuse.err"
 fi
 
-step "11. A registered in-scope orphan makes the survey refuse"
+step "11. A run stopped midway completes by re-invocation"
+# A fixer that appends a mark, but whose answer for the third-planned piece
+# breaks the schema: rows before it land, the run stops there with the
+# remainder named, and re-invoking skips what landed — the property the
+# design says rots silently unless a drill holds it.
+cat > "$WORK/mark-titles.ts" <<'FIXER'
+export default (document: Readonly<Record<string, unknown>>) => {
+  const title = String(document.title ?? "");
+  if (title === "GAMMA") return { ...document, title: 7 as never };
+  return {
+    ...document,
+    ...(title !== "" && !title.endsWith("!")
+      ? { title: `${title}!` }
+      : {}),
+  };
+};
+FIXER
+RUN1=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/mark-titles.ts" --apply --json 2>/dev/null |
+  sed 's/^fvj1://' | jq -r '[(.applied|tostring),
+    (.rows | map(.verdict) | .[0:3] | join(",")),
+    ((.rows | map(.verdict) | map(select(. == "unattempted")) | length > 0)
+      | tostring)] | @tsv')
+check "$(printf '2\trepaired,repaired,failed\ttrue')" "$RUN1" \
+  "the run landed two rows, stopped at the third, and named the rest"
+RUN2=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/mark-titles.ts" --apply --json 2>/dev/null |
+  sed 's/^fvj1://' | jq -r '[(.applied|tostring),
+    (.rows | map(.verdict) | .[0:3] | join(","))] | @tsv')
+check "$(printf '0\tconforms,conforms,failed')" "$RUN2" \
+  "re-invoking skips the landed rows and writes nothing for them"
+cat > "$WORK/mark-titles-v2.ts" <<'FIXER'
+export default (document: Readonly<Record<string, unknown>>) => {
+  const title = String(document.title ?? "");
+  return {
+    ...document,
+    ...(title !== "" && !title.endsWith("!")
+      ? { title: `${title}!` }
+      : {}),
+  };
+};
+FIXER
+RUN3=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
+  --fixer "$WORK/mark-titles-v2.ts" --apply --json 2>/dev/null |
+  sed 's/^fvj1://' | jq -r '[(.applied|tostring), (.complete|tostring)]
+    | @tsv')
+check "$(printf '%s\ttrue' "$((MEMBERS_NOW - 2))")" "$RUN3" \
+  "the amended fixer completes the remainder by re-invocation"
+
+step "12. A registered in-scope orphan makes the survey refuse"
 ORPHAN=$($CF piece new --quiet --main-export Member \
   "$SCRIPT_DIR/pattern/bulk-member.tsx" $ARGS 2>/dev/null |
   grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
@@ -238,7 +306,7 @@ else
   bad "the refusal does not name the orphan"
 fi
 
-step "12. A list survey claims no containment"
+step "13. A list survey claims no containment"
 LIST_FACTS=$($CF piece survey -q --list "$BOARD" $ARGS 2>/dev/null |
   head -1 | jq -r '[.selector, (.enumerated.collection|tostring),
     (.enumerated.registeredOutside|tostring)] | @tsv')

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -112,6 +112,39 @@ export async function runRepair(
   request: RepairRunRequest,
   deps: RepairRunDependencies = {},
 ): Promise<RepairReport> {
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
+  const selector = await resolveSelector(pieces, request.selector, resolve);
+  // The identity of the fixer module's authored closure, computed the way a
+  // retarget's source identity is — without compiling, and so without
+  // running anything — so the plan pins the implementation reviewed rather
+  // than a path whose file can change.
+  const computeIdentity = deps.computeFixerIdentity ??
+    (async (path: string) =>
+      await programEntryIdentity(
+        await resolveLocalSourceProgram(pieces.runtime, { main: path }),
+      ));
+  const fixerIdentity = await computeIdentity(request.fixerPath);
+  const plan = request.planPath === undefined ? undefined : decodePlan(
+    await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
+  );
+  if (plan !== undefined) {
+    // The pin is held before the module is imported: a dynamic import
+    // evaluates the module's top-level code, and an implementation the
+    // plan's reviewer never saw must not run even that much. The library
+    // re-checks the same pin behind the seam.
+    const repinned = plan.rows.filter((row) =>
+      row.op?.kind === "repair" && row.op.fixerIdentity !== fixerIdentity
+    );
+    if (repinned.length > 0) {
+      throw new Error(
+        "The plan pins a different fixer implementation than " +
+          `${request.fixerName} resolves to, on: ` +
+          repinned.map((row) => row.piece).join(", ") +
+          ". Nothing was imported.",
+      );
+    }
+  }
   const importModule = deps.importModule ??
     ((path: string) => import(toFileUrl(path).href));
   const module = await importModule(request.fixerPath);
@@ -122,21 +155,6 @@ export async function runRepair(
         `${request.fixerName}.`,
     );
   }
-  const pieces = await (deps.loadPieces ?? loadPieces)(config);
-  const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
-  const selector = await resolveSelector(pieces, request.selector, resolve);
-  // The identity of the fixer module's authored closure, computed the way a
-  // retarget's source identity is — without compiling — so the plan pins
-  // the implementation reviewed rather than a path whose file can change.
-  const computeIdentity = deps.computeFixerIdentity ??
-    (async (path: string) =>
-      await programEntryIdentity(
-        await resolveLocalSourceProgram(pieces.runtime, { main: path }),
-      ));
-  const fixerIdentity = await computeIdentity(request.fixerPath);
-  const plan = request.planPath === undefined ? undefined : decodePlan(
-    await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
-  );
   return await repairPieces(pieces, {
     selector,
     fixer: fixer as Fixer,

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -24,7 +24,11 @@ import {
   surveyPieces,
   type SurveyResult,
 } from "@commonfabric/piece/ops";
-import { localRetargetOp } from "@commonfabric/piece/ops/bulk-local";
+import {
+  localRetargetOp,
+  programEntryIdentity,
+  resolveLocalSourceProgram,
+} from "@commonfabric/piece/ops/bulk-local";
 import type { JSONSchema } from "@commonfabric/runner";
 
 import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
@@ -93,6 +97,8 @@ export interface RepairRunDependencies {
   readTextFile?: (path: string) => Promise<string>;
   /** The module import, injectable so tests supply a fixer without disk. */
   importModule?: (path: string) => Promise<unknown>;
+  /** The closure-identity computation, injectable the same way. */
+  computeFixerIdentity?: (path: string) => Promise<string>;
 }
 
 /**
@@ -119,6 +125,15 @@ export async function runRepair(
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
   const selector = await resolveSelector(pieces, request.selector, resolve);
+  // The identity of the fixer module's authored closure, computed the way a
+  // retarget's source identity is — without compiling — so the plan pins
+  // the implementation reviewed rather than a path whose file can change.
+  const computeIdentity = deps.computeFixerIdentity ??
+    (async (path: string) =>
+      await programEntryIdentity(
+        await resolveLocalSourceProgram(pieces.runtime, { main: path }),
+      ));
+  const fixerIdentity = await computeIdentity(request.fixerPath);
   const plan = request.planPath === undefined ? undefined : decodePlan(
     await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
   );
@@ -126,6 +141,7 @@ export async function runRepair(
     selector,
     fixer: fixer as Fixer,
     fixerName: request.fixerName,
+    fixerIdentity,
     ...(plan === undefined ? {} : { plan }),
     ...(request.apply === true ? { apply: true } : {}),
   });

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -7,12 +7,19 @@
  * above it stay seams.
  */
 
+import { toFileUrl } from "@std/path";
+
 import { resolvePieceAddress } from "@commonfabric/piece";
 import {
+  decodePlan,
+  type Fixer,
   type PiecePin,
+  type PiecesController,
   type PieceSelector,
   type PlannedRetarget,
   readPiecePin,
+  repairPieces,
+  type RepairReport,
   type RetargetSource,
   surveyPieces,
   type SurveyResult,
@@ -45,6 +52,83 @@ export async function readSourcePin(
     config.piece,
   );
   return await readPiecePin(pieces, piece, new Map(), config.pieceScope);
+}
+
+/**
+ * Resolve a selector's addresses the way every other piece verb resolves
+ * one — slugs included — shared by the survey and the repair so the two
+ * cannot drift in what an address means.
+ */
+async function resolveSelector(
+  pieces: PiecesController,
+  selector: PieceSelector,
+  resolve: typeof resolvePieceAddress,
+): Promise<PieceSelector> {
+  if (selector.kind === "collection") {
+    return { ...selector, holder: await resolve(pieces, selector.holder) };
+  }
+  const resolved: string[] = [];
+  for (const entry of selector.pieces) {
+    resolved.push(await resolve(pieces, entry));
+  }
+  return { kind: "list", pieces: resolved };
+}
+
+/** What one repair run is asked to do, parsed off the command line. */
+export interface RepairRunRequest {
+  selector: PieceSelector;
+  /** The fixer module's absolute path, for the import. */
+  fixerPath: string;
+  /** The fixer's name as supplied, recorded in the emitted plan. */
+  fixerName: string;
+  /** A plan file to execute, row for row, under its preconditions. */
+  planPath?: string;
+  /** Write the fixer's documents; absent, the run is the dry report. */
+  apply?: boolean;
+}
+
+export interface RepairRunDependencies {
+  loadPieces?: typeof loadPieces;
+  resolvePieceAddress?: typeof resolvePieceAddress;
+  readTextFile?: (path: string) => Promise<string>;
+  /** The module import, injectable so tests supply a fixer without disk. */
+  importModule?: (path: string) => Promise<unknown>;
+}
+
+/**
+ * Run the repair: import the fixer module, resolve the selector's addresses
+ * the way the other piece verbs do, decode the plan file when one drives
+ * the run, and hand the library the pieces. Dry by default; the library
+ * owns every refusal beyond the fixer module's own shape.
+ */
+export async function runRepair(
+  config: SpaceConfig,
+  request: RepairRunRequest,
+  deps: RepairRunDependencies = {},
+): Promise<RepairReport> {
+  const importModule = deps.importModule ??
+    ((path: string) => import(toFileUrl(path).href));
+  const module = await importModule(request.fixerPath);
+  const fixer = (module as { default?: unknown }).default;
+  if (typeof fixer !== "function") {
+    throw new Error(
+      `The fixer module must default-export the fixer function: ` +
+        `${request.fixerName}.`,
+    );
+  }
+  const pieces = await (deps.loadPieces ?? loadPieces)(config);
+  const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
+  const selector = await resolveSelector(pieces, request.selector, resolve);
+  const plan = request.planPath === undefined ? undefined : decodePlan(
+    await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
+  );
+  return await repairPieces(pieces, {
+    selector,
+    fixer: fixer as Fixer,
+    fixerName: request.fixerName,
+    ...(plan === undefined ? {} : { plan }),
+    ...(request.apply === true ? { apply: true } : {}),
+  });
 }
 
 /** One `--retarget` flag, parsed: which phase, what source, what label. */
@@ -101,16 +185,7 @@ export async function runSurvey(
 
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
-  let selector = request.selector;
-  if (selector.kind === "collection") {
-    selector = { ...selector, holder: await resolve(pieces, selector.holder) };
-  } else {
-    const resolved: string[] = [];
-    for (const entry of selector.pieces) {
-      resolved.push(await resolve(pieces, entry));
-    }
-    selector = { kind: "list", pieces: resolved };
-  }
+  const selector = await resolveSelector(pieces, request.selector, resolve);
 
   // A null prototype, so a phase named like an `Object.prototype` member is
   // an own key rather than a write through the prototype chain.

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -136,12 +136,26 @@ export async function runRepair(
   const plan = request.planPath === undefined ? undefined : decodePlan(
     await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
   );
-  if (plan !== undefined) {
+  if (plan !== undefined && plan.rows.length > 0) {
     // Every row is held to the run's fixer — operation, name, and pin —
     // before the module is imported: a dynamic import evaluates top-level
     // code, and a plan that cannot run this fixer must not run any of it.
     // The library applies the same gate again behind the seam.
     assertPlanRunsFixer(plan, request.fixerName, fixerIdentity);
+  }
+  if (plan !== undefined && plan.rows.length === 0) {
+    // A zero-row plan pins nothing, so nothing must run under it — the
+    // fixer is not even imported. Whether the plan fits this run is the
+    // library's selection equality, which refuses it against any nonempty
+    // selection; against an empty one the run is a no-op report.
+    return await repairPieces(pieces, {
+      selector,
+      fixer: zeroRowFixer,
+      fixerName: request.fixerName,
+      fixerIdentity,
+      plan,
+      ...(request.apply === true ? { apply: true } : {}),
+    });
   }
   const module = await (deps.importProgram ?? importProgramSnapshot)(program);
   const fixer = (module as { default?: unknown }).default;
@@ -159,6 +173,15 @@ export async function runRepair(
     ...(plan === undefined ? {} : { plan }),
     ...(request.apply === true ? { apply: true } : {}),
   });
+}
+
+/**
+ * The fixer a zero-row plan run carries: such a run evaluates no rows, so
+ * nothing may call this — and it says so if something does, rather than
+ * quietly transforming a document no plan accounted for.
+ */
+export function zeroRowFixer(): Record<string, unknown> {
+  throw new Error("A zero-row plan runs no fixer.");
 }
 
 /**

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -7,10 +7,11 @@
  * above it stay seams.
  */
 
-import { toFileUrl } from "@std/path";
+import { dirname, join, toFileUrl } from "@std/path";
 
 import { resolvePieceAddress } from "@commonfabric/piece";
 import {
+  assertPlanRunsFixer,
   decodePlan,
   type Fixer,
   type PiecePin,
@@ -29,7 +30,7 @@ import {
   programEntryIdentity,
   resolveLocalSourceProgram,
 } from "@commonfabric/piece/ops/bulk-local";
-import type { JSONSchema } from "@commonfabric/runner";
+import type { JSONSchema, RuntimeProgram } from "@commonfabric/runner";
 
 import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
 
@@ -95,10 +96,15 @@ export interface RepairRunDependencies {
   loadPieces?: typeof loadPieces;
   resolvePieceAddress?: typeof resolvePieceAddress;
   readTextFile?: (path: string) => Promise<string>;
-  /** The module import, injectable so tests supply a fixer without disk. */
-  importModule?: (path: string) => Promise<unknown>;
-  /** The closure-identity computation, injectable the same way. */
-  computeFixerIdentity?: (path: string) => Promise<string>;
+  /**
+   * Resolve the fixer's closure snapshot — the one read of the authored
+   * sources that both the identity and the execution come from.
+   */
+  resolveFixerProgram?: (path: string) => Promise<RuntimeProgram>;
+  /** The snapshot's closure identity. */
+  programIdentity?: (program: RuntimeProgram) => Promise<string>;
+  /** Execute the snapshot — never the path it was read from. */
+  importProgram?: (program: RuntimeProgram) => Promise<unknown>;
 }
 
 /**
@@ -115,39 +121,29 @@ export async function runRepair(
   const pieces = await (deps.loadPieces ?? loadPieces)(config);
   const resolve = deps.resolvePieceAddress ?? resolvePieceAddress;
   const selector = await resolveSelector(pieces, request.selector, resolve);
-  // The identity of the fixer module's authored closure, computed the way a
-  // retarget's source identity is — without compiling, and so without
-  // running anything — so the plan pins the implementation reviewed rather
-  // than a path whose file can change.
-  const computeIdentity = deps.computeFixerIdentity ??
-    (async (path: string) =>
-      await programEntryIdentity(
-        await resolveLocalSourceProgram(pieces.runtime, { main: path }),
-      ));
-  const fixerIdentity = await computeIdentity(request.fixerPath);
+  // One closure snapshot serves the whole run: the identity is computed
+  // from it and the execution imports it, so nothing on disk can change
+  // between the hash and the code — the path is read exactly once. The
+  // resolution and the hash are reads, never executions.
+  const program = await (deps.resolveFixerProgram ??
+    ((path: string) =>
+      resolveLocalSourceProgram(pieces.runtime, { main: path })))(
+      request.fixerPath,
+    );
+  const fixerIdentity = await (deps.programIdentity ?? programEntryIdentity)(
+    program,
+  );
   const plan = request.planPath === undefined ? undefined : decodePlan(
     await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
   );
   if (plan !== undefined) {
-    // The pin is held before the module is imported: a dynamic import
-    // evaluates the module's top-level code, and an implementation the
-    // plan's reviewer never saw must not run even that much. The library
-    // re-checks the same pin behind the seam.
-    const repinned = plan.rows.filter((row) =>
-      row.op?.kind === "repair" && row.op.fixerIdentity !== fixerIdentity
-    );
-    if (repinned.length > 0) {
-      throw new Error(
-        "The plan pins a different fixer implementation than " +
-          `${request.fixerName} resolves to, on: ` +
-          repinned.map((row) => row.piece).join(", ") +
-          ". Nothing was imported.",
-      );
-    }
+    // Every row is held to the run's fixer — operation, name, and pin —
+    // before the module is imported: a dynamic import evaluates top-level
+    // code, and a plan that cannot run this fixer must not run any of it.
+    // The library applies the same gate again behind the seam.
+    assertPlanRunsFixer(plan, request.fixerName, fixerIdentity);
   }
-  const importModule = deps.importModule ??
-    ((path: string) => import(toFileUrl(path).href));
-  const module = await importModule(request.fixerPath);
+  const module = await (deps.importProgram ?? importProgramSnapshot)(program);
   const fixer = (module as { default?: unknown }).default;
   if (typeof fixer !== "function") {
     throw new Error(
@@ -163,6 +159,29 @@ export async function runRepair(
     ...(plan === undefined ? {} : { plan }),
     ...(request.apply === true ? { apply: true } : {}),
   });
+}
+
+/**
+ * Execute a resolved closure snapshot: its files land in a fresh temporary
+ * directory — relative imports resolving among themselves exactly as they
+ * did on disk — and the entry is imported from there, so the code that runs
+ * is the code that was hashed, whatever happened to the original path
+ * since. The directory is removed once the module is loaded.
+ */
+async function importProgramSnapshot(
+  program: RuntimeProgram,
+): Promise<unknown> {
+  const dir = await Deno.makeTempDir({ prefix: "cf-fixer-snapshot" });
+  try {
+    for (const file of program.files) {
+      const target = join(dir, file.name);
+      await Deno.mkdir(dirname(target), { recursive: true });
+      await Deno.writeTextFile(target, file.contents);
+    }
+    return await import(toFileUrl(join(dir, program.main)).href);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 }
 
 /** One `--retarget` flag, parsed: which phase, what source, what label. */

--- a/packages/cli/lib/json-output.ts
+++ b/packages/cli/lib/json-output.ts
@@ -84,7 +84,7 @@ export function reservesStdoutForCommandOutput(
   const subcommand = pieceSubcommand(args);
   return subcommand === "get" || subcommand === "get-label" ||
     subcommand === "set-label" || subcommand === "call" ||
-    subcommand === "survey";
+    subcommand === "survey" || subcommand === "repair";
 }
 
 export const stderrConsoleHandler: ConsoleHandler = ({ method, args }) => ({

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -145,7 +145,8 @@ describe("piece-repair", () => {
               hints.push(message);
             },
             printError: () => {},
-            exit: () => {
+            exit: (code) => {
+              expect(code).toBe(1);
               throw new ExitSentinel();
             },
           })
@@ -154,6 +155,18 @@ describe("piece-repair", () => {
       expect(written?.path).toBe("plan.jsonl");
       expect(written?.text).toContain('"piece-plan"');
       expect(hints).toContain("refused: fid1:aaa the fixer threw");
+    });
+
+    it("prints the whole report as JSON under --json", async () => {
+      const rendered: Array<{ value: unknown; json: boolean | undefined }> = [];
+      await repairFromCommand({ ...OPTIONS, path: "topics", json: true }, {
+        runRepair: () => Promise.resolve(REPORT),
+        render: (value, config) => {
+          rendered.push({ value, json: config?.json });
+        },
+        printHint: () => {},
+      });
+      expect(rendered).toEqual([{ value: REPORT, json: true }]);
     });
 
     it("routes cf piece repair to repairFromCommand", () => {

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -68,7 +68,7 @@ const REPORT: RepairReport = {
         retained: true,
         documentHash: "9f2c",
       },
-      op: { kind: "repair", fixer: "fix-seeds.ts" },
+      op: { kind: "repair", fixer: "fix-seeds.ts", fixerIdentity: "impl-v1" },
     }],
   },
   applied: 0,
@@ -341,7 +341,9 @@ describe("piece-repair", () => {
       expect(applied.complete).toBe(true);
 
       // An edited fixer file resolves to a different closure identity, and
-      // the reviewed plan refuses to run it.
+      // the reviewed plan refuses before the module is even imported — a
+      // dynamic import runs top-level code nobody reviewed.
+      let imported = false;
       await expect(
         runRepair({} as never, {
           ...base,
@@ -349,6 +351,10 @@ describe("piece-repair", () => {
           apply: true,
         }, {
           ...deps,
+          importModule: () => {
+            imported = true;
+            return Promise.resolve(upperSeed);
+          },
           computeFixerIdentity: () => Promise.resolve("impl-v2"),
           readTextFile: () =>
             Promise.resolve(
@@ -359,6 +365,7 @@ describe("piece-repair", () => {
             ),
         } as never),
       ).rejects.toThrow("different fixer implementation");
+      expect(imported).toBe(false);
 
       const cell = await member.input.getCell();
       await cell.pull();
@@ -408,15 +415,18 @@ describe("piece-repair", () => {
     });
 
     it("refuses a fixer module that does not default-export a function", async () => {
+      const member = await pieces.create(memberProgram(), {
+        input: { seed: "alpha" },
+      });
       await expect(
         runRepair({} as never, {
-          selector: { kind: "list", pieces: ["fid1:x"] },
+          selector: { kind: "list", pieces: [member.id] },
           fixerPath: "/repairs/empty.ts",
           fixerName: "empty.ts",
         }, {
-          loadPieces: () => {
-            throw new Error("must not load");
-          },
+          loadPieces: () => Promise.resolve(pieces),
+          resolvePieceAddress: (_pieces: unknown, token: string) =>
+            Promise.resolve(token),
           importModule: () => Promise.resolve({}),
           computeFixerIdentity: () => Promise.resolve("impl-v1"),
         } as never),

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -1,11 +1,17 @@
+/**
+ * `cf piece repair`'s command action and its `runRepair` seam: flag intake
+ * and passthrough, output in both modes, the exit discipline, and the run
+ * end to end against a real controller over emulated storage — the fixer
+ * module injected, so no disk import runs in a unit test.
+ */
+
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { createSession, Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { PiecesController, type RepairReport } from "@commonfabric/piece/ops";
+import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { PiecesController } from "@commonfabric/piece/ops";
-import type { RuntimeProgram } from "@commonfabric/runner";
-import type { RepairReport } from "@commonfabric/piece/ops";
 import { decode } from "@commonfabric/utils/encoding";
 
 import { type RepairRunRequest, runRepair } from "../lib/bulk.ts";
@@ -98,7 +104,71 @@ describe("piece-repair", () => {
       expect(request?.fixerName).toBe("fix-seeds.ts");
       expect(request?.fixerPath.endsWith("/fix-seeds.ts")).toBe(true);
       expect(request?.apply).toBeUndefined();
-      expect(hints).toEqual(["would-change: 1"]);
+      // The dry run's product is the exact diff, so it renders beside the
+      // tally.
+      expect(hints).toEqual([
+        "would-change: 1",
+        '~ fid1:aaa /seed "a" -> "A"',
+      ]);
+    });
+
+    it("renders the dry diff through the canonical debug stringifier", async () => {
+      const hints: string[] = [];
+      const fabric: RepairReport = {
+        ...REPORT,
+        rows: [{
+          piece: "fid1:aaa",
+          verdict: "would-change",
+          documentHash: "9f2c",
+          changes: [
+            { path: "/gone", kind: "removed", before: 1 },
+            {
+              path: "/pin",
+              kind: "added",
+              after: FabricHash.fromString("fid1:" + "A".repeat(43)),
+            },
+          ],
+        }],
+      };
+      await captureStdout(() =>
+        repairFromCommand({ ...OPTIONS, path: "topics" }, {
+          runRepair: () => Promise.resolve(fabric),
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(hints).toContain("- fid1:aaa /gone 1");
+      const added = hints.find((line) => line.startsWith("+ fid1:aaa /pin"));
+      // A Fabric special value renders in the canonical debug form — its
+      // kind named, never an empty shell; the value-exact rendering is the
+      // --json encoding's job.
+      expect(added).toBeDefined();
+      expect(added).toContain("/Hash(");
+    });
+
+    it("emits --json in the canonical FabricValue encoding", async () => {
+      const a = FabricHash.fromString("fid1:" + "A".repeat(43));
+      const b = FabricHash.fromString("fid1:" + "B".repeat(42) + "A");
+      const fabric: RepairReport = {
+        ...REPORT,
+        rows: [{
+          piece: "fid1:aaa",
+          verdict: "would-change",
+          documentHash: "9f2c",
+          changes: [{ path: "/pin", kind: "changed", before: a, after: b }],
+        }],
+      };
+      const out = await captureStdout(() =>
+        repairFromCommand({ ...OPTIONS, path: "topics", json: true }, {
+          runRepair: () => Promise.resolve(fabric),
+          printHint: () => {},
+        })
+      );
+      expect(out.startsWith("fvj1:")).toBe(true);
+      // Two distinct hashes stay two distinct hashes, not two empty shells.
+      expect(out).toContain("A".repeat(43));
+      expect(out).toContain("B".repeat(42));
     });
 
     it("passes the plan path and the apply flag through", async () => {
@@ -155,18 +225,6 @@ describe("piece-repair", () => {
       expect(written?.path).toBe("plan.jsonl");
       expect(written?.text).toContain('"piece-plan"');
       expect(hints).toContain("refused: fid1:aaa the fixer threw");
-    });
-
-    it("prints the whole report as JSON under --json", async () => {
-      const rendered: Array<{ value: unknown; json: boolean | undefined }> = [];
-      await repairFromCommand({ ...OPTIONS, path: "topics", json: true }, {
-        runRepair: () => Promise.resolve(REPORT),
-        render: (value, config) => {
-          rendered.push({ value, json: config?.json });
-        },
-        printHint: () => {},
-      });
-      expect(rendered).toEqual([{ value: REPORT, json: true }]);
     });
 
     it("routes cf piece repair to repairFromCommand", () => {
@@ -247,6 +305,10 @@ describe("piece-repair", () => {
           expect(path).toBe("/repairs/fix-seeds.ts");
           return Promise.resolve(upperSeed);
         },
+        computeFixerIdentity: (path: string) => {
+          expect(path).toBe("/repairs/fix-seeds.ts");
+          return Promise.resolve("impl-v1");
+        },
       };
 
       const dry = await runRepair({} as never, base, deps as never);
@@ -255,6 +317,7 @@ describe("piece-repair", () => {
       expect(dry.plan.rows[0].op).toEqual({
         kind: "repair",
         fixer: "fix-seeds.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // The emitted plan drives the apply, read back through the codec.
@@ -277,11 +340,71 @@ describe("piece-repair", () => {
       expect(applied.rows[0].verdict).toBe("repaired");
       expect(applied.complete).toBe(true);
 
+      // An edited fixer file resolves to a different closure identity, and
+      // the reviewed plan refuses to run it.
+      await expect(
+        runRepair({} as never, {
+          ...base,
+          planPath: "/plans/repair.jsonl",
+          apply: true,
+        }, {
+          ...deps,
+          computeFixerIdentity: () => Promise.resolve("impl-v2"),
+          readTextFile: () =>
+            Promise.resolve(
+              [
+                JSON.stringify(dry.plan.header),
+                ...dry.plan.rows.map((row) => JSON.stringify(row)),
+              ].join("\n"),
+            ),
+        } as never),
+      ).rejects.toThrow("different fixer implementation");
+
       const cell = await member.input.getCell();
       await cell.pull();
       expect(
         (cell.getRaw({ lastNode: "value" }) as { seed?: unknown }).seed,
       ).toBe("ALPHA");
+    });
+
+    it("imports a real on-disk fixer and pins its computed identity", async () => {
+      const member = await pieces.create(memberProgram(), {
+        input: { seed: "alpha" },
+      });
+      const dir = await Deno.makeTempDir({ prefix: "cli-repair-fixer" });
+      try {
+        const fixerPath = `${dir}/fix-seeds.ts`;
+        await Deno.writeTextFile(
+          fixerPath,
+          [
+            "export default (document: Readonly<Record<string, unknown>>) => ({",
+            "  ...document,",
+            '  ...(typeof document.seed === "string"',
+            "    ? { seed: document.seed.toUpperCase() }",
+            "    : {}),",
+            "});",
+            "",
+          ].join("\n"),
+        );
+        // No injected import and no injected identity: the defaults import
+        // the module from disk and hash its authored closure.
+        const dry = await runRepair({} as never, {
+          selector: { kind: "list", pieces: [member.id] },
+          fixerPath,
+          fixerName: "fix-seeds.ts",
+        }, {
+          loadPieces: () => Promise.resolve(pieces),
+          resolvePieceAddress: (_pieces: unknown, token: string) =>
+            Promise.resolve(token),
+        } as never);
+        expect(dry.rows[0].verdict).toBe("would-change");
+        const op = dry.plan.rows[0].op;
+        if (op?.kind !== "repair") throw new Error("expected a repair op");
+        expect(op.fixerIdentity).toBeDefined();
+        expect(op.fixerIdentity).not.toBe("");
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
     });
 
     it("refuses a fixer module that does not default-export a function", async () => {
@@ -295,6 +418,7 @@ describe("piece-repair", () => {
             throw new Error("must not load");
           },
           importModule: () => Promise.resolve({}),
+          computeFixerIdentity: () => Promise.resolve("impl-v1"),
         } as never),
       ).rejects.toThrow("must default-export the fixer function");
     });

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { PiecesController } from "@commonfabric/piece/ops";
+import type { RuntimeProgram } from "@commonfabric/runner";
+import type { RepairReport } from "@commonfabric/piece/ops";
+import { decode } from "@commonfabric/utils/encoding";
+
+import { type RepairRunRequest, runRepair } from "../lib/bulk.ts";
+import { piece, repairFromCommand, setQuietMode } from "../commands/piece.ts";
+
+function captureStdout(fn: () => Promise<void>): Promise<string> {
+  let captured = "";
+  const original = Deno.stdout.writeSync;
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    captured += decode(data);
+    return data.length;
+  };
+  return fn().then(() => captured).finally(() => {
+    Deno.stdout.writeSync = original;
+  });
+}
+
+class ExitSentinel extends Error {}
+
+const signer = await Identity.fromPassphrase("cli bulk repair");
+
+const OPTIONS = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  space: "home",
+  piece: "board",
+  quiet: true,
+  fixer: "fix-seeds.ts",
+};
+
+const REPORT: RepairReport = {
+  rows: [{
+    piece: "fid1:aaa",
+    phase: "members",
+    verdict: "would-change",
+    documentHash: "9f2c",
+    changes: [{ path: "/seed", kind: "changed", before: "a", after: "A" }],
+  }],
+  plan: {
+    header: {
+      kind: "piece-plan",
+      v: 1,
+      space: "did:key:test",
+      takenAt: "2026-08-25T00:00:00.000Z",
+      selector: "collection",
+      enumerated: { collection: 1, registry: 0, registeredOutside: 0 },
+    },
+    rows: [{
+      piece: "fid1:aaa",
+      phase: "members",
+      expect: {
+        patternIdentity: "idA",
+        symbol: "default",
+        retained: true,
+        documentHash: "9f2c",
+      },
+      op: { kind: "repair", fixer: "fix-seeds.ts" },
+    }],
+  },
+  applied: 0,
+  complete: true,
+};
+
+describe("piece-repair", () => {
+  // The fixtures pass `quiet`, and the action applies it globally.
+  afterEach(() => setQuietMode(false));
+
+  describe("repairFromCommand()", () => {
+    it("prints the emitted plan to stdout and the verdict tally as a hint", async () => {
+      const hints: string[] = [];
+      let request: RepairRunRequest | undefined;
+      const out = await captureStdout(() =>
+        repairFromCommand({ ...OPTIONS, path: "topics" }, {
+          runRepair: (_config, req) => {
+            request = req;
+            return Promise.resolve(REPORT);
+          },
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(out).toContain('"kind":"piece-plan"');
+      expect(out).toContain('"kind":"repair"');
+      expect(request?.selector).toEqual({
+        kind: "collection",
+        holder: "board",
+        path: ["topics"],
+      });
+      expect(request?.fixerName).toBe("fix-seeds.ts");
+      expect(request?.fixerPath.endsWith("/fix-seeds.ts")).toBe(true);
+      expect(request?.apply).toBeUndefined();
+      expect(hints).toEqual(["would-change: 1"]);
+    });
+
+    it("passes the plan path and the apply flag through", async () => {
+      let request: RepairRunRequest | undefined;
+      await captureStdout(() =>
+        repairFromCommand(
+          { ...OPTIONS, path: "topics", plan: "plan.jsonl", apply: true },
+          {
+            runRepair: (_config, req) => {
+              request = req;
+              return Promise.resolve(REPORT);
+            },
+            printHint: () => {},
+          },
+        )
+      );
+      expect(request?.planPath?.endsWith("/plan.jsonl")).toBe(true);
+      expect(request?.apply).toBe(true);
+    });
+
+    it("writes the plan to --out and exits nonzero on an incomplete run", async () => {
+      let written: { path: string; text: string } | undefined;
+      const hints: string[] = [];
+      const incomplete: RepairReport = {
+        ...REPORT,
+        rows: [{
+          piece: "fid1:aaa",
+          phase: "members",
+          verdict: "refused",
+          documentHash: "9f2c",
+          problem: "the fixer threw",
+        }],
+        complete: false,
+      };
+      await expect(
+        captureStdout(() =>
+          repairFromCommand({ ...OPTIONS, path: "topics", out: "plan.jsonl" }, {
+            runRepair: () => Promise.resolve(incomplete),
+            writeTextFile: (path, text) => {
+              written = { path: String(path), text: String(text) };
+              return Promise.resolve();
+            },
+            printHint: (message) => {
+              hints.push(message);
+            },
+            printError: () => {},
+            exit: () => {
+              throw new ExitSentinel();
+            },
+          })
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      expect(written?.path).toBe("plan.jsonl");
+      expect(written?.text).toContain('"piece-plan"');
+      expect(hints).toContain("refused: fid1:aaa the fixer threw");
+    });
+
+    it("routes cf piece repair to repairFromCommand", () => {
+      const registered = piece.getCommand("repair") as unknown as {
+        actionHandler?: unknown;
+      };
+      expect(registered?.actionHandler).toBe(repairFromCommand);
+    });
+  });
+
+  describe("runRepair()", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let pieces: PiecesController;
+
+    beforeEach(async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      pieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `cli-bulk-repair-${crypto.randomUUID()}`,
+        }),
+        runtime,
+      );
+      await pieces.synced();
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /** The smallest repairable member; `seed` is what the fixer changes. */
+    function memberProgram(): RuntimeProgram {
+      return {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern } from 'commonfabric';",
+            "export default pattern<{ seed?: string }>(({ seed }) => ({",
+            "  [NAME]: 'Member',",
+            "  seed,",
+            "}));",
+            "",
+          ].join("\n"),
+        }],
+      };
+    }
+
+    const upperSeed = {
+      default: (document: Readonly<Record<string, unknown>>) => ({
+        ...document,
+        ...(typeof document.seed === "string"
+          ? { seed: document.seed.toUpperCase() }
+          : {}),
+      }),
+    };
+
+    it("imports the fixer, runs dry, and applies from the emitted plan", async () => {
+      const member = await pieces.create(memberProgram(), {
+        input: { seed: "alpha" },
+      });
+      const base = {
+        selector: { kind: "list" as const, pieces: [member.id] },
+        fixerPath: "/repairs/fix-seeds.ts",
+        fixerName: "fix-seeds.ts",
+      };
+      const deps = {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceAddress: (_pieces: unknown, token: string) =>
+          Promise.resolve(token),
+        importModule: (path: string) => {
+          expect(path).toBe("/repairs/fix-seeds.ts");
+          return Promise.resolve(upperSeed);
+        },
+      };
+
+      const dry = await runRepair({} as never, base, deps as never);
+      expect(dry.rows[0].verdict).toBe("would-change");
+      expect(dry.applied).toBe(0);
+      expect(dry.plan.rows[0].op).toEqual({
+        kind: "repair",
+        fixer: "fix-seeds.ts",
+      });
+
+      // The emitted plan drives the apply, read back through the codec.
+      const applied = await runRepair({} as never, {
+        ...base,
+        planPath: "/plans/repair.jsonl",
+        apply: true,
+      }, {
+        ...deps,
+        readTextFile: (path: string) => {
+          expect(path).toBe("/plans/repair.jsonl");
+          return Promise.resolve(
+            [
+              JSON.stringify(dry.plan.header),
+              ...dry.plan.rows.map((row) => JSON.stringify(row)),
+            ].join("\n"),
+          );
+        },
+      } as never);
+      expect(applied.rows[0].verdict).toBe("repaired");
+      expect(applied.complete).toBe(true);
+
+      const cell = await member.input.getCell();
+      await cell.pull();
+      expect(
+        (cell.getRaw({ lastNode: "value" }) as { seed?: unknown }).seed,
+      ).toBe("ALPHA");
+    });
+
+    it("refuses a fixer module that does not default-export a function", async () => {
+      await expect(
+        runRepair({} as never, {
+          selector: { kind: "list", pieces: ["fid1:x"] },
+          fixerPath: "/repairs/empty.ts",
+          fixerName: "empty.ts",
+        }, {
+          loadPieces: () => {
+            throw new Error("must not load");
+          },
+          importModule: () => Promise.resolve({}),
+        } as never),
+      ).rejects.toThrow("must default-export the fixer function");
+    });
+  });
+});

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -14,7 +14,12 @@ import { Runtime, type RuntimeProgram } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { decode } from "@commonfabric/utils/encoding";
 
-import { type RepairRunRequest, runRepair } from "../lib/bulk.ts";
+import {
+  programEntryIdentity,
+  resolveLocalSourceProgram,
+} from "@commonfabric/piece/ops/bulk-local";
+
+import { type RepairRunRequest, runRepair, zeroRowFixer } from "../lib/bulk.ts";
 import { piece, repairFromCommand, setQuietMode } from "../commands/piece.ts";
 
 function captureStdout(fn: () => Promise<void>): Promise<string> {
@@ -412,7 +417,7 @@ describe("piece-repair", () => {
       ).toBe("ALPHA");
     });
 
-    it("imports a real on-disk fixer and pins its computed identity", async () => {
+    it("hashes and executes one snapshot, whatever the disk does after", async () => {
       const member = await pieces.create(memberProgram(), {
         input: { seed: "alpha" },
       });
@@ -422,17 +427,28 @@ describe("piece-repair", () => {
         await Deno.writeTextFile(
           fixerPath,
           [
+            'import { transform } from "./helper.ts";',
             "export default (document: Readonly<Record<string, unknown>>) => ({",
             "  ...document,",
             '  ...(typeof document.seed === "string"',
-            "    ? { seed: document.seed.toUpperCase() }",
+            "    ? { seed: transform(document.seed) }",
             "    : {}),",
             "});",
             "",
           ].join("\n"),
         );
-        // No injected import and no injected identity: the defaults import
-        // the module from disk and hash its authored closure.
+        await Deno.writeTextFile(
+          `${dir}/helper.ts`,
+          "export const transform = (text: string) => text.toUpperCase();\n",
+        );
+        // The resolution is the test's hook: it hands the run the REAL
+        // resolved snapshot, then rewrites both files on disk. The default
+        // identity and import run on the snapshot, so the recorded pin and
+        // the executed behavior must both be the originals.
+        const snapshot = await resolveLocalSourceProgram(pieces.runtime, {
+          main: fixerPath,
+        });
+        const expectedIdentity = await programEntryIdentity(snapshot);
         const dry = await runRepair({} as never, {
           selector: { kind: "list", pieces: [member.id] },
           fixerPath,
@@ -441,15 +457,95 @@ describe("piece-repair", () => {
           loadPieces: () => Promise.resolve(pieces),
           resolvePieceAddress: (_pieces: unknown, token: string) =>
             Promise.resolve(token),
+          resolveFixerProgram: async () => {
+            await Deno.writeTextFile(
+              `${dir}/helper.ts`,
+              "export const transform = (text: string) => " +
+                "text.toLowerCase();\n",
+            );
+            await Deno.writeTextFile(
+              fixerPath,
+              "export default () => ({ hijacked: true });\n",
+            );
+            return snapshot;
+          },
         } as never);
         expect(dry.rows[0].verdict).toBe("would-change");
+        expect(dry.rows[0].changes).toEqual([
+          { path: "/seed", kind: "changed", before: "alpha", after: "ALPHA" },
+        ]);
         const op = dry.plan.rows[0].op;
         if (op?.kind !== "repair") throw new Error("expected a repair op");
-        expect(op.fixerIdentity).toBeDefined();
-        expect(op.fixerIdentity).not.toBe("");
+        expect(op.fixerIdentity).toBe(expectedIdentity);
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
+    });
+
+    it("never imports the fixer for a zero-row plan", async () => {
+      // A holder with an empty collection: the dry run's plan has no
+      // member rows, which is a valid artifact — and one that pins
+      // nothing, so nothing may run under it, the import included.
+      const holder = await pieces.create({
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern } from 'commonfabric';",
+            "export default pattern<{ members?: unknown[] }>(",
+            "  ({ members }) => ({ [NAME]: 'Holder', members }),",
+            ");",
+            "",
+          ].join("\n"),
+        }],
+      }, { input: { members: [] } });
+      // A real (if trivial) fixer file, so the default snapshot
+      // resolution and identity run for real; only the import is a spy.
+      const dir = await Deno.makeTempDir({ prefix: "cli-repair-zero" });
+      const fixerPath = `${dir}/fix.ts`;
+      await Deno.writeTextFile(
+        fixerPath,
+        "export default (d: Readonly<Record<string, unknown>>) => ({ ...d });\n",
+      );
+      let imports = 0;
+      const deps = {
+        loadPieces: () => Promise.resolve(pieces),
+        resolvePieceAddress: (_pieces: unknown, token: string) =>
+          Promise.resolve(token),
+        importProgram: () => {
+          imports += 1;
+          return Promise.resolve(upperSeed);
+        },
+      };
+      const base = {
+        selector: {
+          kind: "collection" as const,
+          holder: holder.id,
+          path: ["members"],
+        },
+        fixerPath,
+        fixerName: "fix.ts",
+      };
+      const dry = await runRepair({} as never, base, deps as never);
+      expect(dry.plan.rows).toEqual([]);
+      expect(imports).toBe(1);
+
+      const applied = await runRepair({} as never, {
+        ...base,
+        planPath: "/plans/empty.jsonl",
+        apply: true,
+      }, {
+        ...deps,
+        readTextFile: () => Promise.resolve(JSON.stringify(dry.plan.header)),
+      } as never);
+      expect(applied.rows).toEqual([]);
+      expect(applied.complete).toBe(true);
+      expect(applied.applied).toBe(0);
+      // The dry run imported once; the zero-row apply imported nothing.
+      expect(imports).toBe(1);
+      await Deno.remove(dir, { recursive: true });
+      // The stub a zero-row run carries refuses if anything ever calls it.
+      expect(() => zeroRowFixer()).toThrow("runs no fixer");
     });
 
     it("refuses a fixer module that does not default-export a function", async () => {

--- a/packages/cli/test/piece-repair.test.ts
+++ b/packages/cli/test/piece-repair.test.ts
@@ -297,17 +297,27 @@ describe("piece-repair", () => {
         fixerPath: "/repairs/fix-seeds.ts",
         fixerName: "fix-seeds.ts",
       };
+      // One snapshot serves identity and execution alike; the stubs stand
+      // in for both halves of that single resolution.
+      const snapshot = {
+        main: "/fix-seeds.ts",
+        files: [{ name: "/fix-seeds.ts", contents: "// stub" }],
+      };
       const deps = {
         loadPieces: () => Promise.resolve(pieces),
         resolvePieceAddress: (_pieces: unknown, token: string) =>
           Promise.resolve(token),
-        importModule: (path: string) => {
+        resolveFixerProgram: (path: string) => {
           expect(path).toBe("/repairs/fix-seeds.ts");
-          return Promise.resolve(upperSeed);
+          return Promise.resolve(snapshot);
         },
-        computeFixerIdentity: (path: string) => {
-          expect(path).toBe("/repairs/fix-seeds.ts");
+        programIdentity: (program: unknown) => {
+          expect(program).toBe(snapshot);
           return Promise.resolve("impl-v1");
+        },
+        importProgram: (program: unknown) => {
+          expect(program).toBe(snapshot);
+          return Promise.resolve(upperSeed);
         },
       };
 
@@ -340,8 +350,8 @@ describe("piece-repair", () => {
       expect(applied.rows[0].verdict).toBe("repaired");
       expect(applied.complete).toBe(true);
 
-      // An edited fixer file resolves to a different closure identity, and
-      // the reviewed plan refuses before the module is even imported — a
+      // An edited fixer resolves to a different closure identity, and the
+      // reviewed plan refuses before the module is even imported — a
       // dynamic import runs top-level code nobody reviewed.
       let imported = false;
       await expect(
@@ -351,11 +361,11 @@ describe("piece-repair", () => {
           apply: true,
         }, {
           ...deps,
-          importModule: () => {
+          importProgram: () => {
             imported = true;
             return Promise.resolve(upperSeed);
           },
-          computeFixerIdentity: () => Promise.resolve("impl-v2"),
+          programIdentity: () => Promise.resolve("impl-v2"),
           readTextFile: () =>
             Promise.resolve(
               [
@@ -366,6 +376,34 @@ describe("piece-repair", () => {
         } as never),
       ).rejects.toThrow("different fixer implementation");
       expect(imported).toBe(false);
+
+      // A plan that cannot run any fixer — an op-less row — refuses before
+      // the import too, for the same reason.
+      let importedOpless = false;
+      await expect(
+        runRepair({} as never, {
+          ...base,
+          planPath: "/plans/repair.jsonl",
+          apply: true,
+        }, {
+          ...deps,
+          importProgram: () => {
+            importedOpless = true;
+            return Promise.resolve(upperSeed);
+          },
+          readTextFile: () =>
+            Promise.resolve(
+              [
+                JSON.stringify(dry.plan.header),
+                ...dry.plan.rows.map((row) => {
+                  const { op: _, ...survey } = row;
+                  return JSON.stringify(survey);
+                }),
+              ].join("\n"),
+            ),
+        } as never),
+      ).rejects.toThrow("no repair operation");
+      expect(importedOpless).toBe(false);
 
       const cell = await member.input.getCell();
       await cell.pull();
@@ -427,8 +465,13 @@ describe("piece-repair", () => {
           loadPieces: () => Promise.resolve(pieces),
           resolvePieceAddress: (_pieces: unknown, token: string) =>
             Promise.resolve(token),
-          importModule: () => Promise.resolve({}),
-          computeFixerIdentity: () => Promise.resolve("impl-v1"),
+          resolveFixerProgram: () =>
+            Promise.resolve({
+              main: "/empty.ts",
+              files: [{ name: "/empty.ts", contents: "" }],
+            }),
+          programIdentity: () => Promise.resolve("impl-v1"),
+          importProgram: () => Promise.resolve({}),
         } as never),
       ).rejects.toThrow("must default-export the fixer function");
     });

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -161,6 +161,14 @@ export interface RepairOp {
   kind: "repair";
   /** The fixer's name as supplied — a module path or label; never resolved. */
   fixer: string;
+  /**
+   * The content identity of the fixer module's authored closure — the same
+   * no-compile identity a retarget's source carries — which is the pin the
+   * name cannot be: a path re-resolved elsewhere, or a file edited after
+   * review, changes this and the apply refuses the plan. The name is for
+   * readers; this is for the run.
+   */
+  fixerIdentity?: string;
 }
 
 /** What a plan row does to its piece, absent on a survey-only row. */
@@ -472,7 +480,8 @@ function isPlanRow(value: unknown): value is PiecePlanRow {
 function isPieceOp(value: unknown): value is PieceOp {
   if (!isRecord(value)) return false;
   if (value.kind === "repair") {
-    return typeof value.fixer === "string" && value.fixer !== "";
+    return typeof value.fixer === "string" && value.fixer !== "" &&
+      isOptionalName(value.fixerIdentity);
   }
   if (
     typeof value.patternIdentity !== "string" ||

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -152,10 +152,10 @@ export interface RestoreOp {
 
 /**
  * Run a caller-supplied fixer over the piece's stored input document. The
- * fixer itself is a TypeScript module the run imports, so the plan records
- * only its name for readers and for diffing — the row's enforceable half is
- * `expect.documentHash`, which pins the document the fixer's answer was
- * computed from.
+ * fixer itself is a TypeScript module the run imports; the row's
+ * enforceable halves are `expect.documentHash`, which pins the document
+ * the fixer's answer was computed from, and `fixerIdentity`, which pins
+ * the implementation itself. The name is for readers and for diffing.
  */
 export interface RepairOp {
   kind: "repair";
@@ -165,10 +165,11 @@ export interface RepairOp {
    * The content identity of the fixer module's authored closure — the same
    * no-compile identity a retarget's source carries — which is the pin the
    * name cannot be: a path re-resolved elsewhere, or a file edited after
-   * review, changes this and the apply refuses the plan. The name is for
-   * readers; this is for the run.
+   * review, changes this and the apply refuses the plan. Required: a
+   * repair row without it is a plan nothing can hold to what was
+   * reviewed, so the codec refuses it rather than carrying a bypass.
    */
-  fixerIdentity?: string;
+  fixerIdentity: string;
 }
 
 /** What a plan row does to its piece, absent on a survey-only row. */
@@ -481,7 +482,7 @@ function isPieceOp(value: unknown): value is PieceOp {
   if (!isRecord(value)) return false;
   if (value.kind === "repair") {
     return typeof value.fixer === "string" && value.fixer !== "" &&
-      isOptionalName(value.fixerIdentity);
+      typeof value.fixerIdentity === "string" && value.fixerIdentity !== "";
   }
   if (
     typeof value.patternIdentity !== "string" ||

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -151,6 +151,14 @@ export interface RepairOptions {
    */
   fixerName?: string;
   /**
+   * The content identity of the fixer module's authored closure — the pin
+   * the name cannot be. Recorded on every emitted repair op, and held
+   * against a supplied plan's recorded identities: a plan reviewed against
+   * one implementation must not execute another, however the file is
+   * spelled or what it holds today.
+   */
+  fixerIdentity?: string;
+  /**
    * A previously emitted plan, which then IS the execution: its rows run
    * in its order, each row's recorded document hash is its precondition,
    * and the plan must agree with this run — same space, same fixer name,
@@ -611,6 +619,29 @@ export async function repairPieces(
           disagreeing.map((row) => row.piece).join(", ") + ".",
       );
     }
+    const pinned = plan.rows.filter((row) =>
+      row.op?.kind === "repair" && row.op.fixerIdentity !== undefined
+    );
+    if (pinned.length > 0 && options.fixerIdentity === undefined) {
+      throw new Error(
+        "The plan pins its fixer's implementation and this run supplies " +
+          "no fixerIdentity to hold it against.",
+      );
+    }
+    const repinned = pinned.filter((row) =>
+      row.op?.kind === "repair" &&
+      row.op.fixerIdentity !== options.fixerIdentity
+    );
+    if (repinned.length > 0) {
+      // The name matching is not the pin: the file behind it may have
+      // changed since the plan was reviewed, and a reviewed plan must not
+      // execute an implementation nobody reviewed.
+      throw new Error(
+        "The plan pins a different fixer implementation than this run " +
+          "supplies, on: " + repinned.map((row) => row.piece).join(", ") +
+          ".",
+      );
+    }
     const surveyByPiece = new Map(members.map((row) => [row.piece, row]));
     const planPieces = new Set(plan.rows.map((row) => row.piece));
     const missing = members.filter((row) => !planPieces.has(row.piece));
@@ -737,7 +768,13 @@ export async function repairPieces(
           ...phase,
           expect: { ...row.expect, documentHash: decision.documentHash },
           ...(options.fixerName === undefined ? {} : {
-            op: { kind: "repair", fixer: options.fixerName },
+            op: {
+              kind: "repair",
+              fixer: options.fixerName,
+              ...(options.fixerIdentity === undefined
+                ? {}
+                : { fixerIdentity: options.fixerIdentity }),
+            },
           }),
         });
         return;

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -530,10 +530,20 @@ export async function repairPieces(
   pieces: PiecesController,
   options: RepairOptions,
 ): Promise<RepairReport> {
-  if (options.fixerName === "") {
-    // Stamped into the artifact it would be an op the codec refuses, so a
-    // successful apply would return a plan nothing can decode or resume.
-    throw new Error("A fixerName must be nonempty when given.");
+  if (options.fixerName === "" || options.fixerIdentity === "") {
+    // Stamped into the artifact either would be an op the codec refuses,
+    // so a successful apply would return a plan nothing can decode.
+    throw new Error(
+      "A fixerName and a fixerIdentity must be nonempty when given.",
+    );
+  }
+  if (
+    (options.fixerName === undefined) !== (options.fixerIdentity === undefined)
+  ) {
+    // The name is for readers and the identity is the pin; an op carrying
+    // one without the other is a plan the codec refuses, so the pair is
+    // required together before anything is read.
+    throw new Error("fixerName and fixerIdentity travel together.");
   }
   const survey = await surveyPieces(pieces, { selector: options.selector });
   if (!survey.complete) {
@@ -619,16 +629,10 @@ export async function repairPieces(
           disagreeing.map((row) => row.piece).join(", ") + ".",
       );
     }
-    const pinned = plan.rows.filter((row) =>
-      row.op?.kind === "repair" && row.op.fixerIdentity !== undefined
-    );
-    if (pinned.length > 0 && options.fixerIdentity === undefined) {
-      throw new Error(
-        "The plan pins its fixer's implementation and this run supplies " +
-          "no fixerIdentity to hold it against.",
-      );
-    }
-    const repinned = pinned.filter((row) =>
+    // No separate has-identity check: the pair rule above means a run with
+    // a fixerName carries the identity too, and the fixerName requirement
+    // for plans has already fired for a run with neither.
+    const repinned = plan.rows.filter((row) =>
       row.op?.kind === "repair" &&
       row.op.fixerIdentity !== options.fixerIdentity
     );
@@ -767,15 +771,16 @@ export async function repairPieces(
           piece: row.piece,
           ...phase,
           expect: { ...row.expect, documentHash: decision.documentHash },
-          ...(options.fixerName === undefined ? {} : {
-            op: {
-              kind: "repair",
-              fixer: options.fixerName,
-              ...(options.fixerIdentity === undefined
-                ? {}
-                : { fixerIdentity: options.fixerIdentity }),
-            },
-          }),
+          ...(options.fixerName === undefined ||
+              options.fixerIdentity === undefined
+            ? {}
+            : {
+              op: {
+                kind: "repair",
+                fixer: options.fixerName,
+                fixerIdentity: options.fixerIdentity,
+              },
+            }),
         });
         return;
       }

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -176,6 +176,52 @@ export interface RepairOptions {
   apply?: boolean;
 }
 
+/**
+ * Hold a plan's rows to the run's fixer — every row must carry a repair
+ * operation, its recorded name must match, and its implementation pin must
+ * match. Exported apart from execution so a command seam can hold the pin
+ * BEFORE the fixer module is imported: a dynamic import runs top-level
+ * code, and an implementation the plan's reviewer never saw must not run
+ * even that much. `repairPieces` applies the same gate behind the seam.
+ */
+export function assertPlanRunsFixer(
+  plan: PiecePlan,
+  fixerName: string,
+  fixerIdentity: string,
+): void {
+  const unrunnable = plan.rows.filter((row) => row.op?.kind !== "repair");
+  if (unrunnable.length > 0) {
+    throw new Error(
+      "The plan carries rows with no repair operation, which cannot be " +
+        "executed or precondition-checked: " +
+        unrunnable.map((row) => row.piece).join(", ") + ".",
+    );
+  }
+  const disagreeing = plan.rows.filter((row) =>
+    row.op?.kind === "repair" && row.op.fixer !== fixerName
+  );
+  if (disagreeing.length > 0) {
+    throw new Error(
+      `The plan records a different fixer than this run supplies ` +
+        `(${fixerName}) on: ` +
+        disagreeing.map((row) => row.piece).join(", ") + ".",
+    );
+  }
+  const repinned = plan.rows.filter((row) =>
+    row.op?.kind === "repair" && row.op.fixerIdentity !== fixerIdentity
+  );
+  if (repinned.length > 0) {
+    // The name matching is not the pin: the file behind it may have
+    // changed since the plan was reviewed, and a reviewed plan must not
+    // execute an implementation nobody reviewed.
+    throw new Error(
+      "The plan pins a different fixer implementation than this run " +
+        "supplies, on: " + repinned.map((row) => row.piece).join(", ") +
+        ".",
+    );
+  }
+}
+
 /** How one evaluation of the fixer over one document came out. */
 export type FixerOutcome =
   | { kind: "conforms" }
@@ -611,41 +657,10 @@ export async function repairPieces(
           `targets ${survey.plan.header.space}.`,
       );
     }
-    const unrunnable = plan.rows.filter((row) => row.op?.kind !== "repair");
-    if (unrunnable.length > 0) {
-      throw new Error(
-        "The plan carries rows with no repair operation, which cannot be " +
-          "executed or precondition-checked: " +
-          unrunnable.map((row) => row.piece).join(", ") + ".",
-      );
-    }
-    const disagreeing = plan.rows.filter((row) =>
-      row.op?.kind === "repair" && row.op.fixer !== options.fixerName
-    );
-    if (disagreeing.length > 0) {
-      throw new Error(
-        `The plan records a different fixer than this run supplies ` +
-          `(${options.fixerName}) on: ` +
-          disagreeing.map((row) => row.piece).join(", ") + ".",
-      );
-    }
-    // No separate has-identity check: the pair rule above means a run with
-    // a fixerName carries the identity too, and the fixerName requirement
-    // for plans has already fired for a run with neither.
-    const repinned = plan.rows.filter((row) =>
-      row.op?.kind === "repair" &&
-      row.op.fixerIdentity !== options.fixerIdentity
-    );
-    if (repinned.length > 0) {
-      // The name matching is not the pin: the file behind it may have
-      // changed since the plan was reviewed, and a reviewed plan must not
-      // execute an implementation nobody reviewed.
-      throw new Error(
-        "The plan pins a different fixer implementation than this run " +
-          "supplies, on: " + repinned.map((row) => row.piece).join(", ") +
-          ".",
-      );
-    }
+    // The pair rule above means a run with a fixerName carries the
+    // identity too, and the fixerName requirement for plans has already
+    // fired for a run with neither.
+    assertPlanRunsFixer(plan, options.fixerName, options.fixerIdentity!);
     const surveyByPiece = new Map(members.map((row) => [row.piece, row]));
     const planPieces = new Set(plan.rows.map((row) => row.piece));
     const missing = members.filter((row) => !planPieces.has(row.piece));

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -183,12 +183,21 @@ export interface RepairOptions {
  * BEFORE the fixer module is imported: a dynamic import runs top-level
  * code, and an implementation the plan's reviewer never saw must not run
  * even that much. `repairPieces` applies the same gate behind the seam.
+ *
+ * A zero-row plan is refused here outright: it pins nothing, so this gate
+ * would hold nothing, and a caller with a legitimately empty run has no
+ * fixer to gate — it skips the gate and the import both.
  */
 export function assertPlanRunsFixer(
   plan: PiecePlan,
   fixerName: string,
   fixerIdentity: string,
 ): void {
+  if (plan.rows.length === 0) {
+    throw new Error(
+      "A zero-row plan pins no fixer, so nothing can be gated against it.",
+    );
+  }
   const unrunnable = plan.rows.filter((row) => row.op?.kind !== "repair");
   if (unrunnable.length > 0) {
     throw new Error(
@@ -659,8 +668,12 @@ export async function repairPieces(
     }
     // The pair rule above means a run with a fixerName carries the
     // identity too, and the fixerName requirement for plans has already
-    // fired for a run with neither.
-    assertPlanRunsFixer(plan, options.fixerName, options.fixerIdentity!);
+    // fired for a run with neither. A zero-row plan pins nothing and gates
+    // nothing; whether it fits this run is the selection equality's
+    // question below, which refuses it against any nonempty selection.
+    if (plan.rows.length > 0) {
+      assertPlanRunsFixer(plan, options.fixerName, options.fixerIdentity!);
+    }
     const surveyByPiece = new Map(members.map((row) => [row.piece, row]));
     const planPieces = new Set(plan.rows.map((row) => row.piece));
     const missing = members.filter((row) => !planPieces.has(row.piece));

--- a/packages/piece/src/ops/mod.ts
+++ b/packages/piece/src/ops/mod.ts
@@ -17,6 +17,7 @@ export {
   type SurveyProblem,
 } from "./bulk-plan.ts";
 export {
+  assertPlanRunsFixer,
   collectLinkPaths,
   type DocumentChange,
   documentChanges,

--- a/packages/piece/test/ops/bulk-diff.test.ts
+++ b/packages/piece/test/ops/bulk-diff.test.ts
@@ -59,7 +59,11 @@ describe("bulk-diff", () => {
             retained: true,
             documentHash: "9f2c",
           },
-          op: { kind: "repair" as const, fixer: "fix-titles.ts" },
+          op: {
+            kind: "repair" as const,
+            fixer: "fix-titles.ts",
+            fixerIdentity: "impl-v1",
+          },
         }],
       };
       expect(() => diffPlan(plan, plan)).toThrow(

--- a/packages/piece/test/ops/bulk-plan.test.ts
+++ b/packages/piece/test/ops/bulk-plan.test.ts
@@ -145,7 +145,11 @@ describe("bulk-plan", () => {
         rows: [{
           piece: plan.rows[0].piece,
           expect: { ...plan.rows[0].expect, documentHash: "9f2c" },
-          op: { kind: "repair" as const, fixer: "fix-titles.ts" },
+          op: {
+            kind: "repair" as const,
+            fixer: "fix-titles.ts",
+            fixerIdentity: "impl-v1",
+          },
         }],
       };
       expect(() => deriveRollbackPlan(withRepair, "later")).toThrow(
@@ -244,12 +248,17 @@ describe("bulk-plan", () => {
         piece: plan.rows[0].piece,
         phase: plan.rows[0].phase,
         expect: { ...plan.rows[0].expect, documentHash: "9f2c" },
-        op: { kind: "repair", fixer: "fix-titles.ts" },
+        op: {
+          kind: "repair",
+          fixer: "fix-titles.ts",
+          fixerIdentity: "impl-v1",
+        },
       };
       const good = JSON.stringify(header) + "\n" + JSON.stringify(repairRow);
       expect(decodePlan(good).rows[0].op).toEqual({
         kind: "repair",
         fixer: "fix-titles.ts",
+        fixerIdentity: "impl-v1",
       });
       const hashless = {
         ...repairRow,
@@ -260,10 +269,19 @@ describe("bulk-plan", () => {
       ).toThrow("row 1");
       const nameless = {
         ...repairRow,
-        op: { kind: "repair", fixer: "" },
+        op: { kind: "repair", fixer: "", fixerIdentity: "impl-v1" },
       };
       expect(() =>
         decodePlan(JSON.stringify(header) + "\n" + JSON.stringify(nameless))
+      ).toThrow("row 1");
+      // A repair op without its implementation pin is the bypass the codec
+      // exists to refuse: nothing could hold the run to what was reviewed.
+      const pinless = {
+        ...repairRow,
+        op: { kind: "repair", fixer: "fix-titles.ts" },
+      };
+      expect(() =>
+        decodePlan(JSON.stringify(header) + "\n" + JSON.stringify(pinless))
       ).toThrow("row 1");
     });
 

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -495,6 +495,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // Both hashes computed independently from the stored documents, so
@@ -531,8 +532,8 @@ describe("bulk-repair", () => {
       // document-hash precondition and the named repair, and the codec
       // round-trips it.
       expect(report.plan.rows.map((row) => row.op)).toEqual([
-        { kind: "repair", fixer: "upper-seed.ts" },
-        { kind: "repair", fixer: "upper-seed.ts" },
+        { kind: "repair", fixer: "upper-seed.ts", fixerIdentity: "impl-v1" },
+        { kind: "repair", fixer: "upper-seed.ts", fixerIdentity: "impl-v1" },
       ]);
       // Computed independently from the stored document, so a wrong hash
       // cannot certify itself.
@@ -549,6 +550,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // Something other than the plan changes the SECOND piece's document:
@@ -561,6 +563,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: dry.plan,
         apply: true,
       });
@@ -822,6 +825,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // Preflight sees both rows clean; a concurrent writer then moves the
@@ -852,6 +856,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: dry.plan,
         apply: true,
       });
@@ -871,12 +876,14 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       const first = await repairPieces(pieces, {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: dry.plan,
         apply: true,
       });
@@ -889,6 +896,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: dry.plan,
         apply: true,
       });
@@ -908,6 +916,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       const reversed = {
@@ -942,6 +951,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: reversed,
         apply: true,
       });
@@ -957,6 +967,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: truncated,
           apply: true,
         }),
@@ -996,6 +1007,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       await expect(
@@ -1003,6 +1015,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: {
             header: {
               ...dry.plan.header,
@@ -1024,6 +1037,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // A repair row stripped of its document hash: the codec would refuse
@@ -1041,6 +1055,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: hashless as never,
           apply: true,
         }),
@@ -1057,6 +1072,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: doubled,
           apply: true,
         }),
@@ -1082,6 +1098,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       // Move the second piece so the plan-driven apply blocks at preflight.
@@ -1092,6 +1109,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: dry.plan,
         apply: true,
       });
@@ -1113,6 +1131,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
         plan: blocked.plan,
         apply: true,
       });
@@ -1159,7 +1178,7 @@ describe("bulk-repair", () => {
           plan: dry.plan,
           apply: true,
         }),
-      ).rejects.toThrow("no fixerIdentity");
+      ).rejects.toThrow("travel together");
       expect((await rawInput(a)).seed).toBe("alpha");
 
       const applied = await repairPieces(pieces, {
@@ -1180,6 +1199,7 @@ describe("bulk-repair", () => {
         selector: collectionOf(holder),
         fixer: upperSeed,
         fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
       });
 
       await expect(
@@ -1187,6 +1207,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: {
             header: { ...dry.plan.header, space: "did:key:somewhere-else" },
             rows: dry.plan.rows,
@@ -1200,6 +1221,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "other-fixer.ts",
+          fixerIdentity: "impl-v1",
           plan: dry.plan,
           apply: true,
         }),
@@ -1218,6 +1240,7 @@ describe("bulk-repair", () => {
           selector: collectionOf(holder),
           fixer: upperSeed,
           fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v1",
           plan: opless,
           apply: true,
         }),

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -10,6 +10,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import {
+  assertPlanRunsFixer,
   collectLinkPaths,
   documentChanges,
   evaluateFixer,
@@ -1140,6 +1141,28 @@ describe("bulk-repair", () => {
         "repaired",
       ]);
       expect(resumed.complete).toBe(true);
+    });
+
+    it("refuses to gate against a zero-row plan", () => {
+      // The gate holds rows to a fixer; a plan with none would pass every
+      // check vacuously, which is exactly the bypass this refusal closes.
+      expect(() =>
+        assertPlanRunsFixer(
+          {
+            header: {
+              kind: "piece-plan",
+              v: 1,
+              space: "did:key:test",
+              takenAt: "2026-08-25T00:00:00.000Z",
+              selector: "collection",
+              enumerated: { collection: 0, registry: 0, registeredOutside: 0 },
+            },
+            rows: [],
+          },
+          "upper-seed.ts",
+          "impl-v1",
+        )
+      ).toThrow("pins no fixer");
     });
 
     it("pins the fixer implementation, not its name", async () => {

--- a/packages/piece/test/ops/bulk-repair.test.ts
+++ b/packages/piece/test/ops/bulk-repair.test.ts
@@ -1123,6 +1123,56 @@ describe("bulk-repair", () => {
       expect(resumed.complete).toBe(true);
     });
 
+    it("pins the fixer implementation, not its name", async () => {
+      const a = await member("alpha");
+      const holder = await seedHolder([a]);
+      const dry = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
+      });
+      expect(dry.plan.rows[0].op).toEqual({
+        kind: "repair",
+        fixer: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
+      });
+      expect(decodePlan(encodePlan(dry.plan))).toEqual(dry.plan);
+
+      // The same name over a different implementation is exactly what the
+      // pin exists to refuse.
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "upper-seed.ts",
+          fixerIdentity: "impl-v2",
+          plan: dry.plan,
+          apply: true,
+        }),
+      ).rejects.toThrow("different fixer implementation");
+      await expect(
+        repairPieces(pieces, {
+          selector: collectionOf(holder),
+          fixer: upperSeed,
+          fixerName: "upper-seed.ts",
+          plan: dry.plan,
+          apply: true,
+        }),
+      ).rejects.toThrow("no fixerIdentity");
+      expect((await rawInput(a)).seed).toBe("alpha");
+
+      const applied = await repairPieces(pieces, {
+        selector: collectionOf(holder),
+        fixer: upperSeed,
+        fixerName: "upper-seed.ts",
+        fixerIdentity: "impl-v1",
+        plan: dry.plan,
+        apply: true,
+      });
+      expect(applied.rows[0].verdict).toBe("repaired");
+    });
+
     it("refuses a plan that disagrees with the run", async () => {
       const a = await member("alpha");
       const holder = await seedHolder([a]);


### PR DESCRIPTION
## Why

Stage 2's repair library merged in #6255 with its `cf` entry point and demo act deferred to this stacked change. Without the entry point the fixer runner is unreachable outside tests; without the drill and demo coverage, the stage's last checklist box — the demo act converting from pending to live — stays open. This completes stage 2 of `docs/plans/piece-bulk-operations.md`.

## What Changed

- `cf piece repair` in the `piece` group (decision 1's spelling): the survey's selection surface (`--piece/--path/--side` or `--list`), `--fixer <module.ts>` (default export = the transform; the compiled binary's on-disk TS import is measured, not assumed), `--apply` (dry otherwise), `--plan` (row-for-row execution under document-hash preconditions), `--out`, `--json`. Emitted plan to stdout/`--out`; verdict tally and per-row problems as hints; an incomplete run exits nonzero with each row's problem in the message itself, since a quiet script is the caller most in need of the why.
- The selection intake is extracted from the survey into `readBulkSelection` — one function for both bulk commands, so they cannot drift — with operation-neutral refusal wording. `runRepair` joins `lib/bulk.ts` with an injectable module import; `repair` joins the stdout-reservation allowlist.
- The drill's new step runs against the built binary: dry (every plan row records its fixer), plan-driven apply asserted from its own JSON report (114 repaired), resume (applied 0, all conforms), and a field-dropping fixer refused naming the incomplete document. 26 assertions total.
- The demo's repair act is live: the fixer module shown, the dry run's tally, a plan row with its hash and op, the plan-driven apply (`repaired: 114`), and resume (`conforms: 114`). The plan doc ticks stage 2's last box and the status line now reads: stages 1 and 2 built, every later stage unbuilt. The README documents the command.

## Test plan

`deno task check` green; fmt/lint clean; 200 test steps green across the piece ops and cli suites; coverage intersect shows zero new-uncovered lines in `commands/piece.ts`, `lib/bulk.ts`, and `lib/json-output.ts`; `check-docs` green. Drill 26/26 against a fresh isolated toolshed under `CF_BINARY` (the compiled cf); demo transcript clean end to end with the live repair act, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

