### PR TITLE
refactor(runtime-client): one send and one receive per IPC direction

### DIFF
--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -264,10 +264,11 @@ export class VDomRenderer {
         rootId: notification.rootId,
       });
 
-      // Track root node ID if provided (for cleanup)
+      // Track the root node for cleanup. An absent `rootId` says nothing
+      // about the root and leaves the tracked one standing; `null` is the
+      // reconciler reporting a tree with no root child, and clears it.
       if (notification.rootId !== undefined) {
-        const rootId = notification.rootId;
-        this.rootNodeId = (rootId !== null) && (rootId > 0) ? rootId : null;
+        this.rootNodeId = notification.rootId;
       }
 
       if (notification.mountId !== undefined) {

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -266,7 +266,8 @@ export class VDomRenderer {
 
       // Track root node ID if provided (for cleanup)
       if (notification.rootId !== undefined) {
-        this.rootNodeId = notification.rootId > 0 ? notification.rootId : null;
+        const rootId = notification.rootId;
+        this.rootNodeId = (rootId !== null) && (rootId > 0) ? rootId : null;
       }
 
       if (notification.mountId !== undefined) {

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -159,6 +159,10 @@ export type VDomBatch = {
   /** The operations to apply, in order */
   ops: VDomOp[];
 
-  /** Optional: the root node ID for this render tree */
-  rootId?: number;
+  /**
+   * The root node ID for this render tree; `null` while the tree has no root
+   * child, which the reconciler reports as a value rather than by omission.
+   * Absent when the batch says nothing about the root at all.
+   */
+  rootId?: number | null;
 };

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -1003,6 +1003,16 @@ Deno.test("DomApplicator - batch with rootId", async (t) => {
       onEvent: () => {},
     });
 
+    // Registering a container makes `CONTAINER_NODE_ID` a node that resolves,
+    // as it does in every applicator outside a test. Without it, a root
+    // coerced to 0 reads back as no root at all -- `getRootNode()` returning
+    // `null` from a lookup that missed rather than from the field being
+    // cleared -- and this step would pass for an implementation that puts the
+    // container on the root.
+    applicator.setContainer(
+      doc.createElement("section") as unknown as HTMLElement,
+    );
+
     applicator.applyBatch({
       batchId: 1,
       ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -974,6 +974,48 @@ Deno.test("DomApplicator - batch with rootId", async (t) => {
     const root = applicator.getRootNode();
     assertEquals((root as any).tagName, "SPAN");
   });
+
+  await t.step("keeps the root when a batch omits rootId", () => {
+    const doc = createMockDocument();
+    const applicator = new DomApplicator({
+      document: doc,
+      runtimeClient: createMockRuntimeClient(),
+      onEvent: () => {},
+    });
+
+    applicator.applyBatch({
+      batchId: 1,
+      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+      rootId: 1,
+    });
+
+    applicator.applyBatch({ batchId: 2, ops: [] });
+
+    const root = applicator.getRootNode();
+    assertEquals((root as any).tagName, "DIV");
+  });
+
+  await t.step("clears the root when a batch says rootId is null", () => {
+    const doc = createMockDocument();
+    const applicator = new DomApplicator({
+      document: doc,
+      runtimeClient: createMockRuntimeClient(),
+      onEvent: () => {},
+    });
+
+    applicator.applyBatch({
+      batchId: 1,
+      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+      rootId: 1,
+    });
+
+    applicator.applyBatch({ batchId: 2, ops: [], rootId: null });
+
+    // Node 1 outlives the batch, so a root still reported here would be the
+    // stale one rather than a lookup that happened to miss.
+    assertExists(applicator.getNode(1));
+    assertEquals(applicator.getRootNode(), null);
+  });
 });
 
 Deno.test("DomApplicator - setContainer", async (t) => {

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -237,6 +237,56 @@ Deno.test("VDomRenderer - acknowledges applied batches", async () => {
   await renderer.dispose();
 });
 
+Deno.test("VDomRenderer - a batch's null rootId clears the tracked root", async () => {
+  const connection = new MockConnection();
+  const mock = new MockDoc(
+    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+  );
+  const renderer = new VDomRenderer({
+    runtimeClient: {} as any,
+    connection: connection as any,
+    document: mock.document,
+  });
+
+  const cellRef = {
+    space: "did:key:test",
+    id: "cell-id",
+    path: [],
+    type: "application/json",
+  } as unknown as CellRef;
+
+  const container = mock.document.getElementById("root")!;
+  await renderer.render(container as unknown as HTMLElement, cellRef);
+  const mountId = renderer.getMountId();
+  if (mountId === null) {
+    throw new Error("expected renderer to have an active mount");
+  }
+
+  const batch = (batchId: number, rootId: number | null | undefined) => ({
+    type: "vdom:batch",
+    batchId,
+    mountId,
+    ops: batchId === 1
+      ? [{ op: "create-element", nodeId: 1, tagName: "button" }]
+      : [],
+    ...(rootId === undefined ? {} : { rootId }),
+  });
+
+  connection.emit("vdombatch", batch(1, 1));
+  assertEquals(renderer.getRootNode() !== null, true);
+
+  // Absent says nothing about the root, so the tracked one stands.
+  connection.emit("vdombatch", batch(2, undefined));
+  assertEquals(renderer.getRootNode() !== null, true);
+
+  // `null` is what the reconciler reports for a tree with no root child, and
+  // it is a statement rather than a silence: the tracked root goes away.
+  connection.emit("vdombatch", batch(3, null));
+  assertEquals(renderer.getRootNode(), null);
+
+  await renderer.dispose();
+});
+
 Deno.test("VDomRenderer - constructs without throwing against an already-disposed connection", async () => {
   const connection = new MockConnection();
   // Dispose before the renderer attaches: attachVDom runs the teardown

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   defaultRenderConfidentialityCeiling,
   RuntimeInternals,
 } from "@commonfabric/lib-shell";
+import { TransportNotificationType } from "@commonfabric/runtime-client";
 
 type MockRuntimeClientEvents = {
   console: [unknown];
@@ -486,7 +487,11 @@ describe("RuntimeInternals", () => {
         constructor(_url: URL | string) {
           super();
           queueMicrotask(() =>
-            this.dispatchEvent(new MessageEvent("message", { data: "READY" }))
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: { type: TransportNotificationType.WorkerReady },
+              }),
+            )
           );
         }
         postMessage(message: unknown): void {

--- a/packages/runtime-client/backends/post-to-client.ts
+++ b/packages/runtime-client/backends/post-to-client.ts
@@ -1,0 +1,12 @@
+import type { IPCRemotePost } from "../protocol/mod.ts";
+
+/**
+ * Posts one message from the worker to its client. This is the whole of the
+ * worker's outbound side: every response, error, and notification crosses
+ * here.
+ */
+export function postToClient(message: IPCRemotePost): void {
+  // Read off `self` at call time rather than captured at module load, so that
+  // a test driving this without a real worker can substitute its own.
+  self.postMessage(message);
+}

--- a/packages/runtime-client/backends/runtime-error.ts
+++ b/packages/runtime-client/backends/runtime-error.ts
@@ -1,5 +1,6 @@
 import { CompilerStackLoadError } from "../../runner/src/harness/deferred-compiler-stack.ts";
 import { NotificationType, RuntimeErrorCode } from "../protocol/mod.ts";
+import { postToClient } from "./post-to-client.ts";
 
 function runtimeErrorCode(error: Error): RuntimeErrorCode | undefined {
   return error instanceof CompilerStackLoadError
@@ -10,7 +11,7 @@ function runtimeErrorCode(error: Error): RuntimeErrorCode | undefined {
 /** Post an asynchronous renderer error to the shell. */
 export function postRuntimeError(error: Error): void {
   const code = runtimeErrorCode(error);
-  self.postMessage({
+  postToClient({
     type: NotificationType.ErrorReport,
     message: error.message,
     ...(code ? { code } : {}),
@@ -30,7 +31,7 @@ export function postContextualRuntimeError(
   error: ContextualRuntimeError,
 ): void {
   const code = runtimeErrorCode(error);
-  self.postMessage({
+  postToClient({
     type: NotificationType.ErrorReport,
     message: error.message,
     ...(code ? { code } : {}),

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -182,6 +182,7 @@ import {
 } from "../protocol/mod.ts";
 import type { VDomOp } from "../protocol/types.ts";
 import { cellRefToKey } from "../shared/utils.ts";
+import { postToClient } from "./post-to-client.ts";
 import {
   postContextualRuntimeError,
   postRuntimeError,
@@ -605,7 +606,7 @@ export class RuntimeProcessor {
     // consults it from its beforeunload handler, so a reload with unconfirmed
     // writes prompts the user instead of silently dropping them.
     storageManager.subscribePendingCommits((pending) => {
-      self.postMessage({
+      postToClient({
         type: NotificationType.PendingWritesChanged,
         pending,
       });
@@ -623,7 +624,7 @@ export class RuntimeProcessor {
         telemetry,
       ),
       consoleHandler: ({ metadata, method, args }) => {
-        self.postMessage({
+        postToClient({
           type: NotificationType.ConsoleMessage,
           metadata,
           method,
@@ -634,7 +635,7 @@ export class RuntimeProcessor {
 
       navigateCallback: (target) => {
         const link = parseLink(target.getAsLink()) as NormalizedFullLink;
-        self.postMessage({
+        postToClient({
           type: NotificationType.NavigateRequest,
           targetCellRef: link,
         });
@@ -1096,10 +1097,10 @@ export class RuntimeProcessor {
       // in a microtask so that the subscription response returns
       // before a notification fires.
       queueMicrotask(() =>
-        self.postMessage({
+        postToClient({
           type: NotificationType.CellUpdate,
           cell: request.cell,
-          value: converted,
+          value: converted as JSONValue,
           ...(request.includeCfcLabel ? { cfcLabel: redactedLabel } : {}),
         })
       );
@@ -1628,7 +1629,7 @@ export class RuntimeProcessor {
   #onTelemetry = (event: Event) => {
     if (!this.#telemetryEnabled) return;
     const marker = (event as RuntimeTelemetryEvent).marker;
-    self.postMessage({
+    postToClient({
       type: NotificationType.Telemetry,
       marker,
     });
@@ -2002,7 +2003,7 @@ export class RuntimeProcessor {
       membershipProvider: this.renderMembershipProvider,
       onOps: (ops: VDomOp[]) => {
         const batchId = this.vdomBatchIdCounter++;
-        self.postMessage({
+        postToClient({
           type: NotificationType.VDomBatch,
           batchId,
           ops,

--- a/packages/runtime-client/backends/web-worker-console-bridge.test.ts
+++ b/packages/runtime-client/backends/web-worker-console-bridge.test.ts
@@ -8,8 +8,10 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { CompilerStackLoadError } from "../../runner/src/harness/deferred-compiler-stack.ts";
 import {
   ClientNotificationType,
+  isWorkerConsoleNotification,
   RequestType,
   RuntimeErrorCode,
+  TransportNotificationType,
 } from "../protocol/mod.ts";
 import { RuntimeProcessor } from "./mod.ts";
 
@@ -20,7 +22,7 @@ import { RuntimeProcessor } from "./mod.ts";
 // `MessageEvent`s — exercising the opt-in console bridge and the request
 // branches without spawning a real worker or initializing the runtime.
 
-type Posted = Record<string, unknown> | string;
+type Posted = Record<string, unknown>;
 
 function dispatch(data: unknown): Promise<void> {
   globalThis.dispatchEvent(new MessageEvent("message", { data }));
@@ -45,15 +47,18 @@ describe("web worker console bridge", () => {
     };
 
     try {
-      // Importing registers the message listener and posts "READY".
+      // Importing registers the message listener and posts the ready
+      // notification.
       await import("./web-worker/index.ts");
-      expect(posted).toContain("READY");
+      expect(posted).toContainEqual({
+        type: TransportNotificationType.WorkerReady,
+      });
 
       const consoleMessages = () =>
-        posted.filter(
-          (m): m is { __workerConsole: { level: string; text: string } } =>
-            typeof m === "object" && m !== null && "__workerConsole" in m,
-        ).map((m) => m.__workerConsole);
+        posted.filter(isWorkerConsoleNotification).map(({ level, text }) => ({
+          level,
+          text,
+        }));
 
       // A request before initialization is rejected (not patched yet, so no
       // forwarded copy reaches `posted`).

--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -18,8 +18,12 @@ import {
   isIPCClientNotification,
   RequestType,
   RuntimeErrorCode,
+  TransportNotificationType,
+  WORKER_CONSOLE_LEVELS,
+  WorkerConsoleLevel,
 } from "../../protocol/mod.ts";
 import { RuntimeProcessor } from "../mod.ts";
+import { postToClient } from "../post-to-client.ts";
 
 // Count-only ledger of request traffic as seen by the worker: one
 // `received/<type>` per request that reached this message handler and one
@@ -68,14 +72,12 @@ const loopLagLogger = getLogger("runner.loop", { enabled: false });
 let worker: RuntimeProcessor | undefined;
 let workerInitialization: Promise<RuntimeProcessor> | undefined;
 
-const CONSOLE_LEVELS = ["log", "warn", "error"] as const;
-type ConsoleLevel = (typeof CONSOLE_LEVELS)[number];
 type ConsoleMethod = (...args: unknown[]) => void;
 
 // The worker's original console methods, saved while the bridge is installed.
 // `undefined` means the bridge is off and `console` is untouched, so disabled
 // forwarding adds no per-log cost.
-let savedConsole: Record<ConsoleLevel, ConsoleMethod> | undefined;
+let savedConsole: Record<WorkerConsoleLevel, ConsoleMethod> | undefined;
 
 function formatConsoleArg(arg: unknown): string {
   if (typeof arg === "string") return arg;
@@ -92,28 +94,27 @@ function formatConsoleArg(arg: unknown): string {
 
 /**
  * Patch the worker's `console.log`/`warn`/`error` so each call also posts a
- * structured `{ __workerConsole: { level, text } }` message that the web-worker
- * transport re-emits on the page console. The original method is called first,
- * so nothing is lost in the worker's own console. No-op if already installed.
+ * `WorkerConsoleNotification` that the web-worker transport re-emits on the
+ * page console. The original method is called first, so nothing is lost in the
+ * worker's own console. No-op if already installed.
  */
 function installWorkerConsoleBridge(): void {
   if (savedConsole) return;
-  const saved: Record<ConsoleLevel, ConsoleMethod> = {
+  const saved: Record<WorkerConsoleLevel, ConsoleMethod> = {
     log: console.log,
     warn: console.warn,
     error: console.error,
   };
   savedConsole = saved;
 
-  for (const level of CONSOLE_LEVELS) {
+  for (const level of WORKER_CONSOLE_LEVELS) {
     console[level] = (...args: unknown[]) => {
       saved[level].apply(console, args);
       try {
-        self.postMessage({
-          __workerConsole: {
-            level,
-            text: args.map(formatConsoleArg).join(" "),
-          },
+        postToClient({
+          type: TransportNotificationType.WorkerConsole,
+          level,
+          text: args.map(formatConsoleArg).join(" "),
         });
       } catch {
         // A non-cloneable payload or a closed channel must not break the
@@ -129,7 +130,7 @@ function installWorkerConsoleBridge(): void {
  */
 function uninstallWorkerConsoleBridge(): void {
   if (!savedConsole) return;
-  for (const level of CONSOLE_LEVELS) {
+  for (const level of WORKER_CONSOLE_LEVELS) {
     console[level] = savedConsole[level];
   }
   savedConsole = undefined;
@@ -196,7 +197,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
       // (e.g. a non-cloneable payload) the catch below records a
       // `responded-error/*` instead, so the ledger never double-counts one
       // request as both a success and an error.
-      self.postMessage({ msgId: message.msgId });
+      postToClient({ msgId: message.msgId });
       ipcLogger.debug(`responded/${request.type}`, () => []);
       return;
     }
@@ -206,7 +207,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
     // of runtime initialization, so it is answered before the init check.
     if (request.type === RequestType.SetForwardWorkerConsole) {
       setWorkerConsoleBridge(request.enabled);
-      self.postMessage({ msgId });
+      postToClient({ msgId });
       ipcLogger.debug(`responded/${request.type}`, () => []);
       return;
     }
@@ -218,7 +219,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
       // After disposal, silently ack any late-arriving requests.
       // Components may still be unsubscribing or finishing in-flight
       // operations during teardown — no point erroring on these.
-      self.postMessage({ msgId });
+      postToClient({ msgId });
       ipcLogger.debug(`responded/${request.type}`, () => []);
       return;
     }
@@ -235,7 +236,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
     const payload: IPCRemoteResponse = response !== undefined
       ? { msgId, data: response }
       : { msgId };
-    self.postMessage(payload);
+    postToClient(payload);
     ipcLogger.debug(`responded/${request.type}`, () => []);
   } catch (error) {
     console.error("[RuntimeWorker] Error:", error);
@@ -244,7 +245,7 @@ self.addEventListener("message", async (event: MessageEvent) => {
     const code = error instanceof CompilerStackLoadError
       ? RuntimeErrorCode.CompilerStackLoadFailed
       : undefined;
-    self.postMessage({
+    postToClient({
       msgId: message.msgId,
       error: error instanceof Error ? error.message : String(error),
       ...(code ? { code } : {}),
@@ -252,8 +253,12 @@ self.addEventListener("message", async (event: MessageEvent) => {
   }
 });
 
-if (typeof self !== "undefined" && self.postMessage) {
-  // This is a web worker transport only message, coordinating
-  // with the client indicating the web worker is active
-  self.postMessage("READY");
+// `postMessage` is absent from a main-thread global, where a test importing
+// this entry to drive the message handler runs.
+if (
+  (typeof self !== "undefined") && (typeof self.postMessage === "function")
+) {
+  // The transport's own traffic, not the runtime's: it tells the client this
+  // entry has run and the listener above is installed.
+  postToClient({ type: TransportNotificationType.WorkerReady });
 }

--- a/packages/runtime-client/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/client/transport-web-worker.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { TransportNotificationType } from "../protocol/mod.ts";
 import { WebWorkerRuntimeTransport } from "./transports/web-worker/transport-web-worker.ts";
 
-// Exercises the transport's handling of `{ __workerConsole }` messages without
-// a real worker: a fake Worker class lets us construct the transport, then we
-// drive its private message handler directly.
+// Exercises the transport's handling of forwarded worker console output
+// without a real worker: a fake Worker class lets us construct the transport,
+// then we drive its private message handler directly.
 class FakeWorker extends EventTarget {
   posted: unknown[] = [];
   terminated = false;
@@ -36,6 +37,34 @@ function handlerOf(
   })._handleMessage;
 }
 
+describe("WebWorkerRuntimeTransport ready handshake", () => {
+  it("settles `ready()` on the worker's ready notification", async () => {
+    const transport = makeTransport();
+    let settled = false;
+    const ready = transport.ready().then(() => {
+      settled = true;
+    });
+
+    const handle = handlerOf(transport);
+
+    // Anything else leaves it pending, the notification being the one message
+    // that says the worker's entry has run.
+    handle(new MessageEvent("message", { data: { msgId: 1 } }));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    handle(
+      new MessageEvent("message", {
+        data: { type: TransportNotificationType.WorkerReady },
+      }),
+    );
+    await ready;
+    expect(settled).toBe(true);
+
+    await transport.dispose();
+  });
+});
+
 describe("WebWorkerRuntimeTransport worker-console re-emit", () => {
   it("re-emits forwarded worker console at the matching level and stops", async () => {
     const transport = makeTransport();
@@ -57,28 +86,42 @@ describe("WebWorkerRuntimeTransport worker-console re-emit", () => {
 
       handle(
         new MessageEvent("message", {
-          data: { __workerConsole: { level: "error", text: "kaboom" } },
+          data: {
+            type: TransportNotificationType.WorkerConsole,
+            level: "error",
+            text: "kaboom",
+          },
         }),
       );
       handle(
         new MessageEvent("message", {
-          data: { __workerConsole: { level: "warn", text: "careful" } },
-        }),
-      );
-      // A level with no matching console method falls back to console.log.
-      handle(
-        new MessageEvent("message", {
-          data: { __workerConsole: { level: "fatal", text: "fallback" } },
+          data: {
+            type: TransportNotificationType.WorkerConsole,
+            level: "warn",
+            text: "careful",
+          },
         }),
       );
 
       expect(calls).toEqual([
         ["error", "[worker] kaboom"],
         ["warn", "[worker] careful"],
-        ["log", "[worker] fallback"],
       ]);
-      // None of these were treated as IPC messages.
+      // Neither was treated as an IPC message.
       expect(emitted).toEqual([]);
+
+      // A level outside the forwarded roster is not this transport's traffic,
+      // so it is forwarded on rather than logged. The roster is one constant
+      // that the worker's bridge posts from and this transport recognizes by,
+      // so nothing the bridge sends can land here.
+      const offRoster = {
+        type: TransportNotificationType.WorkerConsole,
+        level: "fatal",
+        text: "not console traffic",
+      };
+      handle(new MessageEvent("message", { data: offRoster }));
+      expect(calls).toHaveLength(2);
+      expect(emitted).toEqual([offRoster]);
     } finally {
       console.log = realConsole.log;
       console.warn = realConsole.warn;

--- a/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
@@ -4,6 +4,8 @@ import {
   ErrorNotification,
   IPCClientMessage,
   IPCClientNotification,
+  isWorkerConsoleNotification,
+  isWorkerReadyNotification,
   NotificationType,
 } from "../../../protocol/mod.ts";
 import { RuntimeTransport, RuntimeTransportEvents } from "../../transport.ts";
@@ -79,29 +81,19 @@ export class WebWorkerRuntimeTransport
     // Worker-side console output forwarded by the bridge in
     // `backends/web-worker/index.ts` (opt-in). Re-emit it on the page
     // console so it reaches devtools and integration-test console capture,
-    // then stop: it is not an IPC response and carries no `msgId`.
-    if (
-      data && typeof data === "object" &&
-      (data as { __workerConsole?: unknown }).__workerConsole
-    ) {
-      const { level, text } = (data as {
-        __workerConsole: { level: string; text: string };
-      }).__workerConsole;
-      const sink = (console as unknown as Record<
-        string,
-        (message: string) => void
-      >)[level] ?? console.log;
-      sink(`[worker] ${text}`);
+    // then stop: it is this transport's traffic, not the connection's.
+    if (isWorkerConsoleNotification(data)) {
+      console[data.level](`[worker] ${data.text}`);
       return;
     }
 
-    if (!this._ready && data === "READY") {
+    if (!this._ready && isWorkerReadyNotification(data)) {
       this._ready = true;
       this._readyPromise.resolve();
       return;
     }
 
-    this.emit("message", event.data);
+    this.emit("message", data);
   };
 
   private _handleError = (event: ErrorEvent): void => {

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -18,7 +18,12 @@ import {
   PendingWritesNotification,
   RequestType,
   TelemetryNotification,
+  TransportNotificationType,
   VDomBatchNotification,
+  WORKER_CONSOLE_LEVELS,
+  WorkerConsoleLevel,
+  WorkerConsoleNotification,
+  WorkerReadyNotification,
 } from "./types.ts";
 
 export function isCellRef(value: unknown): value is CellRef {
@@ -163,5 +168,25 @@ export function isVDomBatchNotification(
     value.type === NotificationType.VDomBatch &&
     typeof value.batchId === "number" &&
     Array.isArray(value.ops)
+  );
+}
+
+export function isWorkerReadyNotification(
+  value: unknown,
+): value is WorkerReadyNotification {
+  return (
+    isObjectNotArray(value) &&
+    value.type === TransportNotificationType.WorkerReady
+  );
+}
+
+export function isWorkerConsoleNotification(
+  value: unknown,
+): value is WorkerConsoleNotification {
+  return (
+    isObjectNotArray(value) &&
+    value.type === TransportNotificationType.WorkerConsole &&
+    WORKER_CONSOLE_LEVELS.includes(value.level as WorkerConsoleLevel) &&
+    typeof value.text === "string"
   );
 }

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -171,6 +171,10 @@ export function isVDomBatchNotification(
   );
 }
 
+/**
+ * Is `value` a {@link WorkerReadyNotification}? This is the post the transport
+ * settles `ready()` on, and the only message it treats that way.
+ */
 export function isWorkerReadyNotification(
   value: unknown,
 ): value is WorkerReadyNotification {
@@ -180,6 +184,12 @@ export function isWorkerReadyNotification(
   );
 }
 
+/**
+ * Is `value` a {@link WorkerConsoleNotification}? A `level` outside
+ * {@link WORKER_CONSOLE_LEVELS} is not one, which bounds what this recognizes
+ * to what the worker's console bridge produces: the bridge posts from that
+ * same roster, so nothing it sends is excluded here.
+ */
 export function isWorkerConsoleNotification(
   value: unknown,
 ): value is WorkerConsoleNotification {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -125,6 +125,15 @@ export enum NotificationType {
   PendingWritesChanged = "callback:pending-writes",
 }
 
+// Worker -> main-thread signals the transport acts on itself, rather than
+// forwarding to the connection. Their own enum because they are the channel's
+// traffic rather than the runtime's: one settles the channel and one annotates
+// it, and no `RuntimeConnection` ever sees either.
+export enum TransportNotificationType {
+  WorkerReady = "worker:ready",
+  WorkerConsole = "worker:console",
+}
+
 export type IPCClientMessage = {
   msgId: MessageId;
   data: IPCClientRequest;
@@ -144,6 +153,18 @@ export type IPCRemoteResponse = {
 };
 
 export type IPCRemoteMessage = IPCRemoteNotification | IPCRemoteResponse;
+
+/** The notifications the transport handles itself. */
+export type IPCTransportNotification =
+  | WorkerReadyNotification
+  | WorkerConsoleNotification;
+
+/**
+ * Everything the worker posts: what the connection receives, plus what the
+ * transport intercepts on the way to it. One type for one send, which is what
+ * `postToClient()` takes.
+ */
+export type IPCRemotePost = IPCRemoteMessage | IPCTransportNotification;
 
 /**
  * Base of every request a handler receives.
@@ -1191,6 +1212,35 @@ export type PendingWritesNotification = {
 };
 
 /**
+ * The worker's first post, announcing that its entry module has run and its
+ * message listener is installed. The transport's `ready()` settles on it.
+ */
+export type WorkerReadyNotification = {
+  type: TransportNotificationType.WorkerReady;
+};
+
+/** The `console` methods the worker's console bridge forwards. */
+export const WORKER_CONSOLE_LEVELS = ["log", "warn", "error"] as const;
+
+/** One of {@link WORKER_CONSOLE_LEVELS}. */
+export type WorkerConsoleLevel = (typeof WORKER_CONSOLE_LEVELS)[number];
+
+/**
+ * One line of the worker's own `console` output, forwarded so that it reaches
+ * the page console too. Opt-in, through `SetForwardWorkerConsole`.
+ *
+ * The subject is the worker itself, where `ConsoleNotification`'s is a pattern
+ * running inside it. That is also why this one carries text: the worker's own
+ * logging is rendered where it is written, and a pattern's arguments cross as
+ * values.
+ */
+export type WorkerConsoleNotification = {
+  type: TransportNotificationType.WorkerConsole;
+  level: WorkerConsoleLevel;
+  text: string;
+};
+
+/**
  * The vocabulary of DOM mutations carried by a VDOM batch. The worker
  * reconciler that produces them and the main-thread applicator that consumes
  * them both live in `@commonfabric/html`, which defines the union; the protocol
@@ -1209,8 +1259,12 @@ export type VDomBatchNotification = {
   batchId: number;
   /** The operations to apply, in order */
   ops: VDomOp[];
-  /** Optional: the root node ID for this render tree */
-  rootId?: number;
+  /**
+   * The root node ID for this render tree; `null` while the tree has no root
+   * child, which the reconciler reports as a value rather than by omission.
+   * Absent when the batch says nothing about the root at all.
+   */
+  rootId?: number | null;
   /** The mount ID this batch belongs to */
   mountId?: number;
 };
@@ -1248,6 +1302,7 @@ export type IPCRemoteNotification =
   | ConsoleNotification
   | NavigateRequestNotification
   | ErrorNotification
+  | TelemetryNotification
   | VDomBatchNotification
   | PendingWritesNotification;
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -125,10 +125,12 @@ export enum NotificationType {
   PendingWritesChanged = "callback:pending-writes",
 }
 
-// Worker -> main-thread signals the transport acts on itself, rather than
-// forwarding to the connection. Their own enum because they are the channel's
-// traffic rather than the runtime's: one settles the channel and one annotates
-// it, and no `RuntimeConnection` ever sees either.
+/**
+ * Worker-to-main-thread signals the transport acts on itself, rather than
+ * forwarding to the connection. Their own enum because they are the channel's
+ * traffic rather than the runtime's: one settles the channel and one annotates
+ * it, and no `RuntimeConnection` ever sees either.
+ */
 export enum TransportNotificationType {
   WorkerReady = "worker:ready",
   WorkerConsole = "worker:console",

--- a/packages/shell/integration/worker-runtime.test.ts
+++ b/packages/shell/integration/worker-runtime.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
 import { env } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { isWorkerReadyNotification } from "@commonfabric/runtime-client";
 
 const { FRONTEND_URL } = env;
 
@@ -47,13 +48,15 @@ describe("shell worker runtime", () => {
 
     if ((probe as { type: string }).type !== "message") {
       throw new Error(
-        `Expected worker READY message, got ${JSON.stringify(probe)}`,
+        `Expected worker ready message, got ${JSON.stringify(probe)}`,
       );
     }
 
     const message = probe as { type: "message"; data: unknown };
-    if (message.data !== "READY") {
-      throw new Error(`Expected READY, got ${JSON.stringify(message.data)}`);
+    if (!isWorkerReadyNotification(message.data)) {
+      throw new Error(
+        `Expected a ready notification, got ${JSON.stringify(message.data)}`,
+      );
     }
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Preparation for treating the runtime-client worker IPC envelope as a
`FabricValue` end to end. That change needs one place per direction to attach an
encode and a decode to; the worker did not have one.

## What moves

The worker had fifteen `self.postMessage()` sites — six in
`backends/runtime-processor.ts`, two in `backends/runtime-error.ts`, seven in
`backends/web-worker/index.ts`. They all go through `postToClient()` now, which
is the whole of the worker's outbound side. The client already had a single
`WebWorkerRuntimeTransport.send()` and a single `_handleMessage`, so each
direction is now one function at each end.

`"READY"` and `{ __workerConsole }` become `WorkerReadyNotification` and
`WorkerConsoleNotification` under a `TransportNotificationType` enum, so those
two are ordinary messages the transport recognizes by type rather than by shape
sniffing. Both realms ship as one bundle, so there is no version skew to carry.

## Four disagreements the typed send exposed

Each was invisible while `postMessage()` took `any`. None of them changes
behavior; all of them make a declaration say what actually crosses.

- **`TelemetryNotification` was not in the `IPCRemoteNotification` union**,
  though `#onTelemetry` posts one and `RuntimeConnection._handleMessage`
  dispatches one. `isIPCRemoteNotification()` had it right and the type did not.
- **`rootId` was declared `number`** on both `VDomBatchNotification` and
  `html`'s own `VDomBatch`, where `reconciler.getRootNodeId()` returns
  `number | null` and a rootless tree therefore sends `null`. Both now say
  `number | null`. `applicator.ts` already stored `number | null`;
  `renderer.ts` compared `rootId > 0`, which under `null` was false — it now
  reaches the same result without relying on that.
- **The subscription-update path posted its converted value with no cast**,
  where `handleCellGet` — the pull form of the same conversion — casts to
  `JSONValue`. It now makes the same cast. Both casts go away when the envelope
  carries a `FabricValue`.
- **The ready post's guard tested `self.postMessage` for truthiness.**
  TypeScript reads that as always true (TS2774, previously suppressed because
  the block also called it). The guard is load-bearing — a main-thread global
  has no `postMessage`, and tests import this entry there — so it now tests for
  a function.

## One behavior change, deliberate

A forwarded console message whose `level` is outside the roster used to be
logged through `console.log` as a fallback. It is now not recognized as this
transport's traffic and is forwarded on instead. The roster is a single exported
`WORKER_CONSOLE_LEVELS` that the worker's bridge posts from and the guard
validates against, so nothing the bridge sends can land there — the fallback
guarded a state that cannot occur. The test that covered it now asserts the new
behavior.

## Verification

- `deno task check`, `deno lint`, `deno fmt` (changed files only), and
  `check-docs` / `check-package-cycles` / `check-no-waitfor` /
  `check-skill-facts` / `check-conflict-markers`: all green.
- Full workspace `deno task test`: green, 436s, `deno.lock` untouched.
- **Ablation.** Forcing `isWorkerReadyNotification()` to never match reddened
  `lib-shell` but left `runtime-client` fully green — nothing in this package
  covered the ready handshake, and nothing covered the `"READY"` string before
  it either. `transport-web-worker.test.ts` gains a test for it, after which the
  same ablation reddens this package too. Forcing
  `isWorkerConsoleNotification()` to never match reddens three tests here.

## Added after review

Cubic found no issues; a Fable-model reviewer running the repo's `cf-review`
found none blocking, and raised two non-blocking points that are taken here.

- **`test(html)`** — no test anywhere sent a batch with `rootId: null`, so the
  widening above had added an arm nothing ran. The new test distinguishes
  `null` from an absent field, which is the mistake the widening newly makes
  possible: absent says nothing about the root and leaves the tracked one
  standing, `null` clears it. Rewriting the guard as `!= null` reddens it and
  nothing else.
- **Doc comments** on the three exports this branch added without them, per
  `code-comment-style.md` "What gets one". The wider gap in these files —
  `protocol/guards.ts` carries none on any of its seventeen exports, and
  `protocol/types.ts` on 23 of 149 — is filed as its own change, to land before
  the codec work rather than inside it.
- **`refactor(html)`** — chasing whether the new test could pass for the wrong
  reason turned up a second implementation it does *not* catch, and the
  measurement said the answer was removal rather than another test. The
  notification path tested `rootId > 0`, a sentinel copied from the
  mount-response path where `0` is load-bearing. Here it was dead: the sole
  producer posts `reconciler.getRootNodeId()`, node IDs come from
  `++nodeIdCounter` starting at `0` so the first is `1`, and
  `CONTAINER_NODE_ID` is `0` and never a root child. Ablating the check
  reddened nothing, which is how it was found. `null` is now the whole of what
  a rootless tree says on this path.
- **`test(html)`** — `DomApplicator` carries its own copy of the distinction
  `VDomRenderer` now states, and nothing guarded it either: conflating `null`
  with an absent field there reddened no test in the suite. Two steps, one per
  direction, each reddening on its own mistake and not the other's. The null
  step asserts node 1 is still present before asserting no root, so a lookup
  that missed cannot pass for a root that was cleared.
- **`test(html)`** — the same step had left that hole open at node 0. Nothing
  registered a container, so `CONTAINER_NODE_ID` resolved to nothing and an
  implementation coercing a null root to `0` read back as no root at all,
  passing. Registering a container — which every applicator outside a test has
  — makes the coercion visible. Ablation matrix on
  `DomApplicator.applyBatch`, unmutated green: `?? 0` coercion and `!= null`
  conflation each red the null step; unconditional assignment reds the omit
  step; none reds the other's.

The mount-response path still spells "no root" as a manufactured `0`, because
`VDomMountResponse.rootId` is a plain `number`. That asymmetry is real but is
not this change's to fix; it is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121sxMwWK139eKHNNGrjygY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




