### PR TITLE
fix(state-inspector): every surface that describes an entity sees what a read sees

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -153,6 +153,24 @@ function validatedLimit(limit: number): number {
   return limit;
 }
 
+/**
+ * The row limit a listing will apply, refusing what its SQL used to refuse.
+ *
+ * Distinct from `validatedLimit`, which governs a reconstruction cap and takes
+ * no negative: these listings were `LIMIT ?` clauses, where SQLite reads a
+ * negative as UNLIMITED and answers a fractional or non-finite one with a
+ * datatype mismatch. Any integer passes; everything else is the typo it looks
+ * like, and rounding it silently is how a listing under-reports.
+ */
+function validatedRowLimit(limit: number): number {
+  if (!Number.isInteger(limit)) {
+    throw new ValidationError(
+      `\`--limit\` must be a whole number of rows, not ${limit}.`,
+    );
+  }
+  return limit;
+}
+
 /** The flag that turns a capped result into a failure. Shared by every scan. */
 const requireCompleteOption = [
   "--require-complete",
@@ -897,15 +915,15 @@ export const inspect = new Command()
     "hot <space:string>",
     "Entities ranked by write count (contention proxy).",
   )
-  .option("--limit <n:number>", "Max rows.", { default: 20 })
+  .option("--limit <n:number>", "Max rows; a negative returns every row.", {
+    default: 20,
+  })
   .option("--branch <branch:string>", "Branch (default: '').")
   .action(async (options, space) => {
+    const limit = validatedRowLimit(options.limit);
     const s = await openByToken(space, options);
     try {
-      const rows = hotEntities(s, {
-        limit: options.limit,
-        branch: options.branch,
-      });
+      const rows = hotEntities(s, { limit, branch: options.branch });
       out(!!options.json, rows, () => {
         for (const r of rows) {
           console.log(
@@ -1005,8 +1023,13 @@ export const inspect = new Command()
   )
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--scope <scope:string>", "Scope key (default: space).")
-  .option("--limit <n:number>", "Max contested entities.", { default: 100 })
+  .option(
+    "--limit <n:number>",
+    "Max contested entities; a negative returns every one.",
+    { default: 100 },
+  )
   .action(async (options, space, entity) => {
+    const limit = validatedRowLimit(options.limit);
     const s = await openByToken(space, options);
     try {
       if (entity) {
@@ -1061,7 +1084,7 @@ export const inspect = new Command()
       const rows = contendedEntities(s, {
         branch: options.branch,
         scope: options.scope,
-        limit: options.limit,
+        limit,
       });
       out(!!options.json, rows, () => {
         if (rows.length === 0) {

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -55,6 +55,7 @@ import {
   renderInspectorHtml,
   type RequestSigner,
   resolveSpace,
+  rowLimit,
   type ScanExtent,
   type Scope,
   scopeOverlay,
@@ -163,12 +164,17 @@ function validatedLimit(limit: number): number {
  * like, and rounding it silently is how a listing under-reports.
  */
 function validatedRowLimit(limit: number): number {
-  if (!Number.isInteger(limit)) {
+  try {
+    // `rowLimit` owns the RULE — which limits a row listing accepts, and why.
+    // This owns only how a CLI user hears it: a ValidationError before the
+    // space is opened, rather than the library's stack trace after.
+    rowLimit(limit);
+    return limit;
+  } catch {
     throw new ValidationError(
       `\`--limit\` must be a whole number of rows, not ${limit}.`,
     );
   }
-  return limit;
 }
 
 /** The flag that turns a capped result into a failure. Shared by every scan. */

--- a/packages/cli/test/inspect-truncation.test.ts
+++ b/packages/cli/test/inspect-truncation.test.ts
@@ -333,6 +333,54 @@ describe("cf inspect capped listings", () => {
     });
   });
 
+  it("rejects a fractional `--limit` on the row listings, and lets a negative mean every row", async () => {
+    await withStore(async (path) => {
+      // `conflicts` reports an entity only with TWO writer sessions, and the
+      // seed uses one — without this the negative-limit half of the assertion
+      // compares zero against zero and cannot fail.
+      const db = new Database(path);
+      const other = "session:did%3Akey%3AzBob:s9";
+      for (const [i, id] of ["of:cell-1", "of:cell-2"].entries()) {
+        db.prepare(
+          `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+           VALUES (?, ?, 1, '{}', '{"seq":0}')`,
+        ).run(9100 + i, other);
+        db.prepare(
+          `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+           VALUES (?, ?, 0, 'set', '{"value":"bob"}', ?)`,
+        ).run(id, 9100 + i, 9100 + i);
+      }
+      db.close();
+
+      // These were SQL `LIMIT ?` clauses: SQLite answered a fractional or
+      // non-finite limit with a datatype mismatch and read a NEGATIVE as
+      // unlimited. Moving the bound into a JS `slice` silently turned the first
+      // into a rounded row count and the second into "drop the last".
+      const rows = (out: string[]) => JSON.parse(out.join("\n")).length;
+      for (const command of ["hot", "conflicts"]) {
+        const bad = await cf(`inspect ${command} ${path} --limit 1.5`);
+        expect(bad.code).not.toBe(0);
+        // The CLI's own message, not the library's fallback — the guard has to
+        // fire before the space is opened, or the failure arrives as a stack.
+        expect(stripAnsi(bad.stderr.join("\n"))).toContain(
+          "`--limit` must be a whole number of rows",
+        );
+
+        const capped = await cf(`inspect ${command} ${path} --limit 1 --json`);
+        expect(capped.code).toBe(0);
+        expect(rows(capped.stdout)).toBe(1);
+
+        const unlimited = await cf(
+          `inspect ${command} ${path} --limit -1 --json`,
+        );
+        expect(unlimited.code).toBe(0);
+        // Strictly more than the cap — `slice(0, -1)` would give one FEWER
+        // than uncapped, and both stores hold more than one row here.
+        expect(rows(unlimited.stdout)).toBeGreaterThan(1);
+      }
+    });
+  });
+
   it("notes the cap on a capped HTML explorer and marks the page itself", async () => {
     await withStore(async (path) => {
       const result = await cf(`inspect html ${path} --limit 3`);

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -246,6 +246,18 @@ A standalone `cli.ts` entry exists for use outside the `cf` CLI (local only;
   head is a `delete`. `entities` is the exception that keeps tombstones, because
   it describes the space's records; that is why its `extent.total` can exceed
   `graph`'s over the same space.
+- **Everything that describes an ENTITY reads the branch that owns its visible
+  row.** `entityHistory`, `entityTimeline`, `hotEntities`, `contendedEntities`,
+  the detail version log, `analyzeSpaceSignals`' content searches, and the
+  cross-space convergence scans all resolve ownership before they read. That
+  cuts both ways: an entity a child INHERITED is described with the parent's
+  writes, and one the child OVERRODE with the child's alone, because the
+  parent's writes produced nothing a read from here can reach.
+- **What describes a branch's ACTIVITY stays local, on purpose.**
+  `spaceTimeline` and `churn` count commits made ON the branch. An inherited
+  entity was created by a commit that is not in those timelines, so folding it
+  in would attribute creations to commits they never list. `summarizeSpace`
+  counts the whole store and takes no branch at all.
 - **The other caps are silent**: `history` / `hot` / `conflicts` row limits, and
   the HTML stale-read pass, which caps per bundle and marks un-analyzed cells
   rather than showing them clean. There a count at a round cap may be truncated

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -108,7 +108,9 @@ export function contendedEntities(
 ): ContendedEntity[] {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
-  const limit = opts.limit ?? 100;
+  // Resolved at ENTRY — see `hotEntities`: the refusal belongs before the scan,
+  // where the SQL this replaced put it.
+  const end = rowLimit(opts.limit ?? 100);
 
   // Counted on the branch that OWNS each entity's visible row: a child branch
   // inherits its parent's entities, and reading local rows only would report no
@@ -140,7 +142,7 @@ export function contendedEntities(
     .sort((a, b) =>
       b.sessions - a.sessions || b.writes - a.writes || utf8Compare(a.id, b.id)
     )
-    .slice(0, rowLimit(limit));
+    .slice(0, end);
 
   const writersStmt = space.db.prepare(
     `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -32,6 +32,8 @@ import {
 } from "@commonfabric/memory/v2/engine";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 
+import { rowLimit } from "./model.ts";
+
 import type { SpaceDb } from "./db.ts";
 import {
   branchReadChain,
@@ -138,10 +140,7 @@ export function contendedEntities(
     .sort((a, b) =>
       b.sessions - a.sessions || b.writes - a.writes || utf8Compare(a.id, b.id)
     )
-    // A negative limit meant UNLIMITED while this was a SQL `LIMIT ?`, and the
-    // conflicts CLI still accepts one; `slice` would read it as "drop the last"
-    // and report one fewer contended entity than there are.
-    .slice(0, limit < 0 ? undefined : limit);
+    .slice(0, rowLimit(limit));
 
   const writersStmt = space.db.prepare(
     `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -134,7 +134,10 @@ export function contendedEntities(
     .sort((a, b) =>
       b.sessions - a.sessions || b.writes - a.writes || utf8Compare(a.id, b.id)
     )
-    .slice(0, limit);
+    // A negative limit meant UNLIMITED while this was a SQL `LIMIT ?`, and the
+    // conflicts CLI still accepts one; `slice` would read it as "drop the last"
+    // and report one fewer contended entity than there are.
+    .slice(0, limit < 0 ? undefined : limit);
 
   const writersStmt = space.db.prepare(
     `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -30,7 +30,10 @@ import {
   patchOverlapsNonRecursiveRead,
   patchOverlapsRead,
 } from "@commonfabric/memory/v2/engine";
+import { utf8Compare } from "@commonfabric/utils/utf8";
+
 import type { SpaceDb } from "./db.ts";
+import { branchReadChain, type BranchReadLink } from "./reconstruct.ts";
 import { decodeStored } from "./decode.ts";
 import { parseScope } from "./scopes.ts";
 
@@ -101,24 +104,42 @@ export function contendedEntities(
   const scope = opts.scope ?? "space";
   const limit = opts.limit ?? 100;
 
-  const ids = space.db
-    .prepare(
-      `SELECT r.id, count(DISTINCT c.session_id) sessions, count(*) writes
-       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ? AND r.scope_key = ?
-       GROUP BY r.id HAVING sessions >= 2
-       ORDER BY sessions DESC, writes DESC LIMIT ?`,
+  // Counted on the branch that OWNS each entity's visible row: a child branch
+  // inherits its parent's entities, and reading local rows only would report no
+  // contention at all on a branch whose visible entities are contended.
+  const perBranch = space.db.prepare(
+    `SELECT r.id, count(DISTINCT c.session_id) sessions, count(*) writes
+     FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+     WHERE r.branch = ? AND r.scope_key = ? AND r.seq <= ?
+     GROUP BY r.id`,
+  );
+  const owners = new Map<string, BranchReadLink>();
+  const counted: { id: string; sessions: number; writes: number }[] = [];
+  for (const link of branchReadChain(space, branch)) {
+    for (
+      const r of perBranch.all<
+        { id: string; sessions: number; writes: number }
+      >(
+        link.branch,
+        scope,
+        link.atSeq,
+      )
+    ) {
+      if (owners.has(r.id)) continue;
+      owners.set(r.id, link);
+      if (r.sessions >= 2) counted.push(r);
+    }
+  }
+  const ids = counted
+    .sort((a, b) =>
+      b.sessions - a.sessions || b.writes - a.writes || utf8Compare(a.id, b.id)
     )
-    .all<{ id: string; sessions: number; writes: number }>(
-      branch,
-      scope,
-      limit,
-    );
+    .slice(0, limit);
 
   const writersStmt = space.db.prepare(
     `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at
      FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
      ORDER BY r.seq ASC, r.op_index ASC`,
   );
 
@@ -130,7 +151,7 @@ export function contendedEntities(
         op: string;
         session_id: string;
         created_at: string;
-      }>(branch, e.id, scope)
+      }>(owners.get(e.id)!.branch, e.id, scope, owners.get(e.id)!.atSeq)
       .map((w) => ({
         seq: w.seq,
         commitSeq: w.commit_seq,

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -33,7 +33,11 @@ import {
 import { utf8Compare } from "@commonfabric/utils/utf8";
 
 import type { SpaceDb } from "./db.ts";
-import { branchReadChain, type BranchReadLink } from "./reconstruct.ts";
+import {
+  branchReadChain,
+  type BranchReadLink,
+  owningLink,
+} from "./reconstruct.ts";
 import { decodeStored } from "./decode.ts";
 import { parseScope } from "./scopes.ts";
 
@@ -260,11 +264,18 @@ export function entityConflicts(
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
 
-  const writers: Writer[] = space.db
+  // Who wrote this entity, from the branch that OWNS its visible row — a child
+  // branch inherits its parent's entities, and local rows only would report no
+  // writers for one it reads fine. The stale-read scan below is a different
+  // question and keeps its own branch resolution: it replicates the engine's
+  // `validateConfirmedReads`, where an unqualified read defaults to the READER
+  // COMMIT's branch.
+  const owner = owningLink(space, { branch, scope, id });
+  const writers: Writer[] = (owner === undefined ? [] : space.db
     .prepare(
       `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at
        FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
        ORDER BY r.seq ASC, r.op_index ASC`,
     )
     .all<{
@@ -273,7 +284,7 @@ export function entityConflicts(
       op: string;
       session_id: string;
       created_at: string;
-    }>(branch, id, scope)
+    }>(owner.branch, id, scope, owner.atSeq))
     .map((w) => ({
       seq: w.seq,
       commitSeq: w.commit_seq,

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -25,7 +25,7 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import { openSpace, type SpaceDb } from "./db.ts";
 import { collectLinks } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
 import type { DiscoveredSpace } from "./discover.ts";
 
 export type SpaceRole =
@@ -75,6 +75,42 @@ function isHomeResultValue(v: unknown): boolean {
 }
 
 /**
+ * Ids whose stored rows match every `data LIKE` pattern, across each branch the
+ * read can reach.
+ *
+ * The LIKE set is a CANDIDATE filter — each hit is reconstructed and tested
+ * properly by the caller — so a union across the chain is enough and no
+ * ownership arbitration belongs here: an id matched on a parent but overridden
+ * on the child reconstructs to the child's value and fails the real test on its
+ * own. Searching local rows only is what goes wrong, by never offering an
+ * inherited entity as a candidate at all.
+ */
+function candidatesMatching(
+  space: SpaceDb,
+  opts: { branch: string; scope: string; like: readonly string[] },
+): string[] {
+  const stmt = space.db.prepare(
+    `SELECT DISTINCT id FROM revision
+     WHERE branch = ? AND scope_key = ? AND seq <= ?
+       AND ${opts.like.map(() => "data LIKE ?").join(" AND ")}`,
+  );
+  const ids = new Set<string>();
+  for (const link of branchReadChain(space, opts.branch)) {
+    for (
+      const r of stmt.all<{ id: string }>(
+        link.branch,
+        opts.scope,
+        link.atSeq,
+        ...opts.like,
+      )
+    ) {
+      ids.add(r.id);
+    }
+  }
+  return [...ids];
+}
+
+/**
  * Read the grouping signals from a single space DB. Cheap by design: it never
  * does a full reconstruction pass — it targets home pieces and cross-space
  * carriers with `data LIKE` candidate queries, then reconstructs only those.
@@ -119,14 +155,12 @@ export function analyzeSpaceSignals(
   // Home detection + profiles[] edges
   let isHome = false;
   const profileDids = new Set<string>();
-  const homeCandidates = space.db
-    .prepare(
-      `SELECT DISTINCT id FROM revision
-       WHERE branch = ? AND scope_key = ?
-         AND data LIKE '%createProfile%' AND data LIKE '%"profiles"%'`,
-    )
-    .all<{ id: string }>(branch, scope);
-  for (const { id } of homeCandidates) {
+  const homeCandidates = candidatesMatching(space, {
+    branch,
+    scope,
+    like: ["%createProfile%", '%"profiles"%'],
+  });
+  for (const id of homeCandidates) {
     let doc;
     try {
       doc = reconstructDocument(space, { id, branch, scope });
@@ -154,12 +188,11 @@ export function analyzeSpaceSignals(
   // All cross-space link targets (cheap candidate query)
   const crossSpaceDids = new Set<string>();
   for (
-    const { id } of space.db
-      .prepare(
-        `SELECT DISTINCT id FROM revision
-         WHERE branch = ? AND scope_key = ? AND data LIKE '%"space":"did:key:%'`,
-      )
-      .all<{ id: string }>(branch, scope)
+    const id of candidatesMatching(space, {
+      branch,
+      scope,
+      like: ['%"space":"did:key:%'],
+    })
   ) {
     let doc;
     try {

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -25,7 +25,7 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import { openSpace, type SpaceDb } from "./db.ts";
 import { collectLinks } from "./decode.ts";
-import { branchReadChain, reconstructDocument } from "./reconstruct.ts";
+import { candidatesMatching, reconstructDocument } from "./reconstruct.ts";
 import type { DiscoveredSpace } from "./discover.ts";
 
 export type SpaceRole =
@@ -72,42 +72,6 @@ function didFromPath(path: string): string {
 function isHomeResultValue(v: unknown): boolean {
   return isObjectNotArray(v) &&
     "profiles" in v && "createProfile" in v;
-}
-
-/**
- * Ids whose stored rows match every `data LIKE` pattern, across each branch the
- * read can reach.
- *
- * The LIKE set is a CANDIDATE filter — each hit is reconstructed and tested
- * properly by the caller — so a union across the chain is enough and no
- * ownership arbitration belongs here: an id matched on a parent but overridden
- * on the child reconstructs to the child's value and fails the real test on its
- * own. Searching local rows only is what goes wrong, by never offering an
- * inherited entity as a candidate at all.
- */
-function candidatesMatching(
-  space: SpaceDb,
-  opts: { branch: string; scope: string; like: readonly string[] },
-): string[] {
-  const stmt = space.db.prepare(
-    `SELECT DISTINCT id FROM revision
-     WHERE branch = ? AND scope_key = ? AND seq <= ?
-       AND ${opts.like.map(() => "data LIKE ?").join(" AND ")}`,
-  );
-  const ids = new Set<string>();
-  for (const link of branchReadChain(space, opts.branch)) {
-    for (
-      const r of stmt.all<{ id: string }>(
-        link.branch,
-        opts.scope,
-        link.atSeq,
-        ...opts.like,
-      )
-    ) {
-      ids.add(r.id);
-    }
-  }
-  return [...ids];
 }
 
 /**

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -478,6 +478,22 @@ export const DEFAULT_SCAN_LIMIT = 5000;
  * number: a fractional one no integer count can ever equal is a cap that never
  * takes effect, and the three scans disagreed about which way to round it.
  */
+/**
+ * The end index a row listing slices to, for a limit that may be anything a
+ * caller passed.
+ *
+ * These listings were SQL `LIMIT ?` clauses, where SQLite reads a NEGATIVE as
+ * UNLIMITED, and the CLI still accepts one. A JS `slice` reads the same number
+ * as "drop the last N", so moving the bound out of SQL turns an operator asking
+ * for everything into a silent under-report. Distinct from `scanLimit`, which
+ * governs a reconstruction CAP and floors a negative to zero: nothing to
+ * reconstruct is a coherent answer, while nothing to list is not what a
+ * negative meant here.
+ */
+export function rowLimit(limit: number): number | undefined {
+  return limit < 0 ? undefined : limit;
+}
+
 export function scanLimit(limit: number | undefined): number {
   if (limit === undefined || Number.isNaN(limit)) return DEFAULT_SCAN_LIMIT;
   return Math.max(0, Math.floor(limit));

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -482,9 +482,21 @@ export const DEFAULT_SCAN_LIMIT = 5000;
  * for everything into a silent under-report. Distinct from `scanLimit`, which
  * governs a reconstruction CAP and floors a negative to zero: nothing to
  * reconstruct is a coherent answer, while nothing to list is not what a
- * negative meant here.
+ * negative meant here. A limit that is not a whole number is refused, which is
+ * also what the SQL did.
  */
 export function rowLimit(limit: number): number | undefined {
+  // A non-integer is REFUSED rather than rounded, because that is what these
+  // listings did before the bound moved into JS: SQLite answers `LIMIT 1.5`,
+  // `LIMIT NaN` and `LIMIT Infinity` with a datatype mismatch, while `slice`
+  // reads them as one row, no rows, and every row. Silently coercing a limit
+  // the caller could not have meant is how a listing under-reports without
+  // saying so. `Number.isInteger` rejects all four in one test.
+  if (!Number.isInteger(limit)) {
+    throw new Error(
+      `a row limit must be a whole number of rows, not ${limit}.`,
+    );
+  }
   return limit < 0 ? undefined : limit;
 }
 

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -473,12 +473,6 @@ export function isEntityKind(value: string): value is EntityKind {
 export const DEFAULT_SCAN_LIMIT = 5000;
 
 /**
- * The cap a scan will actually apply, for a limit that may be anything a caller
- * passed. Entities are counted one at a time, so a cap has to be a whole
- * number: a fractional one no integer count can ever equal is a cap that never
- * takes effect, and the three scans disagreed about which way to round it.
- */
-/**
  * The end index a row listing slices to, for a limit that may be anything a
  * caller passed.
  *
@@ -494,6 +488,12 @@ export function rowLimit(limit: number): number | undefined {
   return limit < 0 ? undefined : limit;
 }
 
+/**
+ * The cap a scan will actually apply, for a limit that may be anything a caller
+ * passed. Entities are counted one at a time, so a cap has to be a whole
+ * number: a fractional one no integer count can ever equal is a cap that never
+ * takes effect, and the three scans disagreed about which way to round it.
+ */
 export function scanLimit(limit: number | undefined): number {
   if (limit === undefined || Number.isNaN(limit)) return DEFAULT_SCAN_LIMIT;
   return Math.max(0, Math.floor(limit));

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -31,6 +31,7 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { openSpace, type SpaceDb } from "./db.ts";
 import { annotate, collectLinks } from "./decode.ts";
 import {
+  candidatesMatching,
   getValueAt,
   owningLink,
   reconstructDocument,
@@ -353,13 +354,16 @@ export function buildCrossSpaceLinkIndex(
 
   for (const { label, space } of spaces) {
     const ownDid = spaceDidFromLabel(label);
-    const candidates = space.db
-      .prepare(
-        `SELECT DISTINCT id FROM revision
-         WHERE branch = ? AND scope_key = ? AND data LIKE '%"space":"did:key:%'`,
-      )
-      .all<{ id: string }>(branch, scope);
-    for (const { id } of candidates) {
+    // Candidates across every branch the read can reach: a child branch
+    // inherits its parent's link holders, and an index built from local rows
+    // only would drop their targets' `cross-space-linked` classification while
+    // the scan beside it still finds those targets.
+    const candidates = candidatesMatching(space, {
+      branch,
+      scope,
+      like: ['%"space":"did:key:%'],
+    });
+    for (const id of candidates) {
       examinedEntities++;
       let doc: unknown;
       try {

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -30,7 +30,11 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import { openSpace, type SpaceDb } from "./db.ts";
 import { annotate, collectLinks } from "./decode.ts";
-import { getValueAt, reconstructDocument } from "./reconstruct.ts";
+import {
+  getValueAt,
+  reconstructDocument,
+  visibleRevisionRows,
+} from "./reconstruct.ts";
 
 export interface SpaceRef {
   /** Display label — usually the space DID (DB file basename). */
@@ -447,12 +451,12 @@ export function convergenceScanExact(
   // id -> how many spaces hold it
   const counts = new Map<string, number>();
   for (const { space } of spaces) {
-    const ids = space.db
-      .prepare(
-        `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
-      )
-      .all<{ id: string }>(branch, scope);
-    for (const { id } of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+    // Entities each space can SEE on this branch, ancestry included: a
+    // convergence scan that enumerated only local rows would silently skip
+    // entities both spaces read fine, and report agreement it never checked.
+    for (const { id } of visibleRevisionRows(space, { branch, scope })) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
   }
   const shared = [...counts.entries()].filter(([, n]) => n >= 2).map(([id]) =>
     id
@@ -506,12 +510,12 @@ export function convergenceScan(
     : buildCrossSpaceLinkIndex(spaces, { scope, branch });
   const counts = new Map<string, number>();
   for (const { space } of spaces) {
-    const ids = space.db
-      .prepare(
-        `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
-      )
-      .all<{ id: string }>(branch, scope);
-    for (const { id } of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+    // Entities each space can SEE on this branch, ancestry included: a
+    // convergence scan that enumerated only local rows would silently skip
+    // entities both spaces read fine, and report agreement it never checked.
+    for (const { id } of visibleRevisionRows(space, { branch, scope })) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
   }
   const shared = [...counts.entries()].filter(([, count]) => count >= 2).map(
     ([id]) => id,

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -32,6 +32,7 @@ import { openSpace, type SpaceDb } from "./db.ts";
 import { annotate, collectLinks } from "./decode.ts";
 import {
   getValueAt,
+  owningLink,
   reconstructDocument,
   visibleRevisionRows,
 } from "./reconstruct.ts";
@@ -161,12 +162,18 @@ function entityMeta(
   scope: string,
   branch: string,
 ): SpaceEntityView {
-  const meta = space.db
+  // Resolved through the OWNING branch, like every other surface describing one
+  // entity. `present` gates the value read below, so a branch-local count marks
+  // an inherited entity absent before reconstruction runs — and then the scan
+  // reports it as held by nobody and suppresses the divergence it exists to
+  // find.
+  const owner = owningLink(space, { branch, scope, id });
+  const meta = owner === undefined ? undefined : space.db
     .prepare(
       `SELECT max(seq) headSeq, count(*) revisions FROM revision
-       WHERE branch = ? AND id = ? AND scope_key = ?`,
+       WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ?`,
     )
-    .get<MetaRow>(branch, id, scope);
+    .get<MetaRow>(owner.branch, id, scope, owner.atSeq);
   const present = !!meta && meta.revisions > 0;
   if (!present) {
     return {
@@ -182,10 +189,10 @@ function entityMeta(
     .prepare(
       `SELECT c.session_id, c.created_at FROM revision r
        JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
        ORDER BY r.seq DESC, r.op_index DESC LIMIT 1`,
     )
-    .get<LastRow>(branch, id, scope);
+    .get<LastRow>(owner!.branch, id, scope, owner!.atSeq);
   return {
     label: "",
     present: true,

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -5,6 +5,8 @@
 import type { CommitRow, SpaceDb } from "./db.ts";
 import { hasSchedulerBasisTable } from "./db.ts";
 import { decodeStored } from "./decode.ts";
+import { branchReadChain, owningLink } from "./reconstruct.ts";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 
 export interface SpaceSummary {
   path: string;
@@ -137,7 +139,15 @@ export interface WriteEvent {
   createdAt: string;
 }
 
-/** Every write that touched an entity, in order — the "who wrote this" answer. */
+/**
+ * Every write that touched an entity, in order — the "who wrote this" answer.
+ *
+ * Read from the branch that OWNS the entity's visible row, not the branch
+ * asked about. A child branch inherits its parent's entities, so reading local
+ * rows only would answer "no history" for an entity the same branch reads
+ * fine; and for one the child overrode, the parent's writes produced nothing
+ * the reader can see, so they are not this entity's history from here.
+ */
 export function entityHistory(
   space: SpaceDb,
   opts: { id: string; scope?: string; branch?: string; limit?: number },
@@ -145,12 +155,14 @@ export function entityHistory(
   const scope = opts.scope ?? "space";
   const branch = opts.branch ?? "";
   const limit = opts.limit ?? 200;
+  const owner = owningLink(space, { branch, scope, id: opts.id });
+  if (owner === undefined) return [];
   return space.db
     .prepare(
       `SELECT r.seq, r.commit_seq, r.op_index, r.op,
               c.session_id, c.local_seq, c.created_at
        FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
        ORDER BY r.seq ASC, r.op_index ASC LIMIT ?`,
     )
     .all<{
@@ -161,7 +173,7 @@ export function entityHistory(
       session_id: string;
       local_seq: number;
       created_at: string;
-    }>(branch, opts.id, scope, limit)
+    }>(owner.branch, opts.id, scope, owner.atSeq, limit)
     .map((r) => ({
       seq: r.seq,
       commitSeq: r.commit_seq,
@@ -180,32 +192,49 @@ export interface HotEntity {
   sessions: number;
 }
 
-/** Entities ranked by write count — a contention/hot-path proxy. */
+/**
+ * Entities ranked by write count — a contention/hot-path proxy.
+ *
+ * Counted per entity on the branch that OWNS its visible row, so an entity a
+ * child branch inherited is ranked by the history the child can reach rather
+ * than dropped for having no local rows.
+ */
 export function hotEntities(
   space: SpaceDb,
   opts: { branch?: string; limit?: number } = {},
 ): HotEntity[] {
   const branch = opts.branch ?? "";
   const limit = opts.limit ?? 20;
-  return space.db
-    .prepare(
-      `SELECT r.id, r.scope_key,
-              count(*) writes, count(DISTINCT c.session_id) sessions
-       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ?
-       GROUP BY r.id, r.scope_key
-       ORDER BY writes DESC LIMIT ?`,
-    )
-    .all<{ id: string; scope_key: string; writes: number; sessions: number }>(
-      branch,
-      limit,
-    )
-    .map((r) => ({
-      id: r.id,
-      scope: r.scope_key,
-      writes: r.writes,
-      sessions: r.sessions,
-    }));
+  const perBranch = space.db.prepare(
+    `SELECT r.id, r.scope_key,
+            count(*) writes, count(DISTINCT c.session_id) sessions
+     FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+     WHERE r.branch = ? AND r.seq <= ?
+     GROUP BY r.id, r.scope_key`,
+  );
+  const out: HotEntity[] = [];
+  const claimed = new Set<string>();
+  for (const link of branchReadChain(space, branch)) {
+    for (
+      const r of perBranch.all<
+        { id: string; scope_key: string; writes: number; sessions: number }
+      >(link.branch, link.atSeq)
+    ) {
+      // Nearest link wins, as a read resolves it.
+      const key = `${r.scope_key}\u0000${r.id}`;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      out.push({
+        id: r.id,
+        scope: r.scope_key,
+        writes: r.writes,
+        sessions: r.sessions,
+      });
+    }
+  }
+  return out
+    .sort((a, b) => b.writes - a.writes || utf8Compare(a.id, b.id))
+    .slice(0, limit);
 }
 
 // Entity classification / listing moved to model.ts (`listEntityModels`),

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -233,7 +233,13 @@ export function hotEntities(
     }
   }
   return out
-    .sort((a, b) => b.writes - a.writes || utf8Compare(a.id, b.id))
+    // Scope breaks the last tie: the same id can be held in several scopes, so
+    // id alone leaves equal-write rows in whatever order the walk produced, and
+    // a limited result would return an arbitrary one of them.
+    .sort((a, b) =>
+      b.writes - a.writes || utf8Compare(a.id, b.id) ||
+      utf8Compare(a.scope, b.scope)
+    )
     .slice(0, limit);
 }
 

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -205,7 +205,11 @@ export function hotEntities(
   opts: { branch?: string; limit?: number } = {},
 ): HotEntity[] {
   const branch = opts.branch ?? "";
-  const limit = opts.limit ?? 20;
+  // Resolved at ENTRY, not at the terminal slice: the SQL this replaced refused
+  // a bad limit before reading a row, and evaluating it last would make a
+  // library caller pay the whole chain walk, group-bys and sort before the
+  // refusal landed.
+  const end = rowLimit(opts.limit ?? 20);
   const perBranch = space.db.prepare(
     `SELECT r.id, r.scope_key,
             count(*) writes, count(DISTINCT c.session_id) sessions
@@ -241,7 +245,7 @@ export function hotEntities(
       b.writes - a.writes || utf8Compare(a.id, b.id) ||
       utf8Compare(a.scope, b.scope)
     )
-    .slice(0, rowLimit(limit));
+    .slice(0, end);
 }
 
 // Entity classification / listing moved to model.ts (`listEntityModels`),

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -5,6 +5,7 @@
 import type { CommitRow, SpaceDb } from "./db.ts";
 import { hasSchedulerBasisTable } from "./db.ts";
 import { decodeStored } from "./decode.ts";
+import { rowLimit } from "./model.ts";
 import { branchReadChain, owningLink } from "./reconstruct.ts";
 import { utf8Compare } from "@commonfabric/utils/utf8";
 
@@ -240,7 +241,7 @@ export function hotEntities(
       b.writes - a.writes || utf8Compare(a.id, b.id) ||
       utf8Compare(a.scope, b.scope)
     )
-    .slice(0, limit);
+    .slice(0, rowLimit(limit));
 }
 
 // Entity classification / listing moved to model.ts (`listEntityModels`),

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -230,12 +230,18 @@ export function visibleRevisionRows(
 }
 
 /**
- * The branch that owns one entity's visible row, or undefined when the entity
- * is not visible from here at all.
+ * The branch that owns one entity's records, or undefined when no branch the
+ * read can reach holds any.
  *
  * A pass describing ONE entity's history asks this: nearest-branch ownership
  * decides which log the reader can reach, and it hides a parent's writes for an
  * entity the child overrode exactly as it hides the parent's value.
+ *
+ * NOT a readability check. It follows `visibleRevisionRows` in enumerating
+ * RECORDS, so a tombstoned entity has an owning branch while a read of it
+ * returns nothing — which is right for a history (a delete is a write worth
+ * showing) and wrong as a gate. A caller that needs "can this be read" must
+ * reconstruct, or take the entity from `visibleEntityRows`.
  */
 export function owningLink(
   space: SpaceDb,

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -230,6 +230,21 @@ export function visibleRevisionRows(
 }
 
 /**
+ * The branch that owns one entity's visible row, or undefined when the entity
+ * is not visible from here at all.
+ *
+ * A pass describing ONE entity's history asks this: nearest-branch ownership
+ * decides which log the reader can reach, and it hides a parent's writes for an
+ * entity the child overrode exactly as it hides the parent's value.
+ */
+export function owningLink(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; id: string },
+): BranchReadLink | undefined {
+  return visibleRevisionRows(space, opts)[0]?.link;
+}
+
+/**
  * Resolve the single revision row visible for `id` at `atSeq` on `branch`,
  * replicating the engine's `readRowForBranch` (`engine.ts`): take the latest
  * local row at/before `atSeq`; if the branch has NONE, inherit the parent's row

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -230,6 +230,42 @@ export function visibleRevisionRows(
 }
 
 /**
+ * Ids whose stored rows match every `data LIKE` pattern, across each branch the
+ * read can reach.
+ *
+ * The LIKE set is a CANDIDATE filter — each hit is reconstructed and tested
+ * properly by the caller — so a union across the chain is enough and no
+ * ownership arbitration belongs here: an id matched on a parent but overridden
+ * on the child reconstructs to the child's value and fails the real test on its
+ * own. Searching local rows only is what goes wrong, by never offering an
+ * inherited entity as a candidate at all.
+ */
+export function candidatesMatching(
+  space: SpaceDb,
+  opts: { branch: string; scope: string; like: readonly string[] },
+): string[] {
+  const stmt = space.db.prepare(
+    `SELECT DISTINCT id FROM revision
+     WHERE branch = ? AND scope_key = ? AND seq <= ?
+       AND ${opts.like.map(() => "data LIKE ?").join(" AND ")}`,
+  );
+  const ids = new Set<string>();
+  for (const link of branchReadChain(space, opts.branch)) {
+    for (
+      const r of stmt.all<{ id: string }>(
+        link.branch,
+        opts.scope,
+        link.atSeq,
+        ...opts.like,
+      )
+    ) {
+      ids.add(r.id);
+    }
+  }
+  return [...ids];
+}
+
+/**
  * The branch that owns one entity's records, or undefined when no branch the
  * read can reach holds any.
  *

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -283,7 +283,15 @@ export function owningLink(
   space: SpaceDb,
   opts: { branch?: string; scope?: string; id: string },
 ): BranchReadLink | undefined {
-  return visibleRevisionRows(space, opts)[0]?.link;
+  // `scope` is NOT optional in meaning, only in spelling: ownership is a
+  // property of (scope, entity), and the same id can be owned by different
+  // branches in `space` and in a user scope. Left unfiltered, the first scoped
+  // row to come back would decide, so this defaults the way the rest of the
+  // package does rather than answering about an arbitrary scope.
+  return visibleRevisionRows(space, {
+    ...opts,
+    scope: opts.scope ?? "space",
+  })[0]?.link;
 }
 
 /**

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -29,6 +29,7 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 
 import { annotate, summarize } from "./decode.ts";
 import {
+  branchReadChain,
   type EntityDocument,
   reconstructDocument,
   selectAtPath,
@@ -182,13 +183,17 @@ function scopeHasEntity(
   branch: string,
   atSeq?: number,
 ): boolean {
-  const row = space.db
-    .prepare(
-      `SELECT 1 AS one FROM revision
-       WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ? LIMIT 1`,
-    )
-    .get<{ one: number }>(branch, id, scope, atSeq ?? Number.MAX_SAFE_INTEGER);
-  return !!row;
+  // Across the chain, since a child branch inherits its parent's rows: the
+  // chain's own caps already fold in `atSeq`, so a time-travel read never sees
+  // a parent row from after the fork.
+  const stmt = space.db.prepare(
+    `SELECT 1 AS one FROM revision
+     WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ? LIMIT 1`,
+  );
+  return branchReadChain(space, branch, atSeq ?? Number.MAX_SAFE_INTEGER)
+    .some((link) =>
+      !!stmt.get<{ one: number }>(link.branch, id, scope, link.atSeq)
+    );
 }
 
 /**
@@ -312,16 +317,19 @@ export function spaceParticipants(
     return p;
   };
 
-  // commits + distinct sessions by principal — branch-filtered to match the
-  // scoped-entity counts below (which come from listScopes, also branch-scoped).
+  // Commits + distinct sessions by principal, read across the branch chain to
+  // match the scoped-entity counts below — those come from `listScopes`, which
+  // reads through ancestry, so counting only local commits would pair a child
+  // branch's inherited entities with none of the principals who wrote them.
   const branch = opts.branch ?? "";
+  const perBranch = space.db.prepare(
+    `SELECT session_id, count(*) n FROM "commit"
+     WHERE branch = ? AND seq <= ? GROUP BY session_id`,
+  );
   for (
-    const r of space.db
-      .prepare(
-        `SELECT session_id, count(*) n FROM "commit"
-         WHERE branch = ? GROUP BY session_id`,
-      )
-      .all<{ session_id: string; n: number }>(branch)
+    const r of branchReadChain(space, branch).flatMap((link) =>
+      perBranch.all<{ session_id: string; n: number }>(link.branch, link.atSeq)
+    )
   ) {
     // A commit `session_id` has the same shape as a session scope_key.
     const did = r.session_id ? parseScope(r.session_id).principal : undefined;

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -326,16 +326,30 @@ export function spaceParticipants(
     `SELECT session_id, count(*) n FROM "commit"
      WHERE branch = ? AND seq <= ? GROUP BY session_id`,
   );
-  for (
-    const r of branchReadChain(space, branch).flatMap((link) =>
-      perBranch.all<{ session_id: string; n: number }>(link.branch, link.atSeq)
-    )
-  ) {
+  // Totalled per SESSION before anything is attributed, because the two numbers
+  // combine differently across the chain: commits on a parent and on a child
+  // are different commits and add up, while one session that wrote on both is
+  // still one session. Incrementing per link would count it twice.
+  const commitsBySession = new Map<string, number>();
+  for (const link of branchReadChain(space, branch)) {
+    for (
+      const r of perBranch.all<{ session_id: string; n: number }>(
+        link.branch,
+        link.atSeq,
+      )
+    ) {
+      commitsBySession.set(
+        r.session_id,
+        (commitsBySession.get(r.session_id) ?? 0) + r.n,
+      );
+    }
+  }
+  for (const [sessionId, commits] of commitsBySession) {
     // A commit `session_id` has the same shape as a session scope_key.
-    const did = r.session_id ? parseScope(r.session_id).principal : undefined;
+    const did = sessionId ? parseScope(sessionId).principal : undefined;
     if (!did) continue;
     const p = get(did);
-    p.commits += r.n;
+    p.commits += commits;
     p.sessions += 1;
   }
 

--- a/packages/state-inspector/test/branch-visible.test.ts
+++ b/packages/state-inspector/test/branch-visible.test.ts
@@ -25,7 +25,7 @@ import { entityTimeline, spaceTimeline } from "../timetravel.ts";
 import { analyzeSpaceSignals } from "../grouping.ts";
 import { spaceParticipants, valueAsIdentity } from "../scopes.ts";
 import { convergenceExact, convergenceScanExact } from "../multispace.ts";
-import { reconstructDocument } from "../reconstruct.ts";
+import { owningLink, reconstructDocument } from "../reconstruct.ts";
 
 const SCHEMA = `
 CREATE TABLE "commit" (
@@ -517,6 +517,51 @@ describe("branch-visible", () => {
           expect(seen.overrides).toBe(true);
         },
       );
+    });
+  });
+
+  describe("owningLink() scope", () => {
+    it("answers about the shared scope by default, not whichever row comes back first", async () => {
+      const MINE = "user:did%3Akey%3AzAlice";
+      await withFork(
+        // Owned by the PARENT in `space`...
+        [{ id: "of:x", value: "parent-space" }],
+        // ...and by the CHILD in a user scope. Different owners for one id.
+        [{ id: "of:x", scope: MINE, value: "child-user" }],
+        (space) => {
+          expect(
+            owningLink(space, { branch: "kid", scope: "space", id: "of:x" })
+              ?.branch,
+          ).toBe("");
+          expect(
+            owningLink(space, { branch: "kid", scope: MINE, id: "of:x" })
+              ?.branch,
+          ).toBe("kid");
+          // Omitting scope must mean `space`, the package's default — not the
+          // first scoped row the enumeration happens to return.
+          expect(owningLink(space, { branch: "kid", id: "of:x" })?.branch)
+            .toBe("");
+        },
+      );
+    });
+  });
+
+  describe("hotEntities() limits", () => {
+    it("treats a negative limit as unlimited, as the SQL it replaced did", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        const all = hotEntities(space).map((e) => e.id);
+        expect(all.length).toBe(2);
+        // `slice(0, -1)` would drop the last, under-reporting the hot entities
+        // an operator asked to see all of. Same trap as `contendedEntities`,
+        // in its sibling in the same file.
+        expect(hotEntities(space, { limit: -1 }).map((e) => e.id)).toEqual(all);
+      });
+    });
+
+    it("applies a positive limit", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        expect(hotEntities(space, { limit: 1 }).length).toBe(1);
+      });
     });
   });
 

--- a/packages/state-inspector/test/branch-visible.test.ts
+++ b/packages/state-inspector/test/branch-visible.test.ts
@@ -1,0 +1,256 @@
+/**
+ * A child branch inherits every entity its parent held at the fork, and the
+ * surfaces that DESCRIBE entities have to see the same set a read does — or
+ * they answer "no history", "no contention", "not here" about entities the same
+ * branch reads fine, which is indistinguishable from those things being true.
+ *
+ * Ownership is the other half, and it cuts the other way: an entity the child
+ * OVERRODE has a parent log that produced nothing the child can see, so
+ * describing it with the parent's writes would credit revisions no read from
+ * here can reach. Every case below pins both directions.
+ *
+ * Surfaces that describe a branch's ACTIVITY rather than its entities —
+ * `spaceTimeline`, `churn` — stay branch-local on purpose, and the last case
+ * here holds that line so it reads as a decision rather than an oversight.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Database } from "@db/sqlite";
+
+import { openSpace, type SpaceDb } from "../db.ts";
+import { entityHistory, hotEntities } from "../queries.ts";
+import { contendedEntities } from "../conflicts.ts";
+import { entityTimeline, spaceTimeline } from "../timetravel.ts";
+import { analyzeSpaceSignals } from "../grouping.ts";
+import { reconstructDocument } from "../reconstruct.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq) VALUES ('', 999);
+`;
+
+const ALICE = "session:did%3Akey%3AzAlice:s1";
+const BOB = "session:did%3Akey%3AzBob:s2";
+
+interface Write {
+  branch?: string;
+  id: string;
+  session?: string;
+  value: unknown;
+}
+
+/**
+ * Seed a space, forking `kid` after the parent's writes so everything written
+ * on the parent is inherited and everything on `kid` is the child's own.
+ */
+async function withFork(
+  parent: Write[],
+  child: Write[],
+  run: (space: SpaceDb) => void,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "branch-visible-" });
+  const path = `${dir}/space.sqlite`;
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, branch, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, ?, '{}', '{"seq":0}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (branch, id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+  );
+  let seq = 0;
+  const write = (w: Write) => {
+    seq++;
+    const branch = w.branch ?? "";
+    commit.run(seq, branch, w.session ?? ALICE, seq);
+    rev.run(branch, w.id, seq, JSON.stringify({ value: w.value }), seq);
+  };
+  parent.forEach(write);
+  const forkSeq = seq;
+  db.prepare(
+    `INSERT INTO branch (name, parent_branch, fork_seq, head_seq)
+     VALUES ('kid', '', ?, 999)`,
+  ).run(forkSeq);
+  child.forEach((w) => write({ ...w, branch: "kid" }));
+  db.close();
+
+  const space = openSpace(path);
+  try {
+    run(space);
+  } finally {
+    space.close();
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** Two writers on `of:shared`, two on `of:quiet`, both inherited by `kid`. */
+const CONTENDED_PARENT: Write[] = [
+  { id: "of:shared", session: ALICE, value: "p1" },
+  { id: "of:shared", session: BOB, value: "p2" },
+  { id: "of:shared", session: ALICE, value: "p3" },
+  { id: "of:quiet", session: ALICE, value: "q1" },
+  { id: "of:quiet", session: BOB, value: "q2" },
+];
+
+describe("branch-visible", () => {
+  describe("entityHistory()", () => {
+    it("returns the parent's writes for an entity the child inherited", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        // The entity reads fine from `kid`, so an empty log would be a false
+        // statement about it rather than a gap the caller could notice.
+        expect(reconstructDocument(space, { id: "of:shared", branch: "kid" }))
+          .toEqual({ value: "p3" });
+        expect(
+          entityHistory(space, { id: "of:shared", branch: "kid" })
+            .map((w) => w.seq),
+        ).toEqual([1, 2, 3]);
+      });
+    });
+
+    it("returns only the child's writes for an entity the child overrode", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:quiet", value: "child" },
+      ], (space) => {
+        // The child's write is the visible row, and the value came from it
+        // alone — `reconstructWithinBranch` never composes across the fork — so
+        // the parent's two writes are not this entity's history from here.
+        expect(reconstructDocument(space, { id: "of:quiet", branch: "kid" }))
+          .toEqual({ value: "child" });
+        expect(
+          entityHistory(space, { id: "of:quiet", branch: "kid" })
+            .map((w) => w.seq),
+        ).toEqual([6]);
+      });
+    });
+
+    it("returns nothing for an entity the branch cannot see", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        expect(entityHistory(space, { id: "of:absent", branch: "kid" }))
+          .toEqual([]);
+      });
+    });
+  });
+
+  describe("entityTimeline()", () => {
+    it("replays the writes of the branch that owns the visible row", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        expect(
+          entityTimeline(space, { id: "of:shared", branch: "kid" })
+            .map((s) => s.seq),
+        ).toEqual([1, 2, 3]);
+      });
+    });
+
+    it("replays only the child's writes for an entity it overrode", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:quiet", value: "child" },
+      ], (space) => {
+        expect(
+          entityTimeline(space, { id: "of:quiet", branch: "kid" })
+            .map((s) => s.seq),
+        ).toEqual([6]);
+      });
+    });
+  });
+
+  describe("hotEntities()", () => {
+    it("ranks the entities a child inherited alongside its own", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:kidonly", value: "k" },
+      ], (space) => {
+        expect(
+          hotEntities(space, { branch: "kid" }).map((e) =>
+            `${e.id}:${e.writes}`
+          ),
+        ).toEqual(["of:shared:3", "of:quiet:2", "of:kidonly:1"]);
+      });
+    });
+
+    it("counts an overridden entity on the branch that overrode it", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:quiet", value: "child" },
+      ], (space) => {
+        const quiet = hotEntities(space, { branch: "kid" })
+          .find((e) => e.id === "of:quiet");
+        expect(quiet?.writes).toBe(1);
+      });
+    });
+  });
+
+  describe("contendedEntities()", () => {
+    it("reports contention inherited from the parent", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        // Local rows only would report NO contention on this branch, over two
+        // entities it can read that each carry two writers.
+        expect(
+          contendedEntities(space, { branch: "kid" }).map((e) =>
+            `${e.id}:${e.sessions}`
+          ),
+        ).toEqual(["of:shared:2", "of:quiet:2"]);
+      });
+    });
+
+    it("drops an entity whose override left it with one writer", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:quiet", value: "child" },
+      ], (space) => {
+        expect(
+          contendedEntities(space, { branch: "kid" }).map((e) => e.id),
+        ).toEqual(["of:shared"]);
+      });
+    });
+  });
+
+  describe("analyzeSpaceSignals()", () => {
+    it("detects a home the child branch inherited", async () => {
+      const home = {
+        $NAME: "Home",
+        createProfile: { "/": { id: "of:cp" } },
+        profiles: [],
+      };
+      await withFork([{ id: "of:home", value: home }], [], (space) => {
+        // Assert the parent detects it FIRST: without that, "the branches
+        // agree" is satisfied by both saying false, and the test could not
+        // fail.
+        expect(analyzeSpaceSignals(space).isHome).toBe(true);
+        expect(analyzeSpaceSignals(space, { branch: "kid" }).isHome).toBe(true);
+      });
+    });
+  });
+
+  describe("spaceTimeline()", () => {
+    it("stays local, because a branch's activity is not its inherited entities", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:kidonly", value: "k" },
+      ], (space) => {
+        // Deliberate, and the counterpart to everything above: this describes
+        // the commits made ON the branch. Inherited entities were created by
+        // commits that are not in this timeline, so folding them in would
+        // attribute creations to commits it never lists.
+        expect(
+          spaceTimeline(space, { branch: "kid" }).map((t) => t.commitSeq),
+        ).toEqual([6]);
+      });
+    });
+  });
+});

--- a/packages/state-inspector/test/branch-visible.test.ts
+++ b/packages/state-inspector/test/branch-visible.test.ts
@@ -20,9 +20,10 @@ import { Database } from "@db/sqlite";
 
 import { openSpace, type SpaceDb } from "../db.ts";
 import { entityHistory, hotEntities } from "../queries.ts";
-import { contendedEntities } from "../conflicts.ts";
+import { contendedEntities, entityConflicts } from "../conflicts.ts";
 import { entityTimeline, spaceTimeline } from "../timetravel.ts";
 import { analyzeSpaceSignals } from "../grouping.ts";
+import { spaceParticipants, valueAsIdentity } from "../scopes.ts";
 import { convergenceExact, convergenceScanExact } from "../multispace.ts";
 import { reconstructDocument } from "../reconstruct.ts";
 
@@ -342,6 +343,71 @@ describe("branch-visible", () => {
       });
     });
 
+    it("classifies an inherited cross-space link, not just the entity it points at", async () => {
+      const A = "did:key:zSpaceAAAA";
+      const B = "did:key:zSpaceBBBB";
+      const dir = await Deno.makeTempDir({ prefix: "branch-visible-link-" });
+      const opened: { label: string; space: SpaceDb }[] = [];
+      try {
+        for (const [did, target] of [[A, "A-value"], [B, "B-value"]]) {
+          const path = `${dir}/${did}.sqlite`;
+          const db = new Database(path, { create: true });
+          db.exec(SCHEMA);
+          const commit = db.prepare(
+            `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+             VALUES (?, ?, ?, '{}', '{"seq":0}')`,
+          );
+          const rev = db.prepare(
+            `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+             VALUES (?, ?, 0, 'set', ?, ?)`,
+          );
+          // The replica, diverging between the spaces...
+          commit.run(1, ALICE, 1);
+          rev.run("of:target", 1, JSON.stringify({ value: target }), 1);
+          // ...and a holder linking at the OTHER space's copy of it.
+          commit.run(2, ALICE, 2);
+          rev.run(
+            "of:holder",
+            2,
+            JSON.stringify({
+              value: {
+                ref: {
+                  "/": {
+                    "link@1": {
+                      id: "of:target",
+                      space: did === A ? B : A,
+                      path: [],
+                    },
+                  },
+                },
+              },
+            }),
+            2,
+          );
+          db.prepare(
+            `INSERT INTO branch (name, parent_branch, fork_seq, head_seq)
+             VALUES ('kid', '', 2, 999)`,
+          ).run();
+          db.close();
+          opened.push({ label: `${did}.sqlite`, space: openSpace(path) });
+        }
+
+        // The holder is inherited on `kid`. An index built from local rows
+        // would not see it, so the divergence in `of:target` would come back
+        // classified as an independent instance rather than a replica.
+        const onParent = convergenceScanExact(opened).findings
+          .find((f) => f.id === "of:target");
+        expect(onParent?.relationship).toBe("cross-space-linked");
+
+        const onChild = convergenceScanExact(opened, { branch: "kid" })
+          .findings.find((f) => f.id === "of:target");
+        expect(onChild?.relationship).toBe("cross-space-linked");
+      } finally {
+        for (const { space } of opened) space.close();
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
     it("reports each space as holding the inherited entity, not absent", async () => {
       await twoForkedSpaces((spaces) => {
         const result = convergenceExact(spaces, {
@@ -351,6 +417,70 @@ describe("branch-visible", () => {
         expect(result.views.map((v) => v.present)).toEqual([true, true]);
         expect(result.verdict).toBe("diverged");
       });
+    });
+  });
+
+  describe("entityConflicts()", () => {
+    it("lists the writers of an entity the child inherited", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        expect(
+          entityConflicts(space, "of:shared", { branch: "kid" })
+            .writers.map((w) => w.seq),
+        ).toEqual([1, 2, 3]);
+      });
+    });
+
+    it("lists only the child's writers for an entity it overrode", async () => {
+      await withFork(CONTENDED_PARENT, [
+        { id: "of:quiet", value: "child" },
+      ], (space) => {
+        expect(
+          entityConflicts(space, "of:quiet", { branch: "kid" })
+            .writers.map((w) => w.seq),
+        ).toEqual([6]);
+      });
+    });
+  });
+
+  describe("spaceParticipants()", () => {
+    it("counts the commits behind a branch's inherited entities", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        // `listScopes` reads through ancestry, and this pairs principals with
+        // those same scoped-entity counts — so counting local commits only
+        // would credit a child's inherited entities to nobody.
+        const dids = spaceParticipants(space, { branch: "kid" })
+          .map((p) => p.did).sort();
+        expect(dids).toEqual(spaceParticipants(space).map((p) => p.did).sort());
+        expect(dids.length).toBe(2);
+      });
+    });
+  });
+
+  describe("valueAsIdentity()", () => {
+    it("resolves through a scope the child inherited", async () => {
+      // The STORED form, which is what `resolveScopeChain` builds and what the
+      // engine writes — not the decoded spelling `parseScope` reports.
+      const MINE = "user:did%3Akey%3AzAlice";
+      await withFork(
+        [
+          { id: "of:x", value: "shared" },
+          { id: "of:x", scope: MINE, value: "mine" },
+        ],
+        [],
+        (space) => {
+          // `scopeHasEntity` gates which scope this resolves from; branch-local,
+          // it finds neither and reports the entity absent from a branch that
+          // reads it.
+          const seen = valueAsIdentity(space, {
+            id: "of:x",
+            identity: "did:key:zAlice",
+            branch: "kid",
+          });
+          expect(seen.exists).toBe(true);
+          expect(seen.resolvedScope).toBe(MINE);
+          expect(seen.overrides).toBe(true);
+        },
+      );
     });
   });
 

--- a/packages/state-inspector/test/branch-visible.test.ts
+++ b/packages/state-inspector/test/branch-visible.test.ts
@@ -456,6 +456,42 @@ describe("branch-visible", () => {
     });
   });
 
+  describe("spaceParticipants() across a chain", () => {
+    it("counts a session that wrote on both branches once, with its commits summed", async () => {
+      await withFork(
+        [{ id: "of:a", session: ALICE, value: 1 }, {
+          id: "of:b",
+          session: ALICE,
+          value: 2,
+        }],
+        [{ id: "of:c", session: ALICE, value: 3 }],
+        (space) => {
+          // Commits add across the chain — parent and child commits are
+          // different commits — while the session that made them is still one
+          // session. Attributing per link counts it twice.
+          const [alice] = spaceParticipants(space, { branch: "kid" });
+          expect(alice.commits).toBe(3);
+          expect(alice.sessions).toBe(1);
+        },
+      );
+    });
+
+    it("counts two sessions on one branch as two", async () => {
+      await withFork(
+        [{ id: "of:a", session: ALICE, value: 1 }, {
+          id: "of:b",
+          session: `session:did%3Akey%3AzAlice:s2`,
+          value: 2,
+        }],
+        [],
+        (space) => {
+          const [alice] = spaceParticipants(space, { branch: "kid" });
+          expect(alice.sessions).toBe(2);
+        },
+      );
+    });
+  });
+
   describe("valueAsIdentity()", () => {
     it("resolves through a scope the child inherited", async () => {
       // The STORED form, which is what `resolveScopeChain` builds and what the

--- a/packages/state-inspector/test/branch-visible.test.ts
+++ b/packages/state-inspector/test/branch-visible.test.ts
@@ -23,6 +23,7 @@ import { entityHistory, hotEntities } from "../queries.ts";
 import { contendedEntities } from "../conflicts.ts";
 import { entityTimeline, spaceTimeline } from "../timetravel.ts";
 import { analyzeSpaceSignals } from "../grouping.ts";
+import { convergenceExact, convergenceScanExact } from "../multispace.ts";
 import { reconstructDocument } from "../reconstruct.ts";
 
 const SCHEMA = `
@@ -53,6 +54,7 @@ const BOB = "session:did%3Akey%3AzBob:s2";
 interface Write {
   branch?: string;
   id: string;
+  scope?: string;
   session?: string;
   value: unknown;
 }
@@ -75,15 +77,22 @@ async function withFork(
      VALUES (?, ?, ?, ?, '{}', '{"seq":0}')`,
   );
   const rev = db.prepare(
-    `INSERT INTO revision (branch, id, seq, op_index, op, data, commit_seq)
-     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+    `INSERT INTO revision (branch, id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, ?, 0, 'set', ?, ?)`,
   );
   let seq = 0;
   const write = (w: Write) => {
     seq++;
     const branch = w.branch ?? "";
     commit.run(seq, branch, w.session ?? ALICE, seq);
-    rev.run(branch, w.id, seq, JSON.stringify({ value: w.value }), seq);
+    rev.run(
+      branch,
+      w.id,
+      w.scope ?? "space",
+      seq,
+      JSON.stringify({ value: w.value }),
+      seq,
+    );
   };
   parent.forEach(write);
   const forkSeq = seq;
@@ -234,6 +243,113 @@ describe("branch-visible", () => {
         // fail.
         expect(analyzeSpaceSignals(space).isHome).toBe(true);
         expect(analyzeSpaceSignals(space, { branch: "kid" }).isHome).toBe(true);
+      });
+    });
+  });
+
+  describe("hotEntities() ties", () => {
+    it("orders equal-write rows sharing an id by scope, against the walk order", async () => {
+      const MINE = "user:did:key:zAlice";
+      // The tie-break only bites where walk order and scope order DISAGREE, and
+      // one link cannot produce that: a single `GROUP BY id, scope_key` already
+      // emits scopes ascending. Across a chain it can — the walk takes the
+      // CHILD's link first, so the child's scope arrives before the parent's
+      // whatever the names are. Here the child holds the per-user scope and the
+      // parent the shared one, so the walk yields `user:…` first and the sort
+      // has to put `space` back in front.
+      await withFork(
+        [{ id: "of:x", value: 1 }],
+        [{ id: "of:x", scope: MINE, value: 2 }],
+        (space) => {
+          const hot = hotEntities(space, { branch: "kid" });
+          expect(hot.map((e) => e.scope)).toEqual(["space", MINE]);
+          // And a cap takes the same one every run rather than whichever the
+          // walk happened to reach first.
+          expect(hotEntities(space, { branch: "kid", limit: 1 })[0].scope)
+            .toBe("space");
+        },
+      );
+    });
+  });
+
+  describe("contendedEntities() limits", () => {
+    it("treats a negative limit as unlimited, as the SQL it replaced did", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        const all = contendedEntities(space).map((e) => e.id);
+        expect(all.length).toBe(2);
+        // `slice(0, -1)` would drop the last, reporting one fewer contended
+        // entity than there are — and the conflicts CLI accepts a negative.
+        expect(contendedEntities(space, { limit: -1 }).map((e) => e.id))
+          .toEqual(all);
+      });
+    });
+
+    it("applies a positive limit", async () => {
+      await withFork(CONTENDED_PARENT, [], (space) => {
+        expect(contendedEntities(space, { limit: 1 }).length).toBe(1);
+      });
+    });
+  });
+
+  describe("cross-space convergence on a child branch", () => {
+    /** Two spaces, each holding `of:shared` on the parent, values differing. */
+    async function twoForkedSpaces(
+      run: (spaces: { label: string; space: SpaceDb }[]) => void,
+    ): Promise<void> {
+      const dir = await Deno.makeTempDir({ prefix: "branch-visible-conv-" });
+      const opened: { label: string; space: SpaceDb }[] = [];
+      try {
+        for (const [label, value] of [["a", "A-value"], ["b", "B-value"]]) {
+          const path = `${dir}/${label}.sqlite`;
+          const db = new Database(path, { create: true });
+          db.exec(SCHEMA);
+          db.prepare(
+            `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+             VALUES (1, ?, 1, '{}', '{"seq":0}')`,
+          ).run(ALICE);
+          db.prepare(
+            `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+             VALUES ('of:shared', 1, 0, 'set', ?, 1)`,
+          ).run(JSON.stringify({ value }));
+          db.prepare(
+            `INSERT INTO branch (name, parent_branch, fork_seq, head_seq)
+             VALUES ('kid', '', 1, 999)`,
+          ).run();
+          db.close();
+          opened.push({ label, space: openSpace(path) });
+        }
+        run(opened);
+      } finally {
+        for (const { space } of opened) space.close();
+        await Deno.remove(dir, { recursive: true });
+      }
+    }
+
+    it("finds the divergence in an entity both spaces inherited", async () => {
+      await twoForkedSpaces((spaces) => {
+        // On the parent the scan sees it diverge. The child inherits the same
+        // entity in both spaces and reads the same two values, so the same
+        // divergence has to be found there — enumerating the id and then
+        // reporting it held by nobody would suppress the finding this scan
+        // exists for.
+        expect(convergenceScanExact(spaces).findings.map((f) => f.id))
+          .toEqual(["of:shared"]);
+        expect(
+          convergenceScanExact(spaces, { branch: "kid" }).findings.map((f) =>
+            f.id
+          ),
+        ).toEqual(["of:shared"]);
+      });
+    });
+
+    it("reports each space as holding the inherited entity, not absent", async () => {
+      await twoForkedSpaces((spaces) => {
+        const result = convergenceExact(spaces, {
+          id: "of:shared",
+          branch: "kid",
+        });
+        expect(result.views.map((v) => v.present)).toEqual([true, true]);
+        expect(result.verdict).toBe("diverged");
       });
     });
   });

--- a/packages/state-inspector/test/fingerprint.test.ts
+++ b/packages/state-inspector/test/fingerprint.test.ts
@@ -12,6 +12,7 @@ import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
 
 import { openSpace, type SpaceDb } from "../db.ts";
+import { listEntityModels } from "../model.ts";
 import {
   contentFingerprint,
   diffFingerprints,
@@ -305,6 +306,31 @@ Deno.test("a possibly truncated enumeration is refused, not fingerprinted", () =
       Error,
       "truncated enumeration",
     );
+  });
+});
+
+Deno.test("a scope holding exactly the cap is complete, and is fingerprinted", () => {
+  // The refusal boundary is EXCLUSIVE, which `FingerprintOptions.enumerationCap`
+  // states and nothing pinned: a scope of exactly `cap` entities was enumerated
+  // whole, so refusing it would withhold a hash over a complete reading. One
+  // below the count refuses; at it and above, the same hash comes back.
+  withSpace([], (space) => {
+    // The cap is compared against what the scan ENUMERATES, which is not
+    // `report.entities` — that is the post-exclusion count, smaller by the
+    // generated internal cells the fingerprint drops. Take the number the
+    // refusal actually reads.
+    const enumerated = listEntityModels(space).extent.total;
+    assert(enumerated > 1, "the fixture must hold enough to have a boundary");
+
+    assertThrows(
+      () => contentFingerprint(space, { enumerationCap: enumerated - 1 }),
+      Error,
+      "truncated enumeration",
+    );
+
+    const atCap = contentFingerprint(space, { enumerationCap: enumerated });
+    assertEquals(atCap.hash, contentFingerprint(space).hash);
+    assertEquals(atCap.entities, contentFingerprint(space).entities);
   });
 });
 

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -30,6 +30,8 @@ import { reconstructDocument } from "../reconstruct.ts";
 import { contentFingerprint } from "../fingerprint.ts";
 import { listScopes, scopeOverlay } from "../scopes.ts";
 import { buildAllDetails } from "../detail.ts";
+import { hotEntities } from "../queries.ts";
+import { contendedEntities } from "../conflicts.ts";
 import { buildSpaceGraph, subgraphAround } from "../graph.ts";
 import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
 
@@ -613,6 +615,28 @@ describe("scan-extent", () => {
       // read them as one row, no rows, and every row.
       for (const bad of [1.5, NaN, Infinity, -Infinity]) {
         expect(() => rowLimit(bad)).toThrow("whole number of rows");
+      }
+    });
+  });
+
+  describe("a row listing's refusal", () => {
+    it("lands before the scan, as the SQL LIMIT it replaced did", async () => {
+      // A space with no tables at all. If the limit were checked at the
+      // terminal slice, the walk would run first and fail on the missing
+      // `revision` table — so the error naming the LIMIT is proof the refusal
+      // came before any query, without reaching into the driver to count them.
+      const dir = await Deno.makeTempDir({ prefix: "state-inspector-ff-" });
+      const path = `${dir}/empty.sqlite`;
+      new Database(path, { create: true }).close();
+      const empty = openSpace(path);
+      try {
+        expect(() => hotEntities(empty, { limit: 1.5 }))
+          .toThrow("whole number of rows");
+        expect(() => contendedEntities(empty, { limit: 1.5 }))
+          .toThrow("whole number of rows");
+      } finally {
+        empty.close();
+        await Deno.remove(dir, { recursive: true });
       }
     });
   });

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -22,6 +22,7 @@ import {
   isCompleteScan,
   isEntityKind,
   listEntityModels,
+  rowLimit,
   scanLimit,
   visibleEntityRows,
 } from "../model.ts";
@@ -597,6 +598,22 @@ describe("scan-extent", () => {
       expect(scanLimit(-3)).toBe(0);
       expect(scanLimit(undefined)).toBe(DEFAULT_SCAN_LIMIT);
       expect(scanLimit(NaN)).toBe(DEFAULT_SCAN_LIMIT);
+    });
+  });
+
+  describe("rowLimit()", () => {
+    it("returns undefined for a negative, which a row listing reads as unlimited", () => {
+      expect(rowLimit(-1)).toBeUndefined();
+      expect(rowLimit(0)).toBe(0);
+      expect(rowLimit(20)).toBe(20);
+    });
+
+    it("refuses a limit no SQL LIMIT would have accepted", () => {
+      // SQLite answers each of these with a datatype mismatch; `slice` would
+      // read them as one row, no rows, and every row.
+      for (const bad of [1.5, NaN, Infinity, -Infinity]) {
+        expect(() => rowLimit(bad)).toThrow("whole number of rows");
+      }
     });
   });
 

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -27,7 +27,11 @@ import {
   parseEntityRef,
   summarize,
 } from "./decode.ts";
-import { reconstructDocument, selectAtPath } from "./reconstruct.ts";
+import {
+  owningLink,
+  reconstructDocument,
+  selectAtPath,
+} from "./reconstruct.ts";
 
 /** Annotation depth used for values included in diff output. */
 const COMPARE_DEPTH = 32;
@@ -458,12 +462,17 @@ export function entityTimeline(
   const scope = opts.scope ?? "space";
   const branch = opts.branch ?? "";
   const limit = opts.limit ?? 500;
-  const rows = space.db
+  // The branch that OWNS the visible row, not the branch asked about: the
+  // replay below mirrors `reconstructWithinBranch`, which never composes across
+  // a fork, so the rows to replay are that branch's. Reading local rows only
+  // would return an empty timeline for an entity the branch inherited.
+  const owner = owningLink(space, { branch, scope, id: opts.id });
+  const rows = owner === undefined ? [] : space.db
     .prepare(
       `SELECT r.seq, r.op_index, r.op, r.data, r.commit_seq,
               c.session_id, c.created_at
        FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
-       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ? AND r.seq <= ?
        ORDER BY r.seq ASC, r.op_index ASC LIMIT ?`,
     )
     .all<{
@@ -474,9 +483,9 @@ export function entityTimeline(
       commit_seq: number;
       session_id: string;
       created_at: string;
-    }>(branch, opts.id, scope, limit);
+    }>(owner.branch, opts.id, scope, owner.atSeq, limit);
 
-  // Replay this branch's rows INCREMENTALLY — apply one op per step against a
+  // Replay the owning branch's rows INCREMENTALLY — apply one op per step against a
   // running document — instead of re-reconstructing from scratch at every seq
   // (which is O(writes²) and won't return on a hot entity). The op semantics
   // mirror reconstructWithinBranch: set=decode, patch=applyPatch(doc ?? {}),


### PR DESCRIPTION
#6049 made the space-wide *scans* branch-visible and stopped there. The surfaces that describe **one entity**, and the aggregates over them, were left reading local rows only — so on a child branch they answer confidently about entities the same branch reads fine.

Measured before touching anything, on a branch inheriting two entities from its parent:

```
read of:shared from kid    : {"value":"p3"}       ← readable
entityHistory(shared, kid) : []                    ← "no history"
entityTimeline(shared, kid): []                    ← "no history"
contendedEntities(kid)     : []                    ← "no contention", over two
                                                     entities with two writers each
hotEntities(kid)           : [of:kidonly]          ← inherited entities missing
```

Each is a false statement about the entity rather than a gap a caller could notice — the failure this package keeps being wrong about.

## What changed

Everything that describes an entity resolves **ownership** first: `owningLink()` for a single entity, the chain walk for aggregates. Both live in `reconstruct.ts` beside `branchReadChain`, so the rule has one home.

| surface | file |
| --- | --- |
| `entityHistory`, `hotEntities` | `queries.ts` |
| `entityTimeline` | `timetravel.ts` |
| `contendedEntities`, `entityConflicts` (writers) | `conflicts.ts` |
| `spaceParticipants`, `scopeHasEntity` → `valueAsIdentity` | `scopes.ts` |
| `entityMeta`, both convergence scans, `buildCrossSpaceLinkIndex` | `multispace.ts` |
| `analyzeSpaceSignals`' content searches | `grouping.ts` |

The two content searches keep their `data LIKE` prefilter and run it per link — it only nominates candidates, and the branch-aware reconstruction after it is the real test. `candidatesMatching` is shared between them.

**Ownership cuts both ways, and that is the point.** An entity a child *inherited* is described with the parent's writes; one the child *overrode* with the child's alone, because `reconstructWithinBranch` never composes across a fork and the parent's writes produced nothing a read from here can reach. Every case below is pinned in both directions.

## Deliberately NOT swept — the part worth a human eye

These are judgment calls, and a reviewer that checks whether code does what it claims will not challenge an exclusion working as designed. Each is pinned by a test so it reads as a decision, but a test only proves the code matches my intent, not that the intent is right.

| left branch-local | why |
| --- | --- |
| `churn`, `spaceTimeline` | They describe the commits made **on** a branch. An inherited entity was created by a commit those timelines do not list, so folding it in would attribute a creation to a commit that is not there. |
| `entityConflicts`' stale-read scan | It resolves `rd.branch ?? c.branch` on purpose, replicating the engine's `validateConfirmedReads`. Sweeping it would break the fidelity that code exists for. Only the *writers* list moved. |
| `entities` keeps tombstones | It describes the space's *records*, which is why its `extent.total` can legitimately exceed `graph`'s over the same space. |
| `summarizeSpace` | Counts the whole store and takes no branch at all. |
| the reconstruction primitives | `resolveBranchRow` / `reconstructWithinBranch` ARE the per-link rule. |

## Row limits

`hotEntities` and `contendedEntities` were SQL `LIMIT ?` clauses, and moving the bound into a JS `slice` changed what several numbers mean. Measured rather than assumed:

```
LIMIT -1        3 rows (unlimited)     slice  3
LIMIT 1.5       datatype mismatch      slice  1
LIMIT NaN       datatype mismatch      slice  0
LIMIT Infinity  datatype mismatch      slice  3
```

SQLite accepted integers, read a negative as unlimited, and refused the rest. `rowLimit` restores exactly that, and `cf inspect hot` / `cf inspect conflicts` now refuse a non-integer before opening the space. Sited beside `scanLimit` and documented against it: a negative floors to zero for a reconstruction **cap**, and means unlimited for a row **listing**.

## Also here

A test for `FingerprintOptions.enumerationCap`'s stated boundary — "a scope holding exactly the cap is complete and accepted" — which moved from inclusive to exclusive in #6049 and was pinned by nothing. Writing it surfaced that the cap is compared against what the scan *enumerates*, while `report.entities` is the smaller post-exclusion count; a test reading the boundary off `report.entities` fails against a correct implementation.

## What review changed

Eleven findings (cubic and Sol), all addressed. Most were the same shape and it is worth stating plainly, because it is the risk in a change like this: **covering part of a set and leaving the rest.** `entityMeta` gated the convergence scan I had just made branch-visible, so inherited ids were enumerated and then reported absent — worse than before the sweep. After the fourth instance I stopped fixing them one at a time and enumerated every branch-scoped query in the package, which found three more that review had not reached.

Two later ones were a different shape: routing a query across the chain correctly and breaking an aggregate inside it (`spaceParticipants` counted one session twice), and inheriting the wrong semantics for a number moved out of SQL (the limits above).

## Verification

Every change is covered by a case that fails without it, in both directions, and each was mutation-checked — reverting a routing reds 3–5 tests. Three tests were vacuous when first written (a tie-break that passed with its comparator removed, a link-shape `collectLinks` does not recognize, a contention assertion comparing zero to zero); mutation checking is what caught them, and all three fail correctly now.

Gate: `fmt`, `lint`, `check`, `check-docs`, `check-skill-facts`, `check-no-waitfor`, state-inspector 103/103 (244 steps), cli 176/176 (214 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
