### PR TITLE
fix(ts-transformers): anchor remaining replacement nodes

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -71,6 +71,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 
 ## Shipped or superseded designs and decision records
 
+- [APRIME-LINEAGE-HANDOFF.md](packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md) — the authored-source lineage investigation, per-channel hazards, probes, and execution record for the CT-1868/1869/1870 arc, completed August 2026.
 - [topics-crossref-identity-break.md](topics-crossref-identity-break.md) — decision record for the topics reference-graph contract break shipped in #5921, the first accepted break in the pattern-update registries; backfilled when the registries gained their `record` linkage.
 - [parking-admin-floor-contract-break.md](parking-admin-floor-contract-break.md) — decision record for the parking-coordinator admin-roster contract break shipped in #6091: why correcting a `requiredIntegrity` floor nothing could satisfy had to change the `ifc` at the roster's path, and why a piece holding a roster loses nothing it could have written, August 2026.
 - [lunch-poll-identity-break.md](lunch-poll-identity-break.md) — decision record for the lunch-poll identity contract break: display-name identity replaced by profile cells; stored rows survive the vintage replay, but the root argument contract requires migrating the populated poll to a fresh piece.

--- a/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -1,3 +1,11 @@
+---
+status: historical
+created: 2026-07-21
+archived: 2026-08-25
+reason: "Executed handoff; the CT-1868/1869/1870 authored-lineage arc shipped."
+superseded-by: docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+---
+
 # A′ Master Handoff — transform-time authored source locations (2026-07-07)
 
 **Read this first.** It is the canonical carry-forward for the **A′ work-line**
@@ -279,22 +287,17 @@ throughout).
 - `preserveLineage(node, origin)` = **provenance**: "in authored text I was born
   there, as that node." For replacement-materialization sites, where the
   provenance target and the checker-identity target are the same node.
-- `preserveNodeSourceMap(node, originalNode, identityNode?)` = the resolution
+- `preserveNodeSourceMap(node, originalNode, identityNode)` = the resolution
   for sites where the two concerns **diverge**: a node has exactly one
   `original` pointer, so when position should map to the authored expression but
   identity must point elsewhere (e.g. `getHelperExpr` pointing a fresh
   `__cfHelpers` identifier's original at the module's helper binding so the
   checker resolves it), position goes via smr and original carries identity.
-  Same move as builder-call-hoisting's `setOriginalNode(name, innerCall)`. Keep
-  the name for now. CT-1868 added a third helper, `ast/utils.ts`
-  **`preserveSourceMapRange(node, origin)`** (smr-only free function, the
-  shipped default carrier — §6a), which functionally overlaps
-  `preserveNodeSourceMap`'s no-`identityNode` mode; the acknowledged follow-up
-  (fold into the hygiene pass or CT-1869) is to migrate
-  `preserveNodeSourceMap`'s non-identity callers onto it, leaving the method
-  only for the genuine identity/position-divergence sites. Reading note:
-  `preserveNodeSourceMap`'s `ts.getSourceMapRange(x) ?? x` has a dead `??` —
-  `getSourceMapRange` never returns undefined.
+  Same move as builder-call-hoisting's `setOriginalNode(name, innerCall)`. The
+  identity node is required: source-map-only helper names, property accesses,
+  and calls use `ast/utils.ts`'s
+  **`preserveSourceMapRange(node, origin)`** instead. The method therefore
+  represents only genuine identity/position divergence.
 
 **Hazards (why this isn't a mechanical sweep):**
 
@@ -341,10 +344,9 @@ inert.** The mechanisms, each observed and root-caused during implementation
 ## 7. Narrow vs broad — decision and pricing
 
 **Decision: narrow-first (the §5 set), then a source-map-range-only broad
-sweep.** The narrow set is complete against direct probe evidence and fully
-unblocks A′. The first broad slice covers the replacement sites whose authored
-anchor is already in scope and unambiguous. More opaque sites remain separate: a
-wrong sourcemap anchor is worse than an absent one.
+sweep.** The narrow set and both broad slices are complete against direct probe
+evidence. A wrong source-map anchor is worse than an absent one, so every broad
+site is content-bound to its authored semantic predecessor.
 
 **Sweep results (read-only Opus survey, 2026-07-07, on 39afdb62b; three claims
 spot-verified exactly — treat the rest as a work list to re-verify at
@@ -361,28 +363,34 @@ implementation):**
   containers, handler attributes and initializers, nested array receiver `key()`
   calls, and module-scope `__cf_data` wrappers carry their authored container or
   expression range. These sites use `preserveSourceMapRange` exclusively.
-- **Remaining judgment work:** destructured-binding declarations in
-  `pattern-body-reactive-root-lowering.ts` do not retain the original binding
-  node in their intermediate representation, so they need an explicit anchor
-  design. The diagnostics replacement audit and `CFHelpers` API cleanup remain
-  independent follow-ups. The `ifelse.ts` when/unless helpers anchor on the
-  condition (left operand), not the whole logical expression; that existing
-  choice remains intentionally unchanged pending a focused sourcemap review.
+- **Judgment broad slice:** `DestructureBinding` retains the binding syntax for
+  each lowered leaf. A synthesized temporary root anchors to the authored
+  initializer; local leaf declarations and destructured-parameter prologue
+  declarations anchor to their binding elements. Assert-diagnostics callback
+  bodies anchor to the authored body, and each replacement record block and
+  `return` anchors to the concise expression or authored return it replaces.
+  `CFHelpers.preserveNodeSourceMap` requires a distinct identity node; its
+  former source-map-only uses call `preserveSourceMapRange` directly. A focused
+  review kept the `ifelse.ts` asymmetry: `ifElse` anchors to the whole
+  conditional, while `when` and `unless` anchor to the left condition.
 - **Excluded correctly** (sweep audit list retained in the session record):
   expression-rewrite emitters (delegate to known sites), reactive-variable-for
   (already fully preserved), type-position construction, additive schema/
   coverage/hardening/shadowing machinery, analysis-only stages.
 
-**Final call:** builder-path lineage stays complete, and the straightforward
-broad slice follows the same source-map-range-only safety rule. Opaque anchors
-remain out of scope until their source identity is represented explicitly.
+**Final call:** builder-path lineage and the broad replacement sweep are
+complete. Both broad slices follow the source-map-range-only safety rule.
+End-to-end map probes place the destructuring temporary at its authored
+initializer, each leaf at its binding element, a concise assert record return
+at its expression, and block assert record returns at their authored `return`
+statements. The fixture corpus remains byte-identical because no text range or
+original-node identity is added.
 
-**CT-1869 implementers, carry §6a:** the implementation proved the per-site
-judgment is not just "is the anchor's span correct" but **"does textRange reach
-the printer here"** and **"does an original reach a marker/typeRegistry consumer
-here."** Default to `preserveSourceMapRange`; escalate to full `preserveLineage`
-only with the emit-invariance check (byte-diff `--show-transformed` on corpus
-patterns) and the full fixture suite green.
+The implementation proves the per-site judgment is not just "is the anchor's
+span correct" but **"does textRange reach the printer here"** and **"does an
+original reach a marker/typeRegistry consumer here."** Default to
+`preserveSourceMapRange`; escalate to full `preserveLineage` only with the
+emit-invariance check and the full fixture suite green.
 
 ## 8. Verification discipline for the fix PR
 
@@ -398,7 +406,7 @@ patterns) and the full fixture suite green.
 - Sourcemap spot-check in a dev shell (positions in devtools land on authored
   lines for a rebuilt callback).
 
-## 9. The A′ line proper — shape of remaining work (post-lineage)
+## 9. The A′ line proper — shipped shape
 
 1. **Lineage fix lands** (§5–§8). Everything below reads positions through it.
 2. **Transform-time injection design** (the next design conversation):

--- a/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -296,9 +296,8 @@ throughout).
   Same move as builder-call-hoisting's `setOriginalNode(name, innerCall)`. The
   identity node is required: source-map-only helper names, property accesses,
   and calls use `ast/utils.ts`'s
-  **`preserveSourceMapRange(node, origin)`** instead. A caller whose two
-  targets coincide passes the same node twice: identity carried without the
-  text range `preserveLineage` would add.
+  **`preserveSourceMapRange(node, origin)`** instead. The method therefore
+  represents only genuine identity/position divergence.
 
 **Hazards (why this isn't a mechanical sweep):**
 

--- a/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
+++ b/docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md
@@ -1,6 +1,6 @@
 ---
 status: historical
-created: 2026-07-21
+created: 2026-07-07
 archived: 2026-08-25
 reason: "Executed handoff; the CT-1868/1869/1870 authored-lineage arc shipped."
 superseded-by: docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -296,8 +296,9 @@ throughout).
   Same move as builder-call-hoisting's `setOriginalNode(name, innerCall)`. The
   identity node is required: source-map-only helper names, property accesses,
   and calls use `ast/utils.ts`'s
-  **`preserveSourceMapRange(node, origin)`** instead. The method therefore
-  represents only genuine identity/position divergence.
+  **`preserveSourceMapRange(node, origin)`** instead. A caller whose two
+  targets coincide passes the same node twice: identity carried without the
+  text range `preserveLineage` would add.
 
 **Hazards (why this isn't a mechanical sweep):**
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1712,8 +1712,9 @@ it drives the full pipeline over a five-origin fixture and asserts every
 builder call AND callback recovers to its distinctive authored snippet
 (content is the ground truth, not merely `pos >= 0`). This is the read path
 for transform-time source annotation (A′, CT-1870), and the same fallback
-family §16.2's coverage spans use. Rationale, per-site table, and the probe
-rig: `packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
+family §16.2's coverage spans use. The investigation and probe record is
+archived at
+`docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md`.
 
 The same source-map-range-only rule applies to semantic replacement boundaries
 outside the builder-artifact path. Pattern-body reactive-root replacements,
@@ -1727,6 +1728,24 @@ node's text range or original-node identity.
 `test/replacement-source-map-range.test.ts` runs fixtures through the owning
 pipeline stage and content-binds every recovered range; it also directly pins
 the non-input-bound reactive-wrapper helper branch.
+
+Opaque destructuring uses explicit anchors carried by `DestructureBinding`.
+The temporary-root declaration maps to the authored initializer it names;
+each lowered leaf declaration maps to its binding element. A prologue statement
+created from a destructured callback parameter carries that same binding-element
+range. `AssertDiagnosticsTransformer` maps its rebuilt callback body to the
+authored concise expression or block, and maps each replacement record block
+and `return` to the authored expression or `return` it replaces. These nodes
+carry source-map ranges only, so the lineage does not alter printing or checker
+identity.
+
+`CFHelpers.preserveNodeSourceMap` requires separate range and checker-identity
+nodes and is used only where those channels diverge. Helper names, property
+accesses, and calls that need position alone use `preserveSourceMapRange`.
+The logical-expression helpers keep their asymmetric authored anchors:
+`ifElse` maps to the whole conditional expression, while `when` and `unless`
+map to their left condition. The regression binds all three choices to source
+content.
 
 That file closes with a corpus-wide invariant: across every fixture, no
 synthesized `JsxAttribute`, `JsxElement`, `JsxExpression`, or

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -1739,9 +1739,10 @@ and `return` to the authored expression or `return` it replaces. These nodes
 carry source-map ranges only, so the lineage does not alter printing or checker
 identity.
 
-`CFHelpers.preserveNodeSourceMap` requires separate range and checker-identity
-nodes and is used only where those channels diverge. Helper names, property
-accesses, and calls that need position alone use `preserveSourceMapRange`.
+`CFHelpers.preserveNodeSourceMap` requires explicit range and checker-identity
+nodes; a caller whose targets coincide passes the same node twice to carry
+identity without a text range. Helper names, property accesses, and calls that
+need position alone use `preserveSourceMapRange`.
 The logical-expression helpers keep their asymmetric authored anchors:
 `ifElse` maps to the whole conditional expression, while `when` and `unless`
 map to their left condition. The regression binds all three choices to source

--- a/packages/ts-transformers/src/ast/utils.ts
+++ b/packages/ts-transformers/src/ast/utils.ts
@@ -330,9 +330,9 @@ export function setParentPointers(node: ts.Node, parent?: ts.Node): void {
  *     identity-sensitive classifiers — e.g. a compute wrapper whose original
  *     points into the subtree `markSyntheticComputeOwnedSubtree` just marked
  *     reads as compute-owned itself. Use {@link preserveSourceMapRange} there.
- *   - Where position and checker-identity must point at DIFFERENT nodes (a
- *     node has one `original` pointer), use `CFHelpers.preserveNodeSourceMap`
- *     instead; use this where the two coincide.
+ *   - Where a node needs source-map position and checker identity but must not
+ *     acquire a text range, use `CFHelpers.preserveNodeSourceMap` instead. Its
+ *     range and identity nodes may differ or coincide.
  */
 export function preserveLineage<T extends ts.Node>(
   node: T,

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -45,8 +45,9 @@ export class CFHelpers {
   }
 
   /**
-   * Carries the range of `originalNode` and the distinct checker identity of
-   * `identityNode` onto `node`.
+   * Carries the source-map range of `originalNode` and the checker identity of
+   * `identityNode` onto `node` without assigning a text range. The range and
+   * identity nodes may differ or coincide.
    */
   preserveNodeSourceMap<T extends ts.Node>(
     node: T,

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { preserveSourceMapRange } from "../ast/utils.ts";
 import { TransformationContext } from "./mod.ts";
 
 export const CF_HELPERS_IDENTIFIER = "__cfHelpers";
@@ -43,18 +44,19 @@ export class CFHelpers {
     return !!this.#helperIdent;
   }
 
-  // Returns an PropertyAccessExpression of the requested
-  // helper name e.g. `(__cfHelpers.lift)`.
+  /**
+   * Carries the range of `originalNode` and the distinct checker identity of
+   * `identityNode` onto `node`.
+   */
   preserveNodeSourceMap<T extends ts.Node>(
     node: T,
     originalNode: ts.Node,
-    identityNode?: ts.Node,
+    identityNode: ts.Node,
   ): T {
-    const sourceMapRange = ts.getSourceMapRange(originalNode) ?? originalNode;
-    const preserved = ts.setSourceMapRange(node, sourceMapRange);
-    return identityNode
-      ? ts.setOriginalNode(preserved, identityNode) as T
-      : preserved as T;
+    return ts.setOriginalNode(
+      preserveSourceMapRange(node, originalNode),
+      identityNode,
+    ) as T;
   }
 
   getHelperExpr(
@@ -77,11 +79,11 @@ export class CFHelpers {
       originalNode,
       this.#helperIdent!,
     );
-    const helperName = this.preserveNodeSourceMap(
+    const helperName = preserveSourceMapRange(
       this.#factory.createIdentifier(name),
       originalNode,
     );
-    return this.preserveNodeSourceMap(
+    return preserveSourceMapRange(
       this.#factory.createPropertyAccessExpression(
         helperIdent,
         helperName,
@@ -96,7 +98,7 @@ export class CFHelpers {
     typeArguments: readonly ts.TypeNode[] | undefined,
     argumentsArray: readonly ts.Expression[],
   ): ts.CallExpression {
-    return this.preserveNodeSourceMap(
+    return preserveSourceMapRange(
       this.#factory.createCallExpression(
         this.getHelperExpr(name, originalNode),
         typeArguments,

--- a/packages/ts-transformers/src/transformers/assert-diagnostics.ts
+++ b/packages/ts-transformers/src/transformers/assert-diagnostics.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 import { HelpersOnlyTransformer } from "../core/transformers.ts";
 import type { TransformationContext } from "../core/mod.ts";
 import { resolvesToCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
-import { getNodeText } from "../ast/utils.ts";
+import { getNodeText, preserveSourceMapRange } from "../ast/utils.ts";
 import {
   ASSERT_CAPTURE_HELPER_NAME,
   unwrapExpression,
@@ -150,9 +150,12 @@ function rewriteAssertCall(
   );
   if (!returned) return undefined;
 
-  const body = factory.createBlock(
-    [createPartsDeclaration(partsIdentifier, context), ...returned],
-    true,
+  const body = preserveSourceMapRange(
+    factory.createBlock(
+      [createPartsDeclaration(partsIdentifier, context), ...returned],
+      true,
+    ),
+    callback.body,
   );
   const rewrittenCallback = ts.isArrowFunction(callback)
     ? factory.updateArrowFunction(
@@ -202,7 +205,7 @@ function rewriteResultStatements(
   context: TransformationContext,
 ): ts.Statement[] | undefined {
   if (!ts.isBlock(body)) {
-    return [createRecordReturn(body, partsIdentifier, context)];
+    return [createRecordReturn(body, body, partsIdentifier, context)];
   }
 
   let rewroteAny = false;
@@ -218,7 +221,12 @@ function rewriteResultStatements(
         return node;
       }
       rewroteAny = true;
-      return createRecordReturn(node.expression, partsIdentifier, context);
+      return createRecordReturn(
+        node.expression,
+        node,
+        partsIdentifier,
+        context,
+      );
     }
     return ts.visitEachChild(node, visit, context.tsContext);
   };
@@ -239,6 +247,7 @@ function rewriteResultStatements(
  */
 function createRecordReturn(
   resultExpression: ts.Expression,
+  authoredSite: ts.Node,
   partsIdentifier: ts.Identifier,
   context: TransformationContext,
 ): ts.Statement {
@@ -250,30 +259,40 @@ function createRecordReturn(
     ? instrumentExpression(resultExpression, partsIdentifier, context)
     : resultExpression;
 
-  return factory.createBlock([
-    createOkDeclaration(okIdentifier, instrumented, context),
+  const recordReturn = preserveSourceMapRange(
     factory.createReturnStatement(
-      factory.createObjectLiteralExpression([
-        factory.createPropertyAssignment("ok", okIdentifier),
-        factory.createPropertyAssignment(
-          "source",
-          factory.createStringLiteral(sourceTextOf(resultExpression)),
-        ),
-        // Rendering the recorded operands is deferred to here, and to only the
-        // failing path: `assertRenderParts` returns an empty list when `ok` is
-        // true, so a passing assertion never renders an operand.
-        factory.createPropertyAssignment(
-          "parts",
-          context.cfHelpers.createHelperCall(
-            "assertRenderParts",
-            resultExpression,
-            undefined,
-            [okIdentifier, partsIdentifier],
+      factory.createObjectLiteralExpression(
+        [
+          factory.createPropertyAssignment("ok", okIdentifier),
+          factory.createPropertyAssignment(
+            "source",
+            factory.createStringLiteral(sourceTextOf(resultExpression)),
           ),
-        ),
-      ], true),
+          // Rendering the recorded operands is deferred to here, and to only
+          // the failing path: `assertRenderParts` returns an empty list when
+          // `ok` is true, so a passing assertion never renders an operand.
+          factory.createPropertyAssignment(
+            "parts",
+            context.cfHelpers.createHelperCall(
+              "assertRenderParts",
+              resultExpression,
+              undefined,
+              [okIdentifier, partsIdentifier],
+            ),
+          ),
+        ],
+        true,
+      ),
     ),
-  ], true);
+    authoredSite,
+  );
+  return preserveSourceMapRange(
+    factory.createBlock([
+      createOkDeclaration(okIdentifier, instrumented, context),
+      recordReturn,
+    ], true),
+    authoredSite,
+  );
 }
 
 /** True for a node that owns any `return` written inside it. */

--- a/packages/ts-transformers/src/transformers/destructuring-lowering.ts
+++ b/packages/ts-transformers/src/transformers/destructuring-lowering.ts
@@ -15,6 +15,8 @@ export interface DestructureBinding {
   readonly localName: string;
   readonly path: readonly PathSegment[];
   readonly directKeyExpression?: ts.Expression;
+  /** Binding syntax represented by the lowered declaration. */
+  readonly bindingNode: ts.Identifier | ts.BindingElement;
 }
 
 export interface DefaultDestructureBinding {
@@ -183,6 +185,7 @@ export function collectDestructureBindings(
     bindings.push({
       localName: name.text,
       path,
+      bindingNode: name,
     });
     return;
   }
@@ -231,6 +234,7 @@ export function collectDestructureBindings(
         bindings.push({
           localName: element.name.text,
           path: nextPath,
+          bindingNode: element,
         });
         continue;
       }
@@ -323,6 +327,7 @@ export function collectDestructureBindings(
         localName: element.name.text,
         path: nextPath,
         directKeyExpression,
+        bindingNode: element,
       });
       continue;
     }

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -649,10 +649,13 @@ function rewriteTrackedOpaquePatternBody(
         rootIsFreshOpaqueOrigin = ts.isCallExpression(initializer) &&
           isOpaqueOriginCall(initializer, context);
         rewrittenDeclarations.push(
-          context.factory.createVariableDeclaration(
-            rootIdentifier,
-            undefined,
-            undefined,
+          preserveSourceMapRange(
+            context.factory.createVariableDeclaration(
+              rootIdentifier,
+              undefined,
+              undefined,
+              declaration.initializer,
+            ),
             declaration.initializer,
           ),
         );
@@ -684,11 +687,14 @@ function rewriteTrackedOpaquePatternBody(
         }
 
         rewrittenDeclarations.push(
-          context.factory.createVariableDeclaration(
-            context.factory.createIdentifier(binding.localName),
-            undefined,
-            undefined,
-            loweredInitializer,
+          preserveSourceMapRange(
+            context.factory.createVariableDeclaration(
+              context.factory.createIdentifier(binding.localName),
+              undefined,
+              undefined,
+              loweredInitializer,
+            ),
+            binding.bindingNode,
           ),
         );
       }

--- a/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { preserveSourceMapRange } from "../ast/mod.ts";
 import {
   type CapabilityParamDefault,
   TransformationContext,
@@ -219,19 +220,24 @@ export function transformPatternCallback(
           );
         }
 
-        return factory.createVariableStatement(
-          undefined,
-          factory.createVariableDeclarationList(
-            [
-              factory.createVariableDeclaration(
-                factory.createIdentifier(binding.localName),
-                undefined,
-                undefined,
-                initializer,
-              ),
-            ],
-            ts.NodeFlags.Const,
+        const declaration = preserveSourceMapRange(
+          factory.createVariableDeclaration(
+            factory.createIdentifier(binding.localName),
+            undefined,
+            undefined,
+            initializer,
           ),
+          binding.bindingNode,
+        );
+        return preserveSourceMapRange(
+          factory.createVariableStatement(
+            undefined,
+            factory.createVariableDeclarationList(
+              [declaration],
+              ts.NodeFlags.Const,
+            ),
+          ),
+          binding.bindingNode,
         );
       });
       for (const binding of bindings) {

--- a/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
+++ b/packages/ts-transformers/test/core/cf-helpers-coverage.test.ts
@@ -161,9 +161,19 @@ Deno.test("getHelperExpr with an original node preserves source map ranges and i
 
   const expr = helpers.getHelperExpr("lift", original);
   assert(ts.isPropertyAccessExpression(expr));
+  const helperImport = sf.statements[0];
+  assert(ts.isImportDeclaration(helperImport));
+  const namedBindings = helperImport.importClause?.namedBindings;
+  assert(namedBindings && ts.isNamedImports(namedBindings));
+  const helperIdentity = namedBindings.elements[0]?.name;
+  assert(helperIdentity);
   // The whole property-access is anchored to the original node's source map
   // range (its position), distinguishing this branch from the no-original one.
   assertEquals(ts.getSourceMapRange(expr).pos, original.pos);
+  assert(ts.isIdentifier(expr.expression));
+  assert(ts.getOriginalNode(expr.expression) === helperIdentity);
+  assert(ts.getOriginalNode(expr.name) === expr.name);
+  assert(ts.getOriginalNode(expr) === expr);
   assertEquals(printExpr(expr, sf), "__cfHelpers.lift");
 });
 

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -8,7 +8,8 @@ import { batchTypeCheckFixtures } from "./utils.ts";
 
 /**
  * CT-1868 lineage regression — the hermetic, tracked form of the transform-time
- * lineage probe documented in `APRIME-LINEAGE-HANDOFF.md` §3/§11.
+ * lineage probe recorded in
+ * `docs/history/packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md` §3/§11.
  *
  * The transformer pipeline must arrive at BuilderCallHoisting with every
  * hoisted / authored builder call — its inner call AND its callback — still

--- a/packages/ts-transformers/test/replacement-source-map-range.test.ts
+++ b/packages/ts-transformers/test/replacement-source-map-range.test.ts
@@ -150,6 +150,60 @@ const DATA = { marker: "CT1869_DATA" };
 export default pattern(() => ({ DATA }));
 `;
 
+const OPAQUE_DESTRUCTURE_FIXTURE = `import {
+  fetchText,
+  pattern,
+} from "commonfabric";
+
+interface Input {
+  profile: { label: string };
+}
+
+export default pattern<Input>(({ profile: { label: ctLabel } }) => {
+  const {
+    pending: ctPending,
+    result: ctResult,
+  } = fetchText({ url: "CT1869_DESTRUCTURE" });
+  return { ctLabel, ctPending, ctResult };
+});
+`;
+
+const ASSERT_DIAGNOSTICS_FIXTURE = `import {
+  assert,
+  pattern,
+} from "commonfabric";
+
+interface Input {
+  count: number;
+}
+
+export default pattern<Input>((state) => {
+  const concise = assert(() => state.count > 0);
+  const branched = assert(() => {
+    if (state.count > 10) return state.count < 20;
+    return state.count === 1;
+  });
+  return { concise, branched };
+});
+`;
+
+const CONDITIONAL_HELPER_FIXTURE = `import {
+  pattern,
+} from "commonfabric";
+
+interface Input {
+  count: number;
+  visible: boolean;
+}
+
+export default pattern<Input>((state) => {
+  const shown = state.visible && state.count;
+  const fallback = state.visible || state.count;
+  const selected = state.visible ? state.count : 0;
+  return { shown, fallback, selected };
+});
+`;
+
 interface StageTransformResult {
   readonly original: ts.SourceFile;
   readonly transformed: ts.SourceFile;
@@ -550,6 +604,180 @@ describe("replacement source-map ranges", () => {
       replacement,
       original,
       '{ marker: "CT1869_DATA" }',
+    );
+  });
+
+  it("preserves authored positions on opaque destructuring declarations", async () => {
+    const { original, transformed } = await transformThroughStage(
+      OPAQUE_DESTRUCTURE_FIXTURE,
+      "/ct1869-opaque-destructure.tsx",
+      "PatternCallbackLoweringTransformer",
+    );
+
+    const root = findOnly(
+      transformed,
+      (node): node is ts.VariableDeclaration =>
+        ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text.startsWith("__cf_destructure"),
+      "opaque destructuring temporary root",
+    );
+    expectAuthoredText(
+      root,
+      original,
+      'fetchText({ url: "CT1869_DESTRUCTURE" })',
+    );
+
+    const pending = findOnly(
+      transformed,
+      (node): node is ts.VariableDeclaration =>
+        ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text === "ctPending",
+      "opaque destructuring pending leaf",
+    );
+    expectAuthoredText(pending, original, "pending: ctPending");
+
+    const result = findOnly(
+      transformed,
+      (node): node is ts.VariableDeclaration =>
+        ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text === "ctResult",
+      "opaque destructuring result leaf",
+    );
+    expectAuthoredText(result, original, "result: ctResult");
+
+    const parameterLeaf = findOnly(
+      transformed,
+      (node): node is ts.VariableDeclaration =>
+        ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text === "ctLabel",
+      "opaque destructured-parameter leaf",
+    );
+    expectAuthoredText(parameterLeaf, original, "label: ctLabel");
+  });
+
+  it("preserves authored positions on assert-diagnostics replacements", async () => {
+    const { original, transformed } = await transformThroughStage(
+      ASSERT_DIAGNOSTICS_FIXTURE,
+      "/ct1869-assert-diagnostics.tsx",
+      "AssertDiagnosticsTransformer",
+    );
+
+    const conciseCallback = findOnly(
+      transformed,
+      (node): node is ts.ArrowFunction =>
+        ts.isArrowFunction(node) && node.parameters.length === 0 &&
+        hasString(node, "state.count > 0"),
+      "rewritten concise assert callback",
+    );
+    assert(ts.isBlock(conciseCallback.body));
+    expectAuthoredText(conciseCallback.body, original, "state.count > 0");
+
+    const conciseReturn = findOnly(
+      conciseCallback.body,
+      (node): node is ts.ReturnStatement =>
+        ts.isReturnStatement(node) && hasString(node, "state.count > 0"),
+      "rewritten concise assert return",
+    );
+    expectAuthoredText(conciseReturn, original, "state.count > 0");
+
+    const branchedCallback = findOnly(
+      transformed,
+      (node): node is ts.ArrowFunction =>
+        ts.isArrowFunction(node) && node.parameters.length === 0 &&
+        hasString(node, "state.count < 20") &&
+        hasString(node, "state.count === 1"),
+      "rewritten block assert callback",
+    );
+    assert(ts.isBlock(branchedCallback.body));
+    expectAuthoredText(
+      branchedCallback.body,
+      original,
+      "if (state.count > 10)",
+    );
+
+    const earlyReturnBlock = findOnly(
+      branchedCallback.body,
+      (node): node is ts.Block =>
+        ts.isBlock(node) && hasString(node, "state.count < 20") &&
+        node.statements.some(ts.isReturnStatement),
+      "rewritten early assert return block",
+    );
+    expectAuthoredText(
+      earlyReturnBlock,
+      original,
+      "return state.count < 20;",
+    );
+    const earlyRecordReturn = findOnly(
+      earlyReturnBlock,
+      ts.isReturnStatement,
+      "rewritten early assert record return",
+    );
+    expectAuthoredText(
+      earlyRecordReturn,
+      original,
+      "return state.count < 20;",
+    );
+
+    const finalReturnBlock = findOnly(
+      branchedCallback.body,
+      (node): node is ts.Block =>
+        ts.isBlock(node) && hasString(node, "state.count === 1") &&
+        node.statements.some(ts.isReturnStatement),
+      "rewritten final assert return block",
+    );
+    expectAuthoredText(
+      finalReturnBlock,
+      original,
+      "return state.count === 1;",
+    );
+    const finalRecordReturn = findOnly(
+      finalReturnBlock,
+      ts.isReturnStatement,
+      "rewritten final assert record return",
+    );
+    expectAuthoredText(
+      finalRecordReturn,
+      original,
+      "return state.count === 1;",
+    );
+  });
+
+  it("keeps conditional helpers anchored to their semantic authored sites", async () => {
+    const { original, transformed } = await transformThroughStage(
+      CONDITIONAL_HELPER_FIXTURE,
+      "/ct1869-conditional-helpers.tsx",
+      "PatternCallbackLoweringTransformer",
+    );
+
+    for (const helper of ["when", "unless"] as const) {
+      const call = findOnly(
+        transformed,
+        (node): node is ts.CallExpression =>
+          ts.isCallExpression(node) &&
+          ts.isPropertyAccessExpression(node.expression) &&
+          node.expression.name.text === helper,
+        `rewritten ${helper} call`,
+      );
+      expectAuthoredText(call, original, "state.visible");
+      const position = recoverAuthoredPosition(call);
+      assert(position, `expected authored position for ${helper}`);
+      expect(original.text.slice(position.pos, position.end)).not.toContain(
+        helper === "when" ? "&&" : "||",
+      );
+    }
+
+    const ifElse = findOnly(
+      transformed,
+      (node): node is ts.CallExpression =>
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "ifElse",
+      "rewritten ifElse call",
+    );
+    expectAuthoredText(
+      ifElse,
+      original,
+      "state.visible ? state.count : 0",
     );
   });
 


### PR DESCRIPTION
## Summary

- preserve authored source-map ranges for opaque-destructuring temporary and leaf declarations, including destructured callback-parameter prologues
- preserve authored source-map ranges for assert-diagnostics callback bodies and the replacement blocks and returns generated for assertion results
- require an explicit checker-identity node when `CFHelpers.preserveNodeSourceMap` is used, while keeping source-map-only helper nodes on `preserveSourceMapRange`
- archive the completed A′ lineage handoff and record the final behavior in the live transformer spec

## Investigation outcomes

- **Fixed:** opaque destructuring had no authored range on its temporary root, local leaf declarations, or destructured-parameter prologue declarations.
- **Fixed:** assert-diagnostics replacement blocks and returns had no authored range.
- **Hardened:** `preserveNodeSourceMap` now represents only the genuine range/identity-divergence case. Its source-map-only call sites use the shared source-map helper directly.
- **Kept intentionally:** `ifElse` maps to the whole conditional expression, while `when` and `unless` map to the left condition. A focused content-bound regression test records that decision.

All added production metadata is source-map-range-only. It adds neither text ranges nor original-node identities, and the complete fixture corpus remains byte-identical (zero golden changes).

A direct TypeScript emit/source-map spot-check also confirmed that the generated destructuring temporary maps to its authored initializer, leaf declarations map to their binding elements, the concise assertion return maps to its expression, and block assertion returns map to their authored return statements.

## Verification

- `deno task test` in `packages/ts-transformers`: 1,160 passed (866 steps)
- `deno task check` in `packages/ts-transformers`
- `deno fmt --check`
- `deno lint`
- root `deno task check`
- `deno task check-docs`: 566 code blocks passed
- `deno task check-docs-history-index`
- `deno task check-conflict-markers`
- `deno task check-control-characters`
- `deno task docs-links --orphan`

Part of CT-1869


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

