### PR TITLE
ci: preserve Deno lint core dumps

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -78,7 +78,28 @@ jobs:
 
       - name: 🧹 Lint codebase
         timeout-minutes: *work-timeout
-        run: deno task run-recorded lint repo deno-lint -- deno lint
+        run: |
+          ulimit -c unlimited
+          sudo sysctl -w kernel.core_pattern="$GITHUB_WORKSPACE/deno-core.%p"
+          deno task run-recorded lint repo deno-lint -- deno lint
+
+      - name: 📋 Describe Deno lint core dump
+        if: ${{ failure() }}
+        run: |
+          shopt -s nullglob
+          cores=(deno-core.*)
+          for core in "${cores[@]}"; do
+            file "$core"
+          done
+
+      - name: 📤 Upload Deno lint core dump
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: deno-lint-core-a${{ github.run_attempt }}
+          path: deno-core.*
+          if-no-files-found: ignore
+          retention-days: 14
 
       # This is the only type check for the paths listed in
       # tasks/typecheck.ts: the test jobs in this workflow and the package

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -244,6 +244,43 @@ Deno.test("CI browser tests use the runner's installed Chrome", async () => {
   }
 });
 
+Deno.test("Check preserves a native crash from Deno lint", async () => {
+  const contents = await workflow("deno.yml");
+  const check = jobBlock(contents, "check");
+  const lint = stepBlock(check, "🧹 Lint codebase");
+  const describe = stepBlock(check, "📋 Describe Deno lint core dump");
+  const upload = stepBlock(check, "📤 Upload Deno lint core dump");
+
+  assertStringIncludes(lint, "ulimit -c unlimited");
+  assertStringIncludes(
+    lint,
+    'sudo sysctl -w kernel.core_pattern="$GITHUB_WORKSPACE/deno-core.%p"',
+  );
+  assertStringIncludes(
+    lint,
+    "deno task run-recorded lint repo deno-lint -- deno lint",
+  );
+  assertStringIncludes(describe, "if: ${{ failure() }}");
+  assertStringIncludes(describe, 'file "$core"');
+  assertStringIncludes(upload, "if: ${{ failure() }}");
+  assertStringIncludes(upload, "uses: actions/upload-artifact@v7");
+  assertStringIncludes(
+    upload,
+    "name: deno-lint-core-a${{ github.run_attempt }}",
+  );
+  assertStringIncludes(upload, "path: deno-core.*");
+  assertStringIncludes(upload, "if-no-files-found: ignore");
+  assert(
+    check.indexOf("🧹 Lint codebase") <
+        check.indexOf("📋 Describe Deno lint core dump") &&
+      check.indexOf("📋 Describe Deno lint core dump") <
+        check.indexOf("📤 Upload Deno lint core dump") &&
+      check.indexOf("📤 Upload Deno lint core dump") <
+        check.indexOf("🔎 Type check codebase"),
+    "the lint crash report must run immediately after the lint step",
+  );
+});
+
 Deno.test("Status waits for every pull request validation job", async () => {
   const contents = await workflow("deno.yml");
   const gate = jobBlock(contents, "status");


### PR DESCRIPTION
Main's Check job recorded that Deno lint terminated with SIGSEGV, but the runner discarded the process image at job teardown. The log therefore contains no native stack or memory state that can attribute the crash.

Enable core dumps in the lint step and direct them into the checked-out workspace. After a failure, describe each dump in the job log and upload it as a fourteen-day artifact. Include the workflow attempt in the artifact name so a rerun cannot collide with the immutable artifact from an earlier attempt. An ordinary lint error leaves no dump, so the artifact upload quietly has no files.

Add a workflow regression test that holds the core-dump setup, immediate failure reporting, artifact retention, and attempt-specific name in place.

Verification:
- deno test -A tasks/ci-workflow.test.ts
- deno task check
- deno fmt --check
- deno lint

deflaked by Hixie's agent

Agent: Codex

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

