### PR TITLE
refactor(topics): lift the pivot's join to a seam a duplicate can reach

### DIFF
--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -117,6 +117,36 @@ export interface TopicIndexRow {
 }
 
 /**
+ * The topics that mention `topic`, out of `list` — the pivot's whole join,
+ * lifted out so it can be handed a list a board cannot produce.
+ *
+ * `mentions[i]` is what `list[i]` points at, read once by the caller because
+ * reading it through the reactive array costs a link resolution per topic per
+ * topic.
+ *
+ * The exclusion is asked of IDENTITY, never of array position, and that is the
+ * whole reason this is a named function. A board listing one topic at two
+ * indices must not route its self-mention through the twin and call the result
+ * an inbound edge — and a position comparison passes every test where each
+ * topic appears once, which is every test a board can set up. Handing this
+ * function a duplicated list is what tells the two apart.
+ *
+ * `equals` resolves BOTH sides before comparing, so it answers "do these name
+ * the same document" whether each side arrived as a cell or as the raw link a
+ * read left behind. A method call on the value would depend on which it is.
+ */
+export function mentionedBy<T extends object>(
+  topic: T,
+  list: readonly T[],
+  mentions: readonly (readonly (object | undefined)[] | undefined)[],
+): T[] {
+  return list.filter((other, from) =>
+    !equals(other, topic) &&
+    mentions[from]?.some((mention) => equals(mention, topic))
+  );
+}
+
+/**
  * The board's mention pivot: one row per topic, naming the topics that mention
  * it.
  *
@@ -172,25 +202,17 @@ const crossrefTable = lift(
       // is no id to key a map by — and nothing to mint, keep in step, or
       // migrate when a piece moves. At board scale this is a few hundred
       // comparisons of already-resolved links.
-      const mentionedBy = list.filter((other, from) =>
-        // A topic mentioning itself is not an edge, the rule a self-link has
-        // always had here — asked of the topic rather than of its position, so
-        // a board listing one topic twice cannot route a self-mention through
-        // the twin and call it an inbound edge.
-        !equals(other, topic) &&
-        // `equals` resolves BOTH sides before comparing, so it returns "do
-        // these name the same document" whether each side arrived as a cell or
-        // as the raw link a read left behind. A method call on the value would
-        // depend on which of those it happens to be.
-        mentions[from]?.some((mention) => equals(mention, topic))
-      );
+      const inbound = mentionedBy(topic, list, mentions);
       // Addressed by the topic it describes, so a row keeps its identity
       // wherever it sits and however the board is reordered. That is what lets
       // every topic's lookup re-run freely on any board change and still write
       // nothing: an unchanged row recomputes to the same links at the same
       // address.
       rows.push(
-        Writable.for<TopicCrossrefRow>(topic).set({ topic, mentionedBy }),
+        Writable.for<TopicCrossrefRow>(topic).set({
+          topic,
+          mentionedBy: inbound,
+        }),
       );
     });
     return rows as TopicCrossrefRow[];

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "commonfabric";
 import { pattern } from "commonfabric";
 import Topics, {
+  mentionedBy,
   submitProfileTopic,
   type TopicCrossrefRow,
   type TopicPiece,
@@ -600,6 +601,24 @@ export default pattern(() => {
   });
 
   // A fresh comment on the FIRST topic makes it the most recently active.
+  // The pivot's join, handed a list a board cannot produce: the SAME topic at
+  // two indices. That is the only shape that separates the rule the pivot
+  // actually holds — exclude by identity — from the one that passes every
+  // board-built test, exclude by array position. With a position check the
+  // twin at index 1 is not excluded, its mention of `twin` matches, and a
+  // topic that only ever mentioned itself is reported as referenced from
+  // elsewhere.
+  const twinA = Topic({ title: "Twin" });
+  const twinB = Topic({ title: "Other" });
+  const assert_self_mention_inert_through_a_twin = assert(() =>
+    mentionedBy(twinA, [twinA, twinA, twinB], [[twinA], [twinA], []])
+        .length === 0 &&
+    // The same list still reports a real inbound edge, so the exclusion is
+    // not simply swallowing everything.
+    mentionedBy(twinB, [twinA, twinA, twinB], [[twinB], [twinB], []])
+        .length === 2
+  );
+
   const assert_pure_helpers = assert(() =>
     snippet("a b  c", 3) === "a b…" &&
     snippet("hi", 10) === "hi" &&
@@ -1001,6 +1020,7 @@ export default pattern(() => {
       { render: legacy[UI] },
       { assertion: assert_legacy_fields_load },
       { assertion: assert_pure_helpers },
+      { assertion: assert_self_mention_inert_through_a_twin },
       { action: action_add_graph_topics },
       { assertion: assert_graph_baseline },
       { action: action_source_mentions_target },


### PR DESCRIPTION
## Why

The board's mention pivot excludes a topic from its own inbound edges by **identity**, never by array position. That distinction is load-bearing: a board listing one topic at two indices must not route its self-mention through the twin and report the topic as referenced from elsewhere.

Nothing could check it except a board holding a duplicate — and review of #6267 showed why that is a problem. Replacing `!equals(other, topic)` with a position comparison passes **every** test where each topic appears once, which is every test a board can set up. The one existing case that catches it, `assert_twin_earns_no_edge`, needs a duplicate in the board's list, and a duplicate cannot be built from outside a board by any route available:

| route | result |
| --- | --- |
| `push` the piece into the board's array | action never runs — `stream action argument is undefined (potential schema mismatch)` |
| seed the array at construction | `Cell.of() only accepts static data, but found a reactive value (Cell)` |
| the controller's `input` at `["topics", N]` | refused by `assertSchemaSubset` |

So the rule was pinned only by a test shape that #6143 is about to make impossible, with no way to rehouse it. This lifts the join to a seam a test can hand any list at all — which is what `COVERAGE.md` prescribes for exactly this situation: "Extract the code into something a plain unit test can call directly if that is what it takes."

## What Changed

- `packages/patterns/topics/main.tsx` — the pivot's filter becomes `mentionedBy(topic, list, mentions)`, exported. `crossrefTable` calls it and is otherwise unchanged; its own doc comment stays attached to it.
- `packages/patterns/topics/topics.test.tsx` — `assert_self_mention_inert_through_a_twin` hands the function the same topic at two indices and pins both directions: the twin's self-mention earns nothing, and a genuine inbound edge over the same list is still reported, so the exclusion is not simply swallowing everything.

## Test plan

- `deno task cf test packages/patterns/topics/topics.test.tsx` — 46 passed, 0 failed.
- The mutation that matters: replacing the identity check with `from !== list.indexOf(topic)` turns **two** assertions red — the new one and the existing board-level `assert_twin_earns_no_edge`. That pair is the evidence the seam reproduces the coverage rather than approximating it, and it is what will let #6143 retire the board-level case.
- Worth recording, since it is why the gap existed: deleting the exclusion outright — the mutation I first reached for — is a strictly stronger break than the plausible regression and passes while proving much less.
- `deno fmt`, `deno lint` clean; `cf check` on `main.tsx` reports 0 errors.

Related: #6267 (where review surfaced this), #6143 (which needs it before it can retire the board-level twin test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

