### PR TITLE
feat(piece): bulk retarget — the upgrade apply over grouped sessions (stage 3, PR 1)

### DIFF
--- a/packages/piece/deno.jsonc
+++ b/packages/piece/deno.jsonc
@@ -16,6 +16,7 @@
     // Deno-only (reads the local filesystem); kept out of the ops barrel so
     // browser-hosted importers of "./ops" never load it.
     "./ops/bulk-local": "./src/ops/bulk-local.deno.ts",
+    "./ops/bulk-retarget": "./src/ops/bulk-retarget.deno.ts",
     "./schema-compatibility": "./src/schema-compatibility.ts"
   }
 }

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -60,7 +60,9 @@ export interface RetargetSessions {
  * is, so the run stops (or never starts). `refused` is a row this run must
  * not apply — a source resolving to a different reference than the row
  * recorded. `failed` is an operational failure, state-checked; and
- * `unattempted` names the rows after a stop.
+ * `unattempted` names the rows a stop leaves untouched — the pieces of a
+ * group whose session never opened among them, nothing having been written
+ * to them.
  */
 export type RetargetVerdict =
   | "landed"
@@ -77,12 +79,20 @@ export interface RetargetRow {
   /** The plan row's phase label, carried as the plan stamped it. */
   phase?: string;
   verdict: RetargetVerdict;
-  /** What a moved, refused, or failed row broke; absent otherwise. */
+  /**
+   * What a moved, refused, or failed row broke; absent otherwise. A row
+   * names its own piece's trouble alone — the run's own, a session that
+   * would not open or close, is the report's `stopReason`.
+   */
   problem?: string;
   /**
-   * The row's wall-clock cost in milliseconds, present on attempted apply
-   * rows. The number the plan wants reported as the run proceeds: a run
-   * whose cost per piece is unknown cannot be improved.
+   * The row's wall-clock cost in milliseconds, present on every row an
+   * apply session began work on: a row reclassified as landed, moved, or
+   * refused cost the reads and resolution that reclassified it, and reports
+   * that cost as an applied row reports its write. Absent on a preflight
+   * classification and on an unattempted row, neither of which an apply
+   * session worked on. The number the plan wants reported as the run
+   * proceeds: a run whose cost per piece is unknown cannot be improved.
    */
   elapsedMs?: number;
 }
@@ -94,10 +104,20 @@ export interface RetargetReport {
   applied: number;
   /**
    * True when every row is `landed` (or, on a dry run, `outstanding` —
-   * that is the dry run's answer, not a defect): nothing moved, nothing
-   * refused, nothing failed, nothing unattempted.
+   * that is the dry run's answer, not a defect) and no session boundary
+   * failed: nothing moved, nothing refused, nothing failed, nothing
+   * unattempted, and every session this run opened was released.
    */
   complete: boolean;
+  /**
+   * Why the run stopped when no piece is at fault: a session that could not
+   * be opened or could not be released. A piece's own trouble rides its
+   * row's `problem`; a boundary failure belongs to the run rather than to
+   * any one piece, so it is reported here — and its presence makes
+   * `complete` false whatever the rows say, since a run whose session
+   * accounting broke did not finish cleanly.
+   */
+  stopReason?: string;
 }
 
 export interface RetargetOptions {
@@ -150,13 +170,38 @@ function classify(
 }
 
 /**
+ * Release a session, handing back what a failure broke instead of throwing
+ * it. Once a run holds outcomes worth reporting, a session boundary that
+ * fails must not throw them away — the rows a partial migration produced
+ * are exactly what its operator needs — so the failure is returned to be
+ * named as the run's stop reason.
+ */
+async function closeSession(
+  sessions: RetargetSessions,
+  pieces: PiecesController,
+): Promise<string | undefined> {
+  try {
+    await sessions.close(pieces);
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+/**
  * Apply a retarget plan, or — without `apply` — report where every piece
  * stands. Serial in plan order; preflight proves every row's precondition
  * before the first write; grouped sessions bound what stays live; a stop
- * names every unattempted piece. Op-less rows — the pre-state record, a
- * collection's holder among them — carry no work and are left out of the
- * report; a restore or repair row is refused outright, this run applying
- * retargets alone.
+ * names every unattempted piece. The plan's space is held against the
+ * session's, so a plan replayed elsewhere is refused rather than run
+ * against whatever pieces happen to answer to its addresses. A session
+ * boundary that fails once outcomes exist is a stop like any other — the
+ * rows stand, the remainder is named, and `stopReason` says what broke;
+ * only the preflight's own open throws, there being no report to lose.
+ * Op-less rows —
+ * the pre-state record, a collection's holder among them — carry no work
+ * and are left out of the report; a restore or repair row is refused
+ * outright, this run applying retargets alone.
  */
 export async function retargetPieces(
   sessions: RetargetSessions,
@@ -219,13 +264,27 @@ export async function retargetPieces(
     "landed" | "outstanding" | { blocked: RetargetRow }
   >();
   let startBlocked = false;
+  /** The run's own trouble, as opposed to any piece's: see `stopReason`. */
+  let sessionProblem: string | undefined;
   {
     const pieces = await sessions.open();
     try {
+      // A piece address names a piece within a space, so the same address
+      // names a different piece in another one. A plan surveyed elsewhere
+      // is refused here, before any read is classified from it.
+      if (pieces.getSpace() !== plan.header.space) {
+        throw new Error(
+          `The plan names space ${plan.header.space}; this run targets ` +
+            `${pieces.getSpace()}.`,
+        );
+      }
+      // One retained-source cache for the session: a board on one identity
+      // pays its retained load once, not once per row.
+      const retainedByIdentity = new Map<string, boolean>();
       for (const row of work) {
         const phase = row.phase === undefined ? {} : { phase: row.phase };
         try {
-          const pin = await readPiecePin(pieces, row.piece);
+          const pin = await readPiecePin(pieces, row.piece, retainedByIdentity);
           const standing = classify(pin, row);
           if (standing === "moved-elsewhere") {
             preflight.set(row.piece, {
@@ -259,7 +318,16 @@ export async function retargetPieces(
         }
       }
     } finally {
-      await sessions.close(pieces);
+      // The classification exists by now, so a preflight session that will
+      // not release keeps its report rather than losing it to a rejection —
+      // and blocks the start, nothing having been written yet.
+      const problem = await closeSession(sessions, pieces);
+      if (problem !== undefined) {
+        sessionProblem = problem +
+          "; the preflight session could not be released, so nothing was " +
+          "written.";
+        startBlocked = true;
+      }
     }
   }
   if (startBlocked || options.apply !== true) {
@@ -275,17 +343,25 @@ export async function retargetPieces(
         report(standing.blocked);
       }
     }
-    const complete = rows.every((row) =>
-      row.verdict === "landed" ||
-      (options.apply !== true && row.verdict === "outstanding")
-    );
-    return { rows, applied: 0, complete };
+    const complete = sessionProblem === undefined &&
+      rows.every((row) =>
+        row.verdict === "landed" ||
+        (options.apply !== true && row.verdict === "outstanding")
+      );
+    return {
+      rows,
+      applied: 0,
+      complete,
+      ...(sessionProblem === undefined ? {} : { stopReason: sessionProblem }),
+    };
   }
 
-  // The serial apply, in plan order, over bounded session groups. Rows the
-  // preflight saw landed are reported without a write — a resume must not
-  // rewrite them — and each remaining row's precondition is re-proved in
-  // the group's own session immediately before its write.
+  // The serial apply, in plan order, over bounded session groups. Every
+  // row's standing is proved again in its group's own session immediately
+  // before its write, the preflight's verdict deciding nothing here: a row
+  // proved landed there is reported without a write — a resume must not
+  // rewrite one — and a row another writer moved since is caught by the
+  // same read that would have skipped it.
   let applied = 0;
   let stopped = false;
   for (let start = 0; start < work.length; start += groupSize) {
@@ -297,7 +373,27 @@ export async function retargetPieces(
       }
       continue;
     }
-    const pieces = await sessions.open();
+    let pieces: PiecesController;
+    try {
+      pieces = await sessions.open();
+    } catch (error) {
+      // A session that never opened wrote nothing, so its group's pieces
+      // are unattempted rather than failed — their state is known, not
+      // unknown — and no row is at fault, so the reason is the run's. The
+      // stop names the remainder the way every other stop does.
+      sessionProblem =
+        (error instanceof Error ? error.message : String(error)) +
+        "; this group's session could not be opened, so its pieces were " +
+        "not attempted.";
+      for (const row of group) {
+        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        report({ piece: row.piece, ...phase, verdict: "unattempted" });
+      }
+      stopped = true;
+      continue;
+    }
+    // One retained-source cache for this group's session, as in preflight.
+    const retainedByIdentity = new Map<string, boolean>();
     try {
       for (const row of group) {
         const phase = row.phase === undefined ? {} : { phase: row.phase };
@@ -305,19 +401,20 @@ export async function retargetPieces(
           report({ piece: row.piece, ...phase, verdict: "unattempted" });
           continue;
         }
-        if (preflight.get(row.piece) === "landed") {
-          report({ piece: row.piece, ...phase, verdict: "landed" });
-          continue;
-        }
         const startedAt = now();
         try {
           // The precondition again, in this session, immediately before
           // the write: preflight's read has aged by up to a group's worth
           // of work.
-          const pin = await readPiecePin(pieces, row.piece);
+          const pin = await readPiecePin(pieces, row.piece, retainedByIdentity);
           const standing = classify(pin, row);
           if (standing === "landed") {
-            report({ piece: row.piece, ...phase, verdict: "landed" });
+            report({
+              piece: row.piece,
+              ...phase,
+              verdict: "landed",
+              elapsedMs: now() - startedAt,
+            });
             continue;
           }
           if (standing === "moved-elsewhere") {
@@ -327,6 +424,7 @@ export async function retargetPieces(
               verdict: "moved-elsewhere",
               problem: "The piece left its recorded reference after " +
                 "preflight; something other than this plan moved it.",
+              elapsedMs: now() - startedAt,
             });
             stopped = true;
             continue;
@@ -347,6 +445,7 @@ export async function retargetPieces(
               verdict: "refused",
               problem: `The source resolves to ${identity}, not the ` +
                 `${row.op.patternIdentity} this row recorded.`,
+              elapsedMs: now() - startedAt,
             });
             stopped = true;
             continue;
@@ -380,7 +479,11 @@ export async function retargetPieces(
           let state =
             "; the piece could not be re-read, so its state is unknown";
           try {
-            const pin = await readPiecePin(pieces, row.piece);
+            const pin = await readPiecePin(
+              pieces,
+              row.piece,
+              retainedByIdentity,
+            );
             const standing = classify(pin, row);
             state = standing === "landed"
               ? "; the piece is on the row's target reference, so the " +
@@ -402,11 +505,25 @@ export async function retargetPieces(
         }
       }
     } finally {
-      await sessions.close(pieces);
+      // This group's rows have settled, and its writes are committed. A
+      // session that will not release loses none of that: the run stops
+      // here, later groups are named as any stop names its remainder, and
+      // the reason is the run's rather than any piece's.
+      const problem = await closeSession(sessions, pieces);
+      if (problem !== undefined) {
+        sessionProblem = problem +
+          "; the session serving this group could not be released, so the " +
+          "run stopped.";
+        stopped = true;
+      }
     }
   }
-  const complete = rows.every((row) =>
-    row.verdict === "landed" || row.verdict === "applied"
-  );
-  return { rows, applied, complete };
+  const complete = sessionProblem === undefined &&
+    rows.every((row) => row.verdict === "landed" || row.verdict === "applied");
+  return {
+    rows,
+    applied,
+    complete,
+    ...(sessionProblem === undefined ? {} : { stopReason: sessionProblem }),
+  };
 }

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -61,8 +61,8 @@ export interface RetargetSessions {
  * not apply — a source resolving to a different reference than the row
  * recorded. `failed` is an operational failure, state-checked; and
  * `unattempted` names the rows a stop leaves untouched — the pieces of a
- * group whose session never opened among them, nothing having been written
- * to them.
+ * group whose session never opened, or opened onto another space, among
+ * them, nothing having been written to them.
  */
 export type RetargetVerdict =
   | "landed"
@@ -111,7 +111,8 @@ export interface RetargetReport {
   complete: boolean;
   /**
    * Why the run stopped when no piece is at fault: a session that could not
-   * be opened or could not be released. A piece's own trouble rides its
+   * be opened, could not be released, or opened onto a space other than the
+   * plan's. A piece's own trouble rides its
    * row's `problem`; a boundary failure belongs to the run rather than to
    * any one piece, so it is reported here — and its presence makes
    * `complete` false whatever the rows say, since a run whose session
@@ -192,9 +193,11 @@ async function closeSession(
  * Apply a retarget plan, or — without `apply` — report where every piece
  * stands. Serial in plan order; preflight proves every row's precondition
  * before the first write; grouped sessions bound what stays live; a stop
- * names every unattempted piece. The plan's space is held against the
- * session's, so a plan replayed elsewhere is refused rather than run
- * against whatever pieces happen to answer to its addresses. A session
+ * names every unattempted piece. The plan's space is held against every
+ * session's, so a plan replayed elsewhere is refused before it reads
+ * rather than run against whatever pieces happen to answer to its
+ * addresses — the preflight's mismatch refusing the run outright, a later
+ * group's stopping it with the remainder named. A session
  * boundary that fails once outcomes exist is a stop like any other — the
  * rows stand, the remainder is named, and `stopReason` says what broke;
  * only the preflight's own open throws, there being no report to lose.
@@ -390,6 +393,28 @@ export async function retargetPieces(
         report({ piece: row.piece, ...phase, verdict: "unattempted" });
       }
       stopped = true;
+      continue;
+    }
+    if (pieces.getSpace() !== plan.header.space) {
+      // Every session, not just the preflight's: the factory is the
+      // caller's, and a later one can answer for another space, where these
+      // addresses name different pieces — or nothing at all. The rows are
+      // untouched, so they are unattempted and the reason is the run's.
+      const mismatch = `The plan names space ${plan.header.space}; this ` +
+        `group's session targets ${pieces.getSpace()}.`;
+      for (const row of group) {
+        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        report({ piece: row.piece, ...phase, verdict: "unattempted" });
+      }
+      stopped = true;
+      // This session opened, so it is released like any other. A release
+      // that fails too is named after the mismatch and never instead of
+      // it: the wrong space is why the run stopped.
+      const closeProblem = await closeSession(sessions, pieces);
+      sessionProblem = mismatch +
+        (closeProblem === undefined
+          ? ""
+          : ` Its session could not be released either: ${closeProblem}.`);
       continue;
     }
     // One retained-source cache for this group's session, as in preflight.

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -112,9 +112,9 @@ export interface RetargetReport {
   /**
    * Why the run stopped when no piece is at fault: a session that could not
    * be opened, could not be released, or opened onto a space other than the
-   * plan's. A piece's own trouble rides its
-   * row's `problem`; a boundary failure belongs to the run rather than to
-   * any one piece, so it is reported here — and its presence makes
+   * plan's. A piece's own trouble rides its row's `problem`; a boundary
+   * failure belongs to the run rather than to any one piece, so it is
+   * reported here — and its presence makes
    * `complete` false whatever the rows say, since a run whose session
    * accounting broke did not finish cleanly.
    */
@@ -134,7 +134,13 @@ export interface RetargetOptions {
    * live at once stay bounded by it.
    */
   groupSize?: number;
-  /** Called as each row settles, for reporting as the run proceeds. */
+  /**
+   * Called as each row settles, for reporting as the run proceeds. A throw
+   * from it is the caller's error rather than the run's: it reaches the
+   * caller in place of a report, having released the session in hand, and
+   * is never mistaken for the operational failure that turns a row
+   * `failed`.
+   */
   onRow?: (row: RetargetRow) => void;
   /** The clock behind `elapsedMs`, injectable for deterministic tests. */
   now?: () => number;
@@ -253,9 +259,20 @@ export async function retargetPieces(
     throw new Error("groupSize must be a positive integer.");
   }
   const rows: RetargetRow[] = [];
+  // Set when a caller's `onRow` throws, so the row handling below can tell
+  // that error from the operational ones it classifies: the row it was
+  // handed has already settled, and re-reporting it would put one plan row
+  // in the report twice under two verdicts.
+  let reporterThrew = false;
   const report = (row: RetargetRow) => {
     rows.push(row);
-    options.onRow?.(row);
+    if (options.onRow === undefined) return;
+    try {
+      options.onRow(row);
+    } catch (error) {
+      reporterThrew = true;
+      throw error;
+    }
   };
 
   // Preflight: every row classified from one read, before the first write.
@@ -402,19 +419,24 @@ export async function retargetPieces(
       // untouched, so they are unattempted and the reason is the run's.
       const mismatch = `The plan names space ${plan.header.space}; this ` +
         `group's session targets ${pieces.getSpace()}.`;
-      for (const row of group) {
-        const phase = row.phase === undefined ? {} : { phase: row.phase };
-        report({ piece: row.piece, ...phase, verdict: "unattempted" });
-      }
       stopped = true;
-      // This session opened, so it is released like any other. A release
-      // that fails too is named after the mismatch and never instead of
-      // it: the wrong space is why the run stopped.
-      const closeProblem = await closeSession(sessions, pieces);
-      sessionProblem = mismatch +
-        (closeProblem === undefined
-          ? ""
-          : ` Its session could not be released either: ${closeProblem}.`);
+      try {
+        for (const row of group) {
+          const phase = row.phase === undefined ? {} : { phase: row.phase };
+          report({ piece: row.piece, ...phase, verdict: "unattempted" });
+        }
+      } finally {
+        // This session opened, so it is released like any other — in a
+        // `finally`, because reporting runs a caller's callback and one
+        // that throws must take a session with it. A release that fails
+        // too is named after the mismatch and never instead of it: the
+        // wrong space is why the run stopped.
+        const closeProblem = await closeSession(sessions, pieces);
+        sessionProblem = mismatch +
+          (closeProblem === undefined
+            ? ""
+            : ` Its session could not be released either: ${closeProblem}.`);
+      }
       continue;
     }
     // One retained-source cache for this group's session, as in preflight.
@@ -496,8 +518,14 @@ export async function retargetPieces(
             elapsedMs: now() - startedAt,
           });
         } catch (error) {
-          // The failure is classified by a state check made after it, the
-          // way the design requires — never a probe before.
+          // A reporting callback that threw is the caller's own error, and
+          // the row it was handed has already settled: state-checking it
+          // would report that one plan row a second time, under a verdict
+          // contradicting the one the caller just saw. It leaves instead,
+          // the group's `finally` releasing the session on the way.
+          if (reporterThrew) throw error;
+          // Every other failure is classified by a state check made after
+          // it, the way the design requires — never a probe before.
           const problem = error instanceof Error
             ? error.message
             : String(error);

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -1,0 +1,412 @@
+/**
+ * Bulk retarget: the upgrade apply. One source package moves across the
+ * pieces a plan names — serial, in plan order, each row's precondition
+ * proved before its write, stopping at the first failure with the remainder
+ * named, and recomputing what is outstanding on every invocation
+ * (docs/plans/piece-bulk-operations.md, stage 3).
+ *
+ * The plan is the whole input: each retarget row carries the reference pair
+ * the piece must still be on (`expect`) and the pair its resolved source
+ * produces (`op`), and classification compares both halves of a pair, never
+ * an identity alone. A piece on its row's `expect` pair is outstanding; on
+ * the `op` pair it landed and is not rewritten, which is what makes a
+ * re-invocation a resume; on neither, something this plan does not account
+ * for moved it, and the run stops — or never starts, when preflight finds
+ * it first.
+ *
+ * Sessions are grouped: a fresh session serves a bounded number of pieces
+ * and is then released, so the expensive warm-up is paid once per group
+ * while the pieces live at once stay bounded by the group size — a knob,
+ * not a constant. A group boundary is thereby a resume point: a run that
+ * dies inside a group loses at most that group's warm-up, because every
+ * landed row reads as landed on the next invocation.
+ *
+ * Applying implies no verdict. The verification is the survey-diff — a
+ * survey taken afterwards, compared against this plan — and it stays a
+ * separate invocation by design; this module only applies and reports.
+ *
+ * Deno-only, like the local resolution it builds on: each row's source is
+ * resolved from disk and its identity recomputed — without compiling —
+ * immediately before the write, and a source that no longer produces the
+ * reference its row recorded is refused rather than applied.
+ */
+
+import type { RuntimeProgram } from "@commonfabric/runner";
+
+import {
+  programEntryIdentity,
+  resolveLocalSourceProgram,
+} from "./bulk-local.deno.ts";
+import { normalizePlan, type PiecePlan, type RetargetOp } from "./bulk-plan.ts";
+import { readPiecePin } from "./bulk-survey.ts";
+import type { PiecesController } from "./pieces-controller.ts";
+
+/**
+ * The session supply a run draws on. `open` yields a fresh session over the
+ * target space; `close` releases one, ending the group whose pieces it kept
+ * live. Production closes by disposing the session's runtime; a test
+ * harness may defer disposal while still observing every boundary.
+ */
+export interface RetargetSessions {
+  open(): Promise<PiecesController>;
+  close(pieces: PiecesController): Promise<void>;
+}
+
+/**
+ * One piece's outcome. `landed` and `outstanding` are the preflight's
+ * verdicts — already on the op's pair, or still on the expected one — and
+ * an apply turns `outstanding` into `applied`. `moved-elsewhere` is a piece
+ * on neither of its row's pairs: nothing in the plan accounts for where it
+ * is, so the run stops (or never starts). `refused` is a row this run must
+ * not apply — a source resolving to a different reference than the row
+ * recorded. `failed` is an operational failure, state-checked; and
+ * `unattempted` names the rows after a stop.
+ */
+export type RetargetVerdict =
+  | "landed"
+  | "outstanding"
+  | "applied"
+  | "moved-elsewhere"
+  | "refused"
+  | "failed"
+  | "unattempted";
+
+/** One piece's row in a retarget report. */
+export interface RetargetRow {
+  piece: string;
+  /** The plan row's phase label, carried as the plan stamped it. */
+  phase?: string;
+  verdict: RetargetVerdict;
+  /** What a moved, refused, or failed row broke; absent otherwise. */
+  problem?: string;
+  /**
+   * The row's wall-clock cost in milliseconds, present on attempted apply
+   * rows. The number the plan wants reported as the run proceeds: a run
+   * whose cost per piece is unknown cannot be improved.
+   */
+  elapsedMs?: number;
+}
+
+/** What one retarget run found, and — under `apply` — did. */
+export interface RetargetReport {
+  rows: readonly RetargetRow[];
+  /** Sources applied. Zero on a dry run and on a fully landed re-run. */
+  applied: number;
+  /**
+   * True when every row is `landed` (or, on a dry run, `outstanding` —
+   * that is the dry run's answer, not a defect): nothing moved, nothing
+   * refused, nothing failed, nothing unattempted.
+   */
+  complete: boolean;
+}
+
+export interface RetargetOptions {
+  plan: PiecePlan;
+  /**
+   * Write the sources the rows resolve. Absent, the run is the preflight
+   * classification alone — where every piece stands, and no write at all.
+   */
+  apply?: boolean;
+  /**
+   * Pieces served by one session before it is replaced. The knob the
+   * design requires: warm-up amortizes across a group while the pieces
+   * live at once stay bounded by it.
+   */
+  groupSize?: number;
+  /** Called as each row settles, for reporting as the run proceeds. */
+  onRow?: (row: RetargetRow) => void;
+  /** The clock behind `elapsedMs`, injectable for deterministic tests. */
+  now?: () => number;
+}
+
+/** A plan row narrowed to the retarget work this run performs. */
+interface WorkRow {
+  piece: string;
+  phase?: string;
+  expect: { patternIdentity: string; symbol: string };
+  op: RetargetOp;
+}
+
+const DEFAULT_GROUP_SIZE = 25;
+
+/**
+ * Classify one pin against its row: both halves of a pair, never the
+ * identity alone — two patterns one module exports share an identity and
+ * differ only in symbol.
+ */
+function classify(
+  pin: { patternIdentity: string; symbol: string } | undefined,
+  row: WorkRow,
+): "landed" | "outstanding" | "moved-elsewhere" {
+  if (
+    pin !== undefined && pin.patternIdentity === row.op.patternIdentity &&
+    pin.symbol === row.op.symbol
+  ) return "landed";
+  if (
+    pin !== undefined && pin.patternIdentity === row.expect.patternIdentity &&
+    pin.symbol === row.expect.symbol
+  ) return "outstanding";
+  return "moved-elsewhere";
+}
+
+/**
+ * Apply a retarget plan, or — without `apply` — report where every piece
+ * stands. Serial in plan order; preflight proves every row's precondition
+ * before the first write; grouped sessions bound what stays live; a stop
+ * names every unattempted piece. Op-less rows — the pre-state record, a
+ * collection's holder among them — carry no work and are left out of the
+ * report; a restore or repair row is refused outright, this run applying
+ * retargets alone.
+ */
+export async function retargetPieces(
+  sessions: RetargetSessions,
+  options: RetargetOptions,
+): Promise<RetargetReport> {
+  const plan = normalizePlan(options.plan);
+  if (
+    (plan.header.problems?.length ?? 0) > 0 ||
+    (plan.header.outside?.length ?? 0) > 0
+  ) {
+    throw new Error(
+      "No retarget can run from an incomplete plan: its header names " +
+        "pieces the survey did not account for.",
+    );
+  }
+  const foreign = plan.rows.filter((row) =>
+    row.op !== undefined && row.op.kind !== "retarget"
+  );
+  if (foreign.length > 0) {
+    throw new Error(
+      "This run applies retargets alone; the plan carries other " +
+        "operations on: " + foreign.map((row) => row.piece).join(", ") + ".",
+    );
+  }
+  const work: WorkRow[] = plan.rows.flatMap((row) =>
+    row.op?.kind === "retarget"
+      ? [{
+        piece: row.piece,
+        ...(row.phase === undefined ? {} : { phase: row.phase }),
+        expect: {
+          patternIdentity: row.expect.patternIdentity,
+          symbol: row.expect.symbol,
+        },
+        op: row.op,
+      }]
+      : []
+  );
+  if (work.length === 0) {
+    throw new Error(
+      "The plan has no retarget rows, so there is nothing to apply.",
+    );
+  }
+  const now = options.now ?? Date.now;
+  const groupSize = options.groupSize ?? DEFAULT_GROUP_SIZE;
+  if (!Number.isSafeInteger(groupSize) || groupSize < 1) {
+    throw new Error("groupSize must be a positive integer.");
+  }
+  const rows: RetargetRow[] = [];
+  const report = (row: RetargetRow) => {
+    rows.push(row);
+    options.onRow?.(row);
+  };
+
+  // Preflight: every row classified from one read, before the first write.
+  // A piece on neither of its row's references — or one that cannot be
+  // read — keeps the run from starting at all, with every row reporting
+  // where it stands and nothing applied.
+  const preflight = new Map<
+    string,
+    "landed" | "outstanding" | { blocked: RetargetRow }
+  >();
+  let startBlocked = false;
+  {
+    const pieces = await sessions.open();
+    try {
+      for (const row of work) {
+        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        try {
+          const pin = await readPiecePin(pieces, row.piece);
+          const standing = classify(pin, row);
+          if (standing === "moved-elsewhere") {
+            preflight.set(row.piece, {
+              blocked: {
+                piece: row.piece,
+                ...phase,
+                verdict: "moved-elsewhere",
+                problem: pin === undefined
+                  ? "The piece carries no pattern identity to compare."
+                  : `The piece is on ${pin.patternIdentity}#${pin.symbol}, ` +
+                    `which is neither the reference this row recorded nor ` +
+                    `the one it produces.`,
+              },
+            });
+            startBlocked = true;
+            continue;
+          }
+          preflight.set(row.piece, standing);
+        } catch (error) {
+          preflight.set(row.piece, {
+            blocked: {
+              piece: row.piece,
+              ...phase,
+              verdict: "failed",
+              problem:
+                (error instanceof Error ? error.message : String(error)) +
+                "; the run did not start, so nothing was written.",
+            },
+          });
+          startBlocked = true;
+        }
+      }
+    } finally {
+      await sessions.close(pieces);
+    }
+  }
+  if (startBlocked || options.apply !== true) {
+    for (const row of work) {
+      const phase = row.phase === undefined ? {} : { phase: row.phase };
+      // Every work row was classified above — the loop writes one of the
+      // three outcomes for each, and duplicates cannot collapse two rows
+      // onto one key, the codec having refused them.
+      const standing = preflight.get(row.piece)!;
+      if (standing === "landed" || standing === "outstanding") {
+        report({ piece: row.piece, ...phase, verdict: standing });
+      } else {
+        report(standing.blocked);
+      }
+    }
+    const complete = rows.every((row) =>
+      row.verdict === "landed" ||
+      (options.apply !== true && row.verdict === "outstanding")
+    );
+    return { rows, applied: 0, complete };
+  }
+
+  // The serial apply, in plan order, over bounded session groups. Rows the
+  // preflight saw landed are reported without a write — a resume must not
+  // rewrite them — and each remaining row's precondition is re-proved in
+  // the group's own session immediately before its write.
+  let applied = 0;
+  let stopped = false;
+  for (let start = 0; start < work.length; start += groupSize) {
+    const group = work.slice(start, start + groupSize);
+    if (stopped) {
+      for (const row of group) {
+        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        report({ piece: row.piece, ...phase, verdict: "unattempted" });
+      }
+      continue;
+    }
+    const pieces = await sessions.open();
+    try {
+      for (const row of group) {
+        const phase = row.phase === undefined ? {} : { phase: row.phase };
+        if (stopped) {
+          report({ piece: row.piece, ...phase, verdict: "unattempted" });
+          continue;
+        }
+        if (preflight.get(row.piece) === "landed") {
+          report({ piece: row.piece, ...phase, verdict: "landed" });
+          continue;
+        }
+        const startedAt = now();
+        try {
+          // The precondition again, in this session, immediately before
+          // the write: preflight's read has aged by up to a group's worth
+          // of work.
+          const pin = await readPiecePin(pieces, row.piece);
+          const standing = classify(pin, row);
+          if (standing === "landed") {
+            report({ piece: row.piece, ...phase, verdict: "landed" });
+            continue;
+          }
+          if (standing === "moved-elsewhere") {
+            report({
+              piece: row.piece,
+              ...phase,
+              verdict: "moved-elsewhere",
+              problem: "The piece left its recorded reference after " +
+                "preflight; something other than this plan moved it.",
+            });
+            stopped = true;
+            continue;
+          }
+          const program: RuntimeProgram = await resolveLocalSourceProgram(
+            pieces.runtime,
+            row.op.source,
+          );
+          // The identity the source produces NOW, not the one it produced
+          // at plan time: a source edited since no longer lands the row's
+          // recorded reference, and applying it would land something the
+          // plan's reviewer never saw.
+          const identity = await programEntryIdentity(program);
+          if (identity !== row.op.patternIdentity) {
+            report({
+              piece: row.piece,
+              ...phase,
+              verdict: "refused",
+              problem: `The source resolves to ${identity}, not the ` +
+                `${row.op.patternIdentity} this row recorded.`,
+            });
+            stopped = true;
+            continue;
+          }
+          // No separate export check: the codec refuses a row whose symbol
+          // disagrees with its source's requested export, and the resolver
+          // echoes that request — so a decoded row's `op.symbol` is the
+          // export this program runs, by construction. A source that lost
+          // the export outright fails resolution above, named.
+          const controller = await pieces.get(row.piece, false);
+          // The override comes from the row and nowhere else, so the plan
+          // shows exactly which rows ran with the gate open.
+          await controller.setPattern(program, {
+            ...(row.op.allowIncompatible === true
+              ? { dangerouslyAllowIncompatibleSchema: true }
+              : {}),
+          });
+          applied += 1;
+          report({
+            piece: row.piece,
+            ...phase,
+            verdict: "applied",
+            elapsedMs: now() - startedAt,
+          });
+        } catch (error) {
+          // The failure is classified by a state check made after it, the
+          // way the design requires — never a probe before.
+          const problem = error instanceof Error
+            ? error.message
+            : String(error);
+          let state =
+            "; the piece could not be re-read, so its state is unknown";
+          try {
+            const pin = await readPiecePin(pieces, row.piece);
+            const standing = classify(pin, row);
+            state = standing === "landed"
+              ? "; the piece is on the row's target reference, so the " +
+                "write landed"
+              : standing === "outstanding"
+              ? "; the piece is still on its recorded reference"
+              : "; the piece is on neither of the row's references";
+          } catch {
+            // The re-read failing changes nothing: `state` already says so.
+          }
+          report({
+            piece: row.piece,
+            ...phase,
+            verdict: "failed",
+            problem: problem + state,
+            elapsedMs: now() - startedAt,
+          });
+          stopped = true;
+        }
+      }
+    } finally {
+      await sessions.close(pieces);
+    }
+  }
+  const complete = rows.every((row) =>
+    row.verdict === "landed" || row.verdict === "applied"
+  );
+  return { rows, applied, complete };
+}

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   retargetPieces,
   type RetargetReport,
+  type RetargetRow,
   type RetargetSessions,
 } from "../../src/ops/bulk-retarget.deno.ts";
 import type {
@@ -596,6 +597,79 @@ describe("bulk-retarget", () => {
     expect((await pinOf(ids[2]))?.patternIdentity).toBe(
       plan.rows[2].expect.patternIdentity,
     );
+  });
+
+  it("hands a row callback's throw back rather than failing the row it settled", async () => {
+    const { plan, ids } = await seed(3);
+    const before = { opens, closes };
+    const seen: RetargetRow[] = [];
+    let failure: unknown;
+
+    // The reporter gives up on the first row whose write lands.
+    const report = await retargetPieces(sessions, {
+      plan,
+      apply: true,
+      groupSize: 2,
+      onRow: (row) => {
+        seen.push(row);
+        if (row.verdict === "applied") {
+          throw new Error("the reporter gave up");
+        }
+      },
+    }).catch((error: unknown) => {
+      failure = error;
+      return undefined;
+    });
+
+    // One plan row, one report row: the piece whose write landed is never
+    // also reported failed, and the run does not carry on past the throw.
+    expect(seen.map((row) => row.verdict)).toEqual(["applied"]);
+    expect(seen[0].piece).toBe(ids[0]);
+    // The caller's own error reaches the caller, in place of a report.
+    expect((failure as Error | undefined)?.message).toBe(
+      "the reporter gave up",
+    );
+    expect(report).toBeUndefined();
+    // The session in hand was released on the way out.
+    expect(opens - before.opens).toBe(2);
+    expect(closes - before.closes).toBe(2);
+    // The write the caller was told about did land, and stands.
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      (plan.rows[0].op as RetargetOp).patternIdentity,
+    );
+  });
+
+  it("releases a wrong-space group's session when a row callback throws", async () => {
+    const { plan } = await seed(3);
+    const elsewhere = `${spaceName}-elsewhere`;
+    const before = { opens, closes };
+    let attempts = 0;
+    const strayGroup: RetargetSessions = {
+      open: () => {
+        attempts += 1;
+        return attempts === 3 ? openSession(elsewhere) : sessions.open();
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+
+    // The reporter gives up exactly on the row the wrong-space group names.
+    await expect(
+      retargetPieces(strayGroup, {
+        plan,
+        apply: true,
+        groupSize: 2,
+        onRow: (row) => {
+          if (row.verdict === "unattempted") {
+            throw new Error("the reporter gave up");
+          }
+        },
+      }),
+    ).rejects.toThrow("the reporter gave up");
+
+    // The run kept no session: the wrong-space one was released on the way
+    // out, so every open this run made has its close.
+    expect(opens - before.opens).toBe(3);
+    expect(closes - before.closes).toBe(3);
   });
 
   it("names the remainder when a group's session cannot be released", async () => {

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -65,20 +65,7 @@ describe("bulk-retarget", () => {
     opens = 0;
     closes = 0;
     sessions = {
-      open: async () => {
-        opens += 1;
-        const runtime = new Runtime({
-          apiUrl: new URL("http://toolshed.test"),
-          storageManager,
-        });
-        runtimes.push(runtime);
-        const pieces = new PiecesController(
-          await createSession({ identity: signer, spaceName }),
-          runtime,
-        );
-        await pieces.synced();
-        return pieces;
-      },
+      open: () => openSession(),
       // Disposal deferred to afterEach: the emulated store lives in its
       // runtimes, so closing for real would lose the space between groups.
       // The boundary itself — one close per open — is still observed.
@@ -97,6 +84,28 @@ describe("bulk-retarget", () => {
     await storageManager.close();
     await Deno.remove(dir, { recursive: true });
   });
+
+  /**
+   * A counted session over `name`, the space under test by default. Every
+   * open a run sees comes through here, so the open and close counts stay
+   * comparable however a test bends the factory.
+   */
+  async function openSession(
+    name: string = spaceName,
+  ): Promise<PiecesController> {
+    opens += 1;
+    const runtime = new Runtime({
+      apiUrl: new URL("http://toolshed.test"),
+      storageManager,
+    });
+    runtimes.push(runtime);
+    const pieces = new PiecesController(
+      await createSession({ identity: signer, spaceName: name }),
+      runtime,
+    );
+    await pieces.synced();
+    return pieces;
+  }
 
   /** Create `count` pieces on v1 and the plan retargeting them to v2. */
   async function seed(
@@ -535,6 +544,57 @@ describe("bulk-retarget", () => {
     // The writes the first group committed are still committed.
     expect((await pinOf(ids[0]))?.patternIdentity).toBe(
       (plan.rows[0].op as RetargetOp).patternIdentity,
+    );
+  });
+
+  it("stops when a group's session serves another space", async () => {
+    const { plan, ids } = await seed(3);
+    const elsewhere = `${spaceName}-elsewhere`;
+    const namer = await openSession(elsewhere);
+    const strayDid = namer.getSpace();
+    await sessions.close(namer);
+    const before = { opens, closes };
+    let attempts = 0;
+    const strayGroup: RetargetSessions = {
+      open: () => {
+        attempts += 1;
+        // Preflight and the first apply group serve the plan's space; the
+        // second group's session answers for the other one.
+        return attempts === 3 ? openSession(elsewhere) : sessions.open();
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+
+    const report = await retargetPieces(strayGroup, {
+      plan,
+      apply: true,
+      groupSize: 2,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "applied",
+      "unattempted",
+    ]);
+    expect(report.rows[2].piece).toBe(ids[2]);
+    // Untouched, not accused: the row is where the plan left it, and a run
+    // that read the wrong space would report it moved by another writer.
+    expect(report.rows[2].problem).toBeUndefined();
+    expect(report.applied).toBe(2);
+    expect(report.complete).toBe(false);
+    expect(report.stopReason).toContain(plan.header.space);
+    expect(report.stopReason).toContain(strayDid);
+    // The session opened, so it is released like any other.
+    expect(opens - before.opens).toBe(3);
+    expect(closes - before.closes).toBe(3);
+    // The other space holds nothing at that address, this run included.
+    const strayReader = await openSession(elsewhere);
+    const strayPin = await readPiecePin(strayReader, ids[2]);
+    await sessions.close(strayReader);
+    expect(strayPin).toBeUndefined();
+    // The row stands where it stood in the plan's own space.
+    expect((await pinOf(ids[2]))?.patternIdentity).toBe(
+      plan.rows[2].expect.patternIdentity,
     );
   });
 

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -1,0 +1,579 @@
+/**
+ * The retarget apply: preflight classification, the serial plan-order
+ * apply over grouped sessions, resume as re-invocation, the stop that
+ * names its remainder, and the refusals — a source resolving off its
+ * recorded reference, foreign operations, incomplete plans. Sessions come
+ * from a counting factory whose close defers disposal: the emulated store
+ * lives in its runtimes, so the boundaries are observed while the state
+ * survives; the drill exercises real disposal against a real server.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import {
+  programEntryIdentity,
+  resolveLocalSourceProgram,
+} from "../../src/ops/bulk-local.deno.ts";
+import {
+  retargetPieces,
+  type RetargetReport,
+  type RetargetSessions,
+} from "../../src/ops/bulk-retarget.deno.ts";
+import type {
+  PiecePlan,
+  PiecePlanRow,
+  RetargetOp,
+} from "../../src/ops/bulk-plan.ts";
+import { readPiecePin } from "../../src/ops/bulk-survey.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("bulk retarget");
+
+/** A generation's source text; `version` is what tells generations apart. */
+function memberSource(version: string): string {
+  return [
+    "import { NAME, pattern } from 'commonfabric';",
+    "export default pattern<{ seed?: string }>(({ seed }) => ({",
+    "  [NAME]: 'Member',",
+    `  version: ${JSON.stringify(version)},`,
+    "  seed,",
+    "}));",
+    "",
+  ].join("\n");
+}
+
+describe("bulk-retarget", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let spaceName: string;
+  let runtimes: Runtime[];
+  let opens: number;
+  let closes: number;
+  let sessions: RetargetSessions;
+  let dir: string;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    spaceName = `bulk-retarget-${crypto.randomUUID()}`;
+    runtimes = [];
+    opens = 0;
+    closes = 0;
+    sessions = {
+      open: async () => {
+        opens += 1;
+        const runtime = new Runtime({
+          apiUrl: new URL("http://toolshed.test"),
+          storageManager,
+        });
+        runtimes.push(runtime);
+        const pieces = new PiecesController(
+          await createSession({ identity: signer, spaceName }),
+          runtime,
+        );
+        await pieces.synced();
+        return pieces;
+      },
+      // Disposal deferred to afterEach: the emulated store lives in its
+      // runtimes, so closing for real would lose the space between groups.
+      // The boundary itself — one close per open — is still observed.
+      close: () => {
+        closes += 1;
+        return Promise.resolve();
+      },
+    };
+    dir = await Deno.makeTempDir({ prefix: "bulk-retarget-src" });
+    await Deno.writeTextFile(`${dir}/member-v1.tsx`, memberSource("one"));
+    await Deno.writeTextFile(`${dir}/member-v2.tsx`, memberSource("two"));
+  });
+
+  afterEach(async () => {
+    for (const runtime of runtimes) await runtime.dispose();
+    await storageManager.close();
+    await Deno.remove(dir, { recursive: true });
+  });
+
+  /** Create `count` pieces on v1 and the plan retargeting them to v2. */
+  async function seed(
+    count: number,
+  ): Promise<{ plan: PiecePlan; ids: string[] }> {
+    const setup = await sessions.open();
+    const v1 = await resolveLocalSourceProgram(setup.runtime, {
+      main: `${dir}/member-v1.tsx`,
+    });
+    const v2 = await resolveLocalSourceProgram(setup.runtime, {
+      main: `${dir}/member-v2.tsx`,
+    });
+    const v1id = await programEntryIdentity(v1);
+    const v2id = await programEntryIdentity(v2);
+    const ids: string[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const piece = await setup.create(v1, { input: { seed: `s${index}` } });
+      ids.push(piece.id);
+    }
+    await setup.synced();
+    await sessions.close(setup);
+    const rows: PiecePlanRow[] = ids.map((piece) => ({
+      piece,
+      phase: "items",
+      expect: { patternIdentity: v1id, symbol: "default", retained: true },
+      op: {
+        kind: "retarget",
+        source: { main: `${dir}/member-v2.tsx` },
+        patternIdentity: v2id,
+        symbol: "default",
+      } satisfies RetargetOp,
+    }));
+    return {
+      plan: {
+        header: {
+          kind: "piece-plan",
+          v: 1,
+          space: "did:key:test",
+          takenAt: "2026-08-25T00:00:00.000Z",
+          selector: "collection",
+          enumerated: {
+            collection: count,
+            registry: count,
+            registeredOutside: 0,
+          },
+        },
+        rows,
+      },
+      ids,
+    };
+  }
+
+  async function pinOf(piece: string) {
+    const reader = await sessions.open();
+    const pin = await readPiecePin(reader, piece);
+    await sessions.close(reader);
+    return pin;
+  }
+
+  it("classifies every row from one preflight read on a dry run", async () => {
+    const { plan } = await seed(2);
+    const before = { opens, closes };
+
+    const report = await retargetPieces(sessions, { plan });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "outstanding",
+      "outstanding",
+    ]);
+    expect(report.applied).toBe(0);
+    expect(report.complete).toBe(true);
+    // The dry run is the preflight alone: one session, opened and closed.
+    expect(opens - before.opens).toBe(1);
+    expect(closes - before.closes).toBe(1);
+  });
+
+  it("applies serially over bounded session groups, and reports timing", async () => {
+    const { plan, ids } = await seed(3);
+    const before = { opens, closes };
+    const seen: string[] = [];
+    let tick = 0;
+
+    const report = await retargetPieces(sessions, {
+      plan,
+      apply: true,
+      groupSize: 2,
+      onRow: (row) => seen.push(`${row.verdict}:${row.piece}`),
+      now: () => tick += 5,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "applied",
+      "applied",
+    ]);
+    expect(report.applied).toBe(3);
+    expect(report.complete).toBe(true);
+    expect(report.rows.every((row) => row.elapsedMs !== undefined)).toBe(true);
+    expect(seen.length).toBe(3);
+    // Preflight plus ceil(3/2) groups: three sessions, each closed.
+    expect(opens - before.opens).toBe(3);
+    expect(closes - before.closes).toBe(3);
+
+    const pin = await pinOf(ids[0]);
+    expect(pin?.patternIdentity).toBe(
+      (plan.rows[0].op as RetargetOp).patternIdentity,
+    );
+  });
+
+  it("resumes as a re-invocation: landed rows are not rewritten", async () => {
+    const { plan } = await seed(2);
+    await retargetPieces(sessions, { plan, apply: true });
+
+    const again = await retargetPieces(sessions, { plan, apply: true });
+
+    expect(again.rows.map((row) => row.verdict)).toEqual([
+      "landed",
+      "landed",
+    ]);
+    expect(again.applied).toBe(0);
+    expect(again.complete).toBe(true);
+  });
+
+  it("does not start when preflight finds a piece on neither reference", async () => {
+    const { plan, ids } = await seed(2);
+    // Something other than the plan moves the second piece: a third
+    // generation neither recorded nor produced by its row.
+    await Deno.writeTextFile(`${dir}/member-v3.tsx`, memberSource("three"));
+    const mover = await sessions.open();
+    const v3 = await resolveLocalSourceProgram(mover.runtime, {
+      main: `${dir}/member-v3.tsx`,
+    });
+    const moved = await mover.get(ids[1], false);
+    await moved.setPattern(v3);
+    await mover.synced();
+    await sessions.close(mover);
+
+    const report = await retargetPieces(sessions, { plan, apply: true });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "outstanding",
+      "moved-elsewhere",
+    ]);
+    expect(report.rows[1].problem).toContain("neither");
+    expect(report.applied).toBe(0);
+    expect(report.complete).toBe(false);
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      plan.rows[0].expect.patternIdentity,
+    );
+  });
+
+  it("refuses a source that no longer produces the recorded reference", async () => {
+    const { plan, ids } = await seed(3);
+    // The source file changes after the plan was reviewed: the recomputed
+    // identity disagrees with the row, and the row before it has landed.
+    const tampered: PiecePlan = {
+      header: plan.header,
+      rows: plan.rows.map((row, index) =>
+        index === 1
+          ? {
+            ...row,
+            op: {
+              ...(row.op as RetargetOp),
+              patternIdentity: "I".padEnd(43, "x"),
+            },
+          }
+          : row
+      ),
+    };
+
+    const report = await retargetPieces(sessions, {
+      plan: tampered,
+      apply: true,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "refused",
+      "unattempted",
+    ]);
+    expect(report.rows[1].problem).toContain("resolves to");
+    expect(report.applied).toBe(1);
+    expect(report.complete).toBe(false);
+    expect((await pinOf(ids[2]))?.patternIdentity).toBe(
+      plan.rows[2].expect.patternIdentity,
+    );
+  });
+
+  it("stops on a mid-run failure, names the rest, and completes on re-invocation", async () => {
+    const { plan, ids } = await seed(3);
+    // The second apply-session read of the middle piece fails once: the
+    // run stops there with the tail named, and the same invocation later
+    // completes from where it stood.
+    // The failure holds for the whole armed session, so the state check's
+    // own re-read fails too and the row honestly reports unknown state.
+    let armed = false;
+    const flaky: RetargetSessions = {
+      open: async () => {
+        const pieces = await sessions.open();
+        return new Proxy(pieces, {
+          get(target, prop, receiver) {
+            if (prop === "get" && armed) {
+              return (id: string, run?: boolean) => {
+                if (id === ids[1]) {
+                  return Promise.reject(new Error("the connection dropped"));
+                }
+                return target.get(id, run);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as PiecesController;
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+    const arm = () => {
+      armed = true;
+    };
+
+    const first: RetargetReport = await (async () => {
+      const preflightAware: RetargetSessions = {
+        open: (() => {
+          let calls = 0;
+          return async () => {
+            calls += 1;
+            if (calls === 2) arm();
+            return await flaky.open();
+          };
+        })(),
+        close: flaky.close,
+      };
+      return await retargetPieces(preflightAware, { plan, apply: true });
+    })();
+
+    expect(first.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "failed",
+      "unattempted",
+    ]);
+    expect(first.rows[1].problem).toContain("the connection dropped");
+    expect(first.rows[1].problem).toContain("state is unknown");
+    expect(first.rows[2].piece).toBe(ids[2]);
+    expect(first.complete).toBe(false);
+
+    const resumed = await retargetPieces(sessions, { plan, apply: true });
+    expect(resumed.rows.map((row) => row.verdict)).toEqual([
+      "landed",
+      "applied",
+      "applied",
+    ]);
+    expect(resumed.applied).toBe(2);
+    expect(resumed.complete).toBe(true);
+  });
+
+  it("blocks the start on a preflight read failure, naming the row", async () => {
+    const { plan, ids } = await seed(2);
+    const flaky: RetargetSessions = {
+      open: async () => {
+        const pieces = await sessions.open();
+        return new Proxy(pieces, {
+          get(target, prop, receiver) {
+            if (prop === "get") {
+              return (id: string, run?: boolean) => {
+                if (id === ids[1]) {
+                  return Promise.reject(new Error("the connection dropped"));
+                }
+                return target.get(id, run);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as PiecesController;
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+
+    const report = await retargetPieces(flaky, { plan, apply: true });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "outstanding",
+      "failed",
+    ]);
+    expect(report.rows[1].problem).toContain("the run did not start");
+    expect(report.applied).toBe(0);
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      plan.rows[0].expect.patternIdentity,
+    );
+  });
+
+  it("names every unattempted piece across the groups a stop skips", async () => {
+    const { plan, ids } = await seed(4);
+    const tampered: PiecePlan = {
+      header: {
+        ...plan.header,
+        enumerated: { ...plan.header.enumerated, collection: 4, registry: 4 },
+      },
+      rows: plan.rows.map((row, index) =>
+        index === 1
+          ? {
+            ...row,
+            op: {
+              ...(row.op as RetargetOp),
+              patternIdentity: "I".padEnd(43, "x"),
+            },
+          }
+          : row
+      ),
+    };
+
+    const report = await retargetPieces(sessions, {
+      plan: tampered,
+      apply: true,
+      groupSize: 2,
+    });
+
+    // The stop lands inside group one; group two is never opened, and its
+    // rows are named rather than counted.
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "refused",
+      "unattempted",
+      "unattempted",
+    ]);
+    expect(report.rows[2].piece).toBe(ids[2]);
+    expect(report.rows[3].piece).toBe(ids[3]);
+  });
+
+  it("re-proves each row in its own group session: a race skips or stops", async () => {
+    // Between preflight and a row's write, another writer moves pieces:
+    // one onto the row's own target (skipped as landed, never rewritten),
+    // and — in a second run — one onto a third generation (a stop).
+    await Deno.writeTextFile(`${dir}/member-v3.tsx`, memberSource("three"));
+    const raceTo = (main: string, victim: string): RetargetSessions => {
+      let raced = false;
+      let sessionIndex = 0;
+      return {
+        open: async () => {
+          sessionIndex += 1;
+          const applySession = sessionIndex >= 2;
+          const pieces = await sessions.open();
+          return new Proxy(pieces, {
+            get(target, prop, receiver) {
+              if (prop === "get") {
+                return async (id: string, run?: boolean) => {
+                  if (id === victim && !raced && applySession) {
+                    raced = true;
+                    const program = await resolveLocalSourceProgram(
+                      pieces.runtime,
+                      { main },
+                    );
+                    const piece = await target.get(id, false);
+                    await piece.setPattern(program, {
+                      dangerouslyAllowIncompatibleSchema: true,
+                    });
+                    await pieces.synced();
+                  }
+                  return target.get(id, run);
+                };
+              }
+              const value = Reflect.get(target, prop, receiver);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          }) as PiecesController;
+        },
+        close: (pieces) => sessions.close(pieces),
+      };
+    };
+
+    const landedRace = await seed(2);
+    const landed = await retargetPieces(
+      raceTo(`${dir}/member-v2.tsx`, landedRace.ids[0]),
+      { plan: landedRace.plan, apply: true },
+    );
+    expect(landed.rows.map((row) => row.verdict)).toEqual([
+      "landed",
+      "applied",
+    ]);
+    expect(landed.applied).toBe(1);
+
+    const movedRace = await seed(2);
+    const moved = await retargetPieces(
+      raceTo(`${dir}/member-v3.tsx`, movedRace.ids[0]),
+      { plan: movedRace.plan, apply: true },
+    );
+    expect(moved.rows.map((row) => row.verdict)).toEqual([
+      "moved-elsewhere",
+      "unattempted",
+    ]);
+    expect(moved.rows[0].problem).toContain("after preflight");
+    expect(moved.applied).toBe(0);
+  });
+
+  it("honors the compatibility override from the row field alone", async () => {
+    // The v2 here narrows the input schema, which the pattern-compatibility
+    // gate refuses; only a row carrying the override may pass it.
+    await Deno.writeTextFile(
+      `${dir}/member-incompat.tsx`,
+      [
+        "import { NAME, pattern } from 'commonfabric';",
+        "export default pattern<{ count?: number }>(({ count }) => ({",
+        "  [NAME]: 'Member',",
+        "  count,",
+        "}));",
+        "",
+      ].join("\n"),
+    );
+    const { plan, ids } = await seed(1);
+    const probe = await sessions.open();
+    const incompat = await resolveLocalSourceProgram(probe.runtime, {
+      main: `${dir}/member-incompat.tsx`,
+    });
+    const incompatId = await programEntryIdentity(incompat);
+    await sessions.close(probe);
+    const toIncompat = (allow: boolean): PiecePlan => ({
+      header: plan.header,
+      rows: [{
+        ...plan.rows[0],
+        op: {
+          kind: "retarget",
+          source: { main: `${dir}/member-incompat.tsx` },
+          patternIdentity: incompatId,
+          symbol: "default",
+          ...(allow ? { allowIncompatible: true } : {}),
+        },
+      }],
+    });
+
+    const refused = await retargetPieces(sessions, {
+      plan: toIncompat(false),
+      apply: true,
+    });
+    expect(refused.rows[0].verdict).toBe("failed");
+    expect(refused.rows[0].problem).toContain("still on its recorded");
+
+    const allowed = await retargetPieces(sessions, {
+      plan: toIncompat(true),
+      apply: true,
+    });
+    expect(allowed.rows[0].verdict).toBe("applied");
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(incompatId);
+  });
+
+  it("refuses foreign operations, empty work, and incomplete plans", async () => {
+    const { plan } = await seed(1);
+    await expect(
+      retargetPieces(sessions, {
+        plan: {
+          header: plan.header,
+          rows: [{
+            ...plan.rows[0],
+            expect: { ...plan.rows[0].expect, documentHash: "9f2c" },
+            op: { kind: "repair", fixer: "f.ts", fixerIdentity: "impl-v1" },
+          }],
+        },
+        apply: true,
+      }),
+    ).rejects.toThrow("retargets alone");
+    await expect(
+      retargetPieces(sessions, {
+        plan: {
+          header: plan.header,
+          rows: [{ piece: plan.rows[0].piece, expect: plan.rows[0].expect }],
+        },
+      }),
+    ).rejects.toThrow("nothing to apply");
+    await expect(
+      retargetPieces(sessions, {
+        plan: {
+          header: {
+            ...plan.header,
+            problems: [{ piece: "fid1:x", problem: "unreadable" }],
+          },
+          rows: plan.rows,
+        },
+      }),
+    ).rejects.toThrow("incomplete plan");
+    await expect(
+      retargetPieces(sessions, { plan, groupSize: 0 }),
+    ).rejects.toThrow("positive integer");
+  });
+});

--- a/packages/piece/test/ops/bulk-retarget.test.ts
+++ b/packages/piece/test/ops/bulk-retarget.test.ts
@@ -1,8 +1,11 @@
 /**
  * The retarget apply: preflight classification, the serial plan-order
- * apply over grouped sessions, resume as re-invocation, the stop that
- * names its remainder, and the refusals — a source resolving off its
- * recorded reference, foreign operations, incomplete plans. Sessions come
+ * apply over grouped sessions, the re-proof each row gets in its group's
+ * own session, one retained-source load per session, resume as
+ * re-invocation, the stop that names its remainder — a session boundary
+ * that fails once outcomes exist among the stops — and the refusals — a
+ * plan surveyed against another space, a source resolving off its recorded
+ * reference, foreign operations, incomplete plans. Sessions come
  * from a counting factory whose close defers disposal: the emulated store
  * lives in its runtimes, so the boundaries are observed while the state
  * survives; the drill exercises real disposal against a real server.
@@ -108,6 +111,7 @@ describe("bulk-retarget", () => {
     });
     const v1id = await programEntryIdentity(v1);
     const v2id = await programEntryIdentity(v2);
+    const space = setup.getSpace();
     const ids: string[] = [];
     for (let index = 0; index < count; index += 1) {
       const piece = await setup.create(v1, { input: { seed: `s${index}` } });
@@ -131,7 +135,7 @@ describe("bulk-retarget", () => {
         header: {
           kind: "piece-plan",
           v: 1,
-          space: "did:key:test",
+          space,
           takenAt: "2026-08-25T00:00:00.000Z",
           selector: "collection",
           enumerated: {
@@ -151,6 +155,66 @@ describe("bulk-retarget", () => {
     const pin = await readPiecePin(reader, piece);
     await sessions.close(reader);
     return pin;
+  }
+
+  /**
+   * Sessions whose `nth` close rejects: the boundary failure a run must
+   * survive with the outcomes it already holds, counting the preflight's
+   * close as the first.
+   */
+  function failingCloseAt(nth: number): RetargetSessions {
+    let attempts = 0;
+    return {
+      open: () => sessions.open(),
+      close: (pieces) => {
+        attempts += 1;
+        if (attempts === nth) {
+          return Promise.reject(new Error("the session would not release"));
+        }
+        return sessions.close(pieces);
+      },
+    };
+  }
+
+  /**
+   * Sessions whose first apply-session read of `victim` is preceded by
+   * another writer putting `main` on it — the race a group session's own
+   * read is there to catch.
+   */
+  function raceTo(main: string, victim: string): RetargetSessions {
+    let raced = false;
+    let sessionIndex = 0;
+    return {
+      open: async () => {
+        sessionIndex += 1;
+        const applySession = sessionIndex >= 2;
+        const pieces = await sessions.open();
+        return new Proxy(pieces, {
+          get(target, prop, receiver) {
+            if (prop === "get") {
+              return async (id: string, run?: boolean) => {
+                if (id === victim && !raced && applySession) {
+                  raced = true;
+                  const program = await resolveLocalSourceProgram(
+                    pieces.runtime,
+                    { main },
+                  );
+                  const piece = await target.get(id, false);
+                  await piece.setPattern(program, {
+                    dangerouslyAllowIncompatibleSchema: true,
+                  });
+                  await pieces.synced();
+                }
+                return target.get(id, run);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as PiecesController;
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
   }
 
   it("classifies every row from one preflight read on a dry run", async () => {
@@ -275,6 +339,10 @@ describe("bulk-retarget", () => {
       "unattempted",
     ]);
     expect(report.rows[1].problem).toContain("resolves to");
+    // The refused row was attempted — its reads and resolution ran — so it
+    // reports what it cost; the row after the stop was not.
+    expect(typeof report.rows[1].elapsedMs).toBe("number");
+    expect(report.rows[2].elapsedMs).toBeUndefined();
     expect(report.applied).toBe(1);
     expect(report.complete).toBe(false);
     expect((await pinOf(ids[2]))?.patternIdentity).toBe(
@@ -423,46 +491,143 @@ describe("bulk-retarget", () => {
     expect(report.rows[3].piece).toBe(ids[3]);
   });
 
+  it("names the remainder when a group's session cannot be opened", async () => {
+    const { plan, ids } = await seed(3);
+    const before = { opens, closes };
+    let attempts = 0;
+    // Preflight and the first apply group open; the second group's session
+    // does not, after two writes have already been committed.
+    const failingGroup: RetargetSessions = {
+      open: () => {
+        attempts += 1;
+        if (attempts === 3) {
+          return Promise.reject(new Error("the session could not start"));
+        }
+        return sessions.open();
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+
+    const report = await retargetPieces(failingGroup, {
+      plan,
+      apply: true,
+      groupSize: 2,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "applied",
+      "unattempted",
+    ]);
+    expect(report.rows[2].piece).toBe(ids[2]);
+    // No piece is at fault, so the reason is the run's rather than a row's.
+    expect(report.rows[2].problem).toBeUndefined();
+    expect(report.stopReason).toContain("the session could not start");
+    expect(report.stopReason).toContain("could not be opened");
+    // Nothing was written for it, so it carries no cost either.
+    expect(report.rows[2].elapsedMs).toBeUndefined();
+    expect(report.applied).toBe(2);
+    expect(report.complete).toBe(false);
+    // The session that never opened is never closed: the run's two live
+    // sessions are its two closes.
+    expect(opens - before.opens).toBe(2);
+    expect(closes - before.closes).toBe(2);
+    // The writes the first group committed are still committed.
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      (plan.rows[0].op as RetargetOp).patternIdentity,
+    );
+  });
+
+  it("names the remainder when a group's session cannot be released", async () => {
+    const { plan, ids } = await seed(3);
+
+    // Preflight releases; the first apply group's session does not, its two
+    // writes already committed.
+    const report = await retargetPieces(failingCloseAt(2), {
+      plan,
+      apply: true,
+      groupSize: 2,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "applied",
+      "unattempted",
+    ]);
+    expect(report.rows[2].piece).toBe(ids[2]);
+    expect(report.stopReason).toContain("the session would not release");
+    expect(report.stopReason).toContain("could not be released");
+    expect(report.applied).toBe(2);
+    expect(report.complete).toBe(false);
+    // The writes the group committed outlive the failure that followed them.
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      (plan.rows[0].op as RetargetOp).patternIdentity,
+    );
+    expect((await pinOf(ids[1]))?.patternIdentity).toBe(
+      (plan.rows[1].op as RetargetOp).patternIdentity,
+    );
+    // The named piece is untouched: its group never opened.
+    expect((await pinOf(ids[2]))?.patternIdentity).toBe(
+      plan.rows[2].expect.patternIdentity,
+    );
+  });
+
+  it("reports a last group that cannot be released as an incomplete run", async () => {
+    const { plan } = await seed(2);
+
+    // Every row applied, and then the only apply group's session would not
+    // release. There is no remainder to name, so the reason is all that
+    // separates this from a clean completion — and it must.
+    const report = await retargetPieces(failingCloseAt(2), {
+      plan,
+      apply: true,
+    });
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "applied",
+      "applied",
+    ]);
+    expect(report.applied).toBe(2);
+    expect(report.complete).toBe(false);
+    expect(report.stopReason).toContain("could not be released");
+  });
+
+  it("keeps the classification when the preflight session cannot be released", async () => {
+    const { plan, ids } = await seed(2);
+
+    const dry = await retargetPieces(failingCloseAt(1), { plan });
+
+    expect(dry.rows.map((row) => row.verdict)).toEqual([
+      "outstanding",
+      "outstanding",
+    ]);
+    expect(dry.applied).toBe(0);
+    expect(dry.complete).toBe(false);
+    expect(dry.stopReason).toContain("preflight session could not be released");
+
+    // The same failure on an apply run blocks the start: the classification
+    // is reported and nothing is written.
+    const attempted = await retargetPieces(failingCloseAt(1), {
+      plan,
+      apply: true,
+    });
+
+    expect(attempted.rows.map((row) => row.verdict)).toEqual([
+      "outstanding",
+      "outstanding",
+    ]);
+    expect(attempted.applied).toBe(0);
+    expect(attempted.complete).toBe(false);
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      plan.rows[0].expect.patternIdentity,
+    );
+  });
+
   it("re-proves each row in its own group session: a race skips or stops", async () => {
     // Between preflight and a row's write, another writer moves pieces:
     // one onto the row's own target (skipped as landed, never rewritten),
     // and — in a second run — one onto a third generation (a stop).
     await Deno.writeTextFile(`${dir}/member-v3.tsx`, memberSource("three"));
-    const raceTo = (main: string, victim: string): RetargetSessions => {
-      let raced = false;
-      let sessionIndex = 0;
-      return {
-        open: async () => {
-          sessionIndex += 1;
-          const applySession = sessionIndex >= 2;
-          const pieces = await sessions.open();
-          return new Proxy(pieces, {
-            get(target, prop, receiver) {
-              if (prop === "get") {
-                return async (id: string, run?: boolean) => {
-                  if (id === victim && !raced && applySession) {
-                    raced = true;
-                    const program = await resolveLocalSourceProgram(
-                      pieces.runtime,
-                      { main },
-                    );
-                    const piece = await target.get(id, false);
-                    await piece.setPattern(program, {
-                      dangerouslyAllowIncompatibleSchema: true,
-                    });
-                    await pieces.synced();
-                  }
-                  return target.get(id, run);
-                };
-              }
-              const value = Reflect.get(target, prop, receiver);
-              return typeof value === "function" ? value.bind(target) : value;
-            },
-          }) as PiecesController;
-        },
-        close: (pieces) => sessions.close(pieces),
-      };
-    };
 
     const landedRace = await seed(2);
     const landed = await retargetPieces(
@@ -474,6 +639,9 @@ describe("bulk-retarget", () => {
       "applied",
     ]);
     expect(landed.applied).toBe(1);
+    // The skipped row was still attempted: the read that reclassified it
+    // cost what it cost, and the row reports it.
+    expect(typeof landed.rows[0].elapsedMs).toBe("number");
 
     const movedRace = await seed(2);
     const moved = await retargetPieces(
@@ -485,7 +653,99 @@ describe("bulk-retarget", () => {
       "unattempted",
     ]);
     expect(moved.rows[0].problem).toContain("after preflight");
+    expect(typeof moved.rows[0].elapsedMs).toBe("number");
+    expect(moved.rows[1].elapsedMs).toBeUndefined();
     expect(moved.applied).toBe(0);
+  });
+
+  it("stops when a row preflight saw landed is moved before its group runs", async () => {
+    // The preflight verdict decides nothing at write time: a row already on
+    // its target when the run started is proved again in its group's
+    // session, so a writer moving it in between is a stop rather than a
+    // report of a completion that never happened.
+    await Deno.writeTextFile(`${dir}/member-v3.tsx`, memberSource("three"));
+    const { plan, ids } = await seed(2);
+    const lander = await sessions.open();
+    const v2 = await resolveLocalSourceProgram(lander.runtime, {
+      main: `${dir}/member-v2.tsx`,
+    });
+    const already = await lander.get(ids[0], false);
+    await already.setPattern(v2);
+    await lander.synced();
+    await sessions.close(lander);
+
+    const report = await retargetPieces(
+      raceTo(`${dir}/member-v3.tsx`, ids[0]),
+      { plan, apply: true },
+    );
+
+    expect(report.rows.map((row) => row.verdict)).toEqual([
+      "moved-elsewhere",
+      "unattempted",
+    ]);
+    expect(report.rows[0].problem).toContain("after preflight");
+    expect(report.applied).toBe(0);
+    expect(report.complete).toBe(false);
+  });
+
+  it("loads a retained source once per session rather than once per row", async () => {
+    // Every row of a board on one generation shares one retained-source
+    // load within a session: the cache is the session's, so the loads a run
+    // pays are its session count, not its row count.
+    let loads = 0;
+    const counted: RetargetSessions = {
+      open: async () => {
+        const pieces = await sessions.open();
+        const patternManager = new Proxy(pieces.runtime.patternManager, {
+          get(target, prop) {
+            if (prop === "getPatternSourceProgramByIdentity") {
+              return (
+                ...args: Parameters<
+                  typeof target.getPatternSourceProgramByIdentity
+                >
+              ) => {
+                loads += 1;
+                return target.getPatternSourceProgramByIdentity(...args);
+              };
+            }
+            const value = Reflect.get(target, prop);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+        const runtime = new Proxy(pieces.runtime, {
+          get(target, prop) {
+            if (prop === "patternManager") return patternManager;
+            const value = Reflect.get(target, prop);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+        return new Proxy(pieces, {
+          get(target, prop, receiver) {
+            if (prop === "runtime") return runtime;
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as PiecesController;
+      },
+      close: (pieces) => sessions.close(pieces),
+    };
+    const { plan } = await seed(3);
+
+    await retargetPieces(counted, { plan });
+    // The dry run is the preflight session alone, and its three rows share
+    // one generation.
+    expect(loads).toBe(1);
+
+    loads = 0;
+    const report = await retargetPieces(counted, {
+      plan,
+      apply: true,
+      groupSize: 2,
+    });
+
+    expect(report.applied).toBe(3);
+    // Preflight plus two apply groups: one load each, not one per row.
+    expect(loads).toBe(3);
   });
 
   it("honors the compatibility override from the row field alone", async () => {
@@ -536,6 +796,29 @@ describe("bulk-retarget", () => {
     });
     expect(allowed.rows[0].verdict).toBe("applied");
     expect((await pinOf(ids[0]))?.patternIdentity).toBe(incompatId);
+  });
+
+  it("refuses a plan surveyed against another space", async () => {
+    // A piece address names a piece within a space; replayed elsewhere, the
+    // same addresses can name pieces the plan's reviewer never saw.
+    const { plan, ids } = await seed(1);
+
+    await expect(
+      retargetPieces(sessions, {
+        plan: {
+          header: { ...plan.header, space: "did:key:somewhere-else" },
+          rows: plan.rows,
+        },
+        apply: true,
+      }),
+    ).rejects.toThrow(
+      `The plan names space did:key:somewhere-else; this run targets ` +
+        `${plan.header.space}.`,
+    );
+
+    expect((await pinOf(ids[0]))?.patternIdentity).toBe(
+      plan.rows[0].expect.patternIdentity,
+    );
   });
 
   it("refuses foreign operations, empty work, and incomplete plans", async () => {


### PR DESCRIPTION
## Why

Stages 1 and 2 landed the survey and the repair (#6211/#6213/#6214, #6255/#6264). Stage 3 is the arc's point: the upgrade apply — one source package moved across the pieces a plan names — which is what the Topics rehearsal and eventually the real board migration run on. This is the library half; the `cf piece retarget` entry point (spelling settled with @mpsalisbury — `cf piece apply` was taken by the whole-document input write), `cf piece survey --diff`, the drill, and the demo conversions follow in a stacked change.

## What Changed

- `packages/piece/src/ops/bulk-retarget.deno.ts` — `retargetPieces(sessions, {plan, apply?, groupSize?, onRow?, now?})`. Preflight classifies every row from one read before the first write (`landed` / `outstanding` / `moved-elsewhere`, both halves of the reference pair, never identity alone); a moved or unreadable piece keeps the run from starting with every row reporting its standing. The serial pass runs in plan order over **grouped sessions** — a fresh session per bounded group, size as a knob — re-proves each row's precondition in its own group's session, resolves the row's source from disk and recomputes its identity (refusing a source that no longer produces the recorded reference, by both identities), honors `allowIncompatible` from the row field alone, and reports per-piece timing as the run proceeds. A stop names every unattempted piece; failures get the after-the-fact state check. Applying implies no verdict — verification remains the survey-diff, a separate invocation.
- `packages/piece/test/ops/bulk-retarget.test.ts` — 11 steps: dry preflight (one session, opened and closed), the grouped apply with session/close counts and timing, resume-as-reinvocation, preflight blocks (moved piece; unreadable piece), the tampered-source refusal with the remainder named across skipped groups, mid-run failure with unknown-state reporting and completion by re-invocation, both post-preflight races (onto the target → skipped as landed; onto a third generation → stop), the compatibility override honored per row, and the plan-shape refusals. The session factory counts boundaries while deferring disposal — the emulated store lives in its runtimes (measured; the persistence test's precedent) — and the drill will exercise real disposal against a real server.

## Test plan

`deno task check` green; fmt/lint clean; the piece ops suite green (171 steps) with the engine at zero unhit lines, verified directly against the lcov rather than through the diff intersect — which this round taught me can lie when the branch has no commits yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

