### PR TITLE
diagnostic: trace OW61 pre-watch cid effects

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1185,7 +1185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         total: [10]
     steps:
       - name: 📥 Checkout repository
@@ -1370,7 +1370,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1]
         total: [10]
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1185,7 +1185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1]
         total: [10]
     steps:
       - name: 📥 Checkout repository
@@ -1406,12 +1406,10 @@ jobs:
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
-          # Space-root ensure OFF for test lanes (see the package ON
-          # lane's note; RULED 2026-08-24).
+          # OW61 DIAGNOSTIC: run the production ensure-ON posture.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -1470,7 +1468,6 @@ jobs:
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -455,6 +455,7 @@ export class Client {
           session.sessionId === message.sessionId &&
           session.space === message.space
         ) {
+          session.ow61NoteSocketEffect(payload, message.effect);
           session.handleEffect(message.effect);
         }
       }
@@ -933,6 +934,27 @@ export class SpaceSession {
     }
     this.scheduleAck(effect.toSeq);
     this.noteCaughtUpLocalSeq(effect.caughtUpLocalSeq);
+  }
+
+  // OW61 TEMPORARY DIAGNOSTIC: this is session-local by construction. It
+  // records the raw socket frame beside the exact SpaceSession that receives
+  // it, avoiding the shared-browser-realm ambiguity of the earlier probe.
+  ow61NoteSocketEffect(payload: string, effect: SessionSync): void {
+    const decodedCids = effect.upserts.flatMap((upsert) =>
+      typeof upsert.id === "string" && upsert.id.startsWith("cid:")
+        ? [upsert.id]
+        : []
+    );
+    if (decodedCids.length === 0) return;
+    const rawCids = decodedCids.filter((id) =>
+      payload.includes(`"id":"${id}"`)
+    );
+    console.error(
+      `[ow61-S1-session] session=${this.#sessionId} space=${this.space}` +
+        ` toSeq=${effect.toSeq} beforeWatch=${this.#watchView === null}` +
+        ` raw=${rawCids.length}/${decodedCids.length}` +
+        ` cids=${decodedCids.map((id) => id.slice(9, 16)).join(",")}`,
+    );
   }
 
   async restore(): Promise<void> {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -81,6 +81,8 @@ export type SessionOpenAuthFactory = (
 
 export type WatchMutationResult = {
   view: WatchView;
+  /** Effects delivered before the first watch response, in wire order. */
+  precedingSyncs: SessionSync[];
   sync: SessionSync;
 };
 
@@ -598,6 +600,7 @@ export class SpaceSession {
   }>();
   #watchSpecs: WatchSpec[] = [];
   #watchView: WatchView | null = null;
+  #precedingWatchSyncs: SessionSync[] = [];
   #sessionId: string;
   #sessionToken: string | undefined;
   #serverSeq: number;
@@ -856,6 +859,7 @@ export class SpaceSession {
         this.scheduleAck(result.serverSeq);
         return {
           view: this.#watchView,
+          precedingSyncs: this.takePrecedingWatchSyncs(),
           sync: result.sync,
         };
       },
@@ -898,6 +902,7 @@ export class SpaceSession {
         this.scheduleAck(result.serverSeq);
         return {
           view: this.#watchView,
+          precedingSyncs: this.takePrecedingWatchSyncs(),
           sync: result.sync,
         };
       },
@@ -929,6 +934,10 @@ export class SpaceSession {
     this.noteResult(effect.toSeq);
     if (this.#watchView === null) {
       this.#watchView = WatchView.fromSync(effect);
+      this.#precedingWatchSyncs.push(effect);
+    } else if (this.#precedingWatchSyncs.length > 0) {
+      this.#watchView.applySync(effect, false);
+      this.#precedingWatchSyncs.push(effect);
     } else {
       this.#watchView.applySync(effect, true);
     }
@@ -1173,6 +1182,12 @@ export class SpaceSession {
    */
   setConcurrentWatchRefresh(enabled: boolean): void {
     this.#concurrentWatchRefresh = enabled;
+  }
+
+  private takePrecedingWatchSyncs(): SessionSync[] {
+    const syncs = this.#precedingWatchSyncs;
+    this.#precedingWatchSyncs = [];
+    return syncs;
   }
 
   /**

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4120,6 +4120,18 @@ class SpaceReplica implements ISpaceReplica {
 
       this.#watchView = view;
       try {
+        const ow61Cids = sync.upserts.flatMap((upsert) =>
+          typeof upsert.id === "string" && upsert.id.startsWith("cid:")
+            ? [upsert.id.slice(9, 16)]
+            : []
+        );
+        if (ow61Cids.length > 0) {
+          console.error(
+            `[ow61-S2-replica] session=${session.sessionId}` +
+              ` space=${this.#space} type=${type} toSeq=${sync.toSeq}` +
+              ` cids=${ow61Cids.join(",")}`,
+          );
+        }
         this.applySessionSync(sync, type);
       } catch (error) {
         // The frame failed validation, so this refresh's view never gets a

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -4111,7 +4111,9 @@ class SpaceReplica implements ISpaceReplica {
         },
       }));
 
-      const { view, sync } = await session.watchAddSync(watches);
+      const { view, precedingSyncs, sync } = await session.watchAddSync(
+        watches,
+      );
 
       if (this.#closed) {
         view.close();
@@ -4120,6 +4122,22 @@ class SpaceReplica implements ISpaceReplica {
 
       this.#watchView = view;
       try {
+        for (const precedingSync of precedingSyncs) {
+          const precedingCids = precedingSync.upserts.flatMap((upsert) =>
+            typeof upsert.id === "string" && upsert.id.startsWith("cid:")
+              ? [upsert.id.slice(9, 16)]
+              : []
+          );
+          if (precedingCids.length > 0) {
+            console.error(
+              `[ow61-S2-replica] session=${session.sessionId}` +
+                ` space=${this.#space} type=preceding` +
+                ` toSeq=${precedingSync.toSeq}` +
+                ` cids=${precedingCids.join(",")}`,
+            );
+          }
+          this.applySessionSync(precedingSync, "integrate");
+        }
         const ow61Cids = sync.upserts.flatMap((upsert) =>
           typeof upsert.id === "string" && upsert.id.startsWith("cid:")
             ? [upsert.id.slice(9, 16)]

--- a/packages/runner/test/memory-v2-pre-watch-effect.test.ts
+++ b/packages/runner/test/memory-v2-pre-watch-effect.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Pins delivery of a session effect that arrives before the first watch
+ * response. The scripted transport exercises the memory client wire boundary,
+ * the watch view, and the runner replica's schema-document arrival validator.
+ */
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchemaObj } from "@commonfabric/api";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model/schema-hash";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
+import {
+  type EntityDocument,
+  type SessionSync,
+  type SessionSyncUpsert,
+} from "@commonfabric/memory/v2";
+import type { IStorageProvider } from "../src/storage/interface.ts";
+import {
+  ScriptedSessionTransport,
+  type ScriptedTransportMessage,
+  SingleSessionFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+type TestProvider = IStorageProvider & {
+  get(uri: URI): EntityDocument | undefined;
+};
+
+const upsert = (
+  id: URI,
+  seq: number,
+  document: SessionSyncUpsert["doc"],
+): SessionSyncUpsert => ({
+  branch: "",
+  id,
+  seq,
+  doc: document,
+});
+
+const sync = (
+  fromSeq: number,
+  toSeq: number,
+  upserts: SessionSyncUpsert[],
+): SessionSync => ({
+  type: "sync",
+  fromSeq,
+  toSeq,
+  upserts,
+  removes: [],
+});
+
+class PreWatchEffectTransport extends ScriptedSessionTransport {
+  watchResponseSent = false;
+  effectSentBeforeWatchResponse = false;
+
+  constructor(
+    space: MemorySpace,
+    private readonly schemaId: URI,
+    private readonly schema: JSONSchemaObj,
+    private readonly referrerId: URI,
+  ) {
+    super({
+      name: "pre-watch-effect",
+      sessionId: "session:pre-watch-effect",
+      space,
+    });
+  }
+
+  protected override ackServerSeq(): number {
+    return 2;
+  }
+
+  protected override handle(message: ScriptedTransportMessage): void {
+    if (message.type !== "session.watch.add") {
+      throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+
+    this.effectSentBeforeWatchResponse = !this.watchResponseSent;
+    this.emitSync(sync(0, 1, [
+      upsert(this.schemaId, 1, { value: this.schema }),
+    ]));
+
+    this.watchResponseSent = true;
+    this.respond({
+      type: "response",
+      requestId: message.requestId!,
+      ok: {
+        serverSeq: 2,
+        sync: sync(1, 2, [
+          upsert(this.referrerId, 2, {
+            value: {
+              carried: {
+                "/": {
+                  "link@1": {
+                    id: "of:pre-watch-effect-target",
+                    path: [],
+                    schema: { $ref: this.schemaId },
+                  },
+                },
+              },
+            },
+          }),
+        ]),
+      },
+    });
+  }
+}
+
+describe("memory-v2-pre-watch-effect", () => {
+  it("stores a schema effect received before the first watch response", async () => {
+    const signer = await Identity.fromPassphrase("memory-v2-pre-watch-effect");
+    const space = signer.did();
+    const schema: JSONSchemaObj = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+    const schemaHash = internSchemaAsTaggedHashString(schema);
+    const schemaId = `cid:${schemaHash}` as URI;
+    const referrerId = "of:pre-watch-effect-referrer" as URI;
+    const transport = new PreWatchEffectTransport(
+      space,
+      schemaId,
+      schema,
+      referrerId,
+    );
+    const storageManager = TestStorageManager.create({
+      as: signer,
+      memoryHost: new URL("memory://runner-v2-pre-watch-effect"),
+    }, new SingleSessionFactory(transport));
+    const provider = storageManager.open(space) as TestProvider;
+
+    try {
+      const result = await provider.sync(referrerId, {
+        path: [],
+        schema: false,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(transport.effectSentBeforeWatchResponse).toBe(true);
+      expect(provider.get(schemaId)?.value).toEqual(schema);
+      expect(provider.get(referrerId)?.value).toBeDefined();
+    } finally {
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Throwaway OW61 diagnostic. Restricts the ensure-ON pattern lane to shard 1 and records raw cid-bearing socket effects per receiving session, before the client watch view handles them.

This branch intentionally remains on the red pre-fix state for its first CI run. It will be updated with the client handoff fix for a second measurement, then closed without merging.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

