### PR TITLE
fix(dashboard): show 150 runs in five-row trust grids

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -947,8 +947,8 @@ Notes:
 Everything below is a tunable constant in `config.ts`:
 
 - **Status thresholds:** `TRUST_GOOD`/`TRUST_WARN` (first-try-green %), `DUR_GOOD`/`DUR_WARN` (median CI minutes).
-- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the entire fetched window. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
-- **ci-trust cell grid:** `TRUST_COLS=40` sets the column count. The grid has up to `CI_RUNS_MAX=200` cells, one for every fetched run. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
+- **Data windows:** The shared fetch returns at most `CI_RUNS_MAX=200` workflow runs and stops at `CI_RUNS_MAX_AGE_DAYS=60` days. CI trust uses the newest `TRUST_RUNS_MAX=150` fetched runs. CI duration uses whichever is larger: `DUR_MIN_RUNS=20` passing runs or `DUR_MAX_AGE_HOURS=6` hours. The benchmark trend uses the same larger-of-the-two idea in days: `BENCH_TREND_MIN_RUNS=20` runs or `BENCH_TREND_MAX_AGE_DAYS=14` days. Recent runs shows `RECENT_DISPLAY=50` entries.
+- **ci-trust cell grid:** `TRUST_COLS=30` sets the column count. The grid has up to `TRUST_RUNS_MAX=150` cells, one for every run in the trust window. First-try successes are green. In-progress runs are blue. Completed runs that lower the trust percentage are red. Ignored runs are gray.
 
 ## Local development
 

--- a/packages/dashboard/config.ts
+++ b/packages/dashboard/config.ts
@@ -20,15 +20,15 @@ export const PROD_SERVICE = "toolshed-production";
 export const LOOM_REPO = Deno.env.get("DASHBOARD_LOOM_REPO") ?? "commontoolsinc/loom";
 export const LOOM_CI_WORKFLOW = "test-fast.yml";
 
-// Shared fetch window — the widest any tile needs (ci-trust's): the fetch stops
-// at whichever of these two yields fewer workflow runs. Every CI tile slices
-// from it.
+// Shared fetch window: the fetch stops at whichever of these two yields fewer
+// workflow runs. Every CI tile slices from it.
 export const CI_RUNS_MAX = 200; // workflow runs
 export const CI_RUNS_MAX_AGE_DAYS = 60; // ~2 months
 
-// Status thresholds (tune here).
+// Tile display windows and status thresholds (tune here).
 export const TRUST_GOOD = 90, TRUST_WARN = 75; // first-try-green %
-export const TRUST_COLS = 40; // columns in the ci-trust cell grid (more = smaller cells)
+export const TRUST_RUNS_MAX = 150; // newest runs scored and shown by ci-trust
+export const TRUST_COLS = 30; // columns in the ci-trust cell grid (more = smaller cells)
 export const DUR_GOOD = 12, DUR_WARN = 20; // median CI minutes
 // ci-duration median window — the larger of these two (more runs wins).
 export const DUR_MIN_RUNS = 20;

--- a/packages/dashboard/tiles.test.ts
+++ b/packages/dashboard/tiles.test.ts
@@ -100,23 +100,27 @@ Deno.test("labs ci trust: only first-attempt success counts as green", async () 
 });
 
 Deno.test(
-  "labs ci trust grid: every run in the latest 200-run window has a cell",
+  "labs ci trust grid: every run in the latest 150-run window has a cell",
   async () => {
     const runs = [
       run({ status: "in_progress", conclusion: null }),
-      ...Array.from({ length: 199 }, () => run({ conclusion: "success" })),
+      ...Array.from({ length: 149 }, () => run({ conclusion: "success" })),
       run({ conclusion: "failure" }),
     ];
     const view = await labsCiTrust.collect(ctx(runs));
     const cells = (view.extra ?? "").match(/class="cell"/g)?.length ?? 0;
-    assertEquals(cells, 200);
+    assertEquals(cells, 150);
+    assertStringIncludes(
+      view.extra ?? "",
+      "grid-template-columns:repeat(30,1fr)",
+    );
     assertEquals(
       view.sub,
-      "first-try green · 199 of last 200 runs",
+      "first-try green · 149 of last 150 runs",
     );
     assert(
       !(view.extra ?? "").includes("var(--status-bad)"),
-      "the 201st run must be outside the grid and percentage window",
+      "the 151st run must be outside the grid and percentage window",
     );
   },
 );

--- a/packages/dashboard/tiles/ci-trust.ts
+++ b/packages/dashboard/tiles/ci-trust.ts
@@ -1,7 +1,7 @@
 /**
  * Reports the share of recent completed runs that passed on the first attempt,
- * which is the wall's signal for flakiness, with a history strip carrying
- * every run in the fetched window. One factory builds both the labs and loom
+ * which is the wall's signal for flakiness, with a history strip carrying the
+ * newest runs in the trust window. One factory builds both the labs and loom
  * instances against their own repository and workflow.
  */
 
@@ -13,7 +13,7 @@ import {
   type TileView,
 } from "../types.ts";
 import { strip } from "../lib.ts";
-import { CI_RUNS_MAX, CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_WARN } from "../config.ts";
+import { CI_WORKFLOW, LOOM_CI_WORKFLOW, LOOM_REPO, REPO, TRUST_COLS, TRUST_GOOD, TRUST_RUNS_MAX, TRUST_WARN } from "../config.ts";
 
 type TrustOutcome = "green" | "red" | "run" | "gray";
 
@@ -30,7 +30,7 @@ function makeCiTrust(opts: { id: string; label: string; repo: string; workflow: 
     runSources: [runSource(opts.repo, opts.workflow)],
     async collect(ctx): Promise<TileView> {
       const runs = await ctx.runsFor(opts.repo, opts.workflow);
-      const scored = runs.slice(0, CI_RUNS_MAX).map((run) => ({
+      const scored = runs.slice(0, TRUST_RUNS_MAX).map((run) => ({
         run,
         outcome: trustOutcome(run),
       }));


### PR DESCRIPTION
The CI trust tiles inherited the shared 200-run collection limit as both their scoring window and cell count. Anchored pagination intentionally returns 199 distinct runs, coupling the presentation to collection capacity and leaving an uneven grid.

Introduce a separate 150-run trust limit and use it for both scoring and the rendered history. Keep the shared fetch limit at 200 so collection and its other consumers remain unchanged. Use thirty columns so a full trust window forms five complete rows.

Update the boundary test so a failing 151st run cannot affect the percentage or grid, assert the generated column count, and document the collection and display limits separately.

Verified with the complete dashboard test task, including the headless browser suite, focused tile tests after rebasing, and repository-wide formatting and lint checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

