### PR TITLE
fix(runner): the argument link-target pre-sync follows declared schemas

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -177,6 +177,8 @@ ensureNotRenderThread();
 
 const logger = getLogger("cell", { level: "warn" });
 
+const markDocumentSynced = Symbol("markDocumentSynced");
+
 type SinkOptions = {
   changeGroup?: ChangeGroup;
 
@@ -867,6 +869,17 @@ export function createCell<T>(
 }
 
 /**
+ * Mark a cell handle as covered by a document-level sync barrier owned by the
+ * caller. Separate handles for the same document otherwise each try to load it.
+ */
+export function markCellDocumentSynced(cell: Cell<any>): void {
+  if (!(cell instanceof CellImpl)) {
+    throw new TypeError("Expected a runner CellImpl handle");
+  }
+  cell[markDocumentSynced]();
+}
+
+/**
  * Shared container for entity ID and cause information across sibling cells.
  * When cells are created via .asSchema(), .withTx(), they share the same
  * logical identity (same entity id) but may have different paths or schemas.
@@ -947,6 +960,10 @@ export class CellImpl<T extends FabricValue>
 
     this.#kind = kind ?? "cell";
     this.#cfcLabelView = cloneCfcLabelView(_cfcLabelView);
+  }
+
+  [markDocumentSynced](): void {
+    this.#synced = true;
   }
 
   isReadableCell(): boolean {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -273,9 +273,14 @@ function isReferenceOnlySchema(
       depth - 1,
     );
   }
-  const arms = (schema.anyOf ?? schema.oneOf) as
-    | readonly JSONSchema[]
-    | undefined;
+  // Both keywords together describe one set of alternatives the run may
+  // take, so they combine rather than one shadowing the other — the same
+  // reading `schemaAtPath` gives them when it narrows through a union.
+  const anyOf = schema.anyOf as readonly JSONSchema[] | undefined;
+  const oneOf = schema.oneOf as readonly JSONSchema[] | undefined;
+  const arms = anyOf !== undefined && oneOf !== undefined
+    ? [...anyOf, ...oneOf]
+    : anyOf ?? oneOf;
   if (arms !== undefined && arms.length > 0) {
     return arms.every((arm) => isReferenceOnlySchema(arm, depth - 1));
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -245,6 +245,14 @@ type StartAttempt = {
   settled?: Promise<boolean>;
 };
 
+// One root of the argument link-target scan: an argument document plus the
+// schema declaring what the resumed runs read from it. A root without a
+// schema is scanned in full.
+type ArgumentLinkRoot = {
+  cell: Cell<any>;
+  schema?: JSONSchema;
+};
+
 // The debug-name builders reuse the action's already-computed
 // `schedulerActionInstanceKey` as their uniquifying suffix instead of hashing
 // the same links a second time (one hashOf per action creation, not two). The
@@ -5014,8 +5022,10 @@ export class Runner {
     const argumentCell = this.runtime.getCellFromLink(argumentLink);
     await argumentCell.sync();
     const argumentValue = argumentCell.getRawUntyped();
+    // No declared schema here: the setup path scans the stored argument in
+    // full, the undeclared-root form of the method below.
     await this.#syncArgumentLinkTargets(
-      [argumentCell],
+      [{ cell: argumentCell }],
       "setupArgumentLinkTargetSync",
       [argumentValue],
     );
@@ -5094,8 +5104,10 @@ export class Runner {
     const cells: Cell<any>[] = [];
     // Argument documents (node inputs + the pattern's own argument meta doc)
     // whose VALUES may hold links to documents nothing in this tree owns —
-    // scanned after the main sync wave (see below).
-    const argumentCells: Cell<any>[] = [];
+    // scanned after the main sync wave (see below). Each root carries the
+    // schema declaring what the resumed runs read from it, which is what
+    // bounds that scan; a root without one is scanned in full.
+    const argumentRoots: ArgumentLinkRoot[] = [];
 
     // Sync all the inputs and outputs of the pattern nodes. Bindings are
     // unwrapped (bound to the argument/result documents) first, so named-cell
@@ -5152,16 +5164,23 @@ export class Runner {
           continue;
         }
 
-        // TODO(seefeld): This ignores schemas provided by modules, so it might
-        // still fetch a lot.
         [...inputs, ...outputs].forEach((link) => {
           cells.push(this.runtime.getCellFromLink(link));
         });
+        // Each input link carries the schema its binding declared, which is
+        // the read surface the node's first run holds to — the bound the
+        // link-target scan follows.
         inputs.forEach((link) => {
-          argumentCells.push(this.runtime.getCellFromLink(link));
+          argumentRoots.push({
+            cell: this.runtime.getCellFromLink(link),
+            schema: link.schema,
+          });
         });
       }
-      argumentCells.push(this.runtime.getCellFromLink(argumentMetaLink));
+      argumentRoots.push({
+        cell: this.runtime.getCellFromLink(argumentMetaLink),
+        schema: pattern.argumentSchema,
+      });
     }
 
     // Sync the owned (derived internal) cells of this pattern and every nested
@@ -5222,13 +5241,10 @@ export class Runner {
     // basis at seq 0 — a guaranteed ConflictError against the durable server
     // state (the home-rehydration reload-churn regression; v1's populate
     // pass subscribed such targets in aborted transactions before any
-    // commit). Two levels deep — argument value → container doc → target doc
-    // is the measured chain (defaultProfile → container → per-user profile
-    // doc); deeper or wider walks were measured to add loads without
-    // removing further conflicts. Deduped, values only, schema-less doc
-    // syncs; an unloadable target is skipped rather than failing the resume.
+    // commit). Each root's declared schema bounds its scan — see the method
+    // for the exact rules and the fallback where a declaration runs out.
     await this.#syncArgumentLinkTargets(
-      argumentCells,
+      argumentRoots,
       "resumeArgumentLinkTargetSync",
     );
 
@@ -5236,59 +5252,147 @@ export class Runner {
   }
 
   /**
-   * Load two levels of documents linked from stored arguments. This covers the
-   * measured defaultProfile container chain without loading an unbounded graph.
+   * Pre-sync the documents linked from stored arguments that a resumed
+   * pattern's first runs read through.
+   *
+   * Collection follows each root's declared schema, walking value and schema
+   * in lockstep: a link on a schema-named path has its target synced, and
+   * the walk continues INTO that target under the same path schema — a
+   * declared read through a link reaches the linked document's fields, so
+   * the pre-sync does too, as deep as the declaration goes. A path whose
+   * schema carries `asCell` is handed to the run as a reference, so its
+   * target document is synced and its contents are not walked. A property a
+   * `properties`-bearing schema does not select is invisible to the run and
+   * is not walked at all.
+   *
+   * Where a declaration runs out — a `true` schema, an object schema with no
+   * `properties`, a root with no schema — the walk falls back to the
+   * undeclared form: every link in the raw value, two link hops deep from
+   * that point, which covers the measured defaultProfile container chain and
+   * any read the transformer could not see. Deduped, values only; an
+   * unloadable target is skipped rather than failing the resume.
    */
   async #syncArgumentLinkTargets(
-    argumentCells: Cell<any>[],
+    roots: readonly ArgumentLinkRoot[],
     timingLabel: "resumeArgumentLinkTargetSync" | "setupArgumentLinkTargetSync",
     initialValues?: readonly (FabricValue | undefined)[],
   ): Promise<void> {
+    // Link-hop budgets: how many further documents a walk may step INTO from
+    // a synced target. The undeclared budget preserves the two-hop reach the
+    // defaultProfile regression fixed; the declared budget only bounds a
+    // pathological declaration, since schemas end on their own.
+    const UNDECLARED_LINK_HOPS = 2;
+    const DECLARED_LINK_HOPS = 8;
     const seenTargets = new Set<string>();
-    let frontier: Cell<any>[] = argumentCells;
-    for (let depth = 0; depth < 2 && frontier.length > 0; depth++) {
-      const targets: Cell<any>[] = [];
+    type PendingTarget = {
+      cell: Cell<any>;
+      schema: JSONSchema | undefined;
+      hopsLeft: number;
+    };
+    let frontier: PendingTarget[] = roots.map((root) => ({
+      cell: root.cell,
+      schema: root.schema,
+      hopsLeft: root.schema !== undefined
+        ? DECLARED_LINK_HOPS
+        : UNDECLARED_LINK_HOPS,
+    }));
+    let wave = 0;
+    while (frontier.length > 0) {
+      const targets: PendingTarget[] = [];
       const targetPromises: Promise<any>[] = [];
-      const collectLinkTargets = (value: any, base: Cell<any>) => {
+      const enqueue = (
+        link: NormalizedFullLink,
+        schema: JSONSchema | undefined,
+        hopsLeft: number,
+      ) => {
+        const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
+        if (seenTargets.has(key)) return;
+        seenTargets.add(key);
+        const target = this.runtime.getCellFromLink(link);
+        const targetSyncStart = performance.now();
+        targetPromises.push(
+          Promise.resolve(target.sync())
+            .catch((error) => {
+              logger.warn("resume-argument-link-targets", () => [
+                "argument link target sync failed; resuming without it",
+                error,
+              ]);
+            })
+            .finally(() =>
+              logger.time(
+                targetSyncStart,
+                "start",
+                timingLabel,
+              )
+            ),
+        );
+        if (hopsLeft > 0) targets.push({ cell: target, schema, hopsLeft });
+      };
+      const collect = (
+        value: any,
+        base: Cell<any>,
+        schema: JSONSchema | undefined,
+        hopsLeft: number,
+      ) => {
+        if (schema === false) return;
+        // A `true` or absent schema is where the declaration ran out; scan
+        // from here in the undeclared form with a fresh two-hop budget.
+        const declared = schema !== undefined && schema !== true;
         const link = parseLink(value, base);
         if (link) {
-          const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
-          if (seenTargets.has(key)) return;
-          seenTargets.add(key);
-          const target = this.runtime.getCellFromLink(link);
-          targets.push(target);
-          const targetSyncStart = performance.now();
-          targetPromises.push(
-            Promise.resolve(target.sync())
-              .catch((error) => {
-                logger.warn("resume-argument-link-targets", () => [
-                  "argument link target sync failed; resuming without it",
-                  error,
-                ]);
-              })
-              .finally(() =>
-                logger.time(
-                  targetSyncStart,
-                  "start",
-                  timingLabel,
-                )
-              ),
+          // `asCell` marks a reference the run holds rather than reads
+          // through: sync the target document, walk no further. The marker
+          // rides the declared property schema itself, beside any `$ref`.
+          const reference = declared &&
+            isObjectOrArray(schema) && schema.asCell !== undefined;
+          enqueue(
+            link,
+            declared ? schema : undefined,
+            reference ? 0 : Math.min(
+              hopsLeft - 1,
+              declared ? DECLARED_LINK_HOPS : UNDECLARED_LINK_HOPS,
+            ),
           );
-        } else if (isObjectOrArray(value)) {
-          // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`, and
-          // `for..in` sees none of its state, so a link inside a
+          return;
+        }
+        if (!isObjectOrArray(value)) return;
+        if (!declared) {
+          // TODO(danfuzz): `isObjectOrArray` admits a `FabricSpecialObject`,
+          // and `for..in` sees none of its state, so a link inside a
           // `FabricInstance` held in a raw argument value is never pre-synced
           // — a cold target can then enter the commit basis, the exact
           // failure this walk exists to prevent.
-          for (const key in value) collectLinkTargets(value[key], base);
+          for (const key in value) {
+            collect(value[key], base, undefined, hopsLeft);
+          }
+          return;
+        }
+        // Structural descent: narrow the declared schema one segment at a
+        // time. `defaultMissingProperty: false` makes an unselected property
+        // invisible, matching what the run can see; `defaultEmptyProperties:
+        // true` makes an unstructured object read fall back to the
+        // undeclared scan above, since such a read is unbounded.
+        for (const key in value) {
+          collect(
+            value[key],
+            base,
+            ContextualFlowControl.schemaAtPath(
+              schema,
+              [key],
+              undefined,
+              true,
+              false,
+            ),
+            hopsLeft,
+          );
         }
       };
-      for (const [index, cell] of frontier.entries()) {
+      for (const [index, entry] of frontier.entries()) {
         try {
-          const value = depth === 0 && initialValues !== undefined
+          const value = wave === 0 && initialValues !== undefined
             ? initialValues[index]
-            : cell.getRawUntyped();
-          collectLinkTargets(value, cell);
+            : entry.cell.getRawUntyped();
+          collect(value, entry.cell, entry.schema, entry.hopsLeft);
         } catch (error) {
           // A shape the raw read cannot resolve contributes nothing rather
           // than breaking the resume; log so a skipped target is diagnosable.
@@ -5300,6 +5404,7 @@ export class Runner {
       }
       await Promise.all(targetPromises);
       frontier = targets;
+      wave++;
     }
   }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,4 +1,5 @@
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { resolveSchemaRefsCanonical } from "./traverse.ts";
 import {
   fabricFromNativeValue,
   FabricInstance,
@@ -37,6 +38,7 @@ import {
   isPattern,
   isStreamValue,
   type JSONSchema,
+  type JSONSchemaObj,
   JSONValue,
   type Module,
   NAME,
@@ -252,6 +254,31 @@ type ArgumentLinkRoot = {
   cell: Cell<any>;
   schema?: JSONSchema;
 };
+
+// Whether a declared schema hands the run a reference rather than a value to
+// read through: `asCell` on the schema itself, or a union or reference whose
+// every resolved arm is itself reference-only. A union with one readable arm
+// is readable — the walk must cover the arm the run may take. Bounded ref
+// resolution guards against a self-referential declaration.
+function isReferenceOnlySchema(
+  schema: JSONSchema | undefined,
+  depth: number = 4,
+): boolean {
+  if (depth <= 0 || !isObjectOrArray(schema)) return false;
+  if (schema.asCell !== undefined) return true;
+  if ("$ref" in schema) {
+    const resolved = resolveSchemaRefsCanonical(schema as JSONSchemaObj);
+    if (resolved === schema) return false;
+    return isReferenceOnlySchema(resolved, depth - 1);
+  }
+  const arms = (schema.anyOf ?? schema.oneOf) as
+    | readonly JSONSchema[]
+    | undefined;
+  if (arms !== undefined && arms.length > 0) {
+    return arms.every((arm) => isReferenceOnlySchema(arm, depth - 1));
+  }
+  return false;
+}
 
 // The debug-name builders reuse the action's already-computed
 // `schedulerActionInstanceKey` as their uniquifying suffix instead of hashing
@@ -5278,12 +5305,23 @@ export class Runner {
     initialValues?: readonly (FabricValue | undefined)[],
   ): Promise<void> {
     // Link-hop budgets: how many further documents a walk may step INTO from
-    // a synced target. The undeclared budget preserves the two-hop reach the
-    // defaultProfile regression fixed; the declared budget only bounds a
-    // pathological declaration, since schemas end on their own.
+    // a synced target. Both keep the two-hop reach the defaultProfile
+    // regression fixed. Declared descent could in principle go as deep as the
+    // declaration, but deployed schemas declare reference GRAPHS (a topic's
+    // mentions reach topics whose mentions reach topics), and following them
+    // syncs documents no first run reads — measured on the topics board, a
+    // deeper declared budget collected more than the undeclared walk it
+    // replaced. Raising it is evidence-driven tuning, not headroom.
     const UNDECLARED_LINK_HOPS = 2;
-    const DECLARED_LINK_HOPS = 8;
-    const seenTargets = new Set<string>();
+    const DECLARED_LINK_HOPS = 2;
+    // Syncing is document-granular and walking is subtree-granular, so they
+    // dedupe separately: one sync per document, one walk per (document, path,
+    // declared/undeclared) subtree. A reference visit (`asCell`, no walk)
+    // therefore never blocks a later read-through visit from walking the same
+    // document, and two links into different paths of one document each get
+    // their own descent.
+    const syncedDocs = new Set<string>();
+    const walkedSubtrees = new Set<string>();
     type PendingTarget = {
       cell: Cell<any>;
       schema: JSONSchema | undefined;
@@ -5305,28 +5343,41 @@ export class Runner {
         schema: JSONSchema | undefined,
         hopsLeft: number,
       ) => {
-        const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
-        if (seenTargets.has(key)) return;
-        seenTargets.add(key);
+        const docKey = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
         const target = this.runtime.getCellFromLink(link);
-        const targetSyncStart = performance.now();
-        targetPromises.push(
-          Promise.resolve(target.sync())
-            .catch((error) => {
-              logger.warn("resume-argument-link-targets", () => [
-                "argument link target sync failed; resuming without it",
-                error,
-              ]);
-            })
-            .finally(() =>
-              logger.time(
-                targetSyncStart,
-                "start",
-                timingLabel,
-              )
-            ),
-        );
-        if (hopsLeft > 0) targets.push({ cell: target, schema, hopsLeft });
+        if (!syncedDocs.has(docKey)) {
+          syncedDocs.add(docKey);
+          const targetSyncStart = performance.now();
+          targetPromises.push(
+            Promise.resolve(target.sync())
+              .catch((error) => {
+                logger.warn("resume-argument-link-targets", () => [
+                  "argument link target sync failed; resuming without it",
+                  error,
+                ]);
+              })
+              .finally(() =>
+                logger.time(
+                  targetSyncStart,
+                  "start",
+                  timingLabel,
+                )
+              ),
+          );
+        } else {
+          // The document was synced through another handle. Mark this one
+          // synced too, or the next wave's raw read fires a background sync
+          // whose rejection nothing awaits — the same shape-cast doStart's
+          // `wasSyncedAtEntry` reads through.
+          (target as Cell<any> & { synced?: boolean }).synced = true;
+        }
+        if (hopsLeft <= 0) return;
+        const walkKey = `${docKey}\0${link.path.join("/")}\0${
+          schema !== undefined ? "declared" : "undeclared"
+        }`;
+        if (walkedSubtrees.has(walkKey)) return;
+        walkedSubtrees.add(walkKey);
+        targets.push({ cell: target, schema, hopsLeft });
       };
       const collect = (
         value: any,
@@ -5342,9 +5393,10 @@ export class Runner {
         if (link) {
           // `asCell` marks a reference the run holds rather than reads
           // through: sync the target document, walk no further. The marker
-          // rides the declared property schema itself, beside any `$ref`.
-          const reference = declared &&
-            isObjectOrArray(schema) && schema.asCell !== undefined;
+          // usually rides the declared property schema beside any `$ref`;
+          // where the declaration is a union or ends in a reference, it
+          // counts as opaque only when every resolved arm does.
+          const reference = declared && isReferenceOnlySchema(schema);
           enqueue(
             link,
             declared ? schema : undefined,
@@ -5363,7 +5415,15 @@ export class Runner {
           // — a cold target can then enter the commit basis, the exact
           // failure this walk exists to prevent.
           for (const key in value) {
-            collect(value[key], base, undefined, hopsLeft);
+            // The undeclared scan runs on its own two-hop budget from the
+            // point the declaration ran out (the enqueue clamp enforces the
+            // same bound; stating it here keeps the transition visible).
+            collect(
+              value[key],
+              base,
+              undefined,
+              Math.min(hopsLeft, UNDECLARED_LINK_HOPS),
+            );
           }
           return;
         }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -58,7 +58,12 @@ import {
   useCancelGroup,
   useDeferredCancelOwnership,
 } from "./cancel.ts";
-import { type Cell, createCell, isCell } from "./cell.ts";
+import {
+  type Cell,
+  createCell,
+  isCell,
+  markCellDocumentSynced,
+} from "./cell.ts";
 import {
   ContextualFlowControl,
   resolveExternalRootRefForStructure,
@@ -5428,11 +5433,9 @@ export class Runner {
               ),
           );
         } else {
-          // The document was synced through another handle. Mark this one
-          // synced too, or the next wave's raw read fires a background sync
-          // whose rejection nothing awaits — the same shape-cast doStart's
-          // `wasSyncedAtEntry` reads through.
-          (target as Cell<any> & { synced?: boolean }).synced = true;
+          // The walk awaits the sibling handle's document sync before
+          // advancing to the next wave.
+          markCellDocumentSynced(target);
         }
         if (hopsLeft <= 0) return;
         // The key names the subtree a walk would descend: the document, the

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -256,11 +256,46 @@ type ArgumentLinkRoot = {
 };
 
 // Whether a declared schema hands the run a reference rather than a value to
-// read through: `asCell` on the schema itself, or a union or reference whose
-// every resolved arm is itself reference-only. A union with one readable arm
-// is readable — the walk must cover the arm the run may take. The depth bound
+// read through: `asCell` on the schema itself, or a union or reference that
+// resolves to one. A union counts when ANY arm carries the marker, because
+// that is the arm the reader takes — `preferAsCellBranch` in schema-view.ts
+// picks the `asCell` branch and hands back a cell handle, so `Cell<T> |
+// undefined` is a handle rather than something read through. The depth bound
 // terminates a declaration that refers to itself, which resolves to itself
 // however many times it is followed.
+// The child schema a declared read sees at `key`, mirroring `childSchema` in
+// schema-view.ts: `schemaAtPath` decides which children exist from the
+// schema's `type`, so a schema that declares `properties` or `items` and omits
+// `type` narrows to `false` — no child selected — while an eager read reaches
+// those children anyway. Read the subschema directly there, so the pre-sync
+// covers what the reader covers. A subschema of `false` turns the child down
+// rather than describing one, and stays refused.
+function narrowChildSchema(schema: JSONSchema, key: string): JSONSchema {
+  let narrowed: JSONSchema;
+  try {
+    narrowed = ContextualFlowControl.schemaAtPath(
+      schema,
+      [key],
+      undefined,
+      true,
+      false,
+    );
+  } catch {
+    // A declaration that cannot resolve is one that ran out: scan rather
+    // than skip.
+    return true;
+  }
+  if (narrowed !== false || !isObjectOrArray(schema)) return narrowed;
+  const properties = schema.properties;
+  if (isObjectOrArray(properties) && Object.hasOwn(properties, key)) {
+    return (properties as Record<string, JSONSchema>)[key];
+  }
+  if (/^(?:0|[1-9][0-9]*)$/.test(key) && schema.items !== undefined) {
+    return schema.items as JSONSchema;
+  }
+  return narrowed;
+}
+
 function isReferenceOnlySchema(
   schema: JSONSchema | undefined,
   depth: number = 4,
@@ -282,7 +317,7 @@ function isReferenceOnlySchema(
     ? [...anyOf, ...oneOf]
     : anyOf ?? oneOf;
   if (arms !== undefined && arms.length > 0) {
-    return arms.every((arm) => isReferenceOnlySchema(arm, depth - 1));
+    return arms.some((arm) => isReferenceOnlySchema(arm, depth - 1));
   }
   return false;
 }
@@ -5293,7 +5328,8 @@ export class Runner {
    * in lockstep: a link on a schema-named path has its target synced, and
    * the walk continues INTO that target under the same path schema — a
    * declared read through a link reaches the linked document's fields, so
-   * the pre-sync does too, as deep as the declaration goes. A path whose
+   * the pre-sync does too, two link hops deep — the reach the undeclared
+   * walk has always had, kept while declared depth stays unmeasured. A path whose
    * schema carries `asCell` is handed to the run as a reference, so its
    * target document is synced and its contents are not walked. A property a
    * `properties`-bearing schema does not select is invisible to the run and
@@ -5379,8 +5415,15 @@ export class Runner {
           (target as Cell<any> & { synced?: boolean }).synced = true;
         }
         if (hopsLeft <= 0) return;
-        const walkKey = `${docKey}\0${link.path.join("/")}\0${
-          schema !== undefined ? "declared" : "undeclared"
+        // The key names the subtree a walk would descend: the document, the
+        // path within it, and the schema the descent follows. All three are
+        // needed — two links can reach one document at different paths, and
+        // two bindings can read one path under disjoint declarations, and
+        // each of those is a walk this one cannot stand in for. `path` is
+        // encoded injectively, since joining segments lets `["a/b"]` and
+        // `["a", "b"]` collide.
+        const walkKey = `${docKey}\0${JSON.stringify(link.path)}\0${
+          schema === undefined ? "undeclared" : hashStringOf(schema)
         }`;
         if (walkedSubtrees.has(walkKey)) return;
         walkedSubtrees.add(walkKey);
@@ -5440,21 +5483,7 @@ export class Runner {
         // true` makes an unstructured object read fall back to the
         // undeclared scan above, since such a read is unbounded.
         for (const key in value) {
-          let narrowed: JSONSchema;
-          try {
-            narrowed = ContextualFlowControl.schemaAtPath(
-              schema,
-              [key],
-              undefined,
-              true,
-              false,
-            );
-          } catch {
-            // A declaration that cannot resolve (an unresolvable reference,
-            // say) is one that ran out: scan rather than skip.
-            narrowed = true;
-          }
-          collect(value[key], base, narrowed, hopsLeft);
+          collect(value[key], base, narrowChildSchema(schema, key), hopsLeft);
         }
       };
       for (const [index, entry] of frontier.entries()) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5107,7 +5107,7 @@ export class Runner {
     const argumentValue = argumentCell.getRawUntyped();
     // No declared schema here: the setup path scans the stored argument in
     // full, the undeclared-root form of the method below.
-    await this.#syncArgumentLinkTargets(
+    await this.syncArgumentLinkTargets(
       [{ cell: argumentCell }],
       "setupArgumentLinkTargetSync",
       [argumentValue],
@@ -5326,7 +5326,7 @@ export class Runner {
     // pass subscribed such targets in aborted transactions before any
     // commit). Each root's declared schema bounds its scan — see the method
     // for the exact rules and the fallback where a declaration runs out.
-    await this.#syncArgumentLinkTargets(
+    await this.syncArgumentLinkTargets(
       argumentRoots,
       "resumeArgumentLinkTargetSync",
     );
@@ -5363,7 +5363,7 @@ export class Runner {
    * only, and an unloadable target is skipped rather than failing the
    * resume.
    */
-  async #syncArgumentLinkTargets(
+  private async syncArgumentLinkTargets(
     roots: readonly ArgumentLinkRoot[],
     timingLabel: "resumeArgumentLinkTargetSync" | "setupArgumentLinkTargetSync",
     initialValues?: readonly (FabricValue | undefined)[],

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,5 +1,8 @@
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
-import { resolveSchemaRefsCanonical } from "./traverse.ts";
+import {
+  combineSchemaForLink,
+  resolveSchemaRefsCanonical,
+} from "./traverse.ts";
 import {
   fabricFromNativeValue,
   FabricInstance,
@@ -303,6 +306,16 @@ function isReferenceOnlySchema(
 ): boolean {
   if (depth <= 0 || !isObjectOrArray(schema)) return false;
   if (schema.asCell !== undefined) return true;
+  // `unknown` is the deliberate request for reference semantics — a value
+  // compared by identity rather than read through, opaque at this hop and
+  // every deeper one (docs/specs/link-schema-precedence.md). The board's
+  // `mentions` and crossref rows are declared this way.
+  if (
+    schema.type === "unknown" ||
+    (Array.isArray(schema.type) && schema.type.includes("unknown"))
+  ) {
+    return true;
+  }
   if ("$ref" in schema) {
     return isReferenceOnlySchema(
       resolveSchemaRefsCanonical(schema as JSONSchemaObj),
@@ -5325,39 +5338,44 @@ export class Runner {
    * Pre-sync the documents linked from stored arguments that a resumed
    * pattern's first runs read through.
    *
-   * Collection follows each root's declared schema, walking value and schema
-   * in lockstep: a link on a schema-named path has its target synced, and
-   * the walk continues INTO that target under the same path schema — a
-   * declared read through a link reaches the linked document's fields, so
-   * the pre-sync does too, two link hops deep — the reach the undeclared
-   * walk has always had, kept while declared depth stays unmeasured. A path whose
-   * schema carries `asCell` is handed to the run as a reference, so its
-   * target document is synced and its contents are not walked. A property a
-   * `properties`-bearing schema does not select is invisible to the run and
-   * is not walked at all.
+   * Collection walks value and schema in lockstep, so what is warmed is what
+   * the declaration says a run can reach. A property a `properties`-bearing
+   * schema does not select is invisible to the run and is not walked.
+   *
+   * A link is crossed the way a read crosses it, through
+   * `combineSchemaForLink`: a shaped reader carries its own schema into the
+   * target and the link cannot widen it, while a permissive reader adopts
+   * what the link declares. Following the runtime's own rule is what keeps
+   * this walk and the reader in agreement, including under the rollback
+   * posture that rule answers to.
+   *
+   * A value the run holds rather than reads through is synced and not
+   * walked: `asCell` names a handle, and `unknown` asks for reference
+   * semantics — compared by identity, opaque at this hop and every deeper
+   * one.
    *
    * Where a declaration runs out — a `true` schema, an object schema with no
-   * `properties`, a root with no schema — the walk falls back to the
-   * undeclared form: every link in the raw value within the same overall
-   * two-link-hop bound, which covers the measured defaultProfile container
-   * chain and any read the transformer could not see. Deduped, values only;
-   * an unloadable target is skipped rather than failing the resume.
+   * `properties`, a link that declares nothing — the walk falls back to
+   * scanning the raw value, which covers the measured defaultProfile
+   * container chain and any read the transformer could not see. Either form
+   * reaches two link hops, the bound the undeclared walk has always had.
+   * Deduped per document for syncing and per subtree for walking; values
+   * only, and an unloadable target is skipped rather than failing the
+   * resume.
    */
   async #syncArgumentLinkTargets(
     roots: readonly ArgumentLinkRoot[],
     timingLabel: "resumeArgumentLinkTargetSync" | "setupArgumentLinkTargetSync",
     initialValues?: readonly (FabricValue | undefined)[],
   ): Promise<void> {
-    // Link-hop budgets: how many further documents a walk may step INTO from
-    // a synced target. Both keep the two-hop reach the defaultProfile
-    // regression fixed. Declared descent could in principle go as deep as the
-    // declaration, but deployed schemas declare reference GRAPHS (a topic's
-    // mentions reach topics whose mentions reach topics), and following them
-    // syncs documents no first run reads — measured on the topics board, a
-    // deeper declared budget collected more than the undeclared walk it
-    // replaced. Raising it is evidence-driven tuning, not headroom.
-    const UNDECLARED_LINK_HOPS = 2;
-    const DECLARED_LINK_HOPS = 2;
+    // How many further documents a walk may step INTO from a synced target.
+    // Two keeps the reach the defaultProfile regression fixed. A declaration
+    // could in principle be followed as far as it goes, but deployed schemas
+    // declare reference GRAPHS (a topic's mentions reach topics whose
+    // mentions reach topics), and a deeper budget measured on the topics
+    // board collected more than the undeclared walk it replaced. Raising it
+    // is evidence-driven tuning, not headroom.
+    const LINK_HOPS = 2;
     // Syncing is document-granular and walking is subtree-granular, so they
     // dedupe separately: one sync per document, one walk per (document, path,
     // declared/undeclared) subtree. A reference visit (`asCell`, no walk)
@@ -5368,15 +5386,16 @@ export class Runner {
     const walkedSubtrees = new Set<string>();
     type PendingTarget = {
       cell: Cell<any>;
-      schema: JSONSchema | undefined;
+      schema: JSONSchema;
       hopsLeft: number;
     };
+    // A root without a declaration enters as the permissive reader it is:
+    // `true` crosses links by adopting what they declare, so an undeclared
+    // root is typed by the first link it follows rather than scanned blind.
     let frontier: PendingTarget[] = roots.map((root) => ({
       cell: root.cell,
-      schema: root.schema,
-      hopsLeft: root.schema !== undefined
-        ? DECLARED_LINK_HOPS
-        : UNDECLARED_LINK_HOPS,
+      schema: root.schema ?? true,
+      hopsLeft: LINK_HOPS,
     }));
     let wave = 0;
     while (frontier.length > 0) {
@@ -5384,7 +5403,7 @@ export class Runner {
       const targetPromises: Promise<any>[] = [];
       const enqueue = (
         link: NormalizedFullLink,
-        schema: JSONSchema | undefined,
+        schema: JSONSchema,
         hopsLeft: number,
       ) => {
         const docKey = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
@@ -5424,7 +5443,7 @@ export class Runner {
         // encoded injectively, since joining segments lets `["a/b"]` and
         // `["a", "b"]` collide.
         const walkKey = `${docKey}\0${JSON.stringify(link.path)}\0${
-          schema === undefined ? "undeclared" : hashStringOf(schema)
+          hashStringOf(schema)
         }`;
         if (walkedSubtrees.has(walkKey)) return;
         walkedSubtrees.add(walkKey);
@@ -5433,28 +5452,32 @@ export class Runner {
       const collect = (
         value: any,
         base: Cell<any>,
-        schema: JSONSchema | undefined,
+        schema: JSONSchema,
         hopsLeft: number,
       ) => {
         if (schema === false) return;
-        // A `true` or absent schema is where the declaration ran out; scan
-        // from here in the undeclared form with the remaining overall budget.
-        const declared = schema !== undefined && schema !== true;
+        // A `true` schema is where the declaration ran out; scan from here in
+        // the undeclared form with the remaining overall budget.
+        const declared = schema !== true;
         const link = parseLink(value, base);
         if (link) {
-          // `asCell` marks a reference the run holds rather than reads
-          // through: sync the target document, walk no further. The marker
-          // usually rides the declared property schema beside any `$ref`;
-          // where the declaration is a union or ends in a reference, any
-          // resolved arm carrying the marker makes the value a handle.
-          const reference = declared && isReferenceOnlySchema(schema);
+          // Cross the link the way a read crosses it. `combineSchemaForLink`
+          // is the runtime's own rule and follows the same
+          // `readerSchemaPrecedence` posture, so the pre-sync covers what the
+          // reader will reach under whichever posture is in force: a shaped
+          // reader keeps its own schema and the link cannot widen it, while a
+          // permissive one adopts what the link declares rather than falling
+          // back to scanning everything behind it.
+          const crossed = combineSchemaForLink(schema, link.schema ?? true);
+          // Nothing is selected past this point, so no first run reads it.
+          if (crossed === false) return;
+          // A handle is held rather than read through — sync the document it
+          // names, and stop.
+          const opaque = isReferenceOnlySchema(crossed);
           enqueue(
             link,
-            declared ? schema : undefined,
-            reference ? 0 : Math.min(
-              hopsLeft - 1,
-              declared ? DECLARED_LINK_HOPS : UNDECLARED_LINK_HOPS,
-            ),
+            crossed,
+            opaque ? 0 : Math.min(hopsLeft - 1, LINK_HOPS),
           );
           return;
         }
@@ -5468,12 +5491,7 @@ export class Runner {
           for (const key in value) {
             // The undeclared scan keeps the remaining share of the overall
             // two-hop budget; the clamp states that transition explicitly.
-            collect(
-              value[key],
-              base,
-              undefined,
-              Math.min(hopsLeft, UNDECLARED_LINK_HOPS),
-            );
+            collect(value[key], base, true, Math.min(hopsLeft, LINK_HOPS));
           }
           return;
         }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -258,8 +258,9 @@ type ArgumentLinkRoot = {
 // Whether a declared schema hands the run a reference rather than a value to
 // read through: `asCell` on the schema itself, or a union or reference whose
 // every resolved arm is itself reference-only. A union with one readable arm
-// is readable — the walk must cover the arm the run may take. Bounded ref
-// resolution guards against a self-referential declaration.
+// is readable — the walk must cover the arm the run may take. The depth bound
+// terminates a declaration that refers to itself, which resolves to itself
+// however many times it is followed.
 function isReferenceOnlySchema(
   schema: JSONSchema | undefined,
   depth: number = 4,
@@ -267,9 +268,10 @@ function isReferenceOnlySchema(
   if (depth <= 0 || !isObjectOrArray(schema)) return false;
   if (schema.asCell !== undefined) return true;
   if ("$ref" in schema) {
-    const resolved = resolveSchemaRefsCanonical(schema as JSONSchemaObj);
-    if (resolved === schema) return false;
-    return isReferenceOnlySchema(resolved, depth - 1);
+    return isReferenceOnlySchema(
+      resolveSchemaRefsCanonical(schema as JSONSchemaObj),
+      depth - 1,
+    );
   }
   const arms = (schema.anyOf ?? schema.oneOf) as
     | readonly JSONSchema[]

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -5433,18 +5433,21 @@ export class Runner {
         // true` makes an unstructured object read fall back to the
         // undeclared scan above, since such a read is unbounded.
         for (const key in value) {
-          collect(
-            value[key],
-            base,
-            ContextualFlowControl.schemaAtPath(
+          let narrowed: JSONSchema;
+          try {
+            narrowed = ContextualFlowControl.schemaAtPath(
               schema,
               [key],
               undefined,
               true,
               false,
-            ),
-            hopsLeft,
-          );
+            );
+          } catch {
+            // A declaration that cannot resolve (an unresolvable reference,
+            // say) is one that ran out: scan rather than skip.
+            narrowed = true;
+          }
+          collect(value[key], base, narrowed, hopsLeft);
         }
       };
       for (const [index, entry] of frontier.entries()) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -9,6 +9,7 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { hashOf, hashStringOf } from "@commonfabric/data-model/value-hash";
+import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { BoundedKeyMap } from "@commonfabric/utils/cache";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -255,14 +256,6 @@ type ArgumentLinkRoot = {
   schema?: JSONSchema;
 };
 
-// Whether a declared schema hands the run a reference rather than a value to
-// read through: `asCell` on the schema itself, or a union or reference that
-// resolves to one. A union counts when ANY arm carries the marker, because
-// that is the arm the reader takes — `preferAsCellBranch` in schema-view.ts
-// picks the `asCell` branch and hands back a cell handle, so `Cell<T> |
-// undefined` is a handle rather than something read through. The depth bound
-// terminates a declaration that refers to itself, which resolves to itself
-// however many times it is followed.
 // The child schema a declared read sees at `key`, mirroring `childSchema` in
 // schema-view.ts: `schemaAtPath` decides which children exist from the
 // schema's `type`, so a schema that declares `properties` or `items` and omits
@@ -290,12 +283,20 @@ function narrowChildSchema(schema: JSONSchema, key: string): JSONSchema {
   if (isObjectOrArray(properties) && Object.hasOwn(properties, key)) {
     return (properties as Record<string, JSONSchema>)[key];
   }
-  if (/^(?:0|[1-9][0-9]*)$/.test(key) && schema.items !== undefined) {
+  if (isArrayIndexPropertyName(key) && schema.items !== undefined) {
     return schema.items as JSONSchema;
   }
   return narrowed;
 }
 
+// Whether a declared schema hands the run a reference rather than a value to
+// read through: `asCell` on the schema itself, or a union or reference that
+// resolves to one. A union counts when ANY arm carries the marker, because
+// that is the arm the reader takes — `preferAsCellBranch` in schema-view.ts
+// picks the `asCell` branch and hands back a cell handle, so `Cell<T> |
+// undefined` is a handle rather than something read through. The depth bound
+// terminates a declaration that refers to itself, which resolves to itself
+// however many times it is followed.
 function isReferenceOnlySchema(
   schema: JSONSchema | undefined,
   depth: number = 4,
@@ -5337,10 +5338,10 @@ export class Runner {
    *
    * Where a declaration runs out — a `true` schema, an object schema with no
    * `properties`, a root with no schema — the walk falls back to the
-   * undeclared form: every link in the raw value, two link hops deep from
-   * that point, which covers the measured defaultProfile container chain and
-   * any read the transformer could not see. Deduped, values only; an
-   * unloadable target is skipped rather than failing the resume.
+   * undeclared form: every link in the raw value within the same overall
+   * two-link-hop bound, which covers the measured defaultProfile container
+   * chain and any read the transformer could not see. Deduped, values only;
+   * an unloadable target is skipped rather than failing the resume.
    */
   async #syncArgumentLinkTargets(
     roots: readonly ArgumentLinkRoot[],
@@ -5437,15 +5438,15 @@ export class Runner {
       ) => {
         if (schema === false) return;
         // A `true` or absent schema is where the declaration ran out; scan
-        // from here in the undeclared form with a fresh two-hop budget.
+        // from here in the undeclared form with the remaining overall budget.
         const declared = schema !== undefined && schema !== true;
         const link = parseLink(value, base);
         if (link) {
           // `asCell` marks a reference the run holds rather than reads
           // through: sync the target document, walk no further. The marker
           // usually rides the declared property schema beside any `$ref`;
-          // where the declaration is a union or ends in a reference, it
-          // counts as opaque only when every resolved arm does.
+          // where the declaration is a union or ends in a reference, any
+          // resolved arm carrying the marker makes the value a handle.
           const reference = declared && isReferenceOnlySchema(schema);
           enqueue(
             link,
@@ -5465,9 +5466,8 @@ export class Runner {
           // — a cold target can then enter the commit basis, the exact
           // failure this walk exists to prevent.
           for (const key in value) {
-            // The undeclared scan runs on its own two-hop budget from the
-            // point the declaration ran out (the enqueue clamp enforces the
-            // same bound; stating it here keeps the transition visible).
+            // The undeclared scan keeps the remaining share of the overall
+            // two-hop budget; the clamp states that transition explicitly.
             collect(
               value[key],
               base,

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -144,4 +144,112 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(ids.hidden);
     expect(syncedIds).toContain(ids.deep);
   });
+
+  // Builds documents for a test that needs its own shapes.
+  function docBuilder(prefix: string) {
+    const tx = runtime.edit();
+    const make = (name: string, value: unknown) => {
+      const cell = runtime.getCell<unknown>(
+        space,
+        `${prefix} ${name}`,
+        undefined,
+        tx,
+      );
+      cell.set(value);
+      return cell;
+    };
+    return { make, commit: () => tx.commit() };
+  }
+  const id = (cell: Cell<unknown>) => cell.getAsNormalizedFullLink().id;
+
+  it("walks a document a reference visit reached first, when a read-through path also declares it", async () => {
+    const { make, commit } = docBuilder("reference then read");
+    const inner = make("inner", { leaf: 1 });
+    const shared = make("shared", { child: inner });
+    const root = make("root", { ref: shared, read: shared });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        ref: { type: "object", asCell: ["cell"] },
+        read: {
+          type: "object",
+          properties: { child: { type: "object" } },
+        },
+      },
+    } as JSONSchema);
+    expect(syncedIds).toContain(id(shared));
+    expect(syncedIds).toContain(id(inner));
+  });
+
+  it("walks both subtrees when two links address different paths of one document", async () => {
+    const { make, commit } = docBuilder("two paths");
+    const leftLeaf = make("left leaf", { n: 1 });
+    const rightLeaf = make("right leaf", { n: 2 });
+    const shared = make("shared", {
+      left: { l: leftLeaf },
+      right: { r: rightLeaf },
+    });
+    const root = make("root", {
+      a: shared.key("left"),
+      b: shared.key("right"),
+    });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        a: { type: "object", properties: { l: { type: "object" } } },
+        b: { type: "object", properties: { r: { type: "object" } } },
+      },
+    });
+    expect(syncedIds).toContain(id(leftLeaf));
+    expect(syncedIds).toContain(id(rightLeaf));
+  });
+
+  it("treats a union as a reference only when every arm is one", async () => {
+    const { make, commit } = docBuilder("union arms");
+    const behindOpaque = make("behind opaque", { n: 1 });
+    const opaque = make("opaque", { child: behindOpaque });
+    const behindReadable = make("behind readable", { n: 2 });
+    const readable = make("readable", { child: behindReadable });
+    const root = make("root", { allRef: opaque, mixed: readable });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        allRef: {
+          anyOf: [
+            { type: "object", asCell: ["cell"] },
+            { type: "object", asCell: ["stream"] },
+          ],
+        },
+        mixed: {
+          anyOf: [
+            { type: "object", asCell: ["cell"] },
+            { type: "object", properties: { child: { type: "object" } } },
+          ],
+        },
+      },
+    } as JSONSchema);
+    expect(syncedIds).toContain(id(opaque));
+    expect(syncedIds).not.toContain(id(behindOpaque));
+    expect(syncedIds).toContain(id(readable));
+    expect(syncedIds).toContain(id(behindReadable));
+  });
+
+  it("gives an undeclared subtree below a declared root the two-hop budget", async () => {
+    const { make, commit } = docBuilder("budget");
+    const third = make("third", { n: 3 });
+    const second = make("second", { c: third });
+    const first = make("first", { c: second });
+    const root = make("root", { sub: { c: first } });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: { sub: true },
+    });
+    expect(syncedIds).toContain(id(first));
+    expect(syncedIds).toContain(id(second));
+    expect(syncedIds).not.toContain(id(third));
+  });
 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -105,7 +105,10 @@ describe("syncArgumentLinkTargets", () => {
   }
 
   async function run(root: Cell<unknown>, schema: JSONSchema | undefined) {
+    // Both ledgers are scoped to the walk under test, so a fixture's own
+    // reads and syncs never count toward an assertion about it.
     syncedIds.length = 0;
+    walkedIds.length = 0;
     await (runtime.runner as unknown as {
       syncArgumentLinkTargets(
         roots: readonly { cell: Cell<unknown>; schema?: JSONSchema }[],

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -382,6 +382,23 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(leaf));
   });
 
+  it("applies `items` to an array index when the schema omits `type`", async () => {
+    const { make, commit } = docBuilder("items fallback");
+    const leaf = make("leaf", { n: 1 });
+    const element = make("element", { child: leaf });
+    const root = make("root", { list: [element] });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: { list: { items: { properties: { child: {} } } } },
+    } as JSONSchema);
+    // `schemaAtPath` selects no child for a schema that declares `items` and
+    // omits `type: "array"`, so the index resolves through the same fallback
+    // the reader uses — and the walk follows the element's own declaration.
+    expect(syncedIds).toContain(id(element));
+    expect(syncedIds).toContain(id(leaf));
+  });
+
   it("does not treat an out-of-range numeric property as an array item", async () => {
     const { make, commit } = docBuilder("non-index property");
     const leaf = make("leaf", { n: 1 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -19,6 +19,11 @@ describe("syncArgumentLinkTargets", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let syncedIds: string[];
+  // One entry per raw value read the walk performs, which is one per subtree
+  // it descends into — the observable that separates walking a subtree twice
+  // from walking it once. Sync counts cannot show it: documents dedupe
+  // separately, so a doubled walk syncs the same documents.
+  let walkedIds: string[];
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -27,6 +32,7 @@ describe("syncArgumentLinkTargets", () => {
       storageManager,
     });
     syncedIds = [];
+    walkedIds = [];
     const original = runtime.storageManager.syncCell.bind(
       runtime.storageManager,
     );
@@ -35,6 +41,27 @@ describe("syncArgumentLinkTargets", () => {
     }).syncCell = (cell) => {
       syncedIds.push(cell.getAsNormalizedFullLink().id);
       return original(cell);
+    };
+    const originalFromLink = runtime.getCellFromLink.bind(runtime);
+    const counted = new WeakSet<object>();
+    (runtime as unknown as {
+      getCellFromLink: (...args: unknown[]) => Cell<unknown>;
+    }).getCellFromLink = (...args: unknown[]) => {
+      const cell = originalFromLink(
+        ...args as Parameters<typeof originalFromLink>,
+      );
+      if (!counted.has(cell)) {
+        counted.add(cell);
+        const originalGetRaw = cell.getRawUntyped.bind(cell);
+        Object.defineProperty(cell, "getRawUntyped", {
+          configurable: true,
+          value: () => {
+            walkedIds.push(cell.getAsNormalizedFullLink().id);
+            return originalGetRaw();
+          },
+        });
+      }
+      return cell;
     };
   });
 
@@ -265,7 +292,7 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(behindMissing));
   });
 
-  it("walks a subtree once when two declared paths link to it", async () => {
+  it("descends a subtree once when two declared paths link to it", async () => {
     const { make, commit } = docBuilder("diamond");
     const leaf = make("leaf", { n: 1 });
     const shared = make("shared", { child: leaf });
@@ -279,11 +306,37 @@ describe("syncArgumentLinkTargets", () => {
       type: "object",
       properties: { left: childSchema, right: childSchema },
     } as JSONSchema);
-    // Both arms of the diamond reach the same document at the same path, so
-    // the second walk is dropped; the subtree below it is still synced.
+    // Both arms of the diamond reach the same document at the same path.
+    // Without the walk ledger the frontier carries that subtree twice and
+    // descends it twice, which only the read count shows — the documents
+    // themselves dedupe either way.
+    expect(walkedIds.filter((each) => each === id(shared))).toHaveLength(1);
     expect(syncedIds).toContain(id(shared));
     expect(syncedIds).toContain(id(leaf));
-    expect(syncedIds.filter((each) => each === id(leaf))).toHaveLength(1);
+  });
+
+  it("reads a union whose `oneOf` arm is readable beside a reference-only `anyOf`", async () => {
+    const { make, commit } = docBuilder("both keywords");
+    const behind = make("behind", { n: 1 });
+    const target = make("target", { child: behind });
+    const root = make("root", { both: target });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        both: {
+          anyOf: [{ type: "object", asCell: ["cell"] }],
+          oneOf: [{
+            type: "object",
+            properties: { child: { type: "object" } },
+          }],
+        },
+      },
+    } as JSONSchema);
+    // The `oneOf` arm is an alternative the run may take, so the link is not
+    // reference-only and the document behind it is pre-synced.
+    expect(syncedIds).toContain(id(target));
+    expect(syncedIds).toContain(id(behind));
   });
 
   it("gives an undeclared subtree below a declared root the two-hop budget", async () => {

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -5,6 +5,10 @@ import type { Cell } from "../src/cell.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import {
+  resetReaderSchemaPrecedenceConfig,
+  setReaderSchemaPrecedenceConfig,
+} from "../src/reader-schema-precedence-config.ts";
 
 // The argument link-target pre-sync follows each root's declared schema:
 // targets on schema-named paths are synced (reading through links, two link
@@ -442,6 +446,62 @@ describe("syncArgumentLinkTargets", () => {
     // collapse them and drop the second.
     expect(syncedIds).toContain(id(nestedLeaf));
     expect(syncedIds).toContain(id(slashLeaf));
+  });
+
+  it("holds an `unknown`-typed link as a reference instead of reading through it", async () => {
+    const { make, commit } = docBuilder("unknown ref");
+    const behind = make("behind", { n: 1 });
+    const referenced = make("referenced", { child: behind });
+    const root = make("root", { mention: referenced });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: { mention: { type: "unknown" } },
+    } as JSONSchema);
+    // `unknown` asks for reference semantics: the value is compared by
+    // identity, never read through, and stays opaque at every deeper hop.
+    expect(syncedIds).toContain(id(referenced));
+    expect(syncedIds).not.toContain(id(behind));
+  });
+
+  it("adopts a link's own schema when the reader brought no shape", async () => {
+    const { make, commit } = docBuilder("schema lineage");
+    const wanted = make("wanted", { n: 1 });
+    const unwanted = make("unwanted", { n: 2 });
+    const target = make("target", { a: wanted, b: unwanted });
+    const typed = target.asSchema({
+      type: "object",
+      properties: { a: { type: "object" } },
+    } as JSONSchema);
+    const root = make("root", { child: typed });
+    await commit();
+    await run(root, true);
+    // A permissive reader is typed by the link it crosses, so the walk
+    // follows that declaration rather than scanning everything behind it:
+    // `a` is selected, `b` is not.
+    expect(syncedIds).toContain(id(target));
+    expect(syncedIds).toContain(id(wanted));
+    expect(syncedIds).not.toContain(id(unwanted));
+  });
+
+  it("still covers the declared read surface under the rollback posture", async () => {
+    setReaderSchemaPrecedenceConfig(false);
+    try {
+      const { root, ids } = await linkedFixture("rollback posture");
+      await run(root, {
+        type: "object",
+        properties: {
+          a: { type: "object", properties: { inner: { type: "number" } } },
+        },
+      });
+      // With reader precedence off, crossings go back to the strict
+      // pseudo-intersection, which can only widen what the walk carries —
+      // so the declared surface stays covered.
+      expect(syncedIds).toContain(ids.a);
+      expect(syncedIds).toContain(ids.deep);
+    } finally {
+      resetReaderSchemaPrecedenceConfig();
+    }
   });
 
   it("gives an undeclared subtree below a declared root the two-hop budget", async () => {

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -7,8 +7,8 @@ import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 
 // The argument link-target pre-sync follows each root's declared schema:
-// targets on schema-named paths are synced (reading through links, as deep as
-// the declaration goes), an `asCell` path syncs its target without walking
+// targets on schema-named paths are synced (reading through links, two link
+// hops deep), an `asCell` path syncs its target without walking
 // it, an unselected property is invisible, and a root whose declaration runs
 // out falls back to the undeclared two-hop scan.
 
@@ -236,35 +236,39 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(rightLeaf));
   });
 
-  it("treats a union as a reference only when every arm is one", async () => {
+  it("treats a union as a reference when any arm carries the marker", async () => {
     const { make, commit } = docBuilder("union arms");
-    const behindOpaque = make("behind opaque", { n: 1 });
-    const opaque = make("opaque", { child: behindOpaque });
-    const behindReadable = make("behind readable", { n: 2 });
-    const readable = make("readable", { child: behindReadable });
-    const root = make("root", { allRef: opaque, mixed: readable });
+    const behindHandle = make("behind handle", { n: 1 });
+    const handle = make("handle", { child: behindHandle });
+    const behindPlain = make("behind plain", { n: 2 });
+    const plain = make("plain", { child: behindPlain });
+    const root = make("root", { optional: handle, readable: plain });
     await commit();
     await run(root, {
       type: "object",
       properties: {
-        allRef: {
+        // The shape a generated optional handle takes. `preferAsCellBranch`
+        // hands the reader the `asCell` branch, so the run holds a handle
+        // and never reads through it.
+        optional: {
           anyOf: [
             { type: "object", asCell: ["cell"] },
-            { type: "object", asCell: ["stream"] },
+            { type: "undefined" },
           ],
         },
-        mixed: {
+        readable: {
           anyOf: [
-            { type: "object", asCell: ["cell"] },
             { type: "object", properties: { child: { type: "object" } } },
+            { type: "undefined" },
           ],
         },
       },
     } as JSONSchema);
-    expect(syncedIds).toContain(id(opaque));
-    expect(syncedIds).not.toContain(id(behindOpaque));
-    expect(syncedIds).toContain(id(readable));
-    expect(syncedIds).toContain(id(behindReadable));
+    expect(syncedIds).toContain(id(handle));
+    expect(syncedIds).not.toContain(id(behindHandle));
+    // No arm of the second union carries the marker, so it is read through.
+    expect(syncedIds).toContain(id(plain));
+    expect(syncedIds).toContain(id(behindPlain));
   });
 
   it("treats an `asCell` marker behind a `$ref` as a reference, and an unresolvable `$ref` as readable", async () => {
@@ -318,7 +322,7 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(leaf));
   });
 
-  it("reads a union whose `oneOf` arm is readable beside a reference-only `anyOf`", async () => {
+  it("sees a marker in the `oneOf` arms when a schema carries both keywords", async () => {
     const { make, commit } = docBuilder("both keywords");
     const behind = make("behind", { n: 1 });
     const target = make("target", { child: behind });
@@ -328,18 +332,85 @@ describe("syncArgumentLinkTargets", () => {
       type: "object",
       properties: {
         both: {
-          anyOf: [{ type: "object", asCell: ["cell"] }],
-          oneOf: [{
+          anyOf: [{
             type: "object",
             properties: { child: { type: "object" } },
           }],
+          oneOf: [{ type: "object", asCell: ["cell"] }],
         },
       },
     } as JSONSchema);
-    // The `oneOf` arm is an alternative the run may take, so the link is not
-    // reference-only and the document behind it is pre-synced.
+    // Both keywords describe one set of alternatives, so the `oneOf` marker
+    // counts: the target is synced as a handle and not read through. Letting
+    // `anyOf` shadow `oneOf` would walk it instead.
     expect(syncedIds).toContain(id(target));
-    expect(syncedIds).toContain(id(behind));
+    expect(syncedIds).not.toContain(id(behind));
+  });
+
+  it("walks the same document at one path under two disjoint declarations", async () => {
+    const { make, commit } = docBuilder("disjoint schemas");
+    const leftLeaf = make("left leaf", { n: 1 });
+    const rightLeaf = make("right leaf", { n: 2 });
+    const shared = make("shared", { left: leftLeaf, right: rightLeaf });
+    const root = make("root", { viaLeft: shared, viaRight: shared });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        viaLeft: { type: "object", properties: { left: { type: "object" } } },
+        viaRight: { type: "object", properties: { right: { type: "object" } } },
+      },
+    } as JSONSchema);
+    // One document, one path, two bindings that read different fields of it.
+    // Neither walk stands in for the other, so both leaves are pre-synced.
+    expect(syncedIds).toContain(id(leftLeaf));
+    expect(syncedIds).toContain(id(rightLeaf));
+  });
+
+  it("descends a schema that declares `properties` without a `type`", async () => {
+    const { make, commit } = docBuilder("no type");
+    const leaf = make("leaf", { n: 1 });
+    const target = make("target", { child: leaf });
+    const root = make("root", { a: target });
+    await commit();
+    await run(root, {
+      properties: { a: { properties: { child: {} } } },
+    } as JSONSchema);
+    // An eager read reaches these children even though `schemaAtPath` selects
+    // none of them, so the pre-sync follows the declaration it can see.
+    expect(syncedIds).toContain(id(target));
+    expect(syncedIds).toContain(id(leaf));
+  });
+
+  it("keeps two subtrees apart when one path segment contains a separator", async () => {
+    const { make, commit } = docBuilder("path collision");
+    const nestedLeaf = make("nested leaf", { n: 1 });
+    const slashLeaf = make("slash leaf", { n: 2 });
+    const shared = make("shared", {
+      a: { b: nestedLeaf },
+      "a/b": slashLeaf,
+    });
+    await commit();
+    const root = (() => {
+      const b = docBuilder("path collision root");
+      const cell = b.make("root", {
+        nested: shared.key("a").key("b"),
+        slashed: shared.key("a/b"),
+      });
+      return { cell, commit: b.commit };
+    })();
+    await root.commit();
+    await run(root.cell, {
+      type: "object",
+      properties: {
+        nested: { type: "object" },
+        slashed: { type: "object" },
+      },
+    } as JSONSchema);
+    // `["a", "b"]` and `["a/b"]` are different subtrees; a joined key would
+    // collapse them and drop the second.
+    expect(syncedIds).toContain(id(nestedLeaf));
+    expect(syncedIds).toContain(id(slashLeaf));
   });
 
   it("gives an undeclared subtree below a declared root the two-hop budget", async () => {

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -392,6 +392,7 @@ describe("syncArgumentLinkTargets", () => {
     } as JSONSchema);
     // One document, one path, two bindings that read different fields of it.
     // Neither walk stands in for the other, so both leaves are pre-synced.
+    expect(syncedIds.filter((each) => each === id(shared))).toHaveLength(1);
     expect(syncedIds).toContain(id(leftLeaf));
     expect(syncedIds).toContain(id(rightLeaf));
   });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -382,6 +382,20 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(leaf));
   });
 
+  it("does not treat an out-of-range numeric property as an array item", async () => {
+    const { make, commit } = docBuilder("non-index property");
+    const leaf = make("leaf", { n: 1 });
+    const root = make("root", { "4294967295": leaf });
+    await commit();
+    await run(root, {
+      items: { type: "object" },
+    } as JSONSchema);
+    // 2^32 - 1 is an ordinary property name, not an array index. The reader's
+    // child-schema fallback therefore does not apply `items` to it, and the
+    // pre-sync must leave the same property unselected.
+    expect(syncedIds).not.toContain(id(leaf));
+  });
+
   it("keeps two subtrees apart when one path segment contains a separator", async () => {
     const { make, commit } = docBuilder("path collision");
     const nestedLeaf = make("nested leaf", { n: 1 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -265,6 +265,27 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(behindMissing));
   });
 
+  it("walks a subtree once when two declared paths link to it", async () => {
+    const { make, commit } = docBuilder("diamond");
+    const leaf = make("leaf", { n: 1 });
+    const shared = make("shared", { child: leaf });
+    const root = make("root", { left: shared, right: shared });
+    await commit();
+    const childSchema = {
+      type: "object",
+      properties: { child: { type: "object" } },
+    } as JSONSchema;
+    await run(root, {
+      type: "object",
+      properties: { left: childSchema, right: childSchema },
+    } as JSONSchema);
+    // Both arms of the diamond reach the same document at the same path, so
+    // the second walk is dropped; the subtree below it is still synced.
+    expect(syncedIds).toContain(id(shared));
+    expect(syncedIds).toContain(id(leaf));
+    expect(syncedIds.filter((each) => each === id(leaf))).toHaveLength(1);
+  });
+
   it("gives an undeclared subtree below a declared root the two-hop budget", async () => {
     const { make, commit } = docBuilder("budget");
     const third = make("third", { n: 3 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -237,6 +237,34 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(behindReadable));
   });
 
+  it("treats an `asCell` marker behind a `$ref` as a reference, and an unresolvable `$ref` as readable", async () => {
+    const { make, commit } = docBuilder("ref arms");
+    const behindRef = make("behind ref", { n: 1 });
+    const viaRef = make("via ref", { child: behindRef });
+    const behindMissing = make("behind missing", { n: 2 });
+    const viaMissing = make("via missing", { child: behindMissing });
+    const root = make("root", { r: viaRef, m: viaMissing });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        r: { "$ref": "#/$defs/RefCell" },
+        m: { "$ref": "#/$defs/Missing" },
+      },
+      "$defs": {
+        RefCell: { type: "object", asCell: ["cell"] },
+      },
+    } as JSONSchema);
+    // The resolved definition carries `asCell`: target synced, not walked.
+    expect(syncedIds).toContain(id(viaRef));
+    expect(syncedIds).not.toContain(id(behindRef));
+    // An unresolvable reference is not a reference marker; the target is
+    // walked under it (the schema resolves to nothing, so the scan falls
+    // back rather than going opaque).
+    expect(syncedIds).toContain(id(viaMissing));
+    expect(syncedIds).toContain(id(behindMissing));
+  });
+
   it("gives an undeclared subtree below a declared root the two-hop budget", async () => {
     const { make, commit } = docBuilder("budget");
     const third = make("third", { n: 3 });

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Cell } from "../src/cell.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+// The argument link-target pre-sync follows each root's declared schema:
+// targets on schema-named paths are synced (reading through links, as deep as
+// the declaration goes), an `asCell` path syncs its target without walking
+// it, an unselected property is invisible, and a root whose declaration runs
+// out falls back to the undeclared two-hop scan.
+
+const signer = await Identity.fromPassphrase("sync argument link targets");
+const space = signer.did();
+
+describe("syncArgumentLinkTargets", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let syncedIds: string[];
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    syncedIds = [];
+    const original = runtime.storageManager.syncCell.bind(
+      runtime.storageManager,
+    );
+    (runtime.storageManager as unknown as {
+      syncCell: (cell: Cell<unknown>) => Promise<Cell<unknown>>;
+    }).syncCell = (cell) => {
+      syncedIds.push(cell.getAsNormalizedFullLink().id);
+      return original(cell);
+    };
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  // A root document holding links under `a`, `b`, and `hidden`; the document
+  // behind `a` links onward to `deep`, and the one behind `b` to `behindB`.
+  async function linkedFixture(prefix: string) {
+    const tx = runtime.edit();
+    const make = (name: string, value: unknown) => {
+      const cell = runtime.getCell<unknown>(
+        space,
+        `${prefix} ${name}`,
+        undefined,
+        tx,
+      );
+      cell.set(value);
+      return cell;
+    };
+    const deep = make("deep", { leaf: 1 });
+    const behindB = make("behind b", { leaf: 2 });
+    const a = make("a", { inner: deep });
+    const b = make("b", { deeper: behindB });
+    const hidden = make("hidden", { leaf: 3 });
+    const root = make("root", { a, b, hidden });
+    await tx.commit();
+    const id = (cell: Cell<unknown>) => cell.getAsNormalizedFullLink().id;
+    return {
+      root,
+      ids: {
+        deep: id(deep),
+        behindB: id(behindB),
+        a: id(a),
+        b: id(b),
+        hidden: id(hidden),
+      },
+    };
+  }
+
+  async function run(root: Cell<unknown>, schema: JSONSchema | undefined) {
+    syncedIds.length = 0;
+    await (runtime.runner as unknown as {
+      syncArgumentLinkTargets(
+        roots: readonly { cell: Cell<unknown>; schema?: JSONSchema }[],
+        label: string,
+      ): Promise<void>;
+    }).syncArgumentLinkTargets(
+      [{ cell: root, schema }],
+      "resumeArgumentLinkTargetSync",
+    );
+  }
+
+  it("syncs targets on schema-named paths, reading through links, and skips unselected properties", async () => {
+    const { root, ids } = await linkedFixture("named paths");
+    await run(root, {
+      type: "object",
+      properties: {
+        a: {
+          type: "object",
+          properties: { inner: { type: "number" } },
+        },
+      },
+    });
+    expect(syncedIds).toContain(ids.a);
+    expect(syncedIds).toContain(ids.deep);
+    expect(syncedIds).not.toContain(ids.b);
+    expect(syncedIds).not.toContain(ids.hidden);
+  });
+
+  it("syncs an `asCell` path's target without walking its contents", async () => {
+    const { root, ids } = await linkedFixture("as cell");
+    await run(root, {
+      type: "object",
+      properties: {
+        b: { type: "object", asCell: ["cell"] },
+      },
+    } as JSONSchema);
+    expect(syncedIds).toContain(ids.b);
+    expect(syncedIds).not.toContain(ids.behindB);
+    expect(syncedIds).not.toContain(ids.a);
+  });
+
+  it("scans in full, two link hops deep, where the declaration runs out", async () => {
+    const { root, ids } = await linkedFixture("true schema");
+    await run(root, true);
+    expect(syncedIds).toContain(ids.a);
+    expect(syncedIds).toContain(ids.b);
+    expect(syncedIds).toContain(ids.hidden);
+    expect(syncedIds).toContain(ids.deep);
+    expect(syncedIds).toContain(ids.behindB);
+  });
+
+  it("scans a schemaless root the same as a `true` one", async () => {
+    const { root, ids } = await linkedFixture("no schema");
+    await run(root, undefined);
+    expect(syncedIds).toContain(ids.hidden);
+    expect(syncedIds).toContain(ids.deep);
+  });
+
+  it("falls back to the full scan under an unstructured object schema", async () => {
+    const { root, ids } = await linkedFixture("unstructured");
+    await run(root, { type: "object" });
+    expect(syncedIds).toContain(ids.a);
+    expect(syncedIds).toContain(ids.hidden);
+    expect(syncedIds).toContain(ids.deep);
+  });
+});

--- a/packages/runner/test/sync-argument-link-targets.test.ts
+++ b/packages/runner/test/sync-argument-link-targets.test.ts
@@ -275,6 +275,31 @@ describe("syncArgumentLinkTargets", () => {
     expect(syncedIds).toContain(id(behindPlain));
   });
 
+  it("holds a value declared `unknown` in either spelling of `type`", async () => {
+    const { make, commit } = docBuilder("unknown reference");
+    const behindScalar = make("behind scalar", { n: 1 });
+    const scalar = make("scalar", { child: behindScalar });
+    const behindArray = make("behind array", { n: 2 });
+    const array = make("array", { child: behindArray });
+    const root = make("root", { scalar, array });
+    await commit();
+    await run(root, {
+      type: "object",
+      properties: {
+        // `unknown` asks for reference semantics: compared by identity, not
+        // read through, opaque at this hop and every deeper one. The reader
+        // honors both spellings of `type`, so the pre-sync has to as well,
+        // or it warms documents a run declared it would never read.
+        scalar: { type: "unknown" },
+        array: { type: ["unknown", "string"] },
+      },
+    } as JSONSchema);
+    expect(syncedIds).toContain(id(scalar));
+    expect(syncedIds).not.toContain(id(behindScalar));
+    expect(syncedIds).toContain(id(array));
+    expect(syncedIds).not.toContain(id(behindArray));
+  });
+
   it("treats an `asCell` marker behind a `$ref` as a reference, and an unresolvable `$ref` as readable", async () => {
     const { make, commit } = docBuilder("ref arms");
     const behindRef = make("behind ref", { n: 1 });


### PR DESCRIPTION
## The defect

On piece resume, `syncArgumentLinkTargets` pre-syncs the documents a first
run may read through links — a correctness guard, not an optimization: a
document that arrives cold lands in the instantiation commit's conflict
basis, the commit loses, and the batched instantiation reverts.

It decided what to warm by walking stored argument **values** with a
schema-blind recursive `for..in`, two link hops deep. Its own
`TODO(seefeld)` said so: "ignores schemas provided by modules, so it might
still fetch a lot." Measured on a clone of the production topics board,
~58% of what it collected were links inside persisted `$UI` vnode trees —
the full-page UI of every topic — that the board's card list never reads,
plus per-topic verb streams and draft cells no derivation declares.

The declared read surface is what a first run can reach. Warming documents
no declaration names is the bound being wrong, not just wide.

## The fix

Collection walks value and schema in lockstep:

- Roots carry their declared schemas — each node input's `link.schema`, and
  the pattern's `argumentSchema` for the argument meta root.
- Descent narrows one segment at a time. `narrowChildSchema` mirrors what
  `schema-view.ts`'s `childSchema` already does, including the case where a
  schema declares `properties` or `items` and omits `type`, which
  `schemaAtPath` narrows to `false` while an eager read reaches those
  children anyway.
- **A link is crossed through `combineSchemaForLink`** — the same rule the
  reader uses (#6338). A shaped reader carries its schema into the target
  and the link cannot widen it; a permissive reader adopts what the link
  declares. Because that function answers to `readerSchemaPrecedence`, the
  pre-sync tracks whichever posture is in force, rollback included.
- A value the run holds rather than reads through is synced and not walked:
  `asCell` names a handle, and `unknown` asks for reference semantics —
  compared by identity, opaque at this hop and every deeper one, which is
  how this board declares `mentions` and its crossref rows.
- Where a declaration runs out — `true`, an unstructured object, a link
  declaring nothing, an unresolvable `$ref` — the walk falls back to
  scanning the raw value. That preserves the previous behavior for
  everything the transformer cannot see, including the defaultProfile
  container chain this machinery was built for. Both forms reach two link
  hops, the bound the undeclared walk has always had.

A blanket `$UI` denylist was tried and rejected: it produced a
commit-revert, exactly the failure the pre-sync guards.

## Measured

Warm loads on the board-clone rig (113-topic production clone), each build
measured on its own so the attribution is real:

| build | pre-synced targets | cell syncs | churn |
| --- | --- | --- | --- |
| before (main) | 5,029 | 173 | 1 / 1 |
| #6338 alone | 4,760 | 148 | 0 / 0 |
| **this change, on #6338** | **1,247** | 148 | 0 / 0 |

#6338 governs how reads combine schemas at a crossing; the walk it finds
here consulted no schema at all, so the two changes are complementary
rather than overlapping — this one is what makes the pre-sync honor a
declaration, and #6338 is what makes that declaration authoritative once a
link is crossed.

## Tests

`packages/runner/test/sync-argument-link-targets.test.ts` — 20 cases
covering: schema-named paths reading through links while unselected
properties stay invisible; `asCell` and `unknown` synced without being
walked; unions (any marked arm makes a handle; both keywords combine);
`true`, schemaless, unstructured-object and unresolvable-`$ref` roots
taking the full scan; `properties`/`items` without `type`; the walk ledger
keyed by document, path and schema (a diamond descends once; disjoint
declarations over one path each descend; a separator inside a path segment
does not collide); the two-hop budget; and the rollback posture with
`readerSchemaPrecedence` off.

Each behavioral guard was mutation-verified — the inverse applied, the
named test watched to fail — rather than assumed from a passing run.
