### PR TITLE
fix(ci): avoid flaky Astral browser downloads

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -21,6 +21,9 @@ concurrency:
 # variables holding the numbers are how a workflow declares a value an anchor
 # can name; nothing reads them.
 env:
+  # GitHub's Ubuntu image includes Chrome. Astral uses it directly instead of
+  # downloading another browser when the first browser test starts.
+  ASTRAL_BIN_PATH: /usr/bin/google-chrome
   WORK_TIMEOUT_MINUTES: &work-timeout 30
   JOB_TIMEOUT_MINUTES: &job-timeout 40
   CLI_WORK_TIMEOUT_MINUTES: &cli-work-timeout 10

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
+import { getBinary } from "@astral/astral";
 import { phaseOf } from "./ci-step-phases.ts";
 import { EXPECTED_COVERAGE_ARTIFACT_NAMES } from "./coverage-check.ts";
 import { PATTERN_INTEGRATION_SHARD_COUNT } from "./select-pattern-integration-files.ts";
@@ -187,6 +188,60 @@ Deno.test("every workflow and composite action is valid YAML", async () => {
       "schedule NO jobs from them, and every text-level check in this file " +
       "stays green while it does",
   );
+});
+
+Deno.test("CI browser tests use the runner's installed Chrome", async () => {
+  const contents = await workflow("deno.yml");
+  const configuredPath = contents.match(
+    /^ {2}ASTRAL_BIN_PATH: (\S+)$/m,
+  )?.[1];
+  const cache = await Deno.makeTempDir();
+  const savedPath = Deno.env.get("ASTRAL_BIN_PATH");
+  const savedCi = Deno.env.get("CI");
+  const savedFetch = globalThis.fetch;
+
+  try {
+    Deno.env.set("CI", "1");
+    Deno.env.delete("ASTRAL_BIN_PATH");
+    if (configuredPath) Deno.env.set("ASTRAL_BIN_PATH", Deno.execPath());
+    globalThis.fetch = (input) => {
+      const url = String(input);
+      if (url.endsWith("known-good-versions-with-downloads.json")) {
+        return Promise.resolve(Response.json({
+          versions: [{
+            version: "125.0.6400.0",
+            downloads: {
+              chrome: [
+                "linux64",
+                "mac-arm64",
+                "mac-x64",
+                "win64",
+              ].map((platform) => ({
+                platform,
+                url: "https://example.invalid/truncated.zip",
+              })),
+            },
+          }],
+        }));
+      }
+      const truncatedArchive = new Uint8Array(22);
+      truncatedArchive.set([0x50, 0x4b, 0x03, 0x04]);
+      return Promise.resolve(new Response(truncatedArchive));
+    };
+
+    assertEquals(
+      await getBinary("chrome", { cache }),
+      Deno.execPath(),
+    );
+    assertEquals(configuredPath, "/usr/bin/google-chrome");
+  } finally {
+    globalThis.fetch = savedFetch;
+    if (savedPath === undefined) Deno.env.delete("ASTRAL_BIN_PATH");
+    else Deno.env.set("ASTRAL_BIN_PATH", savedPath);
+    if (savedCi === undefined) Deno.env.delete("CI");
+    else Deno.env.set("CI", savedCi);
+    await Deno.remove(cache, { recursive: true });
+  }
 });
 
 Deno.test("Status waits for every pull request validation job", async () => {

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -201,6 +201,7 @@ Deno.test("CI browser tests use the runner's installed Chrome", async () => {
   const savedFetch = globalThis.fetch;
 
   try {
+    assertEquals(configuredPath, "/usr/bin/google-chrome");
     Deno.env.set("CI", "1");
     Deno.env.delete("ASTRAL_BIN_PATH");
     if (configuredPath) Deno.env.set("ASTRAL_BIN_PATH", Deno.execPath());
@@ -233,7 +234,6 @@ Deno.test("CI browser tests use the runner's installed Chrome", async () => {
       await getBinary("chrome", { cache }),
       Deno.execPath(),
     );
-    assertEquals(configuredPath, "/usr/bin/google-chrome");
   } finally {
     globalThis.fetch = savedFetch;
     if (savedPath === undefined) Deno.env.delete("ASTRAL_BIN_PATH");


### PR DESCRIPTION
Astral downloads and expands its pinned Chrome release on the first browser launch. A partial response can leave a truncated ZIP that fails with "End of central directory not found". Each isolated CI runner repeats that download because the workflow does not cache Astral's browser directory.

Use the Chrome installation supplied by GitHub's Ubuntu runner. Add a workflow regression test that exercises Astral's real browser lookup against a deliberately truncated download and confirms CI bypasses that path.

Verification:
- The cfc-spec-gallery integration test passes with Chrome 151.
- The CI workflow test suite passes.
- deno task check
- deno fmt --check
- deno lint

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

