### PR TITLE
Make `FabricContainerValue` the name for a value a walk descends into

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -36,10 +36,11 @@ JavaScript "wild west" (unknown/any) <-> Strongly typed (FabricValue) <-> Serial
   handling.
 
 - **Middle layer — `FabricValue`.** The strongly typed core of the data model.
-  Contains only primitives, `FabricInstance` implementations (including wrapper
-  classes for native JS types), and recursive containers. No raw native JS
-  objects appear at this layer — they are wrapped into `FabricInstance`
-  implementations by the conversion functions (Section 8).
+  Contains only primitives and containers, the latter being arrays, plain
+  objects, and `FabricInstance` implementations (including wrapper classes for
+  native JS types). No raw native JS objects appear at this layer — they are
+  wrapped into `FabricInstance` implementations by the conversion functions
+  (Section 8).
 
 - **Right layer — Serialized form.** The wire/storage representation
   (`Uint8Array` for binary formats, JSON-compatible trees for the JSON engine).
@@ -127,7 +128,7 @@ type FabricValue =
   //       - System types: `UnknownValue`, `ProblematicValue`
   | FabricInstance
 
-  // (d) Recursive containers -- read-only; see the immutability callout below
+  // (d) Plain containers -- read-only; see the immutability callout below
   | readonly FabricValue[]
   | { readonly [key: string]: FabricValue };
 ```
@@ -139,32 +140,43 @@ naming the `FabricPrimitive` subclasses individually — describes exactly the
 same set while saying more about it. Read the split as this document's
 elaboration of one implementation arm.
 
-> **Fabric values are deeply read-only, with one intentional hole.** The
+Arms (c) and (d) are the **containers** — the values that hold other
+`FabricValue`s, and so the values a walk descends into. The implementation
+names that set `FabricContainerValue`. What divides the two arms is where the
+contents live, not whether there are any: a plain container's contents are its
+own indices and keys, while a `FabricInstance` holds its contents privately and
+reaches them through the protocol of Section 2.3. Arms (a) and (b) are the
+non-containers, holding no `FabricValue` at all.
+
+> **Fabric values are deeply read-only, with one intentional hole.** The plain
 > container arms are read-only, and because their element and property types are
 > themselves `FabricValue`, that read-only-ness is inherited all the way down: a
 > `FabricValue` tree cannot be written through at any depth. The implementation
-> names the two container arms `FabricArray` (`ReadonlyArray<FabricValue>`) and
+> names those two arms `FabricArray` (`ReadonlyArray<FabricValue>`) and
 > `FabricPlainObject` (`Readonly<Record<string, FabricValue>>`); this is the
 > type-level counterpart of the runtime deep-freeze contract in Section 8.6, and
 > the two are meant to agree.
 >
-> The hole is the `FabricInstance` arm. An instance exposes arbitrary members,
-> and a member can change instance state — including which values the instance
-> refers to — so the read-only-ness stops at an instance boundary and does not
-> reach what lies beyond it. This is deliberate rather than an oversight: the
-> intended semantics *are* expressible in TypeScript, but not concisely enough
-> to be worth the cost at every use site. Treat the type-level guarantee as
-> covering the containers and the primitives, and Section 8.6 as the statement
-> that actually binds instances.
+> The hole is the `FabricInstance` arm — the one container the guarantee does
+> not reach. An instance exposes arbitrary members, and a member can change
+> instance state — including which values the instance refers to — so the
+> read-only-ness stops at an instance boundary and does not reach what lies
+> beyond it. This is deliberate rather than an oversight: the intended semantics
+> *are* expressible in TypeScript, but not concisely enough to be worth the cost
+> at every use site. Treat the type-level guarantee as covering the plain
+> containers and the primitives, and Section 8.6 as the statement that actually
+> binds instances.
 >
-> **Construction is the exception that proves the rule.** Building a container
-> requires writing to it, so the implementation provides
+> **Construction is the exception that proves the rule.** Building a plain
+> container requires writing to it, so the implementation provides
 > `MutableFabricValueLayer` — a value whose *root* container is mutable
 > (`MutableFabricArrayLayer` is `FabricValue[]`, `MutableFabricPlainObjectLayer`
 > is `Record<string, FabricValue>`) while everything nested within it remains an
-> ordinary read-only `FabricValue`. It is a single construction layer, not a
-> deep thaw, and it is a builder's type: a value that has finished being built
-> is a `FabricValue`.
+> ordinary read-only `FabricValue`. `MutableFabricContainerValueLayer` is that
+> same layer narrowed to the container arms, for a caller that has already
+> established it holds one. Each is a single construction layer, not a deep
+> thaw, and each is a builder's type: a value that has finished being built is a
+> `FabricValue`.
 
 > **Restricted and excluded JS types.**
 >
@@ -176,7 +188,7 @@ elaboration of one implementation arm.
 >   are rejected. The TypeScript `symbol` type cannot express this distinction,
 >   so it is enforced at runtime by the conversion, hashing, and encoding
 >   boundaries (Sections 4.9, 6, and 5). Symbol-keyed *properties* on plain
->   objects are a separate matter — see Section 1.5 (Recursive Containers /
+>   objects are a separate matter — see Section 1.5 (Plain Containers /
 >   Objects).
 > - `function` — Functions are opaque closures with no portable representation.
 >   They are explicitly **not** representable as `FabricValue`s, eliciting a
@@ -1369,7 +1381,11 @@ owned class to host a `[CODEC]`); see Section 4.5.
 > subclasses (`FabricEpochNsec`, `FabricEpochDay`, `FabricHash`, `FabricBytes`,
 > `FabricRegExp`) under `packages/data-model/fabric-primitives/`.
 
-### 1.5 Recursive Containers
+### 1.5 Plain Containers
+
+Two of the three container arms: the ones whose contents are structural, held
+as the value's own indices and keys. The third, `FabricInstance`, keeps its
+contents private and is governed by the protocol of Section 2.3 instead.
 
 **Arrays:**
 - Direct `Array` instances only: the prototype must be `Array.prototype`
@@ -2717,10 +2733,10 @@ act and hand the work to it. An engine is otherwise its configuration — the
 codec registry and the leniency setting — and the two factories that say which
 act classes this format uses.
 
-The walk itself, and the format's account of how a container is written down,
-belong to the acts. That is what lets the walk be written without a threaded
-parameter: the state one call carries and the methods that consult it are the
-same object.
+The walk itself, and the format's account of how a plain container is written
+down, belong to the acts. That is what lets the walk be written without a
+threaded parameter: the state one call carries and the methods that consult it
+are the same object.
 
 ```typescript
 // Shown at module scope.
@@ -3476,9 +3492,9 @@ export function hashOf(value: unknown): FabricHash {
 
 Hashing operates on `FabricValue` directly, using codec-encoded state for
 `FabricInstance`s (including the native object wrappers; via `codecOf()`,
-Section 2.4) and type-specific handling for primitives and containers. This
-makes identity hashing independent of any particular wire encoding — the same
-hash whether later serialized to JSON, CBOR, or Automerge.
+Section 2.4) and type-specific handling for primitives and plain containers.
+This makes identity hashing independent of any particular wire encoding — the
+same hash whether later serialized to JSON, CBOR, or Automerge.
 
 ### 6.6 Use Cases
 
@@ -3559,14 +3575,14 @@ boundary-only encoding and the three-layer architecture:
 
 > **`toJSON()` is not a conversion route.** The conversion functions give a
 > `toJSON()` method no standing: a value that is not a `FabricValue`, a
-> `FabricNativeObject`, or an accepted container does not become representable
-> by carrying one. An object bearing `toJSON` is read as the record it is, so
-> the method itself is an ordinary member — a function, which no record may
-> hold. Anything that needs a representation of its own implements the fabric
-> protocol (`FabricInstance` + `[CODEC]`); anything that a caller wants encoded
-> on its way in is that caller's to encode before it reaches the conversion.
-> Honoring `toJSON()` would eagerly convert to JSON-compatible shapes, which is
-> incompatible with late serialization.
+> `FabricNativeObject`, or an accepted plain container does not become
+> representable by carrying one. An object bearing `toJSON` is read as the
+> record it is, so the method itself is an ordinary member — a function, which
+> no record may hold. Anything that needs a representation of its own implements
+> the fabric protocol (`FabricInstance` + `[CODEC]`); anything that a caller
+> wants encoded on its way in is that caller's to encode before it reaches the
+> conversion. Honoring `toJSON()` would eagerly convert to JSON-compatible
+> shapes, which is incompatible with late serialization.
 
 ### 7.2 Unifying JSON Encoding
 
@@ -3999,9 +4015,9 @@ export function nativeFromFabricValue(
 | Plain objects | Recursively unwrapped; output frozen | Recursively unwrapped; output NOT frozen |
 
 The output type is `FabricConvertibleValue` (Section 1.2), reflecting that the
-result may contain native JS types at any depth — a container of them is neither
-a `FabricValue` nor a `FabricNativeObject`, so the recursive type is what names
-it.
+result may contain native JS types at any depth — a plain container of them is
+neither a `FabricValue` nor a `FabricNativeObject`, so the recursive type is
+what names it.
 
 > **Implementation: `FabricNativeWrapper` dispatch.** The unwrapping functions
 > use a single `instanceof FabricNativeWrapper` check to identify all native
@@ -4192,8 +4208,8 @@ from internal codec machinery to callers:
   calls `deepFreeze()`: the codec-produced value (often a `FabricPrimitive`
   subclass, already frozen — the cache hit makes this O(1)), the lenient-mode
   `ProblematicValue` fallback, and the unknown-tag arm's `UnknownValue`. A
-  container arm calls `Object.freeze()` on the array or object it has just
-  built, whose children the leaf arms have already deep-frozen, so the
+  plain-container arm calls `Object.freeze()` on the array or object it has
+  just built, whose children the leaf arms have already deep-frozen, so the
   guarantee holds without walking them a second time. Which arm produced a
   value is therefore not something a caller has to know. See Section 4.5
   step 4.

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -140,13 +140,16 @@ naming the `FabricPrimitive` subclasses individually — describes exactly the
 same set while saying more about it. Read the split as this document's
 elaboration of one implementation arm.
 
-Arms (c) and (d) are the **containers** — the values that hold other
-`FabricValue`s, and so the values a walk descends into. The implementation
-names that set `FabricContainerValue`. What divides the two arms is where the
-contents live, not whether there are any: a plain container's contents are its
-own indices and keys, while a `FabricInstance` holds its contents privately and
-reaches them through the protocol of Section 2.3. Arms (a) and (b) are the
-non-containers, holding no `FabricValue` at all.
+Arms (c) and (d) are the **containers** — the values that expose other
+`FabricValue`s for a walk to descend into. The implementation names that set
+`FabricContainerValue`. What divides the two arms is where the contents live,
+not whether there are any: a plain container's contents are its own indices and
+keys, while a `FabricInstance` holds its contents privately and exposes them
+through the protocol of Section 2.3. Arms (a) and (b) are the non-containers. A
+`FabricPrimitive` may hold `FabricValue`s of its own — a `FabricRegExp` its
+source and flags, a `FabricKeyPair` holding material two `FabricBytes` — but
+holds them privately and self-freezes at construction, so it exposes none of
+them and a walk stops there (Section 8.6).
 
 > **Fabric values are deeply read-only, with one intentional hole.** The plain
 > container arms are read-only, and because their element and property types are

--- a/docs/specs/space-model-formal-spec/4-realm-encoding.md
+++ b/docs/specs/space-model-formal-spec/4-realm-encoding.md
@@ -248,7 +248,7 @@ Where JSON must tag four of the seven primitive types, this format tags one.
 `symbol` is the exception — the transport refuses it outright — so it crosses
 under a tag like any other value a transport cannot carry directly.
 
-### 3.2 Containers
+### 3.2 Plain Containers
 
 Arrays and plain objects are carried directly.
 
@@ -266,14 +266,14 @@ Arrays and plain objects are carried directly.
   of every object.
 - **A `/`-prefixed key is ordinary.** This format reserves no key.
 
-`__proto__` and `constructor` are nonetheless refused on both sides, and that
-is a limit of this implementation rather than of the format. The two are
-refused for different reasons: `__proto__` cannot be rebuilt by the assignment
-this implementation copies records with, while `constructor` copies faithfully
-and is refused because boundaries further on drop it. Section 4 of
-`3-json-encoding.md` gives the fuller account, which is about the host and so
-holds for either format. Like every rule in this section, the refusal applies
-to a container the walk *traverses*; Section 3.3 says which values those are.
+`__proto__` and `constructor` are nonetheless refused on both sides, and that is
+a limit of this implementation rather than of the format. The two are refused
+for different reasons: `__proto__` cannot be rebuilt by the assignment this
+implementation copies records with, while `constructor` copies faithfully and is
+refused because boundaries further on drop it. Section 4 of `3-json-encoding.md`
+gives the fuller account, which is about the host and so holds for either
+format. Like every rule in this section, the refusal applies to a plain
+container the walk *traverses*; Section 3.3 says which values those are.
 
 ### 3.3 The Tagged Form
 
@@ -300,7 +300,7 @@ This is what terminality buys and what it costs. A codec that wants its state
 examined declares itself nonterminal, and then every rule here applies to that
 state, because the walk goes through it.
 
-Three positional slots rather than a container keyed by the tag, because an
+Three positional slots rather than a record keyed by the tag, because an
 array is the cheapest shape the transport carries: no hash table, and a tag
 string that is the codec's own constant rather than a key built per tagged
 form.
@@ -468,7 +468,8 @@ leniency:
   `Date`, a `Map`, a `Set`, or any other class instance. `ArrayBuffer` is worth
   naming: it is the one such type this format's own value union contains, and
   it is legitimate only as the state under a byte-carrying tag.
-- A key this runtime reserves, per Section 3.2, in a container it traverses.
+- A key this runtime reserves, per Section 3.2, in a plain container it
+  traverses.
 - A tag that is not syntactically a tag, per Section 9 of
   [3-json-encoding.md](./3-json-encoding.md), whose tag syntax this format
   shares.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -351,6 +351,15 @@ export type FabricValue =
   | FabricPlainObject
   | undefined;
 
+/**
+ * The container types that are part of `FabricValue`. Note that
+ * `FabricSpecialObject` is a combination of container and non-container.
+ */
+export type FabricContainerValue =
+  | FabricArray
+  | FabricInstance // One of the two direct subclasses of `FabricSpecialObject`.
+  | FabricPlainObject;
+
 /** A `FabricValue` other than `null` or `undefined`. */
 export type NonNullableFabricValue = NonNullable<FabricValue>;
 

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -10,6 +10,7 @@
 // base class.
 export {
   type FabricArray,
+  type FabricContainerValue,
   type FabricConvertibleValue,
   FabricInstance,
   type FabricNativeObject,

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -20,6 +20,7 @@ export {
   type FabricValue,
   type FabricValueLayer,
   type MutableFabricArrayLayer,
+  type MutableFabricContainerValueLayer,
   type MutableFabricPlainObjectLayer,
   type MutableFabricValueLayer,
   type NonNullableFabricValue,

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -40,6 +40,7 @@ export {
 } from "./value-clone.ts";
 
 export {
+  isFabricContainerValue,
   isFabricObjectOrArray,
   isFabricPlainObject,
   isValidFabricPlainObject,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -164,20 +164,25 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * violates it can corrupt data-model invariants, as any broken contract can.
  */
 export type FabricValue =
-  // -- Primitives --
-  | null
+  | bigint
   | boolean
+  | null
   | number
   | string
-  | bigint
   | symbol
-  // -- Fabric special objects --
-  | FabricSpecialObject
-  // -- Containers --
+  | undefined
   | FabricArray
   | FabricPlainObject
-  // -- undefined --
-  | undefined;
+  | FabricSpecialObject;
+
+/**
+ * The container types that are part of `FabricValue`. Note that
+ * `FabricSpecialObject` is a combination of container and non-container.
+ */
+export type FabricContainerValue =
+  | FabricArray
+  | FabricInstance // One of the two direct subclasses of `FabricSpecialObject`.
+  | FabricPlainObject;
 
 /** A `FabricValue` other than `null` or `undefined`. */
 export type NonNullableFabricValue = NonNullable<FabricValue>;

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -222,6 +222,18 @@ export type MutableFabricArrayLayer = FabricValue[];
 export type MutableFabricPlainObjectLayer = Record<string, FabricValue>;
 
 /**
+ * A `FabricContainerValue` with a mutable root. Nested containers remain
+ * ordinary (readonly) `FabricValue`s, so this models a single construction
+ * layer rather than a deep thaw. A `FabricInstance` arm passes through
+ * unchanged: an instance's mutability is its own frozen state to report, not
+ * something a type can layer over it.
+ */
+export type MutableFabricContainerValueLayer =
+  | FabricInstance
+  | MutableFabricArrayLayer
+  | MutableFabricPlainObjectLayer;
+
+/**
  * A `FabricValue` with a mutable root container. Nested containers remain
  * ordinary (readonly) `FabricValue`s, so this models a single construction
  * layer rather than a deep thaw.

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -16,9 +16,15 @@
 
 import { isInertArray } from "@commonfabric/utils/arrays";
 import { isInertPlainObject } from "@commonfabric/utils/objects";
-import { isPlainObject, unsafeObjectKeyIn } from "@commonfabric/utils/types";
+import {
+  isPlainContainer,
+  isPlainObject,
+  unsafeObjectKeyIn,
+} from "@commonfabric/utils/types";
 
 import {
+  type FabricContainerValue,
+  FabricInstance,
   type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
@@ -214,6 +220,20 @@ export function isValidFabricPlainObject(
 }
 
 /**
+ * Narrows to the container arms of `FabricValue` -- a plain object, an array,
+ * or a `FabricInstance` -- that is, the values that hold other `FabricValue`s.
+ *
+ * Contrast `isFabricObjectOrArray()`, which is one arm wider: it also accepts a
+ * `FabricPrimitive`, an object that is not a container. The two are not
+ * interchangeable where the answer decides a descent.
+ */
+export function isFabricContainerValue(
+  value: FabricValue,
+): value is FabricContainerValue {
+  return isPlainContainer(value) || value instanceof FabricInstance;
+}
+
+/**
  * Indicates whether a `FabricValue` is a plain object, an array, or a
  * `FabricSpecialObject` -- everything a `typeof value === "object"` test
  * accepts, minus `null`. The name states the array case because "object" alone
@@ -227,7 +247,8 @@ export function isValidFabricPlainObject(
  *
  * Contrast `isFabricPlainObject()`, which is strictly narrower at RUNTIME: it
  * accepts only plain objects, rejecting arrays and `FabricSpecialObject`s. The
- * two are not interchangeable.
+ * two are not interchangeable. `isFabricContainerValue()` sits between them,
+ * rejecting only the `FabricPrimitive` half of `FabricSpecialObject`.
  */
 export function isFabricObjectOrArray(
   value: FabricValue,

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -20,7 +20,6 @@ import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
 import {
-  FabricContainerValue,
   FabricInstance,
   FabricValue,
   MutableFabricArrayLayer,
@@ -29,6 +28,7 @@ import {
 } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
+import { isFabricContainerValue } from "./type-check.ts";
 import { toDebugKindString } from "./value-debug.ts";
 
 /** Options for `cloneIfNecessary()`. */
@@ -509,7 +509,9 @@ export function cloneForMutation<T extends FabricValue>(
 
   // Empty-path fast path
   if (path.length === 0) {
-    if (!isMutableHandle(value)) {
+    // A non-container is a primitive or a `FabricPrimitive`, and neither has a
+    // mutable handle to hand back.
+    if (!isFabricContainerValue(value)) {
       throw new CloneForMutationError(
         "non-mutable-root",
         -1,
@@ -581,7 +583,8 @@ export function cloneForMutation<T extends FabricValue>(
     }
 
     if (isLast) {
-      if (!isMutableHandle(next)) {
+      // A non-container leaf has no mutable handle; see the root check above.
+      if (!isFabricContainerValue(next)) {
         throw new CloneForMutationError(
           "non-mutable-leaf",
           i,
@@ -644,15 +647,6 @@ function createMissingContainer(
   nextKey: string,
 ): MutableFabricArrayLayer | MutableFabricPlainObjectLayer {
   return isArrayIndexPropertyName(nextKey) || nextKey === "-" ? [] : {};
-}
-
-/**
- * Returns `true` when `cloneForMutation` can produce a mutable handle for
- * the value at `path`. A container qualifies; primitives and
- * `FabricPrimitive`s (which are immutable by construction) do not.
- */
-function isMutableHandle(value: unknown): value is FabricContainerValue {
-  return isPlainContainer(value) || value instanceof FabricInstance;
 }
 
 /**

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -19,7 +19,14 @@ import { backtickQuote } from "@commonfabric/utils/markdown";
 import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 
-import { FabricInstance, FabricValue } from "./interface.ts";
+import {
+  FabricContainerValue,
+  FabricInstance,
+  FabricValue,
+  MutableFabricArrayLayer,
+  MutableFabricContainerValueLayer,
+  MutableFabricPlainObjectLayer,
+} from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { deepFreeze, isValidDeepFrozenFabricValue } from "./deep-freeze.ts";
 import { toDebugKindString } from "./value-debug.ts";
@@ -429,7 +436,7 @@ export interface CloneForMutationResult<T extends FabricValue> {
    * own children remain identity-shared with the input. For a
    * `FabricInstance` at `path`, `pathValue` is its `shallowClone(false)`.
    */
-  pathValue: FabricValue;
+  pathValue: MutableFabricContainerValueLayer;
 }
 
 /**
@@ -494,7 +501,10 @@ export function cloneForMutation<T extends FabricValue>(
   const createMissing = options?.createMissing ?? false;
   const nextKeyAfterPath = options?.nextKeyAfterPath ?? "";
   // Used for every per-container shallow thaw along the spine, and for the
-  // final value-at-`path` thaw, whichever container arm that lands on.
+  // final value-at-`path` thaw, whichever container arm that lands on. The
+  // `frozen: false` overload returns the input type, so a thawed container
+  // arrives here as the readonly view of itself; that is what the casts to
+  // `MutableFabricContainerValueLayer` below correct.
   const cloneOpts = { frozen: false as const, deep: false as const, force };
 
   // Empty-path fast path
@@ -511,7 +521,10 @@ export function cloneForMutation<T extends FabricValue>(
       );
     }
     const newRoot = cloneIfNecessary(value, cloneOpts) as T;
-    return { value: newRoot, pathValue: newRoot };
+    return {
+      value: newRoot,
+      pathValue: newRoot as MutableFabricContainerValueLayer,
+    };
   }
 
   // Non-empty path: The root must be a plain container; descent through a
@@ -533,9 +546,8 @@ export function cloneForMutation<T extends FabricValue>(
   // `current` is always a plain container at the top of each loop iteration:
   // we enter with `newRoot` (a plain container by the root check above) and
   // before descending we always type-check the next container.
-  let current: Record<string, FabricValue> | FabricValue[] = newRoot as
-    | Record<string, FabricValue>
-    | FabricValue[];
+  let current: MutableFabricArrayLayer | MutableFabricPlainObjectLayer =
+    newRoot as MutableFabricArrayLayer | MutableFabricPlainObjectLayer;
 
   for (let i = 0; i < path.length; i++) {
     const key = path[i]!;
@@ -549,12 +561,12 @@ export function cloneForMutation<T extends FabricValue>(
       // the next key that will be used against it: `path[i+1]` for
       // intermediate steps, `nextKeyAfterPath` for the final step.
       const nextKey = isLast ? nextKeyAfterPath : path[i + 1]!;
-      next = createMissingContainer(nextKey);
-      (current as Record<string, FabricValue>)[key] = next;
-      // `next` is freshly allocated and already mutable; skip the
+      const fresh = createMissingContainer(nextKey);
+      (current as Record<string, FabricValue>)[key] = fresh;
+      // `fresh` is freshly allocated and already mutable; skip the
       // shallow-thaw step below.
-      if (isLast) return { value: newRoot, pathValue: next };
-      current = next as Record<string, FabricValue> | FabricValue[];
+      if (isLast) return { value: newRoot, pathValue: fresh };
+      current = fresh;
       continue;
     } else {
       throw new CloneForMutationError(
@@ -604,13 +616,16 @@ export function cloneForMutation<T extends FabricValue>(
     }
 
     if (isLast) {
-      return { value: newRoot, pathValue: thawed };
+      return {
+        value: newRoot,
+        pathValue: thawed as MutableFabricContainerValueLayer,
+      };
     }
 
     // Type assertion safe: we type-checked `next` is a plain container,
     // and shallow-thaw preserves prototype, so `thawed` is also a plain
     // container.
-    current = thawed as Record<string, FabricValue> | FabricValue[];
+    current = thawed as MutableFabricArrayLayer | MutableFabricPlainObjectLayer;
   }
 
   // Unreachable: the loop always returns on its final iteration when
@@ -627,7 +642,7 @@ export function cloneForMutation<T extends FabricValue>(
  */
 function createMissingContainer(
   nextKey: string,
-): Record<string, FabricValue> | FabricValue[] {
+): MutableFabricArrayLayer | MutableFabricPlainObjectLayer {
   return isArrayIndexPropertyName(nextKey) || nextKey === "-" ? [] : {};
 }
 
@@ -636,7 +651,7 @@ function createMissingContainer(
  * the value at `path`. A container qualifies; primitives and
  * `FabricPrimitive`s (which are immutable by construction) do not.
  */
-function isMutableHandle(value: unknown): boolean {
+function isMutableHandle(value: unknown): value is FabricContainerValue {
   return isPlainContainer(value) || value instanceof FabricInstance;
 }
 

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -373,15 +373,14 @@ export interface CloneForMutationOptions {
   force?: boolean;
 
   /**
-   * Whether to create missing intermediate containers along `path` as the
-   * helper descends. Default: `false` (throws `CloneForMutationError` with kind
-   * `"missing-segment"` on the first missing slot).
+   * Whether to create missing intermediate plain containers along `path` as
+   * the helper descends. Default: `false` (throws `CloneForMutationError` with
+   * kind `"missing-segment"` on the first missing slot).
    *
    * When `createMissing: true`, at each path step where the container at that
-   * key is absent, the helper allocates a fresh container and splices it into
-   * its parent before descending. The new container's shape (array vs. plain
-   * object) is chosen from the NEXT segment that will be used as a key against
-   * it:
+   * key is absent, the helper allocates a fresh plain container and splices it
+   * into its parent before descending. Its shape (array vs. plain object) is
+   * chosen from the NEXT segment that will be used as a key against it:
    *
    * - For intermediate path steps, the next segment is `path[i+1]`.
    * - For the final path step, the next segment is `nextKeyAfterPath` if
@@ -394,8 +393,8 @@ export interface CloneForMutationOptions {
   createMissing?: boolean;
 
   /**
-   * Hint for the container shape to create at the final path step when it's
-   * missing and `createMissing: true`. Should be the next key the caller
+   * Hint for the plain-container shape to create at the final path step when
+   * it's missing and `createMissing: true`. Should be the next key the caller
    * intends to access against the value-at-path. Ignored when `createMissing:
    * false` or when the final path step already exists. Default: `""` (selects a
    * plain object).
@@ -471,7 +470,7 @@ export interface CloneForMutationResult<T extends FabricValue> {
  *
  * By default (`createMissing: false`), missing segments throw a
  * `CloneForMutationError` with kind `"missing-segment"`. With
- * `createMissing: true`, the helper allocates fresh containers as it
+ * `createMissing: true`, the helper allocates fresh plain containers as it
  * descends through missing slots; see {@link CloneForMutationOptions} for
  * the shape-selection rules (in particular the `nextKeyAfterPath` hint).
  *
@@ -483,8 +482,7 @@ export interface CloneForMutationResult<T extends FabricValue> {
  * propagate as plain `Error`s.
  *
  * @param value - The input value tree.
- * @param path - Path to the container (or `FabricInstance`) to expose as
- *   mutable.
+ * @param path - Path to the container to expose as mutable.
  * @param options - See `CloneForMutationOptions`.
  */
 export function cloneForMutation<T extends FabricValue>(
@@ -496,7 +494,7 @@ export function cloneForMutation<T extends FabricValue>(
   const createMissing = options?.createMissing ?? false;
   const nextKeyAfterPath = options?.nextKeyAfterPath ?? "";
   // Used for every per-container shallow thaw along the spine, and for the
-  // final value-at-`path` thaw if it's a plain container or `FabricInstance`.
+  // final value-at-`path` thaw, whichever container arm that lands on.
   const cloneOpts = { frozen: false as const, deep: false as const, force };
 
   // Empty-path fast path
@@ -547,8 +545,8 @@ export function cloneForMutation<T extends FabricValue>(
     if (Object.hasOwn(current, key)) {
       next = (current as Record<string, FabricValue>)[key];
     } else if (createMissing) {
-      // Allocate a fresh container at this slot. Its shape comes from the
-      // next key that will be used against it: `path[i+1]` for
+      // Allocate a fresh plain container at this slot. Its shape comes from
+      // the next key that will be used against it: `path[i+1]` for
       // intermediate steps, `nextKeyAfterPath` for the final step.
       const nextKey = isLast ? nextKeyAfterPath : path[i + 1]!;
       next = createMissingContainer(nextKey);
@@ -596,10 +594,10 @@ export function cloneForMutation<T extends FabricValue>(
       }
     }
 
-    // Shallow-thaw the next spine container. For plain containers and
-    // `FabricInstance`s this is a `cloneIfNecessary(_, { frozen: false,
-    // deep: false, force })` call; under `force: false` and an
-    // already-mutable input it short-circuits to identity.
+    // Shallow-thaw the next spine container. Whichever container arm it is,
+    // that is a `cloneIfNecessary(_, { frozen: false, deep: false, force })`
+    // call; under `force: false` and an already-mutable input it
+    // short-circuits to identity.
     const thawed = cloneIfNecessary(next, cloneOpts);
     if (thawed !== next) {
       (current as Record<string, FabricValue>)[key] = thawed;
@@ -622,8 +620,8 @@ export function cloneForMutation<T extends FabricValue>(
 }
 
 /**
- * Allocates a fresh, mutable container of the right shape for `nextKey`.
- * Array-index-shaped keys (per `isArrayIndexPropertyName`) and the
+ * Allocates a fresh, mutable plain container of the right shape for
+ * `nextKey`. Array-index-shaped keys (per `isArrayIndexPropertyName`) and the
  * JSON-Pointer append marker `"-"` produce an array; everything else
  * produces a plain object.
  */
@@ -635,9 +633,8 @@ function createMissingContainer(
 
 /**
  * Returns `true` when `cloneForMutation` can produce a mutable handle for
- * the value at `path`. Plain containers and `FabricInstance`s qualify;
- * primitives and `FabricPrimitive`s (which are immutable by construction)
- * do not.
+ * the value at `path`. A container qualifies; primitives and
+ * `FabricPrimitive`s (which are immutable by construction) do not.
  */
 function isMutableHandle(value: unknown): boolean {
   return isPlainContainer(value) || value instanceof FabricInstance;
@@ -678,15 +675,16 @@ const hasChildAt = (
 
 /**
  * Returns a deep-frozen clone of `root` with `value` set at `path`, creating
- * missing intermediate containers as needed (their array-vs-object shape is
- * chosen from the next path segment, per `cloneForMutation`'s `createMissing`).
+ * missing intermediate plain containers as needed (their array-vs-object
+ * shape is chosen from the next path segment, per `cloneForMutation`'s
+ * `createMissing`).
  * Subtrees off the mutated spine are shared by identity. An empty `path`
  * replaces the whole value.
  *
- * Like `cloneForMutation`, descent through a *present* non-container along the
- * path -- a primitive, or a `FabricInstance`/`FabricPrimitive` -- throws a
- * `CloneForMutationError` rather than silently replacing that leaf with fresh
- * spine structure. Cyclic values are not yet supported (see
+ * Like `cloneForMutation`, descent through a *present* value that is not a
+ * plain container -- a primitive, or a `FabricInstance`/`FabricPrimitive` --
+ * throws a `CloneForMutationError` rather than silently replacing that leaf
+ * with fresh spine structure. Cyclic values are not yet supported (see
  * `cloneIfNecessary`).
  */
 export function cloneWithValueAtPath(

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -653,8 +653,9 @@ describe("type-check", () => {
 
     describe("given a non-container `FabricValue`", () => {
       // The whole of the difference from `isFabricObjectOrArray()`, which
-      // accepts these: a `FabricPrimitive` is an object that holds no
-      // `FabricValue`, so there is nothing in one to descend into.
+      // accepts these: a `FabricPrimitive` self-freezes at construction and
+      // exposes no `FabricValue` for a walk to descend into, whatever it holds
+      // privately.
       it("returns `false` for a `FabricPrimitive`", () => {
         expect(isFabricContainerValue(new FabricBytes(new Uint8Array([1]))))
           .toBe(false);

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -15,6 +15,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import {
+  isFabricContainerValue,
   isFabricPlainObject,
   isValidFabricPlainObject,
   isValidFabricValue,
@@ -626,6 +627,53 @@ describe("type-check", () => {
       it("returns `false` for a `FabricSpecialObject`", () => {
         expect(isValidFabricPlainObject(new FabricBytes(new Uint8Array([1]))))
           .toBe(false);
+      });
+    });
+  });
+
+  describe("isFabricContainerValue()", () => {
+    describe("given a container arm of `FabricValue`", () => {
+      it("returns `true` for a plain object", () => {
+        expect(isFabricContainerValue({})).toBe(true);
+        expect(isFabricContainerValue({ a: 1, b: "two" })).toBe(true);
+      });
+
+      it("returns `true` for an array", () => {
+        expect(isFabricContainerValue([])).toBe(true);
+        expect(isFabricContainerValue([1, 2, 3])).toBe(true);
+      });
+
+      it("returns `true` for a `FabricInstance`", () => {
+        expect(
+          isFabricContainerValue(FabricError.fromNativeError(new Error("x"))),
+        )
+          .toBe(true);
+      });
+    });
+
+    describe("given a non-container `FabricValue`", () => {
+      // The whole of the difference from `isFabricObjectOrArray()`, which
+      // accepts these: a `FabricPrimitive` is an object that holds no
+      // `FabricValue`, so there is nothing in one to descend into.
+      it("returns `false` for a `FabricPrimitive`", () => {
+        expect(isFabricContainerValue(new FabricBytes(new Uint8Array([1]))))
+          .toBe(false);
+        expect(isFabricContainerValue(new FabricEpochNsec(1n))).toBe(false);
+      });
+
+      it("returns `false` for `null`", () => {
+        expect(isFabricContainerValue(null)).toBe(false);
+      });
+
+      it("returns `false` for `undefined`", () => {
+        expect(isFabricContainerValue(undefined)).toBe(false);
+      });
+
+      it("returns `false` for a scalar", () => {
+        expect(isFabricContainerValue(1)).toBe(false);
+        expect(isFabricContainerValue("a")).toBe(false);
+        expect(isFabricContainerValue(true)).toBe(false);
+        expect(isFabricContainerValue(42n)).toBe(false);
       });
     });
   });

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -4,6 +4,7 @@ import {
   cloneForMutation,
   CloneForMutationError,
   cloneIfNecessary,
+  type MutableFabricContainerValueLayer,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { isInstance, isObjectNotArray } from "@commonfabric/utils/types";
@@ -126,7 +127,7 @@ const thawSpine = (
   options?: { createMissing?: boolean; nextKeyAfterPath?: string },
 ): { root: FabricValue; container: PatchContainer } => {
   let value: FabricValue;
-  let pathValue: FabricValue;
+  let pathValue: MutableFabricContainerValueLayer;
   try {
     ({ value, pathValue } = cloneForMutation(root, thawPath, options));
   } catch (e) {


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

A `FabricInstance` holds other `FabricValue`s and is descended by any walk over
one, so it is a container. `FabricContainerValue` names that set — arrays,
plain objects, and `FabricInstance`s — and this change makes the rest of the
repository agree with the name.

## The type, and its mutable counterpart

`FabricContainerValue` is the three container arms of `FabricValue`.
`MutableFabricContainerValueLayer` is the same set with a mutable root and
readonly children, alongside the existing `MutableFabricArrayLayer` /
`MutableFabricPlainObjectLayer` / `MutableFabricValueLayer`. A `FabricInstance`
arm passes through unchanged: an instance's mutability is its own frozen state
to report, not something a type can layer over it.

Both are mirrored into `packages/api/index.ts` to the extent that file mirrors
its neighbors — it carries `FabricContainerValue` and none of the
`Mutable*Layer` family, matching what was already there.

## What the spec said, and what it says now

`docs/specs/space-model-formal-spec/1-fabric-values.md` used "container" for
arrays and plain objects only. Its §1.5 was titled "Recursive Containers" and
covered just those two, and its immutability callout drew the line by name:
"The **container arms** are read-only… The hole is the `FabricInstance` arm."

§1.2 now names the grouping directly:

> Arms (c) and (d) are the **containers** — the values that hold other
> `FabricValue`s, and so the values a walk descends into. […] What divides the
> two arms is where the contents live, not whether there are any: a plain
> container's contents are its own indices and keys, while a `FabricInstance`
> holds its contents privately and reaches them through the protocol of
> Section 2.3.

Everything else follows. §1.5 is retitled **Plain Containers** with a lead
placing it against the third arm; the immutability callout's hole becomes "the
one container the guarantee does not reach"; and the passages that genuinely
mean arrays-and-objects-only — the codec-engine walk, hashing, the `toJSON()`
callout, `nativeFromFabricValue()`'s output, the decode-walker egress — say
"plain container". `4-realm-encoding.md` §3.2 is retitled likewise.

`2-hash-byte-format.md` needed nothing, and is quiet corroboration: its
"**compound** (`0x1N`) for containers whose children are tagged values" indexes
`TAG_ARRAY` / `TAG_OBJECT` / `TAG_INSTANCE` — the wider set, already.

## The predicate

`value-clone.ts` held the membership test privately as `isMutableHandle()`,
which named why one caller asked rather than what it answers. It is now
`isFabricContainerValue()` in `type-check.ts`, beside the neighbor it is one arm
narrower than: `isFabricObjectOrArray()` also accepts a `FabricPrimitive`, which
self-freezes at construction and exposes no `FabricValue` for a walk to descend
into. Both doc comments state the contrast.

The two `cloneForMutation()` gates each gain a clause tying "not a container"
back to the `non-mutable-*` error they raise, which the old name carried.

## Use sites

`CloneForMutationResult.pathValue` was declared `FabricValue` while its doc
promised a mutable container, so every consumer recovered the type by hand. It
is now `MutableFabricContainerValueLayer`. The narrowing predicate feeds the
spine loop, which is how the first typecheck found all three return sites at
once. One cast disappears outright; the spine cursor and
`createMissingContainer()`'s return use the named layer types instead of inline
spellings; `memory/v2/patch.ts`'s local is tightened, which makes its
`isContainer()` visibly a narrowing rather than a validation.

Two casts remain inside `cloneForMutation()`, both the same gap:
`cloneIfNecessary()`'s `frozen: false` overload returns the input type, so a
thawed container arrives as the readonly view of itself. The `frozen: true`
overload says `Immutable<T>`; the mutable side says nothing. Closing that needs
a generic "mutable layer of `T`" that does not exist, and is left alone here.

## Testing

A differential test pins the arm that separates the new predicate from its
neighbor. **Control**: reimplementing `isFabricContainerValue()` as
`isFabricObjectOrArray()`'s body (`typeof value === "object" && value !== null`)
reddens ``returns `false` for a `FabricPrimitive` `` and, independently, a
`cloneForMutation()` case — 2 failed, 50 passed. Restored: 52 passed, 0 failed.

Everything else here is behavior-preserving: type declarations, comments, and
spec prose.

Gates run repo-wide on the merged tree: `deno task check`, `check-docs` (566
blocks), `deno fmt --check` (5048 files), `deno lint` (4954 files), `cfcheck`
(421 pattern files), and the standalone `check-docs-history-index`,
`check-conflict-markers`, `check-control-characters`, `check-skill-facts`,
`check-package-cycles`, `check-no-waitfor`. Suites: `api` 26 passed,
`data-model` 52 passed, `memory` 574 passed, 0 failed.

## Known bug, deliberately not fixed here

Tightening `pathValue` made a latent bug visible rather than introducing one.
`cloneForMutation()` requires a plain container at every *intermediate* path
step but permits any container arm as the value **at** `path`, and the path-edit
helpers then index that value as a record:

```
cloneWithValueAtPath(Object.freeze({ err: FabricError.fromNativeError(...) }),
                     ["err", "extra"], 42)
→ after.err is FabricError: true
→ own props on it: [ "extra" ]
```

That contradicts `FabricInstance`'s own doc — "holds all of its state privately
… so it has no own properties at all" — and the written value is invisible to
the codec. The same shape is at
`packages/runner/src/storage/transaction/mutable-path-write.ts:149` and
`packages/runner/src/cfc/prepare.ts:2611`, whose casts compiled silently while
`pathValue` was `FabricValue`. It is a real refusal to add, so it belongs in its
own change rather than inside a behavior-preserving one; a follow-on starts
immediately after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJXgfsmLofm3ViCtBth5tb


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


