### PR TITLE
fix(piece): surface dropped commit errors in registry and default-pattern writes

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -455,10 +455,16 @@ export class PiecesController<T = unknown> {
   async linkDefaultPattern(
     defaultPatternCell: Cell<any>,
   ): Promise<void> {
-    await this.runtime.editWithRetry((tx) => {
+    const { error } = await this.runtime.editWithRetry((tx) => {
       const spaceCellWithTx = this.spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(defaultPatternCell.withTx(tx));
     });
+    if (error) {
+      throw new Error(
+        `Linking the default pattern failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
     await this.runtime.idle();
   }
 
@@ -467,10 +473,16 @@ export class PiecesController<T = unknown> {
    * Used when the default pattern is being deleted.
    */
   async unlinkDefaultPattern(): Promise<void> {
-    await this.runtime.editWithRetry((tx) => {
+    const { error } = await this.runtime.editWithRetry((tx) => {
       const spaceCellWithTx = this.spaceCell.withTx(tx);
       spaceCellWithTx.key("defaultPattern").set(undefined);
     });
+    if (error) {
+      throw new Error(
+        `Unlinking the default pattern failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
     await this.runtime.idle();
   }
 
@@ -1161,7 +1173,12 @@ export class PiecesController<T = unknown> {
     return piece;
   }
 
-  // note: removing a piece doesn't clean up the piece's cells
+  /**
+   * Remove a piece from this space's registry. Does not clean up the piece's
+   * cells. Returns whether this call removed the piece — `false` means the
+   * piece was not registered. A removal that cannot commit throws instead, so
+   * `false` never stands in for a storage failure.
+   */
   async remove(pieceOrId: string | Cell<unknown>): Promise<boolean> {
     const piece = typeof pieceOrId === "string"
       ? this.runtime.getCellFromEntityId(this.space, entityIdFrom(pieceOrId))
@@ -1178,7 +1195,7 @@ export class PiecesController<T = unknown> {
       await this.unlinkDefaultPattern();
     }
 
-    const { ok } = await this.runtime.editWithRetry((tx) => {
+    const { ok, error } = await this.runtime.editWithRetry((tx) => {
       const pieces = piecesCell.withTx(tx);
 
       // Remove from main list
@@ -1190,6 +1207,12 @@ export class PiecesController<T = unknown> {
         return false;
       }
     });
+    if (error) {
+      throw new Error(
+        `Removing the piece failed because storage returned ${error.name}: ${error.message}`,
+        { cause: error },
+      );
+    }
 
     // Ensure full synchronization
     if (ok) {

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -1176,8 +1176,11 @@ export class PiecesController<T = unknown> {
   /**
    * Remove a piece from this space's registry. Does not clean up the piece's
    * cells. Returns whether this call removed the piece — `false` means the
-   * piece was not registered. A removal that cannot commit throws instead, so
-   * `false` never stands in for a storage failure.
+   * piece was not registered, and nothing was written. When the removed piece
+   * is the space's default pattern, the link to it is cleared in the same
+   * commit, so the registry and the link cannot land in a split state. A
+   * removal that cannot commit throws instead, so `false` never stands in for
+   * a storage failure.
    */
   async remove(pieceOrId: string | Cell<unknown>): Promise<boolean> {
     const piece = typeof pieceOrId === "string"
@@ -1186,26 +1189,29 @@ export class PiecesController<T = unknown> {
     const piecesCell = await this.getPieceRegistry();
     await this.syncPieces(piecesCell);
 
-    // Check if this is the default pattern and clear the link
-    const defaultPattern = await this.getDefaultPattern(false);
-    if (
-      defaultPattern &&
-      piece.resolveAsCell().equals(defaultPattern.resolveAsCell())
-    ) {
-      await this.unlinkDefaultPattern();
-    }
-
     const { ok, error } = await this.runtime.editWithRetry((tx) => {
       const pieces = piecesCell.withTx(tx);
 
       // Remove from main list
       const newPieces = filterOutCell(pieces, piece);
-      if (newPieces.length !== pieces.get().length) {
-        pieces.set(newPieces);
-        return true;
-      } else {
+      if (newPieces.length === pieces.get().length) {
         return false;
       }
+      pieces.set(newPieces);
+
+      // Clear the default-pattern link when it points at the removed piece,
+      // in the same commit as the registry write. Read the link inside the
+      // transaction: a conflict retry reruns this callback against fresh
+      // state, and a link concurrently repointed at another piece must be
+      // left in place (the same precondition-guard shape as the roll-forward
+      // swap in startEnsuredDefaultPattern).
+      const defaultPatternCell = this.spaceCell.withTx(tx)
+        .key("defaultPattern");
+      const linked = defaultPatternCell.get();
+      if (linked && piece.resolveAsCell().equals(linked.resolveAsCell())) {
+        defaultPatternCell.set(undefined);
+      }
+      return true;
     });
     if (error) {
       throw new Error(

--- a/packages/piece/test/ops/pieces-controller.test.ts
+++ b/packages/piece/test/ops/pieces-controller.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../../../runner/src/builder/factory.ts";
+import type { Cell } from "../../../runner/src/builder/types.ts";
+import { pieceId } from "../../src/piece-id.ts";
+import { PiecesController } from "../../src/ops/pieces-controller.ts";
+
+const signer = await Identity.fromPassphrase("pieces controller registry");
+
+/** A default pattern exposing the registry surface `add()` drives. */
+function defaultRegistryPattern() {
+  const { commonfabric } = createBuilder();
+  const { handler, pattern } = commonfabric;
+
+  const addPiece = handler<
+    { piece: Cell<unknown> },
+    { pieceRegistry: Cell<Cell<unknown>[]> }
+  >(
+    true,
+    {
+      type: "object",
+      properties: { pieceRegistry: { type: "array", asCell: ["cell"] } },
+    },
+    ({ piece }, { pieceRegistry }) => {
+      pieceRegistry.push(piece);
+    },
+  );
+  return pattern<{ pieceRegistry: Cell<unknown>[] }>(
+    ({ pieceRegistry }) => ({
+      pieceRegistry,
+      addPiece: addPiece({ pieceRegistry }),
+    }),
+  );
+}
+
+function valuePattern() {
+  const { commonfabric } = createBuilder();
+  return commonfabric.pattern<{ value: number }>(({ value }) => ({ value }));
+}
+
+describe("pieces-controller", () => {
+  describe("PiecesController", () => {
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let runtime: Runtime;
+    let pieces: PiecesController;
+    let piece: Cell<unknown>;
+
+    beforeEach(async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL("http://toolshed.test"),
+        storageManager,
+      });
+      pieces = new PiecesController(
+        await createSession({
+          identity: signer,
+          spaceName: `pieces-controller-${crypto.randomUUID()}`,
+        }),
+        runtime,
+      );
+      await pieces.synced();
+
+      const defaultRoot = await pieces.runPersistent(
+        defaultRegistryPattern(),
+        { pieceRegistry: [] },
+        "pieces-controller-default-root",
+      );
+      await pieces.linkDefaultPattern(defaultRoot);
+      await runtime.idle();
+      await pieces.synced();
+
+      piece = await pieces.runPersistent(
+        valuePattern(),
+        { value: 42 },
+        "pieces-controller-registered-piece",
+      );
+      await pieces.add([piece]);
+      await runtime.idle();
+      await pieces.synced();
+    });
+
+    afterEach(async () => {
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    /**
+     * Replace `editWithRetry` with one that reports a commit failure without
+     * running the callback, so no write happens. Returns the restore function.
+     */
+    function failCommits(): () => void {
+      const editWithRetry = runtime.editWithRetry;
+      runtime.editWithRetry = (() =>
+        Promise.resolve({
+          error: {
+            name: "StorageTransactionAborted",
+            message: "commit rejected by test",
+          },
+        })) as unknown as typeof runtime.editWithRetry;
+      return () => {
+        runtime.editWithRetry = editWithRetry;
+      };
+    }
+
+    async function registeredIds(): Promise<string[]> {
+      return (await pieces.getRegisteredPieces()).map((entry) => entry.id);
+    }
+
+    describe("instance members", () => {
+      describe("remove()", () => {
+        it("returns `true` and unregisters the piece it removes", async () => {
+          const id = pieceId(piece)!;
+          expect(await registeredIds()).toContain(id);
+
+          const removed = await pieces.remove(piece);
+
+          expect(removed).toBe(true);
+          expect(await registeredIds()).not.toContain(id);
+        });
+
+        it("returns `false` for a piece that is not registered", async () => {
+          await pieces.remove(piece);
+
+          expect(await pieces.remove(piece)).toBe(false);
+        });
+
+        it("throws when the removal cannot commit, leaving the piece registered", async () => {
+          const restore = failCommits();
+          try {
+            await expect(pieces.remove(piece)).rejects.toThrow(
+              "Removing the piece failed because storage returned " +
+                "StorageTransactionAborted: commit rejected by test",
+            );
+          } finally {
+            restore();
+          }
+          expect(await registeredIds()).toContain(pieceId(piece)!);
+        });
+      });
+
+      describe("linkDefaultPattern()", () => {
+        it("throws when the link cannot commit", async () => {
+          const restore = failCommits();
+          try {
+            await expect(pieces.linkDefaultPattern(piece)).rejects.toThrow(
+              "Linking the default pattern failed because storage returned " +
+                "StorageTransactionAborted: commit rejected by test",
+            );
+          } finally {
+            restore();
+          }
+        });
+      });
+
+      describe("unlinkDefaultPattern()", () => {
+        it("throws when the unlink cannot commit, leaving the link in place", async () => {
+          const restore = failCommits();
+          try {
+            await expect(pieces.unlinkDefaultPattern()).rejects.toThrow(
+              "Unlinking the default pattern failed because storage returned " +
+                "StorageTransactionAborted: commit rejected by test",
+            );
+          } finally {
+            restore();
+          }
+          expect(await pieces.getDefaultPattern(false)).toBeDefined();
+        });
+      });
+    });
+  });
+});

--- a/packages/piece/test/ops/pieces-controller.test.ts
+++ b/packages/piece/test/ops/pieces-controller.test.ts
@@ -47,6 +47,7 @@ describe("pieces-controller", () => {
     let storageManager: ReturnType<typeof StorageManager.emulate>;
     let runtime: Runtime;
     let pieces: PiecesController;
+    let defaultRoot: Cell<unknown>;
     let piece: Cell<unknown>;
 
     beforeEach(async () => {
@@ -64,7 +65,7 @@ describe("pieces-controller", () => {
       );
       await pieces.synced();
 
-      const defaultRoot = await pieces.runPersistent(
+      defaultRoot = await pieces.runPersistent(
         defaultRegistryPattern(),
         { pieceRegistry: [] },
         "pieces-controller-default-root",
@@ -139,6 +140,52 @@ describe("pieces-controller", () => {
             restore();
           }
           expect(await registeredIds()).toContain(pieceId(piece)!);
+        });
+
+        it("removes a registered default pattern and clears its link in a single commit", async () => {
+          await pieces.add([defaultRoot]);
+          const registry = await pieces.getPieceRegistry();
+
+          const editWithRetry = runtime.editWithRetry;
+          let commits = 0;
+          runtime.editWithRetry = ((fn, maxRetries) => {
+            commits += 1;
+            return editWithRetry.call(runtime, fn, maxRetries);
+          }) as typeof runtime.editWithRetry;
+          try {
+            expect(await pieces.remove(defaultRoot)).toBe(true);
+          } finally {
+            runtime.editWithRetry = editWithRetry;
+          }
+
+          expect(commits).toBe(1);
+          expect(
+            registry.get().map((entry) => pieceId(entry)),
+          ).not.toContain(pieceId(defaultRoot)!);
+          expect(await pieces.getDefaultPattern(false)).toBeUndefined();
+        });
+
+        it("leaves the registry and the default link intact when removing the default pattern cannot commit", async () => {
+          await pieces.add([defaultRoot]);
+
+          const restore = failCommits();
+          try {
+            await expect(pieces.remove(defaultRoot)).rejects.toThrow(
+              "Removing the piece failed because storage returned " +
+                "StorageTransactionAborted: commit rejected by test",
+            );
+          } finally {
+            restore();
+          }
+
+          expect(await registeredIds()).toContain(pieceId(defaultRoot)!);
+          expect(await pieces.getDefaultPattern(false)).toBeDefined();
+        });
+
+        it("returns `false` and leaves the default-pattern link in place for an unregistered default pattern", async () => {
+          expect(await pieces.remove(defaultRoot)).toBe(false);
+
+          expect(await pieces.getDefaultPattern(false)).toBeDefined();
         });
       });
 


### PR DESCRIPTION
## Summary

Audit of every `runtime.editWithRetry(...)` call site in `packages/piece/src/ops/pieces-controller.ts` and `piece-controller.ts` for unchecked results — the silent-no-op shape that bit `cf piece setsrc` during the topics-estuary migration. Three sites dropped the `error` arm of the result, reporting a failed commit as success; all three are in `pieces-controller.ts` and are fixed here:

- **`linkDefaultPattern` / `unlinkDefaultPattern`** ignored the result entirely, silently keeping a stale (or missing) default-pattern link on a commit failure.
- **`remove`** destructured only `{ ok }`, so a commit failure returned `false` — indistinguishable from "piece not registered", which `cf piece remove` then reported as `Piece "X" not found`.

Each now throws a cause-chained `Error` naming the storage failure, in the wrapping style the file already uses. `remove`'s boolean contract is unchanged and now documented: `false` means the piece was not in the registry, never a storage failure.

## Sites audited and left alone

- `link` and the `recreateDefaultPattern` creation write: void callbacks, so a superseded `{ ok: false }` cannot occur; both already throw on `error` (creation also read-back-verifies via `getDefaultPattern`).
- The roll-forward swap: already checks both arms and fails closed on supersede (the site whose comment states the `ok === false` convention).
- `PiecePropIo.edit`: binds `{ ok, error }`, throws on error, returns the committed no-write decision as `{ wrote: false }`; its callback never returns literal `false`.
- `changeSource` detach: callback unconditionally returns `true`; `error` is thrown and the catch re-verifies via a committed-transition read-back.

One contract note for future reviews: a `false` return does not literally abort the transaction — `Runtime.editWithRetry` commits whatever the callback staged. The convention holds because these callbacks return `false` before staging any write, so the commit is empty.

## Tests

New `packages/piece/test/ops/pieces-controller.test.ts` (5 tests): `remove`'s true/false contract, plus one commit-failure test per fixed method, stubbing `editWithRetry` per the precedent in `piece-source-lifecycle.test.ts`. Red-verified: with the source fix stashed, exactly the three error-path tests fail.

## Gates

- `deno task test` in `packages/piece`: 46 files, 651 steps, 0 failed
- Repo-wide `deno fmt --check` and `deno lint`: clean
- `deno check` on touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

