### PR TITLE
fix(ts-transformers): every stripper reads the whole wrapper set

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -748,6 +748,13 @@ that reference to the defining module identity, export symbol, exact manifest
 digest, and an owning-space placeholder. Direct imports and pinned `cf:` imports
 retain the dependency's identity.
 
+Both recognizers read a declaration's initializer through the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes), so an
+authored rule or ruleset is recognized however it is spelled. A spelling not
+stripped does not surface as a wrapper problem: the authoring pass reports the
+rule as invalid, and the `PolicyOf` pass reports that the binding must resolve
+to an `exchangeRules()` declaration — each naming the declaration rather than
+the wrapper that hid it.
+
 `WriteAuthorizedByValidationTransformer` separately validates writer-binding
 claims.
 
@@ -1027,6 +1034,19 @@ The rewriter uses normalized data-flow dependencies and ordered emitters:
 7. prefix unary
 8. container expression
 
+The container emitter owns a literal that holds other expressions, and a
+transparent wrapper around one: it rewrites the children and leaves the
+container unwrapped. It reads the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes), so a wrapped container is owned on the
+same terms as a bare one.
+
+The data-flow analysis behind these emitters reads that same set twice. An
+expression wrapped in it is analyzed as the expression it wraps, which is what
+carries the inner analysis's `rewriteHint` out to the caller — a spelling not
+named there falls to the generic child walk, which merges through
+`mergeAnalyses` and drops the hint. Normalization then groups flows by their
+normalized text, and strips the set before comparing, so flows differing only
+by a wrapper collapse into one dependency instead of splitting.
+
 Key rewrite rules:
 
 - `a && b`: lowers to `when(condition, value)` only in pattern context
@@ -1123,7 +1143,13 @@ Transforms inline JSX event handlers:
 
 - `<el onClick={() => ...} />` ->
   `onClick={handler<Event,State>((event, params) => ...)(captures)}`
-- currently unwraps arrow functions only (not function expressions)
+- currently unwraps arrow functions only (not function expressions), and
+  reaches the arrow through the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes)
+- boundary classification looks for the JSX attribute from the outermost
+  wrapper around the callback rather than from the callback itself, so
+  extraction and classification agree on where the callback sits. When they
+  disagree the cost is a false positive on legal source — a wrapped handler
+  draws `pattern-context:*` diagnostics its bare spelling does not
 - preserves body after recursive child transforms
 
 ### 9.3 Action strategy

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -808,8 +808,11 @@ reports:
   (`src/transformers/verb-return-validation.ts`) — a block body contains a
   top-level `return <expr>` whose expression is **definitely plain-shaped**:
   an object/array literal, a string/number/boolean/null literal, a template
-  string, or arithmetic/concatenation over such operands (recursing through
-  parentheses, non-`any` assertions, and conditionals). The message points
+  string, or arithmetic/concatenation over such operands (recursing through the
+  transparent wrapper set — parentheses, `as`, `<T>x`, `satisfies`, `!`, and
+  partially emitted nodes — and through conditionals). An assertion whose type
+  is `any` opts the expression out whichever assertion form carries it, because
+  the validator then cannot judge the shape. The message points
   the author at declaring the result (`action<Event, Result>` /
   `handler<Event, State, Result>`) or using a bare `return;` for an early
   exit.
@@ -1135,7 +1138,10 @@ Transforms `action(...)` to handler factory invocation:
   emitted `handler`, which is where the declared result would otherwise be
   lost: the rewritten call carries schemas rather than the authored type
   arguments. SchemaInjection lowers that slot (§10.3).
-- callback extraction currently supports arrow callbacks only
+- callback extraction supports arrow callbacks only, and reaches the arrow
+  through the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes). The whole set comes off: a spelling left on hides the callback
+  from this strategy, and `action(...)` then survives into the emitted module,
+  where the runtime throws because `action` exists only to be lowered here
 
 ### 9.4 Array-method strategy
 
@@ -1591,6 +1597,12 @@ builder call to a named module-scope `const` and rewrites the original site to
 reference that name. Three builder shapes are registered in
 `HOISTABLE_BUILDERS`:
 
+A module-scope `const` initializer is read through the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes) before its builder
+shape is matched, so a wrapped builder const registers in `__cfReg` on the same
+terms as a bare one. A spelling not stripped costs the const its
+content-addressed provenance and drops it to the SES source fallback at resolve
+time.
+
 - **Applied builders** (`lift`, `handler`): the site is `builder(...)(captures)`
   — the callee is itself the inner `builder(...)` call. Hoist the inner call,
   leave `__cfLift_N(captures)` / `__cfHandler_N(captures)` at the site (any
@@ -1908,6 +1920,10 @@ in the one window where its inference is pure syntax: handler factories are
 already hoisted with LITERAL bound-state schemas, the pattern call carries its
 generated result-schema literal, and the callback's returned identifiers are
 not yet `.for(...)`-wrapped.
+
+Expressions this inference reads — the returned verb and the values it walks
+to reach an action — are read through the transparent wrapper set (parentheses, `as`, `<T>x`, `satisfies`, `!`, and partially emitted nodes), so a wrapped verb marks as its bare
+form does.
 
 For each `pattern(cb, argumentSchema, resultSchema)` call it marks
 result-schema stream properties `tier: "wrapper"` — the verb-listing mark

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1850,10 +1850,10 @@ Behavior:
 2. evaluate literal options object — string, boolean and `null` literals,
    object and array literals, and numbers in any of their spellings (bare
    literal, sign-prefixed, or the `NaN` / `Infinity` globals, the latter only
-   where the name is not shadowed). Parentheses and the type-only assertion
-   forms (`as`, `satisfies`, `<T>x`) are transparent at any depth, including
-   nested inside a sign (`-(1 as number)`). A property whose value is none of
-   these is dropped from the options object.
+   where the name is not shadowed). The transparent wrapper set — parentheses
+   and the type-only assertion forms `as`, `satisfies`, `<T>x`, `!` — is
+   transparent at any depth, including nested inside a sign (`-(1 as number)`).
+   A property whose value is none of these is dropped from the options object.
 
    The code carries a `checker.getConstantValue()` fallback intended to recover
    a named constant or enum member. It runs, but the call returns `undefined`

--- a/packages/ts-transformers/src/ast/call-arguments.ts
+++ b/packages/ts-transformers/src/ast/call-arguments.ts
@@ -1,5 +1,7 @@
 import ts from "typescript";
 
+import { outermostTransparentWrapper } from "../utils/expression.ts";
+
 /**
  * A node's position as a direct call argument: the call that lists it, the
  * argument node as listed, and its index in the argument list.
@@ -26,19 +28,20 @@ export interface CallArgumentPosition {
  * the two spellings apart. Parentheses only: type-level wrappers (`as`,
  * `satisfies`) change what the checker sees and stay visible to callers.
  *
- * Returns undefined when `node` (paren wrappers included) is not a direct
+ * Returns undefined when `node` (transparent wrappers included) is not a direct
  * argument of a call — including when it is the callee, or an argument of a
  * `new` expression.
  */
 export function getCallArgumentPosition(
   node: ts.Node,
 ): CallArgumentPosition | undefined {
-  let argument: ts.Node = node;
-  let parent: ts.Node | undefined = node.parent;
-  while (parent && ts.isParenthesizedExpression(parent)) {
-    argument = parent;
-    parent = parent.parent;
-  }
+  // The argument the call actually holds is the outermost transparent wrapper
+  // around `node`, so the walk runs out to the usage site and reports that node
+  // rather than the inner one — callers index into `call.arguments` with it.
+  const argument: ts.Node = ts.isExpression(node)
+    ? outermostTransparentWrapper(node)
+    : node;
+  const parent: ts.Node | undefined = argument.parent;
   if (!parent || !ts.isCallExpression(parent) || !ts.isExpression(argument)) {
     return undefined;
   }

--- a/packages/ts-transformers/src/ast/call-arguments.ts
+++ b/packages/ts-transformers/src/ast/call-arguments.ts
@@ -10,9 +10,9 @@ export interface CallArgumentPosition {
   /** The call whose argument list carries the node. */
   readonly call: ts.CallExpression;
 
-  /** The node `call.arguments` lists — the queried node itself, or the
-   *  outermost parenthesized wrapper around it. Identity comparisons against
-   *  entries of `call.arguments` must use this node, never the queried one. */
+  /** The node `call.arguments` lists — the queried node itself, or its
+   *  outermost transparent wrapper. Identity comparisons against entries of
+   *  `call.arguments` must use this node, never the queried one. */
   readonly argument: ts.Expression;
 
   /** Index of `argument` within `call.arguments`. */
@@ -20,13 +20,12 @@ export interface CallArgumentPosition {
 }
 
 /**
- * Locates the call that lists `node` as a direct argument, treating
- * parentheses as spelling: `f(((x) => 0))` occupies the same argument
- * position as `f((x) => 0)`, per the paren-invariance the target-language
- * spec holds across site classification (§5.7). Argument-position decisions —
- * membership, index, owning call — go through here so no classifier can tell
- * the two spellings apart. Parentheses only: type-level wrappers (`as`,
- * `satisfies`) change what the checker sees and stay visible to callers.
+ * Locates the call that lists `node` as a direct argument, walking outward
+ * through the transparent-wrapper set. Argument-position decisions —
+ * membership, index, owning call — go through here so wrapper spelling cannot
+ * change a node's position. The returned `argument` is still the outermost
+ * wrapper actually listed by the call, so callers can inspect type-level
+ * wrappers when their semantics matter.
  *
  * Returns undefined when `node` (transparent wrappers included) is not a direct
  * argument of a call — including when it is the callee, or an argument of a

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -1064,20 +1064,13 @@ export function createDataFlowAnalyzer(
       };
     }
 
-    if (ts.isParenthesizedExpression(expression)) {
-      return analyzeExpression(expression.expression, scope, context);
-    }
-
-    if (ts.isAsExpression(expression)) {
-      return analyzeExpression(expression.expression, scope, context);
-    }
-
-    if (ts.isTypeAssertionExpression(expression)) {
-      return analyzeExpression(expression.expression, scope, context);
-    }
-
-    if (ts.isNonNullExpression(expression)) {
-      return analyzeExpression(expression.expression, scope, context);
+    // A transparent wrapper is analyzed as the expression it wraps. This has to
+    // name the whole set: an unlisted spelling falls to the generic child walk
+    // below, which reaches the same operands but merges them through
+    // `mergeAnalyses` and so drops the inner `rewriteHint`.
+    const unwrappedTarget = unwrapTransparentWrapperOnce(expression);
+    if (unwrappedTarget) {
+      return analyzeExpression(unwrappedTarget, scope, context);
     }
 
     if (ts.isConditionalExpression(expression)) {

--- a/packages/ts-transformers/src/ast/normalize.ts
+++ b/packages/ts-transformers/src/ast/normalize.ts
@@ -1,5 +1,7 @@
 import ts from "typescript";
 
+import { unwrapTransparentWrapperOnce } from "../utils/expression.ts";
+
 import type {
   DataFlowAnalysis,
   DataFlowGraph,
@@ -240,21 +242,13 @@ export function normalizeDataFlows(
 
     // Only normalize away truly meaningless wrappers that don't change semantics
     while (true) {
-      // Remove parentheses - purely syntactic, no semantic difference
-      if (ts.isParenthesizedExpression(current)) {
-        current = current.expression;
-        continue;
-      }
-
-      // Remove type assertions - don't affect runtime behavior
-      if (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
-        current = current.expression;
-        continue;
-      }
-
-      // Remove non-null assertions - don't affect runtime behavior
-      if (ts.isNonNullExpression(current)) {
-        current = current.expression;
+      // Remove transparent wrappers - parentheses are purely syntactic, and
+      // the assertion forms do not affect runtime behavior. Two data flows that
+      // differ only by one of these normalize to the same expression and group
+      // together, so the set has to be the whole one.
+      const unwrapped = unwrapTransparentWrapperOnce(current);
+      if (unwrapped) {
+        current = unwrapped;
         continue;
       }
 

--- a/packages/ts-transformers/src/closures/utils/ast-helpers.ts
+++ b/packages/ts-transformers/src/closures/utils/ast-helpers.ts
@@ -1,17 +1,19 @@
 import ts from "typescript";
 
+import { unwrapExpression } from "../../utils/expression.ts";
+
 /**
- * Unwrap an arrow function from parenthesized expressions.
+ * The arrow function an expression denotes, looking through every transparent
+ * wrapper, or `undefined` when it denotes something else.
+ *
+ * The whole set has to come off. A spelling left on hides the callback from the
+ * closure strategies, and `action(...)` then reaches the runtime unrewritten —
+ * where it throws by construction, because it exists only to be lowered to
+ * `handler()` at compile time.
  */
 export function unwrapArrowFunction(
   expression: ts.Expression,
 ): ts.ArrowFunction | undefined {
-  let current = expression;
-  while (ts.isParenthesizedExpression(current)) {
-    current = current.expression;
-  }
-  if (ts.isArrowFunction(current)) {
-    return current;
-  }
-  return undefined;
+  const current = unwrapExpression(expression);
+  return ts.isArrowFunction(current) ? current : undefined;
 }

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -9,6 +9,7 @@ import {
   isCollectingPlainArrayMethodCallback,
 } from "../ast/call-kind.ts";
 import { isEventHandlerJsxAttribute } from "../ast/event-handlers.ts";
+import { outermostTransparentWrapper } from "../utils/expression.ts";
 
 export interface CallbackBoundaryLookup {
   isArrayMethodCallback(node: ts.Node): boolean;
@@ -140,7 +141,9 @@ export function classifyCallbackBoundary(
   checker: ts.TypeChecker,
   lookup?: CallbackBoundaryLookup,
 ): CallbackBoundaryDecision {
-  const jsxParent = callback.parent;
+  // The attribute holds the outermost wrapper around the callback, so the
+  // JSX lookup starts from the usage site rather than the callback itself.
+  const jsxParent = outermostTransparentWrapper(callback).parent;
   if (
     ts.isJsxExpression(jsxParent) &&
     ts.isJsxAttribute(jsxParent.parent) &&

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -466,21 +466,15 @@ function collectTopLevelBuilderArtifacts(
   }
 }
 
-/** Strip parentheses and `as` / `satisfies` / type-assertion wrappers to reach
- * the underlying builder/identifier expression. Used both for `export default x`
- * recognition and for top-level `const foo = handler(...) as XFactory`
- * registration — without unwrapping, a cast-wrapped builder const is excluded
- * from `__cfReg`, loses content-addressed provenance, and falls to the SES
- * fallback at resolve time (CT-1743). */
+/** Strip the transparent wrapper set to reach the underlying
+ * builder/identifier expression. Used both for `export default x` recognition
+ * and for top-level `const foo = handler(...) as XFactory` registration —
+ * without unwrapping, a wrapped builder const is excluded from `__cfReg`, loses
+ * content-addressed provenance, and falls to the SES fallback at resolve time
+ * (CT-1743). Reading the shared set is what keeps that true of every spelling
+ * rather than of the casts alone. */
 function unwrapTypeWrappers(expr: ts.Expression): ts.Expression {
-  let current = expr;
-  while (
-    ts.isParenthesizedExpression(current) || ts.isAsExpression(current) ||
-    ts.isSatisfiesExpression(current) || ts.isTypeAssertionExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
+  return unwrapExpression(expr);
 }
 
 /**

--- a/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
+++ b/packages/ts-transformers/src/transformers/cfc-policy-authoring.ts
@@ -4,6 +4,7 @@ import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import { TransformationContext, Transformer } from "../core/mod.ts";
 import type { CfcPolicyCompilerManifestV1 } from "../core/runtime-contract.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 
 const USER = "https://commonfabric.org/cfc/atom/User";
 const HAS_ROLE = "https://commonfabric.org/cfc/atom/HasRole";
@@ -55,19 +56,6 @@ const assertKeys = (
 
 const isCallOf = (node: ts.Expression, names: ReadonlySet<string>): boolean =>
   ts.isIdentifier(node) && names.has(node.text);
-
-const unwrapExpression = (node: ts.Expression): ts.Expression => {
-  let current = node;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isTypeAssertionExpression(current) ||
-    ts.isSatisfiesExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
-};
 
 const propertyName = (node: ts.PropertyName): string | undefined => {
   if (ts.isIdentifier(node) || ts.isStringLiteral(node)) return node.text;

--- a/packages/ts-transformers/src/transformers/cfc-policy-of-validation.ts
+++ b/packages/ts-transformers/src/transformers/cfc-policy-of-validation.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { CFC_AUTHORING_MODULES } from "./cfc-policy-authoring.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 
 export class CfcPolicyOfValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -69,12 +70,9 @@ function isExchangeRulesCall(
   expression: ts.Expression,
   context: TransformationContext,
 ): boolean {
-  while (
-    ts.isParenthesizedExpression(expression) ||
-    ts.isAsExpression(expression) || ts.isSatisfiesExpression(expression)
-  ) expression = expression.expression;
-  if (!ts.isCallExpression(expression)) return false;
-  const callee = expression.expression;
+  const target = unwrapExpression(expression);
+  if (!ts.isCallExpression(target)) return false;
+  const callee = target.expression;
   if (!ts.isIdentifier(callee)) return false;
   return isImportedCfcAuthoringBinding(callee, "exchangeRules", context);
 }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/container-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/container-expression.ts
@@ -1,15 +1,18 @@
 import ts from "typescript";
 
 import type { EmitterContext } from "../types.ts";
+import { isTransparentWrapper } from "../../../utils/expression.ts";
 
-const isContainerExpression = (expression: ts.Expression): boolean => {
-  return ts.isObjectLiteralExpression(expression) ||
-    ts.isArrayLiteralExpression(expression) ||
-    ts.isParenthesizedExpression(expression) ||
-    ts.isAsExpression(expression) ||
-    ts.isTypeAssertionExpression(expression) ||
-    ts.isNonNullExpression(expression);
-};
+/**
+ * True for an expression the container emitter owns: a literal that holds other
+ * expressions, or a transparent wrapper around one. A wrapper spelling missing
+ * here is not inert — the emitter declines the expression, and it falls to
+ * whichever emitter claims it next.
+ */
+const isContainerExpression = (expression: ts.Expression): boolean =>
+  ts.isObjectLiteralExpression(expression) ||
+  ts.isArrayLiteralExpression(expression) ||
+  isTransparentWrapper(expression);
 
 export const emitContainerExpression = ({
   expression,

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -15,7 +15,10 @@ import {
   HelpersOnlyTransformer,
   TransformationContext,
 } from "../core/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../utils/expression.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
 import { normalizeWriterIdentityFile } from "../utils/writer-identity-file.ts";
 import { compileCfcPolicyManifestsForSource } from "./cfc-policy-authoring.ts";
@@ -603,13 +606,11 @@ function evaluateExpression(
 ): unknown {
   // Wrappers that do not change the value: parentheses, and the type-only
   // assertion forms. Without this every parenthesized option is dropped, of
-  // whatever type -- `("text")` as surely as `(-1)`. The schema-generator side
-  // of this pair has always unwrapped them.
-  if (
-    ts.isParenthesizedExpression(node) || ts.isAsExpression(node) ||
-    ts.isTypeAssertionExpression(node) || ts.isSatisfiesExpression(node)
-  ) {
-    return evaluateExpression(node.expression, checker);
+  // whatever type -- `("text")` as surely as `(-1)`. Reading the shared set
+  // keeps that list the same one the rest of the pipeline looks through.
+  const unwrapped = unwrapTransparentWrapperOnce(node);
+  if (unwrapped) {
+    return evaluateExpression(unwrapped, checker);
   }
 
   if (ts.isStringLiteral(node)) return node.text;

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -36,7 +36,10 @@
 
 import ts from "typescript";
 
-import { unwrapTransparentWrapperOnce } from "../utils/expression.ts";
+import {
+  unwrapExpression,
+  unwrapTransparentWrapperOnce,
+} from "../utils/expression.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import {
   declaredVerbResultTypeNode,
@@ -112,10 +115,15 @@ export class VerbReturnValidationTransformer extends HelpersOnlyTransformer {
 function verbCallback(
   call: ts.CallExpression,
 ): ts.ArrowFunction | ts.FunctionExpression | undefined {
-  const fns = call.arguments.filter(
-    (arg): arg is ts.ArrowFunction | ts.FunctionExpression =>
-      ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
-  );
+  // Each argument is resolved through the transparent wrapper set first: a
+  // wrapped callback is still the verb body, and leaving it unresolved hides
+  // the body from this validator entirely rather than judging it differently.
+  const fns = call.arguments
+    .map((arg) => unwrapExpression(arg))
+    .filter(
+      (arg): arg is ts.ArrowFunction | ts.FunctionExpression =>
+        ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
+    );
   return fns.length === 1 ? fns[0] : undefined;
 }
 

--- a/packages/ts-transformers/src/transformers/verb-return-validation.ts
+++ b/packages/ts-transformers/src/transformers/verb-return-validation.ts
@@ -35,6 +35,8 @@
  */
 
 import ts from "typescript";
+
+import { unwrapTransparentWrapperOnce } from "../utils/expression.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import {
   declaredVerbResultTypeNode,
@@ -125,12 +127,19 @@ function verbCallback(
  * An `any` assertion anywhere below opts the expression out.
  */
 function isDefinitelyPlainShaped(expr: ts.Expression): boolean {
-  if (ts.isParenthesizedExpression(expr)) {
-    return isDefinitelyPlainShaped(expr.expression);
+  // An assertion to `any` opts the expression out, whichever form carries it.
+  // That rule is stated once, before the wrapper set is stepped through, so a
+  // wrapper spelling added later cannot slip past it.
+  if (
+    (ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr) ||
+      ts.isTypeAssertionExpression(expr)) &&
+    expr.type.kind === ts.SyntaxKind.AnyKeyword
+  ) {
+    return false;
   }
-  if (ts.isAsExpression(expr) || ts.isSatisfiesExpression(expr)) {
-    if (expr.type.kind === ts.SyntaxKind.AnyKeyword) return false;
-    return isDefinitelyPlainShaped(expr.expression);
+  const unwrappedExpr = unwrapTransparentWrapperOnce(expr);
+  if (unwrappedExpr) {
+    return isDefinitelyPlainShaped(unwrappedExpr);
   }
   if (ts.isConditionalExpression(expr)) {
     return isDefinitelyPlainShaped(expr.whenTrue) &&

--- a/packages/ts-transformers/src/transformers/verb-tier-mark.ts
+++ b/packages/ts-transformers/src/transformers/verb-tier-mark.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { TransformationContext, Transformer } from "../core/mod.ts";
 import { detectCallKind } from "../ast/call-kind.ts";
 import { visitEachChildWithJsx } from "../ast/utils.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 
 /**
  * Verb listing marks, producer 1 (verb contract WS-F): a stream whose handler
@@ -164,15 +165,9 @@ function staticPropertyName(name: ts.PropertyName): string | undefined {
   return undefined;
 }
 
-/** Strip parentheses and `as const` / `satisfies` wrappers. */
+/** Strip the transparent wrapper set to reach the expression a tier reads. */
 function unwrapExpr(expr: ts.Expression): ts.Expression {
-  let current = expr;
-  while (true) {
-    if (ts.isParenthesizedExpression(current)) current = current.expression;
-    else if (ts.isAsExpression(current)) current = current.expression;
-    else if (ts.isSatisfiesExpression(current)) current = current.expression;
-    else return current;
-  }
+  return unwrapExpression(expr);
 }
 
 function callbackBodyStatements(

--- a/packages/ts-transformers/test/cfc-authoring.test.ts
+++ b/packages/ts-transformers/test/cfc-authoring.test.ts
@@ -310,8 +310,9 @@ Deno.test("exchange-rule declarations survive every transparent wrapper spelling
   // wrapper problem — the rule binding simply stops resolving, and
   // `exchangeRules()` reports the rule as invalid, which points the author at
   // the wrong thing entirely.
-  const ruleSource = (suffix: string) => `
-    export const releaseToReviewer = exchangeRule({
+  const ruleSource = (wrap: (rule: string) => string) => `
+    export const releaseToReviewer = ${
+    wrap(`exchangeRule({
       appliesTo: THIS_POLICY,
       pre: {
         integrity: [cfcPattern.hasRole(
@@ -323,17 +324,30 @@ Deno.test("exchange-rule declarations survive every transparent wrapper spelling
       post: {
         addAlternatives: [cfcPattern.user(v("reviewer"))],
       },
-    })${suffix};
+    })`)
+  };
 
     export const releaseRules = exchangeRules([releaseToReviewer]);
   `;
 
-  for (const suffix of ["", " satisfies unknown", "!"]) {
-    const manifests = compilePolicySource(ruleSource(suffix));
+  // Policy sources compile as .ts, so the angle-bracket assertion is available
+  // here alongside the spellings a .tsx pattern can use.
+  const spellings: Record<string, (rule: string) => string> = {
+    bare: (rule) => rule,
+    parenthesized: (rule) => `(${rule})`,
+    "as-cast": (rule) => `(${rule}) as never`,
+    satisfies: (rule) => `(${rule}) satisfies unknown`,
+    "non-null": (rule) => `(${rule})!`,
+    "angle-bracket": (rule) => `<never>(${rule})`,
+    nested: (rule) => `((${rule}) satisfies unknown)!`,
+  };
+
+  for (const [name, wrap] of Object.entries(spellings)) {
+    const manifests = compilePolicySource(ruleSource(wrap));
     assertEquals(
       manifests.length,
       1,
-      `expected one manifest for initializer suffix "${suffix}"`,
+      `expected one manifest for the ${name} spelling`,
     );
     assertEquals(manifests[0]!.manifest.symbol, "releaseRules");
   }
@@ -698,6 +712,53 @@ Deno.test("PolicyOf lowers a local exported ruleset to an exact schema marker", 
   );
   assertEquals(output.includes("__ctOwningSpace: true"), true);
   assertEquals(output.includes("__ctPolicyIdentityOf"), false);
+});
+
+Deno.test("PolicyOf resolves a ruleset binding through each wrapper spelling", async () => {
+  // The recognizer looks through wrappers to the `exchangeRules()` call. A
+  // spelling it does not strip surfaces as "PolicyOf binding must resolve to an
+  // exchangeRules() declaration" — a diagnostic that names the binding rather
+  // than the wrapper, and so points the author at the wrong thing.
+  const spellings: Record<string, string> = {
+    bare: "exchangeRules([release])",
+    parenthesized: "(exchangeRules([release]))",
+    "as-cast": "exchangeRules([release]) as never",
+    satisfies: "exchangeRules([release]) satisfies unknown",
+    "non-null": "exchangeRules([release])!",
+  };
+
+  for (const [name, ruleset] of Object.entries(spellings)) {
+    const { diagnostics } = await validateSource(
+      `/// <cts-enable />
+      import { Confidential, toSchema } from "commonfabric";
+      import type { PolicyOf } from "commonfabric/cfc";
+      import {
+        cfcPattern, exchangeRule, exchangeRules, THIS_POLICY, v,
+      } from "commonfabric/cfc";
+      export const release = exchangeRule({
+        appliesTo: THIS_POLICY,
+        pre: { integrity: [cfcPattern.hasRole(v("user"), THIS_POLICY.subject, "reader")] },
+        post: { addAlternatives: [cfcPattern.user(v("user"))] },
+      });
+      export const rules = ${ruleset};
+      export const schema = toSchema<
+        Confidential<string, [PolicyOf<typeof rules>]>
+      >();
+    `,
+      {
+        types: COMMONFABRIC_TYPES,
+        moduleIdentities: new Map([["/test.tsx", "sha256:module"]]),
+      },
+    );
+
+    assertEquals(
+      diagnostics.filter((diagnostic) =>
+        diagnostic.message.includes("must resolve to an exchangeRules()")
+      ).length,
+      0,
+      `the ${name} spelling should resolve as a ruleset binding`,
+    );
+  }
 });
 
 Deno.test("PolicyOf retains the defining identity of an imported ruleset", async () => {

--- a/packages/ts-transformers/test/cfc-authoring.test.ts
+++ b/packages/ts-transformers/test/cfc-authoring.test.ts
@@ -304,6 +304,41 @@ Deno.test("static exchange-rule declarations emit a deterministic side-channel m
   assertEquals(repeated, manifests);
 });
 
+Deno.test("exchange-rule declarations survive every transparent wrapper spelling", () => {
+  // The authoring grammar reads through wrappers that do not change the value a
+  // declaration denotes. A spelling left out of that set does not fail as a
+  // wrapper problem — the rule binding simply stops resolving, and
+  // `exchangeRules()` reports the rule as invalid, which points the author at
+  // the wrong thing entirely.
+  const ruleSource = (suffix: string) => `
+    export const releaseToReviewer = exchangeRule({
+      appliesTo: THIS_POLICY,
+      pre: {
+        integrity: [cfcPattern.hasRole(
+          v("reviewer"),
+          THIS_POLICY.subject,
+          "reader",
+        )],
+      },
+      post: {
+        addAlternatives: [cfcPattern.user(v("reviewer"))],
+      },
+    })${suffix};
+
+    export const releaseRules = exchangeRules([releaseToReviewer]);
+  `;
+
+  for (const suffix of ["", " satisfies unknown", "!"]) {
+    const manifests = compilePolicySource(ruleSource(suffix));
+    assertEquals(
+      manifests.length,
+      1,
+      `expected one manifest for initializer suffix "${suffix}"`,
+    );
+    assertEquals(manifests[0]!.manifest.symbol, "releaseRules");
+  }
+});
+
 Deno.test("exchange-rule authoring rejects dynamic and unguarded declarations", async () => {
   const { diagnostics } = await validateSource(
     `/// <cts-enable />

--- a/packages/ts-transformers/test/cfc-authoring.test.ts
+++ b/packages/ts-transformers/test/cfc-authoring.test.ts
@@ -714,7 +714,7 @@ Deno.test("PolicyOf lowers a local exported ruleset to an exact schema marker", 
   assertEquals(output.includes("__ctPolicyIdentityOf"), false);
 });
 
-Deno.test("PolicyOf resolves a ruleset binding through each wrapper spelling", async () => {
+Deno.test("PolicyOf resolves a ruleset binding through each .tsx wrapper spelling", async () => {
   // The recognizer looks through wrappers to the `exchangeRules()` call. A
   // spelling it does not strip surfaces as "PolicyOf binding must resolve to an
   // exchangeRules() declaration" — a diagnostic that names the binding rather
@@ -759,6 +759,39 @@ Deno.test("PolicyOf resolves a ruleset binding through each wrapper spelling", a
       `the ${name} spelling should resolve as a ruleset binding`,
     );
   }
+});
+
+Deno.test("PolicyOf resolves a ruleset binding behind an angle-bracket assertion", async () => {
+  // `<T>x` is JSX in a .tsx source, so the angle-bracket spelling is only
+  // reachable from a .ts module — which is where a policy module usually is.
+  const { diagnostics } = await validateFiles({
+    "/policy.ts": `/// <cts-enable />
+      import { Confidential, toSchema } from "commonfabric";
+      import type { PolicyOf } from "commonfabric/cfc";
+      import {
+        cfcPattern, exchangeRule, exchangeRules, THIS_POLICY, v,
+      } from "commonfabric/cfc";
+      export const release = exchangeRule({
+        appliesTo: THIS_POLICY,
+        pre: { integrity: [cfcPattern.hasRole(v("user"), THIS_POLICY.subject, "reader")] },
+        post: { addAlternatives: [cfcPattern.user(v("user"))] },
+      });
+      export const rules = <never>exchangeRules([release]);
+      export const schema = toSchema<
+        Confidential<string, [PolicyOf<typeof rules>]>
+      >();
+    `,
+  }, {
+    types: COMMONFABRIC_TYPES,
+    moduleIdentities: new Map([["/policy.ts", "sha256:module"]]),
+  });
+
+  assertEquals(
+    diagnostics.filter((diagnostic) =>
+      diagnostic.message.includes("must resolve to an exchangeRules()")
+    ).length,
+    0,
+  );
 });
 
 Deno.test("PolicyOf retains the defining identity of an imported ruleset", async () => {

--- a/packages/ts-transformers/test/reactive/dataflow.test.ts
+++ b/packages/ts-transformers/test/reactive/dataflow.test.ts
@@ -34,6 +34,30 @@ describe("data flow analyzer", () => {
     );
   });
 
+  // A transparent wrapper is analyzed as the expression it wraps, so the hint
+  // the inner analysis produced reaches the caller. A spelling not named there
+  // falls to the generic child walk, which merges through `mergeAnalyses` and
+  // hardcodes `rewriteHint: undefined` — the hint is lost silently.
+  for (
+    const [name, wrap] of Object.entries({
+      parenthesized: (inner: string) => `(${inner})`,
+      "as-cast": (inner: string) => `(${inner}) as never`,
+      satisfies: (inner: string) => `(${inner}) satisfies unknown`,
+      "non-null": (inner: string) => `(${inner})!`,
+    })
+  ) {
+    it(`keeps the ifElse hint through a ${name} wrapper`, () => {
+      const { analysis } = analyzeExpression(
+        wrap("ifElse(state.count > 3, 'hi', 'bye')"),
+      );
+
+      assert(
+        analysis.rewriteHint && analysis.rewriteHint.kind === "call-if-else",
+      );
+      assertEquals(analysis.rewriteHint.predicate.getText(), "state.count > 3");
+    });
+  }
+
   it("identifies array map calls that should skip wrapping", () => {
     const { analysis } = analyzeExpression(
       "state.items.map(item => item + state.count)",

--- a/packages/ts-transformers/test/schema-generator-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-generator-coverage.test.ts
@@ -226,6 +226,10 @@ const s = toSchema<C>({
   list: [1, "a", true, null],
   nested: { inner: 3, deep: { x: "y" } },
   constant: E.V,
+  wrappedParen: ("p"),
+  wrappedCast: "c" as string,
+  wrappedSatisfies: "t" satisfies string,
+  wrappedNonNull: "n"!,
 });
 export { s };
 `);
@@ -236,4 +240,10 @@ export { s };
   assertEquals(schema.nested, { inner: 3, deep: { x: "y" } });
   assertEquals(schema.constant, 5);
   assert(!("undef" in schema), "undefined option should be dropped");
+  // Every transparent wrapper spelling reaches the same value; the
+  // evaluator reads the shared set rather than a hand-written subset.
+  assertEquals(schema.wrappedParen, "p");
+  assertEquals(schema.wrappedCast, "c");
+  assertEquals(schema.wrappedSatisfies, "t");
+  assertEquals(schema.wrappedNonNull, "n");
 });

--- a/packages/ts-transformers/test/schema-generator-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-generator-coverage.test.ts
@@ -240,8 +240,9 @@ export { s };
   assertEquals(schema.nested, { inner: 3, deep: { x: "y" } });
   assertEquals(schema.constant, 5);
   assert(!("undef" in schema), "undefined option should be dropped");
-  // Every transparent wrapper spelling reaches the same value; the
-  // evaluator reads the shared set rather than a hand-written subset.
+  // Each wrapper spelling a .tsx source can carry reaches the same value; the
+  // evaluator reads the shared set rather than a hand-written subset. The
+  // angle-bracket assertion is JSX in .tsx and so is not among them.
   assertEquals(schema.wrappedParen, "p");
   assertEquals(schema.wrappedCast, "c");
   assertEquals(schema.wrappedSatisfies, "t");

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -95,14 +95,16 @@ export function make() {
     assertEquals(literalToValue(receiver.arguments[1]!), { type: "number" });
   });
 
-  it("registers cast-wrapped non-exported builder consts in __cfReg (CT-1743)", async () => {
+  it("registers wrapped non-exported builder consts in __cfReg (CT-1743)", async () => {
     // A non-exported top-level handler written as `const x = handler(...) as T`
-    // must still be __cfReg-registered. Without unwrapping the `as` cast its
-    // AsExpression initializer fails the CallExpression check, so it is excluded
-    // from __cfReg, gets no content-addressed provenance, and at resolve time
-    // falls to the SES source fallback that strips its builder imports — the
-    // CT-1743 `navigateTo`-of-undefined crash. The no-cast sibling is the
-    // positive control (it has always registered).
+    // must still be __cfReg-registered. Without unwrapping the wrapper its
+    // initializer fails the CallExpression check, so it is excluded from
+    // __cfReg, gets no content-addressed provenance, and at resolve time falls
+    // to the SES source fallback that strips its builder imports — the CT-1743
+    // `navigateTo`-of-undefined crash. Every transparent wrapper spelling has
+    // to register, not just the cast: the registration reads the shared set, so
+    // a spelling left out of it fails silently at runtime rather than loudly
+    // here. The no-wrapper sibling is the positive control.
     const source = `
 import { handler } from "commonfabric";
 
@@ -114,6 +116,20 @@ const openWithCast = handler<
 >((_event, { count }) => {
   void count;
 }) as OpenFactory;
+
+const openWithNonNull = handler<
+  { id: string },
+  { count: number }
+>((_event, { count }) => {
+  void count;
+})!;
+
+const openWithSatisfies = handler<
+  { id: string },
+  { count: number }
+>((_event, { count }) => {
+  void count;
+}) satisfies unknown;
 
 const openNoCast = handler<
   { id: string },
@@ -142,6 +158,8 @@ const openNoCast = handler<
     );
     assert(keys.includes("openNoCast")); // positive control
     assert(keys.includes("openWithCast")); // CT-1743 regression guard
+    assert(keys.includes("openWithNonNull"));
+    assert(keys.includes("openWithSatisfies"));
   });
 
   it("adds stable property causes to pattern-owned lowered derives", async () => {

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -126,6 +126,83 @@ describe("transparent wrapper consistency", () => {
     });
   });
 
+  describe("verb callback resolution", () => {
+    // The matrix above varies the wrapper around the RETURNED value. This one
+    // varies the wrapper around the CALLBACK, which is a separate lookup: an
+    // unresolved wrapper hides the body from the validator entirely, so it
+    // judges nothing rather than judging it differently.
+    const undeclaredReturns = async (source: string) => {
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      return (diagnostics as readonly TransformationDiagnostic[]).filter((d) =>
+        d.type === "verb-result:undeclared-return"
+      );
+    };
+
+    for (const [name, wrap] of Object.entries(TSX_SPELLINGS)) {
+      it(`reads an action body behind a ${name} callback`, async () => {
+        const source = `      import { action } from "commonfabric";
+      const verb = action(${
+          wrap("(id: string) => { return { picked: id }; }")
+        });
+      export { verb };
+    `;
+
+        expect((await undeclaredReturns(source)).length).toBe(1);
+      });
+
+      it(`reads a handler body behind a ${name} callback`, async () => {
+        const source = `      import { handler } from "commonfabric";
+      const verb = handler<{ id: string }, Record<string, never>>(${
+          wrap("(event) => { return { picked: event.id }; }")
+        });
+      export { verb };
+    `;
+
+        expect((await undeclaredReturns(source)).length).toBe(1);
+      });
+    }
+  });
+
+  describe("callback boundary classification", () => {
+    // Extraction and boundary classification have to agree about where a
+    // callback sits. When they disagree, an otherwise legal body is reported
+    // against — a false positive on valid source, not a missed rewrite.
+    const patternContextErrors = async (source: string) => {
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      return (diagnostics as readonly TransformationDiagnostic[]).filter((d) =>
+        d.type.startsWith("pattern-context:")
+      );
+    };
+
+    const body = "() => { const o = { run: () => { n; } }; o.run(); }";
+
+    for (const [name, wrap] of Object.entries(TSX_SPELLINGS)) {
+      it(`leaves a ${name} action callback free of pattern-context errors`, async () => {
+        const source = `      import { action, pattern } from "commonfabric";
+      export default pattern<{ n: number }, { go: unknown }>(({ n }) => ({
+        go: action(${wrap(body)}),
+      }));
+    `;
+
+        expect(await patternContextErrors(source)).toEqual([]);
+      });
+
+      it(`leaves a ${name} JSX event handler free of pattern-context errors`, async () => {
+        const source = `      import { pattern } from "commonfabric";
+      export default pattern<{ n: number }, { ui: unknown }>(({ n }) => ({
+        ui: <button onClick={${wrap(body)}}>hi</button>,
+      }));
+    `;
+
+        expect(await patternContextErrors(source)).toEqual([]);
+      });
+    }
+  });
+
   describe("normalizeDataFlows()", () => {
     // Built directly rather than through the pipeline: a partially emitted node
     // is synthetic, so a hand-built graph is the only way to put one in front

--- a/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
+++ b/packages/ts-transformers/test/transparent-wrapper-consistency.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The transparent wrapper set — `(x)`, `x as T`, `<T>x`, `x satisfies T`, `x!`,
+ * and the partially emitted node — is defined once in `src/utils/expression.ts`
+ * and read by every stage that looks through a wrapper to the expression it
+ * wraps.
+ *
+ * These tests pin the property that makes that worth doing: a stage's answer
+ * does not depend on which spelling the author reached for. They span several
+ * source files on purpose, because the failure they guard against is one
+ * consumer drifting away from the others rather than any single stage being
+ * wrong on its own.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import ts from "typescript";
+
+import { transformFiles, transformSource, validateSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { normalizeDataFlows } from "../src/ast/normalize.ts";
+import type { DataFlowGraph, DataFlowNode } from "../src/ast/dataflow.ts";
+
+/** Every spelling available in a `.tsx` source. `<T>x` is JSX there, so it is
+ * exercised separately against a `.ts` module. */
+const TSX_SPELLINGS: Readonly<Record<string, (inner: string) => string>> = {
+  bare: (inner) => inner,
+  parenthesized: (inner) => `(${inner})`,
+  "as-cast": (inner) => `(${inner}) as never`,
+  satisfies: (inner) => `(${inner}) satisfies unknown`,
+  "non-null": (inner) => `(${inner})!`,
+};
+
+describe("transparent wrapper consistency", () => {
+  describe("action() callback lowering", () => {
+    // `action()` throws when it reaches the runtime — it exists only to be
+    // rewritten to `handler()` at compile time. A spelling the callback
+    // unwrapper does not strip therefore does not degrade the output, it
+    // compiles a guaranteed runtime failure.
+    const source = (callback: string) =>
+      `      import { action, pattern } from "commonfabric";
+      export default pattern<{ n: number }, { go: unknown }>(({ n }) => ({
+        go: action(${callback}),
+      }));
+    `;
+
+    for (const [name, wrap] of Object.entries(TSX_SPELLINGS)) {
+      it(`rewrites the callback to a handler when it is ${name}`, async () => {
+        const output = await transformSource(source(wrap("() => { n; }")), {
+          types: COMMONFABRIC_TYPES,
+        });
+
+        expect(/\baction\(/.test(output)).toBe(false);
+        expect(/handler\(|__cfHandler/.test(output)).toBe(true);
+      });
+    }
+
+    it("rewrites the callback behind an angle-bracket assertion in a `.ts` module", async () => {
+      const output = await transformFiles({
+        "/m.ts": `      import { action, pattern } from "commonfabric";
+      export default pattern<{ n: number }, { go: unknown }>(({ n }) => ({
+        go: action(<() => void>(() => { n; })),
+      }));
+    `,
+      }, { types: COMMONFABRIC_TYPES });
+
+      expect(/\baction\(/.test(output["/m.ts"]!)).toBe(false);
+    });
+  });
+
+  describe("verb tier marking", () => {
+    const source = (verb: string) =>
+      `      import { action, pattern, type PerSession, Stream, type Writable } from "commonfabric";
+      interface Out {
+        draft: PerSession<Writable<string>>;
+        openComposer: Stream<void>;
+      }
+      export default pattern<Record<string, never>, Out>(() => {
+        const draft = new Writable("");
+        const openComposer = ${verb};
+        return { draft, openComposer };
+      });
+    `;
+
+    for (const [name, wrap] of Object.entries(TSX_SPELLINGS)) {
+      it(`marks the verb wrapper-tier when the action is ${name}`, async () => {
+        const output = await transformSource(
+          source(wrap(`action(() => { draft.set(""); })`)),
+          { types: COMMONFABRIC_TYPES },
+        );
+        const start = output.indexOf("openComposer: {");
+
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(output.slice(start, start + 400)).toContain('tier: "wrapper"');
+      });
+    }
+  });
+
+  describe("verb return validation", () => {
+    const errorsIn = async (body: string) => {
+      const { diagnostics } = await validateSource(
+        `      import { action } from "commonfabric";
+      const verb = action((id: string) => {
+        return ${body};
+      });
+      export { verb };
+    `,
+        { types: COMMONFABRIC_TYPES },
+      );
+      return (diagnostics as readonly TransformationDiagnostic[]).filter((d) =>
+        d.type === "verb-result:undeclared-return"
+      );
+    };
+
+    for (const [name, wrap] of Object.entries(TSX_SPELLINGS)) {
+      it(`reports an undeclared return when the value is ${name}`, async () => {
+        expect((await errorsIn(wrap("{ picked: id }"))).length).toBe(1);
+      });
+    }
+
+    it("stays opted out when the value is asserted to `any`", async () => {
+      // The deliberate fail-open: an `any` assertion means the validator
+      // cannot judge the shape, whichever assertion form carries it.
+      expect((await errorsIn("{ picked: id } as any")).length).toBe(0);
+      expect((await errorsIn("({ picked: id }) satisfies any")).length).toBe(0);
+    });
+  });
+
+  describe("normalizeDataFlows()", () => {
+    // Built directly rather than through the pipeline: a partially emitted node
+    // is synthetic, so a hand-built graph is the only way to put one in front
+    // of the normalizer.
+    const graphOf = (...expressions: ts.Expression[]): DataFlowGraph => ({
+      nodes: expressions.map((expression, id): DataFlowNode => ({
+        id,
+        expression,
+        canonicalKey: `k${id}`,
+        parentId: null,
+        scopeId: 0,
+        isExplicit: true,
+      })),
+      scopes: [{ id: 0, parentId: null, parameters: [] }],
+      rootScopeId: 0,
+    });
+
+    const parseInitializers = (code: string): ts.Expression[] => {
+      const sourceFile = ts.createSourceFile(
+        "/t.ts",
+        code,
+        ts.ScriptTarget.Latest,
+        true,
+      );
+      const found: ts.Expression[] = [];
+      const walk = (candidate: ts.Node) => {
+        if (ts.isVariableDeclaration(candidate) && candidate.initializer) {
+          found.push(candidate.initializer);
+        }
+        ts.forEachChild(candidate, walk);
+      };
+      walk(sourceFile);
+      return found;
+    };
+
+    it("groups flows that differ only by a transparent wrapper", () => {
+      const [bare, cast, satisfied, nonNull] = parseInitializers(
+        `const a = obj.value;
+         const b = (obj.value) as never;
+         const c = (obj.value) satisfies unknown;
+         const d = (obj.value)!;`,
+      );
+
+      const normalized = normalizeDataFlows(
+        graphOf(bare!, cast!, satisfied!, nonNull!),
+      );
+
+      expect(normalized.length).toBe(1);
+      expect(normalized[0]!.occurrences.length).toBe(4);
+    });
+
+    it("groups a partially emitted wrapper with the expression it wraps", () => {
+      const [bare] = parseInitializers(`const a = obj.value;`);
+      const wrapped = ts.factory.createPartiallyEmittedExpression(bare!);
+
+      const normalized = normalizeDataFlows(graphOf(bare!, wrapped));
+
+      expect(normalized.length).toBe(1);
+    });
+
+    it("keeps flows that differ by more than a wrapper apart", () => {
+      const [a, b] = parseInitializers(
+        `const a = obj.value;
+         const b = (obj.other) as never;`,
+      );
+
+      expect(normalizeDataFlows(graphOf(a!, b!)).length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
The tail of the wrapper-vocabulary thread (#6067, #6242, #6257). Three strippers read the transparent set **minus non-null `!`**, and none of them documented the omission — the tell that it was oversight rather than design. `schema-generator.ts` even contradicted its own comment, which says it strips "the type-only assertion forms"; `!` is one.

Compare `pattern-body-reactive-root-lowering.ts`, which *does* carry an explicit "preserves casts and `satisfies` on purpose" note. That is what a deliberate narrow set looks like. None of these three had anything like it.

## The three, ordered by how badly they failed

**1. Builder-call hoisting — silent, and the code already knew the cost.** A `!`-wrapped builder const was dropped from `__cfReg` outright:

```
const poke = handler(...);                    __cfReg({ ping, pingNamed, pingDeclared, poke })
const poke = (handler(...));                  __cfReg({ ping, pingNamed, pingDeclared, poke })
const poke = handler(...) satisfies unknown;  __cfReg({ ping, pingNamed, pingDeclared, poke })
const poke = handler(...)!;                   __cfReg({ ping, pingNamed, pingDeclared })
```

The function's own comment records the consequence — the const "loses content-addressed provenance, and falls to the SES fallback at resolve time (CT-1743)". That comment was written about casts while the identical hole stayed open for `!`. A runtime degradation with no compile-time signal is the worst shape a bug in this area can take, and it is what carries this PR.

**2. CFC policy authoring — loud, but misdiagnosed.** A `!`-wrapped `exchangeRule(...)` left the binding unresolved, so `exchangeRules()` reported `references invalid rule "releaseToReviewer"`. The rule was fine. An author reading that message would go looking in entirely the wrong place.

This copy was *also named `unwrapExpression`*, shadowing the canonical helper with a different set inside one module — the drift shape that is invisible at the call site. Deleting it in favour of the import leaves all 8 call sites unchanged.

**3. Schema-generator option evaluator — real but effectively unreachable.** `description: "MARKER"!` dropped the option. Reaching it needs `!` written directly on a literal, which TypeScript itself flags as unnecessary — plain references are dropped here regardless of wrapper (already documented in the spec). Corrected for consistency, not for a defect; on its own it would not have justified a PR.

## Why this is safe

Every change is **monotonic** — it makes the transformer recognize something it should always have recognized. Nothing that produced a correct result before produces a different one now.

- **`UPDATE_GOLDENS=1`** — zero golden diffs.
- **`deno task cfcheck`** — exit 0 across all **421** pattern files.
- Full suite **1160 passed, 0 failed**; repo-wide `deno fmt --check`, `deno lint`, `deno task check`, and every `check-*` gate.
- Three regression tests, one per site, each pinning all spellings to one outcome and **each confirmed to fail against the wrapper list it replaces**.

Two of the three extend tests that already existed rather than adding parallel ones — the CT-1743 `__cfReg` test now covers every spelling instead of just the cast, and the `toSchema` option-evaluator test gains the four wrapper forms.

## Spec

`ts_transformers_current_behavior_spec.md` §"evaluate literal options object" listed the old set. Updated to name the transparent wrapper set including `!`. The other two sites have no live prose describing their wrapper handling. `spec-sync.test.ts` and `check-docs` pass.

## Deliberately not done

**The wrapped-callee divergence in `isArrayMethodReceiverExpression`** (#6067). Fixing it changes which receivers reach the synthetic-array path in reactive lowering — a genuine semantic change, the highest risk of anything in this thread, against **zero** occurrences across 1526 files. Not worth it.

**Nothing.** An earlier revision of this description said two further `satisfies`-less sets could not be measured because an instrument would not fire. That was wrong, and the cause was my own probe: the injected logging called `chr(10)`, which is Python, not TypeScript. It threw `ReferenceError` on every call straight into the probe's own `catch { /* ignore */ }`, so it wrote nothing and looked like silence from the code.

With a working instrument, `analyzeExpression` records **216056 calls** across the suite, **50** of them a `SatisfiesExpression`. So the shape arrives, and the gap was real — just not in the way "latent" suggested. Those sites are now fixed here too, as a second commit:

- **`dataflow.ts` `analyzeExpression`** — a wrapper is analyzed as the expression it wraps, one branch per kind, and `satisfies` had none. Not inert: it fell to the generic child walk at the end of the function, which reaches the same operands but merges them through `mergeAnalyses` — and that hardcodes `rewriteHint: undefined`. A `satisfies`-wrapped expression lost a hint its `as`-wrapped equivalent kept. That asymmetry is exactly why the other four have explicit branches.
- **`normalize.ts` `normalizeExpression`** — groups data flows by normalized text, so two flows differing only by a wrapper should collapse into one. An unstripped spelling splits the group.
- **`container-expression.ts` `isContainerExpression`** — decides whether the container emitter owns an expression; a missing spelling makes it decline, and the expression falls to whichever emitter claims it next.

All three read the shared set now, with no golden change — so nothing in the corpus exercised the differences, and they are corrected as drift with the mechanism recorded at each site.

After this, a sweep of the package finds no stripper naming a subset of the wrapper set. What remains is `utils/expression.ts` itself and `compute-wrap-invariants.ts`, whose set is a deliberate *superset* (JSX elements and literals) answering a different question.

Refs #6067, #6242, #6257, #6050.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


