### PR TITLE
Protect owner-scoped agent connector data

### DIFF
--- a/docs/history/INDEX.md
+++ b/docs/history/INDEX.md
@@ -74,6 +74,7 @@ One line per archived document; [`README.md`](README.md) has the rules for this 
 ## Shipped or superseded designs and decision records
 
 - [APRIME-LINEAGE-HANDOFF.md](packages/ts-transformers/APRIME-LINEAGE-HANDOFF.md) — the authored-source lineage investigation, per-channel hazards, probes, and execution record for the CT-1868/1869/1870 arc, completed August 2026.
+- [agent-connector-owner-identity-break.md](agent-connector-owner-identity-break.md) — decision record for the agent connector debug pattern's pre-deployment cutover to explicit owner identity and one protected writable command cell, August 2026.
 - [topics-crossref-identity-break.md](topics-crossref-identity-break.md) — decision record for the topics reference-graph contract break shipped in #5921, the first accepted break in the pattern-update registries; backfilled when the registries gained their `record` linkage.
 - [parking-admin-floor-contract-break.md](parking-admin-floor-contract-break.md) — decision record for the parking-coordinator admin-roster contract break shipped in #6091: why correcting a `requiredIntegrity` floor nothing could satisfy had to change the `ifc` at the roster's path, and why a piece holding a roster loses nothing it could have written, August 2026.
 - [lunch-poll-identity-break.md](lunch-poll-identity-break.md) — decision record for the lunch-poll identity contract break: display-name identity replaced by profile cells; stored rows survive the vintage replay, but the root argument contract requires migrating the populated poll to a fresh piece.

--- a/docs/history/agent-connector-owner-identity-break.md
+++ b/docs/history/agent-connector-owner-identity-break.md
@@ -35,7 +35,8 @@ currently reports the first argument issue:
 
 - `argument.ownerDid`: a newly required argument has no default.
 
-Accepting that issue exposes the second argument issue:
+Holding `ownerDid` compatible in a separate proof reports the second argument
+issue:
 
 - `argument.commandsCell`: the earlier optional opaque cell is replaced by a
   required writable array cell.

--- a/docs/history/agent-connector-owner-identity-break.md
+++ b/docs/history/agent-connector-owner-identity-break.md
@@ -1,0 +1,55 @@
+---
+status: historical
+created: 2026-08-25
+archived: 2026-08-25
+reason: "Decision record for the connector-managed agent sessions debug
+  pattern's owner-scoped input contract before its first deployment."
+---
+
+# Agent connector owner-scoped input contract break
+
+The agent connector and its debug view now receive an explicit owner DID and
+one authoritative command cell. The owner participates in every deterministic
+cell identity and stored protocol value. Common Fabric labels restrict session
+discovery and command submission to that owner.
+
+## The decision
+
+The debug pattern's argument contract now requires `ownerDid` and a writable
+`commandsCell`. The host is the only supported deployer of this pattern. It
+always supplies its configured identity and the owner-protected command queue.
+The earlier recorded contract was created before the connector was deployed
+and has no running pieces to update.
+
+The owner cannot have a safe default. An empty or shared default would either
+mislabel private agent state or make command authorization ambiguous. Making
+the field optional would move the same ambiguity into every read and write.
+The command cell cannot remain an optional opaque input because the pattern
+writes commands through it. The contract break is therefore accepted for the
+single earlier baseline.
+
+## What broke, on purpose
+
+The compatibility checker reports at most one issue for each contract role. It
+currently reports the first argument issue:
+
+- `argument.ownerDid`: a newly required argument has no default.
+
+Accepting that issue exposes the second argument issue:
+
+- `argument.commandsCell`: the earlier optional opaque cell is replaced by a
+  required writable array cell.
+
+The legacy required `commands` argument is also removed. It duplicated the
+command data instead of naming the cell the pattern writes. Extra argument
+properties remain acceptable, so its removal does not produce a separate
+compatibility finding.
+
+The new contract is recorded as a baseline after this exemption. Later changes
+must remain compatible with the owner-scoped shape.
+
+## Disposition of deployed pieces
+
+There are no deployed pieces using the earlier contract. The connector host
+creates a fresh owner-scoped debug piece and passes the owner DID with the
+owner-protected index, health, receipt, and command cells.

--- a/packages/agents-host/README.md
+++ b/packages/agents-host/README.md
@@ -325,7 +325,7 @@ The package root exports the following orchestration surfaces:
 | `startAgentsHost(options)`            | Takes both process locks, opens every dependency, starts the host, and returns a running handle |
 | `RunningAgentsHost.stop(reason?)`     | Performs one idempotent graceful shutdown and runtime disposal                                  |
 | `AgentsHostProcessLock.acquire(path)` | Takes one non-blocking operating-system lock                                                    |
-| `defaultTargetProcessLockPath(...)`   | Derives the local executor lock from the API URL origin and resolved space DID                  |
+| `defaultTargetProcessLockPath(...)`   | Derives the local executor lock from the API URL origin, resolved space DID, and owner DID      |
 | `parseAgentFabricApiUrl(value)`       | Parses an API URL and reports a credential-free error when the value is invalid                 |
 
 `startAgentsHost()` is the main embedding API. Its caller supplies connection

--- a/packages/agents-host/README.md
+++ b/packages/agents-host/README.md
@@ -35,8 +35,8 @@ options. Command-line values take precedence.
 
 The program prints the destination space DID, command cell ID, receipt cell ID,
 durable command ledger path, and debug piece ID after the initial collection.
-The debug piece is registered with the space's default app, so it appears with
-the other pieces in that space.
+The owner-confidential debug registration is not added to the space-wide default
+app registry. The printed piece ID is its local discovery handle.
 
 ## Command-line interface
 
@@ -51,16 +51,16 @@ the other pieces in that space.
 | `-h`, `--help`      | Print usage                                                             |
 
 The command ledger lives in the operating system's durable per-user state
-directory. Its filename is derived from the Fabric API URL origin and the
-resolved space DID. Credentials, paths, queries, and fragments do not create
-separate histories. Configurations in different directories, and a space name
-and its equivalent DID, therefore use the same command history. The host locks
-the ledger file and also takes a target lock using the same target identity. The
-target locks for one user are kept below the operating system's runtime
-directory. `CF_AGENTS_HOST_LOCK_DIR` overrides the runtime lock directory.
-Windows also keeps a `.previous` ledger generation beside the printed path. The
-connector alternates between those files so an interrupted write cannot destroy
-the newest valid command history.
+directory. Its filename is derived from the Fabric API URL origin, the resolved
+space DID, and the configured owner DID. Credentials, paths, queries, and
+fragments do not create separate histories. Configurations in different
+directories, and a space name and its equivalent DID, therefore use the same
+command history for one owner. The host locks the ledger file and also takes a
+target lock using the same target identity. The target locks for one user are
+kept below the operating system's runtime directory. `CF_AGENTS_HOST_LOCK_DIR`
+overrides the runtime lock directory. Windows also keeps a `.previous` ledger
+generation beside the printed path. The connector alternates between those files
+so an interrupted write cannot destroy the newest valid command history.
 
 The host creates its state and lock directories for the current user only. On
 systems with Unix permissions, it rejects a directory or existing file owned by
@@ -89,12 +89,13 @@ failure.
 
 ## Configuration file
 
-The configuration format is strict. Unknown fields are errors so misspelled
-options do not silently change provider behavior.
+The configuration uses one unversioned schema and remains strict. Unknown fields
+are errors so misspelled options do not silently change provider behavior.
 
 ```jsonc
 {
-  "schema": "commonfabric.agents-host.config.v1",
+  "schema": "commonfabric.agents-host.config",
+  "ownerDid": "did:key:replace-with-the-identity-did",
   "collectionIntervalMs": 900000,
   "checkoutRoots": ["/workspace/checkouts"],
   "sources": [
@@ -112,6 +113,17 @@ options do not silently change provider behavior.
   ]
 }
 ```
+
+`ownerDid` identifies the person whose local sessions and workspaces this host
+publishes. It must match the DID in the PKCS#8 file selected by `--identity`.
+Startup fails before opening Fabric storage when they differ.
+
+Every connector cause and stored protocol envelope includes this owner DID.
+Session graphs, indexes, health, commands, and receipts carry a Common Fabric
+confidentiality label for that owner. Connector-managed cells also require the
+owner principal and the connector writer identity for changes. The debug command
+queue requires the owner principal and its compiled, verified command submission
+handler. A different principal cannot write commands into it.
 
 Source IDs must already be trimmed and lowercase. They are durable identities in
 session keys and command routing. Duplicate IDs are rejected.
@@ -162,18 +174,26 @@ flowchart LR
 ### Startup
 
 1. The CLI validates its flags and parses the JSONC configuration.
-2. `openAgentFabricRuntime()` reads the identity, creates the requested session,
-   opens remote storage, checks API health, and opens an `AgentFabricTarget` in
+2. `openAgentFabricRuntime()` reads the identity and verifies that its DID
+   matches `ownerDid`. It then creates the requested session, opens remote
+   storage, checks API health, and opens an owner-scoped `AgentFabricTarget` in
    the resolved space DID.
-3. The process derives one target identity from the API URL origin and resolved
-   space DID. It uses that identity to locate the durable command ledger and the
-   runtime target lock.
+3. The process derives one target identity from the API URL origin, resolved
+   space DID, and owner DID. It uses that identity to locate the durable command
+   ledger and the runtime target lock.
 4. The process takes exclusive operating-system locks for the target and ledger.
    A second command executor for that target under the same operating-system
    user fails immediately.
-5. `deployAgentSessionsDebugView()` compiles the repository pattern, links its
-   five inputs directly to the target's cells, and registers the stable debug
-   piece with the default app. `--no-debug-view` skips this step.
+5. `deployAgentSessionsDebugView()` compiles the repository pattern and links
+   its owner-confidential inputs to the target's cells. The pattern owns the
+   command composer, while the host supplies the deterministic owner-scoped
+   command queue before the pattern starts. The host labels the rendered result
+   for the same owner. The queue's write policy accepts only the configured
+   owner through the pattern's command-sending handler. The host binds command
+   processing to that exact protected queue. It stores the debug registration
+   under the owner label and does not add the piece to the space-wide default
+   app registry. `--no-debug-view` skips this step and disables command
+   acceptance.
 6. The host opens the command ledger.
 7. `AgentsHost.start()` creates and starts every enabled driver. A failed source
    remains visible in health while successful sources continue. A source whose
@@ -181,7 +201,8 @@ flowchart LR
    host then publishes recovered and previously unpublished receipts from the
    ledger.
 8. The host performs and publishes one complete collection. It then subscribes
-   to the Fabric command cell unless `--once` was used.
+   to the owner-protected Fabric command cell unless `--once` or
+   `--no-debug-view` was used.
 
 The command-line host keeps startup health local until it has completed these
 steps and owns a ready or degraded host. Its first health publication includes
@@ -193,7 +214,7 @@ which publishes terminal health.
 
 Operating-system locks coordinate processes owned by one user. Deployments that
 run this host under multiple users or on more than one machine must provide
-external single-instance coordination for each Fabric API and space pair. The
+external single-instance coordination for each Fabric API, space, and owner. The
 connector also reads each command's deterministic Fabric receipt before a
 provider call. This prevents sequential failover from repeating an operation
 when the replacement host does not share the earlier host's local ledger.
@@ -252,8 +273,8 @@ No part of this lifecycle uses an elapsed-time limit, sleep, or retry loop.
 
 ## Debug data
 
-The host publishes `commonfabric.agent-connector.health.v1` with these
-host-owned fields:
+The host publishes `commonfabric.agent-connector.health` with these host-owned
+fields:
 
 - overall status and timestamps;
 - destination space, debug piece, and all five top-level cell IDs;
@@ -271,14 +292,23 @@ The host does not copy configured commands, provider environment values, or
 identity bytes into health. Provider error messages remain visible and can
 contain provider-supplied context. The debug pattern shows the actual Fabric
 command values, including prompt payloads, because it is an inspection tool.
-Access to the destination space therefore grants access to sensitive session and
-command content.
+Common Fabric permits those reads only for the configured owner. Membership in
+the destination space without the owner identity does not grant access to
+session, workspace, health, command, or receipt content.
+
+The connector has one owner-scoped storage layout. Protocol schema names and
+deterministic cell causes are not versioned. Future readers must keep existing
+stored values and causes readable. New fields must be optional so older writers
+can omit them without changing the meaning of existing fields or identities.
 
 The debug pattern's inspection surfaces cannot change connector data. Its
 command composer can append a validated command after showing the exact value in
-a confirmation modal. It cannot write indexes, health, receipts, session
-manifests, or event chunks. Drafts, confirmation state, tab selection, and
-filters are session-scoped and are not shared between viewers.
+a confirmation modal. The command queue requires the configured owner and the
+debug pattern's command-sending handler. Another principal cannot modify that
+queue, including by reusing the pattern handler. The pattern cannot write
+indexes, health, receipts, session manifests, or event chunks. Drafts,
+confirmation state, tab selection, and filters are session-scoped and are not
+shared between viewers.
 
 ## Programmatic API
 
@@ -290,7 +320,7 @@ The package root exports the following orchestration surfaces:
 | `loadAgentsHostConfig(path)`          | Reads JSONC and then applies the same validation                                                |
 | `parseAgentsHostCliOptions(argv)`     | Resolves flags and supported environment fallbacks                                              |
 | `openAgentFabricRuntime(options)`     | Opens the identity session, remote runtime, piece manager, and connector target                 |
-| `deployAgentSessionsDebugView(...)`   | Creates or updates the stable debug piece and registers it with the default app                 |
+| `deployAgentSessionsDebugView(...)`   | Creates or updates the owner-confidential debug piece and its private registration              |
 | `AgentsHost`                          | Owns driver, collection, command, health, activity, and shutdown lifecycle                      |
 | `startAgentsHost(options)`            | Takes both process locks, opens every dependency, starts the host, and returns a running handle |
 | `RunningAgentsHost.stop(reason?)`     | Performs one idempotent graceful shutdown and runtime disposal                                  |

--- a/packages/agents-host/example.config.jsonc
+++ b/packages/agents-host/example.config.jsonc
@@ -1,5 +1,6 @@
 {
-  "schema": "commonfabric.agents-host.config.v1",
+  "schema": "commonfabric.agents-host.config",
+  "ownerDid": "did:key:replace-with-the-identity-did",
   "collectionIntervalMs": 900000,
   "checkoutRoots": ["/workspace/checkouts"],
   "sources": [

--- a/packages/agents-host/src/cli.ts
+++ b/packages/agents-host/src/cli.ts
@@ -89,6 +89,7 @@ export async function runAgentsHostCli(
       running = await dependencies.start({
         apiUrl: options.apiUrl,
         identityPath: options.identityPath,
+        ownerDid: config.ownerDid,
         space: options.space,
         sources: config.sources,
         checkoutRoots: config.checkoutRoots,

--- a/packages/agents-host/src/config.ts
+++ b/packages/agents-host/src/config.ts
@@ -6,13 +6,15 @@ import type {
 import { normalizeSourceId } from "@commonfabric/agents-connector";
 import { parse as parseJsonc } from "@std/jsonc";
 import { isAbsolute } from "@std/path";
+import { isDID } from "@commonfabric/identity";
 
-export const AGENTS_HOST_CONFIG_SCHEMA = "commonfabric.agents-host.config.v1";
+export const AGENTS_HOST_CONFIG_SCHEMA = "commonfabric.agents-host.config";
 export const DEFAULT_COLLECTION_INTERVAL_MS = 15 * 60 * 1_000;
 export const MAX_COLLECTION_INTERVAL_MS = 2_147_483_647;
 
 export interface AgentsHostConfig {
   schema: typeof AGENTS_HOST_CONFIG_SCHEMA;
+  ownerDid: string;
   collectionIntervalMs: number;
   checkoutRoots?: string[];
   sources: AgentSourceConfig[];
@@ -177,9 +179,11 @@ function parseSource(value: unknown, index: number): AgentSourceConfig {
 export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   const config = record(value, "configuration");
   for (const key of Object.keys(config)) {
-    const allowed = key === "schema" || key === "collectionIntervalMs" ||
-      key === "sources" || key === "checkoutRoots";
-    if (!allowed) {
+    if (
+      key !== "schema" && key !== "ownerDid" &&
+      key !== "collectionIntervalMs" && key !== "sources" &&
+      key !== "checkoutRoots"
+    ) {
       throw new Error(`configuration has an unknown field: ${key}`);
     }
   }
@@ -190,6 +194,11 @@ export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   }
   if (!Array.isArray(config.sources) || config.sources.length === 0) {
     throw new Error("configuration.sources must be a non-empty array");
+  }
+  const ownerDid = nonEmptyString(config.ownerDid, "configuration.ownerDid")
+    .trim();
+  if (!isDID(ownerDid)) {
+    throw new Error("configuration.ownerDid must be a DID");
   }
   const collectionIntervalMs = "collectionIntervalMs" in config
     ? config.collectionIntervalMs
@@ -239,6 +248,7 @@ export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   }
   return {
     schema: AGENTS_HOST_CONFIG_SCHEMA,
+    ownerDid,
     collectionIntervalMs,
     ...(checkoutRoots.length > 0 ? { checkoutRoots } : {}),
     sources,

--- a/packages/agents-host/src/debug-view.ts
+++ b/packages/agents-host/src/debug-view.ts
@@ -1,5 +1,10 @@
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
-import { stableCellId } from "@commonfabric/agents-connector/fabric-graph";
+import {
+  AGENT_CONNECTOR_WRITER_ID,
+  agentOwnerSchema,
+  cellHasOwnerProtection,
+  stableCellId,
+} from "@commonfabric/agents-connector/fabric-graph";
 import type {
   FabricPlainObject,
   FabricValue,
@@ -12,6 +17,7 @@ import {
   asPatternIdentityRef,
   type Cell,
   compileAndSavePattern,
+  deepEqual,
   type Pattern,
 } from "@commonfabric/runner";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
@@ -19,8 +25,6 @@ import { dirname, fromFileUrl, join, resolve } from "@std/path";
 import type { AgentsHostTargetDescription } from "./host.ts";
 
 const AGENT_SESSIONS_DEBUG_CAUSE_PREFIX = "agent-sessions-debug";
-const AGENT_SESSIONS_DEBUG_REGISTRATION_CAUSE =
-  "agent-sessions-debug-registration-v1";
 const SHALLOW_PIECE_LINK_LIST_SCHEMA = internSchema({
   type: "array",
   items: { type: "unknown" },
@@ -30,6 +34,75 @@ const SHALLOW_DEBUG_PIECE_SCHEMA = internSchema({
   type: "object",
   properties: {},
 });
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+export function debugCommandWriterAuthorization(
+  pattern: Pattern,
+): unknown | undefined {
+  const root = recordValue(pattern.resultSchema);
+  const properties = recordValue(root?.properties);
+  let authorization = recordValue(properties?.commandAuthorization);
+  const reference = authorization?.$ref;
+  if (typeof reference === "string" && reference.startsWith("#/$defs/")) {
+    const definitions = recordValue(root?.$defs);
+    authorization = recordValue(
+      definitions?.[decodeURIComponent(reference.slice("#/$defs/".length))],
+    );
+  }
+  const ifc = recordValue(authorization?.ifc);
+  const writers = ifc?.writeAuthorizedBy;
+  return writers === null ? undefined : writers;
+}
+
+async function protectOwnerDebugCells(
+  manager: PiecesController,
+  cells: readonly Cell<unknown>[],
+  ownerDid: string,
+  expectedDocuments?: ReadonlyMap<Cell<unknown>, unknown>,
+): Promise<void> {
+  const tx = manager.runtime.edit();
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: AGENT_CONNECTOR_WRITER_ID,
+  });
+  try {
+    for (const cell of cells) {
+      const expectedDocument = expectedDocuments?.get(cell);
+      if (
+        expectedDocuments?.has(cell) &&
+        !deepEqual(readDocumentRootWithTx(tx, cell), expectedDocument)
+      ) {
+        throw new Error("debug view changed before owner protection");
+      }
+      cell.withTx(tx).asSchema(agentOwnerSchema(ownerDid))
+        .applyCfcSchemaToExistingValue();
+    }
+    tx.prepareCfc();
+  } catch (error) {
+    tx.abort(error);
+    throw error;
+  }
+  const committed = await tx.commit();
+  if (committed.error) {
+    throw new Error(
+      `could not protect the owner debug result: ${committed.error.message}`,
+      { cause: committed.error },
+    );
+  }
+}
+
+export function protectOwnerDebugResult(
+  manager: PiecesController,
+  result: Cell<unknown>,
+  ownerDid: string,
+): Promise<void> {
+  return protectOwnerDebugCells(manager, [result], ownerDid);
+}
 const DEBUG_REGISTRATION_SCHEMA = internSchema({
   type: "object",
   properties: {
@@ -62,6 +135,14 @@ interface DebugRegistration extends FabricPlainObject {
   retiredCauses: string[];
 }
 
+const EMPTY_DEBUG_REGISTRATION: DebugRegistration = {
+  cause: "",
+  pieceId: "",
+  patternIdentity: "",
+  patternSymbol: "",
+  retiredCauses: [],
+};
+
 interface DebugRegistrationState {
   link: ReturnType<Cell<unknown>["getAsNormalizedFullLink"]>;
   value: DebugRegistration | undefined;
@@ -93,12 +174,17 @@ async function serializeDebugDeployment<T>(
   }
 }
 
-function debugPieceCause(patternRef: {
+function debugPieceCause(ownerDid: string, patternRef: {
   identity: string;
   symbol: string;
 }): string {
-  return `${AGENT_SESSIONS_DEBUG_CAUSE_PREFIX}:${patternRef.identity}:` +
+  return `${AGENT_SESSIONS_DEBUG_CAUSE_PREFIX}:${ownerDid}:` +
+    `${patternRef.identity}:` +
     encodeURIComponent(patternRef.symbol);
+}
+
+function debugRegistrationCause(ownerDid: string): string {
+  return `agent-sessions-debug-registration:${ownerDid}`;
 }
 
 async function syncDocumentRoot(
@@ -122,6 +208,26 @@ function readDocumentValue(
   return tx.readValueOrThrow(cell.getAsNormalizedFullLink());
 }
 
+function readDocumentRootWithTx(
+  tx: ReturnType<PiecesController["runtime"]["readTx"]>,
+  cell: Cell<unknown>,
+): unknown {
+  const link = cell.getAsNormalizedFullLink();
+  return tx.readOrThrow({
+    space: link.space,
+    id: link.id,
+    path: [],
+    ...(link.scope !== undefined && { scope: link.scope }),
+  });
+}
+
+function readDocumentRoot(
+  manager: PiecesController,
+  cell: Cell<unknown>,
+): unknown {
+  return readDocumentRootWithTx(manager.runtime.readTx(), cell);
+}
+
 function readDocumentMeta(
   manager: PiecesController,
   cell: Cell<unknown>,
@@ -141,6 +247,8 @@ async function currentDebugPiece(
   manager: PiecesController,
   pattern: Pattern,
   cause: string,
+  ownerDid: string,
+  expectedArguments: Record<string, unknown>,
 ): Promise<Cell<unknown> | undefined> {
   const expectedPattern = manager.runtime.patternManager.getArtifactEntryRef(
     pattern,
@@ -152,16 +260,30 @@ async function currentDebugPiece(
     SHALLOW_DEBUG_PIECE_SCHEMA,
   );
   await syncDocumentRoot(manager, shallowPiece);
-  const storedPattern = asPatternIdentityRef(
-    readDocumentMeta(manager, shallowPiece, "patternIdentity"),
+  const initialPattern = readDocumentMeta(
+    manager,
+    shallowPiece,
+    "patternIdentity",
   );
-  const argument = readDocumentMeta(manager, shallowPiece, "argument");
+  const initialArgument = readDocumentMeta(manager, shallowPiece, "argument");
   if (
-    storedPattern === undefined && argument === undefined &&
+    initialPattern === undefined && initialArgument === undefined &&
     readDocumentValue(manager, shallowPiece) === undefined
   ) {
     return undefined;
   }
+  if (
+    !cellHasOwnerProtection(manager.runtime.readTx(), shallowPiece, ownerDid)
+  ) {
+    throw new Error(
+      `refusing to adopt an unprotected debug view for ${ownerDid}`,
+    );
+  }
+  await protectOwnerDebugCells(manager, [shallowPiece], ownerDid);
+  const storedPattern = asPatternIdentityRef(
+    readDocumentMeta(manager, shallowPiece, "patternIdentity"),
+  );
+  const argument = readDocumentMeta(manager, shallowPiece, "argument");
   if (
     storedPattern === undefined ||
     storedPattern.identity !== expectedPattern.identity ||
@@ -170,6 +292,30 @@ async function currentDebugPiece(
   ) {
     throw new Error(
       `debug view cause ${cause} contains a different prepared piece`,
+    );
+  }
+  const argumentCell = manager.getArgument(shallowPiece);
+  await argumentCell.sync();
+  if (
+    !cellHasOwnerProtection(manager.runtime.readTx(), argumentCell, ownerDid)
+  ) {
+    throw new Error(
+      `refusing to adopt unprotected debug view arguments for ${ownerDid}`,
+    );
+  }
+  await protectOwnerDebugCells(manager, [argumentCell], ownerDid);
+  const storedArguments = recordValue(argumentCell.getRaw());
+  if (
+    storedArguments === undefined ||
+    Object.entries(expectedArguments).some(([name, expected]) => {
+      const stored = storedArguments[name];
+      return typeof expected === "string"
+        ? stored !== expected
+        : !areLinksSame(stored, expected, argumentCell);
+    })
+  ) {
+    throw new Error(
+      `debug view cause ${cause} contains different owner inputs`,
     );
   }
   return shallowPiece.asSchema(pattern.resultSchema);
@@ -196,6 +342,14 @@ function asDebugRegistration(
     candidate.retiredCauses.some((cause) => typeof cause !== "string")
   ) {
     throw new Error("debug view registration is malformed");
+  }
+  if (
+    candidate.cause === "" && candidate.pieceId === "" &&
+    candidate.patternIdentity === "" && candidate.patternSymbol === "" &&
+    candidate.deploymentId === undefined &&
+    candidate.retiredCauses.length === 0
+  ) {
+    return undefined;
   }
   return {
     cause: candidate.cause,
@@ -273,13 +427,43 @@ async function stopAndDrainPieces(
 
 async function debugRegistration(
   manager: PiecesController,
+  ownerDid: string,
 ): Promise<DebugRegistrationState> {
   const registration = manager.runtime.getCell<DebugRegistration>(
     manager.getSpace(),
-    AGENT_SESSIONS_DEBUG_REGISTRATION_CAUSE,
+    debugRegistrationCause(ownerDid),
     DEBUG_REGISTRATION_SCHEMA,
   );
   await syncDocumentRoot(manager, registration);
+  const tx = manager.runtime.edit();
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: AGENT_CONNECTOR_WRITER_ID,
+  });
+  try {
+    const protectedRegistration = registration.withTx(tx);
+    const value = tx.readValueOrThrow(registration.getAsNormalizedFullLink());
+    if (value === undefined) {
+      protectedRegistration.setRawUntyped(EMPTY_DEBUG_REGISTRATION);
+    } else if (!cellHasOwnerProtection(tx, registration, ownerDid)) {
+      throw new Error(
+        `refusing to adopt an unprotected debug registration for ${ownerDid}`,
+      );
+    }
+    protectedRegistration.asSchema(agentOwnerSchema(ownerDid))
+      .applyCfcSchemaToExistingValue();
+    tx.prepareCfc();
+  } catch (error) {
+    tx.abort(error);
+    throw error;
+  }
+  const committed = await tx.commit();
+  if (committed.error) {
+    throw new Error(
+      `could not claim the owner debug registration: ${committed.error.message}`,
+      { cause: committed.error },
+    );
+  }
   return {
     link: registration.getAsNormalizedFullLink(),
     value: asDebugRegistration(readDocumentValue(manager, registration)),
@@ -305,6 +489,9 @@ async function debugRegistrationLists(
     await list.sync();
     lists.set(name, list);
   }
+  if (!lists.has("pieceRegistry")) {
+    throw new Error("default pattern does not expose a piece registry");
+  }
   return lists;
 }
 
@@ -315,12 +502,13 @@ async function registerDebugPiece(
   cause: string,
   patternRef: { identity: string; symbol: string },
   deploymentId: string,
+  ownerDid: string,
   signal?: AbortSignal,
 ): Promise<void> {
   signal?.throwIfAborted();
   const [lists, registration] = await Promise.all([
     debugRegistrationLists(defaultPattern),
-    debugRegistration(manager),
+    debugRegistration(manager, ownerDid),
   ]);
   const precedingPiece = registration.value?.cause !== undefined &&
       registration.value.cause !== cause
@@ -363,14 +551,83 @@ async function registerDebugPiece(
   if (!nextRegistration.pieceId) {
     throw new Error("debug view piece has no entity ID");
   }
-  const priorListValues = new Map<DebugRegistrationListName, FabricValue[]>();
-  const removedListValues = new Map<
-    DebugRegistrationListName,
-    FabricValue[]
-  >();
+  const candidateLink = piece.getAsNormalizedFullLink();
+  const piecesToRemove = [...piecesToUnregister, piece];
+  const removePublicDebugLinks = async () => {
+    return await manager.runtime.editWithRetry((tx) => {
+      const activeDefaultPatternCell = manager.getSpaceCellContents().withTx(tx)
+        .key("defaultPattern");
+      const activeDefaultPattern = activeDefaultPatternCell.get();
+      if (
+        !activeDefaultPattern ||
+        !areLinksSame(
+          activeDefaultPattern,
+          defaultPattern,
+          activeDefaultPatternCell,
+        )
+      ) {
+        throw new Error(
+          "default pattern changed during debug view deployment",
+        );
+      }
+      const activeRegistry = defaultPattern.withTx(tx).key("pieceRegistry");
+      if (
+        activeRegistry.getRawUntyped() === undefined ||
+        !areLinksSame(
+          activeRegistry.resolveAsCell(),
+          lists.get("pieceRegistry")!,
+          activeRegistry,
+        )
+      ) {
+        throw new Error(
+          "default pattern registry changed during debug view deployment",
+        );
+      }
+      let changed = false;
+      for (const [name, list] of lists) {
+        const listWithTx = list.withTx(tx);
+        const current = listWithTx.getRawUntyped({ frozen: false });
+        if (!Array.isArray(current)) {
+          throw new Error(`default pattern ${name} is not an array`);
+        }
+        const retained = current.filter((value) =>
+          !piecesToRemove.some((target) =>
+            areLinksSame(value, target, listWithTx)
+          )
+        );
+        if (retained.length !== current.length) {
+          listWithTx.setRawUntyped(retained);
+          changed = true;
+        }
+      }
+      return changed;
+    });
+  };
   signal?.throwIfAborted();
-  const { error } = await manager.runtime.editWithRetry((tx) => {
-    const candidateLink = piece.getAsNormalizedFullLink();
+  const publicUpdate = await removePublicDebugLinks();
+  if (publicUpdate.error) {
+    throw new Error(
+      `Could not update public debug view registrations: ${publicUpdate.error.message}`,
+      { cause: publicUpdate.error },
+    );
+  }
+  try {
+    signal?.throwIfAborted();
+  } catch (error) {
+    const cleanup = await removePublicDebugLinks();
+    if (cleanup.error) {
+      throw new AggregateError(
+        [error, cleanup.error],
+        "debug view abort and public-list cleanup failed",
+      );
+    }
+    throw error;
+  }
+  const privateUpdate = await manager.runtime.editWithRetry((tx) => {
+    tx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
     const candidatePattern = asPatternIdentityRef(tx.readOrThrow({
       space: candidateLink.space,
       id: candidateLink.id,
@@ -402,75 +659,23 @@ async function registerDebugPiece(
         "debug view registration changed during deployment",
       );
     }
-    const activeDefaultPatternCell = manager.getSpaceCellContents().withTx(tx)
-      .key("defaultPattern");
-    const activeDefaultPattern = activeDefaultPatternCell.get();
-    if (
-      !activeDefaultPattern ||
-      !areLinksSame(
-        activeDefaultPattern,
-        defaultPattern,
-        activeDefaultPatternCell,
-      )
-    ) {
-      throw new Error("default pattern changed during debug view deployment");
-    }
-    const activeRegistry = defaultPattern.withTx(tx).key("pieceRegistry");
-    if (
-      activeRegistry.getRawUntyped() === undefined ||
-      !areLinksSame(
-        activeRegistry.resolveAsCell(),
-        lists.get("pieceRegistry")!,
-        activeRegistry,
-      )
-    ) {
-      throw new Error(
-        "default pattern registry changed during debug view deployment",
-      );
-    }
-    let changed = false;
-    for (const [name, list] of lists) {
-      const listWithTx = list.withTx(tx);
-      const current = listWithTx.getRawUntyped({ frozen: false });
-      if (!Array.isArray(current)) {
-        throw new Error(`default pattern ${name} is not an array`);
-      }
-      priorListValues.set(name, [...current]);
-      const remove = name === "pieceRegistry"
-        ? [...piecesToUnregister, piece]
-        : piecesToUnregister;
-      removedListValues.set(
-        name,
-        current.filter((value) =>
-          remove.some((target) => areLinksSame(value, target, listWithTx))
-        ),
-      );
-      const retained = current.filter((value) =>
-        !remove.some((target) => areLinksSame(value, target, listWithTx))
-      );
-      if (name === "pieceRegistry") {
-        retained.push(piece.getAsLink({
-          base: listWithTx,
-          includeSchema: true,
-        }));
-      }
-      if (retained.length !== current.length || name === "pieceRegistry") {
-        listWithTx.setRawUntyped(retained);
-        changed = true;
-      }
-    }
-    tx.writeValueOrThrow(registration.link, nextRegistration);
-    changed = true;
-    return changed;
+    manager.runtime.getCellFromLink(registration.link, undefined, tx)
+      .asSchema(agentOwnerSchema(ownerDid))
+      .setRawUntyped(nextRegistration);
+    return true;
   });
-  if (error) {
-    const message = typeof error === "object" && error !== null &&
-        "message" in error
-      ? String(error.message)
-      : String(error);
-    throw new Error(`Could not update debug view registrations: ${message}`, {
-      cause: error,
-    });
+  if (privateUpdate.error) {
+    const cleanup = await removePublicDebugLinks();
+    if (cleanup.error) {
+      throw new AggregateError(
+        [privateUpdate.error, cleanup.error],
+        "debug view registration update and public-list cleanup failed",
+      );
+    }
+    throw new Error(
+      `Could not update private debug view registration: ${privateUpdate.error.message}`,
+      { cause: privateUpdate.error },
+    );
   }
   let supersededPiecesStopped = false;
   const stopPreceding = async (): Promise<void> => {
@@ -509,76 +714,27 @@ async function registerDebugPiece(
         );
       }
     }
-    const rollback = await manager.runtime.editWithRetry((tx) => {
+    const registrationRollback = await manager.runtime.editWithRetry((tx) => {
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: AGENT_CONNECTOR_WRITER_ID,
+      });
       const activeRegistration = asDebugRegistration(
         tx.readValueOrThrow(registration.link),
       );
       if (!debugRegistrationsMatch(activeRegistration, nextRegistration)) {
         return false;
       }
-      for (const [name, list] of lists) {
-        const previous = priorListValues.get(name);
-        const removed = removedListValues.get(name);
-        if (previous === undefined || removed === undefined) {
-          throw new Error(`default pattern ${name} snapshot is missing`);
-        }
-        const listWithTx = list.withTx(tx);
-        const current = listWithTx.getRawUntyped({ frozen: false });
-        if (!Array.isArray(current)) {
-          throw new Error(`default pattern ${name} is not an array`);
-        }
-        const restored = current.filter((value) =>
-          !areLinksSame(value, piece, listWithTx)
-        );
-        const valuesToRestore = [
-          ...removed,
-          ...previous.filter((value) => areLinksSame(value, piece, listWithTx)),
-        ];
-        for (const removedValue of valuesToRestore) {
-          if (
-            restored.some((value) =>
-              areLinksSame(value, removedValue, listWithTx)
-            )
-          ) {
-            continue;
-          }
-          const previousIndex = previous.indexOf(removedValue);
-          const following = previous.slice(previousIndex + 1).find((value) =>
-            restored.some((candidate) =>
-              areLinksSame(candidate, value, listWithTx)
-            )
-          );
-          if (following !== undefined) {
-            const followingIndex = restored.findIndex((candidate) =>
-              areLinksSame(candidate, following, listWithTx)
-            );
-            restored.splice(followingIndex, 0, removedValue);
-            continue;
-          }
-          const preceding = previous.slice(0, previousIndex).findLast((value) =>
-            restored.some((candidate) =>
-              areLinksSame(candidate, value, listWithTx)
-            )
-          );
-          if (preceding === undefined) {
-            restored.push(removedValue);
-            continue;
-          }
-          const precedingIndex = restored.findLastIndex((candidate) =>
-            areLinksSame(candidate, preceding, listWithTx)
-          );
-          restored.splice(precedingIndex + 1, 0, removedValue);
-        }
-        listWithTx.setRawUntyped(restored);
-      }
-      tx.writeValueOrThrow(registration.link, registration.value);
+      manager.runtime.getCellFromLink(registration.link, undefined, tx)
+        .asSchema(agentOwnerSchema(ownerDid))
+        .setRawUntyped(registration.value ?? EMPTY_DEBUG_REGISTRATION);
       return true;
     });
-    if (rollback.error) {
+    if (registrationRollback.error) {
       let registrationWasRestored = true;
       try {
         registrationWasRestored = debugRegistrationsMatch(
-          (await debugRegistration(manager)).value,
+          (await debugRegistration(manager, ownerDid)).value,
           registration.value,
         );
       } catch {
@@ -589,17 +745,24 @@ async function registerDebugPiece(
           await stopPreceding();
         } catch (cleanupError) {
           throw new AggregateError(
-            [abortError, rollback.error, cleanupError],
+            [abortError, registrationRollback.error, cleanupError],
             "debug view rollback and cleanup failed",
           );
         }
       }
       throw new AggregateError(
-        [abortError, rollback.error],
+        [abortError, registrationRollback.error],
         "debug view rollback failed",
       );
     }
-    if (!rollback.ok && precedingStarted) {
+    const listCleanup = await removePublicDebugLinks();
+    if (listCleanup.error) {
+      throw new AggregateError(
+        [abortError, listCleanup.error],
+        "debug view public-list cleanup failed",
+      );
+    }
+    if (!registrationRollback.ok && precedingStarted) {
       try {
         await stopPreceding();
       } catch (cleanupError) {
@@ -654,7 +817,7 @@ export function deployAgentSessionsDebugView(
   signal?: AbortSignal,
 ): Promise<string> {
   return serializeDebugDeployment(
-    manager.getSpace(),
+    `${manager.getSpace()}:${target.conn.ownerDid}`,
     () => deployAgentSessionsDebugViewNow(manager, target, location, signal),
   );
 }
@@ -688,31 +851,73 @@ async function deployAgentSessionsDebugViewNow(
     pattern,
   );
   if (!patternRef) throw new Error("debug view pattern has no identity");
-  const cause = debugPieceCause(patternRef);
-  const currentPiece = await currentDebugPiece(manager, pattern, cause);
-  const piece = currentPiece ?? await manager.setupPersistent(
-    pattern,
-    {
-      recentIndex: target.cells.index,
-      allIndex: target.cells.allIndex,
-      health: target.cells.health,
-      commands: target.cells.commands,
-      receipts: target.cells.receipts,
-      recentIndexCell: target.cells.index,
-      allIndexCell: target.cells.allIndex,
-      healthCell: target.cells.health,
-      commandsCell: target.cells.commands,
-      receiptsCell: target.cells.receipts,
-    },
-    cause,
+  const commandWriterAuthorization = debugCommandWriterAuthorization(pattern);
+  if (commandWriterAuthorization === undefined) {
+    throw new Error("debug view has no verified command writer authorization");
+  }
+  await target.bindCommandCell(
+    target.cells.commands,
+    commandWriterAuthorization,
   );
-  const existingRegistration = (await debugRegistration(manager)).value;
+  const cause = debugPieceCause(target.conn.ownerDid, patternRef);
+  const setupArguments = {
+    ownerDid: target.conn.ownerDid,
+    recentIndex: target.cells.index,
+    allIndex: target.cells.allIndex,
+    health: target.cells.health,
+    receipts: target.cells.receipts,
+    recentIndexCell: target.cells.index,
+    allIndexCell: target.cells.allIndex,
+    healthCell: target.cells.health,
+    commandsCell: target.cells.commands,
+    receiptsCell: target.cells.receipts,
+  };
+  const currentPiece = await currentDebugPiece(
+    manager,
+    pattern,
+    cause,
+    target.conn.ownerDid,
+    setupArguments,
+  );
+  let piece = currentPiece;
+  if (piece === undefined) {
+    const createdPiece = await manager.setupPersistent(
+      pattern,
+      setupArguments,
+      cause,
+    );
+    const createdArgument = manager.getArgument(createdPiece);
+    await protectOwnerDebugCells(
+      manager,
+      [createdPiece, createdArgument],
+      target.conn.ownerDid,
+      new Map([
+        [createdPiece, readDocumentRoot(manager, createdPiece)],
+        [createdArgument, readDocumentRoot(manager, createdArgument)],
+      ]),
+    );
+    piece = await currentDebugPiece(
+      manager,
+      pattern,
+      cause,
+      target.conn.ownerDid,
+      setupArguments,
+    );
+    if (piece === undefined) {
+      throw new Error("new debug view disappeared after owner protection");
+    }
+  }
+  const existingRegistration = (await debugRegistration(
+    manager,
+    target.conn.ownerDid,
+  )).value;
   const pieceWasRegistered = debugRegistrationTargets(
     existingRegistration,
     cause,
     pieceId(piece),
     patternRef,
   );
+  signal?.throwIfAborted();
   const stopStartingPiece = () => manager.runtime.runner.stop(piece);
   if (!pieceWasRegistered) {
     signal?.addEventListener("abort", stopStartingPiece, { once: true });
@@ -746,12 +951,16 @@ async function deployAgentSessionsDebugViewNow(
       cause,
       patternRef,
       deploymentId,
+      target.conn.ownerDid,
       signal,
     );
   } catch (error) {
     let registrationIsOwned = true;
     try {
-      const activeRegistration = (await debugRegistration(manager)).value;
+      const activeRegistration = (await debugRegistration(
+        manager,
+        target.conn.ownerDid,
+      )).value;
       registrationIsOwned = debugRegistrationTargets(
         activeRegistration,
         cause,
@@ -788,6 +997,7 @@ export function describeAgentFabricTarget(
 ): AgentsHostTargetDescription {
   return {
     spaceDid,
+    ownerDid: target.conn.ownerDid,
     ...(debugPieceId ? { debugPieceId } : {}),
     cells: {
       recentIndex: stableCellId(target.cells.index),

--- a/packages/agents-host/src/fabric-runtime.ts
+++ b/packages/agents-host/src/fabric-runtime.ts
@@ -35,6 +35,7 @@ export async function openAgentFabricRuntime(options: {
   identityPath: string;
   ownerDid: string;
   space: string;
+  deferStorageClaim?: boolean;
   signal?: AbortSignal;
 }): Promise<AgentFabricRuntime> {
   options.signal?.throwIfAborted();
@@ -103,12 +104,15 @@ export async function openAgentFabricRuntime(options: {
     const manager = new PiecesController(session, runtime);
     await stage(manager.synced());
     options.signal?.throwIfAborted();
+    const connection = {
+      runtime,
+      spaceDid: session.space,
+      ownerDid: options.ownerDid,
+    };
     const target = await stage(
-      AgentFabricTarget.open({
-        runtime,
-        spaceDid: session.space,
-        ownerDid: options.ownerDid,
-      }),
+      options.deferStorageClaim
+        ? AgentFabricTarget.connect(connection)
+        : AgentFabricTarget.open(connection),
     );
     options.signal?.throwIfAborted();
     return {

--- a/packages/agents-host/src/fabric-runtime.ts
+++ b/packages/agents-host/src/fabric-runtime.ts
@@ -16,11 +16,24 @@ export interface AgentFabricRuntime {
   manager: PiecesController;
   spaceDid: MemorySpace;
   target: AgentFabricTarget;
+  ownerDid: string;
+}
+
+export function assertConfiguredOwner(
+  identity: Identity,
+  ownerDid: string,
+): void {
+  if (identity.did() !== ownerDid) {
+    throw new Error(
+      `configured owner ${ownerDid} does not match identity ${identity.did()}`,
+    );
+  }
 }
 
 export async function openAgentFabricRuntime(options: {
   apiUrl: string;
   identityPath: string;
+  ownerDid: string;
   space: string;
   signal?: AbortSignal;
 }): Promise<AgentFabricRuntime> {
@@ -29,6 +42,7 @@ export async function openAgentFabricRuntime(options: {
   const identityBytes = await Deno.readFile(options.identityPath);
   options.signal?.throwIfAborted();
   const identity = await Identity.fromPkcs8(identityBytes);
+  assertConfiguredOwner(identity, options.ownerDid);
   options.signal?.throwIfAborted();
   const session =
     await (isDID(options.space)
@@ -93,10 +107,17 @@ export async function openAgentFabricRuntime(options: {
       AgentFabricTarget.open({
         runtime,
         spaceDid: session.space,
+        ownerDid: options.ownerDid,
       }),
     );
     options.signal?.throwIfAborted();
-    return { runtime, manager, spaceDid: session.space, target };
+    return {
+      runtime,
+      manager,
+      spaceDid: session.space,
+      target,
+      ownerDid: options.ownerDid,
+    };
   } catch (error) {
     try {
       await dispose();

--- a/packages/agents-host/src/host.ts
+++ b/packages/agents-host/src/host.ts
@@ -67,6 +67,7 @@ export interface AgentsHostSyncHealth {
 
 export interface AgentsHostTargetDescription {
   spaceDid: string;
+  ownerDid: string;
   debugPieceId?: string;
   cells: {
     recentIndex: string;
@@ -79,7 +80,6 @@ export interface AgentsHostTargetDescription {
 
 export interface AgentsHostHealth {
   service: "agents-host";
-  formatVersion: 1;
   status: AgentsHostStatus;
   startedAt: string;
   updatedAt: string;
@@ -212,7 +212,6 @@ export class AgentsHost {
   health(): AgentsHostHealth {
     return structuredClone({
       service: "agents-host",
-      formatVersion: 1,
       status: this.#status,
       startedAt: this.#startedAt,
       updatedAt: this.#updatedAt,
@@ -309,6 +308,7 @@ export class AgentsHost {
       this.#drivers,
       [observedTarget],
       this.#ledger,
+      this.#targetDescription.ownerDid,
       (receipt) => this.#recordReceipt(receipt),
       (failure) => this.#recordCommandFailure(failure),
     );

--- a/packages/agents-host/src/process-lock.ts
+++ b/packages/agents-host/src/process-lock.ts
@@ -100,9 +100,10 @@ export function defaultAgentsHostLockDirectory(
 export async function defaultTargetProcessLockPath(
   apiUrl: string,
   spaceDid: string,
+  ownerDid: string,
   lockDirectory = defaultAgentsHostLockDirectory(),
 ): Promise<string> {
-  const key = await agentTargetKey(apiUrl, spaceDid);
+  const key = await agentTargetKey(apiUrl, spaceDid, ownerDid);
   return join(resolve(lockDirectory), `target-${key}.lock`);
 }
 

--- a/packages/agents-host/src/start.ts
+++ b/packages/agents-host/src/start.ts
@@ -30,6 +30,7 @@ function failureSummary(failures: unknown[]): string {
 export interface StartAgentsHostOptions {
   apiUrl: string;
   identityPath: string;
+  ownerDid: string;
   space: string;
   sources: AgentSourceConfig[];
   checkoutRoots?: string[];
@@ -118,13 +119,18 @@ export async function startAgentsHost(
     fabric = await openAgentFabricRuntime(options);
     options.signal?.throwIfAborted();
     const targetLockPath = options.targetLockPath ??
-      await defaultTargetProcessLockPath(options.apiUrl, fabric.spaceDid);
+      await defaultTargetProcessLockPath(
+        options.apiUrl,
+        fabric.spaceDid,
+        fabric.ownerDid,
+      );
     options.signal?.throwIfAborted();
     processLocks.push(await AgentsHostProcessLock.acquire(targetLockPath));
     options.signal?.throwIfAborted();
     const ledgerPath = await defaultTargetLedgerPath(
       options.apiUrl,
       fabric.spaceDid,
+      fabric.ownerDid,
     );
     options.signal?.throwIfAborted();
     processLocks.push(
@@ -160,7 +166,8 @@ export async function startAgentsHost(
     });
     const hostStartTask = trackStartup(host.start({
       signal: options.signal,
-      acceptCommands: options.acceptCommands,
+      acceptCommands: options.acceptCommands !== false &&
+        debugPieceId !== undefined && fabric.target.commandsAreBound(),
       deferHealthUntilReady: true,
       onHealthOwnership: () => {
         healthOwnership = true;

--- a/packages/agents-host/src/start.ts
+++ b/packages/agents-host/src/start.ts
@@ -116,7 +116,10 @@ export async function startAgentsHost(
     abortable(trackStartup(task), options.signal);
   try {
     options.signal?.throwIfAborted();
-    fabric = await openAgentFabricRuntime(options);
+    fabric = await openAgentFabricRuntime({
+      ...options,
+      deferStorageClaim: true,
+    });
     options.signal?.throwIfAborted();
     const targetLockPath = options.targetLockPath ??
       await defaultTargetProcessLockPath(
@@ -126,6 +129,8 @@ export async function startAgentsHost(
       );
     options.signal?.throwIfAborted();
     processLocks.push(await AgentsHostProcessLock.acquire(targetLockPath));
+    options.signal?.throwIfAborted();
+    await waitForStartup(fabric.target.claimStorage());
     options.signal?.throwIfAborted();
     const ledgerPath = await defaultTargetLedgerPath(
       options.apiUrl,

--- a/packages/agents-host/src/target-state.ts
+++ b/packages/agents-host/src/target-state.ts
@@ -16,6 +16,7 @@ export function parseAgentFabricApiUrl(
 export async function agentTargetKey(
   apiUrl: string,
   spaceDid: string,
+  ownerDid: string,
 ): Promise<string> {
   const endpoint = parseAgentFabricApiUrl(apiUrl);
   endpoint.username = "";
@@ -23,7 +24,7 @@ export async function agentTargetKey(
   endpoint.hash = "";
   endpoint.search = "";
   endpoint.pathname = "/";
-  const identity = `${endpoint.href}\n${spaceDid}`;
+  const identity = `${endpoint.href}\n${spaceDid}\n${ownerDid}`;
   const digest = new Uint8Array(
     await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity)),
   );
@@ -67,10 +68,15 @@ export function defaultAgentsHostStateDirectory(
 export async function defaultTargetLedgerPath(
   apiUrl: string,
   spaceDid: string,
+  ownerDid: string,
   stateDirectory = defaultAgentsHostStateDirectory(),
 ): Promise<string> {
   return join(
     resolve(stateDirectory),
-    `target-${await agentTargetKey(apiUrl, spaceDid)}.command-ledger.json`,
+    `target-${await agentTargetKey(
+      apiUrl,
+      spaceDid,
+      ownerDid,
+    )}.command-ledger.json`,
   );
 }

--- a/packages/agents-host/test/cli_test.ts
+++ b/packages/agents-host/test/cli_test.ts
@@ -17,7 +17,8 @@ async function writeConfig(
   await Deno.writeTextFile(
     path,
     JSON.stringify({
-      schema: "commonfabric.agents-host.config.v1",
+      schema: "commonfabric.agents-host.config",
+      ownerDid: "did:key:test-owner",
       ...interval,
       sources: [{
         id: "codex",

--- a/packages/agents-host/test/config_test.ts
+++ b/packages/agents-host/test/config_test.ts
@@ -8,10 +8,24 @@ import {
 } from "../src/config.ts";
 import { parseAgentsHostCliOptions } from "../src/cli-options.ts";
 import { basename, join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { assertConfiguredOwner } from "../src/fabric-runtime.ts";
+
+Deno.test("configured owner must match the signing identity", async () => {
+  const owner = await Identity.fromPassphrase("agents host configured owner");
+  const other = await Identity.fromPassphrase("agents host other owner");
+  assertConfiguredOwner(owner, owner.did());
+  assertThrows(
+    () => assertConfiguredOwner(owner, other.did()),
+    Error,
+    "does not match identity",
+  );
+});
 
 Deno.test("parseAgentsHostConfig validates and preserves provider options", () => {
   const config = parseAgentsHostConfig({
     schema: AGENTS_HOST_CONFIG_SCHEMA,
+    ownerDid: "did:key:test-owner",
     collectionIntervalMs: 1_234,
     checkoutRoots: ["/workspace/checkouts"],
     sources: [
@@ -85,6 +99,7 @@ Deno.test("parseAgentsHostConfig rejects ambiguous source identities", () => {
     () =>
       parseAgentsHostConfig({
         schema: AGENTS_HOST_CONFIG_SCHEMA,
+        ownerDid: "did:key:test-owner",
         sources: [
           {
             id: "Codex",
@@ -103,6 +118,7 @@ Deno.test("parseAgentsHostConfig requires commands for enabled ACP sources", () 
     () =>
       parseAgentsHostConfig({
         schema: AGENTS_HOST_CONFIG_SCHEMA,
+        ownerDid: "did:key:test-owner",
         sources: [{ id: "acp", driver: "acp", enabled: true }],
       }),
     Error,
@@ -119,6 +135,7 @@ Deno.test("loadAgentsHostConfig accepts JSONC", async () => {
       `{
         // One source is enough for a host.
         "schema": "${AGENTS_HOST_CONFIG_SCHEMA}",
+        "ownerDid": "did:key:test-owner",
         "sources": [
           { "id": "claude", "driver": "claude-agent-sdk", "enabled": true }
         ]
@@ -149,6 +166,7 @@ Deno.test("parseAgentsHostConfig rejects invalid collection intervals", () => {
       () =>
         parseAgentsHostConfig({
           schema: AGENTS_HOST_CONFIG_SCHEMA,
+          ownerDid: "did:key:test-owner",
           collectionIntervalMs,
           sources: [{
             id: "codex",

--- a/packages/agents-host/test/config_test.ts
+++ b/packages/agents-host/test/config_test.ts
@@ -48,6 +48,7 @@ Deno.test("parseAgentsHostConfig validates and preserves provider options", () =
     ],
   });
 
+  assertEquals(config.ownerDid, "did:key:test-owner");
   assertEquals(config.collectionIntervalMs, 1_234);
   assertEquals(config.checkoutRoots, ["/workspace/checkouts"]);
   assertEquals(config.sources, [
@@ -82,6 +83,7 @@ Deno.test("parseAgentsHostConfig validates checkout search roots", () => {
       () =>
         parseAgentsHostConfig({
           schema: AGENTS_HOST_CONFIG_SCHEMA,
+          ownerDid: "did:key:test-owner",
           checkoutRoots,
           sources: [{
             id: "codex",
@@ -91,6 +93,87 @@ Deno.test("parseAgentsHostConfig validates checkout search roots", () => {
         }),
       Error,
     );
+  }
+});
+
+Deno.test("parseAgentsHostConfig rejects a non-DID owner", () => {
+  assertThrows(
+    () =>
+      parseAgentsHostConfig({
+        schema: AGENTS_HOST_CONFIG_SCHEMA,
+        ownerDid: "not-a-did",
+        sources: [{
+          id: "codex",
+          driver: "codex-app-server",
+          enabled: true,
+        }],
+      }),
+    Error,
+    "configuration.ownerDid must be a DID",
+  );
+});
+
+Deno.test("parseAgentsHostConfig rejects malformed boundary fields", () => {
+  const source = {
+    id: "codex",
+    driver: "codex-app-server",
+    enabled: true,
+  };
+  const config = {
+    schema: AGENTS_HOST_CONFIG_SCHEMA,
+    ownerDid: "did:key:test-owner",
+    sources: [source],
+  };
+  const cases: Array<[unknown, string]> = [
+    [null, "configuration must be an object"],
+    [{ ...config, extra: true }, "configuration has an unknown field"],
+    [{ ...config, schema: "wrong" }, "configuration.schema must be"],
+    [{ ...config, sources: [] }, "sources must be a non-empty array"],
+    [{ ...config, sources: [null] }, "sources[0] must be an object"],
+    [
+      { ...config, sources: [{ ...source, command: [] }] },
+      "command must be a non-empty string array",
+    ],
+    [
+      { ...config, sources: [{ ...source, env: { BAD: 1 } }] },
+      "env.BAD must be a string",
+    ],
+    [
+      { ...config, sources: [{ ...source, extra: true }] },
+      "sources[0] has an unknown field",
+    ],
+    [
+      { ...config, sources: [{ ...source, driver: "unknown" }] },
+      "driver is not supported",
+    ],
+    [
+      { ...config, sources: [{ ...source, enabled: "yes" }] },
+      "enabled must be a boolean",
+    ],
+    [
+      { ...config, sources: [{ ...source, codexTransport: "unknown" }] },
+      "codexTransport is not supported",
+    ],
+    [
+      { ...config, sources: [{ ...source, allowDangerFullAccess: "yes" }] },
+      "allowDangerFullAccess must be a boolean",
+    ],
+    [
+      { ...config, checkoutRoots: "/workspace" },
+      "checkoutRoots must be a string array",
+    ],
+    [
+      { ...config, checkoutRoots: ["/workspace", "/workspace"] },
+      "checkoutRoots contains a duplicate path",
+    ],
+    [{ ...config, sources: [source, source] }, "duplicate source id"],
+    [
+      { ...config, sources: [{ ...source, enabled: false }] },
+      "must enable at least one source",
+    ],
+  ];
+  for (const [value, message] of cases) {
+    assertThrows(() => parseAgentsHostConfig(value), Error, message);
   }
 });
 

--- a/packages/agents-host/test/debug_view_deployment_test.ts
+++ b/packages/agents-host/test/debug_view_deployment_test.ts
@@ -9,6 +9,7 @@ import {
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
 import {
   AGENT_CONNECTOR_WRITER_ID,
+  agentOwnerSchema,
   agentPrincipalSchema,
   cellHasOwnerConfidentiality,
   cellHasOwnerProtection,
@@ -567,6 +568,144 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
   }
 });
 
+Deno.test("debug deployment rejects stale registration across runtimes", async () => {
+  const server = newSharedServer();
+  const spaceName = `debug-registration-race-${crypto.randomUUID()}`;
+  const readerSession = await createSession({ identity, spaceName });
+  const readerStorage = SharedServerStorageManager.connectTo(server, {
+    as: readerSession.as,
+  });
+  const readerRuntime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: readerStorage,
+  });
+  try {
+    const readerManager = new PiecesController(readerSession, readerRuntime);
+    await readerManager.synced();
+    const defaultPattern = await installDefaultPattern(readerManager);
+    const ownerDid = readerSession.as.did();
+    const target = await AgentFabricTarget.open({
+      runtime: readerRuntime,
+      spaceDid: readerSession.space,
+      ownerDid,
+    });
+    const originalPieceId = await deployAgentSessionsDebugView(
+      readerManager,
+      target,
+    );
+    await readerStorage.synced();
+
+    const writerSession = await createSession({ identity, spaceName });
+    const writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: writerSession.as,
+    });
+    const writerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    try {
+      const writerManager = new PiecesController(writerSession, writerRuntime);
+      await writerManager.synced();
+      const registration = writerRuntime.getCell(
+        writerSession.space,
+        `agent-sessions-debug-registration:${ownerDid}`,
+      );
+      await registration.sync();
+      const competingRegistration = {
+        cause: "agent-sessions-debug:competing",
+        pieceId: "fid1:competing-debug-piece",
+        patternIdentity: "fid1:competing-debug-pattern",
+        patternSymbol: "default",
+        retiredCauses: [],
+      };
+      const commitEntered = Promise.withResolvers<void>();
+      const releaseCommit = Promise.withResolvers<void>();
+      const originalStartPiece = readerManager.startPiece;
+      const originalEditWithRetry = readerRuntime.editWithRetry.bind(
+        readerRuntime,
+      );
+      let interceptRegistrationCommit = false;
+      let intercepted = false;
+      readerManager.startPiece = (async (piece, options) => {
+        await originalStartPiece.call(readerManager, piece, options);
+        interceptRegistrationCommit = true;
+      }) as typeof readerManager.startPiece;
+      readerRuntime.editWithRetry = ((action, maxRetries) =>
+        originalEditWithRetry((transaction) => {
+          const result = action(transaction);
+          if (interceptRegistrationCommit && !intercepted) {
+            intercepted = true;
+            const originalCommit = transaction.commit.bind(transaction);
+            transaction.commit = async () => {
+              commitEntered.resolve();
+              await releaseCommit.promise;
+              return await originalCommit();
+            };
+          }
+          return result;
+        }, maxRetries)) as typeof readerRuntime.editWithRetry;
+      try {
+        const defaultLocation = defaultDebugPatternLocation();
+        const deployment = deployAgentSessionsDebugView(
+          readerManager,
+          target,
+          {
+            rootPath: defaultLocation.rootPath,
+            mainPath: fromFileUrl(
+              new URL("./fixtures/alternate-debug-view.tsx", import.meta.url),
+            ),
+          },
+        );
+        await commitEntered.promise;
+        const competingResult = await writerRuntime.editWithRetry((tx) => {
+          tx.setCfcImplementationIdentity({
+            kind: "builtin",
+            builtinId: AGENT_CONNECTOR_WRITER_ID,
+          });
+          registration.withTx(tx).asSchema(agentOwnerSchema(ownerDid))
+            .setRawUntyped(competingRegistration);
+        });
+        if (competingResult.error) {
+          throw competingResult.error;
+        }
+        releaseCommit.resolve();
+
+        await assertRejects(
+          () =>
+            deployment,
+          Error,
+          "debug view registration changed during deployment",
+        );
+        assertEquals(registration.getRaw(), competingRegistration);
+        assertEquals(
+          await registeredPieceIds(defaultPattern, "pieceRegistry"),
+          [],
+        );
+        await target.publish([{
+          source: sourceDescriptor(),
+          sessions: [sessionSnapshot(1)],
+          errors: [],
+          complete: true,
+        }]);
+        await readerRuntime.settled();
+        const originalPiece = await readerManager.get(originalPieceId, false);
+        assertEquals(await originalPiece.result.get(["sessionCount"]), 1);
+      } finally {
+        releaseCommit.resolve();
+        readerManager.startPiece = originalStartPiece;
+        readerRuntime.editWithRetry = originalEditWithRetry;
+      }
+    } finally {
+      await writerRuntime.dispose();
+      await writerStorage.close();
+    }
+  } finally {
+    await readerRuntime.dispose();
+    await readerStorage.close();
+    await server.close();
+  }
+});
+
 Deno.test("debug deployment refuses a pre-created unprotected piece", async () => {
   const session = await createSession({
     identity,
@@ -658,7 +797,7 @@ Deno.test("debug registration rejects writes from another owner", async () => {
       target,
     );
     await readerStorage.synced();
-    assertEquals(await registeredPieceIds(defaultPattern, "allPieces"), []);
+    assertEquals(await registeredPieceIds(defaultPattern, "pieceRegistry"), []);
     const registration = readerRuntime.getCell(
       readerSession.space,
       `agent-sessions-debug-registration:${readerSession.as.did()}`,
@@ -894,6 +1033,7 @@ Deno.test("debug deployment rejects an in-place registry change", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const originalStartPiece = manager.startPiece;
     const originalEditWithRetry = runtime.editWithRetry.bind(runtime);

--- a/packages/agents-host/test/debug_view_deployment_test.ts
+++ b/packages/agents-host/test/debug_view_deployment_test.ts
@@ -7,6 +7,12 @@ import {
   deployAgentSessionsDebugView,
 } from "../src/debug-view.ts";
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
+import {
+  AGENT_CONNECTOR_WRITER_ID,
+  agentPrincipalSchema,
+  cellHasOwnerConfidentiality,
+  cellHasOwnerProtection,
+} from "@commonfabric/agents-connector/fabric-graph";
 import { createSession } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
@@ -25,6 +31,47 @@ import {
   sourceDescriptor,
 } from "./debug_view_support.ts";
 
+Deno.test("debug deployment requires verified command authorization", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-command-authorization-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const defaultLocation = defaultDebugPatternLocation();
+    await assertRejects(
+      () =>
+        deployAgentSessionsDebugView(manager, target, {
+          rootPath: defaultLocation.rootPath,
+          mainPath: fromFileUrl(
+            new URL(
+              "./fixtures/debug-view-without-command-authorization.tsx",
+              import.meta.url,
+            ),
+          ),
+        }),
+      Error,
+      "debug view has no verified command writer authorization",
+    );
+    assertEquals(target.commandsAreBound(), false);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("debug deployment replaces a view when its pattern identity changes", async () => {
   const session = await createSession({
     identity,
@@ -42,6 +89,7 @@ Deno.test("debug deployment replaces a view when its pattern identity changes", 
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const defaultLocation = defaultDebugPatternLocation();
     const alternateLocation = {
@@ -68,11 +116,7 @@ Deno.test("debug deployment replaces a view when its pattern identity changes", 
       defaultPattern,
       "pieceRegistry",
     );
-    assertEquals(registeredIds.includes(originalPieceId), false);
-    assertEquals(
-      registeredIds.filter((id) => id === alternatePieceId).length,
-      1,
-    );
+    assertEquals(registeredIds, []);
     const originalPiece = await manager.getPieceCell(
       originalPieceId,
       false,
@@ -112,6 +156,7 @@ Deno.test("debug deployment replaces a view when its pattern identity changes", 
           originalPieceId,
         ),
         false,
+        name,
       );
     }
   } finally {
@@ -137,6 +182,7 @@ Deno.test("debug deployment starts and restarts its registered view", async () =
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const debugPieceId = await deployAgentSessionsDebugView(manager, target);
     const piece = await manager.get(debugPieceId, false);
@@ -189,6 +235,7 @@ Deno.test("debug deployment removes a view that fails to start", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const originalStartPiece = manager.startPiece;
     manager.startPiece = (() =>
@@ -216,6 +263,66 @@ Deno.test("debug deployment removes a view that fails to start", async () => {
   }
 });
 
+Deno.test("debug deployment protects its result before starting", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-protection-failure-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    const defaultPattern = await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const originalSetupPersistent = manager.setupPersistent;
+    const originalStartPiece = manager.startPiece;
+    const originalEdit = runtime.edit;
+    let rejectProtection = false;
+    let startCount = 0;
+    manager.setupPersistent = (async (...args) => {
+      const piece = await originalSetupPersistent.apply(manager, args);
+      rejectProtection = true;
+      return piece;
+    }) as typeof manager.setupPersistent;
+    manager.startPiece = (async (...args) => {
+      startCount++;
+      return await originalStartPiece.apply(manager, args);
+    }) as typeof manager.startPiece;
+    runtime.edit = ((...args) => {
+      if (rejectProtection) {
+        throw new Error("debug result protection rejected");
+      }
+      return originalEdit.apply(runtime, args);
+    }) as typeof runtime.edit;
+    try {
+      await assertRejects(
+        () => deployAgentSessionsDebugView(manager, target),
+        Error,
+        "debug result protection rejected",
+      );
+    } finally {
+      manager.setupPersistent = originalSetupPersistent;
+      manager.startPiece = originalStartPiece;
+      runtime.edit = originalEdit;
+    }
+
+    assertEquals(startCount, 0);
+    assertEquals(await registeredPieceIds(defaultPattern, "pieceRegistry"), []);
+    assertEquals(await registeredPieceIds(defaultPattern, "recentPieces"), []);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("debug deployment preserves a view when its replacement fails", async () => {
   const session = await createSession({
     identity,
@@ -233,6 +340,7 @@ Deno.test("debug deployment preserves a view when its replacement fails", async 
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const originalPieceId = await deployAgentSessionsDebugView(
       manager,
@@ -262,7 +370,7 @@ Deno.test("debug deployment preserves a view when its replacement fails", async 
 
     assertEquals(
       await registeredPieceIds(defaultPattern, "pieceRegistry"),
-      [originalPieceId],
+      [],
     );
     await target.publish([{
       source: sourceDescriptor(),
@@ -296,6 +404,7 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const originalPieceId = await deployAgentSessionsDebugView(
       manager,
@@ -410,7 +519,7 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
     });
     assertEquals(
       await registeredPieceIds(defaultPattern, "pieceRegistry"),
-      [originalPieceId],
+      [],
     );
     assertEquals(
       await registeredPieceIds(defaultPattern, "recentPieces"),
@@ -436,7 +545,12 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
     await abortRegistration(defaultLocation);
     assertEquals(
       await registeredPieceIds(defaultPattern, "recentPieces"),
-      [originalPieceId],
+      [],
+    );
+
+    assertEquals(
+      await deployAgentSessionsDebugView(manager, target),
+      originalPieceId,
     );
 
     await target.publish([{
@@ -453,9 +567,75 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
   }
 });
 
-Deno.test("debug deployment rejects stale registration across runtimes", async () => {
+Deno.test("debug deployment refuses a pre-created unprotected piece", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-piece-squatting-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const originalSetupPersistent = manager.setupPersistent;
+    let debugCause: string | undefined;
+    manager.setupPersistent = ((...args) => {
+      if (typeof args[2] === "string") debugCause = args[2];
+      throw new Error("captured debug view cause");
+    }) as typeof manager.setupPersistent;
+    try {
+      await assertRejects(
+        () => deployAgentSessionsDebugView(manager, target),
+        Error,
+        "captured debug view cause",
+      );
+    } finally {
+      manager.setupPersistent = originalSetupPersistent;
+    }
+    if (debugCause === undefined) {
+      throw new Error("debug view cause was not set");
+    }
+    const squattedPiece = runtime.getCell(
+      session.space,
+      debugCause,
+      SHALLOW_PIECE_SCHEMA,
+    );
+    const seed = runtime.edit();
+    squattedPiece.withTx(seed).setRawUntyped({ spoofed: true });
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+
+    await assertRejects(
+      () => deployAgentSessionsDebugView(manager, target),
+      Error,
+      "refusing to adopt an unprotected debug view",
+    );
+    assertEquals(
+      cellHasOwnerProtection(
+        runtime.readTx(),
+        squattedPiece,
+        session.as.did(),
+      ),
+      false,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("debug registration rejects writes from another owner", async () => {
   const server = newSharedServer();
-  const spaceName = `debug-registration-race-${crypto.randomUUID()}`;
+  const spaceName = `debug-registration-owner-${crypto.randomUUID()}`;
   const readerSession = await createSession({ identity, spaceName });
   const readerStorage = SharedServerStorageManager.connectTo(server, {
     as: readerSession.as,
@@ -471,118 +651,138 @@ Deno.test("debug deployment rejects stale registration across runtimes", async (
     const target = await AgentFabricTarget.open({
       runtime: readerRuntime,
       spaceDid: readerSession.space,
+      ownerDid: readerSession.as.did(),
     });
-    const originalPieceId = await deployAgentSessionsDebugView(
+    const debugPieceId = await deployAgentSessionsDebugView(
       readerManager,
       target,
     );
     await readerStorage.synced();
-
-    const writerSession = await createSession({ identity, spaceName });
-    const writerStorage = SharedServerStorageManager.connectTo(server, {
-      as: writerSession.as,
+    assertEquals(await registeredPieceIds(defaultPattern, "allPieces"), []);
+    const registration = readerRuntime.getCell(
+      readerSession.space,
+      `agent-sessions-debug-registration:${readerSession.as.did()}`,
+    );
+    assertEquals(
+      cellHasOwnerConfidentiality(
+        readerRuntime.readTx(),
+        registration,
+        readerSession.as.did(),
+      ),
+      true,
+    );
+    const attack = readerRuntime.edit();
+    attack.setCfcTrustSnapshot({
+      id: "principal:did:key:other-owner",
+      actingPrincipal: "did:key:other-owner",
     });
-    const writerRuntime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: writerStorage,
+    attack.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
     });
-    try {
-      const writerManager = new PiecesController(writerSession, writerRuntime);
-      await writerManager.synced();
-      const registration = writerRuntime.getCell(
-        writerSession.space,
-        "agent-sessions-debug-registration-v1",
-      );
-      await registration.sync();
-      const competingRegistration = {
-        cause: "agent-sessions-debug:competing",
-        pieceId: "fid1:competing-debug-piece",
-        patternIdentity: "fid1:competing-debug-pattern",
-        patternSymbol: "default",
-        retiredCauses: [],
-      };
-      const commitEntered = Promise.withResolvers<void>();
-      const releaseCommit = Promise.withResolvers<void>();
-      const originalStartPiece = readerManager.startPiece;
-      const originalEditWithRetry = readerRuntime.editWithRetry.bind(
-        readerRuntime,
-      );
-      let interceptRegistrationCommit = false;
-      let intercepted = false;
-      readerManager.startPiece = (async (piece, options) => {
-        await originalStartPiece.call(readerManager, piece, options);
-        interceptRegistrationCommit = true;
-      }) as typeof readerManager.startPiece;
-      readerRuntime.editWithRetry = ((action, maxRetries) =>
-        originalEditWithRetry((transaction) => {
-          const result = action(transaction);
-          if (interceptRegistrationCommit && !intercepted) {
-            intercepted = true;
-            const originalCommit = transaction.commit.bind(transaction);
-            transaction.commit = async () => {
-              commitEntered.resolve();
-              await releaseCommit.promise;
-              return await originalCommit();
-            };
-          }
-          return result;
-        }, maxRetries)) as typeof readerRuntime.editWithRetry;
-      try {
-        const defaultLocation = defaultDebugPatternLocation();
-        const deployment = deployAgentSessionsDebugView(
-          readerManager,
-          target,
-          {
-            rootPath: defaultLocation.rootPath,
-            mainPath: fromFileUrl(
-              new URL("./fixtures/alternate-debug-view.tsx", import.meta.url),
-            ),
-          },
-        );
-        await commitEntered.promise;
-        const competingResult = await writerRuntime.editWithRetry((tx) => {
-          registration.withTx(tx).setRawUntyped(competingRegistration);
-        });
-        if (competingResult.error) {
-          throw competingResult.error;
-        }
-        releaseCommit.resolve();
+    registration.withTx(attack).setRawUntyped({
+      cause: "agent-sessions-debug:competing",
+      pieceId: "fid1:competing-debug-piece",
+      patternIdentity: "fid1:competing-debug-pattern",
+      patternSymbol: "default",
+      retiredCauses: [],
+    });
+    attack.prepareCfc();
+    const result = await attack.commit();
+    assertEquals(result.error !== undefined, true);
 
-        await assertRejects(
-          () =>
-            deployment,
-          Error,
-          "debug view registration changed during deployment",
-        );
-        assertEquals(registration.getRaw(), competingRegistration);
-        const registeredIds = await registeredPieceIds(
-          defaultPattern,
-          "pieceRegistry",
-        );
-        assertEquals(registeredIds.includes(originalPieceId), true);
-        assertEquals(registeredIds.length, 1);
-        await target.publish([{
-          source: sourceDescriptor(),
-          sessions: [sessionSnapshot(1)],
-          errors: [],
-          complete: true,
-        }]);
-        await readerRuntime.settled();
-        const originalPiece = await readerManager.get(originalPieceId, false);
-        assertEquals(await originalPiece.result.get(["sessionCount"]), 1);
-      } finally {
-        releaseCommit.resolve();
-        readerManager.startPiece = originalStartPiece;
-        readerRuntime.editWithRetry = originalEditWithRetry;
-      }
-    } finally {
-      await writerRuntime.dispose();
-      await writerStorage.close();
-    }
+    const debugPiece = await readerManager.getPieceCell(
+      debugPieceId,
+      false,
+      SHALLOW_PIECE_SCHEMA,
+    );
+    const argument = readerManager.getArgument(debugPiece);
+    await argument.sync();
+    assertEquals(
+      cellHasOwnerProtection(
+        readerRuntime.readTx(),
+        argument,
+        readerSession.as.did(),
+      ),
+      true,
+    );
+    const argumentAttack = readerRuntime.edit();
+    argumentAttack.setCfcTrustSnapshot({
+      id: "principal:did:key:other-owner",
+      actingPrincipal: "did:key:other-owner",
+    });
+    argumentAttack.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
+    argument.withTx(argumentAttack).setRawUntyped({
+      ...(argument.getRaw() as Record<string, unknown>),
+      ownerDid: "did:key:other-owner",
+    });
+    argumentAttack.prepareCfc();
+    const argumentAttackResult = await argumentAttack.commit();
+    assertEquals(argumentAttackResult.error !== undefined, true);
   } finally {
     await readerRuntime.dispose();
     await readerStorage.close();
     await server.close();
+  }
+});
+
+Deno.test("debug registration rejects another owner-scoped writer", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-registration-writer-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const otherWriter = "another-owner-scoped-pattern";
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const registration = runtime.getCell(
+      session.space,
+      `agent-sessions-debug-registration:${session.as.did()}`,
+      agentPrincipalSchema(session.as.did(), [otherWriter]),
+    );
+    const seed = runtime.edit();
+    seed.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: otherWriter,
+    });
+    registration.withTx(seed).set({
+      cause: "agent-sessions-debug:competing",
+      pieceId: "fid1:competing-debug-piece",
+      patternIdentity: "fid1:competing-debug-pattern",
+      patternSymbol: "default",
+      retiredCauses: [],
+    });
+    registration.withTx(seed).applyCfcSchemaToExistingValue();
+    seed.prepareCfc();
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+    assertEquals(
+      cellHasOwnerProtection(runtime.readTx(), registration, session.as.did()),
+      true,
+    );
+
+    await assertRejects(
+      () => deployAgentSessionsDebugView(manager, target),
+      Error,
+      "writeAuthorizedBy cannot be weakened",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
   }
 });
 
@@ -610,6 +810,7 @@ Deno.test("debug deployment reports malformed registration lists", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
 
     await assertRejects(
@@ -640,6 +841,7 @@ Deno.test("debug deployment rejects a replaced default pattern", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const replacementRoot = runtime.getCell(
       session.space,

--- a/packages/agents-host/test/debug_view_deployment_test.ts
+++ b/packages/agents-host/test/debug_view_deployment_test.ts
@@ -3,8 +3,10 @@
 
 import type { Cell } from "../../runner/src/builder/types.ts";
 import {
+  debugCommandWriterAuthorization,
   defaultDebugPatternLocation,
   deployAgentSessionsDebugView,
+  describeAgentFabricTarget,
 } from "../src/debug-view.ts";
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
 import {
@@ -32,6 +34,25 @@ import {
   sourceDescriptor,
 } from "./debug_view_support.ts";
 
+Deno.test("debug command authorization resolves local schema definitions", () => {
+  assertEquals(
+    debugCommandWriterAuthorization({
+      resultSchema: {
+        type: "object",
+        properties: {
+          commandAuthorization: { $ref: "#/$defs/CommandAuthorization" },
+        },
+        $defs: {
+          CommandAuthorization: {
+            ifc: { writeAuthorizedBy: ["verified-writer"] },
+          },
+        },
+      },
+    } as never),
+    ["verified-writer"],
+  );
+});
+
 Deno.test("debug deployment requires verified command authorization", async () => {
   const session = await createSession({
     identity,
@@ -51,6 +72,10 @@ Deno.test("debug deployment requires verified command authorization", async () =
       spaceDid: session.space,
       ownerDid: session.as.did(),
     });
+    assertEquals(
+      describeAgentFabricTarget(target, session.space).ownerDid,
+      session.as.did(),
+    );
     const defaultLocation = defaultDebugPatternLocation();
     await assertRejects(
       () =>
@@ -411,6 +436,11 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
       manager,
       target,
     );
+    const registration = runtime.getCell(
+      session.space,
+      `agent-sessions-debug-registration:${session.as.did()}`,
+    );
+    const originalRegistration = registration.getRaw();
     const defaultLocation = defaultDebugPatternLocation();
     const alternateLocation = {
       rootPath: defaultLocation.rootPath,
@@ -425,16 +455,18 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
       location: ReturnType<typeof defaultDebugPatternLocation>,
       options: {
         addCandidateToRecent?: boolean;
-        commitNumber?: number;
         abortAfterCommit?: boolean;
+        interceptPrivateRegistration?: boolean;
       } = {},
-    ): Promise<void> => {
+    ): Promise<{ candidateWasStopped: boolean }> => {
       const commitEntered = Promise.withResolvers<void>();
       const releaseCommit = Promise.withResolvers<void>();
       const controller = new AbortController();
       const originalStartPiece = manager.startPiece;
       const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+      const originalStop = runtime.runner.stop.bind(runtime.runner);
       let candidatePiece: Cell<unknown> | undefined;
+      let candidateWasStopped = false;
       let interceptRegistrationCommit = false;
       let commitCount = 0;
       manager.startPiece = (async (piece, options) => {
@@ -442,11 +474,27 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
         if (typeof piece !== "string") candidatePiece = piece;
         interceptRegistrationCommit = true;
       }) as typeof manager.startPiece;
+      runtime.runner.stop = ((piece) => {
+        if (piece === candidatePiece) candidateWasStopped = true;
+        return originalStop(piece);
+      }) as typeof runtime.runner.stop;
       runtime.editWithRetry = (async (action, maxRetries) => {
         if (interceptRegistrationCommit) commitCount++;
-        const shouldIntercept = commitCount === (options.commitNumber ?? 1);
+        let shouldIntercept = false;
         const result = await originalEditWithRetry((transaction) => {
+          const registrationBefore = transaction.readValueOrThrow(
+            registration.getAsNormalizedFullLink(),
+          );
           const result = action(transaction);
+          const registrationAfter = transaction.readValueOrThrow(
+            registration.getAsNormalizedFullLink(),
+          );
+          const registrationChanged = JSON.stringify(registrationBefore) !==
+            JSON.stringify(registrationAfter);
+          shouldIntercept = interceptRegistrationCommit &&
+            (options.interceptPrivateRegistration
+              ? registrationChanged
+              : commitCount === 1);
           if (shouldIntercept) {
             const originalCommit = transaction.commit.bind(transaction);
             transaction.commit = async () => {
@@ -503,8 +551,10 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
       } finally {
         releaseCommit.resolve();
         manager.startPiece = originalStartPiece;
+        runtime.runner.stop = originalStop;
         runtime.editWithRetry = originalEditWithRetry;
       }
+      return { candidateWasStopped };
     };
 
     const originalPiece = await manager.get(originalPieceId, false);
@@ -527,6 +577,32 @@ Deno.test("debug deployment rolls back an aborted registration", async () => {
       [],
     );
     assertEquals(await originalPiece.result.get(["sessionCount"]), 1);
+
+    const abortedPrivateRegistration = await abortRegistration(
+      alternateLocation,
+      {
+        abortAfterCommit: true,
+        interceptPrivateRegistration: true,
+      },
+    );
+    assertEquals(abortedPrivateRegistration.candidateWasStopped, true);
+    assertEquals(registration.getRaw(), originalRegistration);
+    assertEquals(
+      await registeredPieceIds(defaultPattern, "pieceRegistry"),
+      [],
+    );
+    assertEquals(
+      await registeredPieceIds(defaultPattern, "recentPieces"),
+      [],
+    );
+    await target.publish([{
+      source: sourceDescriptor(),
+      sessions: [sessionSnapshot(1), sessionSnapshot(2)],
+      errors: [],
+      complete: true,
+    }]);
+    await runtime.settled();
+    assertEquals(await originalPiece.result.get(["sessionCount"]), 2);
 
     const addRecentResult = await runtime.editWithRetry((transaction) => {
       const list = recentPieces.withTx(transaction);
@@ -772,6 +848,97 @@ Deno.test("debug deployment refuses a pre-created unprotected piece", async () =
   }
 });
 
+Deno.test("debug deployment refuses an unprotected registration", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-registration-squatting-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const registration = runtime.getCell(
+      session.space,
+      `agent-sessions-debug-registration:${session.as.did()}`,
+    );
+    const squattedRegistration = {
+      cause: "agent-sessions-debug:squatted",
+      pieceId: "fid1:squatted-debug-piece",
+      patternIdentity: "fid1:squatted-debug-pattern",
+      patternSymbol: "default",
+      retiredCauses: [],
+    };
+    const seed = runtime.edit();
+    registration.withTx(seed).setRawUntyped(squattedRegistration);
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+
+    await assertRejects(
+      () => deployAgentSessionsDebugView(manager, target),
+      Error,
+      "refusing to adopt an unprotected debug registration",
+    );
+    assertEquals(registration.getRaw(), squattedRegistration);
+    assertEquals(
+      cellHasOwnerProtection(
+        runtime.readTx(),
+        registration,
+        session.as.did(),
+      ),
+      false,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("debug deployment requires the public piece registry", async () => {
+  const session = await createSession({
+    identity,
+    spaceName: `debug-missing-registry-${crypto.randomUUID()}`,
+  });
+  const storageManager = StorageManager.emulate({ as: session.as });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const manager = new PiecesController(session, runtime);
+    await manager.synced();
+    const defaultPattern = await installDefaultPattern(manager);
+    const target = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: session.space,
+      ownerDid: session.as.did(),
+    });
+    const removed = await runtime.editWithRetry((tx) => {
+      defaultPattern.withTx(tx).asSchema(undefined).key("pieceRegistry")
+        .setRawUntyped(undefined);
+    });
+    if (removed.error) throw removed.error;
+
+    await assertRejects(
+      () => deployAgentSessionsDebugView(manager, target),
+      Error,
+      "default pattern does not expose pieceRegistry",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("debug registration rejects writes from another owner", async () => {
   const server = newSharedServer();
   const spaceName = `debug-registration-owner-${crypto.randomUUID()}`;
@@ -802,6 +969,7 @@ Deno.test("debug registration rejects writes from another owner", async () => {
       readerSession.space,
       `agent-sessions-debug-registration:${readerSession.as.did()}`,
     );
+    const originalRegistration = registration.getRaw();
     assertEquals(
       cellHasOwnerConfidentiality(
         readerRuntime.readTx(),
@@ -835,6 +1003,7 @@ Deno.test("debug registration rejects writes from another owner", async () => {
       false,
       SHALLOW_PIECE_SCHEMA,
     );
+    const runningPiece = await readerManager.get(debugPieceId, false);
     const argument = readerManager.getArgument(debugPiece);
     await argument.sync();
     assertEquals(
@@ -845,6 +1014,7 @@ Deno.test("debug registration rejects writes from another owner", async () => {
       ),
       true,
     );
+    const originalArgument = argument.getRaw();
     const argumentAttack = readerRuntime.edit();
     argumentAttack.setCfcTrustSnapshot({
       id: "principal:did:key:other-owner",
@@ -861,6 +1031,35 @@ Deno.test("debug registration rejects writes from another owner", async () => {
     argumentAttack.prepareCfc();
     const argumentAttackResult = await argumentAttack.commit();
     assertEquals(argumentAttackResult.error !== undefined, true);
+    assertEquals(argument.getRaw(), originalArgument);
+
+    const ownerUpdate = readerRuntime.edit();
+    ownerUpdate.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
+    argument.withTx(ownerUpdate).setRawUntyped({
+      ...(argument.getRaw() as Record<string, unknown>),
+      ownerDid: "did:key:other-owner",
+    });
+    ownerUpdate.prepareCfc();
+    const ownerUpdateResult = await ownerUpdate.commit();
+    if (ownerUpdateResult.error) throw ownerUpdateResult.error;
+    await assertRejects(
+      () => deployAgentSessionsDebugView(readerManager, target),
+      Error,
+      "contains different owner inputs",
+    );
+    assertEquals(registration.getRaw(), originalRegistration);
+    assertNotEquals(debugPiece.getRaw(), undefined);
+    await target.publish([{
+      source: sourceDescriptor(),
+      sessions: [sessionSnapshot(1)],
+      errors: [],
+      complete: true,
+    }]);
+    await readerRuntime.settled();
+    assertEquals(await runningPiece.result.get(["sessionCount"]), 1);
   } finally {
     await readerRuntime.dispose();
     await readerStorage.close();

--- a/packages/agents-host/test/debug_view_pattern_test.ts
+++ b/packages/agents-host/test/debug_view_pattern_test.ts
@@ -945,12 +945,12 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       (result as Record<string, unknown>)["$UI"],
       "Raw data",
     );
-    const firstPageRunnerCount = runtime.runner.cancels.size;
     assertEquals(
       countSessionRawDataLinks((result as Record<string, unknown>)["$UI"]),
       SESSION_PAGE_SIZE,
     );
     assertEquals(firstPageLinkIds.length, SESSION_PAGE_SIZE);
+    const firstPageRunnerCount = runtime.runner.cancels.size;
     const nextButton = renderedNodes(
       (result as Record<string, unknown>)["$UI"],
     ).find((node) =>
@@ -981,8 +981,10 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       secondPageLinkIds.every((id) => !firstPageIds.has(id)),
       true,
     );
-    const secondPageRunnerCount = runtime.runner.cancels.size;
-    assertEquals(secondPageRunnerCount > firstPageRunnerCount, true);
+    assertEquals(
+      runtime.runner.cancels.size <= firstPageRunnerCount + 1,
+      true,
+    );
     openedRawSession.key("load").send({});
     await runtime.settled();
     await openedRawSession.pull();
@@ -1013,6 +1015,7 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       ),
       true,
     );
+    const openedRawRunnerCount = runtime.runner.cancels.size;
     (nextPage as { send: (event: unknown) => void }).send({});
     await runtime.settled();
 
@@ -1028,8 +1031,7 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       SESSION_PAGE_SIZE,
     );
     assertEquals(thirdPageLinkIds.length, SESSION_PAGE_SIZE);
-    const thirdPageRunnerCount = runtime.runner.cancels.size;
-    assertEquals(thirdPageRunnerCount < secondPageRunnerCount, true);
+    assertEquals(runtime.runner.cancels.size, openedRawRunnerCount);
     (nextPage as { send: (event: unknown) => void }).send({});
     await runtime.settled();
 
@@ -1037,6 +1039,10 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
     assertEquals(
       countSessionRawDataLinks((lastResult as Record<string, unknown>)["$UI"]),
       trailingSessionCount,
+    );
+    assertEquals(
+      runtime.runner.cancels.size < openedRawRunnerCount,
+      true,
     );
     const filterInput = renderedNodes(
       (lastResult as Record<string, unknown>)["$UI"],
@@ -1113,7 +1119,10 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       ),
       firstPageLinkIds,
     );
-    assertEquals(runtime.runner.cancels.size < thirdPageRunnerCount, true);
+    assertEquals(
+      runtime.runner.cancels.size <= openedRawRunnerCount,
+      true,
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -1212,7 +1221,7 @@ Deno.test("debug pattern resumes sessions published while it was stopped", async
 Deno.test("debug pattern loads connector child cells on a cold replica", async () => {
   const server = newSharedServer();
   const spaceName = `debug-cold-${crypto.randomUUID()}`;
-  const sessionCount = SESSION_PAGE_SIZE * 34;
+  const sessionCount = SESSION_PAGE_SIZE + 1;
   let debugPieceId = "";
   let rawPieceId = "";
   let manifestDocumentId = "";
@@ -1422,7 +1431,7 @@ Deno.test("debug pattern loads connector child cells on a cold replica", async (
         "AgentsHost.health()",
         "preceding seven days",
         "all non-deleted session-row links",
-        "shared action array",
+        "owner-confidential command queue",
         "latest 200 receipt-row links",
       ];
       for (const [index, link] of topLevelRawLinks.entries()) {

--- a/packages/agents-host/test/debug_view_pattern_test.ts
+++ b/packages/agents-host/test/debug_view_pattern_test.ts
@@ -6,6 +6,10 @@ import { resolvedSchema } from "../../runner/test/schema-ref-helpers.ts";
 import { SESSION_PAGE_SIZE } from "../../patterns/agent-sessions-debug/presentation.ts";
 import type { Cell } from "../../runner/src/builder/types.ts";
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
+import {
+  AGENT_CONNECTOR_WRITER_ID,
+  agentOwnerSchema,
+} from "@commonfabric/agents-connector/fabric-graph";
 import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { createSession } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -52,6 +56,7 @@ Deno.test("debug pattern accepts empty target cells before collection", async ()
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const piece = await deployDebugPiece(manager, target);
 
@@ -133,6 +138,7 @@ Deno.test("debug pattern renders sessions published after deployment", async () 
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const piece = await deployDebugPiece(manager, target);
     const snapshot = sessionSnapshot();
@@ -183,9 +189,14 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     spaceName: `debug-command-${crypto.randomUUID()}`,
   });
   const storageManager = StorageManager.emulate({ as: session.as });
+  let actingPrincipal = session.as.did();
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),
     storageManager,
+    trustSnapshotProvider: () => ({
+      id: `principal:${actingPrincipal}`,
+      actingPrincipal,
+    }),
   });
   try {
     const manager = new PiecesController(session, runtime);
@@ -193,6 +204,7 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const source = sourceDescriptor();
     const snapshot = sessionSnapshot();
@@ -215,12 +227,12 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     };
     const health = {
       service: "agents-host",
-      formatVersion: 1,
       status: "ready",
       startedAt: "2026-07-20T00:00:00.000Z",
       updatedAt: "2026-07-20T00:01:00.000Z",
       target: {
         spaceDid: session.space,
+        ownerDid: session.as.did(),
         cells: {
           recentIndex: "recent-index",
           allIndex: "all-index",
@@ -246,6 +258,32 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     await target.publishHealth(health);
     const piece = await deployDebugPiece(manager, target);
     await runtime.settled();
+    const resultCell = await piece.result.getCell();
+    const resultLink = resultCell.getAsNormalizedFullLink();
+    const resultInspect = runtime.edit();
+    const storedResult = resultInspect.readOrThrow({
+      space: resultLink.space,
+      id: resultLink.id,
+      path: [],
+      ...(resultLink.scope !== undefined && { scope: resultLink.scope }),
+    }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
+    assertEquals(
+      storedResult.cfc?.labelMap?.entries?.some((entry) =>
+        JSON.stringify(entry).includes("confidentiality") &&
+        JSON.stringify(entry).includes(session.as.did())
+      ),
+      true,
+    );
+    resultInspect.abort();
+    const resultAttack = runtime.edit();
+    resultAttack.setCfcTrustSnapshot({
+      id: "principal:did:key:other-debug-owner",
+      actingPrincipal: "did:key:other-debug-owner",
+    });
+    resultCell.withTx(resultAttack).setRawUntyped({ compromised: true });
+    resultAttack.prepareCfc();
+    const resultAttackCommit = await resultAttack.commit();
+    assertEquals(resultAttackCommit.error !== undefined, true);
 
     let result = await piece.result.get() as Record<string, unknown>;
     const commandButton = renderedNodes(result["$UI"]).find((node) =>
@@ -301,14 +339,19 @@ Deno.test("debug pattern submits commands and links row data to separate views",
       typeof (send as { send?: unknown } | undefined)?.send,
       "function",
     );
+    actingPrincipal = "did:key:other-owner";
     (send as { send: (event: unknown) => void }).send({});
     await runtime.settled();
+    assertEquals(await target.pollCommands(), []);
 
+    actingPrincipal = session.as.did();
+    (send as { send: (event: unknown) => void }).send({});
+    await runtime.settled();
     const actionValues = await target.pollCommands();
     assertEquals(actionValues.length, 1);
     assertEquals(typeof actionValues[0], "string");
     const command = JSON.parse(String(actionValues[0]));
-    assertEquals(command.schema, "commonfabric.agent-connector.command.v1");
+    assertEquals(command.schema, "commonfabric.agent-connector.command");
     assertEquals(command.sourceId, source.id);
     assertEquals(
       command.nativeSessionId,
@@ -319,9 +362,30 @@ Deno.test("debug pattern submits commands and links row data to separate views",
       command.payload,
       { text: "Continue from the deployed debug view" },
     );
+    const commandLink = target.cells.commands.getAsNormalizedFullLink();
+    const protectedCommandLink = target.cells.commands.resolveAsCell()
+      .getAsNormalizedFullLink();
+    const inspect = runtime.edit();
+    const stored = inspect.readOrThrow({
+      space: protectedCommandLink.space,
+      id: protectedCommandLink.id,
+      path: [],
+      ...(protectedCommandLink.scope !== undefined && {
+        scope: protectedCommandLink.scope,
+      }),
+    }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
+    assertEquals(
+      stored.cfc?.labelMap?.entries?.some((entry) =>
+        JSON.stringify(entry).includes("confidentiality") &&
+        JSON.stringify(entry).includes(session.as.did())
+      ),
+      true,
+    );
+    inspect.abort();
 
     await target.publishReceipt({
-      schema: "commonfabric.agent-connector.command-receipt.v1",
+      schema: "commonfabric.agent-connector.command-receipt",
+      ownerDid: session.as.did(),
       commandId: command.id,
       sourceId: source.id,
       nativeSessionId: snapshot.summary.nativeSessionId,
@@ -384,7 +448,7 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     );
     assertEquals(
       commandProvenance.provenance.origin.includes(
-        "shared commands cell",
+        "owner's protected command queue",
       ),
       true,
     );
@@ -528,7 +592,8 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     );
 
     await target.publishReceipt({
-      schema: "commonfabric.agent-connector.command-receipt.v1",
+      schema: "commonfabric.agent-connector.command-receipt",
+      ownerDid: session.as.did(),
       commandId: "other-command",
       sourceId: source.id,
       nativeSessionId: snapshot.summary.nativeSessionId,
@@ -536,7 +601,8 @@ Deno.test("debug pattern submits commands and links row data to separate views",
       completedAt: "2026-07-20T00:03:00.000Z",
     });
     await target.publishReceipt({
-      schema: "commonfabric.agent-connector.command-receipt.v1",
+      schema: "commonfabric.agent-connector.command-receipt",
+      ownerDid: session.as.did(),
       commandId: command.id,
       sourceId: source.id,
       nativeSessionId: snapshot.summary.nativeSessionId,
@@ -634,7 +700,10 @@ Deno.test("debug pattern submits commands and links row data to separate views",
         }),
     );
     let commandTx = runtime.edit();
-    target.cells.commands.withTx(commandTx).set(pageCommands);
+    target.cells.commands.resolveAsCell()
+      .asSchema(agentOwnerSchema(session.as.did(), false)).withTx(commandTx)
+      .setRawUntyped(pageCommands);
+    commandTx.prepareCfc();
     let commandCommit = await commandTx.commit();
     if (commandCommit.error) throw commandCommit.error;
     await runtime.settled();
@@ -659,15 +728,18 @@ Deno.test("debug pattern submits commands and links row data to separate views",
     )[0];
 
     commandTx = runtime.edit();
-    target.cells.commands.withTx(commandTx).set([
-      ...pageCommands,
-      JSON.stringify({
-        ...command,
-        id: "page-command-25",
-        createdAt: "2026-07-20T00:25:00.000Z",
-        payload: { sequence: 25 },
-      }),
-    ]);
+    target.cells.commands.resolveAsCell()
+      .asSchema(agentOwnerSchema(session.as.did(), false)).withTx(commandTx)
+      .setRawUntyped([
+        ...pageCommands,
+        JSON.stringify({
+          ...command,
+          id: "page-command-25",
+          createdAt: "2026-07-20T00:25:00.000Z",
+          payload: { sequence: 25 },
+        }),
+      ]);
+    commandTx.prepareCfc();
     commandCommit = await commandTx.commit();
     if (commandCommit.error) throw commandCommit.error;
     await runtime.settled();
@@ -697,6 +769,16 @@ Deno.test("debug pattern submits commands and links row data to separate views",
       ),
       { sequence: 1 },
     );
+
+    const attack = runtime.edit();
+    attack.setCfcTrustSnapshot({
+      id: "principal:did:key:other-owner",
+      actingPrincipal: "did:key:other-owner",
+    });
+    attack.writeValueOrThrow(commandLink, []);
+    attack.prepareCfc();
+    const attackResult = await attack.commit();
+    assertEquals(attackResult.error !== undefined, true);
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -721,6 +803,7 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     await target.publish([{
       source: sourceDescriptor(),
@@ -756,9 +839,14 @@ Deno.test("debug pattern bounds raw-data links to one session page", async () =>
       path: [],
     });
     const staleIndexTx = runtime.edit();
+    staleIndexTx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
     staleIndexRow.withTx(staleIndexTx).key("driver").set(
       "claude-agent-sdk",
     );
+    staleIndexTx.prepareCfc();
     const staleIndexCommit = await staleIndexTx.commit();
     if (staleIndexCommit.error) throw staleIndexCommit.error;
     const piece = await deployDebugPiece(manager, target);
@@ -1051,6 +1139,7 @@ Deno.test("debug pattern resumes sessions published while it was stopped", async
     const target = await AgentFabricTarget.open({
       runtime: deployRuntime,
       spaceDid: deploySession.space,
+      ownerDid: deploySession.as.did(),
     });
     debugPieceId = (await deployDebugPiece(manager, target)).id;
     await deployStorage.synced();
@@ -1071,6 +1160,7 @@ Deno.test("debug pattern resumes sessions published while it was stopped", async
     const target = await AgentFabricTarget.open({
       runtime: publishRuntime,
       spaceDid: publishSession.space,
+      ownerDid: publishSession.as.did(),
     });
     const snapshots = Array.from({ length: SESSION_PAGE_SIZE }, (_, index) => {
       const snapshot = sessionSnapshot(index + 1);
@@ -1144,6 +1234,7 @@ Deno.test("debug pattern loads connector child cells on a cold replica", async (
       const target = await AgentFabricTarget.open({
         runtime: writerRuntime,
         spaceDid: writerSession.space,
+        ownerDid: writerSession.as.did(),
       });
       debugPieceId = (await deployDebugPiece(manager, target)).id;
       const source = sourceDescriptor();
@@ -1191,7 +1282,6 @@ Deno.test("debug pattern loads connector child cells on a cold replica", async (
       lastSessionRowDocumentId = lastSessionRowId;
       await target.publishHealth({
         service: "agents-host",
-        formatVersion: 1,
         status: "ready",
         startedAt: "2026-07-20T00:00:00.000Z",
         updatedAt: "2026-07-20T00:01:00.000Z",
@@ -1218,8 +1308,8 @@ Deno.test("debug pattern loads connector child cells on a cold replica", async (
       });
       const manifest = writerRuntime.getCell(writerSession.space, {
         spaceDid: writerSession.space,
+        ownerDid: writerSession.as.did(),
         agentConnector: "session",
-        version: 1,
         sourceId: "codex:test",
         nativeSessionId: "session-1",
       });

--- a/packages/agents-host/test/debug_view_replacement_test.ts
+++ b/packages/agents-host/test/debug_view_replacement_test.ts
@@ -6,11 +6,15 @@ import {
   deployAgentSessionsDebugView,
 } from "../src/debug-view.ts";
 import { AgentFabricTarget } from "@commonfabric/agents-connector/fabric";
+import {
+  agentOwnerSchema,
+  cellHasOwnerConfidentiality,
+} from "@commonfabric/agents-connector/fabric-graph";
 import { createSession } from "@commonfabric/identity";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import {
   identity,
@@ -39,48 +43,66 @@ Deno.test("debug replacement stops every superseded local runner", async () => {
     const target = await AgentFabricTarget.open({
       runtime,
       spaceDid: session.space,
+      ownerDid: session.as.did(),
     });
     const originalPieceId = await deployAgentSessionsDebugView(manager, target);
     const registration = runtime.getCell(
       session.space,
-      "agent-sessions-debug-registration-v1",
+      `agent-sessions-debug-registration:${session.as.did()}`,
     );
     await registration.sync();
     const addRetiredResult = await runtime.editWithRetry((tx) => {
-      const cell = registration.withTx(tx);
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "commonfabric.agents-connector",
+      });
+      const cell = registration.withTx(tx).asSchema(
+        agentOwnerSchema(session.as.did()),
+      );
       const current = cell.getRawUntyped({ frozen: false });
       if (typeof current !== "object" || current === null) {
         throw new Error("debug registration is missing");
+      }
+      if (
+        !("cause" in current) || typeof current.cause !== "string" ||
+        current.cause.length === 0
+      ) {
+        throw new Error("debug registration has no active cause");
       }
       cell.setRawUntyped({
         ...current,
         retiredCauses: ["agent-sessions-debug:retired-test-piece"],
       });
+      tx.prepareCfc();
     });
     if (addRetiredResult.error) throw addRetiredResult.error;
+    assertEquals(
+      (registration.getRaw() as { retiredCauses?: string[] }).retiredCauses,
+      ["agent-sessions-debug:retired-test-piece"],
+    );
+    assertEquals(
+      cellHasOwnerConfidentiality(
+        runtime.readTx(),
+        registration,
+        session.as.did(),
+      ),
+      true,
+    );
 
     const originalStop = runtime.runner.stop;
     let stopCalls = 0;
     runtime.runner.stop = ((piece) => {
       stopCalls++;
       originalStop.call(runtime.runner, piece);
-      if (stopCalls === 1) {
-        throw new Error("retired runner cancellation failed");
-      }
     }) as typeof runtime.runner.stop;
     try {
       const defaultLocation = defaultDebugPatternLocation();
-      await assertRejects(
-        () =>
-          deployAgentSessionsDebugView(manager, target, {
-            rootPath: defaultLocation.rootPath,
-            mainPath: fromFileUrl(
-              new URL("./fixtures/alternate-debug-view.tsx", import.meta.url),
-            ),
-          }),
-        AggregateError,
-        "debug view runner cleanup failed",
-      );
+      await deployAgentSessionsDebugView(manager, target, {
+        rootPath: defaultLocation.rootPath,
+        mainPath: fromFileUrl(
+          new URL("./fixtures/alternate-debug-view.tsx", import.meta.url),
+        ),
+      });
     } finally {
       runtime.runner.stop = originalStop;
     }
@@ -116,6 +138,7 @@ Deno.test("debug replacement preserves a piece owned by another runtime", async 
     const firstTarget = await AgentFabricTarget.open({
       runtime: firstRuntime,
       spaceDid: firstSession.space,
+      ownerDid: firstSession.as.did(),
     });
     const originalPieceId = await deployAgentSessionsDebugView(
       firstManager,
@@ -137,6 +160,7 @@ Deno.test("debug replacement preserves a piece owned by another runtime", async 
       const secondTarget = await AgentFabricTarget.open({
         runtime: secondRuntime,
         spaceDid: secondSession.space,
+        ownerDid: secondSession.as.did(),
       });
       const defaultLocation = defaultDebugPatternLocation();
       await deployAgentSessionsDebugView(secondManager, secondTarget, {

--- a/packages/agents-host/test/debug_view_support.ts
+++ b/packages/agents-host/test/debug_view_support.ts
@@ -13,7 +13,7 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { pieceId } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
-import { Runtime } from "@commonfabric/runner";
+import { compileAndSavePattern, Runtime } from "@commonfabric/runner";
 import { resolveLocalProgram } from "@commonfabric/runner/local-program.deno";
 import {
   EmulatedStorageManager,
@@ -23,7 +23,11 @@ import { fromFileUrl } from "@std/path";
 import type { RawDataProvenance } from "../../patterns/agent-sessions-debug/main.tsx";
 import { createBuilder } from "../../runner/src/builder/factory.ts";
 import type { Cell } from "../../runner/src/builder/types.ts";
-import { defaultDebugPatternLocation } from "../src/debug-view.ts";
+import {
+  debugCommandWriterAuthorization,
+  defaultDebugPatternLocation,
+  protectOwnerDebugResult,
+} from "../src/debug-view.ts";
 
 export const identity = await Identity.fromPassphrase(
   "agent sessions debug deployment test",
@@ -406,14 +410,25 @@ export async function deployDebugPiece(
     (resolver) => manager.runtime.harness.resolve(resolver),
     { main: location.mainPath, root: location.rootPath },
   );
-  return await manager.create(
+  const pattern = await compileAndSavePattern(manager.runtime, program, {
+    space: manager.getSpace(),
+  });
+  const commandWriterAuthorization = debugCommandWriterAuthorization(pattern);
+  if (commandWriterAuthorization === undefined) {
+    throw new Error("debug command writer authorization is missing");
+  }
+  await target.bindCommandCell(
+    target.cells.commands,
+    commandWriterAuthorization,
+  );
+  const piece = await manager.create(
     program,
     {
       input: {
+        ownerDid: target.conn.ownerDid,
         recentIndex: target.cells.index,
         allIndex: target.cells.allIndex,
         health: target.cells.health,
-        commands: target.cells.commands,
         receipts: target.cells.receipts,
         recentIndexCell: target.cells.index,
         allIndexCell: target.cells.allIndex,
@@ -424,6 +439,9 @@ export async function deployDebugPiece(
     },
     cause,
   );
+  const resultCell = await piece.result.getCell();
+  await protectOwnerDebugResult(manager, resultCell, target.conn.ownerDid);
+  return piece;
 }
 
 export async function deployRawDataPiece(

--- a/packages/agents-host/test/fabric_runtime_test.ts
+++ b/packages/agents-host/test/fabric_runtime_test.ts
@@ -15,11 +15,14 @@ import { openAgentFabricRuntime } from "../src/fabric-runtime.ts";
 describe("fabric-runtime", () => {
   describe("openAgentFabricRuntime()", () => {
     let identityPath: string;
+    let ownerDid: string;
     let realFetch: typeof globalThis.fetch;
 
     beforeEach(async () => {
       identityPath = await Deno.makeTempFile({ suffix: ".key" });
-      await Deno.writeFile(identityPath, await Identity.generatePkcs8());
+      const identityBytes = await Identity.generatePkcs8();
+      await Deno.writeFile(identityPath, identityBytes);
+      ownerDid = (await Identity.fromPkcs8(identityBytes)).did();
       realFetch = globalThis.fetch;
     });
 
@@ -51,6 +54,7 @@ describe("fabric-runtime", () => {
       await expect(openAgentFabricRuntime({
         apiUrl: "https://deployment.example",
         identityPath,
+        ownerDid,
         space: "a-space-of-its-own",
         signal: controller.signal,
       })).rejects.toThrow("shutting down");
@@ -67,6 +71,7 @@ describe("fabric-runtime", () => {
       await expect(openAgentFabricRuntime({
         apiUrl: "https://deployment.example",
         identityPath: `${identityPath}.absent`,
+        ownerDid,
         space: "a-space-of-its-own",
       })).rejects.toThrow(Deno.errors.NotFound);
       expect(requested).toBe(false);

--- a/packages/agents-host/test/fixtures/alternate-debug-view.tsx
+++ b/packages/agents-host/test/fixtures/alternate-debug-view.tsx
@@ -1,7 +1,20 @@
-import { NAME, pattern, UI } from "commonfabric";
-import type { DebugInput } from "../../../patterns/agent-sessions-debug/main.tsx";
+import { NAME, pattern, UI, type Writable } from "commonfabric";
+import type {
+  DebugInput,
+  DebugOutput,
+} from "../../../patterns/agent-sessions-debug/main.tsx";
 
-export default pattern<DebugInput>((_) => ({
-  [NAME]: "Alternate agent sessions",
-  [UI]: <cf-screen>Alternate agent sessions</cf-screen>,
-}));
+export default pattern<DebugInput, DebugOutput>(({ commandsCell }) => {
+  const protectedCommands: Writable<DebugOutput["commandQueue"]> = commandsCell;
+  return {
+    [NAME]: "Alternate agent sessions",
+    [UI]: <cf-screen>Alternate agent sessions</cf-screen>,
+    status: "alternate",
+    sourceCount: 0,
+    sessionCount: 0,
+    commandCount: 0,
+    receiptCount: 0,
+    activityCount: 0,
+    commandQueue: protectedCommands,
+  };
+});

--- a/packages/agents-host/test/fixtures/debug-view-without-command-authorization.tsx
+++ b/packages/agents-host/test/fixtures/debug-view-without-command-authorization.tsx
@@ -1,0 +1,7 @@
+import { NAME, pattern, UI } from "commonfabric";
+import type { DebugInput } from "../../../patterns/agent-sessions-debug/main.tsx";
+
+export default pattern<DebugInput>((_) => ({
+  [NAME]: "Agent sessions without command authorization",
+  [UI]: <cf-screen>Agent sessions</cf-screen>,
+}));

--- a/packages/agents-host/test/host_test.ts
+++ b/packages/agents-host/test/host_test.ts
@@ -20,6 +20,7 @@ import { join } from "@std/path";
 
 const TARGET_DESCRIPTION: AgentsHostTargetDescription = {
   spaceDid: "did:key:test-space",
+  ownerDid: "did:key:test-owner",
   debugPieceId: "debug-piece",
   cells: {
     recentIndex: "recent-cell",
@@ -493,6 +494,7 @@ Deno.test("AgentsHost records command receipt activity without prompt contents",
     await host.start();
     target.sendCommands([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-1",
       createdAt: "2026-07-20T00:05:00.000Z",
       sourceId: "codex",
@@ -536,6 +538,7 @@ Deno.test("AgentsHost drains admitted commands before stopping drivers", async (
     driver.promptGate = { entered, release };
     target.sendCommands([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-during-shutdown",
       createdAt: "2026-07-20T00:05:00.000Z",
       sourceId: "codex",
@@ -750,6 +753,7 @@ Deno.test("AgentsHost reports failed post-command session refreshes", async () =
     await host.start();
     target.sendCommands([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-with-stale-refresh",
       createdAt: "2026-07-20T00:05:00.000Z",
       sourceId: "codex",
@@ -798,6 +802,7 @@ Deno.test("AgentsHost flushes unpublished receipts before stopping", async () =>
     await host.start();
     target.sendCommands([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-with-publication-failure",
       createdAt: "2026-07-20T00:05:00.000Z",
       sourceId: "codex",
@@ -1077,6 +1082,7 @@ Deno.test("AgentsHost completes shutdown when subscription cancellation fails", 
     const receiptCount = target.receipts.length;
     target.sendCommands([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-after-stop",
       createdAt: "2026-07-20T00:06:00.000Z",
       sourceId: "codex",

--- a/packages/agents-host/test/process_lock_test.ts
+++ b/packages/agents-host/test/process_lock_test.ts
@@ -11,21 +11,31 @@ Deno.test("target process locks use the canonical API and resolved space", async
     const first = await defaultTargetProcessLockPath(
       "https://user:secret@FABRIC.example.test:443/",
       "did:key:space",
+      "did:key:owner",
       directory,
     );
     const equivalent = await defaultTargetProcessLockPath(
       "https://fabric.example.test/ignored-api-path",
       "did:key:space",
+      "did:key:owner",
       directory,
     );
     const differentSpace = await defaultTargetProcessLockPath(
       "https://fabric.example.test/",
       "did:key:other-space",
+      "did:key:owner",
+      directory,
+    );
+    const differentOwner = await defaultTargetProcessLockPath(
+      "https://fabric.example.test/",
+      "did:key:space",
+      "did:key:other-owner",
       directory,
     );
 
     assertEquals(first, equivalent);
     assertNotEquals(first, differentSpace);
+    assertNotEquals(first, differentOwner);
   } finally {
     await Deno.remove(directory, { recursive: true });
   }

--- a/packages/agents-host/test/target_state_test.ts
+++ b/packages/agents-host/test/target_state_test.ts
@@ -12,21 +12,31 @@ Deno.test("target ledger paths use the canonical API and resolved space", async 
     const first = await defaultTargetLedgerPath(
       "https://user:secret@FABRIC.example.test:443/",
       "did:key:space",
+      "did:key:owner",
       directory,
     );
     const equivalent = await defaultTargetLedgerPath(
       "https://fabric.example.test/ignored-api-path",
       "did:key:space",
+      "did:key:owner",
       directory,
     );
     const differentSpace = await defaultTargetLedgerPath(
       "https://fabric.example.test/",
       "did:key:other-space",
+      "did:key:owner",
+      directory,
+    );
+    const differentOwner = await defaultTargetLedgerPath(
+      "https://fabric.example.test/",
+      "did:key:space",
+      "did:key:other-owner",
       directory,
     );
 
     assertEquals(first, equivalent);
     assertNotEquals(first, differentSpace);
+    assertNotEquals(first, differentOwner);
   } finally {
     await Deno.remove(directory, { recursive: true });
   }

--- a/packages/connectors/agents/docs/architecture.md
+++ b/packages/connectors/agents/docs/architecture.md
@@ -24,14 +24,16 @@ flowchart LR
 
 The host owns process-level policy. It selects enabled sources, provides their
 configuration, creates drivers, and controls their lifecycle. It also creates
-the Common Fabric runtime and chooses the destination space DID.
+the Common Fabric runtime, chooses the destination space DID, and supplies the
+owner DID for the person whose local agents are being synchronized.
 
 The host decides when to run a full collection. It decides whether to subscribe
 to commands, poll commands, or do both. It also supplies health details and the
 location of the local command ledger.
 
 The connector never opens a Common Fabric connection by itself. It receives an
-initialized runtime through `AgentFabricConnection`.
+initialized runtime, destination space, and owner DID through
+`AgentFabricConnection`.
 
 ### Agent drivers
 
@@ -149,7 +151,8 @@ A host normally performs these steps:
 
 1. Build one `AgentSourceConfig` for every enabled source.
 2. Create each driver with `createAgentDriver()` and call `start()`.
-3. Open every `AgentFabricTarget` with an initialized runtime and space DID.
+3. Open every `AgentFabricTarget` with an initialized runtime, space DID, and
+   owner DID.
 4. Open `CommandLedger`, create `CommandWorker`, and call
    `recoverUnpublishedReceipts()`.
 5. Run `collectSource()` for each driver and publish all results together.

--- a/packages/connectors/agents/docs/interfaces.md
+++ b/packages/connectors/agents/docs/interfaces.md
@@ -127,18 +127,29 @@ hashes. The returned chunks contain those captured event values.
 
 ### Fabric connection and target
 
-`AgentFabricConnection` contains an initialized Common Fabric `Runtime` and one
-`MemorySpace` DID:
+`AgentFabricConnection` contains an initialized Common Fabric `Runtime`, one
+`MemorySpace` DID, and the DID of the person who owns the local agent data:
 
 ```ts
 interface AgentFabricConnection {
   runtime: Runtime;
   spaceDid: MemorySpace;
+  ownerDid: string;
 }
 ```
 
+The owner DID participates in every connector cause and stored protocol
+envelope. Every connector cell has a Common Fabric confidentiality label for
+that owner. Connector-managed writes also require the owner principal and the
+connector's trusted writer identity. The debug command queue instead requires
+the owner principal and the verified command-submission handler that created it.
+
 `AgentFabricTarget.open(connection)` creates and synchronizes the connector's
-top-level cells. It also waits for the runtime storage manager to finish its
+top-level cells. It atomically initializes empty index, health, and receipt
+roots with owner protection before reading from them. A populated root without
+that owner protection is rejected rather than adopted. The command queue is
+claimed later when the host can bind its verified command-submission handler.
+Opening a target also waits for the runtime storage manager to finish its
 initial synchronization.
 
 The target exposes these orchestration methods:
@@ -148,8 +159,9 @@ The target exposes these orchestration methods:
 | `beginSessionObservation()`               | Allocates the ordering value that a caller records before it begins a full provider collection.         |
 | `publish(collected, options?)`            | Publishes changed session graphs and replaces both indexes. Returns the number of non-deleted sessions. |
 | `publishHealth(value)`                    | Publishes a host-defined health record under the connector-owned health schema.                         |
-| `subscribeCommands(callback)`             | Subscribes to the command action array. Returns a Common Fabric cancellation function.                  |
-| `pollCommands()`                          | Pulls the current command action array.                                                                 |
+| `subscribeCommands(callback)`             | Subscribes after the exact queue has been bound to its owner and verified writer.                       |
+| `pollCommands()`                          | Pulls commands after the exact queue has been bound to its owner and verified writer.                   |
+| `bindCommandCell(cell, writer)`           | Verifies the exact owner-scoped command queue and applies its owner and verified-writer policy.         |
 | `publishReceipt(receipt)`                 | Publishes one durable receipt cell and updates the bounded receipt index.                               |
 | `readReceipt(commandId)`                  | Reads the deterministic individual receipt cell used as the shared command claim.                       |
 | `refreshSession(driver, nativeSessionId)` | Reads and publishes one session without changing untouched session statuses.                            |
@@ -428,24 +440,24 @@ with an ACP prefix.
 
 ### Top-level cell causes
 
-All top-level causes include the destination `spaceDid`. The remaining fields
-are fixed:
+All top-level causes include the destination `spaceDid` and `ownerDid`. The
+remaining fields are fixed:
 
-| Cell                   | Cause fields                                           |
-| ---------------------- | ------------------------------------------------------ |
-| Recent session index   | `agentConnector: "recent-session-index"`, `version: 1` |
-| Complete session index | `agentConnector: "all-session-index"`, `version: 1`    |
-| Health                 | `agentConnector: "health"`, `version: 1`               |
-| Commands               | `agentConnector: "commands"`, `version: 1`             |
-| Receipt index          | `agentConnector: "receipts"`, `version: 1`             |
+| Cell                   | Cause field                              |
+| ---------------------- | ---------------------------------------- |
+| Recent session index   | `agentConnector: "recent-session-index"` |
+| Complete session index | `agentConnector: "all-session-index"`    |
+| Health                 | `agentConnector: "health"`               |
+| Commands               | `agentConnector: "commands"`             |
+| Receipt index          | `agentConnector: "receipts"`             |
 
 Session, chunk, and individual receipt causes add their durable identities:
 
 ```json
 {
   "spaceDid": "did:key:...",
+  "ownerDid": "did:key:...",
   "agentConnector": "session",
-  "version": 1,
   "sourceId": "codex",
   "nativeSessionId": "session-id"
 }
@@ -459,19 +471,21 @@ Chunk causes use `agentConnector: "session-chunk"` and add `part` and
 
 `AGENT_CONNECTOR_SCHEMAS` exports every format discriminator:
 
-| Value              | Schema                                             |
-| ------------------ | -------------------------------------------------- |
-| Session manifest   | `commonfabric.agent-connector.session.v1`          |
-| Event chunk        | `commonfabric.agent-connector.session-chunk.v1`    |
-| Session index      | `commonfabric.agent-connector.session-index.v1`    |
-| Health             | `commonfabric.agent-connector.health.v1`           |
-| Command            | `commonfabric.agent-connector.command.v1`          |
-| Individual receipt | `commonfabric.agent-connector.command-receipt.v1`  |
-| Receipt index      | `commonfabric.agent-connector.command-receipts.v1` |
-| Local ledger       | `commonfabric.agent-connector.command-ledger.v2`   |
+| Value              | Schema                                          |
+| ------------------ | ----------------------------------------------- |
+| Session manifest   | `commonfabric.agent-connector.session`          |
+| Event chunk        | `commonfabric.agent-connector.session-chunk`    |
+| Session index      | `commonfabric.agent-connector.session-index`    |
+| Health             | `commonfabric.agent-connector.health`           |
+| Command            | `commonfabric.agent-connector.command`          |
+| Individual receipt | `commonfabric.agent-connector.command-receipt`  |
+| Receipt index      | `commonfabric.agent-connector.command-receipts` |
+| Local ledger       | `commonfabric.agent-connector.command-ledger`   |
 
-The connector recognizes only these current values. It does not read earlier
-names or publish compatibility aliases.
+The schema names and deterministic causes are not versioned. Future readers must
+remain compatible with stored values and cell identities. New fields must be
+optional because older writers omit fields they do not know. Readers permit
+additional fields while continuing to validate the fields they use.
 
 ### Session key
 
@@ -494,8 +508,8 @@ A chunk value has this form:
 
 ```json
 {
-  "schema": "commonfabric.agent-connector.session-chunk.v1",
-  "formatVersion": 1,
+  "schema": "commonfabric.agent-connector.session-chunk",
+  "ownerDid": "did:key:...",
   "key": "codex/session-id",
   "part": 0,
   "contentHash": "sha256:...",
@@ -517,7 +531,6 @@ does not change the chunk graph reachable from the retained manifest.
 
 A session manifest contains:
 
-- `formatVersion: 1`
 - `key`, `sourceId`, `driver`, and `nativeSessionId`
 - `metadata`, which repeats the provider-native summary object
 - `summary`, which contains normalized summary fields
@@ -548,11 +561,11 @@ the connector marks their synchronization status as `deleted`.
 
 Each index records generation time, monotonically increasing generation,
 non-deleted session count, older session count, source status rows, and session
-entries. A session entry includes `formatVersion: 1`, the producing `driver`,
-normalized metadata, nullable `archived` and `active` lifecycle fields, provider
-capabilities, up to 12 recent normalized message previews, a live manifest cell
-link, content hash, and synchronization status. The lifecycle fields describe
-provider state. Synchronization status describes the connector's published copy.
+entries. A session entry includes the producing `driver`, normalized metadata,
+nullable `archived` and `active` lifecycle fields, provider capabilities, up to
+12 recent normalized message previews, a live manifest cell link, content hash,
+and synchronization status. The lifecycle fields describe provider state.
+Synchronization status describes the connector's published copy.
 
 Each index also contains one shallow `checkouts` row per non-deleted worktree.
 The row records its root, current branch, current commit, selected repository
@@ -575,8 +588,8 @@ inventory.
 The manifest and chunk fields are stored as `FabricLink`s rather than copied
 objects. A consumer whose schema declares those fields as `Cell` values can read
 one session graph without hydrating every session represented by the index. The
-target rejects an index containing an entry without `formatVersion: 1`. It does
-not convert older entries or manifest link representations.
+target validates the fields it reads and permits additional fields so compatible
+protocol additions do not require a new format.
 
 TODO(@ianh): Add a shallow session directory containing each row link and its
 sortable title, update-time, and worktree keys. The current stable-cell layout
@@ -594,11 +607,10 @@ child cause is independent of the element's array position:
 ```json
 {
   "agentConnector": "array-element",
-  "version": 1,
   "scope": {
     "spaceDid": "did:key:...",
-    "agentConnector": "session-index-array-elements",
-    "version": 1
+    "ownerDid": "did:key:...",
+    "agentConnector": "session-index-array-elements"
   },
   "path": ["sessions"],
   "identity": { "field": "key", "value": "codex/session-id" }
@@ -616,8 +628,8 @@ The publisher assigns one base scope to each stored value:
 | Individual command receipt  | `command-receipt-array-elements`       | `commandId`                                          |
 | Receipt index               | `command-receipt-index-array-elements` | None                                                 |
 
-Every base scope also contains the destination `spaceDid` and `version: 1`.
-These fields and the additional identity participate in the child cell ID.
+Every base scope also contains the destination `spaceDid` and `ownerDid`. These
+fields and the additional identity participate in the child cell ID.
 
 A schema-aware Fabric consumer must declare every array item as
 `Cell<T> | undefined`, not as inline `T`. The `undefined` branch represents a
@@ -699,7 +711,7 @@ as complete cell values. Root values are plain objects.
 ordering also prevents a provider snapshot read earlier from overwriting a
 session refresh that finished sooner. The repository's command-line host takes a
 target process lock. Hosts on different machines need equivalent single-instance
-coordination for each API and space pair.
+coordination for each API, space, and owner.
 
 `pushStableCellGraph()` reports transaction commit errors and does not retry.
 The callback must finish synchronously and return a plain record. Causes and
@@ -723,7 +735,8 @@ preserved-field set, so callers can safely reuse a cache across different read
 policies.
 
 `subscribeStableActions()` treats a non-array cell value as an empty action
-list. `readStableActions()` has the same convention for polling.
+list. `readStableActions()` has the same convention for polling and fully
+hydrates linked action values.
 
 ## Command and receipt formats
 
@@ -734,7 +747,8 @@ JSON string containing one command object.
 
 ```ts
 interface AgentSessionCommand {
-  schema: "commonfabric.agent-connector.command.v1";
+  schema: "commonfabric.agent-connector.command";
+  ownerDid: string;
   id: string;
   createdAt: string;
   sourceId: string;
@@ -764,8 +778,15 @@ Payloads are:
 their behavior based on it. `requestedBy` is retained on the parsed command but
 is not copied to receipts.
 
+The worker rejects a command whose `ownerDid` differs from its configured owner.
 Invalid values are logged and skipped. A command ID already present in the
 ledger or already scheduled in the process is skipped.
+
+Before command processing starts, the host binds the compiled debug handler to
+the deterministic owner-scoped command cell. Binding rejects another cell and
+rejects a populated queue that does not already carry the configured owner's
+confidentiality and integrity labels. The debug pattern receives that protected
+cell as an input; the host never selects a queue from pattern output.
 
 ### Receipt
 
@@ -813,11 +834,11 @@ rewritten index.
 
 ```json
 {
-  "schema": "commonfabric.agent-connector.command-ledger.v2",
+  "schema": "commonfabric.agent-connector.command-ledger",
   "generation": 12,
   "receipts": {
     "command-id": {
-      "schema": "commonfabric.agent-connector.command-receipt.v1",
+      "schema": "commonfabric.agent-connector.command-receipt",
       "commandId": "command-id",
       "sourceId": "codex",
       "nativeSessionId": "session-id",

--- a/packages/connectors/agents/src/array-cell-identity.ts
+++ b/packages/connectors/agents/src/array-cell-identity.ts
@@ -23,7 +23,6 @@ export type StableArrayCellPlan =
 
 export interface StableArrayElementCause {
   agentConnector: "array-element";
-  version: 1;
   scope: unknown;
   path: string[];
   identity: Record<string, unknown>;
@@ -205,7 +204,6 @@ function planArray(
     duplicateCounts.set(duplicateKey, duplicate + 1);
     const cause: StableArrayElementCause = {
       agentConnector: "array-element",
-      version: 1,
       scope,
       path: [...path],
       identity: candidate.identity,
@@ -265,7 +263,6 @@ export function planStableArrayCells(
 
 const HASH_SCOPE = {
   agentConnector: "stable-array-value-hash",
-  version: 1,
 } as const;
 
 interface StoredCellFingerprint {
@@ -315,7 +312,6 @@ function calculateStableArrayValueHash(plan: StableArrayCellPlan): string {
     left.valueHash.localeCompare(right.valueHash)
   );
   return hashFabricValue({
-    formatVersion: 1,
     rootHash,
     cells,
   });

--- a/packages/connectors/agents/src/commands.ts
+++ b/packages/connectors/agents/src/commands.ts
@@ -19,6 +19,7 @@ export type CommandType =
 
 export interface AgentSessionCommand {
   schema: typeof AGENT_CONNECTOR_SCHEMAS.command;
+  ownerDid: string;
   id: string;
   createdAt: string;
   sourceId: string;
@@ -31,6 +32,7 @@ export interface AgentSessionCommand {
 
 export interface AgentSessionCommandReceipt {
   schema: typeof AGENT_CONNECTOR_SCHEMAS.commandReceipt;
+  ownerDid: string;
   commandId: string;
   sourceId: string;
   nativeSessionId: string;
@@ -132,6 +134,9 @@ export function parseCommandReceipt(
       `${context} schema must be ${AGENT_CONNECTOR_SCHEMAS.commandReceipt}: ${commandId}`,
     );
   }
+  if (!isNonEmptyString(value.ownerDid)) {
+    throw new Error(`${context} ownerDid must be a string: ${commandId}`);
+  }
   if (value.commandId !== commandId) {
     throw new Error(`${context} key does not match commandId: ${commandId}`);
   }
@@ -194,6 +199,7 @@ export function parseCommandReceipt(
   }
   return {
     schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+    ownerDid: value.ownerDid,
     commandId,
     sourceId: value.sourceId,
     nativeSessionId: value.nativeSessionId,
@@ -224,7 +230,7 @@ function requiredString(
   return value.trim();
 }
 
-function parseCommand(value: unknown): AgentSessionCommand {
+function parseCommand(value: unknown, ownerDid: string): AgentSessionCommand {
   if (typeof value === "string") {
     let decoded: unknown;
     try {
@@ -232,7 +238,7 @@ function parseCommand(value: unknown): AgentSessionCommand {
     } catch (error) {
       throw new Error(`command JSON is invalid: ${error}`);
     }
-    return parseCommand(decoded);
+    return parseCommand(decoded, ownerDid);
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("command must be an object");
@@ -240,6 +246,9 @@ function parseCommand(value: unknown): AgentSessionCommand {
   const raw = value as Record<string, unknown>;
   if (raw.schema !== AGENT_CONNECTOR_SCHEMAS.command) {
     throw new Error("unsupported command schema");
+  }
+  if (raw.ownerDid !== ownerDid) {
+    throw new Error("command owner does not match this connector");
   }
   const type = raw.type;
   if (
@@ -265,6 +274,7 @@ function parseCommand(value: unknown): AgentSessionCommand {
   sessionKey(sourceId, nativeSessionId);
   return {
     schema: AGENT_CONNECTOR_SCHEMAS.command,
+    ownerDid,
     id,
     createdAt: requiredString(raw.createdAt, "createdAt", 128),
     sourceId,
@@ -285,6 +295,7 @@ function receiptFromResult(
 ): AgentSessionCommandReceipt {
   return {
     schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+    ownerDid: command.ownerDid,
     commandId: command.id,
     sourceId: command.sourceId,
     nativeSessionId: command.nativeSessionId,
@@ -301,6 +312,7 @@ export class CommandWorker {
   readonly #drivers: Map<string, AgentDriver>;
   readonly #targets: CommandTarget[];
   readonly #ledger: CommandLedger;
+  readonly #ownerDid: string;
   readonly #onReceipt?: (
     receipt: AgentSessionCommandReceipt,
   ) => Promise<void> | void;
@@ -316,6 +328,7 @@ export class CommandWorker {
     drivers: Map<string, AgentDriver>,
     targets: CommandTarget[],
     ledger: CommandLedger,
+    ownerDid: string,
     onReceipt?: (
       receipt: AgentSessionCommandReceipt,
     ) => Promise<void> | void,
@@ -324,6 +337,7 @@ export class CommandWorker {
     this.#drivers = drivers;
     this.#targets = targets;
     this.#ledger = ledger;
+    this.#ownerDid = ownerDid;
     this.#onReceipt = onReceipt;
     this.#onTaskFailure = onTaskFailure;
   }
@@ -355,7 +369,7 @@ export class CommandWorker {
     for (const value of values) {
       let command: AgentSessionCommand;
       try {
-        command = parseCommand(value);
+        command = parseCommand(value, this.#ownerDid);
       } catch (error) {
         console.error(`[agents-connector] invalid command: ${error}`);
         continue;
@@ -369,7 +383,8 @@ export class CommandWorker {
         if (existing) {
           if (
             existing.sourceId !== command.sourceId ||
-            existing.nativeSessionId !== command.nativeSessionId
+            existing.nativeSessionId !== command.nativeSessionId ||
+            existing.ownerDid !== command.ownerDid
           ) {
             throw new Error(
               `command ID belongs to another session: ${command.id}`,
@@ -510,6 +525,7 @@ export class CommandWorker {
     const claimedAt = new Date().toISOString();
     const inFlight: AgentSessionCommandReceipt = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: command.ownerDid,
       commandId: command.id,
       sourceId: command.sourceId,
       nativeSessionId: command.nativeSessionId,

--- a/packages/connectors/agents/src/fabric-graph.ts
+++ b/packages/connectors/agents/src/fabric-graph.ts
@@ -2,14 +2,103 @@ import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import {
   type Cancel,
   type Cell,
+  cfcAtom,
+  type JSONSchema,
   type MemorySpace,
   type Runtime,
 } from "@commonfabric/runner";
+import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
 import { stableFabricValue } from "./stable-fabric-value.ts";
 
 export interface AgentFabricConnection {
   runtime: Runtime;
   spaceDid: MemorySpace;
+  ownerDid: string;
+}
+
+export const AGENT_CONNECTOR_WRITER_ID = "commonfabric.agents-connector";
+
+export function cellHasOwnerConfidentiality(
+  tx: Parameters<typeof readStoredCfcMetadata>[0],
+  cell: Cell<unknown>,
+  ownerDid: string,
+): boolean {
+  const ownerAtom = cfcAtom.user(ownerDid);
+  return readStoredCfcMetadata(
+    tx,
+    cell.getAsNormalizedFullLink(),
+  )?.labelMap.entries.some((entry) =>
+    entry.label.confidentiality?.some((clause) =>
+      typeof clause === "object" && clause !== null &&
+      !Array.isArray(clause) && "type" in clause &&
+      clause.type === ownerAtom.type && "subject" in clause &&
+      clause.subject === ownerDid
+    )
+  ) ?? false;
+}
+
+export function cellHasOwnerProtection(
+  tx: Parameters<typeof readStoredCfcMetadata>[0],
+  cell: Cell<unknown>,
+  ownerDid: string,
+): boolean {
+  const metadata = readStoredCfcMetadata(
+    tx,
+    cell.getAsNormalizedFullLink(),
+  );
+  const ownerAtom = cfcAtom.user(ownerDid);
+  return metadata?.labelMap.entries.some((entry) =>
+    entry.path.length === 0 &&
+    entry.label.confidentiality?.some((clause) =>
+        typeof clause === "object" && clause !== null &&
+        !Array.isArray(clause) && "type" in clause &&
+        clause.type === ownerAtom.type && "subject" in clause &&
+        clause.subject === ownerDid
+      ) === true &&
+    entry.label.integrity?.some((atom) =>
+        typeof atom === "object" && atom !== null &&
+        "kind" in atom && atom.kind === "represents-principal" &&
+        "subject" in atom && atom.subject === ownerDid
+      ) === true
+  ) ?? false;
+}
+
+export function agentPrincipalSchema(
+  ownerDid: string,
+  writerAuthorization: unknown,
+): JSONSchema {
+  return {
+    ifc: {
+      confidentiality: [cfcAtom.user(ownerDid)],
+      ownerPrincipal: ownerDid,
+      addIntegrity: [{
+        kind: "represents-principal",
+        subject: ownerDid,
+      }],
+      writeAuthorizedBy: writerAuthorization,
+    },
+  } as JSONSchema;
+}
+
+export function agentOwnerSchema(
+  ownerDid: string,
+  connectorWritable = true,
+): JSONSchema {
+  return {
+    ifc: {
+      confidentiality: [cfcAtom.user(ownerDid)],
+      ...(connectorWritable
+        ? {
+          ownerPrincipal: ownerDid,
+          addIntegrity: [{
+            kind: "represents-principal",
+            subject: ownerDid,
+          }],
+          writeAuthorizedBy: [AGENT_CONNECTOR_WRITER_ID],
+        }
+        : {}),
+    },
+  };
 }
 
 export type StableCellMaterializer = (
@@ -55,16 +144,22 @@ export async function pushStableCellGraph(
 ): Promise<void> {
   if (entries.length === 0) return;
   const tx = connection.runtime.edit();
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: AGENT_CONNECTOR_WRITER_ID,
+  });
   try {
     const writeCellValue = (cell: Cell<unknown>, value: unknown) => {
       const link = cell.getAsNormalizedFullLink();
       if (!isPlainRecord(value)) {
         tx.writeValueOrThrow(link, stableFabricValue(value));
+        cell.withTx(tx).applyCfcSchemaToExistingValue();
         return cell;
       }
       const priorValue = tx.readValueOrThrow(link);
       if (!isPlainRecord(priorValue)) {
         tx.writeValueOrThrow(link, stableFabricValue(value));
+        cell.withTx(tx).applyCfcSchemaToExistingValue();
         return cell;
       }
       for (const key of Object.keys(priorValue)) {
@@ -92,6 +187,7 @@ export async function pushStableCellGraph(
           stableFabricValue(fieldValue),
         );
       }
+      cell.withTx(tx).applyCfcSchemaToExistingValue();
       return cell;
     };
     const materializeCell: StableCellMaterializer = (cause, value) =>
@@ -99,7 +195,7 @@ export async function pushStableCellGraph(
         connection.runtime.getCell(
           connection.spaceDid,
           cause,
-          undefined,
+          agentOwnerSchema(connection.ownerDid),
           tx,
         ),
         value,
@@ -111,6 +207,7 @@ export async function pushStableCellGraph(
     tx.abort(error);
     throw error;
   }
+  tx.prepareCfc();
   const result = await tx.commit();
   if (result.error) {
     throw new Error(commitErrorMessage(result.error), { cause: result.error });
@@ -231,8 +328,9 @@ export async function subscribeStableActions(
 }
 
 export async function readStableActions(
+  connection: AgentFabricConnection,
   cell: Cell<unknown>,
 ): Promise<unknown[]> {
-  const value = await cell.pull();
+  const value = await readStableCellGraphValue(connection, cell);
   return Array.isArray(value) ? [...value] : [];
 }

--- a/packages/connectors/agents/src/fabric-graph.ts
+++ b/packages/connectors/agents/src/fabric-graph.ts
@@ -143,24 +143,82 @@ export async function pushStableCellGraph(
   entries: ReadonlyArray<StableCellGraphEntry>,
 ): Promise<void> {
   if (entries.length === 0) return;
+  const writes: Array<{ cell: Cell<unknown>; value: unknown }> = [];
+  const materializeCell: StableCellMaterializer = (cause, value) => {
+    const cell = connection.runtime.getCell(
+      connection.spaceDid,
+      cause,
+      agentOwnerSchema(connection.ownerDid),
+    );
+    writes.push({ cell, value });
+    return cell;
+  };
+  for (const entry of entries) {
+    writes.push({ cell: entry.cell, value: entry.value(materializeCell) });
+  }
+  const cellsToSync = new Map<string, Cell<unknown>>();
+  for (const { cell } of writes) {
+    const link = cell.getAsNormalizedFullLink();
+    const key = JSON.stringify({
+      space: link.space,
+      scope: link.scope,
+      id: link.id,
+      path: link.path,
+    });
+    cellsToSync.set(key, cell);
+  }
+  const uniqueCells = [...cellsToSync.values()];
+  for (
+    let offset = 0;
+    offset < uniqueCells.length;
+    offset += HYDRATION_BATCH_SIZE
+  ) {
+    await Promise.all(
+      uniqueCells.slice(offset, offset + HYDRATION_BATCH_SIZE).map((cell) =>
+        cell.sync()
+      ),
+    );
+  }
+  await connection.runtime.storageManager.synced();
+
   const tx = connection.runtime.edit();
   tx.setCfcImplementationIdentity({
     kind: "builtin",
     builtinId: AGENT_CONNECTOR_WRITER_ID,
   });
+  const writtenCells = new Set<string>();
   try {
     const writeCellValue = (cell: Cell<unknown>, value: unknown) => {
       const link = cell.getAsNormalizedFullLink();
+      const priorValue = tx.readValueOrThrow(link);
+      const cellKey = JSON.stringify({
+        space: link.space,
+        scope: link.scope,
+        id: link.id,
+        path: link.path,
+      });
+      if (
+        priorValue !== undefined &&
+        !writtenCells.has(cellKey) &&
+        !cellHasOwnerProtection(tx, cell, connection.ownerDid)
+      ) {
+        throw new Error(
+          `refusing to adopt an unprotected stable graph cell for ${connection.ownerDid}`,
+        );
+      }
+      writtenCells.add(cellKey);
+      const protectedCell = cell.withTx(tx).asSchema(
+        agentOwnerSchema(connection.ownerDid),
+      );
       if (!isPlainRecord(value)) {
         tx.writeValueOrThrow(link, stableFabricValue(value));
-        cell.withTx(tx).applyCfcSchemaToExistingValue();
-        return cell;
+        protectedCell.applyCfcSchemaToExistingValue();
+        return protectedCell;
       }
-      const priorValue = tx.readValueOrThrow(link);
       if (!isPlainRecord(priorValue)) {
         tx.writeValueOrThrow(link, stableFabricValue(value));
-        cell.withTx(tx).applyCfcSchemaToExistingValue();
-        return cell;
+        protectedCell.applyCfcSchemaToExistingValue();
+        return protectedCell;
       }
       for (const key of Object.keys(priorValue)) {
         if (!Object.hasOwn(value, key)) {
@@ -187,21 +245,11 @@ export async function pushStableCellGraph(
           stableFabricValue(fieldValue),
         );
       }
-      cell.withTx(tx).applyCfcSchemaToExistingValue();
-      return cell;
+      protectedCell.applyCfcSchemaToExistingValue();
+      return protectedCell;
     };
-    const materializeCell: StableCellMaterializer = (cause, value) =>
-      writeCellValue(
-        connection.runtime.getCell(
-          connection.spaceDid,
-          cause,
-          agentOwnerSchema(connection.ownerDid),
-          tx,
-        ),
-        value,
-      );
-    for (const entry of entries) {
-      writeCellValue(entry.cell, entry.value(materializeCell));
+    for (const write of writes) {
+      writeCellValue(write.cell, write.value);
     }
   } catch (error) {
     tx.abort(error);

--- a/packages/connectors/agents/src/fabric-graph.ts
+++ b/packages/connectors/agents/src/fabric-graph.ts
@@ -8,6 +8,7 @@ import {
   type Runtime,
 } from "@commonfabric/runner";
 import { readStoredCfcMetadata } from "@commonfabric/runner/cfc";
+import { addressKey } from "@commonfabric/runner/shared";
 import { stableFabricValue } from "./stable-fabric-value.ts";
 
 export interface AgentFabricConnection {
@@ -160,12 +161,7 @@ export async function pushStableCellGraph(
   const protectedCells = new Map<string, Cell<unknown>>();
   const protectedWrites = writes.map(({ cell, value }) => {
     const link = cell.getAsNormalizedFullLink();
-    const key = JSON.stringify({
-      space: link.space,
-      scope: link.scope,
-      id: link.id,
-      path: link.path,
-    });
+    const key = addressKey(link);
     let protectedCell = protectedCells.get(key);
     if (protectedCell === undefined) {
       protectedCell = cell.asSchema(ownerSchema);
@@ -196,12 +192,7 @@ export async function pushStableCellGraph(
     const writeCellValue = (cell: Cell<unknown>, value: unknown) => {
       const link = cell.getAsNormalizedFullLink();
       const priorValue = tx.readValueOrThrow(link);
-      const cellKey = JSON.stringify({
-        space: link.space,
-        scope: link.scope,
-        id: link.id,
-        path: link.path,
-      });
+      const cellKey = addressKey(link);
       if (
         priorValue !== undefined &&
         !writtenCells.has(cellKey) &&

--- a/packages/connectors/agents/src/fabric-graph.ts
+++ b/packages/connectors/agents/src/fabric-graph.ts
@@ -156,8 +156,9 @@ export async function pushStableCellGraph(
   for (const entry of entries) {
     writes.push({ cell: entry.cell, value: entry.value(materializeCell) });
   }
-  const cellsToSync = new Map<string, Cell<unknown>>();
-  for (const { cell } of writes) {
+  const ownerSchema = agentOwnerSchema(connection.ownerDid);
+  const protectedCells = new Map<string, Cell<unknown>>();
+  const protectedWrites = writes.map(({ cell, value }) => {
     const link = cell.getAsNormalizedFullLink();
     const key = JSON.stringify({
       space: link.space,
@@ -165,9 +166,14 @@ export async function pushStableCellGraph(
       id: link.id,
       path: link.path,
     });
-    cellsToSync.set(key, cell);
-  }
-  const uniqueCells = [...cellsToSync.values()];
+    let protectedCell = protectedCells.get(key);
+    if (protectedCell === undefined) {
+      protectedCell = cell.asSchema(ownerSchema);
+      protectedCells.set(key, protectedCell);
+    }
+    return { cell: protectedCell, value };
+  });
+  const uniqueCells = [...protectedCells.values()];
   for (
     let offset = 0;
     offset < uniqueCells.length;
@@ -179,7 +185,6 @@ export async function pushStableCellGraph(
       ),
     );
   }
-  await connection.runtime.storageManager.synced();
 
   const tx = connection.runtime.edit();
   tx.setCfcImplementationIdentity({
@@ -207,17 +212,13 @@ export async function pushStableCellGraph(
         );
       }
       writtenCells.add(cellKey);
-      const protectedCell = cell.withTx(tx).asSchema(
-        agentOwnerSchema(connection.ownerDid),
-      );
+      const protectedCell = cell.withTx(tx);
       if (!isPlainRecord(value)) {
-        tx.writeValueOrThrow(link, stableFabricValue(value));
-        protectedCell.applyCfcSchemaToExistingValue();
+        protectedCell.setRawUntyped(stableFabricValue(value));
         return protectedCell;
       }
       if (!isPlainRecord(priorValue)) {
-        tx.writeValueOrThrow(link, stableFabricValue(value));
-        protectedCell.applyCfcSchemaToExistingValue();
+        protectedCell.setRawUntyped(stableFabricValue(value));
         return protectedCell;
       }
       for (const key of Object.keys(priorValue)) {
@@ -248,7 +249,7 @@ export async function pushStableCellGraph(
       protectedCell.applyCfcSchemaToExistingValue();
       return protectedCell;
     };
-    for (const write of writes) {
+    for (const write of protectedWrites) {
       writeCellValue(write.cell, write.value);
     }
   } catch (error) {

--- a/packages/connectors/agents/src/fabric.ts
+++ b/packages/connectors/agents/src/fabric.ts
@@ -44,7 +44,8 @@ import {
   type StableArrayCellPlan,
 } from "./array-cell-identity.ts";
 import { AsyncSerialQueue } from "./serial-queue.ts";
-import { isAbsolute } from "@std/path";
+import { isAbsolute as isPosixAbsolute } from "@std/path/posix";
+import { isAbsolute as isWindowsAbsolute } from "@std/path/windows";
 
 export interface AgentFabricCells {
   index: Cell<unknown>;
@@ -578,7 +579,8 @@ function asIndex(
   for (const [index, checkout] of (record.checkouts ?? []).entries()) {
     if (
       !isRecord(checkout) || typeof checkout.root !== "string" ||
-      !isAbsolute(checkout.root) || checkoutRoots.has(checkout.root) ||
+      !(isPosixAbsolute(checkout.root) || isWindowsAbsolute(checkout.root)) ||
+      checkoutRoots.has(checkout.root) ||
       !isNullableString(checkout.gitRepo) ||
       !isNullableString(checkout.gitBranch) ||
       !isNullableString(checkout.gitHeadSha) ||
@@ -796,15 +798,18 @@ export class AgentFabricTarget implements CommandTarget {
   readonly #latestDescriptorObservationBySource = new Map<string, number>();
   #nextObservationSequence = 1;
   #commandCellBound = false;
+  #storageClaimed: boolean;
 
   private constructor(
     conn: AgentFabricConnection,
     cells: AgentFabricCells,
     gitContext: GitContextResolver,
+    storageClaimed: boolean,
   ) {
     this.conn = conn;
     this.cells = cells;
     this.#gitContext = gitContext;
+    this.#storageClaimed = storageClaimed;
   }
 
   static async open(
@@ -812,7 +817,7 @@ export class AgentFabricTarget implements CommandTarget {
     gitContext = new GitContextResolver(),
   ): Promise<AgentFabricTarget> {
     const cells = await ensureAgentFabricCells(conn);
-    return new AgentFabricTarget(conn, cells, gitContext);
+    return new AgentFabricTarget(conn, cells, gitContext, true);
   }
 
   static async connect(
@@ -820,34 +825,42 @@ export class AgentFabricTarget implements CommandTarget {
     gitContext = new GitContextResolver(),
   ): Promise<AgentFabricTarget> {
     const cells = await syncAgentFabricCells(conn);
-    return new AgentFabricTarget(conn, cells, gitContext);
+    return new AgentFabricTarget(conn, cells, gitContext, false);
   }
 
   claimStorage(): Promise<void> {
-    return this.#mutations.run(() =>
-      claimAgentFabricRoots(this.conn, this.cells)
-    );
+    return this.#mutations.run(async () => {
+      if (this.#storageClaimed) return;
+      await claimAgentFabricRoots(this.conn, this.cells);
+      this.#storageClaimed = true;
+    });
   }
 
-  publish(
+  #assertStorageClaimed(): void {
+    if (!this.#storageClaimed) {
+      throw new Error("agent connector storage has not been claimed");
+    }
+  }
+
+  async publish(
     collected: CollectedSource[],
     options: AgentFabricPublishOptions = {},
   ): Promise<number> {
+    this.#assertStorageClaimed();
     const observationSequence = options.observationSequence ??
       this.beginSessionObservation();
     if (
       !Number.isSafeInteger(observationSequence) || observationSequence < 1
     ) {
-      return Promise.reject(
-        new Error("observationSequence must be a positive safe integer"),
-      );
+      throw new Error("observationSequence must be a positive safe integer");
     }
-    return this.#mutations.run(() =>
+    return await this.#mutations.run(() =>
       this.#publish(collected, { ...options, observationSequence })
     );
   }
 
   beginSessionObservation(): number {
+    this.#assertStorageClaimed();
     const sequence = this.#nextObservationSequence;
     if (!Number.isSafeInteger(sequence)) {
       throw new Error("session observation sequence is exhausted");
@@ -860,6 +873,7 @@ export class AgentFabricTarget implements CommandTarget {
     directory: string,
     signal?: AbortSignal,
   ): Promise<boolean> {
+    this.#assertStorageClaimed();
     return await this.#gitContext.validateCheckout(directory, signal);
   }
 
@@ -1226,8 +1240,9 @@ export class AgentFabricTarget implements CommandTarget {
     return activeSessions.length;
   }
 
-  publishHealth(value: Record<string, unknown>): Promise<void> {
-    return this.#mutations.run(() => this.#publishHealth(value));
+  async publishHealth(value: Record<string, unknown>): Promise<void> {
+    this.#assertStorageClaimed();
+    return await this.#mutations.run(() => this.#publishHealth(value));
   }
 
   async #publishHealth(value: Record<string, unknown>): Promise<void> {
@@ -1247,10 +1262,12 @@ export class AgentFabricTarget implements CommandTarget {
   }
 
   commandCellId(): string {
+    this.#assertStorageClaimed();
     return stableCellId(this.cells.commands.resolveAsCell());
   }
 
   receiptCellId(): string {
+    this.#assertStorageClaimed();
     return stableCellId(this.cells.receipts);
   }
 
@@ -1258,6 +1275,7 @@ export class AgentFabricTarget implements CommandTarget {
     cell: Cell<unknown>,
     writerAuthorization: unknown,
   ): Promise<void> {
+    this.#assertStorageClaimed();
     const suppliedLink = cell.getAsNormalizedFullLink();
     const expectedLink = this.cells.commands.getAsNormalizedFullLink();
     if (
@@ -1326,6 +1344,7 @@ export class AgentFabricTarget implements CommandTarget {
   }
 
   commandsAreBound(): boolean {
+    this.#assertStorageClaimed();
     return this.#commandCellBound;
   }
 
@@ -1338,6 +1357,7 @@ export class AgentFabricTarget implements CommandTarget {
   async readReceipt(
     commandId: string,
   ): Promise<AgentSessionCommandReceipt | undefined> {
+    this.#assertStorageClaimed();
     const cell = this.conn.runtime.getCell(
       this.conn.spaceDid,
       commandReceiptCause(this.conn.spaceDid, this.conn.ownerDid, commandId),
@@ -1394,6 +1414,7 @@ export class AgentFabricTarget implements CommandTarget {
   async subscribeCommands(
     callback: (commands: unknown[]) => void,
   ): Promise<Cancel> {
+    this.#assertStorageClaimed();
     this.#assertCommandCellBound();
     return await subscribeStableActions(
       this.conn,
@@ -1403,14 +1424,16 @@ export class AgentFabricTarget implements CommandTarget {
   }
 
   async pollCommands(): Promise<unknown[]> {
+    this.#assertStorageClaimed();
     this.#assertCommandCellBound();
     return await readStableActions(this.conn, this.cells.commands);
   }
 
-  publishReceipt(
+  async publishReceipt(
     receipt: AgentSessionCommandReceipt,
   ): Promise<void> {
-    return this.#mutations.run(() => {
+    this.#assertStorageClaimed();
+    return await this.#mutations.run(() => {
       const parsed = parseCommandReceipt(receipt.commandId, receipt);
       if (parsed.ownerDid !== this.conn.ownerDid) {
         throw new Error(
@@ -1424,6 +1447,7 @@ export class AgentFabricTarget implements CommandTarget {
   async #publishReceipt(
     receipt: AgentSessionCommandReceipt,
   ): Promise<void> {
+    this.#assertStorageClaimed();
     const cell = this.conn.runtime.getCell(
       this.conn.spaceDid,
       commandReceiptCause(

--- a/packages/connectors/agents/src/fabric.ts
+++ b/packages/connectors/agents/src/fabric.ts
@@ -44,6 +44,7 @@ import {
   type StableArrayCellPlan,
 } from "./array-cell-identity.ts";
 import { AsyncSerialQueue } from "./serial-queue.ts";
+import { isAbsolute } from "@std/path";
 
 export interface AgentFabricCells {
   index: Cell<unknown>;
@@ -424,6 +425,14 @@ export function createAgentFabricCells(
 export async function ensureAgentFabricCells(
   conn: AgentFabricConnection,
 ): Promise<AgentFabricCells> {
+  const cells = await syncAgentFabricCells(conn);
+  await claimAgentFabricRoots(conn, cells);
+  return cells;
+}
+
+async function syncAgentFabricCells(
+  conn: AgentFabricConnection,
+): Promise<AgentFabricCells> {
   const cells = createAgentFabricCells(conn);
   await Promise.all([
     cells.index.sync(),
@@ -433,7 +442,6 @@ export async function ensureAgentFabricCells(
     cells.receipts.sync(),
   ]);
   await conn.runtime.storageManager.synced();
-  await claimAgentFabricRoots(conn, cells);
   return cells;
 }
 
@@ -547,6 +555,7 @@ function asIndex(
     (record.olderSessionCount !== undefined &&
       !isNonNegativeSafeInteger(record.olderSessionCount)) ||
     !Array.isArray(record.sources) ||
+    (record.checkouts !== undefined && !Array.isArray(record.checkouts)) ||
     !Array.isArray(record.sessions)
   ) {
     throw new Error("agent session index has an invalid shape");
@@ -564,6 +573,28 @@ function asIndex(
       );
     }
     sourceIds.add(source.id);
+  }
+  const checkoutRoots = new Set<string>();
+  for (const [index, checkout] of (record.checkouts ?? []).entries()) {
+    if (
+      !isRecord(checkout) || typeof checkout.root !== "string" ||
+      !isAbsolute(checkout.root) || checkoutRoots.has(checkout.root) ||
+      !isNullableString(checkout.gitRepo) ||
+      !isNullableString(checkout.gitBranch) ||
+      !isNullableString(checkout.gitHeadSha) ||
+      !Array.isArray(checkout.gitRemotes) ||
+      !checkout.gitRemotes.every((remote) =>
+        isRecord(remote) && typeof remote.name === "string" &&
+        remote.name.length > 0 && Array.isArray(remote.urls) &&
+        remote.urls.every((url) => typeof url === "string" && url.length > 0)
+      ) ||
+      !isIsoTimestamp(checkout.observedAt)
+    ) {
+      throw new Error(
+        `agent session index checkout ${index} has an invalid shape`,
+      );
+    }
+    checkoutRoots.add(checkout.root);
   }
   const sessionKeys = new Set<string>();
   const statuses = new Set(["complete", "partial", "stale", "deleted"]);
@@ -782,6 +813,20 @@ export class AgentFabricTarget implements CommandTarget {
   ): Promise<AgentFabricTarget> {
     const cells = await ensureAgentFabricCells(conn);
     return new AgentFabricTarget(conn, cells, gitContext);
+  }
+
+  static async connect(
+    conn: AgentFabricConnection,
+    gitContext = new GitContextResolver(),
+  ): Promise<AgentFabricTarget> {
+    const cells = await syncAgentFabricCells(conn);
+    return new AgentFabricTarget(conn, cells, gitContext);
+  }
+
+  claimStorage(): Promise<void> {
+    return this.#mutations.run(() =>
+      claimAgentFabricRoots(this.conn, this.cells)
+    );
   }
 
   publish(

--- a/packages/connectors/agents/src/fabric.ts
+++ b/packages/connectors/agents/src/fabric.ts
@@ -1,6 +1,10 @@
 import type { Cancel, Cell } from "@commonfabric/runner";
 import {
+  AGENT_CONNECTOR_WRITER_ID,
   type AgentFabricConnection,
+  agentOwnerSchema,
+  agentPrincipalSchema,
+  cellHasOwnerProtection,
   pushStableCellGraph,
   readStableActions,
   readStableCellGraphValue,
@@ -8,8 +12,11 @@ import {
   stableCellId,
   subscribeStableActions,
 } from "./fabric-graph.ts";
+import { stableFabricValue } from "./stable-fabric-value.ts";
 import {
   commandReceiptCause,
+  normalizeNativeSessionId,
+  normalizeSourceId,
   sessionCause,
   sessionChunkCause,
   sessionKey,
@@ -61,7 +68,7 @@ interface CellLink {
 }
 
 interface IndexEntry {
-  formatVersion: 1;
+  ownerDid: string;
   key: string;
   sourceId: string;
   driver: string;
@@ -96,7 +103,8 @@ export function recentSessionMessages(
 
 interface AgentSessionIndex {
   schema: typeof AGENT_CONNECTOR_SCHEMAS.sessionIndex;
-  bucket?: "recent" | "all";
+  ownerDid: string;
+  bucket: "recent" | "all";
   generatedAt: string;
   generation: number;
   totalSessionCount?: number;
@@ -192,17 +200,21 @@ function storedCheckoutObservations(
   );
 }
 
-export function agentFabricCauses(spaceDid: string) {
+export function agentFabricCauses(spaceDid: string, ownerDid: string) {
   return {
-    index: { spaceDid, agentConnector: "recent-session-index", version: 1 },
+    index: {
+      spaceDid,
+      ownerDid,
+      agentConnector: "recent-session-index",
+    },
     allIndex: {
       spaceDid,
+      ownerDid,
       agentConnector: "all-session-index",
-      version: 1,
     },
-    health: { spaceDid, agentConnector: "health", version: 1 },
-    commands: { spaceDid, agentConnector: "commands", version: 1 },
-    receipts: { spaceDid, agentConnector: "receipts", version: 1 },
+    health: { spaceDid, ownerDid, agentConnector: "health" },
+    commands: { spaceDid, ownerDid, agentConnector: "commands" },
+    receipts: { spaceDid, ownerDid, agentConnector: "receipts" },
   } as const;
 }
 
@@ -250,6 +262,18 @@ function isIsoTimestamp(value: unknown): value is string {
   return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
 }
 
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isNullableBoolean(value: unknown): value is boolean | null {
+  return value === null || typeof value === "boolean";
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
 function equalCellLink(value: unknown, expected: CellLink): boolean {
   if (!isRecord(value)) return false;
   if (
@@ -279,13 +303,14 @@ function graphEntry(cell: Cell<unknown>, plan: StableArrayCellPlan) {
 
 function childScope(
   spaceDid: string,
+  ownerDid: string,
   owner: string,
   identity?: Record<string, unknown>,
 ) {
   return {
     spaceDid,
+    ownerDid,
     agentConnector: `${owner}-array-elements`,
-    version: 1,
     ...identity,
   };
 }
@@ -297,6 +322,7 @@ function validatedReceiptIndexRows(
   if (
     !isRecord(value) ||
     value.schema !== AGENT_CONNECTOR_SCHEMAS.commandReceipts ||
+    value.ownerDid !== conn.ownerDid ||
     !isIsoTimestamp(value.updatedAt) ||
     !Array.isArray(value.receipts)
   ) {
@@ -318,6 +344,7 @@ function validatedReceiptIndexRows(
       commandId,
       {
         schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+        ownerDid: item.ownerDid,
         commandId,
         sourceId: item.sourceId,
         nativeSessionId: item.nativeSessionId,
@@ -326,6 +353,11 @@ function validatedReceiptIndexRows(
       },
       `command receipt index row ${index}`,
     );
+    if (receipt.ownerDid !== conn.ownerDid) {
+      throw new Error(
+        `command receipt index row belongs to another owner: ${index}`,
+      );
+    }
     if (!isIsoTimestamp(item.updatedAt)) {
       throw new Error(
         `command receipt index row updatedAt is invalid: ${index}`,
@@ -334,7 +366,8 @@ function validatedReceiptIndexRows(
     const expectedLink = fullLink(
       conn.runtime.getCell(
         conn.spaceDid,
-        commandReceiptCause(conn.spaceDid, commandId),
+        commandReceiptCause(conn.spaceDid, conn.ownerDid, commandId),
+        agentOwnerSchema(conn.ownerDid),
       ),
     );
     if (!equalCellLink(item.receipt, expectedLink)) {
@@ -350,6 +383,7 @@ function validatedReceiptIndexRows(
     commandIds.add(commandId);
     return {
       commandId,
+      ownerDid: receipt.ownerDid,
       sourceId: receipt.sourceId,
       nativeSessionId: receipt.nativeSessionId,
       status: receipt.status,
@@ -363,13 +397,27 @@ function validatedReceiptIndexRows(
 export function createAgentFabricCells(
   conn: AgentFabricConnection,
 ): AgentFabricCells {
-  const causes = agentFabricCauses(conn.spaceDid);
+  const causes = agentFabricCauses(conn.spaceDid, conn.ownerDid);
+  const connectorSchema = agentOwnerSchema(conn.ownerDid);
+  const commandSchema = agentOwnerSchema(conn.ownerDid, false);
   return {
-    index: conn.runtime.getCell(conn.spaceDid, causes.index),
-    allIndex: conn.runtime.getCell(conn.spaceDid, causes.allIndex),
-    health: conn.runtime.getCell(conn.spaceDid, causes.health),
-    commands: conn.runtime.getCell(conn.spaceDid, causes.commands),
-    receipts: conn.runtime.getCell(conn.spaceDid, causes.receipts),
+    index: conn.runtime.getCell(conn.spaceDid, causes.index, connectorSchema),
+    allIndex: conn.runtime.getCell(
+      conn.spaceDid,
+      causes.allIndex,
+      connectorSchema,
+    ),
+    health: conn.runtime.getCell(conn.spaceDid, causes.health, connectorSchema),
+    commands: conn.runtime.getCell(
+      conn.spaceDid,
+      causes.commands,
+      commandSchema,
+    ),
+    receipts: conn.runtime.getCell(
+      conn.spaceDid,
+      causes.receipts,
+      connectorSchema,
+    ),
   };
 }
 
@@ -385,10 +433,104 @@ export async function ensureAgentFabricCells(
     cells.receipts.sync(),
   ]);
   await conn.runtime.storageManager.synced();
+  await claimAgentFabricRoots(conn, cells);
   return cells;
 }
 
-function asIndex(value: unknown): AgentSessionIndex | null {
+async function claimAgentFabricRoots(
+  conn: AgentFabricConnection,
+  cells: AgentFabricCells,
+): Promise<void> {
+  const generatedAt = new Date().toISOString();
+  const roots: Array<{
+    name: string;
+    cell: Cell<unknown>;
+    initialValue: Record<string, unknown>;
+  }> = [{
+    name: "recent session index",
+    cell: cells.index,
+    initialValue: {
+      schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: conn.ownerDid,
+      bucket: "recent",
+      generatedAt,
+      generation: 0,
+      totalSessionCount: 0,
+      olderSessionCount: 0,
+      sources: [],
+      sessions: [],
+    },
+  }, {
+    name: "complete session index",
+    cell: cells.allIndex,
+    initialValue: {
+      schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: conn.ownerDid,
+      bucket: "all",
+      generatedAt,
+      generation: 0,
+      totalSessionCount: 0,
+      olderSessionCount: 0,
+      sources: [],
+      sessions: [],
+    },
+  }, {
+    name: "health",
+    cell: cells.health,
+    initialValue: {
+      schema: AGENT_CONNECTOR_SCHEMAS.health,
+      ownerDid: conn.ownerDid,
+    },
+  }, {
+    name: "receipt index",
+    cell: cells.receipts,
+    initialValue: {
+      schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+      ownerDid: conn.ownerDid,
+      receipts: [],
+      updatedAt: generatedAt,
+    },
+  }];
+  const tx = conn.runtime.edit();
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: AGENT_CONNECTOR_WRITER_ID,
+  });
+  try {
+    for (const root of roots) {
+      const link = root.cell.getAsNormalizedFullLink();
+      const value = tx.readValueOrThrow(link);
+      if (value !== undefined) {
+        if (!cellHasOwnerProtection(tx, root.cell, conn.ownerDid)) {
+          throw new Error(
+            `refusing to adopt an unprotected ${root.name} for ${conn.ownerDid}`,
+          );
+        }
+        root.cell.withTx(tx).applyCfcSchemaToExistingValue();
+        continue;
+      }
+      tx.writeValueOrThrow(link, stableFabricValue(root.initialValue));
+      root.cell.withTx(tx).applyCfcSchemaToExistingValue();
+    }
+    tx.prepareCfc();
+  } catch (error) {
+    tx.abort(error);
+    throw error;
+  }
+  const committed = await tx.commit();
+  if (committed.error) {
+    throw new Error(
+      `could not claim agent connector storage: ${committed.error.message}`,
+      { cause: committed.error },
+    );
+  }
+}
+
+function asIndex(
+  value: unknown,
+  ownerDid: string,
+  expectedBucket: "recent" | "all",
+): AgentSessionIndex | null {
   if (value === undefined || value === null) return null;
   if (typeof value !== "object" || Array.isArray(value)) {
     throw new Error("agent session index is not an object");
@@ -396,20 +538,72 @@ function asIndex(value: unknown): AgentSessionIndex | null {
   const record = value as Record<string, unknown>;
   if (
     record.schema !== AGENT_CONNECTOR_SCHEMAS.sessionIndex ||
+    record.ownerDid !== ownerDid ||
+    record.bucket !== expectedBucket ||
+    !isIsoTimestamp(record.generatedAt) ||
+    !isNonNegativeSafeInteger(record.generation) ||
+    (record.totalSessionCount !== undefined &&
+      !isNonNegativeSafeInteger(record.totalSessionCount)) ||
+    (record.olderSessionCount !== undefined &&
+      !isNonNegativeSafeInteger(record.olderSessionCount)) ||
     !Array.isArray(record.sources) ||
     !Array.isArray(record.sessions)
   ) {
     throw new Error("agent session index has an invalid shape");
   }
-  for (const [index, session] of record.sessions.entries()) {
-    if (!isRecord(session) || session.formatVersion !== 1) {
+  const sourceIds = new Set<string>();
+  for (const [index, source] of record.sources.entries()) {
+    if (
+      !isRecord(source) || typeof source.id !== "string" ||
+      normalizeSourceId(source.id) !== source.id || sourceIds.has(source.id) ||
+      typeof source.driver !== "string" || source.driver.length === 0 ||
+      !isDriverCapabilities(source.capabilities)
+    ) {
       throw new Error(
-        `agent session index row ${index} has an invalid formatVersion`,
+        `agent session index source ${index} has an invalid shape`,
       );
+    }
+    sourceIds.add(source.id);
+  }
+  const sessionKeys = new Set<string>();
+  const statuses = new Set(["complete", "partial", "stale", "deleted"]);
+  for (const [index, session] of record.sessions.entries()) {
+    if (!isRecord(session)) {
+      throw new Error(`agent session index row ${index} has an invalid shape`);
     }
     if (typeof session.driver !== "string" || session.driver.length === 0) {
       throw new Error(`agent session index row ${index} has no driver`);
     }
+    if (
+      session.ownerDid !== ownerDid || typeof session.key !== "string" ||
+      typeof session.sourceId !== "string" ||
+      typeof session.nativeSessionId !== "string" ||
+      normalizeSourceId(session.sourceId) !== session.sourceId ||
+      normalizeNativeSessionId(session.nativeSessionId) !==
+        session.nativeSessionId ||
+      session.key !== sessionKey(session.sourceId, session.nativeSessionId) ||
+      sessionKeys.has(session.key) ||
+      typeof session.contentHash !== "string" ||
+      session.contentHash.length === 0 ||
+      typeof session.syncStatus !== "string" ||
+      !statuses.has(session.syncStatus) ||
+      !isNullableString(session.title) || !isNullableString(session.cwd) ||
+      !isNullableString(session.gitRepo) ||
+      !isNullableString(session.gitBranch) ||
+      !isNullableString(session.gitWorktreeRoot) ||
+      !isNullableString(session.createdAt) ||
+      !isNullableString(session.updatedAt) ||
+      !isNullableBoolean(session.archived) ||
+      !isNullableBoolean(session.active) ||
+      !isRecord(session.capabilities) ||
+      (session.recentMessages !== undefined &&
+        !Array.isArray(session.recentMessages)) ||
+      (session.deletedAt !== undefined &&
+        !isIsoTimestamp(session.deletedAt))
+    ) {
+      throw new Error(`agent session index row ${index} has an invalid shape`);
+    }
+    sessionKeys.add(session.key);
   }
   return record as unknown as AgentSessionIndex;
 }
@@ -431,22 +625,30 @@ async function planSessionGraph(
 ): Promise<PlannedSessionGraph> {
   const manifest = conn.runtime.getCell(
     conn.spaceDid,
-    sessionCause(conn.spaceDid, prepared.sourceId, prepared.nativeSessionId),
+    sessionCause(
+      conn.spaceDid,
+      conn.ownerDid,
+      prepared.sourceId,
+      prepared.nativeSessionId,
+    ),
+    agentOwnerSchema(conn.ownerDid),
   );
   const chunkEntries = await Promise.all(prepared.chunks.map(async (chunk) => {
     const cell = conn.runtime.getCell(
       conn.spaceDid,
       sessionChunkCause(
         conn.spaceDid,
+        conn.ownerDid,
         prepared.sourceId,
         prepared.nativeSessionId,
         chunk.part,
         chunk.contentHash,
       ),
+      agentOwnerSchema(conn.ownerDid),
     );
     const value = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionChunk,
-      formatVersion: 1,
+      ownerDid: conn.ownerDid,
       key: prepared.key,
       part: chunk.part,
       contentHash: chunk.contentHash,
@@ -456,7 +658,7 @@ async function planSessionGraph(
       cell,
       plan: await planStableArrayCells(
         value,
-        childScope(conn.spaceDid, "session-events", {
+        childScope(conn.spaceDid, conn.ownerDid, "session-events", {
           sourceId: prepared.sourceId,
           nativeSessionId: prepared.nativeSessionId,
           part: chunk.part,
@@ -474,7 +676,7 @@ async function planSessionGraph(
   }));
   const manifestValue = {
     schema: AGENT_CONNECTOR_SCHEMAS.session,
-    formatVersion: 1,
+    ownerDid: conn.ownerDid,
     key: prepared.key,
     sourceId: prepared.sourceId,
     driver,
@@ -490,7 +692,7 @@ async function planSessionGraph(
   };
   const manifestPlan = await planStableArrayCells(
     manifestValue,
-    childScope(conn.spaceDid, "session", {
+    childScope(conn.spaceDid, conn.ownerDid, "session", {
       sourceId: prepared.sourceId,
       nativeSessionId: prepared.nativeSessionId,
     }),
@@ -499,7 +701,7 @@ async function planSessionGraph(
     chunks: chunkEntries.map(({ cell, plan }) => graphEntry(cell, plan)),
     manifest: graphEntry(manifest, manifestPlan),
     indexEntry: {
-      formatVersion: 1,
+      ownerDid: conn.ownerDid,
       key: prepared.key,
       sourceId: prepared.sourceId,
       driver,
@@ -562,6 +764,7 @@ export class AgentFabricTarget implements CommandTarget {
   readonly #latestCompleteObservationBySource = new Map<string, number>();
   readonly #latestDescriptorObservationBySource = new Map<string, number>();
   #nextObservationSequence = 1;
+  #commandCellBound = false;
 
   private constructor(
     conn: AgentFabricConnection,
@@ -649,6 +852,8 @@ export class AgentFabricTarget implements CommandTarget {
         graphReadCache,
         { preserveLinkFields: new Set(["manifest"]) },
       ),
+      this.conn.ownerDid,
+      "recent",
     );
     const previousAll = asIndex(
       await readStableCellGraphValue(
@@ -657,6 +862,8 @@ export class AgentFabricTarget implements CommandTarget {
         graphReadCache,
         { preserveLinkFields: new Set(["manifest"]) },
       ),
+      this.conn.ownerDid,
+      "all",
     );
     const discoveredCheckouts: GitContext[] = [];
     if (options.checkoutDirectories !== undefined) {
@@ -693,9 +900,11 @@ export class AgentFabricTarget implements CommandTarget {
               this.conn.spaceDid,
               sessionCause(
                 this.conn.spaceDid,
+                this.conn.ownerDid,
                 entry.sourceId,
                 entry.nativeSessionId,
               ),
+              agentOwnerSchema(this.conn.ownerDid),
             ),
           };
           return [
@@ -911,6 +1120,7 @@ export class AgentFabricTarget implements CommandTarget {
       : checkoutEntries(activeSessions, discoveredCheckouts);
     const recentIndex: AgentSessionIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: this.conn.ownerDid,
       bucket: "recent",
       generatedAt,
       generation,
@@ -922,6 +1132,7 @@ export class AgentFabricTarget implements CommandTarget {
     };
     const allIndex: AgentSessionIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: this.conn.ownerDid,
       bucket: "all",
       generatedAt,
       generation,
@@ -933,6 +1144,7 @@ export class AgentFabricTarget implements CommandTarget {
     };
     const indexChildScope = childScope(
       this.conn.spaceDid,
+      this.conn.ownerDid,
       "session-index",
     );
     const [recentIndexPlan, allIndexPlan] = await Promise.all([
@@ -977,10 +1189,11 @@ export class AgentFabricTarget implements CommandTarget {
     const healthValue = {
       ...value,
       schema: AGENT_CONNECTOR_SCHEMAS.health,
+      ownerDid: this.conn.ownerDid,
     };
     const plan = await planStableArrayCells(
       healthValue,
-      childScope(this.conn.spaceDid, "health"),
+      childScope(this.conn.spaceDid, this.conn.ownerDid, "health"),
     );
     await pushStableCellGraph(
       this.conn,
@@ -989,11 +1202,92 @@ export class AgentFabricTarget implements CommandTarget {
   }
 
   commandCellId(): string {
-    return stableCellId(this.cells.commands);
+    return stableCellId(this.cells.commands.resolveAsCell());
   }
 
   receiptCellId(): string {
     return stableCellId(this.cells.receipts);
+  }
+
+  async bindCommandCell(
+    cell: Cell<unknown>,
+    writerAuthorization: unknown,
+  ): Promise<void> {
+    const suppliedLink = cell.getAsNormalizedFullLink();
+    const expectedLink = this.cells.commands.getAsNormalizedFullLink();
+    if (
+      suppliedLink.space !== expectedLink.space ||
+      suppliedLink.id !== expectedLink.id ||
+      suppliedLink.scope !== expectedLink.scope ||
+      suppliedLink.path.length !== expectedLink.path.length ||
+      suppliedLink.path.some((part, index) => part !== expectedLink.path[index])
+    ) {
+      throw new Error("command cell is not the connector's owner-scoped queue");
+    }
+    const authorization = isRecord(writerAuthorization) &&
+        isRecord(writerAuthorization.__ctWriterIdentityOf)
+      ? writerAuthorization.__ctWriterIdentityOf
+      : undefined;
+    if (
+      !authorization || typeof authorization.file !== "string" ||
+      typeof authorization.moduleIdentity !== "string" ||
+      !Array.isArray(authorization.path) ||
+      !authorization.path.every((part) => typeof part === "string")
+    ) {
+      throw new Error("command writer authorization is invalid");
+    }
+    const tx = this.conn.runtime.edit();
+    tx.setCfcImplementationIdentity({
+      kind: "verified",
+      moduleIdentity: authorization.moduleIdentity,
+      sourceFile: authorization.file,
+      bindingPath: authorization.path as string[],
+    });
+    try {
+      const hasOwnerProtection = cellHasOwnerProtection(
+        tx,
+        cell,
+        this.conn.ownerDid,
+      );
+      const protectedCell = cell.withTx(tx);
+      const existing = protectedCell.getRawUntyped({ frozen: false });
+      if (
+        !hasOwnerProtection && existing !== undefined &&
+        (!Array.isArray(existing) || existing.length > 0)
+      ) {
+        throw new Error(
+          "refusing to adopt a populated command queue without its owner label",
+        );
+      }
+      if (existing === undefined) protectedCell.setRawUntyped([]);
+      protectedCell.asSchema(
+        agentPrincipalSchema(this.conn.ownerDid, writerAuthorization),
+      )
+        .applyCfcSchemaToExistingValue();
+      tx.prepareCfc();
+    } catch (error) {
+      tx.abort(error);
+      throw error;
+    }
+    const result = await tx.commit();
+    if (result.error) {
+      throw new Error(
+        `could not protect the owner command cell: ${result.error.message}`,
+        { cause: result.error },
+      );
+    }
+    this.cells.commands = cell;
+    this.#commandCellBound = true;
+  }
+
+  commandsAreBound(): boolean {
+    return this.#commandCellBound;
+  }
+
+  #assertCommandCellBound(): void {
+    if (!this.#commandCellBound) {
+      throw new Error("owner command cell has not been bound");
+    }
   }
 
   async readReceipt(
@@ -1001,30 +1295,85 @@ export class AgentFabricTarget implements CommandTarget {
   ): Promise<AgentSessionCommandReceipt | undefined> {
     const cell = this.conn.runtime.getCell(
       this.conn.spaceDid,
-      commandReceiptCause(this.conn.spaceDid, commandId),
+      commandReceiptCause(this.conn.spaceDid, this.conn.ownerDid, commandId),
+      agentOwnerSchema(this.conn.ownerDid),
     );
+    await cell.sync();
+    await this.conn.runtime.storageManager.synced();
+    const claim = this.conn.runtime.edit();
+    claim.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
+    try {
+      if (
+        claim.readValueOrThrow(cell.getAsNormalizedFullLink()) === undefined
+      ) {
+        claim.abort();
+        return undefined;
+      }
+      if (!cellHasOwnerProtection(claim, cell, this.conn.ownerDid)) {
+        throw new Error(
+          `refusing to trust an unprotected command receipt: ${commandId}`,
+        );
+      }
+      cell.withTx(claim).applyCfcSchemaToExistingValue();
+      claim.prepareCfc();
+    } catch (error) {
+      claim.abort(error);
+      throw error;
+    }
+    const claimed = await claim.commit();
+    if (claimed.error) {
+      throw new Error(
+        `could not verify command receipt ownership: ${claimed.error.message}`,
+        { cause: claimed.error },
+      );
+    }
     const value = await readStableCellGraphValue(this.conn, cell);
-    if (value === undefined || value === null) return undefined;
+    if (value === undefined || value === null) {
+      throw new Error(
+        `command receipt disappeared while reading: ${commandId}`,
+      );
+    }
     if (!value || typeof value !== "object" || Array.isArray(value)) {
       throw new Error(`command receipt is not an object: ${commandId}`);
     }
-    return parseCommandReceipt(commandId, value);
+    const receipt = parseCommandReceipt(commandId, value);
+    if (receipt.ownerDid !== this.conn.ownerDid) {
+      throw new Error(`command receipt belongs to another owner: ${commandId}`);
+    }
+    return receipt;
   }
 
-  subscribeCommands(callback: (commands: unknown[]) => void): Promise<Cancel> {
-    return subscribeStableActions(this.conn, this.cells.commands, callback);
+  async subscribeCommands(
+    callback: (commands: unknown[]) => void,
+  ): Promise<Cancel> {
+    this.#assertCommandCellBound();
+    return await subscribeStableActions(
+      this.conn,
+      this.cells.commands,
+      callback,
+    );
   }
 
-  pollCommands(): Promise<unknown[]> {
-    return readStableActions(this.cells.commands);
+  async pollCommands(): Promise<unknown[]> {
+    this.#assertCommandCellBound();
+    return await readStableActions(this.conn, this.cells.commands);
   }
 
   publishReceipt(
     receipt: AgentSessionCommandReceipt,
   ): Promise<void> {
-    return this.#mutations.run(() =>
-      this.#publishReceipt(parseCommandReceipt(receipt.commandId, receipt))
-    );
+    return this.#mutations.run(() => {
+      const parsed = parseCommandReceipt(receipt.commandId, receipt);
+      if (parsed.ownerDid !== this.conn.ownerDid) {
+        throw new Error(
+          `command receipt belongs to another owner: ${receipt.commandId}`,
+        );
+      }
+      return this.#publishReceipt(parsed);
+    });
   }
 
   async #publishReceipt(
@@ -1032,11 +1381,16 @@ export class AgentFabricTarget implements CommandTarget {
   ): Promise<void> {
     const cell = this.conn.runtime.getCell(
       this.conn.spaceDid,
-      commandReceiptCause(this.conn.spaceDid, receipt.commandId),
+      commandReceiptCause(
+        this.conn.spaceDid,
+        this.conn.ownerDid,
+        receipt.commandId,
+      ),
+      agentOwnerSchema(this.conn.ownerDid),
     );
     const receiptPlan = await planStableArrayCells(
       receipt,
-      childScope(this.conn.spaceDid, "command-receipt", {
+      childScope(this.conn.spaceDid, this.conn.ownerDid, "command-receipt", {
         commandId: receipt.commandId,
       }),
     );
@@ -1059,6 +1413,7 @@ export class AgentFabricTarget implements CommandTarget {
       );
     receipts.push({
       commandId: receipt.commandId,
+      ownerDid: receipt.ownerDid,
       sourceId: receipt.sourceId,
       nativeSessionId: receipt.nativeSessionId,
       status: receipt.status,
@@ -1069,12 +1424,17 @@ export class AgentFabricTarget implements CommandTarget {
     });
     const receiptIndexValue = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+      ownerDid: this.conn.ownerDid,
       receipts: receipts.slice(-200),
       updatedAt: new Date().toISOString(),
     };
     const receiptIndexPlan = await planStableArrayCells(
       receiptIndexValue,
-      childScope(this.conn.spaceDid, "command-receipt-index"),
+      childScope(
+        this.conn.spaceDid,
+        this.conn.ownerDid,
+        "command-receipt-index",
+      ),
     );
     await pushStableCellGraph(
       this.conn,

--- a/packages/connectors/agents/src/protocol.ts
+++ b/packages/connectors/agents/src/protocol.ts
@@ -1,10 +1,10 @@
 export const AGENT_CONNECTOR_SCHEMAS = {
-  session: "commonfabric.agent-connector.session.v1",
-  sessionChunk: "commonfabric.agent-connector.session-chunk.v1",
-  sessionIndex: "commonfabric.agent-connector.session-index.v1",
-  health: "commonfabric.agent-connector.health.v1",
-  command: "commonfabric.agent-connector.command.v1",
-  commandReceipt: "commonfabric.agent-connector.command-receipt.v1",
-  commandReceipts: "commonfabric.agent-connector.command-receipts.v1",
-  commandLedger: "commonfabric.agent-connector.command-ledger.v2",
+  session: "commonfabric.agent-connector.session",
+  sessionChunk: "commonfabric.agent-connector.session-chunk",
+  sessionIndex: "commonfabric.agent-connector.session-index",
+  health: "commonfabric.agent-connector.health",
+  command: "commonfabric.agent-connector.command",
+  commandReceipt: "commonfabric.agent-connector.command-receipt",
+  commandReceipts: "commonfabric.agent-connector.command-receipts",
+  commandLedger: "commonfabric.agent-connector.command-ledger",
 } as const;

--- a/packages/connectors/agents/src/session-contract.ts
+++ b/packages/connectors/agents/src/session-contract.ts
@@ -30,13 +30,14 @@ export function sessionKey(sourceId: string, nativeSessionId: string): string {
 
 export function sessionCause(
   spaceDid: string,
+  ownerDid: string,
   sourceId: string,
   nativeSessionId: string,
 ): Record<string, string | number> {
   return {
     spaceDid,
+    ownerDid: requiredIdentityPart(ownerDid, "ownerDid"),
     agentConnector: "session",
-    version: 1,
     sourceId: normalizeSourceId(sourceId),
     nativeSessionId: normalizeNativeSessionId(nativeSessionId),
   };
@@ -44,6 +45,7 @@ export function sessionCause(
 
 export function sessionChunkCause(
   spaceDid: string,
+  ownerDid: string,
   sourceId: string,
   nativeSessionId: string,
   part: number,
@@ -53,7 +55,7 @@ export function sessionChunkCause(
     throw new Error("part must be a non-negative safe integer");
   }
   return {
-    ...sessionCause(spaceDid, sourceId, nativeSessionId),
+    ...sessionCause(spaceDid, ownerDid, sourceId, nativeSessionId),
     agentConnector: "session-chunk",
     part,
     contentHash: requiredIdentityPart(contentHash, "contentHash"),
@@ -62,12 +64,13 @@ export function sessionChunkCause(
 
 export function commandReceiptCause(
   spaceDid: string,
+  ownerDid: string,
   commandId: string,
 ): Record<string, string | number> {
   return {
     spaceDid,
+    ownerDid: requiredIdentityPart(ownerDid, "ownerDid"),
     agentConnector: "command-receipt",
-    version: 1,
     commandId: normalizeCommandId(commandId),
   };
 }

--- a/packages/connectors/agents/test/array-cell-identity_test.ts
+++ b/packages/connectors/agents/test/array-cell-identity_test.ts
@@ -32,7 +32,7 @@ function cellsById(value: unknown): Map<string, FakeCell> {
 }
 
 Deno.test("array object cells keep their causes when their array is reordered", async () => {
-  const scope = { agentConnector: "session-index", version: 1 };
+  const scope = { agentConnector: "session-index" };
   const first = materialize(
     await planStableArrayCells({
       sessions: [
@@ -75,7 +75,7 @@ Deno.test("every array element is materialized as a stable cell", async () => {
         matrix: [[{ id: "nested", value: 1 }]],
       }],
       primitives: ["one", 2, false, null],
-    }, { agentConnector: "health", version: 1 }),
+    }, { agentConnector: "health" }),
   );
 
   const root = value as Record<string, unknown>;
@@ -97,7 +97,7 @@ Deno.test("every array element is materialized as a stable cell", async () => {
 });
 
 Deno.test("primitive array elements keep content-derived causes when reordered", async () => {
-  const scope = { agentConnector: "source", version: 1 };
+  const scope = { agentConnector: "source" };
   const first = materialize(
     await planStableArrayCells({ modes: ["ask", "edit"] }, scope),
   );
@@ -123,7 +123,7 @@ Deno.test("nested ids are scoped to their owning array object", async () => {
         { key: "codex/one", messages: [{ id: "message-1", text: "one" }] },
         { key: "codex/two", messages: [{ id: "message-1", text: "two" }] },
       ],
-    }, { agentConnector: "session-index", version: 1 }),
+    }, { agentConnector: "session-index" }),
   );
 
   const sessions = (value as Record<string, unknown>).sessions as FakeCell[];
@@ -135,7 +135,7 @@ Deno.test("nested ids are scoped to their owning array object", async () => {
 });
 
 Deno.test("unidentified objects use content identity instead of array position", async () => {
-  const scope = { agentConnector: "health", version: 1 };
+  const scope = { agentConnector: "health" };
   const first = materialize(
     await planStableArrayCells({
       errors: [{ message: "first" }, { message: "second" }],
@@ -168,7 +168,7 @@ Deno.test("unidentified objects use content identity instead of array position",
 });
 
 Deno.test("stable structural identity wins over mutable chunk content", async () => {
-  const scope = { agentConnector: "session", version: 1 };
+  const scope = { agentConnector: "session" };
   const first = materialize(
     await planStableArrayCells({
       chunks: [{ part: 0, contentHash: "sha256:old", eventCount: 1 }],
@@ -186,7 +186,7 @@ Deno.test("stable structural identity wins over mutable chunk content", async ()
 });
 
 Deno.test("command identity wins over the shared session identity", async () => {
-  const scope = { agentConnector: "receipt-index", version: 1 };
+  const scope = { agentConnector: "receipt-index" };
   const first = materialize(
     await planStableArrayCells({
       receipts: [

--- a/packages/connectors/agents/test/canonical-json_test.ts
+++ b/packages/connectors/agents/test/canonical-json_test.ts
@@ -81,7 +81,7 @@ Deno.test("deeply nested arrays are hashed without repeated planning", async () 
   for (let depth = 0; depth < 16; depth++) value = [value];
   assertEquals(
     await hashStableArrayValue(value),
-    "sha256:088140b43d654712acb10e8d3db4b785b2036384b2943e1a2ca908b62d078f47",
+    "sha256:f318e21ba296a8e09bbaaf1083630d431a24082450a0ecac115a135fa2f26f72",
   );
 });
 

--- a/packages/connectors/agents/test/commands_test.ts
+++ b/packages/connectors/agents/test/commands_test.ts
@@ -753,6 +753,15 @@ Deno.test("command receipts require canonical identities and timestamps", () => 
     () =>
       parseCommandReceipt("command", {
         ...receipt,
+        ownerDid: "",
+      }),
+    Error,
+    "ownerDid must be a string",
+  );
+  assertThrows(
+    () =>
+      parseCommandReceipt("command", {
+        ...receipt,
         nativeSessionId: " session-1 ",
       }),
     Error,

--- a/packages/connectors/agents/test/commands_test.ts
+++ b/packages/connectors/agents/test/commands_test.ts
@@ -48,9 +48,11 @@ Deno.test("command worker claims before execution and deduplicates command ids",
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
   const command = {
     schema: AGENT_CONNECTOR_SCHEMAS.command,
+    ownerDid: "did:key:test-owner",
     id: "command-1",
     createdAt: "2026-07-09T00:00:00.000Z",
     sourceId: "fake:default",
@@ -68,6 +70,58 @@ Deno.test("command worker claims before execution and deduplicates command ids",
   await worker.handle([command]);
   assertEquals(renameCalls, 1);
   await Deno.remove(dir, { recursive: true });
+});
+
+Deno.test("command worker ignores commands for another owner", async () => {
+  const dir = await Deno.makeTempDir();
+  const ledger = await CommandLedger.open(`${dir}/ledger.json`);
+  let renameCalls = 0;
+  const driver = {
+    source: {
+      id: "fake:default",
+      driver: "acp",
+      capabilities: {
+        inventory: true,
+        read: true,
+        prompt: true,
+        cancel: true,
+        rename: true,
+        setMode: false,
+        setConfigOption: false,
+      },
+    },
+    renameSession: () => {
+      renameCalls++;
+      return Promise.resolve({ status: "succeeded" as const });
+    },
+  } as unknown as AgentDriver;
+  const worker = new CommandWorker(
+    new Map([[driver.source.id, driver]]),
+    [{
+      publishReceipt: () => Promise.resolve(),
+      refreshSession: () => Promise.resolve(),
+    }],
+    ledger,
+    "did:key:test-owner",
+  );
+
+  try {
+    await worker.handle([{
+      schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:another-owner",
+      id: "foreign-command",
+      createdAt: "2026-07-09T00:00:00.000Z",
+      sourceId: driver.source.id,
+      nativeSessionId: "session-1",
+      type: "rename",
+      payload: { title: "Do not run" },
+    }]);
+    await worker.drain();
+    assertEquals(renameCalls, 0);
+    assertEquals(ledger.get("foreign-command"), undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("commands run concurrently across sessions and cancel bypasses the session queue", async () => {
@@ -118,9 +172,11 @@ Deno.test("commands run concurrently across sessions and cancel bypasses the ses
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
   const command = (id: string, sessionId: string, type = "prompt") => ({
     schema: AGENT_CONNECTOR_SCHEMAS.command,
+    ownerDid: "did:key:test-owner",
     id,
     createdAt: "2026-07-09T00:00:00.000Z",
     sourceId: "fake:default",
@@ -186,9 +242,11 @@ Deno.test("cancel waits for an earlier admitted prompt to become active", async 
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
   const command = (id: string, type: "prompt" | "cancel") => ({
     schema: AGENT_CONNECTOR_SCHEMAS.command,
+    ownerDid: "did:key:test-owner",
     id,
     createdAt: "2026-07-09T00:00:00.000Z",
     sourceId: driver.source.id,
@@ -270,9 +328,11 @@ Deno.test("cancel reaches a prompt while provider metadata is pending", async ()
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
   const command = (id: string, type: "prompt" | "cancel") => ({
     schema: AGENT_CONNECTOR_SCHEMAS.command,
+    ownerDid: "did:key:test-owner",
     id,
     createdAt: "2026-07-09T00:00:00.000Z",
     sourceId: driver.source.id,
@@ -356,11 +416,13 @@ Deno.test("prompt commands publish session state while running and after complet
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
 
   try {
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "prompt-activity",
       createdAt: "2026-07-09T00:00:00.000Z",
       sourceId: "fake:default",
@@ -431,11 +493,13 @@ Deno.test("failed prompts publish terminal session state", async () => {
     new Map([[driver.source.id, driver]]),
     [target],
     ledger,
+    "did:key:test-owner",
   );
 
   try {
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "failed-prompt-activity",
       createdAt: "2026-07-09T00:00:00.000Z",
       sourceId: driver.source.id,
@@ -457,6 +521,7 @@ Deno.test("in-flight commands from a prior process become unknown", async () => 
   const ledger = await CommandLedger.open(path);
   await ledger.put({
     schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+    ownerDid: "did:key:test-owner",
     commandId: "orphan",
     sourceId: "fake:default",
     nativeSessionId: "session-1",
@@ -515,9 +580,11 @@ Deno.test("terminal receipts that failed to publish are replayed after restart",
       new Map([[driver.source.id, driver]]),
       [firstTarget],
       ledger,
+      "did:key:test-owner",
     );
     await firstWorker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "command-with-unpublished-terminal",
       createdAt: "2026-07-09T00:00:00.000Z",
       sourceId: "fake:default",
@@ -549,6 +616,7 @@ Deno.test("terminal receipts that failed to publish are replayed after restart",
         refreshSession: () => Promise.resolve(),
       }],
       reopened,
+      "did:key:test-owner",
     );
     await recoveringWorker.recoverUnpublishedReceipts();
     assertEquals(replayedStatuses, ["succeeded"]);
@@ -573,6 +641,7 @@ Deno.test("overlapping ledger writes all survive reopen", async () => {
   await Promise.all(commandIds.map((commandId) =>
     ledger.put({
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
       commandId,
       sourceId: "fake:default",
       nativeSessionId: `session-${commandId}`,
@@ -589,14 +658,14 @@ Deno.test("overlapping ledger writes all survive reopen", async () => {
   await Deno.remove(dir, { recursive: true });
 });
 
-Deno.test("command ledger rejects obsolete formats", async () => {
+Deno.test("command ledger rejects an unknown schema", async () => {
   const dir = await Deno.makeTempDir();
   const path = `${dir}/ledger.json`;
   try {
     await Deno.writeTextFile(
       path,
       JSON.stringify({
-        schema: "commonfabric.agent-connector.command-ledger.v1",
+        schema: "commonfabric.agent-connector.command-ledger.unknown",
         receipts: {},
       }),
       { mode: 0o600 },
@@ -604,7 +673,7 @@ Deno.test("command ledger rejects obsolete formats", async () => {
     await assertRejects(
       () => CommandLedger.open(path),
       Error,
-      "command ledger schema must be commonfabric.agent-connector.command-ledger.v2",
+      "command ledger schema must be commonfabric.agent-connector.command-ledger",
     );
   } finally {
     await Deno.remove(dir, { recursive: true });
@@ -623,6 +692,7 @@ Deno.test("command ledger validates receipt keys and contents", async () => {
         receipts: {
           "stored-key": {
             schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+            ownerDid: "did:key:test-owner",
             commandId: "different-command",
             sourceId: "fake:default",
             nativeSessionId: "session-1",
@@ -647,6 +717,7 @@ Deno.test("command ledger validates receipt keys and contents", async () => {
         receipts: {
           command: {
             schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+            ownerDid: "did:key:test-owner",
             commandId: "command",
             sourceId: "fake:default",
             nativeSessionId: "session-1",
@@ -670,6 +741,7 @@ Deno.test("command ledger validates receipt keys and contents", async () => {
 Deno.test("command receipts require canonical identities and timestamps", () => {
   const receipt: AgentSessionCommandReceipt = {
     schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+    ownerDid: "did:key:test-owner",
     commandId: "command",
     sourceId: "fake:default",
     nativeSessionId: "session-1",
@@ -705,6 +777,7 @@ Deno.test("command ledger writes private files in a private directory", async ()
     const ledger = await CommandLedger.open(path);
     await ledger.put({
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
       commandId: "command",
       sourceId: "fake:default",
       nativeSessionId: "session-1",
@@ -757,6 +830,7 @@ Deno.test("a published receipt prevents execution with a fresh local ledger", as
     } as unknown as AgentDriver;
     const command = {
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "shared-command",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -769,6 +843,7 @@ Deno.test("a published receipt prevents execution with a fresh local ledger", as
       new Map([[driver.source.id, driver]]),
       [target],
       await CommandLedger.open(`${directory}/first/ledger.json`),
+      "did:key:test-owner",
     );
     await first.handle([command]);
     await first.drain();
@@ -778,6 +853,7 @@ Deno.test("a published receipt prevents execution with a fresh local ledger", as
       new Map([[driver.source.id, driver]]),
       [target],
       await CommandLedger.open(`${directory}/second/ledger.json`),
+      "did:key:test-owner",
     );
     await second.handle([command]);
     await second.drain();
@@ -793,6 +869,7 @@ Deno.test("equivalent target receipts do not depend on object key order", async 
   try {
     const receipt: AgentSessionCommandReceipt = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
       commandId: "shared-command",
       sourceId: "fake:default",
       nativeSessionId: "session-1",
@@ -808,6 +885,7 @@ Deno.test("equivalent target receipts do not depend on object key order", async 
       sourceId: "fake:default",
       commandId: "shared-command",
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
     };
     const published: AgentSessionCommandReceipt[] = [];
     const target = (
@@ -825,10 +903,12 @@ Deno.test("equivalent target receipts do not depend on object key order", async 
       new Map(),
       [target(receipt), target(reordered)],
       ledger,
+      "did:key:test-owner",
     );
 
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "shared-command",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -850,9 +930,15 @@ Deno.test("commands reject control characters before creating a claim", async ()
   const directory = await Deno.makeTempDir();
   try {
     const ledger = await CommandLedger.open(`${directory}/ledger.json`);
-    const worker = new CommandWorker(new Map(), [], ledger);
+    const worker = new CommandWorker(
+      new Map(),
+      [],
+      ledger,
+      "did:key:test-owner",
+    );
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "bad\ncommand",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -861,6 +947,7 @@ Deno.test("commands reject control characters before creating a claim", async ()
       payload: {},
     }, {
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "bad-session-command",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -880,9 +967,15 @@ Deno.test("commands reject non-record payloads before claiming", async () => {
   const directory = await Deno.makeTempDir();
   try {
     const ledger = await CommandLedger.open(`${directory}/ledger.json`);
-    const worker = new CommandWorker(new Map(), [], ledger);
+    const worker = new CommandWorker(
+      new Map(),
+      [],
+      ledger,
+      "did:key:test-owner",
+    );
     const base = {
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
       nativeSessionId: "session-1",
@@ -944,9 +1037,11 @@ Deno.test("synchronous driver failures publish a terminal receipt", async () => 
       new Map([[driver.source.id, driver]]),
       [target],
       ledger,
+      "did:key:test-owner",
     );
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "sync-failure",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -971,6 +1066,7 @@ Deno.test("receipt ownership compares `FabricValue`s", async () => {
     const ledger = await CommandLedger.open(`${directory}/ledger.json`);
     const receipt: AgentSessionCommandReceipt = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
       commandId: "fabric-receipt",
       sourceId: "fake:default",
       nativeSessionId: "session-1",
@@ -986,9 +1082,11 @@ Deno.test("receipt ownership compares `FabricValue`s", async () => {
       new Map(),
       [target({ value: undefined }), target({})],
       ledger,
+      "did:key:test-owner",
     );
     await worker.handle([{
       schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: "did:key:test-owner",
       id: "fabric-receipt",
       createdAt: "2026-07-20T00:00:00.000Z",
       sourceId: "fake:default",
@@ -1009,6 +1107,7 @@ Deno.test("command ledger preserves Fabric receipt results across reopen", async
   try {
     const receipt: AgentSessionCommandReceipt = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:test-owner",
       commandId: "fabric-ledger-result",
       sourceId: "fake:default",
       nativeSessionId: "session-1",

--- a/packages/connectors/agents/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/test/fabric-graph_test.ts
@@ -19,6 +19,8 @@ import {
   planStableArrayCells,
 } from "../src/array-cell-identity.ts";
 import {
+  agentOwnerSchema,
+  cellHasOwnerProtection,
   pushStableCellGraph,
   readStableCellGraphValue,
 } from "../src/fabric-graph.ts";
@@ -159,6 +161,134 @@ Deno.test("stable graph writes preserve native `FabricValue`s", async () => {
     assertEquals(expression.source, "agent-data");
     assertEquals(expression.flags, "gi");
     assertEquals(bytes.slice(), new Uint8Array([1, 2, 3]));
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("stable graph writes refuse populated unprotected cells", async () => {
+  const signer = await Identity.fromPassphrase(
+    "agent connector unprotected graph test",
+  );
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = signer.did();
+  const connection = { runtime, spaceDid: space, ownerDid: space };
+  try {
+    const unprotectedRoot = runtime.getCell(space, {
+      graphTest: "unprotected-root",
+    });
+    const unprotectedChild = runtime.getCell(space, {
+      graphTest: "unprotected-child",
+    });
+    const confidentialOnly = runtime.getCell(
+      space,
+      { graphTest: "confidential-only" },
+      agentOwnerSchema(space, false),
+    );
+    await Promise.all([
+      unprotectedRoot.sync(),
+      unprotectedChild.sync(),
+      confidentialOnly.sync(),
+    ]);
+    await storageManager.synced();
+    const seed = runtime.edit();
+    unprotectedRoot.withTx(seed).setRawUntyped({ exposed: "root" });
+    unprotectedChild.withTx(seed).setRawUntyped({ exposed: "child" });
+    const confidentialSeed = confidentialOnly.withTx(seed);
+    confidentialSeed.setRawUntyped({ exposed: "confidential" });
+    confidentialSeed.applyCfcSchemaToExistingValue();
+    seed.prepareCfc();
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+
+    await assertRejects(
+      () =>
+        pushStableCellGraph(connection, [{
+          cell: unprotectedRoot,
+          value: () => ({ exposed: false }),
+        }]),
+      Error,
+      "refusing to adopt an unprotected stable graph cell",
+    );
+
+    await assertRejects(
+      () =>
+        pushStableCellGraph(connection, [{
+          cell: confidentialOnly,
+          value: () => ({ exposed: false }),
+        }]),
+      Error,
+      "refusing to adopt an unprotected stable graph cell",
+    );
+
+    const parent = runtime.getCell(space, { graphTest: "protected-parent" });
+    await parent.sync();
+    await storageManager.synced();
+    await assertRejects(
+      () =>
+        pushStableCellGraph(connection, [{
+          cell: parent,
+          value: (materializeCell) => ({
+            child: materializeCell(
+              { graphTest: "unprotected-child" },
+              { exposed: false },
+            ),
+          }),
+        }]),
+      Error,
+      "refusing to adopt an unprotected stable graph cell",
+    );
+    assertEquals(unprotectedRoot.getRaw(), { exposed: "root" });
+    assertEquals(unprotectedChild.getRaw(), { exposed: "child" });
+    assertEquals(confidentialOnly.getRaw(), { exposed: "confidential" });
+    assertEquals(parent.getRaw(), undefined);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("stable graph writes one new cell referenced twice", async () => {
+  const signer = await Identity.fromPassphrase(
+    "agent connector repeated graph cell test",
+  );
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = signer.did();
+  const connection = { runtime, spaceDid: space, ownerDid: space };
+  try {
+    const parent = runtime.getCell(space, { graphTest: "repeated-parent" });
+    await pushStableCellGraph(connection, [{
+      cell: parent,
+      value: (materializeCell) => ({
+        first: materializeCell(
+          { graphTest: "repeated-child" },
+          { value: "shared" },
+        ),
+        second: materializeCell(
+          { graphTest: "repeated-child" },
+          { value: "shared" },
+        ),
+      }),
+    }]);
+
+    assertEquals(await readStableCellGraphValue(connection, parent), {
+      first: { value: "shared" },
+      second: { value: "shared" },
+    });
+    const child = runtime.getCell(space, { graphTest: "repeated-child" });
+    assertEquals(
+      cellHasOwnerProtection(runtime.readTx(), child, space),
+      true,
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -321,12 +451,13 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
           space: link.space,
           scope: link.scope,
           id: link.id,
-          path: [],
+          path: ["connectorMetadata"],
         }),
-        {
-          connectorMetadata: { preserved: true },
-          value: { retained: "after" },
-        },
+        { preserved: true },
+      );
+      assertEquals(
+        inspectionTx.readValueOrThrow(link),
+        { retained: "after" },
       );
     } finally {
       inspectionTx.abort();
@@ -344,7 +475,9 @@ function fakeCell(id = "of:parent") {
       id,
       path: [],
     }),
+    sync: () => Promise.resolve(),
     withTx: () => cell,
+    asSchema: () => cell,
     applyCfcSchemaToExistingValue: () => {},
   };
   return cell;
@@ -370,7 +503,10 @@ Deno.test("stable graph writes await one commit", async () => {
     },
   };
   const connection = {
-    runtime: { edit: () => transaction },
+    runtime: {
+      edit: () => transaction,
+      storageManager: { synced: () => Promise.resolve() },
+    },
     spaceDid: "did:test:space",
     ownerDid: "did:test:owner",
   };
@@ -401,6 +537,7 @@ Deno.test("stable graph writes surface a commit failure without retrying", async
   let commitCount = 0;
   const connection = {
     runtime: {
+      storageManager: { synced: () => Promise.resolve() },
       edit: () => ({
         readValueOrThrow: () => undefined,
         writeOrThrow: () => {},

--- a/packages/connectors/agents/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/test/fabric-graph_test.ts
@@ -69,7 +69,7 @@ Deno.test("stable graph writes keep child identity and hydrate linked values", a
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   let coldRuntime: Runtime | undefined;
   try {
     const parent = runtime.getCell(space, { graphTest: "parent" });
@@ -130,7 +130,7 @@ Deno.test("stable graph writes preserve native `FabricValue`s", async () => {
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     const root = runtime.getCell(space, { graphTest: "native-values" });
     await pushStableCellGraph(connection, [{
@@ -174,7 +174,11 @@ Deno.test("stable graph deletes fields whose names exist on the prototype", asyn
     apiUrl: new URL(import.meta.url),
     storageManager,
   });
-  const connection = { runtime, spaceDid: signer.did() };
+  const connection = {
+    runtime,
+    spaceDid: signer.did(),
+    ownerDid: signer.did(),
+  };
   try {
     const root = runtime.getCell(signer.did(), {
       graphTest: "inherited-fields",
@@ -204,7 +208,7 @@ Deno.test("stable graph reads can preserve links in named fields", async () => {
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     const child = runtime.getCell(space, { graphTest: "preserved-child" });
     const parent = runtime.getCell(space, { graphTest: "preserved-parent" });
@@ -243,7 +247,7 @@ Deno.test("stable array planning preserves links to cell subpaths", async () => 
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     const referenced = runtime.getCell(space, {
       graphTest: "subpath-reference",
@@ -285,7 +289,7 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
   });
   const space = signer.did();
   const cell = runtime.getCell(space, { graphTest: "field-writes" });
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     await pushStableCellGraph(connection, [{
       cell,
@@ -334,13 +338,16 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
 });
 
 function fakeCell(id = "of:parent") {
-  return {
+  const cell = {
     getAsNormalizedFullLink: () => ({
       space: "did:test:space",
       id,
       path: [],
     }),
+    withTx: () => cell,
+    applyCfcSchemaToExistingValue: () => {},
   };
+  return cell;
 }
 
 Deno.test("stable graph writes await one commit", async () => {
@@ -353,6 +360,8 @@ Deno.test("stable graph writes await one commit", async () => {
     readValueOrThrow: () => undefined,
     writeOrThrow: () => {},
     writeValueOrThrow: () => {},
+    setCfcImplementationIdentity: () => {},
+    prepareCfc: () => {},
     abort: () => ({ ok: {} }),
     commit: () => {
       commitCount++;
@@ -363,6 +372,7 @@ Deno.test("stable graph writes await one commit", async () => {
   const connection = {
     runtime: { edit: () => transaction },
     spaceDid: "did:test:space",
+    ownerDid: "did:test:owner",
   };
   let settled = false;
   const pending = pushStableCellGraph(
@@ -395,6 +405,8 @@ Deno.test("stable graph writes surface a commit failure without retrying", async
         readValueOrThrow: () => undefined,
         writeOrThrow: () => {},
         writeValueOrThrow: () => {},
+        setCfcImplementationIdentity: () => {},
+        prepareCfc: () => {},
         abort: () => ({ ok: {} }),
         commit: () => {
           commitCount++;
@@ -403,6 +415,7 @@ Deno.test("stable graph writes surface a commit failure without retrying", async
       }),
     },
     spaceDid: "did:test:space",
+    ownerDid: "did:test:owner",
   };
   const error = await assertRejects(
     () =>
@@ -453,7 +466,7 @@ Deno.test("stable graph hydration bounds concurrent child syncs", async () => {
   };
   const pending = readStableCellGraphValue(
     // deno-lint-ignore no-explicit-any -- focused runtime fixture.
-    { runtime, spaceDid: space } as any,
+    { runtime, spaceDid: space, ownerDid: space } as any,
     // deno-lint-ignore no-explicit-any -- focused cell fixture.
     parent as any,
   );

--- a/packages/connectors/agents/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/test/fabric-graph_test.ts
@@ -478,10 +478,80 @@ function fakeCell(id = "of:parent") {
     sync: () => Promise.resolve(),
     withTx: () => cell,
     asSchema: () => cell,
+    setRawUntyped: () => {},
     applyCfcSchemaToExistingValue: () => {},
   };
   return cell;
 }
+
+Deno.test("stable graph hydrates the owner-schema cell before writing", async () => {
+  let schemaBindings = 0;
+  let syncs = 0;
+  let writes = 0;
+  let hydrated = false;
+  const link = {
+    space: "did:test:space",
+    scope: "space",
+    id: "of:parent",
+    path: [],
+  };
+  const protectedCell = {
+    getAsNormalizedFullLink: () => link,
+    sync: () => {
+      syncs++;
+      hydrated = true;
+      return Promise.resolve();
+    },
+    withTx: () => protectedCell,
+    setRawUntyped: () => {
+      assertEquals(hydrated, true);
+      writes++;
+    },
+    applyCfcSchemaToExistingValue: () => assertEquals(hydrated, true),
+  };
+  const makeCell = () => ({
+    getAsNormalizedFullLink: () => link,
+    asSchema: () => {
+      schemaBindings++;
+      return protectedCell;
+    },
+  });
+  const firstCell = makeCell();
+  const secondCell = makeCell();
+  const transaction = {
+    readValueOrThrow: () => undefined,
+    writeOrThrow: () => {},
+    setCfcImplementationIdentity: () => {},
+    prepareCfc: () => {},
+    abort: () => ({ ok: {} }),
+    commit: () => Promise.resolve({ ok: {} }),
+  };
+
+  await pushStableCellGraph(
+    // deno-lint-ignore no-explicit-any -- focused runtime fixture.
+    {
+      runtime: { edit: () => transaction },
+      spaceDid: "did:test:space",
+      ownerDid: "did:test:owner",
+    } as any,
+    [
+      {
+        // deno-lint-ignore no-explicit-any -- focused cell fixture.
+        cell: firstCell as any,
+        value: () => ({ value: "first" }),
+      },
+      {
+        // deno-lint-ignore no-explicit-any -- focused cell fixture.
+        cell: secondCell as any,
+        value: () => ({ value: "second" }),
+      },
+    ],
+  );
+
+  assertEquals(schemaBindings, 1);
+  assertEquals(syncs, 1);
+  assertEquals(writes, 2);
+});
 
 Deno.test("stable graph writes await one commit", async () => {
   const commitStarted = Promise.withResolvers<void>();
@@ -505,7 +575,6 @@ Deno.test("stable graph writes await one commit", async () => {
   const connection = {
     runtime: {
       edit: () => transaction,
-      storageManager: { synced: () => Promise.resolve() },
     },
     spaceDid: "did:test:space",
     ownerDid: "did:test:owner",
@@ -537,7 +606,6 @@ Deno.test("stable graph writes surface a commit failure without retrying", async
   let commitCount = 0;
   const connection = {
     runtime: {
-      storageManager: { synced: () => Promise.resolve() },
       edit: () => ({
         readValueOrThrow: () => undefined,
         writeOrThrow: () => {},

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -613,11 +613,25 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       spaceDid: space,
       agentConnector: "invalid-index-test-array-elements",
     };
+    const validCheckout = {
+      root: "/repo",
+      gitRepo: null,
+      gitBranch: null,
+      gitHeadSha: null,
+      gitRemotes: [],
+      observedAt: "2026-08-21T00:00:00.000Z",
+    };
     const writeInvalidIndex = async (
       session: Record<string, unknown>,
       sources = index.sources,
+      checkouts = index.checkouts,
     ) => {
-      const invalidIndex = { ...index, sources, sessions: [session] };
+      const invalidIndex = {
+        ...index,
+        sources,
+        checkouts,
+        sessions: [session],
+      };
       const [invalidRecentPlan, invalidAllPlan] = await Promise.all([
         planStableArrayCells(
           { ...invalidIndex, bucket: "recent" },
@@ -692,6 +706,48 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       () => target.publish(collected),
       Error,
       "agent session index row 0 has an invalid shape",
+    );
+    await writeInvalidIndex(publishedSession, index.sources, {});
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index has an invalid shape",
+    );
+    await writeInvalidIndex(
+      publishedSession,
+      index.sources,
+      [{ ...validCheckout, root: "repo" }],
+    );
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index checkout 0 has an invalid shape",
+    );
+    await writeInvalidIndex(
+      publishedSession,
+      index.sources,
+      [{
+        ...validCheckout,
+        gitRemotes: [{ name: "origin", urls: [42] }],
+      }],
+    );
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index checkout 0 has an invalid shape",
+    );
+    await writeInvalidIndex(
+      publishedSession,
+      index.sources,
+      [{
+        ...validCheckout,
+        observedAt: "not-a-timestamp",
+      }],
+    );
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index checkout 0 has an invalid shape",
     );
   } finally {
     await runtime.dispose();
@@ -1014,6 +1070,50 @@ Deno.test("stable graph checks remote children before adoption", async () => {
     await otherRuntime.dispose();
     await otherStorage.close();
     await server.close();
+  }
+});
+
+Deno.test("Fabric target can defer its storage claim", async () => {
+  const owner = await Identity.fromPassphrase(
+    "agent connector deferred claim owner",
+  );
+  const storageManager = StorageManager.emulate({ as: owner });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    const connection = {
+      runtime,
+      spaceDid: owner.did(),
+      ownerDid: owner.did(),
+    };
+    const target = await AgentFabricTarget.connect(connection);
+    assertEquals(target.cells.index.getRaw(), undefined);
+    assertEquals(target.cells.commands.getRaw(), undefined);
+
+    await target.claimStorage();
+
+    assertEquals(
+      cellHasOwnerProtection(
+        runtime.readTx(),
+        target.cells.index,
+        owner.did(),
+      ),
+      true,
+    );
+    assertEquals(
+      cellHasOwnerProtection(
+        runtime.readTx(),
+        target.cells.receipts,
+        owner.did(),
+      ),
+      true,
+    );
+    assertEquals(target.cells.commands.getRaw(), undefined);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
   }
 });
 

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -1,14 +1,34 @@
 import {
   assertEquals,
   assertFalse,
+  assertNotEquals,
   assertRejects,
   assertStrictEquals,
 } from "@std/assert";
-import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import { Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
-import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { AgentFabricTarget } from "../src/fabric.ts";
+import {
+  isLinkRef,
+  linkRefFrom,
+  linkRefPayload,
+} from "@commonfabric/data-model/cell-rep";
+import { createSession, Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { type Cell, Runtime } from "@commonfabric/runner";
+import {
+  EmulatedStorageManager,
+  type Options,
+  StorageManager,
+} from "@commonfabric/runner/storage/cache.deno";
+import {
+  agentFabricCauses,
+  AgentFabricTarget,
+  createAgentFabricCells,
+} from "../src/fabric.ts";
+import {
+  AGENT_CONNECTOR_WRITER_ID,
+  agentOwnerSchema,
+  agentPrincipalSchema,
+  cellHasOwnerProtection,
+} from "../src/fabric-graph.ts";
 import {
   pushStableCellGraph,
   readStableCellGraphValue,
@@ -76,6 +96,78 @@ Deno.test("Fabric target validates a discovered checkout", async () => {
   }
 });
 
+const EMULATED_AUDIENCE = "did:key:z6Mk-agent-connector-isolation-test";
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static override connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.#sharedServer = server;
+    return manager;
+  }
+
+  #sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.#sharedServer;
+  }
+}
+
+async function assertOwnerProtectedGraph(
+  runtime: Runtime,
+  root: Cell<unknown>,
+  ownerDid: string,
+): Promise<number> {
+  const pending = [root];
+  const seen = new Set<string>();
+  while (pending.length > 0) {
+    const cell = pending.shift()!;
+    const cellLink = cell.getAsNormalizedFullLink();
+    const key = JSON.stringify({
+      space: cellLink.space,
+      id: cellLink.id,
+      scope: cellLink.scope,
+    });
+    if (seen.has(key)) continue;
+    seen.add(key);
+    await cell.sync();
+    await runtime.storageManager.synced();
+    assertEquals(
+      cellHasOwnerProtection(runtime.readTx(), cell, ownerDid),
+      true,
+      String(cellLink.id),
+    );
+    const visit = (value: unknown): void => {
+      if (isLinkRef(value)) {
+        const link = linkRefPayload(value);
+        if (typeof link.id === "string") {
+          pending.push(runtime.getCellFromLink(
+            {
+              ...link,
+              space: link.space ?? cellLink.space,
+              scope: link.scope ?? cellLink.scope,
+              path: [],
+            } as Parameters<Runtime["getCellFromLink"]>[0],
+          ));
+        }
+        return;
+      }
+      if (Array.isArray(value)) {
+        value.forEach(visit);
+      } else if (value && typeof value === "object") {
+        Object.values(value).forEach(visit);
+      }
+    };
+    visit(cell.getRaw());
+  }
+  return seen.size;
+}
+
 Deno.test("Fabric target publishes sessions and command receipts", async () => {
   const signer = await Identity.fromPassphrase("agent connector target test");
   const storageManager = StorageManager.emulate({ as: signer });
@@ -84,14 +176,13 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     const target = await AgentFabricTarget.open(connection);
     const writeReceiptIndex = async (value: Record<string, unknown>) => {
-      const plan = await planStableArrayCells(value, {
+      const plan = await planStableArrayCells({ ownerDid: space, ...value }, {
         spaceDid: space,
         agentConnector: "receipt-index-test-array-elements",
-        version: 1,
       });
       await pushStableCellGraph(connection, [{
         cell: target.cells.receipts,
@@ -236,6 +327,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
 
     await target.publishReceipt({
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: space,
       commandId: "command-1",
       sourceId: source.id,
       nativeSessionId: snapshot.summary.nativeSessionId,
@@ -259,16 +351,24 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
 
     const malformedReceipt = runtime.getCell(
       space,
-      commandReceiptCause(space, "malformed-command"),
+      commandReceiptCause(space, space, "malformed-command"),
+      agentOwnerSchema(space),
     );
     const malformedReceiptTx = runtime.edit();
+    malformedReceiptTx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
     malformedReceipt.withTx(malformedReceiptTx).set({
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: space,
       commandId: "malformed-command",
       sourceId: source.id,
       nativeSessionId: snapshot.summary.nativeSessionId,
       status: "not-a-status",
     });
+    malformedReceipt.withTx(malformedReceiptTx).applyCfcSchemaToExistingValue();
+    malformedReceiptTx.prepareCfc();
     const malformedReceiptCommit = await malformedReceiptTx.commit();
     if (malformedReceiptCommit.error) throw malformedReceiptCommit.error;
     await assertRejects(
@@ -277,8 +377,31 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       "command receipt status is invalid",
     );
 
+    const unprotectedReceipt = runtime.getCell(
+      space,
+      commandReceiptCause(space, space, "unprotected-command"),
+      undefined,
+    );
+    const unprotectedReceiptTx = runtime.edit();
+    unprotectedReceipt.withTx(unprotectedReceiptTx).setRawUntyped({
+      schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: space,
+      commandId: "unprotected-command",
+      sourceId: source.id,
+      nativeSessionId: snapshot.summary.nativeSessionId,
+      status: "succeeded",
+    });
+    const unprotectedReceiptCommit = await unprotectedReceiptTx.commit();
+    if (unprotectedReceiptCommit.error) throw unprotectedReceiptCommit.error;
+    await assertRejects(
+      () => target.readReceipt("unprotected-command"),
+      Error,
+      "refusing to trust an unprotected command receipt",
+    );
+
     const malformedIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+      ownerDid: space,
       receipts: "not-an-array",
       updatedAt: "2026-07-20T00:00:00.000Z",
     };
@@ -287,6 +410,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       () =>
         target.publishReceipt({
           schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+          ownerDid: space,
           commandId: "command-2",
           sourceId: source.id,
           nativeSessionId: snapshot.summary.nativeSessionId,
@@ -323,10 +447,15 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
         value: { ...validRow, nativeSessionId: " session-1 " },
         message: "nativeSessionId is not normalized",
       },
+      {
+        value: { ...validRow, ownerDid: "did:key:another-owner" },
+        message: "command receipt index row belongs to another owner",
+      },
     ];
     for (const malformed of malformedRows) {
       const malformedRowIndex = {
         schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+        ownerDid: space,
         receipts: [malformed.value],
         updatedAt: "2026-07-20T00:00:00.000Z",
       };
@@ -335,6 +464,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
         () =>
           target.publishReceipt({
             schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+            ownerDid: space,
             commandId: "command-2",
             sourceId: source.id,
             nativeSessionId: snapshot.summary.nativeSessionId,
@@ -351,6 +481,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
 
     const malformedTimestampIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+      ownerDid: space,
       receipts: [validRow],
       updatedAt: "not-a-timestamp",
     };
@@ -359,6 +490,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       () =>
         target.publishReceipt({
           schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+          ownerDid: space,
           commandId: "command-2",
           sourceId: source.id,
           nativeSessionId: snapshot.summary.nativeSessionId,
@@ -370,6 +502,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
 
     const oversizedIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.commandReceipts,
+      ownerDid: space,
       receipts: Array.from({ length: 201 }, () => structuredClone(validRow)),
       updatedAt: "2026-07-20T00:00:00.000Z",
     };
@@ -378,6 +511,7 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       () =>
         target.publishReceipt({
           schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+          ownerDid: space,
           commandId: "command-2",
           sourceId: source.id,
           nativeSessionId: snapshot.summary.nativeSessionId,
@@ -388,16 +522,36 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
     );
 
     const receivedCommands = Promise.withResolvers<unknown[]>();
+    const commandWriterAuthorization = {
+      __ctWriterIdentityOf: {
+        file: "agent-sessions-debug/main.tsx",
+        moduleIdentity: "fid1:target-test-command-writer",
+        path: ["sendOwnerAgentCommand"],
+      },
+    };
+    await target.bindCommandCell(
+      target.cells.commands,
+      commandWriterAuthorization,
+    );
     const cancel = await target.subscribeCommands((commands) => {
       if (commands.length > 0) receivedCommands.resolve(commands);
     });
     try {
+      const command = JSON.stringify({ id: "command-2" });
       const tx = runtime.edit();
-      target.cells.commands.withTx(tx).set([{ id: "command-2" }]);
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity:
+          commandWriterAuthorization.__ctWriterIdentityOf.moduleIdentity,
+        sourceFile: commandWriterAuthorization.__ctWriterIdentityOf.file,
+        bindingPath: commandWriterAuthorization.__ctWriterIdentityOf.path,
+      });
+      target.cells.commands.withTx(tx).set([command]);
+      tx.prepareCfc();
       const result = await tx.commit();
       if (result.error) throw result.error;
-      assertEquals(await receivedCommands.promise, [{ id: "command-2" }]);
-      assertEquals(await target.pollCommands(), [{ id: "command-2" }]);
+      assertEquals(await receivedCommands.promise, [command]);
+      assertEquals(await target.pollCommands(), [command]);
     } finally {
       cancel();
     }
@@ -454,10 +608,12 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
     const invalidIndexScope = {
       spaceDid: space,
       agentConnector: "invalid-index-test-array-elements",
-      version: 1,
     };
-    const writeInvalidIndex = async (session: Record<string, unknown>) => {
-      const invalidIndex = { ...index, sessions: [session] };
+    const writeInvalidIndex = async (
+      session: Record<string, unknown>,
+      sources = index.sources,
+    ) => {
+      const invalidIndex = { ...index, sources, sessions: [session] };
       const [invalidRecentPlan, invalidAllPlan] = await Promise.all([
         planStableArrayCells(
           { ...invalidIndex, bucket: "recent" },
@@ -491,14 +647,466 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       Error,
       "agent session index row 0 has no driver",
     );
-    const { formatVersion: _formatVersion, ...unversionedSession } =
-      publishedSession;
-    await writeInvalidIndex(unversionedSession);
+    await writeInvalidIndex({
+      ...publishedSession,
+      ownerDid: "did:key:another-owner",
+    });
     await assertRejects(
       () => target.publish(collected),
       Error,
-      "agent session index row 0 has an invalid formatVersion",
+      "agent session index row 0 has an invalid shape",
     );
+    await writeInvalidIndex({ ...publishedSession, key: "wrong/session" });
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index row 0 has an invalid shape",
+    );
+    await writeInvalidIndex(publishedSession, [{
+      ...(index.sources as Array<Record<string, unknown>>)[0],
+      id: "Codex:Test",
+    }]);
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index source 0 has an invalid shape",
+    );
+    await writeInvalidIndex({
+      ...publishedSession,
+      sourceId: "Codex:Test",
+    });
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index row 0 has an invalid shape",
+    );
+    await writeInvalidIndex({
+      ...publishedSession,
+      nativeSessionId: " session-1 ",
+    });
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index row 0 has an invalid shape",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("Fabric target data is owner-scoped and owner-confidential", async () => {
+  const owner = await Identity.fromPassphrase("agent connector data owner");
+  const otherOwner = await Identity.fromPassphrase(
+    "agent connector other data owner",
+  );
+  const storageManager = StorageManager.emulate({ as: owner });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = owner.did();
+  try {
+    const connection = { runtime, spaceDid: space, ownerDid: owner.did() };
+    const ownerCells = createAgentFabricCells(connection);
+    const otherCells = createAgentFabricCells({
+      runtime,
+      spaceDid: space,
+      ownerDid: otherOwner.did(),
+    });
+    assertNotEquals(
+      ownerCells.health.getAsNormalizedFullLink().id,
+      otherCells.health.getAsNormalizedFullLink().id,
+    );
+
+    const target = await AgentFabricTarget.open(connection);
+    for (
+      const cell of [
+        target.cells.index,
+        target.cells.allIndex,
+        target.cells.health,
+        target.cells.receipts,
+      ]
+    ) {
+      assertEquals(
+        cellHasOwnerProtection(runtime.readTx(), cell, owner.did()),
+        true,
+      );
+    }
+    await target.publishHealth({
+      status: "ready",
+      localWorkspace: "/private/owner/worktree",
+    });
+    const healthLink = target.cells.health.getAsNormalizedFullLink();
+    const inspect = runtime.edit();
+    const stored = inspect.readOrThrow({
+      space: healthLink.space,
+      id: healthLink.id,
+      path: [],
+      ...(healthLink.scope !== undefined && { scope: healthLink.scope }),
+    }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
+    assertEquals(
+      stored.cfc?.labelMap?.entries?.some((entry) =>
+        JSON.stringify(entry).includes("confidentiality") &&
+        JSON.stringify(entry).includes(owner.did())
+      ),
+      true,
+    );
+    inspect.abort();
+
+    const attack = runtime.edit();
+    attack.setCfcTrustSnapshot({
+      id: `principal:${otherOwner.did()}`,
+      actingPrincipal: otherOwner.did(),
+    });
+    attack.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
+    attack.writeValueOrThrow(healthLink, {
+      status: "compromised",
+    });
+    attack.prepareCfc();
+    const attackResult = await attack.commit();
+    assertEquals(attackResult.error !== undefined, true);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("shared-space agent discovery and commands are owner-isolated", async () => {
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: { audience: EMULATED_AUDIENCE },
+  });
+  const owner = await Identity.fromPassphrase("shared agent graph owner");
+  const otherOwner = await Identity.fromPassphrase(
+    "shared agent graph other owner",
+  );
+  const ownerSession = await createSession({
+    identity: owner,
+    spaceName: `shared-agent-graph-${crypto.randomUUID()}`,
+  });
+  const ownerStorage = SharedServerStorageManager.connectTo(server, {
+    as: ownerSession.as,
+  });
+  const ownerRuntime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: ownerStorage,
+  });
+  let otherRuntime: Runtime | undefined;
+  let otherStorage: SharedServerStorageManager | undefined;
+  try {
+    const target = await AgentFabricTarget.open({
+      runtime: ownerRuntime,
+      spaceDid: ownerSession.space,
+      ownerDid: owner.did(),
+    });
+    await target.bindCommandCell(target.cells.commands, {
+      __ctWriterIdentityOf: {
+        file: "agent-sessions-debug/main.tsx",
+        moduleIdentity: "fid1:owner-command-writer",
+        path: ["sendOwnerAgentCommand"],
+      },
+    });
+    const source: SourceDescriptor = {
+      id: "codex:test",
+      driver: "codex-app-server",
+      capabilities: {
+        inventory: true,
+        read: true,
+        prompt: true,
+        cancel: true,
+        rename: true,
+        setMode: false,
+        setConfigOption: false,
+      },
+    };
+    const snapshot: NativeSessionSnapshot = {
+      summary: {
+        nativeSessionId: "private-session",
+        title: "Private session",
+        cwd: "/private/owner/workspace",
+        createdAt: "2026-08-25T00:00:00.000Z",
+        updatedAt: "2026-08-25T00:01:00.000Z",
+        archived: false,
+        active: true,
+        raw: {},
+      },
+      events: [{
+        type: "message",
+        id: "private-message",
+        role: "user",
+        content: "private prompt",
+      }],
+      normalizedMessages: [{
+        id: "private-message",
+        role: "user",
+        kind: "text",
+        createdAt: "2026-08-25T00:01:00.000Z",
+        textPreview: "private prompt",
+        rawIndex: 0,
+      }],
+      complete: true,
+    };
+    await target.publish([{
+      source,
+      sessions: [snapshot],
+      errors: [],
+      complete: true,
+    }]);
+    await ownerStorage.synced();
+    assertEquals(
+      (await assertOwnerProtectedGraph(
+        ownerRuntime,
+        target.cells.allIndex,
+        owner.did(),
+      )) > 5,
+      true,
+    );
+
+    const otherSession = await createSession({
+      identity: otherOwner,
+      spaceDid: ownerSession.space,
+    });
+    otherStorage = SharedServerStorageManager.connectTo(server, {
+      as: otherSession.as,
+    });
+    otherRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: otherStorage,
+    });
+    const otherTarget = await AgentFabricTarget.open({
+      runtime: otherRuntime,
+      spaceDid: otherSession.space,
+      ownerDid: otherOwner.did(),
+    });
+    const otherIndex = await readStableCellGraphValue(
+      {
+        runtime: otherRuntime,
+        spaceDid: otherSession.space,
+        ownerDid: otherOwner.did(),
+      },
+      otherTarget.cells.allIndex,
+    ) as Record<string, unknown>;
+    assertEquals(otherIndex.sessions, []);
+    assertNotEquals(
+      target.cells.allIndex.getAsNormalizedFullLink().id,
+      otherTarget.cells.allIndex.getAsNormalizedFullLink().id,
+    );
+
+    const causes = agentFabricCauses(ownerSession.space, owner.did());
+    const ownerCommands = otherRuntime.getCell(
+      ownerSession.space,
+      causes.commands,
+    );
+    await ownerCommands.sync();
+    await otherStorage.synced();
+
+    const attack = otherRuntime.edit();
+    ownerCommands.withTx(attack).setRawUntyped([{
+      schema: AGENT_CONNECTOR_SCHEMAS.command,
+      ownerDid: owner.did(),
+      id: "other-owner-command",
+    }]);
+    let rejected = false;
+    try {
+      attack.prepareCfc();
+      rejected = (await attack.commit()).error !== undefined;
+    } catch {
+      rejected = true;
+      attack.abort();
+    }
+    assertEquals(rejected, true);
+  } finally {
+    await otherRuntime?.dispose();
+    await otherStorage?.close();
+    await ownerRuntime.dispose();
+    await ownerStorage.close();
+    await server.close();
+  }
+});
+
+Deno.test("Fabric target refuses an unprotected owner root", async () => {
+  const owner = await Identity.fromPassphrase("agent connector root owner");
+  const storageManager = StorageManager.emulate({ as: owner });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = (await Identity.fromPassphrase(
+    "shared agent connector root space",
+  )).did();
+  try {
+    const connection = { runtime, spaceDid: space, ownerDid: owner.did() };
+    const cells = createAgentFabricCells(connection);
+    const unprotectedIndex = runtime.getCell(
+      space,
+      agentFabricCauses(space, owner.did()).index,
+      undefined,
+    );
+    const seed = runtime.edit();
+    unprotectedIndex.withTx(seed).setRawUntyped({
+      schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: owner.did(),
+      bucket: "recent",
+      generatedAt: "2026-08-25T00:00:00.000Z",
+      generation: 0,
+      sources: [],
+      sessions: [],
+    });
+    const committed = await seed.commit();
+    if (committed.error) throw committed.error;
+
+    await assertRejects(
+      () => AgentFabricTarget.open(connection),
+      Error,
+      "refusing to adopt an unprotected recent session index",
+    );
+    assertEquals(cells.allIndex.getRaw(), undefined);
+    assertEquals(cells.health.getRaw(), undefined);
+    assertEquals(cells.receipts.getRaw(), undefined);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("Fabric target refuses an owner root with another writer", async () => {
+  const owner = await Identity.fromPassphrase(
+    "agent connector wrong writer owner",
+  );
+  const storageManager = StorageManager.emulate({ as: owner });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const otherWriter = "another-owner-scoped-pattern";
+  try {
+    const connection = {
+      runtime,
+      spaceDid: owner.did(),
+      ownerDid: owner.did(),
+    };
+    const root = runtime.getCell(
+      owner.did(),
+      agentFabricCauses(owner.did(), owner.did()).index,
+      agentPrincipalSchema(owner.did(), [otherWriter]),
+    );
+    const seed = runtime.edit();
+    seed.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: otherWriter,
+    });
+    root.withTx(seed).set({
+      schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
+      ownerDid: owner.did(),
+      bucket: "recent",
+      generatedAt: "2026-08-25T00:00:00.000Z",
+      generation: 0,
+      sources: [],
+      sessions: [],
+    });
+    root.withTx(seed).applyCfcSchemaToExistingValue();
+    seed.prepareCfc();
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+
+    assertEquals(
+      cellHasOwnerProtection(runtime.readTx(), root, owner.did()),
+      true,
+    );
+    await assertRejects(
+      () => AgentFabricTarget.open(connection),
+      Error,
+      "writeAuthorizedBy cannot be weakened",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("Fabric target binds only an empty owner command queue", async () => {
+  const owner = await Identity.fromPassphrase("command queue binding owner");
+  const storageManager = StorageManager.emulate({ as: owner });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const writerAuthorization = {
+    __ctWriterIdentityOf: {
+      file: "agent-sessions-debug/main.tsx",
+      moduleIdentity: "fid1:verified-command-writer",
+      path: ["sendOwnerAgentCommand"],
+    },
+  };
+  try {
+    const rawCommandCell = runtime.getCell(
+      owner.did(),
+      agentFabricCauses(owner.did(), owner.did()).commands,
+      undefined,
+    );
+    const seed = runtime.edit();
+    rawCommandCell.withTx(seed).setRawUntyped(["pre-seeded-command"]);
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+    const first = await AgentFabricTarget.open({
+      runtime,
+      spaceDid: owner.did(),
+      ownerDid: owner.did(),
+    });
+    await assertRejects(
+      () => first.bindCommandCell(first.cells.commands, writerAuthorization),
+      Error,
+      "refusing to adopt a populated command queue",
+    );
+    await assertRejects(
+      () =>
+        first.bindCommandCell(
+          runtime.getCell(owner.did(), "redirected-command-queue"),
+          writerAuthorization,
+        ),
+      Error,
+      "not the connector's owner-scoped queue",
+    );
+
+    const secondOwner = await Identity.fromPassphrase(
+      "empty command queue binding owner",
+    );
+    const secondStorage = StorageManager.emulate({ as: secondOwner });
+    const secondRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: secondStorage,
+    });
+    try {
+      const second = await AgentFabricTarget.open({
+        runtime: secondRuntime,
+        spaceDid: secondOwner.did(),
+        ownerDid: secondOwner.did(),
+      });
+      await assertRejects(
+        () => second.pollCommands(),
+        Error,
+        "owner command cell has not been bound",
+      );
+      await assertRejects(
+        () => second.subscribeCommands(() => {}),
+        Error,
+        "owner command cell has not been bound",
+      );
+      await second.bindCommandCell(second.cells.commands, writerAuthorization);
+      assertEquals(second.commandsAreBound(), true);
+      assertEquals(await second.pollCommands(), []);
+    } finally {
+      await secondRuntime.dispose();
+      await secondStorage.close();
+    }
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -833,7 +1441,7 @@ Deno.test("an interrupted publication leaves the prior session graph intact", as
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   const source: SourceDescriptor = {
     id: "codex:test",
     driver: "codex-app-server",
@@ -884,7 +1492,7 @@ Deno.test("an interrupted publication leaves the prior session graph intact", as
     }]);
     const manifest = runtime.getCell(
       space,
-      sessionCause(space, source.id, "session-1"),
+      sessionCause(space, space, source.id, "session-1"),
     );
 
     const originalEdit = runtime.edit;
@@ -972,7 +1580,7 @@ Deno.test("session publication captures native values once", async () => {
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   let conversions = 0;
   const sharedNativeValue = {
     toJSON() {
@@ -1024,7 +1632,7 @@ Deno.test("session publication captures native values once", async () => {
 
     const manifest = runtime.getCell(
       space,
-      sessionCause(space, source.id, "session-1"),
+      sessionCause(space, space, source.id, "session-1"),
     );
     const published = await readStableCellGraphValue(
       connection,
@@ -1055,7 +1663,7 @@ Deno.test("newer session refresh wins over an older full collection", async () =
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   try {
     const target = await AgentFabricTarget.open(connection);
     const source: SourceDescriptor = {

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -932,6 +932,87 @@ Deno.test("shared-space agent discovery and commands are owner-isolated", async 
   }
 });
 
+Deno.test("stable graph checks remote children before adoption", async () => {
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: { audience: EMULATED_AUDIENCE },
+  });
+  const owner = await Identity.fromPassphrase("stable graph remote owner");
+  const otherOwner = await Identity.fromPassphrase(
+    "stable graph remote squatter",
+  );
+  const ownerSession = await createSession({
+    identity: owner,
+    spaceName: `stable-graph-remote-${crypto.randomUUID()}`,
+  });
+  const otherSession = await createSession({
+    identity: otherOwner,
+    spaceDid: ownerSession.space,
+  });
+  const otherStorage = SharedServerStorageManager.connectTo(server, {
+    as: otherSession.as,
+  });
+  const otherRuntime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: otherStorage,
+  });
+  let ownerRuntime: Runtime | undefined;
+  let ownerStorage: SharedServerStorageManager | undefined;
+  try {
+    const childCause = { stableGraphTest: "remote-child" };
+    const otherChild = otherRuntime.getCell(ownerSession.space, childCause);
+    await otherChild.sync();
+    await otherStorage.synced();
+    const seed = otherRuntime.edit();
+    otherChild.withTx(seed).setRawUntyped({ exposed: true });
+    const seeded = await seed.commit();
+    if (seeded.error) throw seeded.error;
+    await otherStorage.synced();
+
+    ownerStorage = SharedServerStorageManager.connectTo(server, {
+      as: ownerSession.as,
+    });
+    ownerRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: ownerStorage,
+    });
+    const connection = {
+      runtime: ownerRuntime,
+      spaceDid: ownerSession.space,
+      ownerDid: owner.did(),
+    };
+    const parent = ownerRuntime.getCell(
+      ownerSession.space,
+      { stableGraphTest: "remote-parent" },
+      agentOwnerSchema(owner.did()),
+    );
+    await assertRejects(
+      () =>
+        pushStableCellGraph(connection, [{
+          cell: parent,
+          value: (materializeCell) => ({
+            child: materializeCell(childCause, { exposed: false }),
+          }),
+        }]),
+      Error,
+      "refusing to adopt an unprotected stable graph cell",
+    );
+
+    assertEquals(otherChild.getRaw(), { exposed: true });
+    assertEquals(parent.getRaw(), undefined);
+  } finally {
+    await ownerRuntime?.dispose();
+    await ownerStorage?.close();
+    await otherRuntime.dispose();
+    await otherStorage.close();
+    await server.close();
+  }
+});
+
 Deno.test("Fabric target refuses an unprotected owner root", async () => {
   const owner = await Identity.fromPassphrase("agent connector root owner");
   const storageManager = StorageManager.emulate({ as: owner });

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -4,6 +4,7 @@ import {
   assertNotEquals,
   assertRejects,
   assertStrictEquals,
+  assertThrows,
 } from "@std/assert";
 import {
   isLinkRef,
@@ -665,6 +666,12 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       Error,
       "agent session index row 0 has no driver",
     );
+    await writeInvalidIndex([] as unknown as Record<string, unknown>);
+    await assertRejects(
+      () => target.publish(collected),
+      Error,
+      "agent session index row 0 has an invalid shape",
+    );
     await writeInvalidIndex({
       ...publishedSession,
       ownerDid: "did:key:another-owner",
@@ -1094,9 +1101,31 @@ Deno.test("Fabric target can defer its storage claim", async () => {
       spaceDid: owner.did(),
       ownerDid: owner.did(),
     };
-    const target = await AgentFabricTarget.connect(connection);
-    assertEquals(target.cells.index.getRaw(), undefined);
-    assertEquals(target.cells.commands.getRaw(), undefined);
+    let gitContextCalls = 0;
+    const target = await AgentFabricTarget.connect(connection, {
+      beginObservation: () => {
+        gitContextCalls++;
+        throw new Error("git context must not be used before storage claim");
+      },
+      validateCheckout: () => {
+        gitContextCalls++;
+        throw new Error("git context must not be used before storage claim");
+      },
+    } as never);
+    const rootValues = () => [
+      target.cells.index.getRaw(),
+      target.cells.allIndex.getRaw(),
+      target.cells.health.getRaw(),
+      target.cells.commands.getRaw(),
+      target.cells.receipts.getRaw(),
+    ];
+    assertEquals(rootValues(), [
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
     await assertRejects(
       () => target.publish([]),
       Error,
@@ -1107,8 +1136,97 @@ Deno.test("Fabric target can defer its storage claim", async () => {
       Error,
       "agent connector storage has not been claimed",
     );
+    assertThrows(
+      () => target.beginSessionObservation(),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.validateCheckout("/repo"),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    assertThrows(
+      () => target.commandCellId(),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    assertThrows(
+      () => target.receiptCellId(),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.bindCommandCell(target.cells.commands, {}),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    assertThrows(
+      () => target.commandsAreBound(),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.readReceipt("command"),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.subscribeCommands(() => {}),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.pollCommands(),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.publishReceipt({} as never),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.refreshSession({} as AgentDriver, "session"),
+      Error,
+      "agent connector storage has not been claimed",
+    );
 
+    assertEquals(rootValues(), [
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    assertEquals(gitContextCalls, 0);
     await target.claimStorage();
+    const claimedRootValues = rootValues();
+    await target.claimStorage();
+    assertEquals(rootValues(), claimedRootValues);
+    await assertRejects(
+      () => target.publish([], { observationSequence: 0 }),
+      Error,
+      "observationSequence must be a positive safe integer",
+    );
+    await assertRejects(
+      () => target.bindCommandCell(target.cells.commands, {}),
+      Error,
+      "command writer authorization is invalid",
+    );
+    await assertRejects(
+      () =>
+        target.publishReceipt({
+          schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+          ownerDid: "did:key:another-owner",
+          commandId: "wrong-owner-command",
+          sourceId: "codex:test",
+          nativeSessionId: "session",
+          status: "succeeded",
+        }),
+      Error,
+      "command receipt belongs to another owner",
+    );
 
     assertEquals(
       cellHasOwnerProtection(

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -749,6 +749,12 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       Error,
       "agent session index checkout 0 has an invalid shape",
     );
+    await writeInvalidIndex(
+      publishedSession,
+      index.sources,
+      [{ ...validCheckout, root: "C:\\repo" }],
+    );
+    assertEquals(await target.publish(collected), 1);
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -1091,6 +1097,16 @@ Deno.test("Fabric target can defer its storage claim", async () => {
     const target = await AgentFabricTarget.connect(connection);
     assertEquals(target.cells.index.getRaw(), undefined);
     assertEquals(target.cells.commands.getRaw(), undefined);
+    await assertRejects(
+      () => target.publish([]),
+      Error,
+      "agent connector storage has not been claimed",
+    );
+    await assertRejects(
+      () => target.publishHealth({ status: "starting" }),
+      Error,
+      "agent connector storage has not been claimed",
+    );
 
     await target.claimStorage();
 

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -382,6 +382,35 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       "command receipt status is invalid",
     );
 
+    const wrongOwnerReceipt = runtime.getCell(
+      space,
+      commandReceiptCause(space, space, "wrong-owner-command"),
+      agentOwnerSchema(space),
+    );
+    const wrongOwnerReceiptTx = runtime.edit();
+    wrongOwnerReceiptTx.setCfcImplementationIdentity({
+      kind: "builtin",
+      builtinId: AGENT_CONNECTOR_WRITER_ID,
+    });
+    wrongOwnerReceipt.withTx(wrongOwnerReceiptTx).set({
+      schema: AGENT_CONNECTOR_SCHEMAS.commandReceipt,
+      ownerDid: "did:key:another-owner",
+      commandId: "wrong-owner-command",
+      sourceId: source.id,
+      nativeSessionId: snapshot.summary.nativeSessionId,
+      status: "succeeded",
+    });
+    wrongOwnerReceipt.withTx(wrongOwnerReceiptTx)
+      .applyCfcSchemaToExistingValue();
+    wrongOwnerReceiptTx.prepareCfc();
+    const wrongOwnerReceiptCommit = await wrongOwnerReceiptTx.commit();
+    if (wrongOwnerReceiptCommit.error) throw wrongOwnerReceiptCommit.error;
+    await assertRejects(
+      () => target.readReceipt("wrong-owner-command"),
+      Error,
+      "command receipt belongs to another owner",
+    );
+
     const unprotectedReceipt = runtime.getCell(
       space,
       commandReceiptCause(space, space, "unprotected-command"),
@@ -1419,6 +1448,51 @@ Deno.test("Fabric target binds only an empty owner command queue", async () => {
         Error,
         "owner command cell has not been bound",
       );
+      const commandValueBefore = second.cells.commands.getRaw();
+      const commandProtectionBefore = cellHasOwnerProtection(
+        secondRuntime.readTx(),
+        second.cells.commands,
+        secondOwner.did(),
+      );
+      const originalEdit = secondRuntime.edit;
+      secondRuntime.edit = function () {
+        const tx = originalEdit.call(this);
+        tx.commit = () => {
+          const failure = Object.assign(
+            new Error("command cell protection interrupted"),
+            {
+              name: "PreconditionFailedError" as const,
+              precondition: "origin-committed" as const,
+            },
+          );
+          tx.abort(failure);
+          return Promise.resolve({ error: failure });
+        };
+        return tx;
+      };
+      try {
+        await assertRejects(
+          () =>
+            second.bindCommandCell(
+              second.cells.commands,
+              writerAuthorization,
+            ),
+          Error,
+          "could not protect the owner command cell: command cell protection interrupted",
+        );
+        assertEquals(second.cells.commands.getRaw(), commandValueBefore);
+        assertEquals(
+          cellHasOwnerProtection(
+            secondRuntime.readTx(),
+            second.cells.commands,
+            secondOwner.did(),
+          ),
+          commandProtectionBefore,
+        );
+      } finally {
+        secondRuntime.edit = originalEdit;
+      }
+      assertEquals(second.commandsAreBound(), false);
       await second.bindCommandCell(second.cells.commands, writerAuthorization);
       assertEquals(second.commandsAreBound(), true);
       assertEquals(await second.pollCommands(), []);

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -58,7 +58,11 @@ Deno.test("Fabric target validates a discovered checkout", async () => {
     apiUrl: new URL(import.meta.url),
     storageManager,
   });
-  const connection = { runtime, spaceDid: signer.did() };
+  const connection = {
+    runtime,
+    spaceDid: signer.did(),
+    ownerDid: signer.did(),
+  };
   const calls: string[][] = [];
   let receivedSignal: AbortSignal | undefined;
   const gitContext = new GitContextResolver(
@@ -1203,7 +1207,11 @@ Deno.test("checkout publication preserves partial-refresh inventory", async () =
     apiUrl: new URL(import.meta.url),
     storageManager,
   });
-  const connection = { runtime, spaceDid: signer.did() };
+  const connection = {
+    runtime,
+    spaceDid: signer.did(),
+    ownerDid: signer.did(),
+  };
   let observedAt = "2026-08-21T00:00:00.000Z";
   let failExtraHead = false;
   let failSessionHead = false;
@@ -1416,7 +1424,7 @@ Deno.test("publication finishes after its first graph commit", async () => {
     storageManager,
   });
   const space = signer.did();
-  const connection = { runtime, spaceDid: space };
+  const connection = { runtime, spaceDid: space, ownerDid: space };
   const source: SourceDescriptor = {
     id: "codex:test",
     driver: "codex-app-server",
@@ -1456,7 +1464,7 @@ Deno.test("publication finishes after its first graph commit", async () => {
     await target.publish(collected("Before"));
     const manifest = runtime.getCell(
       space,
-      sessionCause(space, source.id, "session-1"),
+      sessionCause(space, space, source.id, "session-1"),
     );
     const manifestId = manifest.getAsNormalizedFullLink().id;
     const controller = new AbortController();

--- a/packages/connectors/agents/test/fabric_test.ts
+++ b/packages/connectors/agents/test/fabric_test.ts
@@ -6,31 +6,31 @@ import {
 } from "../src/fabric.ts";
 
 Deno.test("agent connector Fabric causes are stable", () => {
-  assertEquals(agentFabricCauses("did:key:test"), {
+  assertEquals(agentFabricCauses("did:key:test", "did:key:owner"), {
     index: {
       spaceDid: "did:key:test",
+      ownerDid: "did:key:owner",
       agentConnector: "recent-session-index",
-      version: 1,
     },
     allIndex: {
       spaceDid: "did:key:test",
+      ownerDid: "did:key:owner",
       agentConnector: "all-session-index",
-      version: 1,
     },
     health: {
       spaceDid: "did:key:test",
+      ownerDid: "did:key:owner",
       agentConnector: "health",
-      version: 1,
     },
     commands: {
       spaceDid: "did:key:test",
+      ownerDid: "did:key:owner",
       agentConnector: "commands",
-      version: 1,
     },
     receipts: {
       spaceDid: "did:key:test",
+      ownerDid: "did:key:owner",
       agentConnector: "receipts",
-      version: 1,
     },
   });
 });

--- a/packages/connectors/agents/test/session-contract_test.ts
+++ b/packages/connectors/agents/test/session-contract_test.ts
@@ -26,6 +26,7 @@ Deno.test("session identity rejects empty and control-character values", () => {
 Deno.test("session chunk identity includes its content hash", () => {
   const first = sessionChunkCause(
     "did:key:space",
+    "did:key:owner",
     "codex",
     "session",
     0,
@@ -33,6 +34,7 @@ Deno.test("session chunk identity includes its content hash", () => {
   );
   const second = sessionChunkCause(
     "did:key:space",
+    "did:key:owner",
     "codex",
     "session",
     0,
@@ -40,8 +42,8 @@ Deno.test("session chunk identity includes its content hash", () => {
   );
   assertEquals(first, {
     spaceDid: "did:key:space",
+    ownerDid: "did:key:owner",
     agentConnector: "session-chunk",
-    version: 1,
     sourceId: "codex",
     nativeSessionId: "session",
     part: 0,

--- a/packages/patterns/agent-sessions-debug/README.md
+++ b/packages/patterns/agent-sessions-debug/README.md
@@ -60,30 +60,27 @@ stopped.
 Each Raw data link opens a separate read-only piece for that session's stable
 manifest cell. The detail piece reads the provider metadata, complete normalized
 message list, and native event chunks. Those values include the provider session
-ID. The sessions table omits provider IDs. The table shows 20 sessions per page
-and projects the preceding and following pages as a bounded prefetch window.
-This keeps adjacent page changes responsive while keeping every published
-session reachable. At most 60 session rows and their raw-data pieces remain
-active for the table. Raw views opened as separate pages have independent
-lifetimes. The page filter and column sorting apply to the current page only and
-do not load every retained row.
+ID. The sessions table omits provider IDs. The table shows and projects up to 20
+sessions per page. Every published session remains reachable without keeping
+off-page session rows or their raw-data pieces active. Raw views opened as
+separate pages have independent lifetimes. The page filter and column sorting
+apply to the current page only and do not load every retained row.
 
 The complete index stores live cells for session rows. The pattern selects a
-three-page window before projecting those cells into table rows. The list runner
-uses each session cell as the projection identity, reuses overlapping rows as
-the window moves, and stops projections that leave the window. Projection
-results remain row-cell links until the pattern slices out the current page.
-Only those selected row cells feed sorting, filtering, and rendering. A raw view
-that was opened as its own page has an independent lifetime, so reclaiming its
-table row does not stop the open page. A session gets the same raw-view URL when
-it returns to the table page. Each row stores a manifest cell with an empty
-document schema, so validating the table does not follow the manifest's child
-links. When the separate raw session view mounts, its start handler removes that
-listing schema and reads the selected session. Manifests store live cells for
-chunk descriptors, and each descriptor stores a live native-event chunk cell.
-Arrays inside provider JSON use the same stable child-cell convention. The
-rendered loading state does not contain the manifest cell. Opening the session
-table therefore does not read every retained transcript.
+current page before projecting those cells into table rows. The list runner uses
+each session cell as the projection identity and stops projections that leave
+the page. Projection results remain row-cell links. Only those selected row
+cells feed sorting, filtering, and rendering. A raw view that was opened as its
+own page has an independent lifetime, so reclaiming its table row does not stop
+the open page. A session gets the same raw-view URL when it returns to the table
+page. Each row stores a manifest cell with an empty document schema, so
+validating the table does not follow the manifest's child links. When the
+separate raw session view mounts, its start handler removes that listing schema
+and reads the selected session. Manifests store live cells for chunk
+descriptors, and each descriptor stores a live native-event chunk cell. Arrays
+inside provider JSON use the same stable child-cell convention. The rendered
+loading state does not contain the manifest cell. Opening the session table
+therefore does not read every retained transcript.
 
 The debug pattern gives session rows only the shallow fields used by the table.
 Each row keeps its manifest behind an opaque cell link. Opening the table does

--- a/packages/patterns/agent-sessions-debug/README.md
+++ b/packages/patterns/agent-sessions-debug/README.md
@@ -89,17 +89,19 @@ The debug pattern gives session rows only the shallow fields used by the table.
 Each row keeps its manifest behind an opaque cell link. Opening the table does
 not read transcript chunks; the separate raw-data view loads them when opened.
 
-The host prepares and registers the debug piece without starting it. Its static
-name makes the prepared piece visible in the space home. Opening the piece
-starts the view in the reader's runtime. Host startup therefore does not pull
-the view's complete result graph.
+The host protects the deterministic command queue before it creates or starts
+the debug piece. It starts the piece, labels the rendered result for the owner,
+and stores an owner-confidential registration. It does not add the piece to the
+space-wide home registry. The host reports the piece ID as a local discovery
+handle.
 
-On later starts, the host reuses a prepared piece whose pattern identity still
-matches the bundled debug pattern. The pattern identity is part of the piece's
-stable cause. A new pattern identity therefore creates a new piece. A shallow
-registration record identifies the current piece and retains the causes of
-retired pieces. The host removes stale links on every deployment and erases a
-newly superseded root without traversing its result graph.
+On later starts, the host reuses a prepared piece only when its pattern
+identity, configured owner, and every connector input link match. The pattern
+identity is part of the piece's stable cause. A new pattern identity therefore
+creates a new piece. A shallow owner-confidential registration identifies the
+current piece and retains the causes of retired pieces. The host removes stale
+shared-registry links and stops superseded local runners without traversing
+their result graphs.
 
 The Overview tab reports the recent and complete index generations, generation
 times, row counts, total session counts, and older-session counts. It reads the

--- a/packages/patterns/agent-sessions-debug/main.test.tsx
+++ b/packages/patterns/agent-sessions-debug/main.test.tsx
@@ -9,6 +9,7 @@ import {
   Writable,
 } from "commonfabric";
 import {
+  childNodes,
   findElementByText,
   findNode,
   propsOf,
@@ -47,6 +48,31 @@ function elementNamed(root: unknown, name: string): unknown | undefined {
   return findNode(root, (node) =>
     typeof node === "object" && node !== null &&
     (node as { name?: unknown }).name === name);
+}
+
+function countCellLinks(
+  root: unknown,
+  label: string,
+  visited = new Set<object>(),
+): number {
+  const value = readValue(root);
+  if (typeof value !== "object" || value === null) return 0;
+  if (visited.has(value)) return 0;
+  visited.add(value);
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (count, child) => count + countCellLinks(child, label, visited),
+      0,
+    );
+  }
+  const current = (value as { name?: unknown }).name === "cf-cell-link" &&
+      readValue(propsOf(value)?.label) === label
+    ? 1
+    : 0;
+  return current + childNodes(value).reduce<number>(
+    (count, child) => count + countCellLinks(child, label, visited),
+    0,
+  );
 }
 
 const NativeEventFixture = pattern<void, ShardedJsonValue>(() => ({
@@ -586,6 +612,25 @@ export default pattern(() => {
       readValue(propsOf(textarea)?.["$value"]) === "" &&
       statusMessage !== undefined;
   });
+  const action_publish_invalid_command = action(() => {
+    commands.push("not command JSON");
+  });
+  const assert_invalid_command_visible = assert(() => {
+    const commandTable = findElementByText(view[UI], "cf-table", "Payload");
+    return view.commandCount === 2 &&
+      textContent(commandTable).includes("Invalid action value") &&
+      !textContent(commandTable).includes("not command JSON") &&
+      countCellLinks(commandTable, "Raw data") === 2;
+  });
+  const action_publish_nested_array_command = action(() => {
+    commands.push([["nested invalid action"]]);
+  });
+  const assert_nested_array_command_visible = assert(() => {
+    const commandTable = findElementByText(view[UI], "cf-table", "Payload");
+    return view.commandCount === 3 &&
+      !textContent(commandTable).includes("nested invalid action") &&
+      countCellLinks(commandTable, "Raw data") === 3;
+  });
 
   return {
     [TESTS]: [
@@ -616,6 +661,10 @@ export default pattern(() => {
       { action: action_resume_command_admission },
       { action: action_send_command },
       { assertion: assert_command_sent },
+      { action: action_publish_invalid_command },
+      { assertion: assert_invalid_command_visible },
+      { action: action_publish_nested_array_command },
+      { assertion: assert_nested_array_command_visible },
     ],
     view,
   };

--- a/packages/patterns/agent-sessions-debug/main.test.tsx
+++ b/packages/patterns/agent-sessions-debug/main.test.tsx
@@ -9,7 +9,6 @@ import {
   Writable,
 } from "commonfabric";
 import {
-  childNodes,
   findElementByText,
   findNode,
   propsOf,
@@ -17,7 +16,6 @@ import {
   textContent,
 } from "../test/vnode-helpers.ts";
 import DebugView, {
-  type AgentCommand,
   type AgentCommandValue,
   type HostActivity,
   type HostHealth,
@@ -51,31 +49,6 @@ function elementNamed(root: unknown, name: string): unknown | undefined {
     (node as { name?: unknown }).name === name);
 }
 
-function countCellLinks(
-  root: unknown,
-  label: string,
-  visited = new Set<object>(),
-): number {
-  const value = readValue(root);
-  if (typeof value !== "object" || value === null) return 0;
-  if (visited.has(value)) return 0;
-  visited.add(value);
-  if (Array.isArray(value)) {
-    return value.reduce(
-      (count, child) => count + countCellLinks(child, label, visited),
-      0,
-    );
-  }
-  const current = (value as { name?: unknown }).name === "cf-cell-link" &&
-      readValue(propsOf(value)?.label) === label
-    ? 1
-    : 0;
-  return current + childNodes(value).reduce<number>(
-    (count, child) => count + countCellLinks(child, label, visited),
-    0,
-  );
-}
-
 const NativeEventFixture = pattern<void, ShardedJsonValue>(() => ({
   id: "message-1",
   text: "Done",
@@ -85,8 +58,8 @@ const EventChunkFixture = pattern<
   { nativeEvent: Cell<ShardedJsonValue> },
   SessionChunk
 >(({ nativeEvent }) => ({
-  schema: "commonfabric.agent-connector.session-chunk.v1",
-  formatVersion: 1,
+  schema: "commonfabric.agent-connector.session-chunk",
+  ownerDid: "did:key:test-owner",
   key: "codex/session-1",
   part: 0,
   contentHash: "sha256:chunk",
@@ -120,8 +93,8 @@ const ManifestFixture = pattern<
   },
   SessionManifest
 >(({ chunkDescriptor, message }) => ({
-  schema: "commonfabric.agent-connector.session.v1",
-  formatVersion: 1,
+  schema: "commonfabric.agent-connector.session",
+  ownerDid: "did:key:test-owner",
   key: "codex/session-1",
   sourceId: "codex",
   driver: "codex-app-server",
@@ -179,7 +152,6 @@ const SessionFixture = pattern<
   active,
   syncStatus,
 }) => ({
-  formatVersion: 1,
   key,
   sourceId: "codex",
   driver: "codex-app-server",
@@ -210,7 +182,7 @@ const IndexFixture = pattern<
   },
   SessionIndex
 >(({ bucket, source, firstSession, secondSession, sessionCount }) => ({
-  schema: "commonfabric.agent-connector.session-index.v1",
+  schema: "commonfabric.agent-connector.session-index",
   bucket,
   generatedAt: "2026-07-20T00:02:00.000Z",
   generation: 1,
@@ -244,9 +216,9 @@ const HealthFixture = pattern<
     commandAccepting,
   },
 ) => ({
-  schema: "commonfabric.agent-connector.health.v1",
+  schema: "commonfabric.agent-connector.health",
+  ownerDid: "did:key:test-owner",
   service: "agents-host",
-  formatVersion: 1,
   status,
   startedAt: "2026-07-20T00:00:00.000Z",
   updatedAt: "2026-07-20T00:02:00.000Z",
@@ -296,7 +268,8 @@ const ReceiptIndexFixture = pattern<
   { receipt: Cell<ReceiptRow>; receiptCount: number },
   ReceiptIndex
 >(({ receipt, receiptCount }) => ({
-  schema: "commonfabric.agent-connector.command-receipts.v1",
+  schema: "commonfabric.agent-connector.command-receipts",
+  ownerDid: "did:key:test-owner",
   updatedAt: "2026-07-20T00:04:00.000Z",
   receipts: receiptCount === 0 ? [] : [receipt],
 }));
@@ -340,6 +313,7 @@ export default pattern(() => {
   const receipt = ReceiptFixture();
   const status = new Writable("ready");
   const commandAccepting = new Writable(true);
+  const commands = new Writable<AgentCommandValue[]>([]);
   const activityCount = new Writable(1);
   const receiptCount = new Writable(0);
   const publishedSessionCount = new Writable(1);
@@ -365,7 +339,6 @@ export default pattern(() => {
     activityCount,
     commandAccepting,
   });
-  const commands = new Writable<AgentCommandValue[] | undefined>([]);
   const receipts = ReceiptIndexFixture({ receipt, receiptCount });
   const rawView = SessionRawView({
     manifest,
@@ -373,10 +346,10 @@ export default pattern(() => {
     nativeSessionId: "session-1",
   });
   const view = DebugView({
+    ownerDid: "did:key:test-owner",
     recentIndex,
     allIndex,
     health,
-    commands,
     receipts,
     recentIndexCell: recentIndex,
     allIndexCell: allIndex,
@@ -486,20 +459,11 @@ export default pattern(() => {
     status.set("degraded");
     activityCount.set(2);
     receiptCount.set(1);
-    commands.set([{
-      schema: "commonfabric.agent-connector.command.v1",
-      id: "command-1",
-      createdAt: "2026-07-20T00:03:00.000Z",
-      sourceId: "codex",
-      nativeSessionId: "session-1",
-      type: "prompt",
-      payload: { text: "Continue" },
-    }]);
   });
 
   const assert_updated_status = assert(() => view.status === "degraded");
   const assert_updated_sessions = assert(() => view.sessionCount === 0);
-  const assert_updated_commands = assert(() => view.commandCount === 1);
+  const assert_updated_commands = assert(() => view.commandCount === 0);
   const assert_updated_receipts = assert(() => view.receiptCount === 1);
   const assert_updated_activity = assert(() => view.activityCount === 2);
 
@@ -555,7 +519,7 @@ export default pattern(() => {
         readValue(propsOf(node)?.role) === "alert" &&
         textContent(node).includes("Enter a prompt."),
     );
-    return commands.get()?.length === 1 &&
+    return view.commandCount === 0 &&
       readValue(propsOf(modal)?.["$open"]) === false &&
       alert !== undefined;
   });
@@ -568,8 +532,9 @@ export default pattern(() => {
   const assert_command_review = assert(() => {
     const modal = elementNamed(view[UI], "cf-modal");
     const review = textContent(modal);
-    return commands.get()?.length === 1 &&
+    return view.commandCount === 0 &&
       readValue(propsOf(modal)?.["$open"]) === true &&
+      review.includes('"ownerDid": "did:key:test-owner"') &&
       review.includes('"sourceId": "codex"') &&
       review.includes('"nativeSessionId": "session-1"') &&
       review.includes('"type": "prompt"') &&
@@ -602,15 +567,11 @@ export default pattern(() => {
   });
   const assert_stopped_command_rejected = assert(() => {
     const modal = elementNamed(view[UI], "cf-modal");
-    return commands.get()?.length === 1 &&
+    return view.commandCount === 0 &&
       readValue(propsOf(modal)?.["$open"]) === true &&
       textContent(modal).includes("The host is not accepting commands.");
   });
   const assert_command_sent = assert(() => {
-    const values = commands.get() ?? [];
-    const submitted = values[1];
-    if (typeof submitted !== "string") return false;
-    const command = JSON.parse(submitted) as AgentCommand;
     const form = elementNamed(view[UI], "cf-form");
     const textarea = elementNamed(form, "cf-textarea");
     const modal = elementNamed(view[UI], "cf-modal");
@@ -618,38 +579,12 @@ export default pattern(() => {
       view[UI],
       (node) =>
         readValue(propsOf(node)?.role) === "status" &&
-        textContent(node).includes(`Submitted ${command.id}.`),
+        textContent(node).includes("Submitted debug:"),
     );
-    return values.length === 2 &&
-      command.schema === "commonfabric.agent-connector.command.v1" &&
-      command.id.startsWith("debug:") &&
-      command.sourceId === "codex" &&
-      command.nativeSessionId === "session-1" &&
-      command.type === "prompt" &&
-      command.payload.text === "Continue from the debug view" &&
-      view.commandCount === 2 &&
+    return view.commandCount === 1 &&
       readValue(propsOf(modal)?.["$open"]) === false &&
       readValue(propsOf(textarea)?.["$value"]) === "" &&
       statusMessage !== undefined;
-  });
-  const action_publish_invalid_command = action(() => {
-    commands.push("not command JSON");
-  });
-  const assert_invalid_command_visible = assert(() => {
-    const commandTable = findElementByText(view[UI], "cf-table", "Payload");
-    return view.commandCount === 3 &&
-      textContent(commandTable).includes("Invalid action value") &&
-      !textContent(commandTable).includes("not command JSON") &&
-      countCellLinks(commandTable, "Raw data") === 3;
-  });
-  const action_publish_nested_array_command = action(() => {
-    commands.push([["nested invalid action"]]);
-  });
-  const assert_nested_array_command_visible = assert(() => {
-    const commandTable = findElementByText(view[UI], "cf-table", "Payload");
-    return view.commandCount === 4 &&
-      !textContent(commandTable).includes("nested invalid action") &&
-      countCellLinks(commandTable, "Raw data") === 4;
   });
 
   return {
@@ -681,10 +616,6 @@ export default pattern(() => {
       { action: action_resume_command_admission },
       { action: action_send_command },
       { assertion: assert_command_sent },
-      { action: action_publish_invalid_command },
-      { assertion: assert_invalid_command_visible },
-      { action: action_publish_nested_array_command },
-      { assertion: assert_nested_array_command_visible },
     ],
     view,
   };

--- a/packages/patterns/agent-sessions-debug/main.tsx
+++ b/packages/patterns/agent-sessions-debug/main.tsx
@@ -1,17 +1,21 @@
 import {
   action,
   type Cell,
+  Cfc,
   computed,
+  CurrentPrincipal,
   handler,
   lift,
   NAME,
   type OpaqueCell,
   pattern,
+  RepresentsCurrentUser,
   Stream,
   UI,
   type VNode,
   wish,
   Writable,
+  WriteAuthorizedBy,
 } from "commonfabric";
 import {
   conversationState,
@@ -88,7 +92,6 @@ export interface MessagePreview {
 
 export interface SessionChunk {
   schema: string;
-  formatVersion: 1;
   key: string;
   part: number;
   contentHash: string;
@@ -105,7 +108,6 @@ export interface SessionChunkDescriptor {
 
 export interface SessionManifest {
   schema: string;
-  formatVersion: 1;
   key: string;
   sourceId: string;
   driver: string;
@@ -123,7 +125,6 @@ export interface SessionManifest {
 }
 
 export interface SessionRow {
-  formatVersion: 1;
   key: string;
   sourceId: string;
   driver: string;
@@ -227,7 +228,6 @@ export interface HostActivity {
 export interface HostHealth {
   schema: string;
   service: string;
-  formatVersion: number;
   status: string;
   startedAt: string;
   updatedAt: string;
@@ -263,6 +263,7 @@ export type AgentCommandType =
 
 export interface AgentCommand {
   schema: string;
+  ownerDid: string;
   id: string;
   createdAt: string;
   sourceId: string;
@@ -275,6 +276,52 @@ export interface AgentCommand {
 
 // The connector validates each action value before interpreting it as a command.
 export type AgentCommandValue = JsonValue;
+
+export const sendOwnerAgentCommand = handler<
+  void,
+  {
+    commands: Writable<AgentCommandValue[]>;
+    commandAdmission: Cell<boolean>;
+    pendingCommand: Writable<AgentCommand | null>;
+    commandLastSubmission: Writable<string>;
+    commandError: Writable<string>;
+    commandConfirmOpen: Writable<boolean>;
+    commandPromptText: Writable<string>;
+    commandArgument: Writable<string>;
+    commandConfigKey: Writable<string>;
+    commandConfigValue: Writable<string>;
+    commandForce: Writable<boolean>;
+  }
+>((_, state) => {
+  if (state.commandAdmission.get() !== true) {
+    state.commandError.set("The host is not accepting commands.");
+    return;
+  }
+  const command = state.pendingCommand.get();
+  if (command === null || command === undefined) {
+    state.commandError.set("Review the command before sending it.");
+    return;
+  }
+  state.commands.push(JSON.stringify(command));
+  state.commandLastSubmission.set(
+    `Submitted ${command.id}. Watch the receipt index for its outcome.`,
+  );
+  state.commandError.set("");
+  state.commandConfirmOpen.set(false);
+  state.pendingCommand.set(null);
+  state.commandPromptText.set("");
+  state.commandArgument.set("");
+  state.commandConfigKey.set("");
+  state.commandConfigValue.set("");
+  state.commandForce.set(false);
+});
+
+type OwnerCommandQueue = RepresentsCurrentUser<
+  Cfc<
+    WriteAuthorizedBy<AgentCommandValue[], typeof sendOwnerAgentCommand>,
+    { ownerPrincipal: CurrentPrincipal }
+  >
+>;
 
 export interface ReceiptRow {
   commandId: string;
@@ -293,15 +340,15 @@ export interface ReceiptIndex {
 }
 
 export interface DebugInput {
+  ownerDid: string;
   recentIndex: SessionIndexInput | undefined;
   allIndex: SessionIndexInput | undefined;
   health: HostHealth | undefined;
-  commands: Writable<AgentCommandValue[] | undefined>;
   receipts: ReceiptIndex | undefined;
   recentIndexCell: OpaqueCell<DeferredDocument | undefined>;
   allIndexCell: OpaqueCell<DeferredDocument | undefined>;
   healthCell: OpaqueCell<DeferredDocument | undefined>;
-  commandsCell: OpaqueCell<AgentCommandValue[] | undefined>;
+  commandsCell: Writable<AgentCommandValue[]>;
   receiptsCell: OpaqueCell<DeferredDocument | undefined>;
 }
 
@@ -319,6 +366,14 @@ export interface DebugOutput {
   commandCount: number;
   receiptCount: number;
   activityCount: number;
+  commandQueue: OwnerCommandQueue;
+  // The host reads this optional field's schema to label the input command
+  // queue with the verified handler that writes commands. The field has no
+  // stored value.
+  commandAuthorization?: WriteAuthorizedBy<
+    boolean,
+    typeof sendOwnerAgentCommand
+  >;
 }
 
 function stringValue(value: string | null | undefined, fallback = "—"): string {
@@ -431,7 +486,8 @@ function isAgentCommand(value: unknown): value is AgentCommand {
     return false;
   }
   const command = value as Record<string, unknown>;
-  return command.schema === "commonfabric.agent-connector.command.v1" &&
+  return command.schema === "commonfabric.agent-connector.command" &&
+    typeof command.ownerDid === "string" &&
     typeof command.id === "string" &&
     typeof command.createdAt === "string" &&
     typeof command.sourceId === "string" &&
@@ -603,7 +659,7 @@ function sessionIndexJson(
   value: SessionIndexInput | undefined,
 ): SessionIndexInput | undefined {
   if (
-    value?.schema !== "commonfabric.agent-connector.session-index.v1" ||
+    value?.schema !== "commonfabric.agent-connector.session-index" ||
     !Array.isArray(value.sources) ||
     !Array.isArray(value.sessions)
   ) {
@@ -1316,15 +1372,13 @@ const renderCommandTableRow = pattern<
       rawJson,
       source,
       origin: command === undefined
-        ? "This is one unrecognized action value from the connector's shared " +
-          "commands cell. Any Fabric writer with access to that cell can append " +
-          "an action value."
+        ? "This is one unrecognized action value from the owner's protected " +
+          "command queue."
         : `This is the payload field of command ${
           JSON.stringify(command.id)
         }, created at ${JSON.stringify(command.createdAt)}, from the ` +
-          "connector's shared commands cell. The debug composer appends a JSON " +
-          "string. Other Fabric writers can append either a JSON string or an " +
-          "object.",
+          "owner's protected command queue. The debug composer appends a JSON " +
+          "string through its owner-gated sending handler.",
       processing: command === undefined
         ? "The page materializes stable child cells inside the action value and " +
           "formats the complete unrecognized value as JSON."
@@ -1500,7 +1554,7 @@ const commandCellPageFromNewest = lift(
       length,
       page,
     }: {
-      values: OpaqueCell<AgentCommandValue[] | undefined>;
+      values: OpaqueCell<AgentCommandValue[]>;
       length: number;
       page: number;
     },
@@ -1521,15 +1575,17 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       recentIndex,
       allIndex,
       health,
-      commands,
       receipts,
       recentIndexCell,
       allIndexCell,
       healthCell,
       commandsCell,
       receiptsCell,
+      ownerDid,
     },
   ) => {
+    const commands = commandsCell;
+    const protectedCommands: Writable<OwnerCommandQueue> = commandsCell;
     const activeTab = new Writable.perSession<DebugTab>("overview");
     const sessionFilter = new Writable.perSession("");
     const sessionPage = new Writable.perSession(0);
@@ -1600,7 +1656,8 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       if (error) return;
       const createdAt = new Date().toISOString();
       const command: AgentCommand = {
-        schema: "commonfabric.agent-connector.command.v1",
+        schema: "commonfabric.agent-connector.command",
+        ownerDid,
         id: `debug:${createdAt}:${Math.random().toString(36).slice(2, 10)}`,
         createdAt,
         sourceId: fields.sourceId.trim().toLowerCase(),
@@ -1618,28 +1675,18 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       commandConfirmOpen.set(false);
       pendingCommand.set(null);
     });
-    const sendCommand = action(() => {
-      if (!commandAdmission) {
-        commandError.set("The host is not accepting commands.");
-        return;
-      }
-      const command = pendingCommand.get();
-      if (command === null || command === undefined) {
-        commandError.set("Review the command before sending it.");
-        return;
-      }
-      commands.push(JSON.stringify(command));
-      commandLastSubmission.set(
-        `Submitted ${command.id}. Watch the receipt index for its outcome.`,
-      );
-      commandError.set("");
-      commandConfirmOpen.set(false);
-      pendingCommand.set(null);
-      commandPromptText.set("");
-      commandArgument.set("");
-      commandConfigKey.set("");
-      commandConfigValue.set("");
-      commandForce.set(false);
+    const sendCommand = sendOwnerAgentCommand({
+      commands,
+      commandAdmission,
+      pendingCommand,
+      commandLastSubmission,
+      commandError,
+      commandConfirmOpen,
+      commandPromptText,
+      commandArgument,
+      commandConfigKey,
+      commandConfigValue,
+      commandForce,
     });
 
     const recentIndexState = computed(() => sessionIndexState(recentIndex));
@@ -1840,7 +1887,7 @@ const DebugView = pattern<DebugInput, DebugOutput>(
         "source, collection, command, and activity state. " +
         "AgentFabricTarget.publishHealth() stores the snapshot in the " +
         "deterministic top-level health cell whose cause uses " +
-        'agentConnector: "health" and version: 1.',
+        'agentConnector: "health" and the configured owner DID.',
       processing: "The page reads the health cell's stored value when it " +
         "starts and formats it as JSON. Stable child cells remain explicit " +
         "Fabric links. The page does not follow source or activity links.",
@@ -1853,7 +1900,8 @@ const DebugView = pattern<DebugInput, DebugOutput>(
         "top-level index after a provider collection. It contains source rows " +
         "and links to non-deleted sessions updated within the preceding seven " +
         "days. " +
-        'Its cause uses agentConnector: "recent-session-index" and version: 1.',
+        'Its cause uses agentConnector: "recent-session-index" and the ' +
+        "configured owner DID.",
       processing:
         "The page reads the index cell's stored value when it starts " +
         "and formats it as JSON. Session and source child cells remain explicit " +
@@ -1866,7 +1914,8 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       origin: "AgentFabricTarget.publish() rebuilds this deterministic " +
         "top-level index after a provider collection. It contains source rows, " +
         "all non-deleted session-row links, and retained deleted-session rows. " +
-        'Its cause uses agentConnector: "all-session-index" and version: 1.',
+        'Its cause uses agentConnector: "all-session-index" and the ' +
+        "configured owner DID.",
       processing:
         "The page reads the index cell's stored value when it starts " +
         "and formats it as JSON. Session and source child cells remain explicit " +
@@ -1877,10 +1926,9 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       description: "Commands submitted to the connector host",
       value: commandsCell,
       origin:
-        "This is the connector's shared action array. The debug command " +
-        "composer and any other authorized Fabric writer append command values " +
-        "to the deterministic top-level cell whose cause uses " +
-        'agentConnector: "commands" and version: 1. The running host subscribes ' +
+        "This is the owner-confidential command queue supplied by the host. " +
+        "piece. Only the configured owner acting through the debug pattern's " +
+        "command-sending handler can modify it. The running host subscribes " +
         "to this cell.",
       processing: "The page reads the root action array when it starts. It " +
         "formats inline values as JSON and represents linked child cells as " +
@@ -1894,7 +1942,7 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       origin: "AgentFabricTarget.publishReceipt() writes one deterministic " +
         "receipt cell per command. It then updates this deterministic top-level " +
         "index with the latest 200 receipt-row links. The index cause uses " +
-        'agentConnector: "receipts" and version: 1.',
+        'agentConnector: "receipts" and the configured owner DID.',
       processing: "The page reads the receipt index's stored value when it " +
         "starts and formats it as JSON. Receipt rows and individual receipt " +
         "documents remain explicit Fabric links. The page does not follow them.",
@@ -2828,6 +2876,7 @@ const DebugView = pattern<DebugInput, DebugOutput>(
       commandCount,
       receiptCount,
       activityCount,
+      commandQueue: protectedCommands,
     };
   },
 );

--- a/packages/patterns/agent-sessions-debug/main.tsx
+++ b/packages/patterns/agent-sessions-debug/main.tsx
@@ -1740,24 +1740,17 @@ const DebugView = pattern<DebugInput, DebugOutput>(
         ),
       );
     });
-    const projectedSessionStartPage = computed(() =>
-      Math.max(0, currentSessionPage - 1)
-    );
     const projectedSessionEntries = computed(() => {
-      const start = projectedSessionStartPage * SESSION_PAGE_SIZE;
+      const start = currentSessionPage * SESSION_PAGE_SIZE;
       const end = Math.min(
         currentSessionEntries(allIndex).length,
-        (currentSessionPage + 2) * SESSION_PAGE_SIZE,
+        start + SESSION_PAGE_SIZE,
       );
       return currentSessionEntries(allIndex).slice(
         start,
         end,
       );
     });
-    // TODO(@ianh): Replace the adjacent-page projection window with keyed
-    // suspension in mapWithPattern. The list runner needs to retain inactive
-    // element results so page changes can reuse hydrated rows without keeping
-    // three pages of row and raw-view projections active.
     // deno-lint-ignore no-explicit-any
     const projectedSessions = (projectedSessionEntries as any).mapWithPattern(
       // The list runner supplies each linked record in its element field.
@@ -1767,9 +1760,7 @@ const DebugView = pattern<DebugInput, DebugOutput>(
     ) as PublishedSessionRow[];
     const pageSessionCells = slicePublishedSessionCells({
       values: projectedSessions,
-      start: computed(() =>
-        (currentSessionPage - projectedSessionStartPage) * SESSION_PAGE_SIZE
-      ),
+      start: 0,
       count: SESSION_PAGE_SIZE,
     });
     const pageSessions = computed(() => materializedCells(pageSessionCells));

--- a/packages/patterns/baselines/agent-sessions-debug/main.tsx/20260825T185403Z-YINJySlX_M2BWpPA.json
+++ b/packages/patterns/baselines/agent-sessions-debug/main.tsx/20260825T185403Z-YINJySlX_M2BWpPA.json
@@ -1,0 +1,871 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CellLink": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "items": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "type": "array"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "space": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "space",
+          "path"
+        ],
+        "type": "object"
+      },
+      "DeferredDocument": {
+        "properties": {},
+        "type": "object"
+      },
+      "HostActivity": {
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          "id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "at",
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "HostHealth": {
+        "properties": {
+          "activity": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/HostActivity",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "commandProcessing": {
+            "properties": {
+              "accepting": {
+                "type": "boolean"
+              },
+              "failedCommands": {
+                "type": "number"
+              },
+              "lastError": {
+                "type": "string"
+              },
+              "pendingReceiptPublications": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "accepting",
+              "pendingReceiptPublications",
+              "failedCommands"
+            ],
+            "type": "object"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "sources": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/SourceRow",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "sync": {
+            "properties": {
+              "completedAt": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "sessionCount": {
+                "type": "number"
+              },
+              "startedAt": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason",
+              "status",
+              "startedAt"
+            ],
+            "type": "object"
+          },
+          "target": {
+            "properties": {
+              "cells": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              "debugPieceId": {
+                "type": "string"
+              },
+              "spaceDid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "spaceDid",
+              "cells"
+            ],
+            "type": "object"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "service",
+          "status",
+          "startedAt",
+          "updatedAt",
+          "target",
+          "commandProcessing",
+          "sources",
+          "activity"
+        ],
+        "type": "object"
+      },
+      "JsonObject": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/JsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": [
+                    "null",
+                    "number",
+                    "string",
+                    "undefined"
+                  ]
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/$defs/JsonObject"
+                },
+                {
+                  "items": {
+                    "type": "unknown"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "PublishedSessionInput": {
+        "properties": {
+          "active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "archived": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitBranch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitRepo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitWorktreeRoot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manifest": {
+            "$ref": "#/$defs/DeferredDocument",
+            "asCell": [
+              "opaque"
+            ]
+          },
+          "nativeSessionId": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "syncStatus": {
+            "enum": [
+              "complete",
+              "partial",
+              "stale",
+              "deleted"
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sourceId",
+          "nativeSessionId",
+          "title",
+          "cwd",
+          "gitRepo",
+          "gitBranch",
+          "gitWorktreeRoot",
+          "updatedAt",
+          "archived",
+          "active",
+          "manifest",
+          "syncStatus"
+        ],
+        "type": "object"
+      },
+      "ReceiptIndex": {
+        "properties": {
+          "receipts": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/ReceiptRow",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "receipts",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "ReceiptRow": {
+        "properties": {
+          "commandId": {
+            "type": "string"
+          },
+          "error": {
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "message",
+              "retryable"
+            ],
+            "type": "object"
+          },
+          "nativeSessionId": {
+            "type": "string"
+          },
+          "receipt": {
+            "$ref": "#/$defs/CellLink"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "commandId",
+          "sourceId",
+          "nativeSessionId",
+          "status",
+          "updatedAt",
+          "receipt"
+        ],
+        "type": "object"
+      },
+      "SessionIndexInput": {
+        "properties": {
+          "bucket": {
+            "enum": [
+              "recent",
+              "all"
+            ]
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "generation": {
+            "type": "number"
+          },
+          "olderSessionCount": {
+            "type": "number"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/$defs/PublishedSessionInput",
+              "asCell": [
+                "opaque"
+              ]
+            },
+            "type": "array"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/$defs/SourceRow",
+              "asCell": [
+                "opaque"
+              ]
+            },
+            "type": "array"
+          },
+          "totalSessionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "schema",
+          "sources",
+          "sessions"
+        ],
+        "type": "object"
+      },
+      "ShardedJsonObject": {
+        "additionalProperties": {
+          "$ref": "#/$defs/ShardedJsonValue"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "ShardedJsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/ShardedJsonValue",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "SourceError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "nativeSessionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "SourceRow": {
+        "properties": {
+          "capabilities": {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "driver": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "errors": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/SourceError",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastCollectionCompletedAt": {
+            "type": "string"
+          },
+          "lastCollectionStartedAt": {
+            "type": "string"
+          },
+          "lastError": {
+            "type": "string"
+          },
+          "sessionCount": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "driver",
+          "capabilities",
+          "errors"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "allIndex": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/SessionIndexInput"
+          }
+        ]
+      },
+      "allIndexCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "commandsCell": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "type": "array"
+      },
+      "health": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/HostHealth"
+          }
+        ]
+      },
+      "healthCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "ownerDid": {
+        "type": "string"
+      },
+      "receipts": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/ReceiptIndex"
+          }
+        ]
+      },
+      "receiptsCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "recentIndex": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/SessionIndexInput"
+          }
+        ]
+      },
+      "recentIndexCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "ownerDid",
+      "recentIndex",
+      "allIndex",
+      "health",
+      "receipts",
+      "recentIndexCell",
+      "allIndexCell",
+      "healthCell",
+      "commandsCell",
+      "receiptsCell"
+    ],
+    "type": "object"
+  },
+  "pattern": "agent-sessions-debug/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JsonObject": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/JsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": [
+                    "null",
+                    "number",
+                    "string",
+                    "undefined"
+                  ]
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/$defs/JsonObject"
+                },
+                {
+                  "items": {
+                    "type": "unknown"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "OwnerCommandQueue": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/agent-sessions-debug/main.tsx",
+              "moduleIdentity": "O9vYCx7TPcTuwlj8zwu63vBzVhZHsjZ6Gc3wBlwi47g",
+              "path": [
+                "sendOwnerAgentCommand"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "type": "array"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "activityCount": {
+        "type": "number"
+      },
+      "commandAuthorization": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/agent-sessions-debug/main.tsx",
+              "moduleIdentity": "O9vYCx7TPcTuwlj8zwu63vBzVhZHsjZ6Gc3wBlwi47g",
+              "path": [
+                "sendOwnerAgentCommand"
+              ]
+            }
+          }
+        },
+        "type": "boolean"
+      },
+      "commandCount": {
+        "type": "number"
+      },
+      "commandQueue": {
+        "$ref": "#/$defs/OwnerCommandQueue"
+      },
+      "receiptCount": {
+        "type": "number"
+      },
+      "sessionCount": {
+        "type": "number"
+      },
+      "sourceCount": {
+        "type": "number"
+      },
+      "status": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "sourceCount",
+      "sessionCount",
+      "commandCount",
+      "receiptCount",
+      "activityCount",
+      "commandQueue",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/agent-sessions-debug/main.tsx/20260825T201742Z-ht-RG2VOtyYD5F7u.json
+++ b/packages/patterns/baselines/agent-sessions-debug/main.tsx/20260825T201742Z-ht-RG2VOtyYD5F7u.json
@@ -1,0 +1,871 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "CellLink": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "path": {
+            "items": {
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "type": "array"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "space": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "space",
+          "path"
+        ],
+        "type": "object"
+      },
+      "DeferredDocument": {
+        "properties": {},
+        "type": "object"
+      },
+      "HostActivity": {
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          "id": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "at",
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "HostHealth": {
+        "properties": {
+          "activity": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/HostActivity",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "commandProcessing": {
+            "properties": {
+              "accepting": {
+                "type": "boolean"
+              },
+              "failedCommands": {
+                "type": "number"
+              },
+              "lastError": {
+                "type": "string"
+              },
+              "pendingReceiptPublications": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "accepting",
+              "pendingReceiptPublications",
+              "failedCommands"
+            ],
+            "type": "object"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "sources": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/SourceRow",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "sync": {
+            "properties": {
+              "completedAt": {
+                "type": "string"
+              },
+              "error": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "sessionCount": {
+                "type": "number"
+              },
+              "startedAt": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "reason",
+              "status",
+              "startedAt"
+            ],
+            "type": "object"
+          },
+          "target": {
+            "properties": {
+              "cells": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "properties": {},
+                "type": "object"
+              },
+              "debugPieceId": {
+                "type": "string"
+              },
+              "spaceDid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "spaceDid",
+              "cells"
+            ],
+            "type": "object"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "service",
+          "status",
+          "startedAt",
+          "updatedAt",
+          "target",
+          "commandProcessing",
+          "sources",
+          "activity"
+        ],
+        "type": "object"
+      },
+      "JsonObject": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/JsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": [
+                    "null",
+                    "number",
+                    "string",
+                    "undefined"
+                  ]
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/$defs/JsonObject"
+                },
+                {
+                  "items": {
+                    "type": "unknown"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "PublishedSessionInput": {
+        "properties": {
+          "active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "archived": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitBranch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitRepo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gitWorktreeRoot": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manifest": {
+            "$ref": "#/$defs/DeferredDocument",
+            "asCell": [
+              "opaque"
+            ]
+          },
+          "nativeSessionId": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "syncStatus": {
+            "enum": [
+              "complete",
+              "partial",
+              "stale",
+              "deleted"
+            ]
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "sourceId",
+          "nativeSessionId",
+          "title",
+          "cwd",
+          "gitRepo",
+          "gitBranch",
+          "gitWorktreeRoot",
+          "updatedAt",
+          "archived",
+          "active",
+          "manifest",
+          "syncStatus"
+        ],
+        "type": "object"
+      },
+      "ReceiptIndex": {
+        "properties": {
+          "receipts": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/ReceiptRow",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "schema",
+          "receipts",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "ReceiptRow": {
+        "properties": {
+          "commandId": {
+            "type": "string"
+          },
+          "error": {
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "retryable": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "code",
+              "message",
+              "retryable"
+            ],
+            "type": "object"
+          },
+          "nativeSessionId": {
+            "type": "string"
+          },
+          "receipt": {
+            "$ref": "#/$defs/CellLink"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "commandId",
+          "sourceId",
+          "nativeSessionId",
+          "status",
+          "updatedAt",
+          "receipt"
+        ],
+        "type": "object"
+      },
+      "SessionIndexInput": {
+        "properties": {
+          "bucket": {
+            "enum": [
+              "recent",
+              "all"
+            ]
+          },
+          "generatedAt": {
+            "type": "string"
+          },
+          "generation": {
+            "type": "number"
+          },
+          "olderSessionCount": {
+            "type": "number"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/$defs/PublishedSessionInput",
+              "asCell": [
+                "opaque"
+              ]
+            },
+            "type": "array"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/$defs/SourceRow",
+              "asCell": [
+                "opaque"
+              ]
+            },
+            "type": "array"
+          },
+          "totalSessionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "schema",
+          "sources",
+          "sessions"
+        ],
+        "type": "object"
+      },
+      "ShardedJsonObject": {
+        "additionalProperties": {
+          "$ref": "#/$defs/ShardedJsonValue"
+        },
+        "properties": {},
+        "type": "object"
+      },
+      "ShardedJsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/ShardedJsonValue",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "SourceError": {
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "nativeSessionId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "SourceRow": {
+        "properties": {
+          "capabilities": {
+            "$ref": "#/$defs/ShardedJsonObject"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "driver": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "errors": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "undefined"
+                },
+                {
+                  "$ref": "#/$defs/SourceError",
+                  "asCell": [
+                    "cell"
+                  ]
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastCollectionCompletedAt": {
+            "type": "string"
+          },
+          "lastCollectionStartedAt": {
+            "type": "string"
+          },
+          "lastError": {
+            "type": "string"
+          },
+          "sessionCount": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "driver",
+          "capabilities",
+          "errors"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "allIndex": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/SessionIndexInput"
+          }
+        ]
+      },
+      "allIndexCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "commandsCell": {
+        "asCell": [
+          "cell"
+        ],
+        "items": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "type": "array"
+      },
+      "health": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/HostHealth"
+          }
+        ]
+      },
+      "healthCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "ownerDid": {
+        "type": "string"
+      },
+      "receipts": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/ReceiptIndex"
+          }
+        ]
+      },
+      "receiptsCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      },
+      "recentIndex": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/SessionIndexInput"
+          }
+        ]
+      },
+      "recentIndexCell": {
+        "anyOf": [
+          {
+            "type": "undefined"
+          },
+          {
+            "$ref": "#/$defs/DeferredDocument"
+          }
+        ],
+        "asCell": [
+          "opaque"
+        ]
+      }
+    },
+    "required": [
+      "ownerDid",
+      "recentIndex",
+      "allIndex",
+      "health",
+      "receipts",
+      "recentIndexCell",
+      "allIndexCell",
+      "healthCell",
+      "commandsCell",
+      "receiptsCell"
+    ],
+    "type": "object"
+  },
+  "pattern": "agent-sessions-debug/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "JsonObject": {
+        "additionalProperties": true,
+        "properties": {},
+        "type": "object"
+      },
+      "JsonValue": {
+        "anyOf": [
+          {
+            "type": [
+              "null",
+              "number",
+              "string",
+              "undefined"
+            ]
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/$defs/JsonObject"
+          },
+          {
+            "items": {
+              "anyOf": [
+                {
+                  "type": [
+                    "null",
+                    "number",
+                    "string",
+                    "undefined"
+                  ]
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/$defs/JsonObject"
+                },
+                {
+                  "items": {
+                    "type": "unknown"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "OwnerCommandQueue": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "represents-principal",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "ownerPrincipal": {
+            "__ctCurrentPrincipal": true
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/agent-sessions-debug/main.tsx",
+              "moduleIdentity": "0exH1PrN2ZG8kgkKMc3qLoCP41jWXYnNehJXsAUAK6s",
+              "path": [
+                "sendOwnerAgentCommand"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/JsonValue"
+        },
+        "type": "array"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "activityCount": {
+        "type": "number"
+      },
+      "commandAuthorization": {
+        "ifc": {
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/agent-sessions-debug/main.tsx",
+              "moduleIdentity": "0exH1PrN2ZG8kgkKMc3qLoCP41jWXYnNehJXsAUAK6s",
+              "path": [
+                "sendOwnerAgentCommand"
+              ]
+            }
+          }
+        },
+        "type": "boolean"
+      },
+      "commandCount": {
+        "type": "number"
+      },
+      "commandQueue": {
+        "$ref": "#/$defs/OwnerCommandQueue"
+      },
+      "receiptCount": {
+        "type": "number"
+      },
+      "sessionCount": {
+        "type": "number"
+      },
+      "sourceCount": {
+        "type": "number"
+      },
+      "status": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "status",
+      "sourceCount",
+      "sessionCount",
+      "commandCount",
+      "receiptCount",
+      "activityCount",
+      "commandQueue",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -214,4 +214,20 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
       "identity, so it goes with the model it keyed.",
     record: "docs/history/lunch-poll-identity-break.md",
   },
+  {
+    pattern: "agent-sessions-debug/main.tsx",
+    baselines: ["20260818T001423Z-_DSuxwZWgUTcB_2z"],
+    // The proof reports `ownerDid` first. Accepting it exposes the command
+    // cell's change from an optional opaque input to the required writable
+    // queue that the connector host supplies.
+    paths: ["argument.ownerDid", "argument.commandsCell"],
+    reason:
+      "Before its first deployment, the connector-managed debug view changed " +
+      "to require the host's configured owner DID and one authoritative, " +
+      "writable command queue. The owner isolates discovery and commands in " +
+      "a shared space, while the writable queue is the host's protected " +
+      "command input. The earlier contract was not deployed, and neither " +
+      "input has a safe compatibility default.",
+    record: "docs/history/agent-connector-owner-identity-break.md",
+  },
 ];

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -217,9 +217,9 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
   {
     pattern: "agent-sessions-debug/main.tsx",
     baselines: ["20260818T001423Z-_DSuxwZWgUTcB_2z"],
-    // The proof reports `ownerDid` first. Accepting it exposes the command
-    // cell's change from an optional opaque input to the required writable
-    // queue that the connector host supplies.
+    // The proof reports `ownerDid` first. Holding it compatible in a separate
+    // proof reports the command cell's change from an optional opaque input to
+    // the required writable queue that the connector host supplies.
     paths: ["argument.ownerDid", "argument.commandsCell"],
     reason:
       "Before its first deployment, the connector-managed debug view changed " +


### PR DESCRIPTION
Give each connector an explicit owner identity and include it in every Fabric address and protocol envelope. This lets people discover and control their own local agents without exposing another person's sessions or command queue in a shared space.

Apply owner confidentiality and integrity policies to session graphs, index roots, health data, receipts, debug registrations, debug results, and debug arguments. Require the connector's exact writer identity before adopting existing state. Bind command submission to the owner's queue and the verified debug handler before accepting commands.

Reject unprotected populated cells instead of claiming them. Bind fresh debug piece snapshots to the protection transaction and validate persisted owners, canonical identities, links, and receipt contents before trusting them. Keep private debug pieces out of shared registries and make cleanup safe across failed or concurrent deployments.

Use one unversioned protocol because there is no deployed predecessor to migrate. Keep readers strict about fields they consume while allowing extra optional fields so later writers can evolve the stored data compatibly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

