### PR TITLE
refactor(piece): one wording family for the slug commit-failure message

### DIFF
--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -109,7 +109,7 @@ export async function setSlugLink(
   });
   if (error) {
     throw new Error(
-      `Setting slug "${validSlug}" failed with ${error.name}: ${error.message}`,
+      `Linking the slug "${validSlug}" failed because storage returned ${error.name}: ${error.message}`,
       { cause: error },
     );
   }

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -106,6 +106,11 @@ describe("piece slugs", () => {
     // The name is not listed, because the transaction carrying it never
     // committed.
     expect(await listSlugs(pieces)).not.toContain("rejected");
+    // The slug document was not written either: resolving the name still
+    // reports it missing.
+    await expect(resolvePieceAddress(pieces, "rejected")).rejects.toThrow(
+      /Slug "rejected" not found/,
+    );
   });
 
   it("lists every assigned slug, once, however many times a name is set", async () => {


### PR DESCRIPTION
## What this PR is now

This PR originally added error surfacing to `setSlugLink`, whose dropped `editWithRetry` result reported failed commits as success. While it was open, #6077 landed the same fix — identical `{ error }` destructure, throw with `{ cause }`, and an error-path test — differing only in message wording. After rebasing, this PR carries the honest remainder:

- **slugs.ts (1 line)**: the slug message becomes `Linking the slug "<name>" failed because storage returned <name>: <message>`, joining the wording family #6283 established for the package's other storage-commit failures (`Linking/Unlinking the default pattern…`, `Removing the piece…`, `Updating the default pattern…` — all "failed because storage returned"). #6077's `Setting slug "<name>" failed with …` predated that family. The landed test asserts substring containment (slug name, error name, error message), so it holds under the new wording.
- **slug.test.ts (+5 lines)**: the landed error-path test gains the one post-state it didn't observe — the slug document itself never landed, so `resolvePieceAddress` still reports the name missing (it previously checked only the index listing). My near-duplicate test from the original revision is dropped in favor of extending the landed one, keeping a single error-path test with a stable identity.

## Verification

- `deno task test` in packages/piece on the rebased branch: 50 passed (725 steps), 0 failed
- Repo-wide `deno fmt --check` and `deno lint`: clean
- `deno check` on both touched files: clean

If you'd rather not carry a wording-only change, closing this in favor of what #6077 already landed is also perfectly reasonable — the original bug is fixed on main either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)