### PR TITLE
Publish local checkout inventory from agents-host

### DIFF
--- a/packages/agents-host/README.md
+++ b/packages/agents-host/README.md
@@ -89,13 +89,14 @@ failure.
 
 ## Configuration file
 
-The configuration format is current-only and strict. Unknown fields are errors
-so misspelled options do not silently change provider behavior.
+The configuration format is strict. Unknown fields are errors so misspelled
+options do not silently change provider behavior.
 
 ```jsonc
 {
   "schema": "commonfabric.agents-host.config.v1",
   "collectionIntervalMs": 900000,
+  "checkoutRoots": ["/workspace/checkouts"],
   "sources": [
     {
       "id": "codex",
@@ -117,6 +118,12 @@ session keys and command routing. Duplicate IDs are rejected.
 
 `collectionIntervalMs` must be an integer from `0` through `2147483647`. It
 controls complete collection in long-running mode and is ignored by `--once`.
+
+`checkoutRoots` is an optional array of absolute directories. Every complete
+collection finds Git checkouts below those roots and publishes their current
+branch, commit, and remotes in the session indexes. Discovery stops descending
+when it finds a checkout. A failed or cancelled discovery leaves the previous
+session and checkout indexes unchanged.
 
 The source fields are the connector's `AgentSourceConfig` contract:
 

--- a/packages/agents-host/deno.jsonc
+++ b/packages/agents-host/deno.jsonc
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./mod.ts",
     "./cli": "./src/cli.ts",
+    "./checkout-discovery": "./src/checkout-discovery.ts",
     "./config": "./src/config.ts",
     "./debug-view": "./src/debug-view.ts",
     "./fabric-runtime": "./src/fabric-runtime.ts",

--- a/packages/agents-host/example.config.jsonc
+++ b/packages/agents-host/example.config.jsonc
@@ -1,6 +1,7 @@
 {
   "schema": "commonfabric.agents-host.config.v1",
   "collectionIntervalMs": 900000,
+  "checkoutRoots": ["/workspace/checkouts"],
   "sources": [
     {
       "id": "codex",

--- a/packages/agents-host/mod.ts
+++ b/packages/agents-host/mod.ts
@@ -1,4 +1,5 @@
 export * from "./src/cli-options.ts";
+export * from "./src/checkout-discovery.ts";
 export * from "./src/config.ts";
 export * from "./src/debug-view.ts";
 export * from "./src/fabric-runtime.ts";

--- a/packages/agents-host/src/abort.ts
+++ b/packages/agents-host/src/abort.ts
@@ -1,14 +1,17 @@
 export function abortable<T>(
   operation: Promise<T>,
   signal?: AbortSignal,
+  shouldAbort: () => boolean = () => true,
 ): Promise<T> {
   if (!signal) return operation;
-  if (signal.aborted) {
+  if (signal.aborted && shouldAbort()) {
     void operation.catch(() => undefined);
     return Promise.reject(signal.reason);
   }
   return new Promise<T>((resolve, reject) => {
-    const aborted = () => reject(signal.reason);
+    const aborted = () => {
+      if (shouldAbort()) reject(signal.reason);
+    };
     signal.addEventListener("abort", aborted, { once: true });
     operation.then(
       (value) => {

--- a/packages/agents-host/src/checkout-discovery.ts
+++ b/packages/agents-host/src/checkout-discovery.ts
@@ -1,0 +1,77 @@
+import { isAbsolute, join, resolve } from "@std/path";
+
+async function isRegularFile(path: string): Promise<boolean> {
+  try {
+    const info = await Deno.lstat(path);
+    return info.isFile && !info.isSymlink;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+async function hasGitMarker(path: string): Promise<boolean> {
+  const marker = join(path, ".git");
+  try {
+    const info = await Deno.lstat(marker);
+    if (info.isSymlink) return false;
+    if (info.isDirectory) return await isRegularFile(join(marker, "HEAD"));
+    if (!info.isFile) return false;
+
+    const match = (await Deno.readTextFile(marker)).match(
+      /^gitdir:\s*(.+?)\s*$/,
+    );
+    if (!match) return false;
+    const gitDirectory = isAbsolute(match[1])
+      ? resolve(match[1])
+      : resolve(path, match[1]);
+    const gitDirectoryInfo = await Deno.lstat(gitDirectory);
+    return gitDirectoryInfo.isDirectory && !gitDirectoryInfo.isSymlink &&
+      await isRegularFile(join(gitDirectory, "HEAD"));
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+export type ValidateGitCheckout = (
+  directory: string,
+  signal?: AbortSignal,
+) => Promise<boolean>;
+
+/** Find every Git checkout below explicitly configured search roots. */
+export async function discoverGitCheckoutDirectories(
+  roots: string[],
+  signal: AbortSignal | undefined,
+  validateCheckout: ValidateGitCheckout,
+): Promise<string[]> {
+  const checkouts = new Set<string>();
+  const visit = async (directory: string): Promise<void> => {
+    signal?.throwIfAborted();
+    if (
+      await hasGitMarker(directory) &&
+      await validateCheckout(directory, signal)
+    ) {
+      checkouts.add(directory);
+      return;
+    }
+    const entries: Deno.DirEntry[] = [];
+    for await (const entry of Deno.readDir(directory)) entries.push(entry);
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (
+        entry.name === ".git" || !entry.isDirectory || entry.isSymlink
+      ) continue;
+      await visit(join(directory, entry.name));
+    }
+  };
+  for (const configured of roots) {
+    const root = resolve(configured);
+    const info = await Deno.lstat(root);
+    if (info.isSymlink || !info.isDirectory) {
+      throw new Error(`checkout search root is not a directory: ${root}`);
+    }
+    await visit(root);
+  }
+  return [...checkouts].sort();
+}

--- a/packages/agents-host/src/cli.ts
+++ b/packages/agents-host/src/cli.ts
@@ -91,6 +91,7 @@ export async function runAgentsHostCli(
         identityPath: options.identityPath,
         space: options.space,
         sources: config.sources,
+        checkoutRoots: config.checkoutRoots,
         debugView: options.debugView,
         acceptCommands: !options.once,
         signal: startupAbort.signal,

--- a/packages/agents-host/src/config.ts
+++ b/packages/agents-host/src/config.ts
@@ -5,6 +5,7 @@ import type {
 } from "@commonfabric/agents-connector/types";
 import { normalizeSourceId } from "@commonfabric/agents-connector";
 import { parse as parseJsonc } from "@std/jsonc";
+import { isAbsolute } from "@std/path";
 
 export const AGENTS_HOST_CONFIG_SCHEMA = "commonfabric.agents-host.config.v1";
 export const DEFAULT_COLLECTION_INTERVAL_MS = 15 * 60 * 1_000;
@@ -13,6 +14,7 @@ export const MAX_COLLECTION_INTERVAL_MS = 2_147_483_647;
 export interface AgentsHostConfig {
   schema: typeof AGENTS_HOST_CONFIG_SCHEMA;
   collectionIntervalMs: number;
+  checkoutRoots?: string[];
   sources: AgentSourceConfig[];
 }
 
@@ -175,9 +177,9 @@ function parseSource(value: unknown, index: number): AgentSourceConfig {
 export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   const config = record(value, "configuration");
   for (const key of Object.keys(config)) {
-    if (
-      key !== "schema" && key !== "collectionIntervalMs" && key !== "sources"
-    ) {
+    const allowed = key === "schema" || key === "collectionIntervalMs" ||
+      key === "sources" || key === "checkoutRoots";
+    if (!allowed) {
       throw new Error(`configuration has an unknown field: ${key}`);
     }
   }
@@ -204,6 +206,27 @@ export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   }
 
   const sources = config.sources.map(parseSource);
+  let checkoutRoots: string[] = [];
+  if (config.checkoutRoots !== undefined) {
+    if (!Array.isArray(config.checkoutRoots)) {
+      throw new Error("configuration.checkoutRoots must be a string array");
+    }
+    checkoutRoots = config.checkoutRoots.map((root, index) => {
+      const path = nonEmptyString(
+        root,
+        `configuration.checkoutRoots[${index}]`,
+      );
+      if (!isAbsolute(path)) {
+        throw new Error(
+          `configuration.checkoutRoots[${index}] must be an absolute path`,
+        );
+      }
+      return path;
+    });
+    if (new Set(checkoutRoots).size !== checkoutRoots.length) {
+      throw new Error("configuration.checkoutRoots contains a duplicate path");
+    }
+  }
   const ids = new Set<string>();
   for (const source of sources) {
     if (ids.has(source.id)) {
@@ -217,6 +240,7 @@ export function parseAgentsHostConfig(value: unknown): AgentsHostConfig {
   return {
     schema: AGENTS_HOST_CONFIG_SCHEMA,
     collectionIntervalMs,
+    ...(checkoutRoots.length > 0 ? { checkoutRoots } : {}),
     sources,
   };
 }

--- a/packages/agents-host/src/host.ts
+++ b/packages/agents-host/src/host.ts
@@ -11,6 +11,7 @@ import {
 } from "@commonfabric/agents-connector";
 import type { CommandLedger } from "@commonfabric/agents-connector/command-ledger";
 import { abortable } from "./abort.ts";
+import { discoverGitCheckoutDirectories } from "./checkout-discovery.ts";
 
 export type AgentsHostStatus =
   | "created"
@@ -98,8 +99,17 @@ export interface AgentsHostTarget extends CommandTarget {
   beginSessionObservation(): number;
   publish(
     collected: CollectedSource[],
-    options?: { observationSequence?: number },
+    options?: {
+      observationSequence?: number;
+      checkoutDirectories?: string[];
+      signal?: AbortSignal;
+      onCommit?: () => void;
+    },
   ): Promise<number>;
+  validateCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
   publishHealth(value: Record<string, unknown>): Promise<void>;
   subscribeCommands(
     callback: (commands: unknown[]) => void,
@@ -118,6 +128,8 @@ export interface AgentsHostOptions {
   clock?: () => Date;
   logger?: Pick<Console, "error" | "info">;
   activityLimit?: number;
+  checkoutRoots?: string[];
+  discoverCheckouts?: typeof discoverGitCheckoutDirectories;
 }
 
 export interface AgentsHostStopOptions {
@@ -139,6 +151,8 @@ export class AgentsHost {
   readonly #clock: () => Date;
   readonly #logger: Pick<Console, "error" | "info">;
   readonly #activityLimit: number;
+  readonly #checkoutRoots: string[];
+  readonly #discoverCheckouts: typeof discoverGitCheckoutDirectories;
   readonly #drivers = new Map<string, AgentDriver>();
   readonly #cleanupDrivers = new Map<string, AgentDriver>();
   readonly #sources = new Map<string, AgentsHostSourceHealth>();
@@ -175,6 +189,9 @@ export class AgentsHost {
     this.#clock = options.clock ?? (() => new Date());
     this.#logger = options.logger ?? console;
     this.#activityLimit = options.activityLimit ?? 200;
+    this.#checkoutRoots = [...(options.checkoutRoots ?? [])];
+    this.#discoverCheckouts = options.discoverCheckouts ??
+      discoverGitCheckoutDirectories;
     if (!Number.isSafeInteger(this.#activityLimit) || this.#activityLimit < 1) {
       throw new Error("activityLimit must be a positive safe integer");
     }
@@ -352,11 +369,14 @@ export class AgentsHost {
     if (!this.#started || this.#stopping || this.#stopped) {
       return Promise.reject(new Error("agent host is not accepting sync work"));
     }
+    let publicationCommitted = false;
     const operation = this.#syncTail.then(() =>
-      this.#synchronize(reason, signal)
+      this.#synchronize(reason, signal, () => {
+        publicationCommitted = true;
+      })
     );
     this.#syncTail = operation.then(() => undefined, () => undefined);
-    return abortable(operation, signal);
+    return abortable(operation, signal, () => !publicationCommitted);
   }
 
   stop(
@@ -616,7 +636,13 @@ export class AgentsHost {
   async #synchronize(
     reason: string,
     signal?: AbortSignal,
+    onPublicationCommit?: () => void,
   ): Promise<number> {
+    let publicationCommitted = false;
+    const markPublicationCommitted = () => {
+      publicationCommitted = true;
+      onPublicationCommit?.();
+    };
     const observationSequence = this.#target.beginSessionObservation();
     const startedAt = this.#now();
     const previousSourceStates = new Map(
@@ -645,10 +671,21 @@ export class AgentsHost {
         ),
       );
       signal?.throwIfAborted();
+      const checkoutDirectories = this.#checkoutRoots.length > 0
+        ? await this.#discoverCheckouts(
+          this.#checkoutRoots,
+          signal,
+          (directory, checkoutSignal) =>
+            this.#target.validateCheckout(directory, checkoutSignal),
+        )
+        : [];
+      signal?.throwIfAborted();
       const sessionCount = await this.#target.publish(collected, {
         observationSequence,
+        checkoutDirectories,
+        signal,
+        onCommit: markPublicationCommitted,
       });
-      signal?.throwIfAborted();
       const completedAt = this.#now();
       this.#lastSync = {
         reason,
@@ -663,7 +700,7 @@ export class AgentsHost {
         "Full collection completed",
         { reason, sessionCount },
       );
-      await this.#publishHealth(signal);
+      await this.#publishHealth();
       return sessionCount;
     } catch (error) {
       for (const [sourceId, previous] of previousSourceStates) {
@@ -672,7 +709,7 @@ export class AgentsHost {
         state.status = previous.status;
         state.lastCollectionStartedAt = previous.lastCollectionStartedAt;
       }
-      if (signal?.aborted) {
+      if (signal?.aborted && !publicationCommitted) {
         this.#lastSync = {
           reason,
           status: "failed",

--- a/packages/agents-host/src/start.ts
+++ b/packages/agents-host/src/start.ts
@@ -32,6 +32,7 @@ export interface StartAgentsHostOptions {
   identityPath: string;
   space: string;
   sources: AgentSourceConfig[];
+  checkoutRoots?: string[];
   targetLockPath?: string;
   debugView?: boolean;
   acceptCommands?: boolean;
@@ -147,6 +148,7 @@ export async function startAgentsHost(
     options.signal?.throwIfAborted();
     host = new AgentsHost({
       sources: options.sources,
+      checkoutRoots: options.checkoutRoots,
       target: fabric.target,
       targetDescription: describeAgentFabricTarget(
         fabric.target,

--- a/packages/agents-host/test/checkout-discovery.test.ts
+++ b/packages/agents-host/test/checkout-discovery.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { discoverGitCheckoutDirectories } from "../src/checkout-discovery.ts";
+
+describe("discoverGitCheckoutDirectories", () => {
+  it("finds worktrees and does not descend into a checkout", async () => {
+    const directory = await Deno.makeTempDir();
+    try {
+      const repository = join(directory, "repository");
+      const linkedWorktree = join(directory, "nested", "linked-worktree");
+      const linkedGitDirectory = join(
+        directory,
+        "gitdirs",
+        "linked-worktree",
+      );
+      const stale = join(directory, "stale");
+      const nestedCheckout = join(directory, "stale", "nested-checkout");
+      await Deno.mkdir(join(repository, ".git"), { recursive: true });
+      await Deno.writeTextFile(
+        join(repository, ".git", "HEAD"),
+        "ref: main",
+      );
+      await Deno.mkdir(linkedWorktree, { recursive: true });
+      await Deno.mkdir(linkedGitDirectory, { recursive: true });
+      await Deno.writeTextFile(join(linkedGitDirectory, "HEAD"), "ref: main");
+      await Deno.writeTextFile(
+        join(linkedWorktree, ".git"),
+        "gitdir: ../../gitdirs/linked-worktree",
+      );
+      await Deno.mkdir(join(repository, "ignored", ".git"), {
+        recursive: true,
+      });
+      await Deno.mkdir(join(stale, ".git"), { recursive: true });
+      await Deno.writeTextFile(join(stale, ".git", "HEAD"), "invalid");
+      await Deno.mkdir(join(nestedCheckout, ".git"), { recursive: true });
+      await Deno.writeTextFile(
+        join(nestedCheckout, ".git", "HEAD"),
+        "ref: main",
+      );
+
+      expect(
+        await discoverGitCheckoutDirectories(
+          [directory],
+          undefined,
+          (candidate) => Promise.resolve(candidate !== stale),
+        ),
+      ).toEqual([linkedWorktree, repository, nestedCheckout]);
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+
+  it("rejects a search root that is not a directory", async () => {
+    const directory = await Deno.makeTempDir();
+    const file = join(directory, "file");
+    try {
+      await Deno.writeTextFile(file, "not a directory");
+      await expect(
+        discoverGitCheckoutDirectories(
+          [file],
+          undefined,
+          () => Promise.resolve(true),
+        ),
+      ).rejects.toThrow(
+        `checkout search root is not a directory: ${file}`,
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+});

--- a/packages/agents-host/test/config_test.ts
+++ b/packages/agents-host/test/config_test.ts
@@ -13,6 +13,7 @@ Deno.test("parseAgentsHostConfig validates and preserves provider options", () =
   const config = parseAgentsHostConfig({
     schema: AGENTS_HOST_CONFIG_SCHEMA,
     collectionIntervalMs: 1_234,
+    checkoutRoots: ["/workspace/checkouts"],
     sources: [
       {
         id: "codex-work",
@@ -34,6 +35,7 @@ Deno.test("parseAgentsHostConfig validates and preserves provider options", () =
   });
 
   assertEquals(config.collectionIntervalMs, 1_234);
+  assertEquals(config.checkoutRoots, ["/workspace/checkouts"]);
   assertEquals(config.sources, [
     {
       id: "codex-work",
@@ -52,6 +54,30 @@ Deno.test("parseAgentsHostConfig validates and preserves provider options", () =
       enabled: false,
     },
   ]);
+});
+
+Deno.test("parseAgentsHostConfig validates checkout search roots", () => {
+  for (
+    const checkoutRoots of [
+      "/workspace/checkouts",
+      ["relative"],
+      ["/workspace/checkouts", "/workspace/checkouts"],
+    ]
+  ) {
+    assertThrows(
+      () =>
+        parseAgentsHostConfig({
+          schema: AGENTS_HOST_CONFIG_SCHEMA,
+          checkoutRoots,
+          sources: [{
+            id: "codex",
+            driver: "codex-app-server",
+            enabled: true,
+          }],
+        }),
+      Error,
+    );
+  }
 });
 
 Deno.test("parseAgentsHostConfig rejects ambiguous source identities", () => {

--- a/packages/agents-host/test/host_test.ts
+++ b/packages/agents-host/test/host_test.ts
@@ -172,11 +172,13 @@ class FakeTarget implements AgentsHostTarget {
   publications: CollectedSource[][] = [];
   allocatedObservationSequences: number[] = [];
   observationSequences: number[] = [];
+  checkoutDirectories: string[][] = [];
   receipts: AgentSessionCommandReceipt[] = [];
   commandCallback?: (commands: unknown[]) => void;
   subscriptionCancelled = false;
   failSubscriptionCancel = false;
   failRefresh = false;
+  failNextHealth = false;
   refreshCount = 0;
   terminalReceiptFailures = 0;
   terminalReceipt = Promise.withResolvers<AgentSessionCommandReceipt>();
@@ -201,16 +203,29 @@ class FakeTarget implements AgentsHostTarget {
 
   publish(
     collected: CollectedSource[],
-    options?: { observationSequence?: number },
+    options?: {
+      observationSequence?: number;
+      checkoutDirectories?: string[];
+      signal?: AbortSignal;
+      onCommit?: () => void;
+    },
   ): Promise<number> {
     this.publications.push(structuredClone(collected));
     if (options?.observationSequence !== undefined) {
       this.observationSequences.push(options.observationSequence);
     }
+    if (options?.checkoutDirectories !== undefined) {
+      this.checkoutDirectories.push([...options.checkoutDirectories]);
+    }
+    options?.onCommit?.();
     this.afterPublish?.();
     return Promise.resolve(
       collected.reduce((count, source) => count + source.sessions.length, 0),
     );
+  }
+
+  validateCheckout(): Promise<boolean> {
+    return Promise.resolve(true);
   }
 
   async publishHealth(value: Record<string, unknown>): Promise<void> {
@@ -225,6 +240,10 @@ class FakeTarget implements AgentsHostTarget {
     this.healthGate = undefined;
     gate?.entered.resolve();
     await gate?.release.promise;
+    if (this.failNextHealth) {
+      this.failNextHealth = false;
+      throw new Error("health publication rejected");
+    }
   }
 
   async subscribeCommands(
@@ -306,11 +325,19 @@ Deno.test("AgentsHost publishes sessions, health, and lifecycle activity", async
       ledger: await openLedger(directory),
       createDriver: () => driver,
       clock: clock(),
+      checkoutRoots: ["/workspace/checkouts"],
+      discoverCheckouts: (roots) => {
+        assertEquals(roots, ["/workspace/checkouts"]);
+        return Promise.resolve(["/workspace/checkouts/project"]);
+      },
     });
 
     assertEquals(await host.start(), 1);
     assertEquals(target.publications.length, 1);
     assertEquals(target.publications[0][0].source.id, "codex");
+    assertEquals(target.checkoutDirectories, [[
+      "/workspace/checkouts/project",
+    ]]);
     assertEquals(host.health().status, "ready");
     assertEquals(host.health().target.debugPieceId, "debug-piece");
     assertEquals(host.health().sources[0].sessionCount, 1);
@@ -360,6 +387,7 @@ Deno.test("AgentsHost continues when one configured source fails to start", asyn
     assertEquals(target.publications[0].map((source) => source.source.id), [
       "healthy",
     ]);
+    assertEquals(target.checkoutDirectories, [[]]);
     const failedHealth = host.health().sources.find((source) =>
       source.id === "failed"
     );
@@ -856,6 +884,77 @@ Deno.test("AgentsHost checks startup cancellation after initial collection", asy
     );
     await host.stop("startup-cancelled");
     assertEquals(driver.stopped, true);
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("AgentsHost completes a sync committed before cancellation", async () => {
+  const directory = await Deno.makeTempDir();
+  try {
+    const driver = new FakeDriver("codex");
+    const target = new FakeTarget();
+    const host = new AgentsHost({
+      sources: [sourceConfig("codex")],
+      target,
+      targetDescription: TARGET_DESCRIPTION,
+      ledger: await openLedger(directory),
+      createDriver: () => driver,
+      clock: clock(),
+    });
+    await host.start({ acceptCommands: false });
+
+    const controller = new AbortController();
+    target.afterPublish = () => {
+      controller.abort(new Error("cancelled after publication commit"));
+    };
+    assertEquals(
+      await host.synchronize("committed", controller.signal),
+      1,
+    );
+    assertEquals(host.health().sync?.status, "complete");
+    assertEquals(host.health().sync?.reason, "committed");
+    assertEquals(
+      host.health().activity.some((event) => event.type === "sync-cancelled"),
+      false,
+    );
+    await host.stop();
+  } finally {
+    await Deno.remove(directory, { recursive: true });
+  }
+});
+
+Deno.test("AgentsHost reports post-commit health failure", async () => {
+  const directory = await Deno.makeTempDir();
+  try {
+    const driver = new FakeDriver("codex");
+    const target = new FakeTarget();
+    const host = new AgentsHost({
+      sources: [sourceConfig("codex")],
+      target,
+      targetDescription: TARGET_DESCRIPTION,
+      ledger: await openLedger(directory),
+      createDriver: () => driver,
+      clock: clock(),
+    });
+    await host.start({ acceptCommands: false });
+
+    const controller = new AbortController();
+    target.afterPublish = () => {
+      target.failNextHealth = true;
+      controller.abort(new Error("cancelled after publication commit"));
+    };
+    await assertRejects(
+      () => host.synchronize("health-failure", controller.signal),
+      Error,
+      "health publication rejected",
+    );
+    assertEquals(host.health().sync?.status, "failed");
+    assertEquals(
+      host.health().activity.at(-1)?.type,
+      "sync-failed",
+    );
+    await host.stop();
   } finally {
     await Deno.remove(directory, { recursive: true });
   }

--- a/packages/connectors/agents/docs/interfaces.md
+++ b/packages/connectors/agents/docs/interfaces.md
@@ -259,7 +259,8 @@ the corresponding snapshot value is null. A non-null snapshot value takes
 precedence.
 
 The connector enriches `gitRepo`, `gitBranch`, and `gitWorktreeRoot` after the
-driver returns the snapshot.
+driver returns the snapshot. Commit and remote observations live in the shallow
+checkout index rather than each session manifest.
 
 ### Session snapshot
 
@@ -552,6 +553,24 @@ normalized metadata, nullable `archived` and `active` lifecycle fields, provider
 capabilities, up to 12 recent normalized message previews, a live manifest cell
 link, content hash, and synchronization status. The lifecycle fields describe
 provider state. Synchronization status describes the connector's published copy.
+
+Each index also contains one shallow `checkouts` row per non-deleted worktree.
+The row records its root, current branch, current commit, selected repository
+remote, every fetch or push remote, and observation time. Consumers can join
+repository data to local checkouts without loading session manifests or
+deduplicating sessions.
+
+The host can also provide checkout directories discovered below configured
+filesystem roots. Those observations are included even when no retained agent
+session names the checkout. A failed discovery prevents index publication, so a
+partial filesystem scan cannot delete checkout rows. Candidates with stale or
+invalid `.git` markers are omitted from the completed scan.
+
+A publication that omits checkout directories preserves the prior checkout rows.
+This lets a post-command session refresh update one session without deleting
+discovery-only inventory. A complete filesystem scan supplies the directory
+array, including an empty array, and replaces the discovery portion of the
+inventory.
 
 The manifest and chunk fields are stored as `FabricLink`s rather than copied
 objects. A consumer whose schema declares those fields as `Cell` values can read
@@ -860,6 +879,8 @@ ledger's in-memory values without calling `put()`.
 2. `git -C <root> branch --show-current`
 3. `git -C <root> remote get-url upstream`
 4. `git -C <root> remote get-url origin` when upstream is absent
+5. `git -C <root> rev-parse HEAD`
+6. `git -C <root> remote -v`
 
 `beginObservation()` creates a lookup scope for one publication. It deduplicates
 equal working directories and equal repository roots within that scope. A new
@@ -872,5 +893,8 @@ observation.
 A missing working directory, a non-repository directory, or a failed Git process
 produces null metadata rather than a failed session publication.
 
-The connector stores the remote string exactly as Git returns it. It does not
-canonicalize SSH and HTTPS URLs or inspect repository contents.
+The connector removes credentials, query strings, and fragments from standard
+URL remotes before publication. It preserves SCP-style SSH remotes and otherwise
+keeps Git's spelling. It omits local paths, remote-helper commands, and other
+opaque remote forms. It deduplicates the fetch and push forms of an equal URL
+under each remote name. It does not inspect repository contents.

--- a/packages/connectors/agents/src/fabric.ts
+++ b/packages/connectors/agents/src/fabric.ts
@@ -30,7 +30,7 @@ import type {
   NormalizedMessage,
 } from "./types.ts";
 import { AGENT_CONNECTOR_SCHEMAS } from "./protocol.ts";
-import { GitContextResolver } from "./git-context.ts";
+import { type GitContext, GitContextResolver } from "./git-context.ts";
 import {
   materializeStableArrayCells,
   planStableArrayCells,
@@ -49,6 +49,9 @@ export interface AgentFabricCells {
 export interface AgentFabricPublishOptions {
   preserveUntouchedStatus?: boolean;
   observationSequence?: number;
+  checkoutDirectories?: string[];
+  signal?: AbortSignal;
+  onCommit?: () => void;
 }
 
 interface CellLink {
@@ -68,6 +71,9 @@ interface IndexEntry {
   gitRepo: string | null;
   gitBranch: string | null;
   gitWorktreeRoot: string | null;
+  gitHeadSha: string | null;
+  gitRemotes: Array<{ name: string; urls: string[] }>;
+  gitObservedAt: string | null;
   createdAt: string | null;
   updatedAt: string | null;
   archived: boolean | null;
@@ -96,10 +102,30 @@ interface AgentSessionIndex {
   totalSessionCount?: number;
   olderSessionCount?: number;
   sources: Array<Record<string, unknown>>;
+  checkouts?: CheckoutEntry[];
   // TODO(@ianh): Publish a shallow session directory with the row links and
   // sortable title, update-time, and worktree keys. Consumers cannot sort the
   // linked session rows globally without loading every row cell.
   sessions: IndexEntry[];
+}
+
+export interface CheckoutEntry {
+  root: string;
+  gitRepo: string | null;
+  gitBranch: string | null;
+  gitHeadSha: string | null;
+  gitRemotes: Array<{ name: string; urls: string[] }>;
+  observedAt: string;
+}
+
+export interface CheckoutObservation {
+  gitRepo: string | null;
+  gitBranch: string | null;
+  gitWorktreeRoot: string | null;
+  gitHeadSha: string | null;
+  gitRemotes: Array<{ name: string; urls: string[] }>;
+  gitObservedAt: string | null;
+  syncStatus?: "complete" | "stale" | "partial" | "deleted";
 }
 
 const RECENT_SESSION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -122,6 +148,48 @@ export function sessionIndexBuckets<
     all: [...entries],
     olderCount: entries.length - recent.length,
   };
+}
+
+export function checkoutEntries(
+  sessions: CheckoutObservation[],
+  discovered: CheckoutObservation[] = [],
+): CheckoutEntry[] {
+  const checkouts = new Map<string, CheckoutEntry>();
+  const observe = (observation: CheckoutObservation) => {
+    const root = observation.gitWorktreeRoot;
+    const observedAt = observation.gitObservedAt;
+    if (!root || !observedAt || observation.syncStatus === "deleted") return;
+    const prior = checkouts.get(root);
+    if (prior && prior.observedAt > observedAt) return;
+    checkouts.set(root, {
+      root,
+      gitRepo: observation.gitRepo,
+      gitBranch: observation.gitBranch,
+      gitHeadSha: observation.gitHeadSha,
+      gitRemotes: observation.gitRemotes,
+      observedAt,
+    });
+  };
+  for (const session of sessions) observe(session);
+  for (const checkout of discovered) observe(checkout);
+  return [...checkouts.values()].sort((left, right) =>
+    left.root.localeCompare(right.root)
+  );
+}
+
+function storedCheckoutObservations(
+  ...indexes: Array<AgentSessionIndex | null>
+): CheckoutObservation[] {
+  return indexes.flatMap((index) =>
+    (index?.checkouts ?? []).map((checkout) => ({
+      gitRepo: checkout.gitRepo,
+      gitBranch: checkout.gitBranch,
+      gitWorktreeRoot: checkout.root,
+      gitHeadSha: checkout.gitHeadSha,
+      gitRemotes: checkout.gitRemotes,
+      gitObservedAt: checkout.observedAt,
+    }))
+  );
 }
 
 export function agentFabricCauses(spaceDid: string) {
@@ -359,6 +427,7 @@ async function planSessionGraph(
   conn: AgentFabricConnection,
   prepared: PreparedSession,
   driver: string,
+  gitContext: GitContext,
 ): Promise<PlannedSessionGraph> {
   const manifest = conn.runtime.getCell(
     conn.spaceDid,
@@ -440,6 +509,9 @@ async function planSessionGraph(
       gitRepo: prepared.summary.gitRepo ?? null,
       gitBranch: prepared.summary.gitBranch ?? null,
       gitWorktreeRoot: prepared.summary.gitWorktreeRoot ?? null,
+      gitHeadSha: gitContext.gitHeadSha,
+      gitRemotes: gitContext.gitRemotes,
+      gitObservedAt: gitContext.gitObservedAt,
       createdAt: prepared.summary.createdAt,
       updatedAt: prepared.summary.updatedAt,
       archived: prepared.summary.archived,
@@ -536,10 +608,29 @@ export class AgentFabricTarget implements CommandTarget {
     return sequence;
   }
 
+  async validateCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    return await this.#gitContext.validateCheckout(directory, signal);
+  }
+
   async #publish(
     collected: CollectedSource[],
     options: AgentFabricPublishOptions & { observationSequence: number },
   ): Promise<number> {
+    let graphCommitStarted = false;
+    const startGraphCommit = () => {
+      if (graphCommitStarted) return;
+      options.onCommit?.();
+      graphCommitStarted = true;
+    };
+    const throwIfPublicationCanStop = () => {
+      if (!graphCommitStarted) options.signal?.throwIfAborted();
+    };
+    const cancellableSignal = () =>
+      graphCommitStarted ? undefined : options.signal;
+    throwIfPublicationCanStop();
     const isSuperseded = (key: string) =>
       (this.#latestObservationBySession.get(key) ?? 0) >
         options.observationSequence;
@@ -567,6 +658,18 @@ export class AgentFabricTarget implements CommandTarget {
         { preserveLinkFields: new Set(["manifest"]) },
       ),
     );
+    const discoveredCheckouts: GitContext[] = [];
+    if (options.checkoutDirectories !== undefined) {
+      for (const directory of options.checkoutDirectories) {
+        throwIfPublicationCanStop();
+        const checkout = await gitContext.resolveCheckout(
+          directory,
+          cancellableSignal(),
+        );
+        if (checkout) discoveredCheckouts.push(checkout);
+      }
+    }
+    throwIfPublicationCanStop();
     const entriesByKey = new Map<string, IndexEntry>(
       [
         ...(previousRecent?.sessions ?? []),
@@ -575,6 +678,13 @@ export class AgentFabricTarget implements CommandTarget {
         .map((entry): [string, IndexEntry] => {
           const restored = {
             ...entry,
+            gitHeadSha: typeof entry.gitHeadSha === "string"
+              ? entry.gitHeadSha
+              : null,
+            gitRemotes: Array.isArray(entry.gitRemotes) ? entry.gitRemotes : [],
+            gitObservedAt: typeof entry.gitObservedAt === "string"
+              ? entry.gitObservedAt
+              : null,
             archived: typeof entry.archived === "boolean"
               ? entry.archived
               : null,
@@ -611,8 +721,10 @@ export class AgentFabricTarget implements CommandTarget {
     const observedDescriptorSourceIds = new Set<string>();
     const flushGraphs = async () => {
       if (pendingGraphs.length === 0) return;
+      throwIfPublicationCanStop();
       const batch = pendingGraphs;
       pendingGraphs = [];
+      startGraphCommit();
       await pushSessionGraphBatch(this.conn, batch);
     };
 
@@ -636,18 +748,51 @@ export class AgentFabricTarget implements CommandTarget {
       );
       const currentKeys = new Set<string>();
       for (const snapshot of source.sessions) {
+        throwIfPublicationCanStop();
         const key = sessionKey(
           source.source.id,
           snapshot.summary.nativeSessionId,
         );
         currentKeys.add(key);
         if (isSuperseded(key)) continue;
-        const prepared = await prepareSession(
-          source.source.id,
-          await gitContext.enrich(snapshot),
+        const previousEntry = entriesByKey.get(key);
+        const observedContext = await gitContext.resolve(
+          snapshot.summary.cwd,
+          cancellableSignal(),
         );
+        throwIfPublicationCanStop();
+        const preservesPriorGit = previousEntry !== undefined &&
+          (observedContext.gitObservationFailed === true ||
+            (observedContext.gitWorktreeRoot !== null &&
+              observedContext.gitObservedAt === null &&
+              previousEntry.gitWorktreeRoot ===
+                observedContext.gitWorktreeRoot));
+        const context = preservesPriorGit
+          ? {
+            gitRepo: previousEntry!.gitRepo,
+            gitBranch: previousEntry!.gitBranch,
+            gitWorktreeRoot: previousEntry!.gitWorktreeRoot,
+            gitHeadSha: previousEntry!.gitHeadSha,
+            gitRemotes: previousEntry!.gitRemotes,
+            gitObservedAt: previousEntry!.gitObservedAt,
+          }
+          : observedContext;
+        const {
+          gitHeadSha: _gitHeadSha,
+          gitRemotes: _gitRemotes,
+          gitObservedAt: _gitObservedAt,
+          gitObservationFailed: _gitObservationFailed,
+          ...summaryContext
+        } = context;
+        const prepared = await prepareSession(source.source.id, {
+          ...snapshot,
+          summary: {
+            ...snapshot.summary,
+            ...summaryContext,
+          },
+        });
+        throwIfPublicationCanStop();
         observedSessionKeys.add(prepared.key);
-        const previousEntry = entriesByKey.get(prepared.key);
         if (
           previousEntry &&
           previousEntry.contentHash === prepared.snapshotHash &&
@@ -656,6 +801,12 @@ export class AgentFabricTarget implements CommandTarget {
           const { deletedAt: _deletedAt, ...rest } = previousEntry;
           entriesByKey.set(prepared.key, {
             ...rest,
+            gitRepo: prepared.summary.gitRepo ?? null,
+            gitBranch: prepared.summary.gitBranch ?? null,
+            gitWorktreeRoot: prepared.summary.gitWorktreeRoot ?? null,
+            gitHeadSha: context.gitHeadSha,
+            gitRemotes: context.gitRemotes,
+            gitObservedAt: context.gitObservedAt,
             capabilities: { ...capabilities },
             recentMessages: recentSessionMessages(
               prepared.normalizedMessages,
@@ -668,6 +819,7 @@ export class AgentFabricTarget implements CommandTarget {
           this.conn,
           prepared,
           driver,
+          context,
         );
         const entry = graph.indexEntry;
         entry.capabilities = { ...capabilities };
@@ -728,7 +880,7 @@ export class AgentFabricTarget implements CommandTarget {
       }
     }
     await flushGraphs();
-
+    throwIfPublicationCanStop();
     const generatedAt = new Date().toISOString();
     const generation = Math.max(
       previousRecent?.generation ?? 0,
@@ -751,6 +903,12 @@ export class AgentFabricTarget implements CommandTarget {
       left,
       right,
     ) => left.key.localeCompare(right.key));
+    const checkouts = options.checkoutDirectories === undefined
+      ? checkoutEntries(
+        activeSessions,
+        storedCheckoutObservations(previousRecent, previousAll),
+      )
+      : checkoutEntries(activeSessions, discoveredCheckouts);
     const recentIndex: AgentSessionIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
       bucket: "recent",
@@ -759,6 +917,7 @@ export class AgentFabricTarget implements CommandTarget {
       totalSessionCount: activeSessions.length,
       olderSessionCount: buckets.olderCount,
       sources,
+      checkouts,
       sessions: buckets.recent,
     };
     const allIndex: AgentSessionIndex = {
@@ -769,6 +928,7 @@ export class AgentFabricTarget implements CommandTarget {
       totalSessionCount: activeSessions.length,
       olderSessionCount: buckets.olderCount,
       sources,
+      checkouts,
       sessions: allSessions,
     };
     const indexChildScope = childScope(
@@ -779,6 +939,8 @@ export class AgentFabricTarget implements CommandTarget {
       planStableArrayCells(recentIndex, indexChildScope),
       planStableArrayCells(allIndex, indexChildScope),
     ]);
+    throwIfPublicationCanStop();
+    startGraphCommit();
     await pushStableCellGraph(
       this.conn,
       [

--- a/packages/connectors/agents/src/git-context.ts
+++ b/packages/connectors/agents/src/git-context.ts
@@ -156,11 +156,10 @@ class CachedGitContextObservation implements GitContextObservation {
         "Git returned no worktree root for a discovered checkout",
       );
     }
-    const branch = await this.#requiredValue(
+    const branch = (await this.#requiredOutput(
       ["-C", root, "branch", "--show-current"],
       signal,
-      true,
-    );
+    )).trim() || null;
     let repo = valueOf(
       await this.#run(
         ["-C", root, "remote", "get-url", "upstream"],
@@ -308,32 +307,6 @@ class CachedGitContextObservation implements GitContextObservation {
     return symbolicHead
       ? { value: null, complete: true }
       : { value: null, complete: false };
-  }
-
-  #requiredValue(
-    args: string[],
-    signal?: AbortSignal,
-  ): Promise<string>;
-  #requiredValue(
-    args: string[],
-    signal: AbortSignal | undefined,
-    allowEmpty: true,
-  ): Promise<string | null>;
-  async #requiredValue(
-    args: string[],
-    signal?: AbortSignal,
-    allowEmpty = false,
-  ): Promise<string | null> {
-    const output = await this.#requiredOutput(args, signal);
-    const value = output.trim();
-    if (!value && !allowEmpty) {
-      throw new Error(
-        `Git returned no value while observing checkout: ${
-          args.slice(2).join(" ")
-        }`,
-      );
-    }
-    return value || null;
   }
 
   async #requiredOutput(

--- a/packages/connectors/agents/src/git-context.ts
+++ b/packages/connectors/agents/src/git-context.ts
@@ -4,6 +4,10 @@ export interface GitContext {
   gitRepo: string | null;
   gitBranch: string | null;
   gitWorktreeRoot: string | null;
+  gitHeadSha: string | null;
+  gitRemotes: Array<{ name: string; urls: string[] }>;
+  gitObservedAt: string | null;
+  gitObservationFailed?: boolean;
 }
 
 export interface GitCommandResult {
@@ -13,24 +17,46 @@ export interface GitCommandResult {
 
 export type GitCommandRunner = (
   args: string[],
+  signal?: AbortSignal,
 ) => Promise<GitCommandResult>;
+
+export type GitPathCanonicalizer = (path: string) => Promise<string>;
 
 const EMPTY_GIT_CONTEXT: GitContext = {
   gitRepo: null,
   gitBranch: null,
   gitWorktreeRoot: null,
+  gitHeadSha: null,
+  gitRemotes: [],
+  gitObservedAt: null,
 };
 
-const runGitCommand: GitCommandRunner = async (args) => {
-  const output = await new Deno.Command("git", {
+const runGitCommand: GitCommandRunner = async (args, signal) => {
+  signal?.throwIfAborted();
+  const child = new Deno.Command("git", {
     args,
     stdout: "piped",
     stderr: "null",
-  }).output();
-  return {
-    code: output.code,
-    stdout: new TextDecoder().decode(output.stdout),
+  }).spawn();
+  const abort = () => {
+    try {
+      child.kill();
+    } catch {
+      // Killing an exited process can throw.
+    }
   };
+  signal?.addEventListener("abort", abort, { once: true });
+  if (signal?.aborted) abort();
+  try {
+    const output = await child.output();
+    signal?.throwIfAborted();
+    return {
+      code: output.code,
+      stdout: new TextDecoder().decode(output.stdout),
+    };
+  } finally {
+    signal?.removeEventListener("abort", abort);
+  }
 };
 
 function valueOf(result: GitCommandResult): string | null {
@@ -39,55 +65,177 @@ function valueOf(result: GitCommandResult): string | null {
 }
 
 export interface GitContextObservation {
-  resolve(cwd: string | null): Promise<GitContext>;
-  enrich(snapshot: NativeSessionSnapshot): Promise<NativeSessionSnapshot>;
+  resolve(cwd: string | null, signal?: AbortSignal): Promise<GitContext>;
+  validateCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
+  resolveCheckout(
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<GitContext | null>;
+  enrich(
+    snapshot: NativeSessionSnapshot,
+    signal?: AbortSignal,
+  ): Promise<NativeSessionSnapshot>;
 }
 
 class CachedGitContextObservation implements GitContextObservation {
   readonly #runner: GitCommandRunner;
+  readonly #clock: () => Date;
+  readonly #canonicalizePath: GitPathCanonicalizer;
   readonly #directories = new Map<string, Promise<GitContext>>();
   readonly #roots = new Map<
     string,
     Promise<Omit<GitContext, "gitWorktreeRoot">>
   >();
 
-  constructor(runner: GitCommandRunner) {
+  constructor(
+    runner: GitCommandRunner,
+    clock: () => Date,
+    canonicalizePath: GitPathCanonicalizer,
+  ) {
     this.#runner = runner;
+    this.#clock = clock;
+    this.#canonicalizePath = canonicalizePath;
   }
 
-  resolve(cwd: string | null): Promise<GitContext> {
+  resolve(cwd: string | null, signal?: AbortSignal): Promise<GitContext> {
     const directory = cwd?.trim();
     if (!directory) return Promise.resolve({ ...EMPTY_GIT_CONTEXT });
     let context = this.#directories.get(directory);
     if (!context) {
-      context = this.#resolveDirectory(directory);
+      context = this.#resolveDirectory(directory, signal);
       this.#directories.set(directory, context);
     }
     return context;
   }
 
+  async validateCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    signal?.throwIfAborted();
+    const rootResult = await this.#run(
+      ["-C", directory, "rev-parse", "--show-toplevel"],
+      signal,
+    );
+    if (rootResult.code === -1) {
+      throw new Error(
+        "Git process failed while validating a discovered checkout",
+      );
+    }
+    const root = valueOf(rootResult);
+    if (!root) return false;
+    const [canonicalDirectory, canonicalRoot] = await Promise.all([
+      this.#canonicalizePath(directory),
+      this.#canonicalizePath(root),
+    ]);
+    signal?.throwIfAborted();
+    return canonicalDirectory === canonicalRoot;
+  }
+
+  async resolveCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<GitContext | null> {
+    signal?.throwIfAborted();
+    const rootResult = await this.#run(
+      ["-C", directory, "rev-parse", "--show-toplevel"],
+      signal,
+    );
+    if (rootResult.code === -1) {
+      throw new Error(
+        "Git process failed while validating a discovered checkout",
+      );
+    }
+    if (rootResult.code !== 0) return null;
+    const root = valueOf(rootResult);
+    if (!root) {
+      throw new Error(
+        "Git returned no worktree root for a discovered checkout",
+      );
+    }
+    const branch = await this.#requiredValue(
+      ["-C", root, "branch", "--show-current"],
+      signal,
+      true,
+    );
+    let repo = valueOf(
+      await this.#run(
+        ["-C", root, "remote", "get-url", "upstream"],
+        signal,
+      ),
+    );
+    if (!repo) {
+      repo = valueOf(
+        await this.#run(
+          ["-C", root, "remote", "get-url", "origin"],
+          signal,
+        ),
+      );
+    }
+    const headSha = await this.#checkoutHeadSha(root, signal);
+    const remoteOutput = await this.#requiredOutput(
+      ["-C", root, "remote", "-v"],
+      signal,
+    );
+    const remotes = remoteRows(remoteOutput);
+    const publishedRepo = repo ? publishableRemoteUrl(repo) : null;
+    const context: GitContext = {
+      gitRepo: publishedRepo ?? preferredRepo(remotes),
+      gitBranch: branch,
+      gitWorktreeRoot: root,
+      gitHeadSha: headSha,
+      gitRemotes: remotes,
+      gitObservedAt: this.#clock().toISOString(),
+    };
+    const { gitWorktreeRoot: _gitWorktreeRoot, ...rootContext } = context;
+    this.#directories.set(directory, Promise.resolve(context));
+    this.#roots.set(root, Promise.resolve(rootContext));
+    return context;
+  }
+
   async enrich(
     snapshot: NativeSessionSnapshot,
+    signal?: AbortSignal,
   ): Promise<NativeSessionSnapshot> {
-    const context = await this.resolve(snapshot.summary.cwd);
+    const context = await this.resolve(snapshot.summary.cwd, signal);
+    const {
+      gitHeadSha: _gitHeadSha,
+      gitRemotes: _gitRemotes,
+      gitObservedAt: _gitObservedAt,
+      gitObservationFailed: _gitObservationFailed,
+      ...summaryContext
+    } = context;
     return {
       ...snapshot,
       summary: {
         ...snapshot.summary,
-        ...context,
+        ...summaryContext,
       },
     };
   }
 
-  async #resolveDirectory(directory: string): Promise<GitContext> {
-    const root = valueOf(
-      await this.#run(["-C", directory, "rev-parse", "--show-toplevel"]),
+  async #resolveDirectory(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<GitContext> {
+    const rootResult = await this.#run(
+      ["-C", directory, "rev-parse", "--show-toplevel"],
+      signal,
     );
-    if (!root) return { ...EMPTY_GIT_CONTEXT };
+    const root = valueOf(rootResult);
+    if (!root) {
+      return {
+        ...EMPTY_GIT_CONTEXT,
+        ...(rootResult.code === -1 ? { gitObservationFailed: true } : {}),
+      };
+    }
 
     let context = this.#roots.get(root);
     if (!context) {
-      context = this.#resolveRoot(root);
+      context = this.#resolveRoot(root, signal);
       this.#roots.set(root, context);
     }
     return { ...await context, gitWorktreeRoot: root };
@@ -95,48 +243,216 @@ class CachedGitContextObservation implements GitContextObservation {
 
   async #resolveRoot(
     root: string,
+    signal?: AbortSignal,
   ): Promise<Omit<GitContext, "gitWorktreeRoot">> {
-    const branch = valueOf(
-      await this.#run(["-C", root, "branch", "--show-current"]),
+    const branchResult = await this.#run(
+      ["-C", root, "branch", "--show-current"],
+      signal,
     );
+    const branch = valueOf(branchResult);
     let repo = valueOf(
-      await this.#run(["-C", root, "remote", "get-url", "upstream"]),
+      await this.#run(
+        ["-C", root, "remote", "get-url", "upstream"],
+        signal,
+      ),
     );
     if (!repo) {
       repo = valueOf(
-        await this.#run(["-C", root, "remote", "get-url", "origin"]),
+        await this.#run(
+          ["-C", root, "remote", "get-url", "origin"],
+          signal,
+        ),
       );
     }
-    return { gitRepo: repo, gitBranch: branch };
+    const head = await this.#headObservation(root, signal);
+    const remoteResult = await this.#run(
+      ["-C", root, "remote", "-v"],
+      signal,
+    );
+    const remotes = remoteRows(valueOf(remoteResult) ?? "");
+    const publishedRepo = repo ? publishableRemoteUrl(repo) : null;
+    const complete = branchResult.code === 0 && head.complete &&
+      remoteResult.code === 0;
+    return {
+      gitRepo: publishedRepo ?? preferredRepo(remotes),
+      gitBranch: branch,
+      gitHeadSha: head.value,
+      gitRemotes: remotes,
+      gitObservedAt: complete ? this.#clock().toISOString() : null,
+      ...(!complete ? { gitObservationFailed: true } : {}),
+    };
   }
 
-  async #run(args: string[]): Promise<GitCommandResult> {
+  async #checkoutHeadSha(
+    root: string,
+    signal?: AbortSignal,
+  ): Promise<string | null> {
+    const observation = await this.#headObservation(root, signal);
+    if (observation.complete) return observation.value;
+    throw new Error(
+      "Git command failed while observing checkout: rev-parse HEAD",
+    );
+  }
+
+  async #headObservation(
+    root: string,
+    signal?: AbortSignal,
+  ): Promise<{ value: string | null; complete: boolean }> {
+    const result = await this.#run(["-C", root, "rev-parse", "HEAD"], signal);
+    const value = valueOf(result);
+    if (value) return { value, complete: true };
+    if (result.code === -1) return { value: null, complete: false };
+    const symbolicHead = valueOf(
+      await this.#run(["-C", root, "symbolic-ref", "-q", "HEAD"], signal),
+    );
+    return symbolicHead
+      ? { value: null, complete: true }
+      : { value: null, complete: false };
+  }
+
+  #requiredValue(
+    args: string[],
+    signal?: AbortSignal,
+  ): Promise<string>;
+  #requiredValue(
+    args: string[],
+    signal: AbortSignal | undefined,
+    allowEmpty: true,
+  ): Promise<string | null>;
+  async #requiredValue(
+    args: string[],
+    signal?: AbortSignal,
+    allowEmpty = false,
+  ): Promise<string | null> {
+    const output = await this.#requiredOutput(args, signal);
+    const value = output.trim();
+    if (!value && !allowEmpty) {
+      throw new Error(
+        `Git returned no value while observing checkout: ${
+          args.slice(2).join(" ")
+        }`,
+      );
+    }
+    return value || null;
+  }
+
+  async #requiredOutput(
+    args: string[],
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const result = await this.#run(args, signal);
+    if (result.code !== 0) {
+      throw new Error(
+        `Git command failed while observing checkout: ${
+          args.slice(2).join(" ")
+        }`,
+      );
+    }
+    return result.stdout;
+  }
+
+  async #run(
+    args: string[],
+    signal?: AbortSignal,
+  ): Promise<GitCommandResult> {
     try {
-      return await this.#runner(args);
+      return await this.#runner(args, signal);
     } catch {
+      signal?.throwIfAborted();
       return { code: -1, stdout: "" };
     }
   }
 }
 
+const PUBLISHABLE_REMOTE_PROTOCOLS = new Set([
+  "git:",
+  "http:",
+  "https:",
+  "ssh:",
+]);
+const SCP_REMOTE_PATTERN = /^(?:[A-Za-z0-9._-]+@)?[A-Za-z0-9._-]+:(?!\/\/)\S+$/;
+
+function publishableRemoteUrl(value: string): string | null {
+  if (
+    /^[^:]+::/.test(value) || /^file:/i.test(value) || /^[A-Za-z]:/.test(value)
+  ) return null;
+  if (SCP_REMOTE_PATTERN.test(value)) return value;
+  try {
+    const url = new URL(value);
+    if (!PUBLISHABLE_REMOTE_PROTOCOLS.has(url.protocol)) return null;
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function remoteRows(
+  output: string,
+): Array<{ name: string; urls: string[] }> {
+  const byName = new Map<string, Set<string>>();
+  for (const line of output.split("\n")) {
+    const match = line.trim().match(/^(\S+)\s+(.+)\s+\((?:fetch|push)\)$/);
+    if (!match) continue;
+    const urls = byName.get(match[1]) ?? new Set<string>();
+    const url = publishableRemoteUrl(match[2]);
+    if (!url) continue;
+    urls.add(url);
+    byName.set(match[1], urls);
+  }
+  return [...byName.entries()]
+    .map(([name, urls]) => ({ name, urls: [...urls].sort() }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function preferredRepo(
+  remotes: Array<{ name: string; urls: string[] }>,
+): string | null {
+  return remotes.find((remote) => remote.name === "upstream")?.urls[0] ??
+    remotes.find((remote) => remote.name === "origin")?.urls[0] ?? null;
+}
+
 export class GitContextResolver {
   readonly #runner: GitCommandRunner;
+  readonly #clock: () => Date;
+  readonly #canonicalizePath: GitPathCanonicalizer;
 
-  constructor(runner: GitCommandRunner = runGitCommand) {
+  constructor(
+    runner: GitCommandRunner = runGitCommand,
+    clock: () => Date = () => new Date(),
+    canonicalizePath: GitPathCanonicalizer = (path) => Deno.realPath(path),
+  ) {
     this.#runner = runner;
+    this.#clock = clock;
+    this.#canonicalizePath = canonicalizePath;
   }
 
   beginObservation(): GitContextObservation {
-    return new CachedGitContextObservation(this.#runner);
+    return new CachedGitContextObservation(
+      this.#runner,
+      this.#clock,
+      this.#canonicalizePath,
+    );
   }
 
-  resolve(cwd: string | null): Promise<GitContext> {
-    return this.beginObservation().resolve(cwd);
+  resolve(cwd: string | null, signal?: AbortSignal): Promise<GitContext> {
+    return this.beginObservation().resolve(cwd, signal);
+  }
+
+  validateCheckout(
+    directory: string,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    return this.beginObservation().validateCheckout(directory, signal);
   }
 
   enrich(
     snapshot: NativeSessionSnapshot,
+    signal?: AbortSignal,
   ): Promise<NativeSessionSnapshot> {
-    return this.beginObservation().enrich(snapshot);
+    return this.beginObservation().enrich(snapshot, signal);
   }
 }

--- a/packages/connectors/agents/test/checkout-entries.test.ts
+++ b/packages/connectors/agents/test/checkout-entries.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { checkoutEntries } from "../src/fabric.ts";
+import type { GitContext } from "../src/git-context.ts";
+
+function observation(overrides: Partial<GitContext> = {}): GitContext {
+  return {
+    gitRepo: "git@example.test:acme/project.git",
+    gitBranch: "feature",
+    gitWorktreeRoot: "/workspace/project-copy",
+    gitHeadSha: "old-head",
+    gitRemotes: [{
+      name: "upstream",
+      urls: ["git@example.test:acme/project.git"],
+    }],
+    gitObservedAt: "2026-08-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("checkoutEntries", () => {
+  it("keeps the newest Git observation for each checkout", () => {
+    const entries = checkoutEntries([
+      observation(),
+      observation({
+        gitHeadSha: "new-head",
+        gitObservedAt: "2026-08-21T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(entries).toEqual([{
+      root: "/workspace/project-copy",
+      gitRepo: "git@example.test:acme/project.git",
+      gitBranch: "feature",
+      gitHeadSha: "new-head",
+      gitRemotes: [{
+        name: "upstream",
+        urls: ["git@example.test:acme/project.git"],
+      }],
+      observedAt: "2026-08-21T00:00:00.000Z",
+    }]);
+  });
+
+  it("lets a fresh checkout scan replace stale session metadata", () => {
+    const entries = checkoutEntries(
+      [observation()],
+      [observation({
+        gitHeadSha: "scanned-head",
+        gitObservedAt: "2026-08-22T00:00:00.000Z",
+      })],
+    );
+
+    expect(entries[0].gitHeadSha).toBe("scanned-head");
+    expect(entries[0].observedAt).toBe("2026-08-22T00:00:00.000Z");
+  });
+});

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -24,6 +24,30 @@ import {
   GitContextResolver,
 } from "../src/git-context.ts";
 
+Deno.test("Fabric target validates a discovered checkout", async () => {
+  const signer = await Identity.fromPassphrase(
+    "agent connector checkout validation test",
+  );
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const connection = { runtime, spaceDid: signer.did() };
+  const gitContext = new GitContextResolver(
+    () => Promise.resolve({ code: 0, stdout: "/repo\n" }),
+    () => new Date("2026-08-21T00:00:00.000Z"),
+    (path) => Promise.resolve(path),
+  );
+  try {
+    const target = await AgentFabricTarget.open(connection, gitContext);
+    assertEquals(await target.validateCheckout("/repo"), true);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("Fabric target publishes sessions and command receipts", async () => {
   const signer = await Identity.fromPassphrase("agent connector target test");
   const storageManager = StorageManager.emulate({ as: signer });

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertFalse, assertRejects } from "@std/assert";
+import {
+  assertEquals,
+  assertFalse,
+  assertRejects,
+  assertStrictEquals,
+} from "@std/assert";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
@@ -34,14 +39,37 @@ Deno.test("Fabric target validates a discovered checkout", async () => {
     storageManager,
   });
   const connection = { runtime, spaceDid: signer.did() };
+  const calls: string[][] = [];
+  let receivedSignal: AbortSignal | undefined;
   const gitContext = new GitContextResolver(
-    () => Promise.resolve({ code: 0, stdout: "/repo\n" }),
+    (args, signal) => {
+      calls.push(args);
+      receivedSignal = signal;
+      return Promise.resolve({
+        code: 0,
+        stdout: "/requested-checkout\n",
+      });
+    },
     () => new Date("2026-08-21T00:00:00.000Z"),
     (path) => Promise.resolve(path),
   );
+  const controller = new AbortController();
   try {
     const target = await AgentFabricTarget.open(connection, gitContext);
-    assertEquals(await target.validateCheckout("/repo"), true);
+    assertEquals(
+      await target.validateCheckout(
+        "/requested-checkout",
+        controller.signal,
+      ),
+      true,
+    );
+    assertEquals(calls, [[
+      "-C",
+      "/requested-checkout",
+      "rev-parse",
+      "--show-toplevel",
+    ]]);
+    assertStrictEquals(receivedSignal, controller.signal);
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/connectors/agents/test/fabric-target_test.ts
+++ b/packages/connectors/agents/test/fabric-target_test.ts
@@ -19,6 +19,10 @@ import type {
   SourceDescriptor,
 } from "../src/types.ts";
 import { commandReceiptCause, sessionCause } from "../src/session-contract.ts";
+import {
+  type GitCommandRunner,
+  GitContextResolver,
+} from "../src/git-context.ts";
 
 Deno.test("Fabric target publishes sessions and command receipts", async () => {
   const signer = await Identity.fromPassphrase("agent connector target test");
@@ -443,6 +447,324 @@ Deno.test("Fabric target publishes sessions and command receipts", async () => {
       Error,
       "agent session index row 0 has an invalid formatVersion",
     );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("checkout publication preserves partial-refresh inventory", async () => {
+  const signer = await Identity.fromPassphrase(
+    "agent connector checkout publication test",
+  );
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const connection = { runtime, spaceDid: signer.did() };
+  let observedAt = "2026-08-21T00:00:00.000Z";
+  let failExtraHead = false;
+  let failSessionHead = false;
+  let failSessionRoot = false;
+  let sessionHead = "head-session-1";
+  let cancelSessionLookup: AbortController | undefined;
+  const runner: GitCommandRunner = (args, signal) => {
+    const root = args[1];
+    const command = args.slice(2).join(" ");
+    if (command === "rev-parse --show-toplevel") {
+      if (root === "/session-repo" && failSessionRoot) {
+        return Promise.reject(new Deno.errors.NotFound("git"));
+      }
+      if (root === "/session-repo" && cancelSessionLookup) {
+        assertEquals(signal, cancelSessionLookup.signal);
+        const reason = new Error("session Git lookup cancelled");
+        cancelSessionLookup.abort(reason);
+        return Promise.reject(reason);
+      }
+      return Promise.resolve({ code: 0, stdout: `${root}\n` });
+    }
+    if (command === "branch --show-current") {
+      return Promise.resolve({ code: 0, stdout: "main\n" });
+    }
+    if (command === "remote get-url upstream") {
+      return Promise.resolve({
+        code: 0,
+        stdout: `git@github.com:common${root}.git\n`,
+      });
+    }
+    if (command === "rev-parse HEAD") {
+      const failed = failExtraHead && root === "/extra" ||
+        failSessionHead && root === "/session-repo";
+      return Promise.resolve({
+        code: failed ? 128 : 0,
+        stdout: root === "/session-repo" ? `${sessionHead}\n` : "head-extra\n",
+      });
+    }
+    if (command === "remote -v") {
+      return Promise.resolve({
+        code: 0,
+        stdout: `upstream\tgit@github.com:common${root}.git (fetch)\n`,
+      });
+    }
+    return Promise.resolve({ code: 1, stdout: "" });
+  };
+  const gitContext = new GitContextResolver(
+    runner,
+    () => new Date(observedAt),
+  );
+  const source: SourceDescriptor = {
+    id: "codex:test",
+    driver: "codex-app-server",
+    capabilities: {
+      inventory: true,
+      read: true,
+      prompt: false,
+      cancel: false,
+      rename: false,
+      setMode: false,
+      setConfigOption: false,
+    },
+  };
+  const snapshot: NativeSessionSnapshot = {
+    summary: {
+      nativeSessionId: "session-1",
+      title: "Checkout session",
+      cwd: "/session-repo",
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:00:00.000Z",
+      archived: false,
+      active: false,
+      raw: { id: "session-1" },
+    },
+    events: [],
+    normalizedMessages: [],
+    complete: true,
+  };
+  const collected = [{
+    source,
+    sessions: [snapshot],
+    errors: [],
+    complete: true,
+  }];
+  const readIndex = () =>
+    readStableCellGraphValue(
+      connection,
+      target.cells.allIndex,
+    ) as Promise<Record<string, unknown>>;
+  let target: AgentFabricTarget;
+  try {
+    target = await AgentFabricTarget.open(connection, gitContext);
+    await target.publish(collected, { checkoutDirectories: ["/extra"] });
+    const first = await readIndex();
+    const firstSession = (first.sessions as Array<Record<string, unknown>>)[0];
+    assertEquals(
+      (first.checkouts as Array<Record<string, unknown>>).map((checkout) =>
+        checkout.root
+      ),
+      ["/extra", "/session-repo"],
+    );
+
+    observedAt = "2026-08-22T00:00:00.000Z";
+    await target.publish(collected, { preserveUntouchedStatus: true });
+    const refreshed = await readIndex();
+    const refreshedSession =
+      (refreshed.sessions as Array<Record<string, unknown>>)[0];
+    assertEquals(refreshedSession.contentHash, firstSession.contentHash);
+    assertEquals(
+      (refreshed.checkouts as Array<Record<string, unknown>>).map((checkout) =>
+        checkout.root
+      ),
+      ["/extra", "/session-repo"],
+    );
+
+    sessionHead = "head-session-2";
+    observedAt = "2026-08-23T00:00:00.000Z";
+    await target.publish(collected, { preserveUntouchedStatus: true });
+    const changedHead = await readIndex();
+    assertEquals(
+      (changedHead.sessions as Array<Record<string, unknown>>)[0].contentHash,
+      firstSession.contentHash,
+    );
+    const changedHeadCheckouts = changedHead.checkouts as Array<
+      Record<string, unknown>
+    >;
+    assertEquals(
+      changedHeadCheckouts.find((checkout) => checkout.root === "/session-repo")
+        ?.gitHeadSha,
+      "head-session-2",
+    );
+
+    failSessionHead = true;
+    observedAt = "2026-08-24T00:00:00.000Z";
+    await target.publish(collected, { preserveUntouchedStatus: true });
+    const partialGit = await readIndex();
+    assertEquals(partialGit.checkouts, changedHead.checkouts);
+    failSessionHead = false;
+
+    failSessionRoot = true;
+    await target.publish(collected, { preserveUntouchedStatus: true });
+    const failedRootLookup = await readIndex();
+    assertEquals(failedRootLookup.checkouts, changedHead.checkouts);
+    failSessionRoot = false;
+
+    await target.publish(collected, { checkoutDirectories: [] });
+    const authoritative = await readIndex();
+    assertEquals(
+      (authoritative.checkouts as Array<Record<string, unknown>>).map(
+        (checkout) => checkout.root,
+      ),
+      ["/session-repo"],
+    );
+
+    cancelSessionLookup = new AbortController();
+    const generationBeforeCancellation = authoritative.generation;
+    await assertRejects(
+      () =>
+        target.publish(collected, {
+          checkoutDirectories: [],
+          signal: cancelSessionLookup?.signal,
+        }),
+      Error,
+      "session Git lookup cancelled",
+    );
+    cancelSessionLookup = undefined;
+    const afterCancellation = await readIndex();
+    assertEquals(afterCancellation.generation, generationBeforeCancellation);
+    assertEquals(afterCancellation.sessions, authoritative.sessions);
+
+    failExtraHead = true;
+    const generation = authoritative.generation;
+    const changedSnapshot = {
+      ...snapshot,
+      summary: {
+        ...snapshot.summary,
+        title: "Changed during failed checkout collection",
+        raw: {
+          ...snapshot.summary.raw,
+          title: "Changed during failed checkout collection",
+        },
+      },
+    };
+    await assertRejects(
+      () =>
+        target.publish([{
+          ...collected[0],
+          sessions: [changedSnapshot],
+        }], { checkoutDirectories: ["/extra"] }),
+      Error,
+      "Git command failed while observing checkout: rev-parse HEAD",
+    );
+    const afterFailure = await readIndex();
+    assertEquals(afterFailure.generation, generation);
+    assertEquals(afterFailure.checkouts, authoritative.checkouts);
+    assertEquals(afterFailure.sessions, authoritative.sessions);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("publication finishes after its first graph commit", async () => {
+  const signer = await Identity.fromPassphrase(
+    "agent connector publication commit boundary test",
+  );
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = signer.did();
+  const connection = { runtime, spaceDid: space };
+  const source: SourceDescriptor = {
+    id: "codex:test",
+    driver: "codex-app-server",
+    capabilities: {
+      inventory: true,
+      read: true,
+      prompt: false,
+      cancel: false,
+      rename: false,
+      setMode: false,
+      setConfigOption: false,
+    },
+  };
+  const snapshot = (title: string): NativeSessionSnapshot => ({
+    summary: {
+      nativeSessionId: "session-1",
+      title,
+      cwd: null,
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:01:00.000Z",
+      archived: false,
+      active: false,
+      raw: { id: "session-1", title },
+    },
+    events: [],
+    normalizedMessages: [],
+    complete: true,
+  });
+  const collected = (title: string) => [{
+    source,
+    sessions: [snapshot(title)],
+    errors: [],
+    complete: true,
+  }];
+  try {
+    const target = await AgentFabricTarget.open(connection);
+    await target.publish(collected("Before"));
+    const manifest = runtime.getCell(
+      space,
+      sessionCause(space, source.id, "session-1"),
+    );
+    const manifestId = manifest.getAsNormalizedFullLink().id;
+    const controller = new AbortController();
+    const originalEdit = runtime.edit;
+    let manifestCommitObserved = false;
+    runtime.edit = function () {
+      const tx = originalEdit.call(this);
+      let writesManifest = false;
+      const originalWrite = tx.writeOrThrow.bind(tx);
+      tx.writeOrThrow = (...args) => {
+        if (args[0].id === manifestId) writesManifest = true;
+        return originalWrite(...args);
+      };
+      const originalCommit = tx.commit.bind(tx);
+      tx.commit = async () => {
+        const result = await originalCommit();
+        if (writesManifest && !result.error) {
+          manifestCommitObserved = true;
+          controller.abort(new Error("cancelled after manifest commit"));
+        }
+        return result;
+      };
+      return tx;
+    };
+    try {
+      await target.publish(collected("After"), {
+        signal: controller.signal,
+      });
+    } finally {
+      runtime.edit = originalEdit;
+    }
+
+    assertEquals(manifestCommitObserved, true);
+    assertEquals(controller.signal.aborted, true);
+    const index = await readStableCellGraphValue(
+      connection,
+      target.cells.allIndex,
+    ) as Record<string, unknown>;
+    const session = (index.sessions as Array<Record<string, unknown>>)[0];
+    const publishedManifest = await readStableCellGraphValue(
+      connection,
+      manifest,
+    ) as Record<string, unknown>;
+    assertEquals(session.title, "After");
+    assertEquals(
+      (publishedManifest.summary as Record<string, unknown>).title,
+      "After",
+    );
+    assertEquals(session.contentHash, publishedManifest.snapshotHash);
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/connectors/agents/test/git-context_test.ts
+++ b/packages/connectors/agents/test/git-context_test.ts
@@ -1,9 +1,13 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import {
   type GitCommandRunner,
   GitContextResolver,
 } from "../src/git-context.ts";
 import type { NativeSessionSnapshot } from "../src/types.ts";
+
+const GIT_OBSERVED_AT = "2026-08-21T00:00:00.000Z";
+const gitClock = () => new Date(GIT_OBSERVED_AT);
+const identityPath = (path: string) => Promise.resolve(path);
 
 function result(stdout: string, code = 0) {
   return { code, stdout };
@@ -33,9 +37,17 @@ Deno.test("git context refreshes the repo and branch for every observation", asy
         ),
       );
     }
+    if (command === "rev-parse HEAD") {
+      return Promise.resolve(result(`head-${observation}\n`));
+    }
+    if (command === "remote -v") {
+      return Promise.resolve(result(
+        "upstream\tgit@github.com:common/project.git (fetch)\n",
+      ));
+    }
     return Promise.resolve(result("", 1));
   };
-  const resolver = new GitContextResolver(runner);
+  const resolver = new GitContextResolver(runner, gitClock);
 
   const first = await resolver.resolve("/repo/worktree");
   const second = await resolver.resolve("/repo/worktree");
@@ -44,13 +56,25 @@ Deno.test("git context refreshes the repo and branch for every observation", asy
     gitRepo: "git@github.com:common/project.git",
     gitBranch: "feature/sessions",
     gitWorktreeRoot: "/repo",
+    gitHeadSha: "head-1",
+    gitRemotes: [{
+      name: "upstream",
+      urls: ["git@github.com:common/project.git"],
+    }],
+    gitObservedAt: GIT_OBSERVED_AT,
   });
   assertEquals(second, {
     gitRepo: "git@github.com:common/renamed-project.git",
     gitBranch: "main",
     gitWorktreeRoot: "/repo",
+    gitHeadSha: "head-2",
+    gitRemotes: [{
+      name: "upstream",
+      urls: ["git@github.com:common/project.git"],
+    }],
+    gitObservedAt: GIT_OBSERVED_AT,
   });
-  assertEquals(calls.length, 6);
+  assertEquals(calls.length, 10);
 });
 
 Deno.test("git context deduplicates directories and roots within one observation", async () => {
@@ -67,9 +91,17 @@ Deno.test("git context deduplicates directories and roots within one observation
     if (command === "remote get-url upstream") {
       return Promise.resolve(result("git@github.com:common/project.git\n"));
     }
+    if (command === "rev-parse HEAD") {
+      return Promise.resolve(result("abcdef\n"));
+    }
+    if (command === "remote -v") {
+      return Promise.resolve(result(
+        "upstream\tgit@github.com:common/project.git (fetch)\n",
+      ));
+    }
     return Promise.resolve(result("", 1));
   };
-  const resolver = new GitContextResolver(runner);
+  const resolver = new GitContextResolver(runner, gitClock);
   const observation = resolver.beginObservation();
 
   const contexts = await Promise.all([
@@ -117,11 +149,31 @@ Deno.test("git context falls back to origin and enriches a session snapshot", as
       return Promise.resolve(result("", 2));
     }
     if (command === "remote get-url origin") {
-      return Promise.resolve(result("https://github.com/common/project.git\n"));
+      return Promise.resolve(
+        result("https://account:secret@github.com/common/project.git\n"),
+      );
+    }
+    if (command === "rev-parse HEAD") {
+      return Promise.resolve(result("abcdef123456\n"));
+    }
+    if (command === "remote -v") {
+      return Promise.resolve(result(
+        "origin\thttps://account:secret@github.com/common/fork.git (fetch)\n" +
+          "origin\thttps://account:secret@github.com/common/fork.git (push)\n" +
+          "mirror\tgithub.com:common/mirror.git (fetch)\n" +
+          "upstream\tgit@github.com:common/project.git (fetch)\n" +
+          "helper\text::shell command with secret (fetch)\n" +
+          "compact-helper\text::https://account:secret@example.test/repo (fetch)\n" +
+          "file\tfile:/private/credential (fetch)\n" +
+          "windows-slash\tC:/private/credential (fetch)\n" +
+          "windows-backslash\tC:\\private\\credential (fetch)\n" +
+          "windows-relative\tD:private\\credential (fetch)\n" +
+          "local\t/private/credential (fetch)\n",
+      ));
     }
     return Promise.resolve(result("", 1));
   };
-  const resolver = new GitContextResolver(runner);
+  const resolver = new GitContextResolver(runner, gitClock);
   const snapshot: NativeSessionSnapshot = {
     summary: {
       nativeSessionId: "session-1",
@@ -149,22 +201,165 @@ Deno.test("git context falls back to origin and enriches a session snapshot", as
   );
   assertEquals(enriched.summary.gitBranch, "main");
   assertEquals(enriched.summary.gitWorktreeRoot, "/repo");
+  assertEquals("gitHeadSha" in enriched.summary, false);
+  assertEquals("gitRemotes" in enriched.summary, false);
+  assertEquals("gitObservedAt" in enriched.summary, false);
+  assertEquals((await resolver.resolve("/repo/subdir")).gitRemotes, [{
+    name: "mirror",
+    urls: ["github.com:common/mirror.git"],
+  }, {
+    name: "origin",
+    urls: ["https://github.com/common/fork.git"],
+  }, {
+    name: "upstream",
+    urls: ["git@github.com:common/project.git"],
+  }]);
+});
+
+Deno.test("checkout observations accept a repository with unborn HEAD", async () => {
+  const calls: string[] = [];
+  const resolver = new GitContextResolver(
+    (args) => {
+      const command = args.slice(2).join(" ");
+      calls.push(command);
+      if (command === "rev-parse --show-toplevel") {
+        return Promise.resolve(result("/repo\n"));
+      }
+      if (command === "branch --show-current") {
+        return Promise.resolve(result("main\n"));
+      }
+      if (command === "rev-parse HEAD") {
+        return Promise.resolve(result("", 128));
+      }
+      if (command === "symbolic-ref -q HEAD") {
+        return Promise.resolve(result("refs/heads/main\n"));
+      }
+      if (command === "remote -v") return Promise.resolve(result(""));
+      return Promise.resolve(result("", 2));
+    },
+    gitClock,
+    identityPath,
+  );
+
+  assertEquals(await resolver.validateCheckout("/repo"), true);
+  const observation = resolver.beginObservation();
+  assertEquals(await observation.resolveCheckout("/repo"), {
+    gitRepo: null,
+    gitBranch: "main",
+    gitWorktreeRoot: "/repo",
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: GIT_OBSERVED_AT,
+  });
+  assertEquals(await observation.resolve("/repo"), {
+    gitRepo: null,
+    gitBranch: "main",
+    gitWorktreeRoot: "/repo",
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: GIT_OBSERVED_AT,
+  });
+  assertEquals(
+    calls.filter((command) => command === "branch --show-current").length,
+    1,
+  );
+});
+
+Deno.test("checkout observations skip an invalid worktree marker", async () => {
+  const resolver = new GitContextResolver(
+    () => Promise.resolve(result("", 128)),
+    gitClock,
+  );
+
+  assertEquals(
+    await resolver.validateCheckout("/stale-worktree"),
+    false,
+  );
+  assertEquals(
+    await resolver.beginObservation().resolveCheckout("/stale-worktree"),
+    null,
+  );
+});
+
+Deno.test("checkout validation accepts a canonical path alias", async () => {
+  const resolver = new GitContextResolver(
+    () => Promise.resolve(result("/private/tmp/repo\n")),
+    gitClock,
+    (path) => Promise.resolve(path.replace(/^\/tmp\//, "/private/tmp/")),
+  );
+
+  assertEquals(await resolver.validateCheckout("/tmp/repo"), true);
+});
+
+Deno.test("checkout observations fail when Git metadata is incomplete", async () => {
+  const resolver = new GitContextResolver((args) => {
+    const command = args.slice(2).join(" ");
+    if (command === "rev-parse --show-toplevel") {
+      return Promise.resolve(result("/repo\n"));
+    }
+    if (command === "branch --show-current") {
+      return Promise.resolve(result("main\n"));
+    }
+    if (command === "remote get-url upstream") {
+      return Promise.resolve(result("git@github.com:common/project.git\n"));
+    }
+    if (command === "rev-parse HEAD") {
+      return Promise.resolve(result("", 128));
+    }
+    if (command === "symbolic-ref -q HEAD") {
+      return Promise.resolve(result("", 1));
+    }
+    return Promise.resolve(result(""));
+  }, gitClock);
+
+  await assertRejects(
+    () => resolver.beginObservation().resolveCheckout("/repo"),
+    Error,
+    "Git command failed while observing checkout: rev-parse HEAD",
+  );
+});
+
+Deno.test("checkout observations pass cancellation to Git commands", async () => {
+  const controller = new AbortController();
+  const reason = new Error("checkout observation cancelled");
+  const resolver = new GitContextResolver((_args, signal) => {
+    assertEquals(signal, controller.signal);
+    controller.abort(reason);
+    return Promise.reject(reason);
+  }, gitClock);
+
+  await assertRejects(
+    () =>
+      resolver.beginObservation().resolveCheckout(
+        "/repo",
+        controller.signal,
+      ),
+    Error,
+    reason.message,
+  );
 });
 
 Deno.test("git context returns null fields outside a repository", async () => {
-  const resolver = new GitContextResolver(() =>
-    Promise.resolve(result("", 128))
+  const resolver = new GitContextResolver(
+    () => Promise.resolve(result("", 128)),
+    gitClock,
   );
 
   assertEquals(await resolver.resolve("/tmp/not-a-repo"), {
     gitRepo: null,
     gitBranch: null,
     gitWorktreeRoot: null,
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: null,
   });
   assertEquals(await resolver.resolve(null), {
     gitRepo: null,
     gitBranch: null,
     gitWorktreeRoot: null,
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: null,
   });
 });
 
@@ -184,30 +379,52 @@ Deno.test("git context observes a repository created after an earlier lookup", a
     if (command === "remote get-url upstream") {
       return Promise.resolve(result("git@github.com:common/project.git\n"));
     }
+    if (command === "rev-parse HEAD") {
+      return Promise.resolve(result("abcdef\n"));
+    }
+    if (command === "remote -v") {
+      return Promise.resolve(result(
+        "upstream\tgit@github.com:common/project.git (fetch)\n",
+      ));
+    }
     return Promise.resolve(result("", 1));
   };
-  const resolver = new GitContextResolver(runner);
+  const resolver = new GitContextResolver(runner, gitClock);
 
   assertEquals(await resolver.resolve("/repo"), {
     gitRepo: null,
     gitBranch: null,
     gitWorktreeRoot: null,
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: null,
   });
   assertEquals(await resolver.resolve("/repo"), {
     gitRepo: "git@github.com:common/project.git",
     gitBranch: "main",
     gitWorktreeRoot: "/repo",
+    gitHeadSha: "abcdef",
+    gitRemotes: [{
+      name: "upstream",
+      urls: ["git@github.com:common/project.git"],
+    }],
+    gitObservedAt: GIT_OBSERVED_AT,
   });
 });
 
 Deno.test("git context degrades when spawning git fails", async () => {
-  const resolver = new GitContextResolver(() =>
-    Promise.reject(new Deno.errors.NotFound("git"))
+  const resolver = new GitContextResolver(
+    () => Promise.reject(new Deno.errors.NotFound("git")),
+    gitClock,
   );
 
   assertEquals(await resolver.resolve("/repo"), {
     gitRepo: null,
     gitBranch: null,
     gitWorktreeRoot: null,
+    gitHeadSha: null,
+    gitRemotes: [],
+    gitObservedAt: null,
+    gitObservationFailed: true,
   });
 });

--- a/packages/connectors/agents/test/git-context_test.ts
+++ b/packages/connectors/agents/test/git-context_test.ts
@@ -165,6 +165,7 @@ Deno.test("git context falls back to origin and enriches a session snapshot", as
           "helper\text::shell command with secret (fetch)\n" +
           "compact-helper\text::https://account:secret@example.test/repo (fetch)\n" +
           "file\tfile:/private/credential (fetch)\n" +
+          "unsupported\tftp://example.test/repo (fetch)\n" +
           "windows-slash\tC:/private/credential (fetch)\n" +
           "windows-backslash\tC:\\private\\credential (fetch)\n" +
           "windows-relative\tD:private\\credential (fetch)\n" +
@@ -278,6 +279,57 @@ Deno.test("checkout observations skip an invalid worktree marker", async () => {
   assertEquals(
     await resolver.beginObservation().resolveCheckout("/stale-worktree"),
     null,
+  );
+});
+
+Deno.test("checkout validation reports a Git process failure", async () => {
+  const resolver = new GitContextResolver(() =>
+    Promise.reject(new Deno.errors.NotFound("git"))
+  );
+
+  await assertRejects(
+    () => resolver.validateCheckout("/repo"),
+    Error,
+    "Git process failed while validating a discovered checkout",
+  );
+});
+
+Deno.test("checkout observation reports a Git process failure", async () => {
+  const resolver = new GitContextResolver(() =>
+    Promise.reject(new Deno.errors.NotFound("git"))
+  );
+
+  await assertRejects(
+    () => resolver.beginObservation().resolveCheckout("/repo"),
+    Error,
+    "Git process failed while validating a discovered checkout",
+  );
+});
+
+Deno.test("checkout observation rejects a missing worktree root", async () => {
+  const resolver = new GitContextResolver(() => Promise.resolve(result("")));
+
+  await assertRejects(
+    () => resolver.beginObservation().resolveCheckout("/repo"),
+    Error,
+    "Git returned no worktree root for a discovered checkout",
+  );
+});
+
+Deno.test("checkout observation rejects a failed Git command", async () => {
+  const resolver = new GitContextResolver((args) => {
+    const command = args.slice(2).join(" ");
+    return Promise.resolve(
+      command === "rev-parse --show-toplevel"
+        ? result("/repo\n")
+        : result("", 1),
+    );
+  });
+
+  await assertRejects(
+    () => resolver.beginObservation().resolveCheckout("/repo"),
+    Error,
+    "Git command failed while observing checkout: branch --show-current",
   );
 });
 


### PR DESCRIPTION
Agents-host session indexes only describe repositories referenced by agent sessions. This omits local checkouts that have no session yet and prevents consumers from presenting a complete checkout inventory.

Extend the strict version 1 host configuration with optional absolute checkout search roots. Discover Git worktrees below those roots without following symbolic links or descending into valid checkouts. Validate candidates with Git before pruning traversal so corrupt markers cannot hide nested worktrees.

Publish checkout roots, branches, commits, sanitized remotes, and observation times in both session indexes. Reuse checkout observations when enriching sessions. Preserve prior metadata during partial refreshes and failed Git observations, while authoritative full collections remove checkouts that are no longer configured or present.

Keep manifest and index publication consistent across cancellation. Once the first graph write begins, finish the matching index switch and report the committed synchronization accurately. Omit credentials, local paths, remote helpers, and unsupported remote schemes from published metadata.

Document the configuration and index fields. Add coverage for discovery, strict configuration parsing, partial updates, cancellation, Git failures, unborn repositories, path aliases, and remote sanitization.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

