### PR TITLE
refactor: a VDOM mount reports no root as `null`, not a manufactured `0`

### DIFF
--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -11,7 +11,7 @@ import { CellHandle, cellRefToKey } from "@commonfabric/runtime-client";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import { setPropDefault, type SetPropHandler } from "../render-utils.ts";
-import type { VDomBatch, VDomOp } from "../vdom-ops.ts";
+import { CONTAINER_NODE_ID, type VDomBatch, type VDomOp } from "../vdom-ops.ts";
 import { serializeEvent } from "./events.ts";
 import type { DomEventMessage } from "./events.ts";
 import {
@@ -43,12 +43,6 @@ function isElementNode(node: unknown): node is HTMLElement {
 function isTextNode(node: unknown): node is Node {
   return hasNodeType(node, TEXT_NODE);
 }
-
-/**
- * Reserved node ID for the container element.
- * Must match the value in worker/reconciler.ts.
- */
-export const CONTAINER_NODE_ID = 0;
 
 /**
  * Options for creating a DOM applicator.

--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -127,7 +127,7 @@ export class VDomRenderer {
     logger.timeStart("mount", String(this.mountId));
     try {
       const response = await this.session.mount(this.mountId, cellRef);
-      this.rootNodeId = response.rootId > 0 ? response.rootId : null;
+      this.rootNodeId = response.rootId;
 
       const elapsed = logger.timeEnd("mount", String(this.mountId));
       logger.debug("render-mount", () => [

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -8,6 +8,15 @@
 import type { CellRef, JSONValue } from "@commonfabric/runtime-client";
 
 /**
+ * Reserved node ID for the container element. The main thread registers the
+ * container DOM element under it, and the worker names it as the parent when
+ * inserting a child directly into the container. It lives here, with the rest
+ * of the vocabulary the two sides share, because agreeing on it is the whole
+ * of its job.
+ */
+export const CONTAINER_NODE_ID = 0;
+
+/**
  * Create a new DOM element.
  */
 export type CreateElementOp = {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -60,7 +60,7 @@ import {
   isEventHandler,
   isEventProp,
 } from "../render-utils.ts";
-import type { VDomOp } from "../vdom-ops.ts";
+import { CONTAINER_NODE_ID, type VDomOp } from "../vdom-ops.ts";
 import { generateChildKeys } from "./keying.ts";
 import type {
   ChildNodeState,
@@ -132,12 +132,6 @@ const DEFAULT_RENDER_POLICY: RenderPolicy = {
 // Mirrors CFC_ATOM_TYPE.Caveat in @commonfabric/api/cfc (not a dependency of
 // this package).
 const CFC_CAVEAT_ATOM_TYPE = "https://commonfabric.org/cfc/atom/Caveat";
-
-/**
- * Reserved node ID for the container element.
- * The main thread registers the actual container DOM element with this ID.
- */
-export const CONTAINER_NODE_ID = 0;
 
 const logger = getLogger("worker-reconciler", {
   enabled: false,

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { expect } from "@std/expect";
 import {
   $conn,
   CellHandle,
@@ -77,11 +78,14 @@ class MockConnection {
     this.listeners.get(event)?.delete(callback);
   }
 
+  /** What the next `mountVDom` reports as the tree's root. */
+  public mountRootId: number | null = null;
+
   mountVDom(
     _mountId: number,
     _cellRef: CellRef,
-  ): Promise<{ rootId: number }> {
-    return Promise.resolve({ rootId: 0 });
+  ): Promise<{ rootId: number | null }> {
+    return Promise.resolve({ rootId: this.mountRootId });
   }
 
   unmountVDom(mountId: number): Promise<void> {
@@ -109,37 +113,56 @@ class MockConnection {
   }
 }
 
-Deno.test("VDomRenderer - does not remove container when rootId is sentinel 0", async () => {
-  const removedNodes: unknown[] = [];
-  const parentNode = {
-    removeChild(node: unknown) {
-      removedNodes.push(node);
-    },
+Deno.test("VDomRenderer - takes the mount response's rootId as the root", async (t) => {
+  const setup = (mountRootId: number | null) => {
+    const connection = new MockConnection();
+    connection.mountRootId = mountRootId;
+    const mock = new MockDoc(
+      '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+    );
+    const renderer = new VDomRenderer({
+      runtimeClient: {} as any,
+      connection: connection as any,
+      document: mock.document,
+    });
+    const cellRef = {
+      space: "did:key:test",
+      id: "cell-id",
+      path: [],
+      type: "application/json",
+    } as unknown as CellRef;
+    const container = mock.document.getElementById("root")!;
+    return { connection, renderer, cellRef, container };
   };
-  const container = { parentNode };
-  const connection = new MockConnection();
 
-  const renderer = new VDomRenderer({
-    runtimeClient: {} as any,
-    connection: connection as any,
-    document: {
-      createElement: (tagName: string) => ({ tagName }),
-      createTextNode: (text: string) => ({ text }),
-    } as unknown as Document,
+  await t.step("reports no root when the mount reports none", async () => {
+    const { renderer, cellRef, container } = setup(null);
+
+    await renderer.render(container as unknown as HTMLElement, cellRef);
+
+    expect(renderer.getRootNode()).toBe(null);
+
+    await renderer.dispose();
   });
 
-  const cellRef = {
-    space: "did:key:test",
-    id: "cell-id",
-    path: [],
-    type: "application/json",
-  } as unknown as CellRef;
+  await t.step("reports the node the mount named", async () => {
+    const { renderer, cellRef, container } = setup(1);
 
-  await renderer.render(container as unknown as HTMLElement, cellRef);
-  await renderer.stopRendering();
+    await renderer.render(container as unknown as HTMLElement, cellRef);
+    // The mount names a node the applicator has yet to hear of, so create it
+    // before reading back: `getRootNode()` resolves the id through the node
+    // map, and an unresolved id would report no root for the wrong reason --
+    // which is the answer the other step expects, so the two would agree
+    // while measuring different things.
+    renderer.getApplicator().applyBatch({
+      batchId: 1,
+      ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
+    });
 
-  assertEquals(connection.unmountCalls.length, 1);
-  assertEquals(removedNodes.includes(container), false);
+    expect(renderer.getRootNode()).toBe(renderer.getApplicator().getNode(1));
+
+    await renderer.dispose();
+  });
 });
 
 Deno.test("VDomRenderer - forwards trusted event provenance through delivery", async () => {

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -165,6 +165,62 @@ Deno.test("VDomRenderer - takes the mount response's rootId as the root", async 
   });
 });
 
+Deno.test("VDomRenderer - tearing down leaves the caller's container", async (t) => {
+  const setup = (mountRootId: number | null) => {
+    const connection = new MockConnection();
+    connection.mountRootId = mountRootId;
+    const mock = new MockDoc(
+      '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+    );
+    const renderer = new VDomRenderer({
+      runtimeClient: {} as any,
+      connection: connection as any,
+      document: mock.document,
+    });
+    const cellRef = {
+      space: "did:key:test",
+      id: "cell-id",
+      path: [],
+      type: "application/json",
+    } as unknown as CellRef;
+    const container = mock.document.getElementById("root")!;
+    return { renderer, cellRef, container };
+  };
+
+  await t.step("when the mount reported no root", async () => {
+    const { renderer, cellRef, container } = setup(null);
+    await renderer.render(container as unknown as HTMLElement, cellRef);
+
+    await renderer.stopRendering();
+
+    expect((container as any).parentNode).not.toBe(null);
+    await renderer.dispose();
+  });
+
+  await t.step("and removes the root it did report", async () => {
+    const { renderer, cellRef, container } = setup(1);
+    await renderer.render(container as unknown as HTMLElement, cellRef);
+    renderer.getApplicator().applyBatch({
+      batchId: 1,
+      ops: [
+        { op: "create-element", nodeId: 1, tagName: "button" },
+        { op: "insert-child", parentId: 0, childId: 1, beforeId: null },
+      ],
+    });
+    const root = renderer.getApplicator().getNode(1);
+    expect((container as any).childNodes.length).toBe(1);
+
+    await renderer.stopRendering();
+
+    // The root goes and the container stays: teardown reaches into the
+    // container rather than removing it, which is the distinction the two
+    // steps together pin.
+    expect((root as any).parentNode).toBe(null);
+    expect((container as any).parentNode).not.toBe(null);
+    await renderer.dispose();
+  });
+});
+
 Deno.test("VDomRenderer - forwards trusted event provenance through delivery", async () => {
   const connection = new MockConnection();
   const mock = new MockDoc(

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -2021,9 +2021,7 @@ export class RuntimeProcessor {
     // Track this mount
     this.vdomMounts.set(mountId, { reconciler, cancel });
 
-    // Return the root node ID
-    const rootId = reconciler.getRootNodeId() ?? 0;
-    return { rootId };
+    return { rootId: reconciler.getRootNodeId() };
   }
 
   /**

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -995,11 +995,15 @@ export type IPCClientNotification =
   | VDomBatchAppliedNotification;
 
 /**
- * Response to VDomMount with the root node ID.
+ * Response to VDomMount, naming the tree's root node.
  */
 export type VDomMountResponse = {
-  /** The root node ID for this mount */
-  rootId: number;
+  /**
+   * The root node ID for this mount; `null` when the tree has no root child.
+   * `VDomBatchNotification` spells absence the same way, so a reader maps both
+   * directions with one rule.
+   */
+  rootId: number | null;
 };
 
 /**

--- a/packages/ui/src/v2/test-utils/mock-vdom-connection.ts
+++ b/packages/ui/src/v2/test-utils/mock-vdom-connection.ts
@@ -60,8 +60,8 @@ export function createRenderableCellHandle<T>(
     signal: lifetime.signal,
     mount: (_mountId: number, cellRef: CellRef) => {
       log.mounted.push(cellRef);
-      // rootId 0 is the container itself: nothing was rendered above it.
-      return Promise.resolve({ rootId: 0 });
+      // `null`: nothing was rendered, so the tree has no root child.
+      return Promise.resolve({ rootId: null });
     },
     unmount: (mountId: number) => {
       log.unmounted.push(mountId);


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Second prep step for the IPC envelope work, after #6269. It removes the last
place where the two VDOM root-reporting directions disagree about how to say
"no root", so that the codec change lands on one rule rather than two.

## The asymmetry

`VDomBatchNotification.rootId` says `number | null`. `VDomMountResponse.rootId`
said plain `number`, so absence had to be encoded: `runtime-processor.ts` wrote
`reconciler.getRootNodeId() ?? 0`, and `renderer.ts` undid it with
`response.rootId > 0 ? response.rootId : null`. A sentinel manufactured at one
end and decoded at the other, for want of a type that could say "none".

Nothing chose that; it is the end that was not reached when the notification
side gained its `null`. Both now say `number | null`, and the `?? 0` and `> 0`
are gone.

## The replaced test, and why replaced rather than renamed

`main-renderer.test.ts` had a test named "does not remove container when rootId
is sentinel 0". Its premise can no longer occur, and it could not
say **which** guard protected the container. Measured:

| ablated | test |
| --- | --- |
| the `> 0` mapping alone | green |
| `stopRendering()`'s `rootNode !== containerElement` guard alone | green |
| both together | **red** |

The two are a redundant pair, and the test observed the side effect they share
— the container surviving — rather than the mapping its name claimed. Its name
was the only thing tying it to the sentinel.

It did, though, catch **both** guards going at once, and "cannot distinguish
the two" is not "asserts nothing" — cubic caught that this PR had dropped the
property along with the test. `8a7192a5c` restores it, as a pair that is
stronger than what it restores because one step asserts a positive:

| mutation to `stopRendering()` | "when the mount reported no root" | "and removes the root it did report" |
| --- | --- | --- |
| cleanup does nothing at all | ok | **red** |
| null gate and container guard both gone | **red** | ok |

The old test, asserting only that the container survived, was blind to the
first row. The second step inserts the root into the container first, so it
exercises the removal path rather than a no-op.

What replaces it observes the mapping directly, and is a discriminating pair:

| mutation to the mount mapping | "reports no root…" | "reports the node…" |
| --- | --- | --- |
| restore the dead `> 0` | ok | ok |
| ignore the mount response | ok | **red** |
| coerce `null` to `0` | **red** | ok |

The first row is not a gap: it is a third independent confirmation that `> 0`
was dead, alongside the reachability argument (a root is `null` or an
allocator-issued id, and ids start at 1) and the ablation that removed it.

The step that asserts a named root creates the node first and pins node
*identity*, because an unresolved id reports no root — which is the other
step's expected answer, so the two would have agreed while measuring different
things.

## What stays, deliberately

`stopRendering()`'s `rootNode !== this.containerElement` guard is unreachable
by the same argument that condemned the `> 0`, and after this change no test in
`html`, `runtime-client`, `ui`, or `shell` exercises it — ablating it leaves
all four green. It stays anyway, for two reasons the `> 0` did not have: it
guards removing the caller's container from the page rather than mis-mapping a
readout, and its unreachability rests on an invariant nothing enforces
mechanically.

That invariant is the second commit. `CONTAINER_NODE_ID = 0` was declared
twice, once per side of the worker/main boundary, the main-thread copy carrying
the comment "Must match the value in worker/reconciler.ts". It is declared once
now, in `vdom-ops.ts` with the rest of the shared vocabulary. Neither copy was
package surface: `worker/mod.ts` and `client.ts` re-export neither, and nothing
outside `html` names it.

## Verification

- `deno task check`, `deno lint`, `deno fmt --check`: green.
- Full workspace `deno task test` at `7a686d81e`: green, 432s, tree clean
  before and after, `deno.lock` untouched.
- One flake seen and run down rather than waved past: an earlier full run
  failed `runner`'s "Phase 4 client-effect channel" on a 20s timeout. It passes
  in isolation on `main`, in isolation on this branch, and in the full run
  above. Nothing here is reachable from `runner`.
- Ablations as tabulated above, each against a pristine copy compared with
  `cmp` so a no-op edit could not read as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121sxMwWK139eKHNNGrjygY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


