### PR TITLE
Conform the IPC envelope's tests and document its protocol

### DIFF
--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -5,12 +5,12 @@
  * covers the DOM surface the applicator needs in unit tests.
  */
 
-import {
-  assertEquals,
-  assertExists,
-  assertNotStrictEquals,
-  assertStrictEquals,
-} from "@std/assert";
+// `assertExists` stays where `expect()` has no equal: it asserts neither
+// `null` nor `undefined` in one call, and narrows the value's type for the
+// lines that follow. `toBeDefined()` does neither.
+import { describe, it } from "@std/testing/bdd";
+import { assertExists } from "@std/assert";
+import { expect } from "@std/expect";
 
 import { $conn, type CellRef } from "@commonfabric/runtime-client";
 
@@ -156,153 +156,49 @@ function createMockDocument() {
   } as unknown as Document;
 }
 
-Deno.test("DomApplicator - create elements", async (t) => {
-  await t.step("creates an element from create-element op", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
+describe("DomApplicator", () => {
+  describe("create elements", () => {
+    it("creates an element from create-element op", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      const batch: VDomBatch = {
+        batchId: 1,
+        ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+      };
+
+      applicator.applyBatch(batch);
+
+      const node = applicator.getNode(1);
+      assertExists(node);
+      expect((node as any).tagName).toBe("DIV");
     });
 
-    const batch: VDomBatch = {
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
-    };
+    it("creates a text node from create-text op", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
 
-    applicator.applyBatch(batch);
+      const batch: VDomBatch = {
+        batchId: 1,
+        ops: [{ op: "create-text", nodeId: 1, text: "Hello World" }],
+      };
 
-    const node = applicator.getNode(1);
-    assertExists(node);
-    assertEquals((node as any).tagName, "DIV");
-  });
+      applicator.applyBatch(batch);
 
-  await t.step("creates a text node from create-text op", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
+      const node = applicator.getNode(1);
+      assertExists(node);
+      expect((node as any).textContent).toBe("Hello World");
     });
 
-    const batch: VDomBatch = {
-      batchId: 1,
-      ops: [{ op: "create-text", nodeId: 1, text: "Hello World" }],
-    };
-
-    applicator.applyBatch(batch);
-
-    const node = applicator.getNode(1);
-    assertExists(node);
-    assertEquals((node as any).textContent, "Hello World");
-  });
-
-  await t.step("creates multiple elements in one batch", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "span" },
-        { op: "create-text", nodeId: 3, text: "Hello" },
-      ],
-    });
-
-    assertExists(applicator.getNode(1));
-    assertExists(applicator.getNode(2));
-    assertExists(applicator.getNode(3));
-    assertEquals((applicator.getNode(1) as any).tagName, "DIV");
-    assertEquals((applicator.getNode(2) as any).tagName, "SPAN");
-    assertEquals((applicator.getNode(3) as any).textContent, "Hello");
-  });
-
-  await t.step("updates text nodes without DOM globals", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "span" },
-        { op: "create-text", nodeId: 2, text: "0" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-      ],
-    });
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "update-text", nodeId: 2, text: "1" }],
-    });
-
-    const textNode = applicator.getNode(2) as any;
-    assertExists(textNode);
-    assertEquals(textNode.textContent, "1");
-  });
-});
-
-Deno.test("DomApplicator - child operations", async (t) => {
-  await t.step("inserts child at end", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "span" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-      ],
-    });
-
-    const parent = applicator.getNode(1) as any;
-    const child = applicator.getNode(2) as any;
-    assertEquals(parent.childNodes.length, 1);
-    assertEquals(parent.childNodes[0], child);
-    assertEquals(child.parentNode, parent);
-  });
-
-  await t.step("inserts child before another", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "span" },
-        { op: "create-element", nodeId: 3, tagName: "p" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "insert-child", parentId: 1, childId: 3, beforeId: 2 },
-      ],
-    });
-
-    const parent = applicator.getNode(1) as any;
-    assertEquals(parent.childNodes.length, 2);
-    assertEquals(parent.childNodes[0].tagName, "P");
-    assertEquals(parent.childNodes[1].tagName, "SPAN");
-  });
-
-  await t.step(
-    "replays insert when child is created later in the batch",
-    () => {
+    it("creates multiple elements in one batch", () => {
       const doc = createMockDocument();
       const applicator = new DomApplicator({
         document: doc,
@@ -313,23 +209,225 @@ Deno.test("DomApplicator - child operations", async (t) => {
       applicator.applyBatch({
         batchId: 1,
         ops: [
-          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
           { op: "create-element", nodeId: 1, tagName: "div" },
           { op: "create-element", nodeId: 2, tagName: "span" },
+          { op: "create-text", nodeId: 3, text: "Hello" },
         ],
       });
 
-      const parent = applicator.getNode(1) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      assertEquals(parent.childNodes.length, 1);
-      assertEquals(parent.childNodes[0].tagName, "SPAN");
-    },
-  );
+      assertExists(applicator.getNode(1));
+      assertExists(applicator.getNode(2));
+      assertExists(applicator.getNode(3));
+      expect((applicator.getNode(1) as any).tagName).toBe("DIV");
+      expect((applicator.getNode(2) as any).tagName).toBe("SPAN");
+      expect((applicator.getNode(3) as any).textContent).toBe("Hello");
+    });
 
-  await t.step(
-    "does not replay stale placement after child moves elsewhere",
-    () => {
+    it("updates text nodes without DOM globals", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "span" },
+          { op: "create-text", nodeId: 2, text: "0" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+        ],
+      });
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "update-text", nodeId: 2, text: "1" }],
+      });
+
+      const textNode = applicator.getNode(2) as any;
+      assertExists(textNode);
+      expect(textNode.textContent).toBe("1");
+    });
+  });
+
+  describe("child operations", () => {
+    it("inserts child at end", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as any;
+      const child = applicator.getNode(2) as any;
+      expect(parent.childNodes.length).toBe(1);
+      expect(parent.childNodes[0]).toEqual(child);
+      expect(child.parentNode).toEqual(parent);
+    });
+
+    it("inserts child before another", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+          { op: "create-element", nodeId: 3, tagName: "p" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "insert-child", parentId: 1, childId: 3, beforeId: 2 },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as any;
+      expect(parent.childNodes.length).toBe(2);
+      expect(parent.childNodes[0].tagName).toBe("P");
+      expect(parent.childNodes[1].tagName).toBe("SPAN");
+    });
+
+    it(
+      "replays insert when child is created later in the batch",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
+
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+            { op: "create-element", nodeId: 1, tagName: "div" },
+            { op: "create-element", nodeId: 2, tagName: "span" },
+          ],
+        });
+
+        const parent = applicator.getNode(1) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        expect(parent.childNodes.length).toBe(1);
+        expect(parent.childNodes[0].tagName).toBe("SPAN");
+      },
+    );
+
+    it(
+      "does not replay stale placement after child moves elsewhere",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
+
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "section" },
+            { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
+            { op: "create-element", nodeId: 3, tagName: "span" },
+            { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
+            { op: "create-element", nodeId: 2, tagName: "div" },
+          ],
+        });
+
+        const laterParent = applicator.getNode(1) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        const staleParent = applicator.getNode(2) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        expect(laterParent.childNodes.map((child) => child.tagName)).toEqual([
+          "SPAN",
+        ]);
+        expect(staleParent.childNodes).toEqual([]);
+      },
+    );
+
+    it(
+      "waits for beforeId to attach before replaying placement",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
+
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "div" },
+            { op: "create-element", nodeId: 4, tagName: "c" },
+            { op: "insert-child", parentId: 1, childId: 4, beforeId: null },
+            { op: "create-element", nodeId: 2, tagName: "a" },
+            { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
+            { op: "create-element", nodeId: 3, tagName: "b" },
+            { op: "insert-child", parentId: 1, childId: 3, beforeId: 4 },
+          ],
+        });
+
+        const parent = applicator.getNode(1) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        expect(parent.childNodes.map((child) => child.tagName)).toEqual([
+          "A",
+          "B",
+          "C",
+        ]);
+      },
+    );
+
+    it(
+      "does not replay insert after child is removed before creation",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
+
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "div" },
+            { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+            { op: "remove-node", nodeId: 2 },
+            { op: "create-element", nodeId: 2, tagName: "span" },
+          ],
+        });
+
+        const parent = applicator.getNode(1) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        expect(parent.childNodes).toEqual([]);
+        expect(
+          (applicator.getNode(2) as unknown as { tagName: string }).tagName,
+        )
+          .toBe("SPAN");
+      },
+    );
+
+    it("drops pending inserts that target removed descendants", () => {
       const doc = createMockDocument();
       const applicator = new DomApplicator({
         document: doc,
@@ -341,543 +439,69 @@ Deno.test("DomApplicator - child operations", async (t) => {
         batchId: 1,
         ops: [
           { op: "create-element", nodeId: 1, tagName: "section" },
-          { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
-          { op: "create-element", nodeId: 3, tagName: "span" },
-          { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
           { op: "create-element", nodeId: 2, tagName: "div" },
-        ],
-      });
-
-      const laterParent = applicator.getNode(1) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      const staleParent = applicator.getNode(2) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      assertEquals(laterParent.childNodes.map((child) => child.tagName), [
-        "SPAN",
-      ]);
-      assertEquals(staleParent.childNodes, []);
-    },
-  );
-
-  await t.step(
-    "waits for beforeId to attach before replaying placement",
-    () => {
-      const doc = createMockDocument();
-      const applicator = new DomApplicator({
-        document: doc,
-        runtimeClient: createMockRuntimeClient(),
-        onEvent: () => {},
-      });
-
-      applicator.applyBatch({
-        batchId: 1,
-        ops: [
-          { op: "create-element", nodeId: 1, tagName: "div" },
-          { op: "create-element", nodeId: 4, tagName: "c" },
-          { op: "insert-child", parentId: 1, childId: 4, beforeId: null },
-          { op: "create-element", nodeId: 2, tagName: "a" },
-          { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
           { op: "create-element", nodeId: 3, tagName: "b" },
-          { op: "insert-child", parentId: 1, childId: 3, beforeId: 4 },
-        ],
-      });
-
-      const parent = applicator.getNode(1) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      assertEquals(parent.childNodes.map((child) => child.tagName), [
-        "A",
-        "B",
-        "C",
-      ]);
-    },
-  );
-
-  await t.step(
-    "does not replay insert after child is removed before creation",
-    () => {
-      const doc = createMockDocument();
-      const applicator = new DomApplicator({
-        document: doc,
-        runtimeClient: createMockRuntimeClient(),
-        onEvent: () => {},
-      });
-
-      applicator.applyBatch({
-        batchId: 1,
-        ops: [
-          { op: "create-element", nodeId: 1, tagName: "div" },
           { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-          { op: "remove-node", nodeId: 2 },
-          { op: "create-element", nodeId: 2, tagName: "span" },
+          { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
+          { op: "create-element", nodeId: 4, tagName: "a" },
+          { op: "insert-child", parentId: 1, childId: 4, beforeId: 3 },
+          { op: "remove-node", nodeId: 1 },
+          { op: "create-element", nodeId: 5, tagName: "footer" },
         ],
       });
 
-      const parent = applicator.getNode(1) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      assertEquals(parent.childNodes, []);
-      assertEquals(
-        (applicator.getNode(2) as unknown as { tagName: string }).tagName,
-        "SPAN",
-      );
-    },
-  );
-
-  await t.step("drops pending inserts that target removed descendants", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "section" },
-        { op: "create-element", nodeId: 2, tagName: "div" },
-        { op: "create-element", nodeId: 3, tagName: "b" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
-        { op: "create-element", nodeId: 4, tagName: "a" },
-        { op: "insert-child", parentId: 1, childId: 4, beforeId: 3 },
-        { op: "remove-node", nodeId: 1 },
-        { op: "create-element", nodeId: 5, tagName: "footer" },
-      ],
-    });
-
-    assertEquals(applicator.getNode(1), undefined);
-    assertEquals(applicator.getNode(2), undefined);
-    assertEquals(applicator.getNode(3), undefined);
-    const pendingChild = applicator.getNode(4) as unknown as {
-      parentNode: unknown;
-      tagName: string;
-    };
-    assertEquals(pendingChild.tagName, "A");
-    assertEquals(pendingChild.parentNode, null);
-  });
-
-  await t.step(
-    "appends pending insert when only beforeId anchor is removed",
-    () => {
-      const doc = createMockDocument();
-      const applicator = new DomApplicator({
-        document: doc,
-        runtimeClient: createMockRuntimeClient(),
-        onEvent: () => {},
-      });
-
-      applicator.applyBatch({
-        batchId: 1,
-        ops: [
-          { op: "create-element", nodeId: 1, tagName: "section" },
-          { op: "create-element", nodeId: 2, tagName: "a" },
-          { op: "create-element", nodeId: 3, tagName: "b" },
-          { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
-        ],
-      });
-
-      const parent = applicator.getNode(1) as unknown as {
-        childNodes: Array<{ tagName: string }>;
-      };
-      const pendingChild = applicator.getNode(2) as unknown as {
+      expect(applicator.getNode(1)).toBe(undefined);
+      expect(applicator.getNode(2)).toBe(undefined);
+      expect(applicator.getNode(3)).toBe(undefined);
+      const pendingChild = applicator.getNode(4) as unknown as {
         parentNode: unknown;
         tagName: string;
       };
-      assertEquals(parent.childNodes, []);
-      assertEquals(pendingChild.parentNode, null);
-
-      applicator.applyBatch({
-        batchId: 2,
-        ops: [{ op: "remove-node", nodeId: 3 }],
-      });
-
-      assertEquals(parent.childNodes.map((child) => child.tagName), ["A"]);
-      assertEquals(pendingChild.parentNode, parent);
-    },
-  );
-
-  await t.step("re-inserting an attached child moves it", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
+      expect(pendingChild.tagName).toBe("A");
+      expect(pendingChild.parentNode).toBe(null);
     });
 
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "a" },
-        { op: "create-element", nodeId: 3, tagName: "b" },
-        { op: "create-element", nodeId: 4, tagName: "c" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
-        { op: "insert-child", parentId: 1, childId: 4, beforeId: null },
-      ],
-    });
+    it(
+      "appends pending insert when only beforeId anchor is removed",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
 
-    // Move first child to end
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "insert-child", parentId: 1, childId: 2, beforeId: null }],
-    });
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "section" },
+            { op: "create-element", nodeId: 2, tagName: "a" },
+            { op: "create-element", nodeId: 3, tagName: "b" },
+            { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
+          ],
+        });
 
-    const parent = applicator.getNode(1) as any;
-    assertEquals(parent.childNodes.length, 3);
-    assertEquals(parent.childNodes[0].tagName, "B");
-    assertEquals(parent.childNodes[1].tagName, "C");
-    assertEquals(parent.childNodes[2].tagName, "A");
-  });
+        const parent = applicator.getNode(1) as unknown as {
+          childNodes: Array<{ tagName: string }>;
+        };
+        const pendingChild = applicator.getNode(2) as unknown as {
+          parentNode: unknown;
+          tagName: string;
+        };
+        expect(parent.childNodes).toEqual([]);
+        expect(pendingChild.parentNode).toBe(null);
 
-  await t.step("removes a node", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
+        applicator.applyBatch({
+          batchId: 2,
+          ops: [{ op: "remove-node", nodeId: 3 }],
+        });
 
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "span" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-      ],
-    });
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "remove-node", nodeId: 2 }],
-    });
-
-    const parent = applicator.getNode(1) as any;
-    assertEquals(parent.childNodes.length, 0);
-    assertEquals(applicator.getNode(2), undefined);
-  });
-
-  await t.step("removes listeners from removed descendants", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "section" },
-        { op: "create-element", nodeId: 2, tagName: "button" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 11 },
-        { op: "set-event", nodeId: 2, eventType: "click", handlerId: 22 },
-      ],
-    });
-
-    const parentNode = applicator.getNode(1) as unknown as {
-      dispatchEvent(event: {
-        type: string;
-        target: unknown;
-        isTrusted: boolean;
-      }): void;
-    };
-    const childNode = applicator.getNode(2) as unknown as {
-      dispatchEvent(event: {
-        type: string;
-        target: unknown;
-        isTrusted: boolean;
-      }): void;
-    };
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "remove-node", nodeId: 1 }],
-    });
-
-    parentNode.dispatchEvent({
-      type: "click",
-      target: parentNode,
-      isTrusted: true,
-    });
-    childNode.dispatchEvent({
-      type: "click",
-      target: childNode,
-      isTrusted: true,
-    });
-
-    assertEquals(events, []);
-    assertEquals(applicator.getNode(1), undefined);
-    assertEquals(applicator.getNode(2), undefined);
-  });
-});
-
-Deno.test("DomApplicator - event handling", async (t) => {
-  await t.step("sets event listener and dispatches events", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "button" },
-        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
-      ],
-    });
-
-    // Simulate a click
-    const node = applicator.getNode(1) as any;
-    node.dispatchEvent({ type: "click", target: node, isTrusted: true });
-
-    assertEquals(events.length, 1);
-    assertEquals(events[0].type, "dom-event");
-    assertEquals(events[0].handlerId, 42);
-    assertEquals(events[0].nodeId, 1);
-    assertEquals(events[0].event.type, "click");
-    assertEquals(events[0].event.provenance, {
-      origin: "dom",
-      trusted: true,
-    });
-  });
-
-  await t.step("serializes data-ui dataset markers with trusted events", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-      setProp: (target, key, value) => {
-        if (
-          key.startsWith("data-") &&
-          typeof target === "object" &&
-          target !== null &&
-          "setAttribute" in target &&
-          typeof target.setAttribute === "function"
-        ) {
-          target.setAttribute(key, String(value));
-          return;
-        }
-        (target as Record<string, unknown>)[key] = value;
+        expect(parent.childNodes.map((child) => child.tagName)).toEqual(["A"]);
+        expect(pendingChild.parentNode).toEqual(parent);
       },
-    });
+    );
 
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "button" },
-        {
-          op: "set-prop",
-          nodeId: 1,
-          key: "data-ui-action",
-          value: "SubmitDirectCommand",
-        },
-        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
-      ],
-    });
-
-    const node = applicator.getNode(1) as any;
-    node.dispatchEvent({ type: "click", target: node, isTrusted: true });
-
-    assertEquals(events[0].event.target?.dataset, {
-      uiAction: "SubmitDirectCommand",
-    });
-  });
-
-  await t.step("attests nearest trusted UI pattern provenance", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-      setProp: (target, key, value) => {
-        if (
-          key.startsWith("data-") &&
-          typeof target === "object" &&
-          target !== null &&
-          "setAttribute" in target &&
-          typeof target.setAttribute === "function"
-        ) {
-          target.setAttribute(key, String(value));
-          return;
-        }
-        (target as Record<string, unknown>)[key] = value;
-      },
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "section" },
-        {
-          op: "set-prop",
-          nodeId: 1,
-          key: "data-ui-pattern",
-          value: "TrustedDirectCommandSurface",
-        },
-        {
-          op: "set-prop",
-          nodeId: 1,
-          key: "data-ui-event-integrity",
-          value: "TrustedDirectCommandSurface",
-        },
-        { op: "create-element", nodeId: 2, tagName: "button" },
-        {
-          op: "set-prop",
-          nodeId: 2,
-          key: "data-ui-action",
-          value: "SubmitDirectCommand",
-        },
-        {
-          op: "insert-child",
-          parentId: 1,
-          childId: 2,
-          beforeId: null,
-        },
-        { op: "set-event", nodeId: 2, eventType: "click", handlerId: 42 },
-      ],
-    });
-
-    const node = applicator.getNode(2) as any;
-    node.dispatchEvent({ type: "click", target: node, isTrusted: true });
-
-    assertEquals(events[0].event.provenance, {
-      origin: "dom",
-      trusted: true,
-      ui: {
-        pattern: "TrustedDirectCommandSurface",
-        eventIntegrity: ["TrustedDirectCommandSurface"],
-        uiContractDataset: {
-          uiAction: "SubmitDirectCommand",
-        },
-      },
-    });
-  });
-
-  await t.step("removes event listener", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "button" },
-        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
-      ],
-    });
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "remove-event", nodeId: 1, eventType: "click" }],
-    });
-
-    // Simulate a click - should not trigger event
-    const node = applicator.getNode(1) as any;
-    node.dispatchEvent({ type: "click", target: node });
-
-    assertEquals(events.length, 0);
-  });
-
-  await t.step("replaces event handler when setting same event type", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "button" },
-        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 1 },
-      ],
-    });
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "set-event", nodeId: 1, eventType: "click", handlerId: 2 }],
-    });
-
-    const node = applicator.getNode(1) as any;
-    node.dispatchEvent({ type: "click", target: node });
-
-    // Should only have one event with the new handler ID
-    assertEquals(events.length, 1);
-    assertEquals(events[0].handlerId, 2);
-  });
-});
-
-Deno.test("DomApplicator - cell bindings", async (t) => {
-  const cellRef: CellRef = {
-    id: "of:test-cell" as CellRef["id"],
-    space: "did:key:test-space" as CellRef["space"],
-    scope: "space",
-    path: ["value"],
-    schema: { type: "string" },
-  };
-
-  await t.step("does not replace a binding for the same cell ref", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "cf-cell-link" },
-        { op: "set-binding", nodeId: 1, propName: "cell", cellRef },
-      ],
-    });
-
-    const node = applicator.getNode(1) as any;
-    const firstHandle = node.cell;
-    assertExists(firstHandle);
-
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "set-binding", nodeId: 1, propName: "cell", cellRef }],
-    });
-
-    assertStrictEquals(node.cell, firstHandle);
-
-    applicator.applyBatch({
-      batchId: 3,
-      ops: [{
-        op: "set-binding",
-        nodeId: 1,
-        propName: "cell",
-        cellRef: { ...cellRef, schema: { type: "number" } },
-      }],
-    });
-
-    assertNotStrictEquals(node.cell, firstHandle);
-  });
-
-  await t.step(
-    "keeps a nested pattern binding out of authored properties",
-    () => {
+    it("re-inserting an attached child moves it", () => {
       const doc = createMockDocument();
       const applicator = new DomApplicator({
         document: doc,
@@ -888,256 +512,424 @@ Deno.test("DomApplicator - cell bindings", async (t) => {
       applicator.applyBatch({
         batchId: 1,
         ops: [
-          { op: "create-element", nodeId: 1, tagName: "section" },
-          { op: "set-piece-boundary", nodeId: 1, cellRef },
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "a" },
+          { op: "create-element", nodeId: 3, tagName: "b" },
+          { op: "create-element", nodeId: 4, tagName: "c" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
+          { op: "insert-child", parentId: 1, childId: 4, beforeId: null },
         ],
       });
 
-      const node = applicator.getNode(1) as Element & Record<string, unknown>;
-      assertExists(getPieceBoundary(node));
+      // Move first child to end
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "insert-child", parentId: 1, childId: 2, beforeId: null }],
+      });
+
+      const parent = applicator.getNode(1) as any;
+      expect(parent.childNodes.length).toBe(3);
+      expect(parent.childNodes[0].tagName).toBe("B");
+      expect(parent.childNodes[1].tagName).toBe("C");
+      expect(parent.childNodes[2].tagName).toBe("A");
+    });
+
+    it("removes a node", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+        ],
+      });
 
       applicator.applyBatch({
         batchId: 2,
-        ops: [{ op: "clear-piece-boundary", nodeId: 1 }],
+        ops: [{ op: "remove-node", nodeId: 2 }],
       });
-      assertEquals(getPieceBoundary(node), undefined);
+
+      const parent = applicator.getNode(1) as any;
+      expect(parent.childNodes.length).toBe(0);
+      expect(applicator.getNode(2)).toBe(undefined);
+    });
+
+    it("removes listeners from removed descendants", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          { op: "create-element", nodeId: 2, tagName: "button" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 11 },
+          { op: "set-event", nodeId: 2, eventType: "click", handlerId: 22 },
+        ],
+      });
+
+      const parentNode = applicator.getNode(1) as unknown as {
+        dispatchEvent(event: {
+          type: string;
+          target: unknown;
+          isTrusted: boolean;
+        }): void;
+      };
+      const childNode = applicator.getNode(2) as unknown as {
+        dispatchEvent(event: {
+          type: string;
+          target: unknown;
+          isTrusted: boolean;
+        }): void;
+      };
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "remove-node", nodeId: 1 }],
+      });
+
+      parentNode.dispatchEvent({
+        type: "click",
+        target: parentNode,
+        isTrusted: true,
+      });
+      childNode.dispatchEvent({
+        type: "click",
+        target: childNode,
+        isTrusted: true,
+      });
+
+      expect(events).toEqual([]);
+      expect(applicator.getNode(1)).toBe(undefined);
+      expect(applicator.getNode(2)).toBe(undefined);
+    });
+  });
+
+  describe("event handling", () => {
+    it("sets event listener and dispatches events", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "button" },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
+        ],
+      });
+
+      // Simulate a click
+      const node = applicator.getNode(1) as any;
+      node.dispatchEvent({ type: "click", target: node, isTrusted: true });
+
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("dom-event");
+      expect(events[0].handlerId).toBe(42);
+      expect(events[0].nodeId).toBe(1);
+      expect(events[0].event.type).toBe("click");
+      expect(events[0].event.provenance).toEqual({
+        origin: "dom",
+        trusted: true,
+      });
+    });
+
+    it("serializes data-ui dataset markers with trusted events", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+        setProp: (target, key, value) => {
+          if (
+            key.startsWith("data-") &&
+            typeof target === "object" &&
+            target !== null &&
+            "setAttribute" in target &&
+            typeof target.setAttribute === "function"
+          ) {
+            target.setAttribute(key, String(value));
+            return;
+          }
+          (target as Record<string, unknown>)[key] = value;
+        },
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "button" },
+          {
+            op: "set-prop",
+            nodeId: 1,
+            key: "data-ui-action",
+            value: "SubmitDirectCommand",
+          },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
+        ],
+      });
+
+      const node = applicator.getNode(1) as any;
+      node.dispatchEvent({ type: "click", target: node, isTrusted: true });
+
+      expect(events[0].event.target?.dataset).toEqual({
+        uiAction: "SubmitDirectCommand",
+      });
+    });
+
+    it("attests nearest trusted UI pattern provenance", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+        setProp: (target, key, value) => {
+          if (
+            key.startsWith("data-") &&
+            typeof target === "object" &&
+            target !== null &&
+            "setAttribute" in target &&
+            typeof target.setAttribute === "function"
+          ) {
+            target.setAttribute(key, String(value));
+            return;
+          }
+          (target as Record<string, unknown>)[key] = value;
+        },
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          {
+            op: "set-prop",
+            nodeId: 1,
+            key: "data-ui-pattern",
+            value: "TrustedDirectCommandSurface",
+          },
+          {
+            op: "set-prop",
+            nodeId: 1,
+            key: "data-ui-event-integrity",
+            value: "TrustedDirectCommandSurface",
+          },
+          { op: "create-element", nodeId: 2, tagName: "button" },
+          {
+            op: "set-prop",
+            nodeId: 2,
+            key: "data-ui-action",
+            value: "SubmitDirectCommand",
+          },
+          {
+            op: "insert-child",
+            parentId: 1,
+            childId: 2,
+            beforeId: null,
+          },
+          { op: "set-event", nodeId: 2, eventType: "click", handlerId: 42 },
+        ],
+      });
+
+      const node = applicator.getNode(2) as any;
+      node.dispatchEvent({ type: "click", target: node, isTrusted: true });
+
+      expect(events[0].event.provenance).toEqual({
+        origin: "dom",
+        trusted: true,
+        ui: {
+          pattern: "TrustedDirectCommandSurface",
+          eventIntegrity: ["TrustedDirectCommandSurface"],
+          uiContractDataset: {
+            uiAction: "SubmitDirectCommand",
+          },
+        },
+      });
+    });
+
+    it("removes event listener", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "button" },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
+        ],
+      });
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "remove-event", nodeId: 1, eventType: "click" }],
+      });
+
+      // Simulate a click - should not trigger event
+      const node = applicator.getNode(1) as any;
+      node.dispatchEvent({ type: "click", target: node });
+
+      expect(events.length).toBe(0);
+    });
+
+    it("replaces event handler when setting same event type", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "button" },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 1 },
+        ],
+      });
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "set-event", nodeId: 1, eventType: "click", handlerId: 2 }],
+      });
+
+      const node = applicator.getNode(1) as any;
+      node.dispatchEvent({ type: "click", target: node });
+
+      // Should only have one event with the new handler ID
+      expect(events.length).toBe(1);
+      expect(events[0].handlerId).toBe(2);
+    });
+  });
+
+  describe("cell bindings", () => {
+    const cellRef: CellRef = {
+      id: "of:test-cell" as CellRef["id"],
+      space: "did:key:test-space" as CellRef["space"],
+      scope: "space",
+      path: ["value"],
+      schema: { type: "string" },
+    };
+
+    it("does not replace a binding for the same cell ref", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "cf-cell-link" },
+          { op: "set-binding", nodeId: 1, propName: "cell", cellRef },
+        ],
+      });
+
+      const node = applicator.getNode(1) as any;
+      const firstHandle = node.cell;
+      assertExists(firstHandle);
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "set-binding", nodeId: 1, propName: "cell", cellRef }],
+      });
+
+      expect(node.cell).toBe(firstHandle);
 
       applicator.applyBatch({
         batchId: 3,
         ops: [{
           op: "set-binding",
           nodeId: 1,
-          propName: "__commonFabricPieceBoundary",
-          cellRef,
+          propName: "cell",
+          cellRef: { ...cellRef, schema: { type: "number" } },
         }],
       });
-      assertEquals(
-        getPieceBoundary(node),
-        undefined,
-        "authored bindings cannot create a trusted nested pattern boundary",
-      );
 
-      applicator.applyBatch({
-        batchId: 4,
-        ops: [{ op: "set-piece-boundary", nodeId: 1, cellRef }],
-      });
-      assertExists(getPieceBoundary(node));
-      applicator.applyBatch({
-        batchId: 5,
-        ops: [{ op: "remove-node", nodeId: 1 }],
-      });
-      assertEquals(getPieceBoundary(node), undefined);
-    },
-  );
-});
-
-Deno.test("DomApplicator - batch with rootId", async (t) => {
-  await t.step("tracks root node ID", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
+      expect(node.cell).not.toBe(firstHandle);
     });
 
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 5, tagName: "div" }],
-      rootId: 5,
-    });
+    it(
+      "keeps a nested pattern binding out of authored properties",
+      () => {
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
 
-    const root = applicator.getRootNode();
-    assertExists(root);
-    assertEquals((root as any).tagName, "DIV");
-  });
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "section" },
+            { op: "set-piece-boundary", nodeId: 1, cellRef },
+          ],
+        });
 
-  await t.step("updates root when rootId changes", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
+        const node = applicator.getNode(1) as Element & Record<string, unknown>;
+        assertExists(getPieceBoundary(node));
 
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
-      rootId: 1,
-    });
+        applicator.applyBatch({
+          batchId: 2,
+          ops: [{ op: "clear-piece-boundary", nodeId: 1 }],
+        });
+        expect(getPieceBoundary(node)).toBe(undefined);
 
-    applicator.applyBatch({
-      batchId: 2,
-      ops: [{ op: "create-element", nodeId: 2, tagName: "span" }],
-      rootId: 2,
-    });
+        applicator.applyBatch({
+          batchId: 3,
+          ops: [{
+            op: "set-binding",
+            nodeId: 1,
+            propName: "__commonFabricPieceBoundary",
+            cellRef,
+          }],
+        });
+        expect(getPieceBoundary(node)).toBe(undefined);
 
-    const root = applicator.getRootNode();
-    assertEquals((root as any).tagName, "SPAN");
-  });
-
-  await t.step("keeps the root when a batch omits rootId", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
-      rootId: 1,
-    });
-
-    applicator.applyBatch({ batchId: 2, ops: [] });
-
-    const root = applicator.getRootNode();
-    assertEquals((root as any).tagName, "DIV");
-  });
-
-  await t.step("clears the root when a batch says rootId is null", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    // Registering a container makes `CONTAINER_NODE_ID` a node that resolves,
-    // as it does in every applicator outside a test. Without it, a root
-    // coerced to 0 reads back as no root at all -- `getRootNode()` returning
-    // `null` from a lookup that missed rather than from the field being
-    // cleared -- and this step would pass for an implementation that puts the
-    // container on the root.
-    applicator.setContainer(
-      doc.createElement("section") as unknown as HTMLElement,
+        applicator.applyBatch({
+          batchId: 4,
+          ops: [{ op: "set-piece-boundary", nodeId: 1, cellRef }],
+        });
+        assertExists(getPieceBoundary(node));
+        applicator.applyBatch({
+          batchId: 5,
+          ops: [{ op: "remove-node", nodeId: 1 }],
+        });
+        expect(getPieceBoundary(node)).toBe(undefined);
+      },
     );
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
-      rootId: 1,
-    });
-
-    applicator.applyBatch({ batchId: 2, ops: [], rootId: null });
-
-    // Node 1 outlives the batch, so a root still reported here would be the
-    // stale one rather than a lookup that happened to miss.
-    assertExists(applicator.getNode(1));
-    assertEquals(applicator.getRootNode(), null);
-  });
-});
-
-Deno.test("DomApplicator - setContainer", async (t) => {
-  await t.step("registers container element with CONTAINER_NODE_ID (0)", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    const container = doc.createElement("section") as unknown as HTMLElement;
-    applicator.setContainer(container);
-
-    // Verify container is registered with ID 0
-    assertEquals(applicator.getNode(0), container);
   });
 
-  await t.step("allows inserting children directly into container", () => {
-    const doc = createMockDocument();
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-    });
-
-    const container = doc.createElement("section") as unknown as HTMLElement;
-    applicator.setContainer(container);
-
-    // Insert a child directly into the container (node 0)
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "insert-child", parentId: 0, childId: 1, beforeId: null },
-      ],
-    });
-
-    assertEquals((container as any).childNodes.length, 1);
-    assertEquals((container as any).childNodes[0].tagName, "DIV");
-  });
-});
-
-Deno.test("DomApplicator - dispose", async (t) => {
-  await t.step("cleans up all nodes and listeners", () => {
-    const doc = createMockDocument();
-    const events: DomEventMessage[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: (msg) => events.push(msg),
-    });
-
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "div" },
-        { op: "create-element", nodeId: 2, tagName: "button" },
-        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
-        { op: "set-event", nodeId: 2, eventType: "click", handlerId: 1 },
-      ],
-      rootId: 1,
-    });
-
-    applicator.dispose();
-
-    assertEquals(applicator.getNode(1), undefined);
-    assertEquals(applicator.getNode(2), undefined);
-    assertEquals(applicator.getRootNode(), null);
-  });
-});
-
-Deno.test("DomApplicator - error handling", async (t) => {
-  await t.step("continues processing batch after operation error", () => {
-    const doc = createMockDocument();
-    const errors: Error[] = [];
-    const applicator = new DomApplicator({
-      document: doc,
-      runtimeClient: createMockRuntimeClient(),
-      onEvent: () => {},
-      onError: (err) => errors.push(err),
-    });
-
-    // This should not crash even with invalid operations
-    applicator.applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "update-text", nodeId: 999, text: "test" }, // Non-existent node
-        { op: "create-element", nodeId: 1, tagName: "div" }, // Valid
-      ],
-    });
-
-    // Second op should still have worked
-    assertExists(applicator.getNode(1));
-  });
-});
-
-Deno.test("DomApplicator - bindings", async (t) => {
-  await t.step(
-    "requests a custom element update after assigning a CellHandle",
-    async () => {
-      const customElementsDescriptor = Object.getOwnPropertyDescriptor(
-        globalThis,
-        "customElements",
-      );
-      Object.defineProperty(globalThis, "customElements", {
-        configurable: true,
-        value: {
-          whenDefined: () => Promise.resolve(undefined),
-        },
-      });
-
+  describe("batch with rootId", () => {
+    it("tracks root node ID", () => {
       const doc = createMockDocument();
       const applicator = new DomApplicator({
         document: doc,
@@ -1147,61 +939,267 @@ Deno.test("DomApplicator - bindings", async (t) => {
 
       applicator.applyBatch({
         batchId: 1,
-        ops: [{ op: "create-element", nodeId: 1, tagName: "cf-cfc-label" }],
+        ops: [{ op: "create-element", nodeId: 5, tagName: "div" }],
+        rootId: 5,
       });
 
-      const node = applicator.getNode(1) as any;
-      const requested: PropertyKey[] = [];
-      node.localName = "cf-cfc-label";
-      node.requestUpdate = (name?: PropertyKey) => {
-        if (name !== undefined) {
-          requested.push(name);
-        }
-      };
+      const root = applicator.getRootNode();
+      assertExists(root);
+      expect((root as any).tagName).toBe("DIV");
+    });
 
-      try {
-        applicator.applyBatch({
-          batchId: 2,
-          ops: [{
-            op: "set-binding",
-            nodeId: 1,
-            propName: "value",
-            cellRef: {
-              space: "did:key:test",
-              scope: "space",
-              id: "of:test",
-              path: [],
-            },
-          }],
+    it("updates root when rootId changes", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+        rootId: 1,
+      });
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "create-element", nodeId: 2, tagName: "span" }],
+        rootId: 2,
+      });
+
+      const root = applicator.getRootNode();
+      expect((root as any).tagName).toBe("SPAN");
+    });
+
+    it("keeps the root when a batch omits rootId", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+        rootId: 1,
+      });
+
+      applicator.applyBatch({ batchId: 2, ops: [] });
+
+      const root = applicator.getRootNode();
+      expect((root as any).tagName).toBe("DIV");
+    });
+
+    it("clears the root when a batch says rootId is null", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      // Registering a container makes `CONTAINER_NODE_ID` a node that resolves,
+      // as it does in every applicator outside a test. Without it, a root
+      // coerced to 0 reads back as no root at all -- `getRootNode()` returning
+      // `null` from a lookup that missed rather than from the field being
+      // cleared -- and this step would pass for an implementation that puts the
+      // container on the root.
+      applicator.setContainer(
+        doc.createElement("section") as unknown as HTMLElement,
+      );
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [{ op: "create-element", nodeId: 1, tagName: "div" }],
+        rootId: 1,
+      });
+
+      applicator.applyBatch({ batchId: 2, ops: [], rootId: null });
+
+      // Node 1 outlives the batch, so a root still reported here would be the
+      // stale one rather than a lookup that happened to miss.
+      assertExists(applicator.getNode(1));
+      expect(applicator.getRootNode()).toBe(null);
+    });
+  });
+
+  describe("setContainer", () => {
+    it("registers container element with CONTAINER_NODE_ID (0)", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      const container = doc.createElement("section") as unknown as HTMLElement;
+      applicator.setContainer(container);
+
+      // Verify container is registered with ID 0
+      expect(applicator.getNode(0)).toEqual(container);
+    });
+
+    it("allows inserting children directly into container", () => {
+      const doc = createMockDocument();
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      const container = doc.createElement("section") as unknown as HTMLElement;
+      applicator.setContainer(container);
+
+      // Insert a child directly into the container (node 0)
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "insert-child", parentId: 0, childId: 1, beforeId: null },
+        ],
+      });
+
+      expect((container as any).childNodes.length).toBe(1);
+      expect((container as any).childNodes[0].tagName).toBe("DIV");
+    });
+  });
+
+  describe("dispose", () => {
+    it("cleans up all nodes and listeners", () => {
+      const doc = createMockDocument();
+      const events: DomEventMessage[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: (msg) => events.push(msg),
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "button" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "set-event", nodeId: 2, eventType: "click", handlerId: 1 },
+        ],
+        rootId: 1,
+      });
+
+      applicator.dispose();
+
+      expect(applicator.getNode(1)).toBe(undefined);
+      expect(applicator.getNode(2)).toBe(undefined);
+      expect(applicator.getRootNode()).toBe(null);
+    });
+  });
+
+  describe("error handling", () => {
+    it("continues processing batch after operation error", () => {
+      const doc = createMockDocument();
+      const errors: Error[] = [];
+      const applicator = new DomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+        onError: (err) => errors.push(err),
+      });
+
+      // This should not crash even with invalid operations
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "update-text", nodeId: 999, text: "test" }, // Non-existent node
+          { op: "create-element", nodeId: 1, tagName: "div" }, // Valid
+        ],
+      });
+
+      // Second op should still have worked
+      assertExists(applicator.getNode(1));
+    });
+  });
+
+  describe("bindings", () => {
+    it(
+      "requests a custom element update after assigning a CellHandle",
+      async () => {
+        const customElementsDescriptor = Object.getOwnPropertyDescriptor(
+          globalThis,
+          "customElements",
+        );
+        Object.defineProperty(globalThis, "customElements", {
+          configurable: true,
+          value: {
+            whenDefined: () => Promise.resolve(undefined),
+          },
         });
 
-        await Promise.resolve();
+        const doc = createMockDocument();
+        const applicator = new DomApplicator({
+          document: doc,
+          runtimeClient: createMockRuntimeClient(),
+          onEvent: () => {},
+        });
 
-        assertEquals(node.value.constructor.name, "CellHandle");
-        assertEquals(requested, ["value"]);
-      } finally {
-        if (customElementsDescriptor) {
-          Object.defineProperty(
-            globalThis,
-            "customElements",
-            customElementsDescriptor,
-          );
-        } else {
-          Reflect.deleteProperty(globalThis, "customElements");
+        applicator.applyBatch({
+          batchId: 1,
+          ops: [{ op: "create-element", nodeId: 1, tagName: "cf-cfc-label" }],
+        });
+
+        const node = applicator.getNode(1) as any;
+        const requested: PropertyKey[] = [];
+        node.localName = "cf-cfc-label";
+        node.requestUpdate = (name?: PropertyKey) => {
+          if (name !== undefined) {
+            requested.push(name);
+          }
+        };
+
+        try {
+          applicator.applyBatch({
+            batchId: 2,
+            ops: [{
+              op: "set-binding",
+              nodeId: 1,
+              propName: "value",
+              cellRef: {
+                space: "did:key:test",
+                scope: "space",
+                id: "of:test",
+                path: [],
+              },
+            }],
+          });
+
+          await Promise.resolve();
+
+          expect(node.value.constructor.name).toBe("CellHandle");
+          expect(requested).toEqual(["value"]);
+        } finally {
+          if (customElementsDescriptor) {
+            Object.defineProperty(
+              globalThis,
+              "customElements",
+              customElementsDescriptor,
+            );
+          } else {
+            Reflect.deleteProperty(globalThis, "customElements");
+          }
         }
-      }
-    },
-  );
-});
+      },
+    );
+  });
 
-// Note: The following tests require a real DOM environment because the applicator
-// uses `instanceof HTMLElement` checks. They are documented here for completeness
-// but would need to be run in a browser or with jsdom/happy-dom.
-//
-// Skipped tests:
-// - "sets properties" - requires HTMLElement instanceof check
-// - "sets style attribute" - requires HTMLElement instanceof check
-// - "sets data attributes" - requires HTMLElement instanceof check
-// - "removes properties" - requires HTMLElement instanceof check
-// - "updates text content" - requires Node.TEXT_NODE constant
-// - "sets bidirectional binding" - requires HTMLElement instanceof check
+  // Note: The following tests require a real DOM environment because the applicator
+  // uses `instanceof HTMLElement` checks. They are documented here for completeness
+  // but would need to be run in a browser or with jsdom/happy-dom.
+  //
+  // Skipped tests:
+  // - "sets properties" - requires HTMLElement instanceof check
+  // - "sets style attribute" - requires HTMLElement instanceof check
+  // - "sets data attributes" - requires HTMLElement instanceof check
+  // - "removes properties" - requires HTMLElement instanceof check
+  // - "updates text content" - requires Node.TEXT_NODE constant
+  // - "sets bidirectional binding" - requires HTMLElement instanceof check
+});

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -272,8 +272,8 @@ describe("DomApplicator", () => {
       const parent = applicator.getNode(1) as any;
       const child = applicator.getNode(2) as any;
       expect(parent.childNodes.length).toBe(1);
-      expect(parent.childNodes[0]).toEqual(child);
-      expect(child.parentNode).toEqual(parent);
+      expect(parent.childNodes[0]).toStrictEqual(child);
+      expect(child.parentNode).toStrictEqual(parent);
     });
 
     it("inserts child before another", () => {
@@ -355,10 +355,11 @@ describe("DomApplicator", () => {
         const staleParent = applicator.getNode(2) as unknown as {
           childNodes: Array<{ tagName: string }>;
         };
-        expect(laterParent.childNodes.map((child) => child.tagName)).toEqual([
-          "SPAN",
-        ]);
-        expect(staleParent.childNodes).toEqual([]);
+        expect(laterParent.childNodes.map((child) => child.tagName))
+          .toStrictEqual([
+            "SPAN",
+          ]);
+        expect(staleParent.childNodes).toStrictEqual([]);
       },
     );
 
@@ -388,7 +389,7 @@ describe("DomApplicator", () => {
         const parent = applicator.getNode(1) as unknown as {
           childNodes: Array<{ tagName: string }>;
         };
-        expect(parent.childNodes.map((child) => child.tagName)).toEqual([
+        expect(parent.childNodes.map((child) => child.tagName)).toStrictEqual([
           "A",
           "B",
           "C",
@@ -419,7 +420,7 @@ describe("DomApplicator", () => {
         const parent = applicator.getNode(1) as unknown as {
           childNodes: Array<{ tagName: string }>;
         };
-        expect(parent.childNodes).toEqual([]);
+        expect(parent.childNodes).toStrictEqual([]);
         expect(
           (applicator.getNode(2) as unknown as { tagName: string }).tagName,
         )
@@ -488,7 +489,7 @@ describe("DomApplicator", () => {
           parentNode: unknown;
           tagName: string;
         };
-        expect(parent.childNodes).toEqual([]);
+        expect(parent.childNodes).toStrictEqual([]);
         expect(pendingChild.parentNode).toBe(null);
 
         applicator.applyBatch({
@@ -496,8 +497,10 @@ describe("DomApplicator", () => {
           ops: [{ op: "remove-node", nodeId: 3 }],
         });
 
-        expect(parent.childNodes.map((child) => child.tagName)).toEqual(["A"]);
-        expect(pendingChild.parentNode).toEqual(parent);
+        expect(parent.childNodes.map((child) => child.tagName)).toStrictEqual([
+          "A",
+        ]);
+        expect(pendingChild.parentNode).toStrictEqual(parent);
       },
     );
 
@@ -613,7 +616,7 @@ describe("DomApplicator", () => {
         isTrusted: true,
       });
 
-      expect(events).toEqual([]);
+      expect(events).toStrictEqual([]);
       expect(applicator.getNode(1)).toBe(undefined);
       expect(applicator.getNode(2)).toBe(undefined);
     });
@@ -646,7 +649,7 @@ describe("DomApplicator", () => {
       expect(events[0].handlerId).toBe(42);
       expect(events[0].nodeId).toBe(1);
       expect(events[0].event.type).toBe("click");
-      expect(events[0].event.provenance).toEqual({
+      expect(events[0].event.provenance).toStrictEqual({
         origin: "dom",
         trusted: true,
       });
@@ -691,7 +694,7 @@ describe("DomApplicator", () => {
       const node = applicator.getNode(1) as any;
       node.dispatchEvent({ type: "click", target: node, isTrusted: true });
 
-      expect(events[0].event.target?.dataset).toEqual({
+      expect(events[0].event.target?.dataset).toStrictEqual({
         uiAction: "SubmitDirectCommand",
       });
     });
@@ -754,7 +757,7 @@ describe("DomApplicator", () => {
       const node = applicator.getNode(2) as any;
       node.dispatchEvent({ type: "click", target: node, isTrusted: true });
 
-      expect(events[0].event.provenance).toEqual({
+      expect(events[0].event.provenance).toStrictEqual({
         origin: "dom",
         trusted: true,
         ui: {
@@ -1038,7 +1041,7 @@ describe("DomApplicator", () => {
       applicator.setContainer(container);
 
       // Verify container is registered with ID 0
-      expect(applicator.getNode(0)).toEqual(container);
+      expect(applicator.getNode(0)).toStrictEqual(container);
     });
 
     it("allows inserting children directly into container", () => {
@@ -1175,7 +1178,7 @@ describe("DomApplicator", () => {
           await Promise.resolve();
 
           expect(node.value.constructor.name).toBe("CellHandle");
-          expect(requested).toEqual(["value"]);
+          expect(requested).toStrictEqual(["value"]);
         } finally {
           if (customElementsDescriptor) {
             Object.defineProperty(

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   $conn,
@@ -113,291 +113,6 @@ class MockConnection {
   }
 }
 
-Deno.test("VDomRenderer - takes the mount response's rootId as the root", async (t) => {
-  const setup = (mountRootId: number | null) => {
-    const connection = new MockConnection();
-    connection.mountRootId = mountRootId;
-    const mock = new MockDoc(
-      '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-    );
-    const renderer = new VDomRenderer({
-      runtimeClient: {} as any,
-      connection: connection as any,
-      document: mock.document,
-    });
-    const cellRef = {
-      space: "did:key:test",
-      id: "cell-id",
-      path: [],
-      type: "application/json",
-    } as unknown as CellRef;
-    const container = mock.document.getElementById("root")!;
-    return { connection, renderer, cellRef, container };
-  };
-
-  await t.step("reports no root when the mount reports none", async () => {
-    const { renderer, cellRef, container } = setup(null);
-
-    await renderer.render(container as unknown as HTMLElement, cellRef);
-
-    expect(renderer.getRootNode()).toBe(null);
-
-    await renderer.dispose();
-  });
-
-  await t.step("reports the node the mount named", async () => {
-    const { renderer, cellRef, container } = setup(1);
-
-    await renderer.render(container as unknown as HTMLElement, cellRef);
-    // The mount names a node the applicator has yet to hear of, so create it
-    // before reading back: `getRootNode()` resolves the id through the node
-    // map, and an unresolved id would report no root for the wrong reason --
-    // which is the answer the other step expects, so the two would agree
-    // while measuring different things.
-    renderer.getApplicator().applyBatch({
-      batchId: 1,
-      ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
-    });
-
-    expect(renderer.getRootNode()).toBe(renderer.getApplicator().getNode(1));
-
-    await renderer.dispose();
-  });
-});
-
-Deno.test("VDomRenderer - tearing down leaves the caller's container", async (t) => {
-  const setup = (mountRootId: number | null) => {
-    const connection = new MockConnection();
-    connection.mountRootId = mountRootId;
-    const mock = new MockDoc(
-      '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-    );
-    const renderer = new VDomRenderer({
-      runtimeClient: {} as any,
-      connection: connection as any,
-      document: mock.document,
-    });
-    const cellRef = {
-      space: "did:key:test",
-      id: "cell-id",
-      path: [],
-      type: "application/json",
-    } as unknown as CellRef;
-    const container = mock.document.getElementById("root")!;
-    return { renderer, cellRef, container };
-  };
-
-  await t.step("when the mount reported no root", async () => {
-    const { renderer, cellRef, container } = setup(null);
-    await renderer.render(container as unknown as HTMLElement, cellRef);
-
-    await renderer.stopRendering();
-
-    expect((container as any).parentNode).not.toBe(null);
-    await renderer.dispose();
-  });
-
-  await t.step("and removes the root it did report", async () => {
-    const { renderer, cellRef, container } = setup(1);
-    await renderer.render(container as unknown as HTMLElement, cellRef);
-    renderer.getApplicator().applyBatch({
-      batchId: 1,
-      ops: [
-        { op: "create-element", nodeId: 1, tagName: "button" },
-        { op: "insert-child", parentId: 0, childId: 1, beforeId: null },
-      ],
-    });
-    const root = renderer.getApplicator().getNode(1);
-    expect((container as any).childNodes.length).toBe(1);
-
-    await renderer.stopRendering();
-
-    // The root goes and the container stays: teardown reaches into the
-    // container rather than removing it, which is the distinction the two
-    // steps together pin.
-    expect((root as any).parentNode).toBe(null);
-    expect((container as any).parentNode).not.toBe(null);
-    await renderer.dispose();
-  });
-});
-
-Deno.test("VDomRenderer - forwards trusted event provenance through delivery", async () => {
-  const connection = new MockConnection();
-  const mock = new MockDoc(
-    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-  );
-  const renderer = new VDomRenderer({
-    runtimeClient: {} as any,
-    connection: connection as any,
-    document: mock.document,
-  });
-
-  const cellRef = {
-    space: "did:key:test",
-    id: "cell-id",
-    path: [],
-    type: "application/json",
-  } as unknown as CellRef;
-
-  const container = mock.document.getElementById("root")!;
-  await renderer.render(container as unknown as HTMLElement, cellRef);
-  const mountId = renderer.getMountId();
-  if (mountId === null) {
-    throw new Error("expected renderer to have an active mount");
-  }
-
-  renderer.getApplicator().applyBatch({
-    batchId: 1,
-    ops: [
-      { op: "create-element", nodeId: 1, tagName: "button" },
-      { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
-    ],
-  });
-
-  const button = renderer.getApplicator().getNode(1) as any;
-  button.dispatchEvent({
-    type: "click",
-    target: button,
-    isTrusted: true,
-  });
-
-  assertEquals(connection.sentEvents.length, 1);
-  assertEquals(connection.sentEvents[0], {
-    mountId,
-    handlerId: 42,
-    nodeId: 1,
-    event: {
-      type: "click",
-      target: {
-        name: "button",
-      },
-      provenance: { origin: "dom", trusted: true },
-    },
-  });
-
-  await renderer.dispose();
-});
-
-Deno.test("VDomRenderer - acknowledges applied batches", async () => {
-  const connection = new MockConnection();
-  const mock = new MockDoc(
-    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-  );
-  const renderer = new VDomRenderer({
-    runtimeClient: {} as any,
-    connection: connection as any,
-    document: mock.document,
-  });
-
-  const cellRef = {
-    space: "did:key:test",
-    id: "cell-id",
-    path: [],
-    type: "application/json",
-  } as unknown as CellRef;
-
-  const container = mock.document.getElementById("root")!;
-  await renderer.render(container as unknown as HTMLElement, cellRef);
-  const mountId = renderer.getMountId();
-  if (mountId === null) {
-    throw new Error("expected renderer to have an active mount");
-  }
-
-  connection.emit("vdombatch", {
-    type: "vdom:batch",
-    batchId: 7,
-    mountId,
-    ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
-    rootId: 1,
-  });
-
-  assertEquals(connection.acknowledgedBatches, [{ mountId, batchId: 7 }]);
-
-  await renderer.dispose();
-});
-
-Deno.test("VDomRenderer - a batch's null rootId clears the tracked root", async () => {
-  const connection = new MockConnection();
-  const mock = new MockDoc(
-    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-  );
-  const renderer = new VDomRenderer({
-    runtimeClient: {} as any,
-    connection: connection as any,
-    document: mock.document,
-  });
-
-  const cellRef = {
-    space: "did:key:test",
-    id: "cell-id",
-    path: [],
-    type: "application/json",
-  } as unknown as CellRef;
-
-  const container = mock.document.getElementById("root")!;
-  await renderer.render(container as unknown as HTMLElement, cellRef);
-  const mountId = renderer.getMountId();
-  if (mountId === null) {
-    throw new Error("expected renderer to have an active mount");
-  }
-
-  const batch = (batchId: number, rootId: number | null | undefined) => ({
-    type: "vdom:batch",
-    batchId,
-    mountId,
-    ops: batchId === 1
-      ? [{ op: "create-element", nodeId: 1, tagName: "button" }]
-      : [],
-    ...(rootId === undefined ? {} : { rootId }),
-  });
-
-  connection.emit("vdombatch", batch(1, 1));
-  assertEquals(renderer.getRootNode() !== null, true);
-
-  // Absent says nothing about the root, so the tracked one stands.
-  connection.emit("vdombatch", batch(2, undefined));
-  assertEquals(renderer.getRootNode() !== null, true);
-
-  // `null` is what the reconciler reports for a tree with no root child, and
-  // it is a statement rather than a silence: the tracked root goes away.
-  connection.emit("vdombatch", batch(3, null));
-  assertEquals(renderer.getRootNode(), null);
-
-  await renderer.dispose();
-});
-
-Deno.test("VDomRenderer - constructs without throwing against an already-disposed connection", async () => {
-  const connection = new MockConnection();
-  // Dispose before the renderer attaches: attachVDom runs the teardown
-  // synchronously during construction, while `session` is still unassigned.
-  connection.abort();
-
-  const renderer = new VDomRenderer({
-    runtimeClient: {} as any,
-    connection: connection as any,
-    document: {
-      createElement: (tagName: string) => ({ tagName }),
-      createTextNode: (text: string) => ({ text }),
-    } as unknown as Document,
-  });
-
-  // The renderer is torn down, not half-built: no active mount, and the batch
-  // subscription was never registered.
-  assertEquals(renderer.getMountId(), null);
-
-  // A torn-down renderer refuses to mount rather than proceeding half-built.
-  const cellRef = {
-    space: "did:key:test",
-    id: "cell-id",
-    path: [],
-    type: "application/json",
-  } as unknown as CellRef;
-  const cancel = await renderer.render({} as unknown as HTMLElement, cellRef);
-  assertEquals(renderer.getMountId(), null);
-  assertEquals(connection.unmountCalls.length, 0);
-  await cancel();
-});
-
 function workerCellHandle(
   connection: MockConnection,
   id: string,
@@ -413,61 +128,353 @@ function workerCellHandle(
   return new CellHandle(worker, cellRef);
 }
 
-Deno.test("render() drives worker rendering and tears down via the connection", async () => {
-  const connection = new MockConnection();
-  const mock = new MockDoc(
-    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-  );
-  const container = mock.document.getElementById("root")!;
-  const cellHandle = workerCellHandle(connection, "of:render-cell");
+describe("main-renderer", () => {
+  describe("VDomRenderer", () => {
+    describe("the mount response's `rootId`", () => {
+      const setup = (mountRootId: number | null) => {
+        const connection = new MockConnection();
+        connection.mountRootId = mountRootId;
+        const mock = new MockDoc(
+          '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+        );
+        const renderer = new VDomRenderer({
+          runtimeClient: {} as any,
+          connection: connection as any,
+          document: mock.document,
+        });
+        const cellRef = {
+          space: "did:key:test",
+          id: "cell-id",
+          path: [],
+          type: "application/json",
+        } as unknown as CellRef;
+        const container = mock.document.getElementById("root")!;
+        return { connection, renderer, cellRef, container };
+      };
 
-  const cancel = render(
-    container as unknown as HTMLElement,
-    cellHandle as CellHandle<any>,
-    { document: mock.document },
-  );
+      it("reports no root when the mount reports none", async () => {
+        const { renderer, cellRef, container } = setup(null);
 
-  // Let the async mount settle so the cancel closure is wired up and the
-  // render is registered.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  assertEquals(
-    getActiveRenders().has(container as unknown as HTMLElement),
-    true,
-  );
+        await renderer.render(container as unknown as HTMLElement, cellRef);
 
-  cancel();
-  // Cancelling drops the registry entry and unmounts worker-side.
-  assertEquals(
-    getActiveRenders().has(container as unknown as HTMLElement),
-    false,
-  );
-  assertEquals(connection.unmountCalls.length, 1);
-  // Let the deferred renderer.dispose() settle.
-  await new Promise((resolve) => setTimeout(resolve, 0));
-});
+        expect(renderer.getRootNode()).toBe(null);
 
-Deno.test("render() reports a mount failure through onError while alive", async () => {
-  const connection = new MockConnection();
-  // The worker-side mount rejects; render() surfaces it through onError since
-  // the connection is neither cancelled nor disposed.
-  connection.mountVDom = () => Promise.reject(new Error("mount failed"));
-  const mock = new MockDoc(
-    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
-  );
-  const container = mock.document.getElementById("root")!;
-  const cellHandle = workerCellHandle(connection, "of:render-cell-fail");
+        await renderer.dispose();
+      });
 
-  const errors: Error[] = [];
-  const cancel = render(
-    container as unknown as HTMLElement,
-    cellHandle as CellHandle<any>,
-    { document: mock.document, onError: (error) => errors.push(error) },
-  );
+      it("reports the node the mount named", async () => {
+        const { renderer, cellRef, container } = setup(1);
 
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  assertEquals(errors.length, 1);
-  assertEquals(errors[0].message, "mount failed");
+        await renderer.render(container as unknown as HTMLElement, cellRef);
+        // The mount names a node the applicator has yet to hear of, so create it
+        // before reading back: `getRootNode()` resolves the id through the node
+        // map, and an unresolved id would report no root for the wrong reason --
+        // which is the answer the other step expects, so the two would agree
+        // while measuring different things.
+        renderer.getApplicator().applyBatch({
+          batchId: 1,
+          ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
+        });
 
-  cancel();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(renderer.getRootNode()).toBe(
+          renderer.getApplicator().getNode(1),
+        );
+
+        await renderer.dispose();
+      });
+    });
+
+    describe("stopRendering()", () => {
+      const setup = (mountRootId: number | null) => {
+        const connection = new MockConnection();
+        connection.mountRootId = mountRootId;
+        const mock = new MockDoc(
+          '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+        );
+        const renderer = new VDomRenderer({
+          runtimeClient: {} as any,
+          connection: connection as any,
+          document: mock.document,
+        });
+        const cellRef = {
+          space: "did:key:test",
+          id: "cell-id",
+          path: [],
+          type: "application/json",
+        } as unknown as CellRef;
+        const container = mock.document.getElementById("root")!;
+        return { renderer, cellRef, container };
+      };
+
+      it("leaves the caller's container when the mount reported no root", async () => {
+        const { renderer, cellRef, container } = setup(null);
+        await renderer.render(container as unknown as HTMLElement, cellRef);
+
+        await renderer.stopRendering();
+
+        expect((container as any).parentNode).not.toBe(null);
+        await renderer.dispose();
+      });
+
+      it("removes the root the mount reported, and leaves the container", async () => {
+        const { renderer, cellRef, container } = setup(1);
+        await renderer.render(container as unknown as HTMLElement, cellRef);
+        renderer.getApplicator().applyBatch({
+          batchId: 1,
+          ops: [
+            { op: "create-element", nodeId: 1, tagName: "button" },
+            { op: "insert-child", parentId: 0, childId: 1, beforeId: null },
+          ],
+        });
+        const root = renderer.getApplicator().getNode(1);
+        expect((container as any).childNodes.length).toBe(1);
+
+        await renderer.stopRendering();
+
+        // The root goes and the container stays: teardown reaches into the
+        // container rather than removing it, which is the distinction the two
+        // steps together pin.
+        expect((root as any).parentNode).toBe(null);
+        expect((container as any).parentNode).not.toBe(null);
+        await renderer.dispose();
+      });
+    });
+
+    it("forwards trusted event provenance through delivery", async () => {
+      const connection = new MockConnection();
+      const mock = new MockDoc(
+        '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+      );
+      const renderer = new VDomRenderer({
+        runtimeClient: {} as any,
+        connection: connection as any,
+        document: mock.document,
+      });
+
+      const cellRef = {
+        space: "did:key:test",
+        id: "cell-id",
+        path: [],
+        type: "application/json",
+      } as unknown as CellRef;
+
+      const container = mock.document.getElementById("root")!;
+      await renderer.render(container as unknown as HTMLElement, cellRef);
+      const mountId = renderer.getMountId();
+      if (mountId === null) {
+        throw new Error("expected renderer to have an active mount");
+      }
+
+      renderer.getApplicator().applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "button" },
+          { op: "set-event", nodeId: 1, eventType: "click", handlerId: 42 },
+        ],
+      });
+
+      const button = renderer.getApplicator().getNode(1) as any;
+      button.dispatchEvent({
+        type: "click",
+        target: button,
+        isTrusted: true,
+      });
+
+      expect(connection.sentEvents.length).toBe(1);
+      expect(connection.sentEvents[0]).toEqual({
+        mountId,
+        handlerId: 42,
+        nodeId: 1,
+        event: {
+          type: "click",
+          target: {
+            name: "button",
+          },
+          provenance: { origin: "dom", trusted: true },
+        },
+      });
+
+      await renderer.dispose();
+    });
+
+    it("acknowledges applied batches", async () => {
+      const connection = new MockConnection();
+      const mock = new MockDoc(
+        '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+      );
+      const renderer = new VDomRenderer({
+        runtimeClient: {} as any,
+        connection: connection as any,
+        document: mock.document,
+      });
+
+      const cellRef = {
+        space: "did:key:test",
+        id: "cell-id",
+        path: [],
+        type: "application/json",
+      } as unknown as CellRef;
+
+      const container = mock.document.getElementById("root")!;
+      await renderer.render(container as unknown as HTMLElement, cellRef);
+      const mountId = renderer.getMountId();
+      if (mountId === null) {
+        throw new Error("expected renderer to have an active mount");
+      }
+
+      connection.emit("vdombatch", {
+        type: "vdom:batch",
+        batchId: 7,
+        mountId,
+        ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
+        rootId: 1,
+      });
+
+      expect(connection.acknowledgedBatches).toEqual([{ mountId, batchId: 7 }]);
+
+      await renderer.dispose();
+    });
+
+    it("clears the tracked root when a batch's `rootId` is `null`", async () => {
+      const connection = new MockConnection();
+      const mock = new MockDoc(
+        '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+      );
+      const renderer = new VDomRenderer({
+        runtimeClient: {} as any,
+        connection: connection as any,
+        document: mock.document,
+      });
+
+      const cellRef = {
+        space: "did:key:test",
+        id: "cell-id",
+        path: [],
+        type: "application/json",
+      } as unknown as CellRef;
+
+      const container = mock.document.getElementById("root")!;
+      await renderer.render(container as unknown as HTMLElement, cellRef);
+      const mountId = renderer.getMountId();
+      if (mountId === null) {
+        throw new Error("expected renderer to have an active mount");
+      }
+
+      const batch = (batchId: number, rootId: number | null | undefined) => ({
+        type: "vdom:batch",
+        batchId,
+        mountId,
+        ops: batchId === 1
+          ? [{ op: "create-element", nodeId: 1, tagName: "button" }]
+          : [],
+        ...(rootId === undefined ? {} : { rootId }),
+      });
+
+      connection.emit("vdombatch", batch(1, 1));
+      expect(renderer.getRootNode()).not.toBe(null);
+
+      // Absent says nothing about the root, so the tracked one stands.
+      connection.emit("vdombatch", batch(2, undefined));
+      expect(renderer.getRootNode()).not.toBe(null);
+
+      // `null` is what the reconciler reports for a tree with no root child, and
+      // it is a statement rather than a silence: the tracked root goes away.
+      connection.emit("vdombatch", batch(3, null));
+      expect(renderer.getRootNode()).toBe(null);
+
+      await renderer.dispose();
+    });
+
+    it("constructs without throwing against an already-disposed connection", async () => {
+      const connection = new MockConnection();
+      // Dispose before the renderer attaches: attachVDom runs the teardown
+      // synchronously during construction, while `session` is still unassigned.
+      connection.abort();
+
+      const renderer = new VDomRenderer({
+        runtimeClient: {} as any,
+        connection: connection as any,
+        document: {
+          createElement: (tagName: string) => ({ tagName }),
+          createTextNode: (text: string) => ({ text }),
+        } as unknown as Document,
+      });
+
+      // The renderer is torn down, not half-built: no active mount, and the batch
+      // subscription was never registered.
+      expect(renderer.getMountId()).toBe(null);
+
+      // A torn-down renderer refuses to mount rather than proceeding half-built.
+      const cellRef = {
+        space: "did:key:test",
+        id: "cell-id",
+        path: [],
+        type: "application/json",
+      } as unknown as CellRef;
+      const cancel = await renderer.render(
+        {} as unknown as HTMLElement,
+        cellRef,
+      );
+      expect(renderer.getMountId()).toBe(null);
+      expect(connection.unmountCalls.length).toBe(0);
+      await cancel();
+    });
+  });
+
+  describe("render()", () => {
+    it("drives worker rendering and tears down via the connection", async () => {
+      const connection = new MockConnection();
+      const mock = new MockDoc(
+        '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+      );
+      const container = mock.document.getElementById("root")!;
+      const cellHandle = workerCellHandle(connection, "of:render-cell");
+
+      const cancel = render(
+        container as unknown as HTMLElement,
+        cellHandle as CellHandle<any>,
+        { document: mock.document },
+      );
+
+      // Let the async mount settle so the cancel closure is wired up and the
+      // render is registered.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(getActiveRenders().has(container as unknown as HTMLElement))
+        .toBe(true);
+
+      cancel();
+      // Cancelling drops the registry entry and unmounts worker-side.
+      expect(getActiveRenders().has(container as unknown as HTMLElement))
+        .toBe(false);
+      expect(connection.unmountCalls.length).toBe(1);
+      // Let the deferred renderer.dispose() settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    it("reports a mount failure through `onError` while alive", async () => {
+      const connection = new MockConnection();
+      // The worker-side mount rejects; render() surfaces it through onError since
+      // the connection is neither cancelled nor disposed.
+      connection.mountVDom = () => Promise.reject(new Error("mount failed"));
+      const mock = new MockDoc(
+        '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+      );
+      const container = mock.document.getElementById("root")!;
+      const cellHandle = workerCellHandle(connection, "of:render-cell-fail");
+
+      const errors: Error[] = [];
+      const cancel = render(
+        container as unknown as HTMLElement,
+        cellHandle as CellHandle<any>,
+        { document: mock.document, onError: (error) => errors.push(error) },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toBe("mount failed");
+
+      cancel();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  });
 });

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -281,7 +281,7 @@ describe("main-renderer", () => {
       });
 
       expect(connection.sentEvents.length).toBe(1);
-      expect(connection.sentEvents[0]).toEqual({
+      expect(connection.sentEvents[0]).toStrictEqual({
         mountId,
         handlerId: 42,
         nodeId: 1,
@@ -330,7 +330,10 @@ describe("main-renderer", () => {
         rootId: 1,
       });
 
-      expect(connection.acknowledgedBatches).toEqual([{ mountId, batchId: 7 }]);
+      expect(connection.acknowledgedBatches).toStrictEqual([{
+        mountId,
+        batchId: 7,
+      }]);
 
       await renderer.dispose();
     });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1966,27 +1966,30 @@ describe("RuntimeProcessor home pattern IPC", () => {
 });
 
 describe("system-pattern update wiring", () => {
-  it("handleGetSpaceRootPattern returns the root ensured by the controller", async () => {
-    const ref: CellRef = {
-      id: "of:root-result" as CellRef["id"],
-      space: "did:key:test-space" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const rootCell = { getAsLink: () => cellRefToSigilLink(ref) };
-    const cc = {
-      ensureDefaultPattern: () => Promise.resolve({ getCell: () => rootCell }),
-    };
-    const processor = {
-      getSpaceCtx: () => cc,
-    } as unknown as RuntimeProcessor;
+  describe("handleGetSpaceRootPattern()", () => {
+    it("returns the root ensured by the controller", async () => {
+      const ref: CellRef = {
+        id: "of:root-result" as CellRef["id"],
+        space: "did:key:test-space" as CellRef["space"],
+        scope: "space",
+        path: [],
+      };
+      const rootCell = { getAsLink: () => cellRefToSigilLink(ref) };
+      const cc = {
+        ensureDefaultPattern: () =>
+          Promise.resolve({ getCell: () => rootCell }),
+      };
+      const processor = {
+        getSpaceCtx: () => cc,
+      } as unknown as RuntimeProcessor;
 
-    const result = await RuntimeProcessor.prototype.handleGetSpaceRootPattern
-      .call(processor, {
-        type: RequestType.GetSpaceRootPattern,
-        space: "did:key:test-space",
-      });
-    expect(result.page.cell).toEqual(ref);
+      const result = await RuntimeProcessor.prototype.handleGetSpaceRootPattern
+        .call(processor, {
+          type: RequestType.GetSpaceRootPattern,
+          space: "did:key:test-space",
+        });
+      expect(result.page.cell).toEqual(ref);
+    });
   });
 });
 
@@ -3576,199 +3579,211 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     }
   });
 
-  it("handlePageGet with a space resolves the page in that space", async () => {
-    const { processor, runtime, homeSpace } = makeProcessorState();
-    const spaceB = (await Identity.fromPassphrase(
-      "runtime-processor-space-b",
-    )).did();
-    const handlePageGet = (RuntimeProcessor.prototype as any).handlePageGet;
-    try {
-      const resHome = await handlePageGet.call(processor, {
-        type: RequestType.PageGet,
-        pageId: fid("cross-space-probe"),
-        runIt: false,
-        space: homeSpace,
-      });
-      const resB = await handlePageGet.call(processor, {
-        type: RequestType.PageGet,
-        pageId: fid("cross-space-probe"),
-        runIt: false,
-        space: spaceB,
-      });
-      expect(resHome.page.cell.space).toBe(homeSpace);
-      expect(resB.page.cell.space).toBe(spaceB);
-    } finally {
-      await runtime.dispose();
-    }
+  describe("handlePageGet()", () => {
+    it("resolves the page in the space it is given", async () => {
+      const { processor, runtime, homeSpace } = makeProcessorState();
+      const spaceB = (await Identity.fromPassphrase(
+        "runtime-processor-space-b",
+      )).did();
+      const handlePageGet = (RuntimeProcessor.prototype as any).handlePageGet;
+      try {
+        const resHome = await handlePageGet.call(processor, {
+          type: RequestType.PageGet,
+          pageId: fid("cross-space-probe"),
+          runIt: false,
+          space: homeSpace,
+        });
+        const resB = await handlePageGet.call(processor, {
+          type: RequestType.PageGet,
+          pageId: fid("cross-space-probe"),
+          runIt: false,
+          space: spaceB,
+        });
+        expect(resHome.page.cell.space).toBe(homeSpace);
+        expect(resB.page.cell.space).toBe(spaceB);
+      } finally {
+        await runtime.dispose();
+      }
+    });
   });
 
-  it("handleRuntimeSynced awaits every opened space, naming none", async () => {
-    const { processor, runtime } = makeProcessorState();
-    const spaceB = (await Identity.fromPassphrase(
-      "runtime-processor-space-b",
-    )).did();
-    const handleRuntimeSynced =
-      (RuntimeProcessor.prototype as any).handleRuntimeSynced;
-    try {
-      processor.getSpaceCtx(spaceB);
-      // Resolves across home + spaceB over loopback storage; the request
-      // carries no space at all.
-      await handleRuntimeSynced.call(processor);
-    } finally {
-      await runtime.dispose();
-    }
+  describe("handleRuntimeSynced()", () => {
+    it("awaits every opened space, naming none", async () => {
+      const { processor, runtime } = makeProcessorState();
+      const spaceB = (await Identity.fromPassphrase(
+        "runtime-processor-space-b",
+      )).did();
+      const handleRuntimeSynced =
+        (RuntimeProcessor.prototype as any).handleRuntimeSynced;
+      try {
+        processor.getSpaceCtx(spaceB);
+        // Resolves across home + spaceB over loopback storage; the request
+        // carries no space at all.
+        await handleRuntimeSynced.call(processor);
+      } finally {
+        await runtime.dispose();
+      }
+    });
   });
 
-  it("handleIdle awaits commit-durability quiescence, not plain idle", async () => {
-    // The client reads "idle" as a safe point to navigate or reload, so the
-    // handler must await idleWithPendingCommits() — which includes in-flight
-    // commit durability — rather than runtime.idle() (reactive quiescence
-    // only). A fake exposing ONLY idleWithPendingCommits pins the wiring: a
-    // regression to runtime.idle() throws here.
-    const handleIdle = (RuntimeProcessor.prototype as any).handleIdle;
-    let calls = 0;
-    const fake = {
-      runtime: {
-        scheduler: {
-          idleWithPendingCommits: () => {
-            calls++;
-            return Promise.resolve();
+  describe("handleIdle()", () => {
+    it("awaits commit-durability quiescence, not plain idle", async () => {
+      // The client reads "idle" as a safe point to navigate or reload, so the
+      // handler must await idleWithPendingCommits() — which includes in-flight
+      // commit durability — rather than runtime.idle() (reactive quiescence
+      // only). A fake exposing ONLY idleWithPendingCommits pins the wiring: a
+      // regression to runtime.idle() throws here.
+      const handleIdle = (RuntimeProcessor.prototype as any).handleIdle;
+      let calls = 0;
+      const fake = {
+        runtime: {
+          scheduler: {
+            idleWithPendingCommits: () => {
+              calls++;
+              return Promise.resolve();
+            },
           },
         },
-      },
-    };
-    await handleIdle.call(fake);
-    expect(calls).toBe(1);
+      };
+      await handleIdle.call(fake);
+      expect(calls).toBe(1);
+    });
   });
 
-  it("watchSiteTable uses the last usable entry per space without replacing an accepted route", async () => {
-    const { runtime } = createRuntime();
-    const registered: Array<[string, string]> = [];
-    let resolveRegistered = () => {};
-    const entriesRegistered = new Promise<void>((resolve) => {
-      resolveRegistered = resolve;
-    });
-    const registeredRoute = "did:key:z6Mk-table-b" as MemorySpace;
-    const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
-    expect(registerSpaceHost(registeredRoute, "http://ipc-host.test/"))
-      .toBe(true);
-    Object.assign(runtime, {
-      registerSpaceHost: (space: string, host: string) => {
-        registered.push([space, host]);
-        if (registered.length === 3) resolveRegistered();
-        return registerSpaceHost(space as MemorySpace, host);
-      },
-    });
-    const userDid = runtime.userIdentityDID;
-    const table = runtime.getCell(
-      userDid,
-      siteTableCause(userDid),
-      siteTableSchema,
-    );
-    const tx = runtime.edit();
-    table.withTx(tx).set([
-      { did: "did:key:z6Mk-table-a", host: "http://host-a.test/" },
-      { did: "not-a-did", host: "http://ignored.test/" },
-      { did: registeredRoute, host: "http://stale-table.test/" },
-      { did: "did:key:z6Mk-table-c", host: "http://host-c.test/" },
-      { did: "did:key:z6Mk-table-a", host: "http://host-a-new.test/" },
-      { did: "did:key:z6Mk-table-a", host: "not a url" },
-      {
-        did: "did:key:z6Mk-table-credentials",
-        host: "http://user@credentials.test/",
-      },
-      { did: "did:key:z6Mk-table-path", host: "http://path.test/api" },
-      {
-        did: "did:key:z6Mk-table-dot-path",
-        host: "http://dot-path.test/api/..",
-      },
-      { did: "did:key:z6Mk-table-query", host: "http://query.test/?x=1" },
-      { did: "did:key:z6Mk-table-fragment", host: "http://hash.test/#x" },
-    ]);
-    await tx.commit();
-
-    const cc = new PiecesController(
-      { as: cfcSigner, space: userDid },
-      runtime,
-    );
-    const ProcessorConstructor = RuntimeProcessor as unknown as new (
-      runtime: Runtime,
-      cc: PiecesController,
-      initSpace: MemorySpace,
-      identity: Identity,
-      telemetry: RuntimeTelemetry,
-    ) => RuntimeProcessor;
-    const processor = new ProcessorConstructor(
-      runtime,
-      cc,
-      userDid,
-      cfcSigner,
-      new RuntimeTelemetry(),
-    );
-    try {
-      processor.watchSiteTable();
-      await entriesRegistered;
-      expect(registered).toEqual([
-        ["did:key:z6Mk-table-a", "http://host-a-new.test/"],
-        [registeredRoute, "http://stale-table.test/"],
-        ["did:key:z6Mk-table-c", "http://host-c.test/"],
-      ]);
-      expect(runtime.mappedHostFor(registeredRoute)).toBe(
-        "http://ipc-host.test/",
-      );
-      const tableRoute = "did:key:z6Mk-table-a" as MemorySpace;
-      expect(registerSpaceHost(tableRoute, "http://late-ipc.test/"))
-        .toBe(false);
-      expect(runtime.mappedHostFor(tableRoute)).toBe(
-        "http://host-a-new.test/",
-      );
-    } finally {
-      await processor.dispose();
-    }
-  });
-
-  it("handleRegisterSpaceHost forwards to the runtime and reports the verdict", () => {
-    const calls: Array<[string, string]> = [];
-    const processor = {
-      runtime: {
+  describe("watchSiteTable()", () => {
+    it("uses the last usable entry per space without replacing an accepted route", async () => {
+      const { runtime } = createRuntime();
+      const registered: Array<[string, string]> = [];
+      let resolveRegistered = () => {};
+      const entriesRegistered = new Promise<void>((resolve) => {
+        resolveRegistered = resolve;
+      });
+      const registeredRoute = "did:key:z6Mk-table-b" as MemorySpace;
+      const registerSpaceHost = runtime.registerSpaceHost.bind(runtime);
+      expect(registerSpaceHost(registeredRoute, "http://ipc-host.test/"))
+        .toBe(true);
+      Object.assign(runtime, {
         registerSpaceHost: (space: string, host: string) => {
-          calls.push([space, host]);
-          return host === "http://accepted.test/";
+          registered.push([space, host]);
+          if (registered.length === 3) resolveRegistered();
+          return registerSpaceHost(space as MemorySpace, host);
         },
-      },
-    } as unknown as RuntimeProcessor;
-    const handle = (RuntimeProcessor.prototype as unknown as {
-      handleRegisterSpaceHost(
-        r: { type: RequestType; space: string; host: string },
-      ): { value: boolean };
-    }).handleRegisterSpaceHost;
-    expect(handle.call(processor, {
-      type: RequestType.RegisterSpaceHost,
-      space: "did:key:z6Mk-ipc-a",
-      host: "http://accepted.test/",
-    })).toEqual({ value: true });
-    expect(handle.call(processor, {
-      type: RequestType.RegisterSpaceHost,
-      space: "did:key:z6Mk-ipc-b",
-      host: "http://refused.test/",
-    })).toEqual({ value: false });
-    expect(calls.length).toBe(2);
+      });
+      const userDid = runtime.userIdentityDID;
+      const table = runtime.getCell(
+        userDid,
+        siteTableCause(userDid),
+        siteTableSchema,
+      );
+      const tx = runtime.edit();
+      table.withTx(tx).set([
+        { did: "did:key:z6Mk-table-a", host: "http://host-a.test/" },
+        { did: "not-a-did", host: "http://ignored.test/" },
+        { did: registeredRoute, host: "http://stale-table.test/" },
+        { did: "did:key:z6Mk-table-c", host: "http://host-c.test/" },
+        { did: "did:key:z6Mk-table-a", host: "http://host-a-new.test/" },
+        { did: "did:key:z6Mk-table-a", host: "not a url" },
+        {
+          did: "did:key:z6Mk-table-credentials",
+          host: "http://user@credentials.test/",
+        },
+        { did: "did:key:z6Mk-table-path", host: "http://path.test/api" },
+        {
+          did: "did:key:z6Mk-table-dot-path",
+          host: "http://dot-path.test/api/..",
+        },
+        { did: "did:key:z6Mk-table-query", host: "http://query.test/?x=1" },
+        { did: "did:key:z6Mk-table-fragment", host: "http://hash.test/#x" },
+      ]);
+      await tx.commit();
+
+      const cc = new PiecesController(
+        { as: cfcSigner, space: userDid },
+        runtime,
+      );
+      const ProcessorConstructor = RuntimeProcessor as unknown as new (
+        runtime: Runtime,
+        cc: PiecesController,
+        initSpace: MemorySpace,
+        identity: Identity,
+        telemetry: RuntimeTelemetry,
+      ) => RuntimeProcessor;
+      const processor = new ProcessorConstructor(
+        runtime,
+        cc,
+        userDid,
+        cfcSigner,
+        new RuntimeTelemetry(),
+      );
+      try {
+        processor.watchSiteTable();
+        await entriesRegistered;
+        expect(registered).toEqual([
+          ["did:key:z6Mk-table-a", "http://host-a-new.test/"],
+          [registeredRoute, "http://stale-table.test/"],
+          ["did:key:z6Mk-table-c", "http://host-c.test/"],
+        ]);
+        expect(runtime.mappedHostFor(registeredRoute)).toBe(
+          "http://ipc-host.test/",
+        );
+        const tableRoute = "did:key:z6Mk-table-a" as MemorySpace;
+        expect(registerSpaceHost(tableRoute, "http://late-ipc.test/"))
+          .toBe(false);
+        expect(runtime.mappedHostFor(tableRoute)).toBe(
+          "http://host-a-new.test/",
+        );
+      } finally {
+        await processor.dispose();
+      }
+    });
   });
 
-  it("piecesFor returns only existing contexts (no lazy create)", async () => {
-    const { processor, runtime, homeSpace } = makeProcessorState();
-    const spaceB = (await Identity.fromPassphrase(
-      "runtime-processor-space-b",
-    )).did();
-    const piecesFor = (RuntimeProcessor.prototype as any).piecesFor;
-    try {
-      expect(piecesFor.call(processor, homeSpace)).toBe(processor.cc);
-      expect(piecesFor.call(processor, spaceB)).toBeUndefined();
-      const ctxB = processor.getSpaceCtx(spaceB);
-      expect(piecesFor.call(processor, spaceB)).toBe(ctxB);
-    } finally {
-      await runtime.dispose();
-    }
+  describe("handleRegisterSpaceHost()", () => {
+    it("forwards to the runtime and reports the verdict", () => {
+      const calls: Array<[string, string]> = [];
+      const processor = {
+        runtime: {
+          registerSpaceHost: (space: string, host: string) => {
+            calls.push([space, host]);
+            return host === "http://accepted.test/";
+          },
+        },
+      } as unknown as RuntimeProcessor;
+      const handle = (RuntimeProcessor.prototype as unknown as {
+        handleRegisterSpaceHost(
+          r: { type: RequestType; space: string; host: string },
+        ): { value: boolean };
+      }).handleRegisterSpaceHost;
+      expect(handle.call(processor, {
+        type: RequestType.RegisterSpaceHost,
+        space: "did:key:z6Mk-ipc-a",
+        host: "http://accepted.test/",
+      })).toEqual({ value: true });
+      expect(handle.call(processor, {
+        type: RequestType.RegisterSpaceHost,
+        space: "did:key:z6Mk-ipc-b",
+        host: "http://refused.test/",
+      })).toEqual({ value: false });
+      expect(calls.length).toBe(2);
+    });
+  });
+
+  describe("piecesFor()", () => {
+    it("returns only existing contexts, and creates none lazily", async () => {
+      const { processor, runtime, homeSpace } = makeProcessorState();
+      const spaceB = (await Identity.fromPassphrase(
+        "runtime-processor-space-b",
+      )).did();
+      const piecesFor = (RuntimeProcessor.prototype as any).piecesFor;
+      try {
+        expect(piecesFor.call(processor, homeSpace)).toBe(processor.cc);
+        expect(piecesFor.call(processor, spaceB)).toBeUndefined();
+        const ctxB = processor.getSpaceCtx(spaceB);
+        expect(piecesFor.call(processor, spaceB)).toBe(ctxB);
+      } finally {
+        await runtime.dispose();
+      }
+    });
   });
 });
 

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -432,7 +432,7 @@ describe("CellHandle reactive CFC label delivery", () => {
     expect(calls.length).toBe(afterValue);
   });
 
-  it("a value-only notification leaves the cached label untouched", () => {
+  it("leaves the cached label untouched on a value-only update", () => {
     const cell = new CellHandle<string>(makeRuntime(), ref);
     cell.subscribe(() => {}, { includeCfcLabel: true });
     cell[$onCellUpdate]("v1", { cfcLabel: labelA });

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -219,7 +219,7 @@ describe("RuntimeConnection.attachVDom", () => {
     expect(torn).toBe(true);
   });
 
-  it("detach() unregisters the teardown", async () => {
+  it("does not run the teardown after `detach()`", async () => {
     const transport = new FakeTransport();
     const connection = await initializedConnection(transport);
     let torn = false;

--- a/packages/runtime-client/client/transport.ts
+++ b/packages/runtime-client/client/transport.ts
@@ -20,5 +20,11 @@ export interface RuntimeTransport extends EventEmitter<RuntimeTransportEvents> {
    * does not, and cannot be used as-is.
    */
   send(data: IPCClientMessage | IPCClientNotification): void;
+
+  /**
+   * Closes the transport and releases whatever it holds open. Settles once
+   * the far end is gone, so a caller may stand a replacement up after
+   * awaiting it. Messages sent afterwards are not delivered.
+   */
   dispose(): Promise<void>;
 }

--- a/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
@@ -44,6 +44,7 @@ export class WebWorkerRuntimeTransport
     this._worker.addEventListener("error", this._handleError);
   }
 
+  /** @inheritDoc */
   send(data: IPCClientMessage | IPCClientNotification): void {
     // TODO(danfuzz): this send should encode `data` with `codec-realm`, which
     // is what would let the payload carry the whole `FabricValue` domain
@@ -54,6 +55,7 @@ export class WebWorkerRuntimeTransport
     this._worker.postMessage(data);
   }
 
+  /** @inheritDoc */
   dispose(): Promise<void> {
     this.removeAllListeners();
     this._worker.terminate();

--- a/packages/runtime-client/favorites-manager.test.ts
+++ b/packages/runtime-client/favorites-manager.test.ts
@@ -113,102 +113,108 @@ describe("FavoritesManager.addFavorite tag derivation", () => {
 });
 
 describe("FavoritesManager other operations", () => {
-  it("removeFavorite sends the piece reference and its key", async () => {
-    const stub = makeStub();
-    await new FavoritesManager(stub.rt).removeFavorite(space, "piece-x");
-    expect(stub.sent[0]).toMatchObject({
-      piece: { id: "of:piece-x", space },
+  describe("removeFavorite()", () => {
+    it("sends the piece reference and its key", async () => {
+      const stub = makeStub();
+      await new FavoritesManager(stub.rt).removeFavorite(space, "piece-x");
+      expect(stub.sent[0]).toMatchObject({
+        piece: { id: "of:piece-x", space },
+      });
+      // The same key add uses, so the removal reaches the same favorite entity.
+      expect(stub.sent[0].id).toBe(
+        favoriteKey({ space, id: "of:piece-x", path: [] }),
+      );
     });
-    // The same key add uses, so the removal reaches the same favorite entity.
-    expect(stub.sent[0].id).toBe(
-      favoriteKey({ space, id: "of:piece-x", path: [] }),
-    );
   });
 
-  it("getFavorites returns the favorites list", async () => {
-    const entries = [{ cell: {}, tags: ["a"], userTags: [] }];
-    const stub = makeStub({ favorites: entries });
-    const result = await new FavoritesManager(stub.rt).getFavorites();
-    expect(result).toEqual(entries);
+  describe("getFavorites()", () => {
+    it("returns the favorites list", async () => {
+      const entries = [{ cell: {}, tags: ["a"], userTags: [] }];
+      const stub = makeStub({ favorites: entries });
+      const result = await new FavoritesManager(stub.rt).getFavorites();
+      expect(result).toEqual(entries);
+    });
+
+    it("returns `[]` when the cell is empty", async () => {
+      const stub = makeStub({ favorites: undefined });
+      expect(await new FavoritesManager(stub.rt).getFavorites()).toEqual([]);
+    });
   });
 
-  it("getFavorites returns [] when the cell is empty", async () => {
-    const stub = makeStub({ favorites: undefined });
-    expect(await new FavoritesManager(stub.rt).getFavorites()).toEqual([]);
-  });
+  describe("subscribeFavorites()", () => {
+    it("delivers values and stops on unsubscribe", async () => {
+      const stub = makeStub();
+      const seen: unknown[] = [];
+      const cancel = new FavoritesManager(stub.rt).subscribeFavorites((f) =>
+        seen.push(f)
+      );
+      await tick();
+      expect(stub.hasSubscriber()).toBe(true);
 
-  it("subscribeFavorites delivers values and stops on unsubscribe", async () => {
-    const stub = makeStub();
-    const seen: unknown[] = [];
-    const cancel = new FavoritesManager(stub.rt).subscribeFavorites((f) =>
-      seen.push(f)
-    );
-    await tick();
-    expect(stub.hasSubscriber()).toBe(true);
+      stub.invokeSubscribe([{ cell: {}, tags: ["x"], userTags: [] }]);
+      expect(seen).toEqual([[{ cell: {}, tags: ["x"], userTags: [] }]]);
 
-    stub.invokeSubscribe([{ cell: {}, tags: ["x"], userTags: [] }]);
-    expect(seen).toEqual([[{ cell: {}, tags: ["x"], userTags: [] }]]);
+      // A null delivery is normalized to an empty array.
+      stub.invokeSubscribe(undefined);
+      expect(seen[1]).toEqual([]);
 
-    // A null delivery is normalized to an empty array.
-    stub.invokeSubscribe(undefined);
-    expect(seen[1]).toEqual([]);
+      cancel();
+      expect(stub.wasUnsubscribed()).toBe(true);
+      // After cleanup, further deliveries are dropped.
+      stub.invokeSubscribe([{ cell: {}, tags: ["y"], userTags: [] }]);
+      expect(seen.length).toBe(2);
+    });
 
-    cancel();
-    expect(stub.wasUnsubscribed()).toBe(true);
-    // After cleanup, further deliveries are dropped.
-    stub.invokeSubscribe([{ cell: {}, tags: ["y"], userTags: [] }]);
-    expect(seen.length).toBe(2);
-  });
-
-  it("subscribeFavorites reports setup errors to onError", async () => {
-    const stub = makeStub({ ensureThrows: true });
-    const seen: unknown[] = [];
-    let reported: Error | undefined;
-    new FavoritesManager(stub.rt).subscribeFavorites(
-      (f) => seen.push(f),
-      (err) => {
-        reported = err;
-      },
-    );
-    await tick();
-    await tick();
-    expect(reported?.message).toBe("ensure failed");
-    // The callback is still invoked once with an empty list on failure.
-    expect(seen).toEqual([[]]);
-  });
-
-  it("subscribeFavorites treats an aborted runtime as cancellation", async () => {
-    const stub = makeStub({ ensureDisposed: true });
-    const seen: unknown[] = [];
-    let reported: Error | undefined;
-    new FavoritesManager(stub.rt).subscribeFavorites(
-      (f) => seen.push(f),
-      (err) => {
-        reported = err;
-      },
-    );
-    await tick();
-    await tick();
-    // An aborted runtime signal marks an expected teardown race, not an error:
-    // neither onError nor the empty-list callback fires.
-    expect(reported).toBeUndefined();
-    expect(seen).toEqual([]);
-  });
-
-  it("subscribeFavorites logs setup errors when no onError is given", async () => {
-    const stub = makeStub({ ensureThrows: true });
-    const original = console.error;
-    let logged = false;
-    console.error = () => {
-      logged = true;
-    };
-    try {
-      new FavoritesManager(stub.rt).subscribeFavorites(() => {});
+    it("reports setup errors to `onError`", async () => {
+      const stub = makeStub({ ensureThrows: true });
+      const seen: unknown[] = [];
+      let reported: Error | undefined;
+      new FavoritesManager(stub.rt).subscribeFavorites(
+        (f) => seen.push(f),
+        (err) => {
+          reported = err;
+        },
+      );
       await tick();
       await tick();
-    } finally {
-      console.error = original;
-    }
-    expect(logged).toBe(true);
+      expect(reported?.message).toBe("ensure failed");
+      // The callback is still invoked once with an empty list on failure.
+      expect(seen).toEqual([[]]);
+    });
+
+    it("treats an aborted runtime as cancellation", async () => {
+      const stub = makeStub({ ensureDisposed: true });
+      const seen: unknown[] = [];
+      let reported: Error | undefined;
+      new FavoritesManager(stub.rt).subscribeFavorites(
+        (f) => seen.push(f),
+        (err) => {
+          reported = err;
+        },
+      );
+      await tick();
+      await tick();
+      // An aborted runtime signal marks an expected teardown race, not an error:
+      // neither onError nor the empty-list callback fires.
+      expect(reported).toBeUndefined();
+      expect(seen).toEqual([]);
+    });
+
+    it("logs setup errors when no `onError` is given", async () => {
+      const stub = makeStub({ ensureThrows: true });
+      const original = console.error;
+      let logged = false;
+      console.error = () => {
+        logged = true;
+      };
+      try {
+        new FavoritesManager(stub.rt).subscribeFavorites(() => {});
+        await tick();
+        await tick();
+      } finally {
+        console.error = original;
+      }
+      expect(logged).toBe(true);
+    });
   });
 });

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -1,3 +1,12 @@
+/**
+ * Runtime shape tests for the IPC protocol's message types.
+ *
+ * Each one answers what its name asks and stops there. They test the fields a
+ * receiver dispatches on -- a discriminant, a message id -- and not the payload
+ * underneath, so a value passing one of these is routable rather than vetted.
+ * Each doc below says where its particular guarantee stops.
+ */
+
 import { isDID } from "@commonfabric/identity";
 import { isObjectNotArray } from "@commonfabric/utils/types";
 import {
@@ -26,6 +35,11 @@ import {
   WorkerReadyNotification,
 } from "./types.ts";
 
+/**
+ * Is `value` a {@link CellRef}? Checks that `path` is an array, `id` a
+ * non-empty string, and `space` a DID. The path's own entries are not
+ * examined, and nothing here says the cell it addresses exists.
+ */
 export function isCellRef(value: unknown): value is CellRef {
   if (!isObjectNotArray(value)) return false;
   return Array.isArray(value.path) && typeof value.id === "string" &&
@@ -33,6 +47,13 @@ export function isCellRef(value: unknown): value is CellRef {
     isDID(value.space);
 }
 
+/**
+ * Is `value` an {@link InitializationData}? The shallowest guard here: it
+ * checks `apiUrl` and `spaceDid` are strings and that `identity` is present at
+ * all, and looks at nothing else the type declares. What it establishes is
+ * that initialization has something to work with, not that the worker will
+ * accept it.
+ */
 export function isInitializationData(
   value: unknown,
 ): value is InitializationData {
@@ -43,6 +64,11 @@ export function isInitializationData(
   );
 }
 
+/**
+ * Is `value` an {@link IPCClientRequest}? Recognized by its `type` naming a
+ * {@link RequestType} member, which is what dispatch turns on. The fields that
+ * request type goes on to require are the handler's to check.
+ */
 export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
   return (
     isObjectNotArray(value) &&
@@ -53,6 +79,11 @@ export function isIPCClientRequest(value: unknown): value is IPCClientRequest {
   );
 }
 
+/**
+ * Is `value` an {@link IPCClientMessage}? The request envelope: a numeric
+ * `msgId` wrapping something {@link isIPCClientRequest} accepts. Carries that
+ * guard's bound with it -- the request is routable, not vetted.
+ */
 export function isIPCClientMessage(value: unknown): value is IPCClientMessage {
   return (
     isObjectNotArray(value) &&
@@ -61,6 +92,11 @@ export function isIPCClientMessage(value: unknown): value is IPCClientMessage {
   );
 }
 
+/**
+ * Is `value` an {@link IPCClientNotification}? These carry no `msgId` and get
+ * no response, so the `type` naming a {@link ClientNotificationType} member is
+ * the whole of what distinguishes one.
+ */
 export function isIPCClientNotification(
   value: unknown,
 ): value is IPCClientNotification {
@@ -73,12 +109,23 @@ export function isIPCClientNotification(
   );
 }
 
+/**
+ * Is `value` anything the worker sends the connection -- a response or a
+ * notification? The transport's own traffic is not included: a ready or
+ * worker-console notification is handled before dispatch reaches here.
+ */
 export function isIPCRemoteMessage(
   value: unknown,
 ): value is IPCRemoteMessage {
   return isIPCRemoteResponse(value) || isIPCRemoteNotification(value);
 }
 
+/**
+ * Is `value` an {@link IPCRemoteResponse}? A numeric `msgId` identifies one,
+ * and a present `error` must be a string. A bare `{ msgId }` therefore
+ * qualifies, that being how the worker acks a request whose handler returned
+ * nothing. The `data` a successful response carries is not examined.
+ */
 export function isIPCRemoteResponse(
   value: unknown,
 ): value is IPCRemoteResponse {
@@ -89,6 +136,11 @@ export function isIPCRemoteResponse(
   );
 }
 
+/**
+ * Is `value` an {@link IPCRemoteNotification}? The disjunction of the seven
+ * per-notification guards below, so this admits exactly what one of them
+ * admits and adds nothing of its own.
+ */
 export function isIPCRemoteNotification(
   value: unknown,
 ): value is IPCRemoteNotification {
@@ -98,6 +150,12 @@ export function isIPCRemoteNotification(
     isVDomBatchNotification(value) || isPendingWritesNotification(value);
 }
 
+/**
+ * Is `value` a {@link CellUpdateNotification}? Requires `cell` to be an object
+ * and `value` to be *present* rather than of any particular shape, since
+ * `undefined` is a value a cell can hold and the absent case has to stay
+ * distinguishable from it.
+ */
 export function isCellUpdateNotification(
   value: unknown,
 ): value is CellUpdateNotification {
@@ -109,6 +167,11 @@ export function isCellUpdateNotification(
   );
 }
 
+/**
+ * Is `value` a {@link ConsoleNotification}? Checks `method` is a string and
+ * `args` an array; what the arguments themselves are is the decoder's
+ * question, not this one's.
+ */
 export function isConsoleNotification(
   value: unknown,
 ): value is ConsoleNotification {
@@ -120,6 +183,11 @@ export function isConsoleNotification(
   );
 }
 
+/**
+ * Is `value` a {@link NavigateRequestNotification}? `targetCellRef` is checked
+ * for being an object rather than through {@link isCellRef}, so a malformed
+ * target reaches the client and fails there instead.
+ */
 export function isNavigateRequestNotification(
   value: unknown,
 ): value is NavigateRequestNotification {
@@ -130,6 +198,11 @@ export function isNavigateRequestNotification(
   );
 }
 
+/**
+ * Is `value` an {@link ErrorNotification}? Only `message` is required; the
+ * context fields an error may carry -- its piece, space, pattern, and stack --
+ * are all optional and unchecked.
+ */
 export function isErrorNotification(
   value: unknown,
 ): value is ErrorNotification {
@@ -140,6 +213,11 @@ export function isErrorNotification(
   );
 }
 
+/**
+ * Is `value` a {@link TelemetryNotification}? The `marker` is checked for
+ * being an object and not for which marker it is, that being a discrimination
+ * the telemetry consumer makes.
+ */
 export function isTelemetryNotification(
   value: unknown,
 ): value is TelemetryNotification {
@@ -150,6 +228,10 @@ export function isTelemetryNotification(
   );
 }
 
+/**
+ * Is `value` a {@link PendingWritesNotification}? `pending` must be a boolean,
+ * which is the whole of what this notification carries.
+ */
 export function isPendingWritesNotification(
   value: unknown,
 ): value is PendingWritesNotification {
@@ -160,6 +242,11 @@ export function isPendingWritesNotification(
   );
 }
 
+/**
+ * Is `value` a {@link VDomBatchNotification}? Checks `batchId` is a number and
+ * `ops` an array, and looks inside neither `ops` nor `rootId`. A batch passing
+ * this can still carry an operation the applicator rejects.
+ */
 export function isVDomBatchNotification(
   value: unknown,
 ): value is VDomBatchNotification {

--- a/packages/runtime-client/protocol/guards.ts
+++ b/packages/runtime-client/protocol/guards.ts
@@ -151,10 +151,11 @@ export function isIPCRemoteNotification(
 }
 
 /**
- * Is `value` a {@link CellUpdateNotification}? Requires `cell` to be an object
- * and `value` to be *present* rather than of any particular shape, since
- * `undefined` is a value a cell can hold and the absent case has to stay
- * distinguishable from it.
+ * Is `value` a {@link CellUpdateNotification}? Requires `value` to be
+ * *present* rather than of any particular shape, since `undefined` is a value
+ * a cell can hold and the absent case has to stay distinguishable from it.
+ * `cell` is tested with `typeof`, which `null` passes, so a `null` cell gets
+ * through here and fails further in.
  */
 export function isCellUpdateNotification(
   value: unknown,
@@ -214,9 +215,10 @@ export function isErrorNotification(
 }
 
 /**
- * Is `value` a {@link TelemetryNotification}? The `marker` is checked for
- * being an object and not for which marker it is, that being a discrimination
- * the telemetry consumer makes.
+ * Is `value` a {@link TelemetryNotification}? Which marker it is, is a
+ * discrimination the telemetry consumer makes rather than this one. The
+ * `marker` is tested with `typeof`, which `null` passes, so a `null` marker
+ * gets through here.
  */
 export function isTelemetryNotification(
   value: unknown,

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -57,8 +57,10 @@ export type PageRef = {
 
 /**
  * The requests a client sends the worker. Every one is answered, whether or
- * not it carries data back; the `Set*` and `Reset*` members answer with
- * nothing and are acked.
+ * not it carries data back: a request whose handler returns nothing is acked
+ * with a bare envelope, which many members here do -- the `Set*` and `Reset*`
+ * ones, and others besides. {@link Commands} is where a given request's
+ * answer is settled.
  */
 export enum RequestType {
   // Lifecycle
@@ -192,7 +194,9 @@ export enum RequestType {
   /** Sets one named logger's level, or every logger's when none is named. */
   SetLoggerLevel = "runtime:setLoggerLevel",
 
-  /** Enables or disables one named logger, or every logger when none is named. */
+  /**
+   * Enables or disables one named logger, or every logger when none is named.
+   */
   SetLoggerEnabled = "runtime:setLoggerEnabled",
 
   /** Turns telemetry notifications on or off. */
@@ -309,7 +313,10 @@ export enum RequestType {
   /** Stops a running piece. */
   PageStop = "page:stop",
 
-  /** Answers with every piece in a space. */
+  /**
+   * Answers with a ref to the cell holding a space's piece registry. The
+   * pieces themselves are read from that cell, not carried here.
+   */
   PageGetAll = "page:getAll",
 
   /**
@@ -369,8 +376,10 @@ export enum ClientNotificationType {
 
   /**
    * Reports that a batch reached the DOM, by mount and batch id. The worker
-   * uses it to pace what it sends: a renderer that has not acked is one whose
-   * main thread is behind.
+   * holds back the retirement of an event handler whose node a batch removed
+   * until that batch is acked, so an event dispatched against a node the
+   * client had not yet stopped showing still finds its handler. Nothing about
+   * this paces what the worker sends -- ops flush on a microtask regardless.
    */
   VDomBatchApplied = "vdom:batch-applied",
 }
@@ -536,23 +545,17 @@ export type BaseRequest = {
  * lifetime -- nothing here can be changed by a later request.
  */
 export type InitializationData = {
-  // URL of backend server. Also the default host for spaces absent from
-  // `spaceHostMap`.
   /**
-   * The backend server, and the default host for any space
-   * `spaceHostMap` does not list.
+   * The backend server, and the default host for any space `spaceHostMap`
+   * does not list.
    */
   apiUrl: string;
-  // Optional map from space DIDs to HTTP or HTTPS origins. A listed space has
-  // its storage resolved against that host instead of `apiUrl`. Absent map or
-  // absent entry ⇒ `apiUrl`, byte-identical to the single-host behavior.
-  // Plain record: structured-clone-safe — no functions cross the worker
-  // IPC boundary. Fixed for the connection's lifetime.
   /**
-   * Per-space storage hosts. A listed space resolves against its own
-   * host; an absent map or entry falls back to `apiUrl`, byte-identical
-   * to single-host behavior. A plain record, so nothing here needs to
-   * survive structured cloning as anything else.
+   * Per-space storage hosts, by space DID, as HTTP or HTTPS origins. A listed
+   * space resolves against its own host instead of `apiUrl`; an absent map or
+   * an absent entry falls back to `apiUrl`, byte-identical to the single-host
+   * behavior. A plain record, since no function crosses the worker boundary.
+   * Fixed for the connection's lifetime.
    */
   spaceHostMap?: Record<string, string>;
   /**
@@ -562,28 +565,24 @@ export type InitializationData = {
    * boundary whole.
    */
   identity: RealmEncodedValue;
-  // Identity of space.
   /**
    * The space this connection opens on.
    */
   spaceDid: DID;
-  // Temporary space name
   /**
-   * The space's name, where the client knows it.
+   * The space's name, where the client knows it. Temporary.
    */
   spaceName?: string;
   /** Temporary identity of space, encoded as `identity` above is. */
   spaceIdentity?: RealmEncodedValue;
-  // Default timeout in milliseconds.
   /**
-   * How long a request may go unanswered before the client gives up on
-   * it.
+   * How long a request may go unanswered before the client gives up on it.
    */
   timeoutMs?: number;
-  // Experimental space-model feature flags.
   /**
-   * Feature flags the host declares. The worker runs the arm named here
-   * rather than resolving its own, so that the two realms cannot diverge.
+   * Experimental space-model feature flags, declared by the host. The worker
+   * runs the arm named here rather than resolving its own, so that the two
+   * realms cannot diverge.
    */
   experimental?: {
     modernCellRep?: boolean;
@@ -609,81 +608,67 @@ export type InitializationData = {
     | "observe"
     | "enforce-explicit"
     | "enforce-strict";
-  // Flow-label propagation dial for the worker runtime (S16 default
-  // transition; docs/history/plans/cfc-future-work-implementation.md Epic H1):
-  // "off" = no derivation; "observe" = compute the per-tx conservative
-  // join and emit diagnostics, persist nothing; "persist" = write derived
-  // label components. Propagation never rejects by itself. Absent =
-  // the runner's default ("off").
   /**
-   * Whether CFC flow labels are ignored, recorded for observation, or
-   * persisted.
+   * The flow-label propagation dial. `off` derives nothing; `observe`
+   * computes the per-transaction conservative join and emits diagnostics
+   * while persisting nothing; `persist` writes the derived label components.
+   * Propagation never rejects a write by itself. Absent leaves the runner's
+   * default, which is `off`.
    */
   cfcFlowLabels?: "off" | "observe" | "persist";
-  // Whether author-supplied render-boundary declassification is honored.
-  // Defaults to "allow" (current behavior). "deny" ignores author-supplied
-  // `declassifyConfidentiality` so a pattern can't release a secret upward
-  // through a render boundary (audit S15).
   /**
-   * Whether a render may declassify what it shows.
+   * Whether author-supplied render-boundary declassification is honored.
+   * `allow` is the default. `deny` ignores an author's
+   * `declassifyConfidentiality`, so that a pattern cannot release a secret
+   * upward through a render boundary.
    */
   renderDeclassificationPolicy?: "allow" | "deny";
-  // Host-supplied default render ceiling (spec §8.10.6, S16 phase D):
-  // confidentiality a display surface admits by default — exact `atoms`
-  // (the place for acting-user identity atoms) plus Caveat `caveatKinds`
-  // (display-dischargeable classes). Undefined = no ceiling (current
-  // behavior).
   /**
-   * The highest confidentiality a render may reach. A render above it is
-   * refused rather than redacted.
+   * The confidentiality a display surface admits by default: exact `atoms`,
+   * which is where an acting user's identity atoms go, plus the Caveat
+   * `caveatKinds` a display can discharge. Absent means no ceiling.
    */
   renderConfidentialityCeiling?: {
     atoms?: readonly CfcConfClause[];
     caveatKinds?: readonly string[];
   };
-  // Static trust snapshot applied to worker-owned transactions.
   /**
-   * The trust state the host resolved, declared so the worker runs against
-   * the same one rather than resolving its own.
+   * A static trust snapshot applied to worker-owned transactions, declared by
+   * the host so the worker runs against the same one rather than resolving
+   * its own.
    */
   trustSnapshot?: {
     id: string;
     actingPrincipal?: string;
     revision?: string;
   };
-  // When true, the worker mirrors its own console output (log/warn/error)
-  // to the main thread, which re-emits it on the page console prefixed
-  // with `[worker]`, so runtime-internal logs reach devtools and
-  // integration-test console capture. Off by default: each forwarded call
-  // costs one postMessage, so it is enabled only for diagnostic runs.
   /**
-   * Start with the worker's console bridge on.
+   * Mirror the worker's own console output to the main thread, which re-emits
+   * it on the page console prefixed with `[worker]`, so runtime-internal logs
+   * reach devtools and integration-test console capture. Off by default: each
+   * forwarded call costs one `postMessage`, so it is for diagnostic runs.
    * {@link RequestType.SetForwardWorkerConsole} changes it later.
    */
   forwardWorkerConsole?: boolean;
-  // When true, the worker runtime instruments every pattern compile for
-  // statement coverage and accumulates hits, which the integration harness
-  // pulls at teardown via GetPatternCoverage. Test/CI only (the coverage shell
-  // build sets it); off by default. See docs/development/COVERAGE.md.
   /**
-   * Collect pattern coverage. A worker built without a collector reports
-   * `null` rather than an empty report.
+   * Instrument every pattern compile for statement coverage and accumulate
+   * hits, which the integration harness pulls at teardown through
+   * {@link RequestType.GetPatternCoverage}. Test and CI only -- the coverage
+   * shell build sets it -- and off by default.
    */
   patternCoverage?: boolean;
-  // When true, the worker's remote storage overlaps watch-refresh round trips
-  // up to a bounded window instead of the default strict single-flight
-  // (`experimentalConcurrentWatchRefresh`, docs/development/EXPERIMENTAL_OPTIONS.md).
-  // Fixed at StorageManager.open time, so like the render ceiling it takes
-  // effect on the next runtime (reload), not live. Off by default; the shell
-  // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
   /**
-   * Refresh watched cells concurrently rather than one at a time.
+   * Let the worker's remote storage overlap watch-refresh round trips up to a
+   * bounded window, rather than the default strict single-flight. Fixed at
+   * `StorageManager.open` time, so like the render ceiling it takes effect on
+   * the next runtime rather than live. Off by default.
    */
   concurrentWatchRefresh?: boolean;
 };
 
 /**
- * The {@link RequestType.Initialize} request. Its `data` is fixed for the connection's lifetime.
+ * The {@link RequestType.Initialize} request. Its `data` is fixed for the
+ * connection's lifetime.
  */
 export type InitializeRequest = BaseRequest & {
   type: RequestType.Initialize;
@@ -699,7 +684,9 @@ export type DisposeRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.CellGet} request. `meta` reads a metadata field in place of the cell's value, and each `include*` flag adds a field to the answer.
+ * The {@link RequestType.CellGet} request. `meta` reads a metadata field in
+ * place of the cell's value, and each `include*` flag adds a field to the
+ * answer.
  */
 export type CellGetRequest = BaseRequest & {
   type: RequestType.CellGet;
@@ -711,21 +698,18 @@ export type CellGetRequest = BaseRequest & {
    * Reads this metadata field instead of the cell's value.
    */
   meta?: MetaField;
-  // Opt in to having the cell's display CFC label returned alongside the value,
-  // so a caller that needs both pays one round-trip instead of a separate
-  // CellGetCfcLabel request.
   /**
-   * Answer with the cell's display label too.
+   * Have the cell's display label returned alongside the value, so a caller
+   * needing both pays one round trip instead of a separate
+   * {@link RequestType.CellGetCfcLabel}.
    */
   includeCfcLabel?: boolean;
-  // Opt in to having the read cell's own schema-bearing ref returned. Useful
-  // when `meta` names a link field (pattern/argument/result): the resolved
-  // cell's ref lets the caller subscribe to it or read it again directly,
-  // and its schema carries the declarations (e.g. stream fields) that the
-  // value alone does not.
   /**
-   * Answer with a ref to the cell the read resolved to, which a meta
-   * read following a link is not the cell asked for.
+   * Have the read cell's own schema-bearing ref returned. Useful where `meta`
+   * names a link field -- pattern, argument, result -- since the resolved
+   * cell is then not the one asked for: its ref lets the caller subscribe to
+   * it or read it again directly, and its schema carries declarations such as
+   * stream fields that the value alone does not.
    */
   includeRef?: boolean;
 };
@@ -761,7 +745,8 @@ export type WireCellValue =
   | CellRef;
 
 /**
- * The {@link RequestType.CellSet} request. `value` is the whole already-resolved value rather than a delta.
+ * The {@link RequestType.CellSet} request. `value` is the whole
+ * already-resolved value rather than a delta.
  */
 export type CellSetRequest = BaseRequest & {
   type: RequestType.CellSet;
@@ -775,12 +760,12 @@ export type CellSetRequest = BaseRequest & {
   value: WireCellValue;
 };
 
-// A read-modify-write append (`CellHandle.push`). Same wire shape as CellSet —
-// it carries the whole already-appended array — but routed as its own request so
-// the runtime keeps the read-target as a commit precondition (compare-and-set),
-// rather than the blind last-write-wins of CellSet.
 /**
- * The {@link RequestType.CellPush} request. `value` is the whole already-resolved value rather than a delta, as {@link CellSetRequest}'s is; the two differ in how it is applied, not in what they carry.
+ * The {@link RequestType.CellPush} request: a read-modify-write append.
+ * The same wire shape as {@link CellSetRequest}, carrying the whole
+ * already-appended array rather than a delta, but routed as its own request
+ * so the runtime keeps the read target as a commit precondition. That is
+ * the compare-and-set a blind set gives up.
  */
 export type CellPushRequest = BaseRequest & {
   type: RequestType.CellPush;
@@ -795,7 +780,8 @@ export type CellPushRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.CellSend} request. `event` is delivered rather than stored.
+ * The {@link RequestType.CellSend} request. `event` is delivered rather than
+ * stored.
  */
 export type CellSendRequest = BaseRequest & {
   type: RequestType.CellSend;
@@ -810,7 +796,8 @@ export type CellSendRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.CellSubscribe} request. `includeCfcLabel` makes every update carry the cell's label too.
+ * The {@link RequestType.CellSubscribe} request. `includeCfcLabel` makes every
+ * update carry the cell's label too.
  */
 export type CellSubscribeRequest = BaseRequest & {
   type: RequestType.CellSubscribe;
@@ -818,13 +805,12 @@ export type CellSubscribeRequest = BaseRequest & {
    * The cell to watch.
    */
   cell: CellRef;
-  // Opt in to reactive CFC-label delivery: each CellUpdate then carries the
-  // cell's current display label, and the worker reads that label as a tracked
-  // dependency of the sink, so a label-only write (value unchanged) re-fires
-  // the subscription. Off by default — only label-displaying callers pay it.
   /**
-   * Carry the cell's display label with every update, so that a label
-   * change re-renders without a second round trip.
+   * Opt in to reactive label delivery: every update then carries the cell's
+   * current display label, and the worker reads that label as a tracked
+   * dependency of the sink, so a label-only write with the value unchanged
+   * re-fires the subscription. Off by default -- only a label-displaying
+   * caller pays for it.
    */
   includeCfcLabel?: boolean;
 };
@@ -856,9 +842,9 @@ export type CellGetCfcLabelRequest = BaseRequest & {
   cell: CellRef;
 };
 
-// unused?
 /**
- * The {@link RequestType.GetCell} request. `cause` is what derives the cell: the same space and cause always name the same one.
+ * The {@link RequestType.GetCell} request. `cause` is what derives the
+ * cell: the same space and cause always name the same one.
  */
 export type GetCellRequest = BaseRequest & {
   type: RequestType.GetCell;
@@ -877,12 +863,17 @@ export type GetCellRequest = BaseRequest & {
   schema?: JSONSchema;
 };
 
-/** The {@link RequestType.GetHomeSpaceCell} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetHomeSpaceCell} request, which carries no payload.
+ */
 export type GetHomeSpaceCellRequest = BaseRequest & {
   type: RequestType.GetHomeSpaceCell;
 };
 
-/** The {@link RequestType.EnsureHomePatternRunning} request, which carries no payload. */
+/**
+ * The {@link RequestType.EnsureHomePatternRunning} request, which carries no
+ * payload.
+ */
 export type EnsureHomePatternRunningRequest = BaseRequest & {
   type: RequestType.EnsureHomePatternRunning;
 };
@@ -948,17 +939,23 @@ export type FlushCompileCacheWritesRequest = BaseRequest & {
   type: RequestType.FlushCompileCacheWrites;
 };
 
-/** The {@link RequestType.GetGraphSnapshot} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetGraphSnapshot} request, which carries no payload.
+ */
 export type GetGraphSnapshotRequest = BaseRequest & {
   type: RequestType.GetGraphSnapshot;
 };
 
-/** The {@link RequestType.GetLoggerCounts} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetLoggerCounts} request, which carries no payload.
+ */
 export type GetLoggerCountsRequest = BaseRequest & {
   type: RequestType.GetLoggerCounts;
 };
 
-/** The {@link RequestType.GetPatternCoverage} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetPatternCoverage} request, which carries no payload.
+ */
 export type GetPatternCoverageRequest = BaseRequest & {
   type: RequestType.GetPatternCoverage;
 };
@@ -967,7 +964,8 @@ export type GetPatternCoverageRequest = BaseRequest & {
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
 /**
- * The {@link RequestType.SetLoggerLevel} request. An absent `loggerName` addresses every logger.
+ * The {@link RequestType.SetLoggerLevel} request. An absent `loggerName`
+ * addresses every logger.
  */
 export type SetLoggerLevelRequest = BaseRequest & {
   type: RequestType.SetLoggerLevel;
@@ -980,7 +978,8 @@ export type SetLoggerLevelRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.SetLoggerEnabled} request. An absent `loggerName` addresses every logger.
+ * The {@link RequestType.SetLoggerEnabled} request. An absent `loggerName`
+ * addresses every logger.
  */
 export type SetLoggerEnabledRequest = BaseRequest & {
   type: RequestType.SetLoggerEnabled;
@@ -1010,7 +1009,10 @@ export type SetForwardWorkerConsoleRequest = BaseRequest & {
   enabled: boolean;
 };
 
-/** The {@link RequestType.ResetLoggerBaselines} request, which carries no payload. */
+/**
+ * The {@link RequestType.ResetLoggerBaselines} request, which carries no
+ * payload.
+ */
 export type ResetLoggerBaselinesRequest = BaseRequest & {
   type: RequestType.ResetLoggerBaselines;
 };
@@ -1030,12 +1032,17 @@ export type SetSettleStatsEnabledRequest = BaseRequest & {
   enabled: boolean;
 };
 
-/** The {@link RequestType.GetSettleStatsHistory} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetSettleStatsHistory} request, which carries no
+ * payload.
+ */
 export type GetSettleStatsHistoryRequest = BaseRequest & {
   type: RequestType.GetSettleStatsHistory;
 };
 
-/** The {@link RequestType.GetActionRunTrace} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetActionRunTrace} request, which carries no payload.
+ */
 export type GetActionRunTraceRequest = BaseRequest & {
   type: RequestType.GetActionRunTrace;
 };
@@ -1050,7 +1057,9 @@ export type SetActionRunTraceEnabledRequest = BaseRequest & {
   enabled: boolean;
 };
 
-/** The {@link RequestType.GetTriggerTrace} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetTriggerTrace} request, which carries no payload.
+ */
 export type GetTriggerTraceRequest = BaseRequest & {
   type: RequestType.GetTriggerTrace;
 };
@@ -1065,13 +1074,16 @@ export type SetTriggerTraceEnabledRequest = BaseRequest & {
   enabled: boolean;
 };
 
-/** The {@link RequestType.GetWriteStackTrace} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetWriteStackTrace} request, which carries no payload.
+ */
 export type GetWriteStackTraceRequest = BaseRequest & {
   type: RequestType.GetWriteStackTrace;
 };
 
 /**
- * The {@link RequestType.SetWriteStackTraceMatchers} request. The matchers replace the current set rather than adding to it.
+ * The {@link RequestType.SetWriteStackTraceMatchers} request. The matchers
+ * replace the current set rather than adding to it.
  */
 export type SetWriteStackTraceMatchersRequest = BaseRequest & {
   type: RequestType.SetWriteStackTraceMatchers;
@@ -1083,7 +1095,8 @@ export type SetWriteStackTraceMatchersRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.DetectNonIdempotent} request. `durationMs` bounds how long the diagnosis runs.
+ * The {@link RequestType.DetectNonIdempotent} request. `durationMs` bounds how
+ * long the diagnosis runs.
  */
 export type DetectNonIdempotentRequest = BaseRequest & {
   type: RequestType.DetectNonIdempotent;
@@ -1145,7 +1158,9 @@ export type DetectNonIdempotentResponse = {
   result: SchedulerDiagnosisResult;
 };
 
-/** The {@link RequestType.GetPatternSources} request, which carries no payload. */
+/**
+ * The {@link RequestType.GetPatternSources} request, which carries no payload.
+ */
 export type GetPatternSourcesRequest = BaseRequest & {
   type: RequestType.GetPatternSources;
 };
@@ -1186,7 +1201,8 @@ export type PatternSourcesResponse = {
 };
 
 /**
- * The {@link RequestType.SetBreakpoints} request. The ids replace the current breakpoints rather than adding to them.
+ * The {@link RequestType.SetBreakpoints} request. The ids replace the current
+ * breakpoints rather than adding to them.
  */
 export type SetBreakpointsRequest = BaseRequest & {
   type: RequestType.SetBreakpoints;
@@ -1197,7 +1213,9 @@ export type SetBreakpointsRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.UploadBlob} request. `space` is required, and decides which host the upload targets; `suffix` names the extension the stored blob is served under.
+ * The {@link RequestType.UploadBlob} request. `space` is required, and decides
+ * which host the upload targets; `suffix` names the extension the stored blob
+ * is served under.
  */
 export type UploadBlobRequest = BaseRequest & {
   type: RequestType.UploadBlob;
@@ -1234,10 +1252,10 @@ export type UploadBlobResponse = {
   url: string;
 };
 
-// Logger count types for IPC (matches @commonfabric/utils/logger types)
 /**
- * How many messages were recorded at each level, with `total` alongside so a
- * reader need not sum the four.
+ * How many messages were recorded at each level, with `total` alongside so
+ * a reader need not sum the four. Mirrors the shape
+ * `@commonfabric/utils/logger` uses, this being that data on the wire.
  */
 export type LogCounts = {
   /**
@@ -1303,10 +1321,10 @@ export type LoggerInfo = {
 /** Every logger's enabled state and level, by logger name. */
 export type LoggerMetadata = Record<string, LoggerInfo>;
 
-// Timing stats types for IPC (matches @commonfabric/utils/logger types)
 /**
  * One point of a cumulative distribution: a latency, and the fraction of
- * samples at or below it.
+ * samples at or below it. Mirrors the shape
+ * `@commonfabric/utils/logger` uses.
  */
 export type CDFPoint = {
   /**
@@ -1392,7 +1410,8 @@ export type LoggerFlagsData = Record<
 >;
 
 /**
- * The {@link RequestType.PageCreate} request. `source` names a URL or a program, never both.
+ * The {@link RequestType.PageCreate} request. `source` names a URL or a
+ * program, never both.
  */
 export type PageCreateRequest = BaseRequest & {
   type: RequestType.PageCreate;
@@ -1407,13 +1426,14 @@ export type PageCreateRequest = BaseRequest & {
   } | {
     program: Program;
   };
-  // TODO(danfuzz): a piece's argument is a `FabricValue`, and `JSONValue`
-  // narrows it to the JSON-compatible subset with nothing carrying the rest.
-  // The same gap `WireCellValue` is marked with, at the other request that
-  // sends a value into the worker, and closed by the same mechanism
-  // (`codec-realm`).
   /**
    * The argument the piece is created with.
+   *
+   * TODO(danfuzz): a piece's argument is a `FabricValue`, and `JSONValue`
+   * narrows it to the JSON-compatible subset with nothing carrying the rest.
+   * The same gap `WireCellValue` is marked with, at the other request that
+   * sends a value into the worker, and closed by the same mechanism
+   * (`codec-realm`).
    */
   argument?: JSONValue;
   /**
@@ -1451,7 +1471,8 @@ export type RecreateSpaceRootPatternRequest = BaseRequest & {
 };
 
 /**
- * The {@link RequestType.PageGet} request. `runIt` starts the piece as part of the read.
+ * The {@link RequestType.PageGet} request. `runIt` starts the piece as part of
+ * the read.
  */
 export type PageGetRequest = BaseRequest & {
   type: RequestType.PageGet;
@@ -1654,7 +1675,7 @@ export type PieceSourceRevisionView = {
    */
   pattern: PiecePatternRefView;
   /**
-   * Where that pattern came from, where it came from anywhere.
+   * Where that pattern came from, for a pattern that came from anywhere.
    */
   origin?: PieceOriginView;
   /**
@@ -1769,7 +1790,9 @@ export type PieceSourceAction =
   | { kind: "follow"; revisionId: string };
 
 /**
- * The {@link RequestType.PieceUpdateSource} request. `confirmationToken` is the token an incompatibility warning returned; sending it back is what confirms the update.
+ * The {@link RequestType.PieceUpdateSource} request. `confirmationToken` is the
+ * token an incompatibility warning returned; sending it back is what confirms
+ * the update.
  */
 export type PieceUpdateSourceRequest = BaseRequest & {
   type: RequestType.PieceUpdateSource;
@@ -2058,8 +2081,8 @@ export type IPCClientNotification =
 export type VDomMountResponse = {
   /**
    * The root node ID for this mount; `null` when the tree has no root child.
-   * `VDomBatchNotification` spells absence the same way, so a reader maps both
-   * directions with one rule.
+   * `VDomBatchNotification` represents absence the same way, so a reader maps
+   * both directions with one rule.
    */
   rootId: number | null;
 };
@@ -2177,17 +2200,16 @@ export type JSONValueResponse = {
  * metadata read has none to name.
  */
 export type CellGetResponse = JSONValueResponse & {
-  // Present only when the request set `includeCfcLabel`. `undefined` is a valid
-  // value (the cell carries no label); the field is omitted when not requested.
   /**
-   * The cell's display label, present only where the request asked.
+   * The cell's display label, present only where the request set
+   * `includeCfcLabel`. `undefined` is a valid value, the cell carrying no
+   * label; the field is omitted rather than undefined when not requested.
    */
   cfcLabel?: CfcLabelView | undefined;
-  // Present only when the request set `includeRef` and the read resolved to a
-  // cell (a raw-metadata read has no cell to reference).
   /**
-   * A ref to the cell the read resolved to, present only where the
-   * request asked and the read reached one.
+   * A ref to the cell the read resolved to, present only where the request
+   * set `includeRef` and the read reached a cell -- a raw metadata read has
+   * none to reference.
    */
   cell?: CellRef;
 };
@@ -2290,17 +2312,17 @@ export type CellUpdateNotification = {
    * The cell that changed.
    */
   cell: CellRef;
-  // TODO(danfuzz): the same gap `JSONValueResponse` is marked with. This is
-  // the push form of the same read, produced by the same conversion.
   /**
    * Its new value.
+   *
+   * TODO(danfuzz): the same gap `JSONValueResponse` is marked with. This is
+   * the push form of the same read, produced by the same conversion.
    */
   value: JSONValue;
-  // Present only for subscriptions that opted in via `includeCfcLabel`. Carries
-  // the cell's current display label so the client re-renders on label changes
-  // without a separate getCfcLabel round-trip.
   /**
-   * Its display label, carried only for a subscription that opted in.
+   * The cell's current display label, present only for a subscription that
+   * opted in through `includeCfcLabel`, so the client re-renders on a label
+   * change without a separate round trip.
    */
   cfcLabel?: CfcLabelView | undefined;
 };
@@ -2356,8 +2378,8 @@ export type NavigateRequestNotification = {
 
 /**
  * An error with no request to fail -- a renderer error, or one a pattern
- * raised between requests. Every field but `message` is context the raising
- * site had and may not.
+ * raised between requests. Every field but `message` is context that the
+ * raising site may or may not have had.
  */
 export type ErrorNotification = {
   type: NotificationType.ErrorReport;

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -211,25 +211,40 @@ export enum RequestType {
    */
   ResetLoggerBaselines = "runtime:resetLoggerBaselines",
 
-  /** Answers with the scheduler's settle statistics, or `null` when off. */
+  /**
+   * Answers with the scheduler's settle statistics from the last settle pass.
+   * `null` covers two states and does not distinguish them: recording is off,
+   * or it is on and no pass has completed yet.
+   */
   GetSettleStats = "runtime:getSettleStats",
 
   /** Answers with the settle statistics recorded per pass, oldest first. */
   GetSettleStatsHistory = "runtime:getSettleStatsHistory",
 
-  /** Turns settle-statistics recording on or off; it is off by default. */
+  /**
+   * Turns settle-statistics recording on or off. Off by default, the
+   * collection costing something per settle pass. Turning it *off* also
+   * discards the statistics and history already collected, so a client that
+   * toggles it loses what it had.
+   */
   SetSettleStatsEnabled = "runtime:setSettleStatsEnabled",
 
   /** Answers with the recorded per-action run trace. */
   GetActionRunTrace = "runtime:getActionRunTrace",
 
-  /** Turns action-run tracing on or off. */
+  /**
+   * Turns action-run tracing on or off. Off by default, and turning it off
+   * also discards the trace already collected.
+   */
   SetActionRunTraceEnabled = "runtime:setActionRunTraceEnabled",
 
   /** Answers with the recorded trigger trace. */
   GetTriggerTrace = "runtime:getTriggerTrace",
 
-  /** Turns trigger tracing on or off. */
+  /**
+   * Turns trigger tracing on or off. Off by default, and turning it off also
+   * discards the trace already collected.
+   */
   SetTriggerTraceEnabled = "runtime:setTriggerTraceEnabled",
 
   /** Answers with the recorded write stack traces. */
@@ -1009,7 +1024,8 @@ export type GetSettleStatsRequest = BaseRequest & {
 export type SetSettleStatsEnabledRequest = BaseRequest & {
   type: RequestType.SetSettleStatsEnabled;
   /**
-   * Whether settle statistics are recorded.
+   * Whether settle statistics are recorded. Setting it false also discards
+   * what has been collected.
    */
   enabled: boolean;
 };
@@ -1028,7 +1044,8 @@ export type GetActionRunTraceRequest = BaseRequest & {
 export type SetActionRunTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetActionRunTraceEnabled;
   /**
-   * Whether action runs are traced.
+   * Whether action runs are traced. Setting it false also discards the trace
+   * already collected.
    */
   enabled: boolean;
 };
@@ -1042,7 +1059,8 @@ export type GetTriggerTraceRequest = BaseRequest & {
 export type SetTriggerTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetTriggerTraceEnabled;
   /**
-   * Whether triggers are traced.
+   * Whether triggers are traced. Setting it false also discards the trace
+   * already collected.
    */
   enabled: boolean;
 };
@@ -1078,7 +1096,8 @@ export type DetectNonIdempotentRequest = BaseRequest & {
 /** The scheduler's settle statistics, or `null` while recording is off. */
 export type SettleStatsResponse = {
   /**
-   * The statistics, or `null` while recording is off.
+   * The statistics from the last settle pass. `null` where recording is off,
+   * and equally where it is on but no pass has completed.
    */
   stats: SettleStats | null;
 };

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -85,9 +85,13 @@ export enum RequestType {
   CellGet = "cell:get",
 
   /**
-   * Overwrites a cell's value blindly: last write wins, with no
-   * compare-and-set. Which of this and {@link CellPush} a write uses is
-   * decided by the request type rather than by inspecting the value.
+   * Overwrites a cell's value blindly: the write carries no value-equality
+   * precondition, so a concurrent write to the same cell does not make it
+   * fail. That is not the same as unconditional. A blind write still carries
+   * one structural precondition, on the cell's *parent*, so a concurrent
+   * delete of the enclosing document or a reshape of an ancestor rejects it.
+   * Which of this and {@link CellPush} a write uses is decided by the request
+   * type rather than by inspecting the value.
    */
   CellSet = "cell:set",
 
@@ -159,8 +163,10 @@ export enum RequestType {
 
   /**
    * Routes one space's storage to a named host, answering with whether the
-   * route was accepted. An already-accepted route is kept rather than
-   * replaced.
+   * route was accepted. The host is validated here and acceptance is the
+   * storage manager's to decide, so a manager with no remote resolution
+   * declines every route. A host that does not validate is refused with an
+   * error rather than a `false`.
    */
   RegisterSpaceHost = "runtime:registerSpaceHost",
 
@@ -1052,8 +1058,8 @@ export type GetWriteStackTraceRequest = BaseRequest & {
 export type SetWriteStackTraceMatchersRequest = BaseRequest & {
   type: RequestType.SetWriteStackTraceMatchers;
   /**
-   * The writes whose stack to record. Replaces the current set, and an
-   * empty one records nothing.
+   * The writes whose stack to record. Replaces the current set rather than
+   * adding to it.
    */
   matchers: WriteStackTraceMatcher[];
 };

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -27,101 +27,367 @@ export type { JSONSchema, JSONValue, Program };
 
 export type { CfcLabelView };
 
+/**
+ * Identifies one request and the response answering it. The client allocates
+ * them and the worker echoes back what it was sent, so an unmatched id on
+ * either side means a message was lost rather than mis-addressed.
+ */
 export type MessageId = number;
 
+/**
+ * A cell as this connection names it: a normalized link, plus the cell's
+ * display label where the read asked for one. This is what a `CellHandle`
+ * becomes on the wire, and what one is rebuilt from at the other end.
+ */
 export type CellRef = NormalizedFullLink & {
+  /**
+   * The cell's display label, present only where the read that produced
+   * this ref asked for one.
+   */
   cfcLabelView?: CfcLabelView;
 };
 
+/** A piece as this connection names it, by the cell that holds it. */
 export type PageRef = {
+  /**
+   * The cell holding the piece.
+   */
   cell: CellRef;
 };
 
+/**
+ * The requests a client sends the worker. Every one is answered, whether or
+ * not it carries data back; the `Set*` and `Reset*` members answer with
+ * nothing and are acked.
+ */
 export enum RequestType {
   // Lifecycle
+
+  /**
+   * Stands the worker's runtime up from an {@link InitializationData}. Refused
+   * if initialization has already been attempted, successfully or not.
+   */
   Initialize = "initialize",
+
+  /**
+   * Tears the worker's runtime down. Requests arriving after it are acked in
+   * silence rather than refused, teardown running concurrently with whatever
+   * the client had in flight.
+   */
   Dispose = "dispose",
 
   // Cell operations (main -> worker)
+
+  /**
+   * Reads a cell's value, optionally with its display CFC label and a ref to
+   * the cell the read resolved to.
+   */
   CellGet = "cell:get",
+
+  /**
+   * Overwrites a cell's value blindly: last write wins, with no
+   * compare-and-set. Which of this and {@link CellPush} a write uses is
+   * decided by the request type rather than by inspecting the value.
+   */
   CellSet = "cell:set",
+
+  /**
+   * Applies a value to a cell read-modify-write, keeping compare-and-set.
+   * The counterpart to {@link CellSet}'s blind overwrite.
+   */
   CellPush = "cell:push",
+
+  /**
+   * Sends an event to a cell in a transaction of its own. Local visibility
+   * lands with the commit; remote confirmation is not waited for, so that a
+   * slow server cannot block cell IPC.
+   */
   CellSend = "cell:send",
+
+  /**
+   * Starts notifying the client of a cell's changes, optionally including its
+   * display label with each.
+   */
   CellSubscribe = "cell:subscribe",
+
+  /** Stops the notifications {@link CellSubscribe} started. */
   CellUnsubscribe = "cell:unsubscribe",
+
+  /**
+   * Follows a cell's aliases to the cell it stands for, answering with a ref
+   * to that one.
+   */
   CellResolveAsCell = "cell:resolveAsCell",
+
+  /** Reads a cell's display CFC label, without its value. */
   CellGetCfcLabel = "cell:getCfcLabel",
 
   // Runtime operations
+
+  /**
+   * Derives a cell from a space, a cause, and an optional schema, answering
+   * with a ref to it.
+   */
   GetCell = "runtime:getCell",
+
+  /** Answers with a ref to the home space's own cell. */
   GetHomeSpaceCell = "runtime:getHomeSpaceCell",
+
+  /**
+   * Ensures the home space's default pattern is running, answering with a ref
+   * to it. Always through the pieces controller, which reconciles the
+   * persisted identity and repairs an aged home root -- starting the pattern
+   * directly would skip that repair, and nothing else performs it.
+   */
   EnsureHomePatternRunning = "runtime:ensureHomePatternRunning",
+
+  /**
+   * Waits for reactive quiescence *and* for every issued commit to be durable.
+   * The client reads that pair as the point at which navigating or reloading
+   * is safe, so quiescence alone is a weaker condition than this reports.
+   */
   Idle = "runtime:idle",
+
+  /**
+   * Waits for every opened space to finish syncing. {@link PageSynced} is the
+   * same wait narrowed to one space.
+   */
   RuntimeSynced = "runtime:synced",
+
+  /** Resolves a space's name to its DID. */
   ResolveSpaceName = "runtime:resolveSpaceName",
+
+  /**
+   * Routes one space's storage to a named host, answering with whether the
+   * route was accepted. An already-accepted route is kept rather than
+   * replaced.
+   */
   RegisterSpaceHost = "runtime:registerSpaceHost",
+
+  /** Waits for the pattern manager's compile-cache writes to land. */
   FlushCompileCacheWrites = "runtime:flushCompileCacheWrites",
+
+  /** Answers with a snapshot of the scheduler's reactive graph. */
   GetGraphSnapshot = "runtime:getGraphSnapshot",
+
+  /**
+   * Answers with the logger counts, metadata, timings, and flags together, one
+   * round trip covering all four.
+   */
   GetLoggerCounts = "runtime:getLoggerCounts",
+
+  /**
+   * Answers with the pattern coverage collector's data, or `null` where this
+   * worker was built without a collector -- which is a different state from a
+   * collector that recorded nothing.
+   */
   GetPatternCoverage = "runtime:getPatternCoverage",
+
+  /** Sets one named logger's level, or every logger's when none is named. */
   SetLoggerLevel = "runtime:setLoggerLevel",
+
+  /** Enables or disables one named logger, or every logger when none is named. */
   SetLoggerEnabled = "runtime:setLoggerEnabled",
+
+  /** Turns telemetry notifications on or off. */
   SetTelemetryEnabled = "runtime:setTelemetryEnabled",
+
+  /**
+   * Turns the worker's console bridge on or off. Answered by the worker entry
+   * rather than by the runtime -- the console patch lives there -- and so
+   * answered whether or not the runtime is initialized.
+   */
   SetForwardWorkerConsole = "runtime:setForwardWorkerConsole",
+
+  /**
+   * Resets every logger's count and timing baseline, so that reads after it
+   * measure from here rather than from worker start.
+   */
   ResetLoggerBaselines = "runtime:resetLoggerBaselines",
+
+  /** Answers with the scheduler's settle statistics, or `null` when off. */
   GetSettleStats = "runtime:getSettleStats",
+
+  /** Answers with the settle statistics recorded per pass, oldest first. */
   GetSettleStatsHistory = "runtime:getSettleStatsHistory",
+
+  /** Turns settle-statistics recording on or off; it is off by default. */
   SetSettleStatsEnabled = "runtime:setSettleStatsEnabled",
+
+  /** Answers with the recorded per-action run trace. */
   GetActionRunTrace = "runtime:getActionRunTrace",
+
+  /** Turns action-run tracing on or off. */
   SetActionRunTraceEnabled = "runtime:setActionRunTraceEnabled",
+
+  /** Answers with the recorded trigger trace. */
   GetTriggerTrace = "runtime:getTriggerTrace",
+
+  /** Turns trigger tracing on or off. */
   SetTriggerTraceEnabled = "runtime:setTriggerTraceEnabled",
+
+  /** Answers with the recorded write stack traces. */
   GetWriteStackTrace = "runtime:getWriteStackTrace",
+
+  /**
+   * Replaces the matchers deciding which writes have their stack recorded.
+   * Recording every write is expensive, so the matchers are the throttle.
+   */
   SetWriteStackTraceMatchers = "runtime:setWriteStackTraceMatchers",
+
+  /**
+   * Runs the scheduler's non-idempotency diagnosis for a bounded period,
+   * answering with what it found.
+   */
   DetectNonIdempotent = "runtime:detectNonIdempotent",
+
+  /**
+   * Answers with the source of every pattern in the scheduler's graph, one
+   * entry per distinct pattern rather than per node.
+   */
   GetPatternSources = "runtime:getPatternSources",
+
+  /** Replaces the scheduler's breakpoints with the named actions. */
   SetBreakpoints = "runtime:setBreakpoints",
+
+  /**
+   * Uploads bytes to the named space's host, answering with the blob's id and
+   * URL. The space is required and refused when absent, an upload without one
+   * otherwise failing as a confusing server 404.
+   */
   UploadBlob = "runtime:uploadBlob",
 
   // Page operations (main -> worker)
+
+  /**
+   * Answers with a space's root pattern, creating it if the space has none.
+   */
   GetSpaceRootPattern = "pattern:getSpaceRoot",
+
+  /** Replaces a space's root pattern with a freshly created one. */
   RecreateSpaceRootPattern = "pattern:recreateSpaceRoot",
+
+  /**
+   * Creates a piece in a space from a URL or a program, optionally running it
+   * once created.
+   */
   PageCreate = "page:create",
+
+  /** Reads a piece by id, optionally running it. */
   PageGet = "page:get",
+
+  /** Reads a piece's slug, which a piece need not have. */
   PageGetSlug = "page:getSlug",
+
+  /** Removes a piece from its space's list. */
   PageRemove = "page:remove",
+
+  /** Starts a piece running. */
   PageStart = "page:start",
+
+  /** Stops a running piece. */
   PageStop = "page:stop",
+
+  /** Answers with every piece in a space. */
   PageGetAll = "page:getAll",
+
+  /**
+   * Waits for one space's pieces to finish syncing, {@link RuntimeSynced}
+   * being the same wait across every opened space.
+   */
   PageSynced = "page:synced",
+
+  /** Reads a piece's current source. */
   PieceGetSource = "piece:getSource",
+
+  /** Reads one named revision of a piece's source. */
   PieceGetSourceRevision = "piece:getSourceRevision",
+
+  /**
+   * Copies a piece into another space, optionally seeding the copy with
+   * snapshots of the source piece's durable data.
+   */
   PieceClone = "piece:clone",
+
+  /**
+   * Applies a source action to a piece. An incompatible update answers with a
+   * warning and a token rather than proceeding; sending the token back is what
+   * confirms it.
+   */
   PieceUpdateSource = "piece:updateSource",
+
+  /** Reads a space's access list. */
   SpaceGetAcl = "space:getAcl",
+
+  /** Grants one user a capability on a space, replacing any they held. */
   SpaceSetAclEntry = "space:setAclEntry",
+
+  /** Removes one user's entry from a space's access list. */
   SpaceRemoveAclEntry = "space:removeAclEntry",
 
   // VDOM operations (main -> worker)
+
+  /**
+   * Starts rendering a cell as VDOM under a client-chosen mount id, answering
+   * with the tree's root node.
+   */
   VDomMount = "vdom:mount",
+
+  /** Stops the rendering {@link VDomMount} started, by its mount id. */
   VDomUnmount = "vdom:unmount",
 }
 
-// One-way main -> worker notifications. Unlike requests, these carry no
-// msgId and the worker sends no response. Used for fire-and-forget signals
-// where the main thread does not depend on a reply.
+/**
+ * One-way client-to-worker notifications. Unlike a request, one of these
+ * carries no `msgId` and is not answered, which suits a signal the client
+ * does not wait on.
+ */
 export enum ClientNotificationType {
+  /** Delivers a DOM event to the handler a rendered node registered. */
   VDomEvent = "vdom:event",
+
+  /**
+   * Reports that a batch reached the DOM, by mount and batch id. The worker
+   * uses it to pace what it sends: a renderer that has not acked is one whose
+   * main thread is behind.
+   */
   VDomBatchApplied = "vdom:batch-applied",
 }
 
+/**
+ * The worker's unsolicited messages to the client: what it reports rather than
+ * what it answers. None carries a `msgId`, and none is replied to.
+ */
 export enum NotificationType {
+  /** Reports a new value for a cell the client subscribed to. */
   CellUpdate = "cell:update",
+
+  /**
+   * Carries one `console.*` call made by a pattern, with its arguments as
+   * values rather than as rendered text. Distinct from the worker's own
+   * console output, which the transport handles.
+   */
   ConsoleMessage = "callback:console",
+
+  /** Asks the client to navigate to a cell a pattern named. */
   NavigateRequest = "callback:navigate",
+
+  /**
+   * Reports an error that surfaced with no request to fail: a renderer error,
+   * or one raised by a pattern between requests.
+   */
   ErrorReport = "callback:error",
+
+  /** Carries one telemetry marker, sent only while telemetry is enabled. */
   Telemetry = "callback:telemetry",
+
+  /** Carries a batch of DOM mutations for the client's applicator to apply. */
   VDomBatch = "vdom:batch",
+
+  /**
+   * Mirrors the storage manager's durability barrier, so the client can tell
+   * whether a reload would drop an unconfirmed write.
+   */
   PendingWritesChanged = "callback:pending-writes",
 }
 
@@ -132,28 +398,84 @@ export enum NotificationType {
  * it, and no `RuntimeConnection` ever sees either.
  */
 export enum TransportNotificationType {
+  /**
+   * The worker's entry has run and its message listener is installed; see
+   * {@link WorkerReadyNotification}.
+   */
   WorkerReady = "worker:ready",
+
+  /**
+   * One line of the worker's own console output, forwarded for the page
+   * console; see {@link WorkerConsoleNotification}.
+   */
   WorkerConsole = "worker:console",
 }
 
+/**
+ * A request together with the id its answer will carry. The only shape the
+ * client sends that expects a reply -- a notification carries neither.
+ */
 export type IPCClientMessage = {
+  /**
+   * Identifies this request, and the response that will answer it.
+   */
   msgId: MessageId;
+  /**
+   * The request itself.
+   */
   data: IPCClientRequest;
 };
 
+/**
+ * Codes naming a failure the client can act on, carried alongside an error
+ * response or report. A failure with no code is an ordinary one, distinguished
+ * only by its message.
+ */
 export enum RuntimeErrorCode {
+  /**
+   * The worker could not load its compiler stack, so nothing it was asked to
+   * compile can run. Distinguished because the client's remedy is a reload
+   * rather than a retry.
+   */
   CompilerStackLoadFailed = "compiler-stack-load-failed",
 }
 
+/**
+ * One answer to one request, matched to it by `msgId`. Either arm may carry
+ * nothing beyond that id: a success whose handler returned nothing, and an
+ * error whose `code` is absent because no code names its kind.
+ */
 export type IPCRemoteResponse = {
+  /**
+   * The request this answers.
+   */
   msgId: MessageId;
+  /**
+   * What the handler returned, absent where it returned nothing.
+   */
   data?: RemoteResponse;
 } | {
+  /**
+   * The request this answers.
+   */
   msgId: MessageId;
+  /**
+   * What went wrong, as text. Its presence is what makes this the
+   * failure arm.
+   */
   error: string;
+  /**
+   * Names the kind of failure where one is named; an ordinary failure
+   * carries no code.
+   */
   code?: RuntimeErrorCode;
 };
 
+/**
+ * What the connection receives from the worker: an answer to a request, or
+ * something the worker reports unasked. The transport's own traffic is not
+ * among it, having been handled before dispatch.
+ */
 export type IPCRemoteMessage = IPCRemoteNotification | IPCRemoteResponse;
 
 /** The notifications the transport handles itself. */
@@ -180,18 +502,37 @@ export type IPCRemotePost = IPCRemoteMessage | IPCTransportNotification;
  * particular transport -- see `RuntimeTransport.send()`.
  */
 export type BaseRequest = {
+  /**
+   * Which request this is. Every arm narrows it to one member, so it is
+   * the discriminant dispatch turns on.
+   */
   type: RequestType;
 };
 
+/**
+ * Everything the worker needs to stand a runtime up. Sent once, as
+ * {@link RequestType.Initialize}'s payload, and fixed for the connection's
+ * lifetime -- nothing here can be changed by a later request.
+ */
 export type InitializationData = {
   // URL of backend server. Also the default host for spaces absent from
   // `spaceHostMap`.
+  /**
+   * The backend server, and the default host for any space
+   * `spaceHostMap` does not list.
+   */
   apiUrl: string;
   // Optional map from space DIDs to HTTP or HTTPS origins. A listed space has
   // its storage resolved against that host instead of `apiUrl`. Absent map or
   // absent entry ⇒ `apiUrl`, byte-identical to the single-host behavior.
   // Plain record: structured-clone-safe — no functions cross the worker
   // IPC boundary. Fixed for the connection's lifetime.
+  /**
+   * Per-space storage hosts. A listed space resolves against its own
+   * host; an absent map or entry falls back to `apiUrl`, byte-identical
+   * to single-host behavior. A plain record, so nothing here needs to
+   * survive structured cloning as anything else.
+   */
   spaceHostMap?: Record<string, string>;
   /**
    * Signer, as a `codec-realm` encoding of the `FabricKeyPair` it signs with.
@@ -201,14 +542,28 @@ export type InitializationData = {
    */
   identity: RealmEncodedValue;
   // Identity of space.
+  /**
+   * The space this connection opens on.
+   */
   spaceDid: DID;
   // Temporary space name
+  /**
+   * The space's name, where the client knows it.
+   */
   spaceName?: string;
   /** Temporary identity of space, encoded as `identity` above is. */
   spaceIdentity?: RealmEncodedValue;
   // Default timeout in milliseconds.
+  /**
+   * How long a request may go unanswered before the client gives up on
+   * it.
+   */
   timeoutMs?: number;
   // Experimental space-model feature flags.
+  /**
+   * Feature flags the host declares. The worker runs the arm named here
+   * rather than resolving its own, so that the two realms cannot diverge.
+   */
   experimental?: {
     modernCellRep?: boolean;
     // Roll a space's system root pattern (home included) forward in place
@@ -239,22 +594,37 @@ export type InitializationData = {
   // join and emit diagnostics, persist nothing; "persist" = write derived
   // label components. Propagation never rejects by itself. Absent =
   // the runner's default ("off").
+  /**
+   * Whether CFC flow labels are ignored, recorded for observation, or
+   * persisted.
+   */
   cfcFlowLabels?: "off" | "observe" | "persist";
   // Whether author-supplied render-boundary declassification is honored.
   // Defaults to "allow" (current behavior). "deny" ignores author-supplied
   // `declassifyConfidentiality` so a pattern can't release a secret upward
   // through a render boundary (audit S15).
+  /**
+   * Whether a render may declassify what it shows.
+   */
   renderDeclassificationPolicy?: "allow" | "deny";
   // Host-supplied default render ceiling (spec §8.10.6, S16 phase D):
   // confidentiality a display surface admits by default — exact `atoms`
   // (the place for acting-user identity atoms) plus Caveat `caveatKinds`
   // (display-dischargeable classes). Undefined = no ceiling (current
   // behavior).
+  /**
+   * The highest confidentiality a render may reach. A render above it is
+   * refused rather than redacted.
+   */
   renderConfidentialityCeiling?: {
     atoms?: readonly CfcConfClause[];
     caveatKinds?: readonly string[];
   };
   // Static trust snapshot applied to worker-owned transactions.
+  /**
+   * The trust state the host resolved, declared so the worker runs against
+   * the same one rather than resolving its own.
+   */
   trustSnapshot?: {
     id: string;
     actingPrincipal?: string;
@@ -265,11 +635,19 @@ export type InitializationData = {
   // with `[worker]`, so runtime-internal logs reach devtools and
   // integration-test console capture. Off by default: each forwarded call
   // costs one postMessage, so it is enabled only for diagnostic runs.
+  /**
+   * Start with the worker's console bridge on.
+   * {@link RequestType.SetForwardWorkerConsole} changes it later.
+   */
   forwardWorkerConsole?: boolean;
   // When true, the worker runtime instruments every pattern compile for
   // statement coverage and accumulates hits, which the integration harness
   // pulls at teardown via GetPatternCoverage. Test/CI only (the coverage shell
   // build sets it); off by default. See docs/development/COVERAGE.md.
+  /**
+   * Collect pattern coverage. A worker built without a collector reports
+   * `null` rather than an empty report.
+   */
   patternCoverage?: boolean;
   // When true, the worker's remote storage overlaps watch-refresh round trips
   // up to a bounded window instead of the default strict single-flight
@@ -277,31 +655,57 @@ export type InitializationData = {
   // Fixed at StorageManager.open time, so like the render ceiling it takes
   // effect on the next runtime (reload), not live. Off by default; the shell
   // dogfood toggle `commonfabric.concurrentWatchRefresh()` sets it.
+  /**
+   * Refresh watched cells concurrently rather than one at a time.
+   */
   concurrentWatchRefresh?: boolean;
 };
 
+/**
+ * The {@link RequestType.Initialize} request. Its `data` is fixed for the connection's lifetime.
+ */
 export type InitializeRequest = BaseRequest & {
   type: RequestType.Initialize;
+  /**
+   * What the runtime is stood up from.
+   */
   data: InitializationData;
 };
 
+/** The {@link RequestType.Dispose} request, which carries no payload. */
 export type DisposeRequest = BaseRequest & {
   type: RequestType.Dispose;
 };
 
+/**
+ * The {@link RequestType.CellGet} request. `meta` reads a metadata field in place of the cell's value, and each `include*` flag adds a field to the answer.
+ */
 export type CellGetRequest = BaseRequest & {
   type: RequestType.CellGet;
+  /**
+   * The cell to read.
+   */
   cell: CellRef;
+  /**
+   * Reads this metadata field instead of the cell's value.
+   */
   meta?: MetaField;
   // Opt in to having the cell's display CFC label returned alongside the value,
   // so a caller that needs both pays one round-trip instead of a separate
   // CellGetCfcLabel request.
+  /**
+   * Answer with the cell's display label too.
+   */
   includeCfcLabel?: boolean;
   // Opt in to having the read cell's own schema-bearing ref returned. Useful
   // when `meta` names a link field (pattern/argument/result): the resolved
   // cell's ref lets the caller subscribe to it or read it again directly,
   // and its schema carries the declarations (e.g. stream fields) that the
   // value alone does not.
+  /**
+   * Answer with a ref to the cell the read resolved to, which a meta
+   * read following a link is not the cell asked for.
+   */
   includeRef?: boolean;
 };
 
@@ -335,9 +739,18 @@ export type WireCellValue =
   | { readonly [key: string]: WireCellValue }
   | CellRef;
 
+/**
+ * The {@link RequestType.CellSet} request. `value` is the whole already-resolved value rather than a delta.
+ */
 export type CellSetRequest = BaseRequest & {
   type: RequestType.CellSet;
+  /**
+   * The cell to overwrite.
+   */
   cell: CellRef;
+  /**
+   * The value to store, whole and already resolved.
+   */
   value: WireCellValue;
 };
 
@@ -345,59 +758,115 @@ export type CellSetRequest = BaseRequest & {
 // it carries the whole already-appended array — but routed as its own request so
 // the runtime keeps the read-target as a commit precondition (compare-and-set),
 // rather than the blind last-write-wins of CellSet.
+/**
+ * The {@link RequestType.CellPush} request. `value` is the whole already-resolved value rather than a delta, as {@link CellSetRequest}'s is; the two differ in how it is applied, not in what they carry.
+ */
 export type CellPushRequest = BaseRequest & {
   type: RequestType.CellPush;
+  /**
+   * The cell to apply to.
+   */
   cell: CellRef;
+  /**
+   * The value to apply, whole and already resolved.
+   */
   value: WireCellValue;
 };
 
+/**
+ * The {@link RequestType.CellSend} request. `event` is delivered rather than stored.
+ */
 export type CellSendRequest = BaseRequest & {
   type: RequestType.CellSend;
+  /**
+   * The cell to send to.
+   */
   cell: CellRef;
+  /**
+   * The event to deliver.
+   */
   event: WireCellValue;
 };
 
+/**
+ * The {@link RequestType.CellSubscribe} request. `includeCfcLabel` makes every update carry the cell's label too.
+ */
 export type CellSubscribeRequest = BaseRequest & {
   type: RequestType.CellSubscribe;
+  /**
+   * The cell to watch.
+   */
   cell: CellRef;
   // Opt in to reactive CFC-label delivery: each CellUpdate then carries the
   // cell's current display label, and the worker reads that label as a tracked
   // dependency of the sink, so a label-only write (value unchanged) re-fires
   // the subscription. Off by default — only label-displaying callers pay it.
+  /**
+   * Carry the cell's display label with every update, so that a label
+   * change re-renders without a second round trip.
+   */
   includeCfcLabel?: boolean;
 };
 
+/** The {@link RequestType.CellUnsubscribe} request. */
 export type CellUnsubscribeRequest = BaseRequest & {
   type: RequestType.CellUnsubscribe;
+  /**
+   * The cell to stop watching.
+   */
   cell: CellRef;
 };
 
+/** The {@link RequestType.CellResolveAsCell} request. */
 export type CellResolveAsCellRequest = BaseRequest & {
   type: RequestType.CellResolveAsCell;
+  /**
+   * The cell whose aliases to follow.
+   */
   cell: CellRef;
 };
 
+/** The {@link RequestType.CellGetCfcLabel} request. */
 export type CellGetCfcLabelRequest = BaseRequest & {
   type: RequestType.CellGetCfcLabel;
+  /**
+   * The cell whose label to read.
+   */
   cell: CellRef;
 };
 
 // unused?
+/**
+ * The {@link RequestType.GetCell} request. `cause` is what derives the cell: the same space and cause always name the same one.
+ */
 export type GetCellRequest = BaseRequest & {
   type: RequestType.GetCell;
+  /**
+   * The space to derive the cell in.
+   */
   space: DID;
+  /**
+   * What derives the cell. The same space and cause always name the same
+   * cell, which is what makes this a derivation rather than an allocation.
+   */
   cause: FabricValue;
+  /**
+   * The schema to read the cell under, where one is wanted.
+   */
   schema?: JSONSchema;
 };
 
+/** The {@link RequestType.GetHomeSpaceCell} request, which carries no payload. */
 export type GetHomeSpaceCellRequest = BaseRequest & {
   type: RequestType.GetHomeSpaceCell;
 };
 
+/** The {@link RequestType.EnsureHomePatternRunning} request, which carries no payload. */
 export type EnsureHomePatternRunningRequest = BaseRequest & {
   type: RequestType.EnsureHomePatternRunning;
 };
 
+/** The {@link RequestType.Idle} request, which carries no payload. */
 export type IdleRequest = BaseRequest & {
   type: RequestType.Idle;
 };
@@ -415,6 +884,9 @@ export type RuntimeSyncedRequest = BaseRequest & {
  * be retained as fresh-space ACL bootstrap authority. */
 export type ResolveSpaceNameRequest = BaseRequest & {
   type: RequestType.ResolveSpaceName;
+  /**
+   * The name to resolve.
+   */
   name: string;
 };
 
@@ -435,7 +907,13 @@ export type ResolveSpaceNameRequest = BaseRequest & {
  */
 export type RegisterSpaceHostRequest = BaseRequest & {
   type: RequestType.RegisterSpaceHost;
+  /**
+   * The space to route.
+   */
   space: DID;
+  /**
+   * The origin its storage should resolve against.
+   */
   host: string;
 };
 
@@ -449,147 +927,260 @@ export type FlushCompileCacheWritesRequest = BaseRequest & {
   type: RequestType.FlushCompileCacheWrites;
 };
 
+/** The {@link RequestType.GetGraphSnapshot} request, which carries no payload. */
 export type GetGraphSnapshotRequest = BaseRequest & {
   type: RequestType.GetGraphSnapshot;
 };
 
+/** The {@link RequestType.GetLoggerCounts} request, which carries no payload. */
 export type GetLoggerCountsRequest = BaseRequest & {
   type: RequestType.GetLoggerCounts;
 };
 
+/** The {@link RequestType.GetPatternCoverage} request, which carries no payload. */
 export type GetPatternCoverageRequest = BaseRequest & {
   type: RequestType.GetPatternCoverage;
 };
 
+/** The severities a logger records at, least to most severe. */
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
+/**
+ * The {@link RequestType.SetLoggerLevel} request. An absent `loggerName` addresses every logger.
+ */
 export type SetLoggerLevelRequest = BaseRequest & {
   type: RequestType.SetLoggerLevel;
   /** Logger name. If not provided, sets level for all loggers. */
   loggerName?: string;
+  /**
+   * The level to record at.
+   */
   level: LogLevel;
 };
 
+/**
+ * The {@link RequestType.SetLoggerEnabled} request. An absent `loggerName` addresses every logger.
+ */
 export type SetLoggerEnabledRequest = BaseRequest & {
   type: RequestType.SetLoggerEnabled;
   /** Logger name. If not provided, sets enabled for all loggers. */
   loggerName?: string;
+  /**
+   * Whether the addressed loggers record at all.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.SetTelemetryEnabled} request. */
 export type SetTelemetryEnabledRequest = BaseRequest & {
   type: RequestType.SetTelemetryEnabled;
+  /**
+   * Whether telemetry notifications are sent.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.SetForwardWorkerConsole} request. */
 export type SetForwardWorkerConsoleRequest = BaseRequest & {
   type: RequestType.SetForwardWorkerConsole;
+  /**
+   * Whether the worker's console bridge is installed.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.ResetLoggerBaselines} request, which carries no payload. */
 export type ResetLoggerBaselinesRequest = BaseRequest & {
   type: RequestType.ResetLoggerBaselines;
 };
 
+/** The {@link RequestType.GetSettleStats} request, which carries no payload. */
 export type GetSettleStatsRequest = BaseRequest & {
   type: RequestType.GetSettleStats;
 };
 
+/** The {@link RequestType.SetSettleStatsEnabled} request. */
 export type SetSettleStatsEnabledRequest = BaseRequest & {
   type: RequestType.SetSettleStatsEnabled;
+  /**
+   * Whether settle statistics are recorded.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.GetSettleStatsHistory} request, which carries no payload. */
 export type GetSettleStatsHistoryRequest = BaseRequest & {
   type: RequestType.GetSettleStatsHistory;
 };
 
+/** The {@link RequestType.GetActionRunTrace} request, which carries no payload. */
 export type GetActionRunTraceRequest = BaseRequest & {
   type: RequestType.GetActionRunTrace;
 };
 
+/** The {@link RequestType.SetActionRunTraceEnabled} request. */
 export type SetActionRunTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetActionRunTraceEnabled;
+  /**
+   * Whether action runs are traced.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.GetTriggerTrace} request, which carries no payload. */
 export type GetTriggerTraceRequest = BaseRequest & {
   type: RequestType.GetTriggerTrace;
 };
 
+/** The {@link RequestType.SetTriggerTraceEnabled} request. */
 export type SetTriggerTraceEnabledRequest = BaseRequest & {
   type: RequestType.SetTriggerTraceEnabled;
+  /**
+   * Whether triggers are traced.
+   */
   enabled: boolean;
 };
 
+/** The {@link RequestType.GetWriteStackTrace} request, which carries no payload. */
 export type GetWriteStackTraceRequest = BaseRequest & {
   type: RequestType.GetWriteStackTrace;
 };
 
+/**
+ * The {@link RequestType.SetWriteStackTraceMatchers} request. The matchers replace the current set rather than adding to it.
+ */
 export type SetWriteStackTraceMatchersRequest = BaseRequest & {
   type: RequestType.SetWriteStackTraceMatchers;
+  /**
+   * The writes whose stack to record. Replaces the current set, and an
+   * empty one records nothing.
+   */
   matchers: WriteStackTraceMatcher[];
 };
 
+/**
+ * The {@link RequestType.DetectNonIdempotent} request. `durationMs` bounds how long the diagnosis runs.
+ */
 export type DetectNonIdempotentRequest = BaseRequest & {
   type: RequestType.DetectNonIdempotent;
+  /**
+   * How long to run the diagnosis.
+   */
   durationMs?: number;
 };
 
+/** The scheduler's settle statistics, or `null` while recording is off. */
 export type SettleStatsResponse = {
+  /**
+   * The statistics, or `null` while recording is off.
+   */
   stats: SettleStats | null;
 };
 
+/** One entry per recorded settle pass, oldest first. */
 export type SettleStatsHistoryResponse = {
+  /**
+   * One entry per recorded pass, oldest first.
+   */
   history: SettleStatsHistoryEntry[];
 };
 
+/** The recorded action runs, in the order they ran. */
 export type ActionRunTraceResponse = {
+  /**
+   * The recorded runs, in the order they ran.
+   */
   trace: ActionRunTraceEntry[];
 };
 
+/** The recorded triggers, in the order they fired. */
 export type TriggerTraceResponse = {
+  /**
+   * The recorded triggers, in the order they fired.
+   */
   trace: TriggerTraceEntry[];
 };
 
+/**
+ * The recorded write stacks. Only writes matching the configured matchers
+ * appear, recording every write being too costly to leave on.
+ */
 export type WriteStackTraceResponse = {
+  /**
+   * The recorded writes, in the order they happened.
+   */
   trace: WriteStackTraceEntry[];
 };
 
+/** What the scheduler's non-idempotency diagnosis found. */
 export type DetectNonIdempotentResponse = {
+  /**
+   * What the diagnosis found.
+   */
   result: SchedulerDiagnosisResult;
 };
 
+/** The {@link RequestType.GetPatternSources} request, which carries no payload. */
 export type GetPatternSourcesRequest = BaseRequest & {
   type: RequestType.GetPatternSources;
 };
 
+/** One file of a pattern's source, by name and contents. */
 export type PatternSourceFile = {
+  /**
+   * The file's name, as the pattern refers to it.
+   */
   name: string;
+  /**
+   * The file's text.
+   */
   contents: string;
 };
 
+/**
+ * A pattern's source as the worker reports it. `files` carries both code and
+ * data; `dataFiles` is what tells them apart.
+ */
 export type PatternSourceInfo = {
   /** Content identity of the pattern's entry module (`cf:module/<hash>`). */
   identity: string;
+  /**
+   * Every file of the pattern, code and data alike.
+   */
   files: PatternSourceFile[];
   /** Names among `files` that carry data rather than code. */
   dataFiles?: string[];
 };
 
+/** One entry per distinct pattern in the graph, not per graph node. */
 export type PatternSourcesResponse = {
+  /**
+   * One entry per distinct pattern.
+   */
   patterns: PatternSourceInfo[];
 };
 
+/**
+ * The {@link RequestType.SetBreakpoints} request. The ids replace the current breakpoints rather than adding to them.
+ */
 export type SetBreakpointsRequest = BaseRequest & {
   type: RequestType.SetBreakpoints;
+  /**
+   * The actions to break on. Replaces the current set.
+   */
   actionIds: string[];
 };
 
+/**
+ * The {@link RequestType.UploadBlob} request. `space` is required, and decides which host the upload targets; `suffix` names the extension the stored blob is served under.
+ */
 export type UploadBlobRequest = BaseRequest & {
   type: RequestType.UploadBlob;
   /** The space the blob belongs to — uploads target ITS host. */
   space: DID;
+  /**
+   * The media type the blob is served as.
+   */
   contentType: string;
   /**
    * The blob's bytes: a `FabricBytes` in the realm-crossing form, which
@@ -599,60 +1190,168 @@ export type UploadBlobRequest = BaseRequest & {
    * still holds.
    */
   body: RealmEncodedValue;
+  /**
+   * The extension the stored blob is served under, defaulting to `bin`.
+   * A leading dot is stripped.
+   */
   suffix?: string;
 };
 
+/** The stored blob's id, and the URL it is served from. */
 export type UploadBlobResponse = {
+  /**
+   * The stored blob's id.
+   */
   id: string;
+  /**
+   * Where the blob is served from.
+   */
   url: string;
 };
 
 // Logger count types for IPC (matches @commonfabric/utils/logger types)
+/**
+ * How many messages were recorded at each level, with `total` alongside so a
+ * reader need not sum the four.
+ */
 export type LogCounts = {
+  /**
+   * Messages recorded at `debug`.
+   */
   debug: number;
+  /**
+   * Messages recorded at `info`.
+   */
   info: number;
+  /**
+   * Messages recorded at `warn`.
+   */
   warn: number;
+  /**
+   * Messages recorded at `error`.
+   */
   error: number;
+  /**
+   * All four levels together.
+   */
   total: number;
 };
 
+/**
+ * One logger's counts split per distinct message, with the logger's own total
+ * alongside. Keys are message texts, so `total` is reserved and cannot name a
+ * message.
+ */
 export type LoggerBreakdown = {
   [messageKey: string]: LogCounts;
 } & {
+  /**
+   * Every message of this logger together. Reserved, so no message text
+   * may be `total`.
+   */
   total: number;
 };
 
+/**
+ * Counts for every logger, keyed by logger name, with a grand total
+ * alongside. `total` is reserved here the same way.
+ */
 export type LoggerCountsData = Record<string, LoggerBreakdown> & {
+  /**
+   * Every logger together. Reserved, so no logger may be named `total`.
+   */
   total: number;
 };
 
+/** Whether a logger is enabled, and the level it records at. */
 export type LoggerInfo = {
+  /**
+   * Whether the logger records at all.
+   */
   enabled: boolean;
+  /**
+   * The lowest severity it records.
+   */
   level: LogLevel;
 };
 
+/** Every logger's enabled state and level, by logger name. */
 export type LoggerMetadata = Record<string, LoggerInfo>;
 
 // Timing stats types for IPC (matches @commonfabric/utils/logger types)
+/**
+ * One point of a cumulative distribution: a latency, and the fraction of
+ * samples at or below it.
+ */
 export type CDFPoint = {
-  x: number; // Latency in ms
-  y: number; // Cumulative probability (0-1)
+  /**
+   * Latency, in milliseconds.
+   */
+  x: number;
+  /**
+   * The fraction of samples at or below `x`, from 0 to 1.
+   */
+  y: number;
 };
 
+/**
+ * What one timed operation's samples add up to. Two distributions are kept:
+ * `cdf` over every sample since the worker started, and `cdfSinceBaseline`
+ * over those since the last baseline reset, which is `null` until one has
+ * happened.
+ */
 export type TimingStats = {
-  count: number; // Total measurements
-  min: number; // Minimum time (ms)
-  max: number; // Maximum time (ms)
-  totalTime: number; // Sum for average calculation
-  average: number; // totalTime / count
-  p50: number; // Median (50th percentile)
-  p95: number; // 95th percentile
-  lastTime: number; // Most recent measurement
-  lastTimestamp: number; // When last recorded
-  cdf: CDFPoint[]; // CDF of all samples since start
-  cdfSinceBaseline: CDFPoint[] | null; // CDF of samples since baseline reset
+  /**
+   * How many measurements have been taken.
+   */
+  count: number;
+  /**
+   * The fastest measurement, in milliseconds.
+   */
+  min: number;
+  /**
+   * The slowest measurement, in milliseconds.
+   */
+  max: number;
+  /**
+   * Every measurement summed, which is what `average` divides.
+   */
+  totalTime: number;
+  /**
+   * `totalTime` over `count`.
+   */
+  average: number;
+  /**
+   * The median measurement.
+   */
+  p50: number;
+  /**
+   * The 95th percentile measurement.
+   */
+  p95: number;
+  /**
+   * The most recent measurement, in milliseconds.
+   */
+  lastTime: number;
+  /**
+   * When that measurement was taken.
+   */
+  lastTimestamp: number;
+  /**
+   * The distribution over every sample since the worker started.
+   */
+  cdf: CDFPoint[];
+  /**
+   * The distribution over samples since the last baseline reset, `null`
+   * until one has happened.
+   */
+  cdfSinceBaseline: CDFPoint[] | null;
 };
 
+/**
+ * Timing statistics for every timed operation, keyed by logger name and then
+ * by the operation's own name.
+ */
 export type LoggerTimingData = Record<
   string,
   Record<string, TimingStats>
@@ -667,10 +1366,17 @@ export type LoggerFlagsData = Record<
   Record<string, Record<string, FabricPlainObject | null>>
 >;
 
+/**
+ * The {@link RequestType.PageCreate} request. `source` names a URL or a program, never both.
+ */
 export type PageCreateRequest = BaseRequest & {
   type: RequestType.PageCreate;
   /** The space the piece is created in — part of its address. */
   space: DID;
+  /**
+   * Where the piece's program comes from: a URL to fetch, or a program
+   * given directly. Never both.
+   */
   source: {
     url: string;
   } | {
@@ -681,8 +1387,18 @@ export type PageCreateRequest = BaseRequest & {
   // The same gap `WireCellValue` is marked with, at the other request that
   // sends a value into the worker, and closed by the same mechanism
   // (`codec-realm`).
+  /**
+   * The argument the piece is created with.
+   */
   argument?: JSONValue;
+  /**
+   * What derives the piece's identity, so that the same cause names the
+   * same piece.
+   */
   cause?: string;
+  /**
+   * Start the piece once created.
+   */
   run?: boolean;
 };
 
@@ -694,52 +1410,107 @@ export type PageCreateRequest = BaseRequest & {
  */
 export type PageGetSpaceDefault = BaseRequest & {
   type: RequestType.GetSpaceRootPattern;
+  /**
+   * The space whose root pattern to read.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.RecreateSpaceRootPattern} request. */
 export type RecreateSpaceRootPatternRequest = BaseRequest & {
   type: RequestType.RecreateSpaceRootPattern;
+  /**
+   * The space whose root pattern to replace.
+   */
   space: DID;
 };
 
+/**
+ * The {@link RequestType.PageGet} request. `runIt` starts the piece as part of the read.
+ */
 export type PageGetRequest = BaseRequest & {
   type: RequestType.PageGet;
+  /**
+   * The piece to read.
+   */
   pageId: string;
+  /**
+   * Start the piece as part of the read.
+   */
   runIt?: boolean;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageGetSlug} request. */
 export type PageGetSlugRequest = BaseRequest & {
   type: RequestType.PageGetSlug;
+  /**
+   * The piece whose slug to read.
+   */
   pageId: string;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageRemove} request. */
 export type PageRemoveRequest = BaseRequest & {
   type: RequestType.PageRemove;
+  /**
+   * The piece to remove.
+   */
   pageId: string;
+  /**
+   * The space to remove it from.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageStart} request. */
 export type PageStartRequest = BaseRequest & {
   type: RequestType.PageStart;
+  /**
+   * The piece to start.
+   */
   pageId: string;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageStop} request. */
 export type PageStopRequest = BaseRequest & {
   type: RequestType.PageStop;
+  /**
+   * The piece to stop.
+   */
   pageId: string;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageGetAll} request. */
 export type PageGetAllRequest = BaseRequest & {
   type: RequestType.PageGetAll;
+  /**
+   * The space whose pieces to list.
+   */
   space: DID;
 };
 
+/** The {@link RequestType.PageSynced} request. */
 export type PageSyncedRequest = BaseRequest & {
   type: RequestType.PageSynced;
+  /**
+   * The space whose pieces to wait for.
+   */
   space: DID;
 };
 
@@ -750,23 +1521,47 @@ export type PageSyncedRequest = BaseRequest & {
  */
 export type PieceGetSourceRequest = BaseRequest & {
   type: RequestType.PieceGetSource;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
+  /**
+   * The piece whose source to read.
+   */
   pieceId: string;
 };
 
 /** Read the authored files retained for one recorded source revision. */
 export type PieceGetSourceRevisionRequest = BaseRequest & {
   type: RequestType.PieceGetSourceRevision;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
+  /**
+   * The piece whose history to read from.
+   */
   pieceId: string;
+  /**
+   * The revision to read.
+   */
   revisionId: string;
 };
 
 /** Create a copy of a piece in another space. */
 export type PieceCloneRequest = BaseRequest & {
   type: RequestType.PieceClone;
+  /**
+   * The space to copy from.
+   */
   sourceSpace: DID;
+  /**
+   * The piece to copy.
+   */
   pieceId: string;
+  /**
+   * The space to copy into.
+   */
   destinationSpace: DID;
   /** Seed the clone with snapshots of the source piece's durable data. */
   copyData?: boolean;
@@ -775,18 +1570,37 @@ export type PieceCloneRequest = BaseRequest & {
 /** How a piece's origin URL resolves. */
 export type PieceOriginKind = "web" | "fabric-piece" | "fabric-pattern";
 
+/**
+ * Where a piece's source came from. `recorded` is present only when
+ * normalization changed the URL, so that the piece's own text stays visible
+ * next to the resolved form.
+ */
 export type PieceOriginView = {
+  /**
+   * Where the source came from, resolved.
+   */
   url: string;
+  /**
+   * How that URL resolves.
+   */
   kind: PieceOriginKind;
   /** The URL as recorded on the piece, when normalization changed it. */
   recorded?: string;
 };
 
+/** A pattern, named by its content identity and the symbol exported from it. */
 export type PiecePatternRefView = {
+  /**
+   * The pattern's content identity.
+   */
   identity: string;
+  /**
+   * The export within it that is the pattern.
+   */
   symbol: string;
 };
 
+/** What produced one revision of a piece's source. */
 export type PieceSourceRevisionOperation =
   | "baseline"
   | "create"
@@ -797,64 +1611,179 @@ export type PieceSourceRevisionOperation =
   | "follow"
   | "repoint";
 
+/**
+ * One entry of a piece's source history: what the piece pointed at, when, and
+ * which operation put it there.
+ */
 export type PieceSourceRevisionView = {
+  /**
+   * This revision's id.
+   */
   revisionId: string;
+  /**
+   * When it was made.
+   */
   timestamp: number;
+  /**
+   * What the piece pointed at afterwards.
+   */
   pattern: PiecePatternRefView;
+  /**
+   * Where that pattern came from, where it came from anywhere.
+   */
   origin?: PieceOriginView;
+  /**
+   * What produced this revision.
+   */
   operation: PieceSourceRevisionOperation;
+  /**
+   * The revision this operation acted on, for the operations that name
+   * one -- a revert or a follow.
+   */
   selectedRevisionId?: string;
 };
 
+/**
+ * A piece's source as the client displays it -- its name, the patterns bound
+ * to it, where it came from, its files, and its whole revision history.
+ * `displacedPattern` records a pattern an update moved aside rather than one
+ * in use.
+ */
 export type PieceSourceView = {
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
+  /**
+   * The piece this describes.
+   */
   pieceId: string;
+  /**
+   * The piece's name, where it has one.
+   */
   name?: string;
+  /**
+   * The pattern the piece currently runs.
+   */
   pattern?: PiecePatternRefView;
+  /**
+   * The pattern that set the piece up, where that differs from the one
+   * it runs.
+   */
   setupPattern?: PiecePatternRefView;
+  /**
+   * A pattern an update moved aside, with when it happened. Recorded so
+   * the displacement stays visible; this is not a pattern in use.
+   */
   displacedPattern?: PiecePatternRefView & { displacedAt?: number };
+  /**
+   * Where the source came from.
+   */
   origin?: PieceOriginView;
+  /**
+   * The repository the source is tracked in, where it is.
+   */
   repository?: string;
+  /**
+   * The entry file among `files`.
+   */
   entry?: string;
+  /**
+   * Every file of the source, code and data alike.
+   */
   files: PatternSourceFile[];
   /** Names among `files` that carry data rather than code. */
   dataFiles?: string[];
+  /**
+   * Every revision, which is what the current one is chosen from.
+   */
   history: PieceSourceRevisionView[];
+  /**
+   * Which of `history` the piece is on.
+   */
   currentRevisionId?: string;
 };
 
+/** A piece's current source, with its whole revision history. */
 export type PieceSourceResponse = {
+  /**
+   * The piece's source and history.
+   */
   source: PieceSourceView;
 };
 
+/**
+ * One historical revision's source: the pattern and files as they stood then,
+ * without the surrounding history that {@link PieceSourceView} carries.
+ */
 export type PieceSourceRevisionSourceView = {
+  /**
+   * The pattern as of that revision.
+   */
   pattern: PiecePatternRefView;
+  /**
+   * The files as of that revision.
+   */
   files: PatternSourceFile[];
   /** Names among `files` that carry data rather than code. */
   dataFiles?: string[];
 };
 
+/** One named revision of a piece's source, without the history around it. */
 export type PieceSourceRevisionResponse = {
+  /**
+   * That revision's source.
+   */
   source: PieceSourceRevisionSourceView;
 };
 
+/** A change to which source a piece follows. */
 export type PieceSourceAction =
   | { kind: "detach" }
   | { kind: "restore"; revisionId: string }
   | { kind: "follow"; revisionId: string };
 
+/**
+ * The {@link RequestType.PieceUpdateSource} request. `confirmationToken` is the token an incompatibility warning returned; sending it back is what confirms the update.
+ */
 export type PieceUpdateSourceRequest = BaseRequest & {
   type: RequestType.PieceUpdateSource;
+  /**
+   * The space the piece lives in.
+   */
   space: DID;
+  /**
+   * The piece to update.
+   */
   pieceId: string;
+  /**
+   * What to change about which source the piece follows.
+   */
   action: PieceSourceAction;
   /** Opaque token returned with an incompatibility warning. */
   confirmationToken?: string;
 };
 
+/**
+ * The piece's source after an update, or the reason one did not happen. A
+ * `compatibilityWarning` comes with a `confirmationToken`, and sending that
+ * token back is what turns the refusal into an update; an `executionWarning`
+ * reports an update that landed but whose pattern then misbehaved.
+ */
 export type PieceUpdateSourceResponse = PieceSourceResponse & {
+  /**
+   * Why the update was not applied, where it was refused as
+   * incompatible. Comes with a `confirmationToken`.
+   */
   compatibilityWarning?: string;
+  /**
+   * Sent back on a repeat request to apply the update anyway.
+   */
   confirmationToken?: string;
+  /**
+   * Reports an update that landed but whose pattern then misbehaved --
+   * which is a different outcome from a refusal.
+   */
   executionWarning?: string;
 };
 
@@ -863,40 +1792,77 @@ export type SpaceAclCapability = "READ" | "WRITE" | "OWNER";
 
 /** The space ACL and the current principal's ability to administer it. */
 export type SpaceAclView = {
+  /**
+   * The space this describes.
+   */
   space: DID;
+  /**
+   * Whose view this is, capabilities being reported as they stand for
+   * one reader.
+   */
   principal: DID;
+  /**
+   * What each user may do, by user.
+   */
   acl: Record<string, SpaceAclCapability>;
+  /**
+   * Whether `principal` may change the list at all.
+   */
   canEdit: boolean;
 };
 
 /** Response carrying a space's access-control view. */
 export type SpaceAclResponse = {
+  /**
+   * The space's access list, as it stands for the caller.
+   */
   access: SpaceAclView;
 };
 
 /** Reads the ACL for one space. */
 export type SpaceGetAclRequest = BaseRequest & {
   type: RequestType.SpaceGetAcl;
+  /**
+   * The space whose access list to read.
+   */
   space: DID;
 };
 
 /** Adds or replaces one explicit ACL entry in a space. */
 export type SpaceSetAclEntryRequest = BaseRequest & {
   type: RequestType.SpaceSetAclEntry;
+  /**
+   * The space to grant on.
+   */
   space: DID;
+  /**
+   * Who to grant to.
+   */
   user: string;
+  /**
+   * What to grant, replacing whatever the user held.
+   */
   capability: SpaceAclCapability;
 };
 
 /** Removes one explicit ACL entry from a space. */
 export type SpaceRemoveAclEntryRequest = BaseRequest & {
   type: RequestType.SpaceRemoveAclEntry;
+  /**
+   * The space to remove from.
+   */
   space: DID;
+  /**
+   * Whose entry to remove.
+   */
   user: string;
 };
 
 /** Common shape for one-way main -> worker notifications. */
 export type BaseClientNotification = {
+  /**
+   * Which notification this is.
+   */
   type: ClientNotificationType;
 };
 
@@ -919,7 +1885,14 @@ export type VDomEventNotification = BaseClientNotification & {
  * Serialized DOM event data for IPC.
  */
 export type SerializedDomEvent = {
+  /**
+   * The DOM event's type, as `click` or `input`.
+   */
   type: string;
+  /**
+   * Where the event came from, so a handler can tell a real user
+   * gesture from a synthesized one.
+   */
   provenance?: {
     origin?: string;
     trusted?: boolean;
@@ -929,18 +1902,57 @@ export type SerializedDomEvent = {
       uiContractDataset?: Record<string, string>;
     };
   };
+  /**
+   * The key pressed, for a keyboard event.
+   */
   key?: string;
+  /**
+   * The physical key, which `key` does not identify across layouts.
+   */
   code?: string;
+  /**
+   * Whether the key was being held.
+   */
   repeat?: boolean;
+  /**
+   * Whether Alt was held.
+   */
   altKey?: boolean;
+  /**
+   * Whether Control was held.
+   */
   ctrlKey?: boolean;
+  /**
+   * Whether Meta was held.
+   */
   metaKey?: boolean;
+  /**
+   * Whether Shift was held.
+   */
   shiftKey?: boolean;
+  /**
+   * What kind of edit an input event was.
+   */
   inputType?: string;
+  /**
+   * The text an input event inserted, `null` where it inserted none.
+   */
   data?: string | null;
+  /**
+   * Which button a pointer event used.
+   */
   button?: number;
+  /**
+   * Which buttons were held during a pointer event.
+   */
   buttons?: number;
+  /**
+   * What the event fired on, reduced to the fields a handler reads.
+   */
   target?: SerializedEventTarget;
+  /**
+   * A custom event's payload.
+   */
   detail?: JSONValue;
 };
 
@@ -948,12 +1960,33 @@ export type SerializedDomEvent = {
  * Serialized event target data for IPC.
  */
 export type SerializedEventTarget = {
+  /**
+   * The element's name, or its tag where it has none.
+   */
   name?: string;
+  /**
+   * The element's current value.
+   */
   value?: string;
+  /**
+   * Whether a checkbox or radio is checked.
+   */
   checked?: boolean;
+  /**
+   * Whether an option is selected.
+   */
   selected?: boolean;
+  /**
+   * Which option a select is on.
+   */
   selectedIndex?: number;
+  /**
+   * Every selected option's value, for a multiple select.
+   */
   selectedOptions?: { value: string }[];
+  /**
+   * The element's `data-` attributes.
+   */
   dataset?: Record<string, string>;
 };
 
@@ -1076,11 +2109,20 @@ export type IPCClientRequest =
   | SetBreakpointsRequest
   | UploadBlobRequest;
 
+/** A response whose whole content is `null`. */
 export type NullResponse = null;
 
+/**
+ * A response carrying nothing at all. The envelope omits `data` entirely
+ * rather than sending `undefined`, so an ack is a bare `{ msgId }`.
+ */
 export type EmptyResponse = undefined;
 
+/** A single boolean verdict. */
 export type BooleanResponse = {
+  /**
+   * The verdict.
+   */
   value: boolean;
 };
 
@@ -1097,49 +2139,110 @@ export type BooleanResponse = {
  * is one change.
  */
 export type JSONValueResponse = {
+  /**
+   * The value read. `undefined` is a value a cell can hold, so it is not
+   * the same as the read having found nothing.
+   */
   value: JSONValue | undefined;
 };
 
+/**
+ * A cell read's answer. `cfcLabel` is present only when the request asked for
+ * it, and `cell` only when it asked and the read resolved to a cell -- a raw
+ * metadata read has none to name.
+ */
 export type CellGetResponse = JSONValueResponse & {
   // Present only when the request set `includeCfcLabel`. `undefined` is a valid
   // value (the cell carries no label); the field is omitted when not requested.
+  /**
+   * The cell's display label, present only where the request asked.
+   */
   cfcLabel?: CfcLabelView | undefined;
   // Present only when the request set `includeRef` and the read resolved to a
   // cell (a raw-metadata read has no cell to reference).
+  /**
+   * A ref to the cell the read resolved to, present only where the
+   * request asked and the read reached one.
+   */
   cell?: CellRef;
 };
 
+/** A reference to one cell, for a request whose answer is which cell. */
 export type CellResponse = {
+  /**
+   * The cell in question.
+   */
   cell: CellRef;
 };
 
+/**
+ * A cell's display label. `undefined` means the cell carries none, which is
+ * distinct from the request having failed.
+ */
 export type CfcLabelViewResponse = {
+  /**
+   * The cell's display label, `undefined` where it carries none.
+   */
   cfcLabel: CfcLabelView | undefined;
 };
 
+/** A reference to one piece. */
 export type PageResponse = {
+  /**
+   * The piece in question.
+   */
   page: PageRef;
 };
 
+/** A piece's slug, `undefined` where the piece has none. */
 export type SlugResponse = {
+  /**
+   * The piece's slug, `undefined` where it has none.
+   */
   slug: string | undefined;
 };
 
+/** One space, by DID. */
 export type SpaceResponse = {
+  /**
+   * The space in question.
+   */
   space: DID;
 };
 
+/** A snapshot of the scheduler's reactive graph, as of the read. */
 export type GraphSnapshotResponse = {
+  /**
+   * The graph as of the read.
+   */
   snapshot: SchedulerGraphSnapshot;
 };
 
+/**
+ * Everything the logger diagnostics read returns: counts, per-logger
+ * metadata, timings, and active flags, gathered in one round trip because a
+ * client comparing them wants them from the same moment.
+ */
 export type LoggerCountsResponse = {
+  /**
+   * How many messages each logger recorded.
+   */
   counts: LoggerCountsData;
+  /**
+   * Each logger's enabled state and level.
+   */
   metadata: LoggerMetadata;
+  /**
+   * Each timed operation's statistics.
+   */
   timing: LoggerTimingData;
+  /**
+   * The flags currently set, by logger.
+   */
   flags: LoggerFlagsData;
 };
 
+/** The worker's pattern coverage, where this worker collects any. */
 export type PatternCoverageResponse = {
   /**
    * The worker collector's spans and hit counts, or `null` when this worker was
@@ -1151,21 +2254,46 @@ export type PatternCoverageResponse = {
   data: PatternCoverageData | null;
 };
 
+/**
+ * A new value for a subscribed cell. `cfcLabel` rides along only for a
+ * subscription that opted in, so that a label change re-renders without a
+ * second round trip.
+ */
 export type CellUpdateNotification = {
   type: NotificationType.CellUpdate;
+  /**
+   * The cell that changed.
+   */
   cell: CellRef;
   // TODO(danfuzz): the same gap `JSONValueResponse` is marked with. This is
   // the push form of the same read, produced by the same conversion.
+  /**
+   * Its new value.
+   */
   value: JSONValue;
   // Present only for subscriptions that opted in via `includeCfcLabel`. Carries
   // the cell's current display label so the client re-renders on label changes
   // without a separate getCfcLabel round-trip.
+  /**
+   * Its display label, carried only for a subscription that opted in.
+   */
   cfcLabel?: CfcLabelView | undefined;
 };
 
+/**
+ * One `console.*` call made by a pattern, with the arguments it was given.
+ * `metadata` names the piece, pattern, and space it came from where those are
+ * known.
+ */
 export type ConsoleNotification = {
   type: NotificationType.ConsoleMessage;
+  /**
+   * Where the call came from, for the parts of that the worker knows.
+   */
   metadata?: { pieceId?: string; patternId?: string; space?: string };
+  /**
+   * Which `console` method was called.
+   */
   method: string;
   /**
    * The arguments, each encoded on its own. `ConsoleMessage` is this same
@@ -1182,27 +2310,68 @@ export type ConsoleNotification = {
  * back into the values the pattern logged.
  */
 export type ConsoleMessage = Omit<ConsoleNotification, "args"> & {
+  /**
+   * The arguments, decoded back into the values the pattern logged.
+   */
   args: FabricValue[];
 };
 
+/**
+ * A pattern asking the client to navigate to a cell. A request in name only:
+ * it carries no `msgId` and nothing is sent back, so the client is free to
+ * ignore it.
+ */
 export type NavigateRequestNotification = {
   type: NotificationType.NavigateRequest;
+  /**
+   * The cell to navigate to.
+   */
   targetCellRef: CellRef;
 };
 
+/**
+ * An error with no request to fail -- a renderer error, or one a pattern
+ * raised between requests. Every field but `message` is context the raising
+ * site had and may not.
+ */
 export type ErrorNotification = {
   type: NotificationType.ErrorReport;
+  /**
+   * What went wrong.
+   */
   message: string;
+  /**
+   * Names the kind of failure where one is named.
+   */
   code?: RuntimeErrorCode;
+  /**
+   * The piece it happened in, where that is known.
+   */
   pieceId?: string;
+  /**
+   * The space it happened in, where that is known.
+   */
   space?: string;
+  /**
+   * The pattern it happened in, where that is known.
+   */
   patternId?: string;
+  /**
+   * The spell it happened in, where that is known.
+   */
   spellId?: string;
+  /**
+   * The stack as raised, where one survived.
+   */
   stackTrace?: string;
 };
 
+/** One telemetry marker. Sent only while telemetry is enabled. */
 export type TelemetryNotification = {
   type: NotificationType.Telemetry;
+  /**
+   * The marker, with the timestamp the runtime stamped it at.
+   */
   marker: RuntimeTelemetryMarkerResult;
 };
 
@@ -1214,6 +2383,9 @@ export type TelemetryNotification = {
  */
 export type PendingWritesNotification = {
   type: NotificationType.PendingWritesChanged;
+  /**
+   * Whether any issued commit is still unconfirmed.
+   */
   pending: boolean;
 };
 
@@ -1242,7 +2414,13 @@ export type WorkerConsoleLevel = (typeof WORKER_CONSOLE_LEVELS)[number];
  */
 export type WorkerConsoleNotification = {
   type: TransportNotificationType.WorkerConsole;
+  /**
+   * Which `console` method the worker called.
+   */
   level: WorkerConsoleLevel;
+  /**
+   * The call's arguments, already rendered to text.
+   */
   text: string;
 };
 
@@ -1275,6 +2453,10 @@ export type VDomBatchNotification = {
   mountId?: number;
 };
 
+/**
+ * Every shape a successful response can carry. The arm a given request yields
+ * is fixed by {@link Commands} rather than chosen here.
+ */
 export type RemoteResponse =
   | EmptyResponse
   | NullResponse
@@ -1303,6 +2485,10 @@ export type RemoteResponse =
   | PatternSourcesResponse
   | UploadBlobResponse;
 
+/**
+ * Everything the worker reports without being asked. Each arm is recognized
+ * by its own guard in `guards.ts`; adding one means adding both.
+ */
 export type IPCRemoteNotification =
   | CellUpdateNotification
   | ConsoleNotification
@@ -1312,6 +2498,11 @@ export type IPCRemoteNotification =
   | VDomBatchNotification
   | PendingWritesNotification;
 
+/**
+ * The request-and-response pairing for every {@link RequestType}. This is what
+ * types a call site's return, so adding a request means adding its entry here
+ * as well as its arm to {@link IPCClientRequest}.
+ */
 export type Commands = {
   // Runtime requests
   [RequestType.Initialize]: {
@@ -1552,9 +2743,19 @@ export type Commands = {
   };
 };
 
+/**
+ * The request shape a given {@link RequestType} takes, read out of
+ * {@link Commands}. `never` for anything that is not a request type, so a
+ * mistyped call fails where it is written rather than where it is sent.
+ */
 export type CommandRequest<T> = T extends keyof Commands
   ? Commands[T]["request"]
   : never;
+/**
+ * The response shape a given {@link RequestType} yields, read out of
+ * {@link Commands}. `never` for anything that is not a request type, as
+ * {@link CommandRequest} is.
+ */
 export type CommandResponse<T> = T extends keyof Commands
   ? Commands[T]["response"]
   : never;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Third prep step for the IPC envelope work, after #6269 and #6282. It brings the
tests and the protocol declarations in the codec change's blast radius up to
what `unit-test-coding-style.md` and `code-comment-style.md` ask for, so that
the change lands on files that already say what they mean.

Scope was measured before it was chosen: 18 files, 10,448 lines. Two kinds of
gap are **deliberately not** here — wrapping `runtime-processor.test.ts`'s 25
top-level `describe()`s into one would re-indent 4,088 lines of the file the
codec change edits most, and moving `runtime-client`'s 13 test files into a
`test/` tree would collide with everything. Both are filed, together with the class-member layout `main-applicator.test.ts`
still lacks, as one item that waits for the codec change rather than preceding it.

## `test(html)` — BDD and `expect()`

The two files still on `Deno.test` and `assert*()`. Ninety assertions convert:
`assertEquals` against a literal primitive to `toBe`, against anything else to
`toEqual`, which preserves its deep-equality semantics rather than tightening
to identity. Three `assertEquals(x !== null, true)` become
`expect(x).not.toBe(null)`, that shape being one the style doc names as
carrying the weaknesses of both forms.

Twelve `assertExists` calls **stay**, under the style doc's own carve-out, with
a comment saying why: it asserts neither `null` nor `undefined` in one call and
narrows the value for the lines after it, and `toBeDefined()` does neither.
Several sites depend on that narrowing.

**The leaf test set is unchanged**, checked against a recorded inventory of the
run rather than by reading: 31 leaves in the applicator file before and after
with the same names, 10 in the renderer file.

## `test(runtime-client)` — descriptions complete "it"

Sixteen led with their subject, reading as "it `getFavorites` returns the
favorites list". The subject moves into a `describe()` naming the member, which
is where the style doc puts it. The tests were already contiguous by subject,
so nothing is reordered and no execution order changes.

Whole-diff characterization rather than a sample: `runtime-processor.test.ts`
holds 123 `it()` calls before and after, the seven renamed are exactly the seven
intended, and the seven added `describe()` calls are exactly the members they
name.

## `docs(runtime-client)` — the protocol says what it means

`guards.ts` had a doc comment on none of its 17 exports; `types.ts` on 24 of
146 symbols and 6 of 316 members.

For the guards, the bound is the load-bearing half. `isInitializationData`
checks two strings and that `identity` is merely *present*.
`isVDomBatchNotification` looks inside neither `ops` nor `rootId`.
`isIPCRemoteResponse` accepts a bare `{ msgId }`, that being how the worker acks
a handler that returned nothing. Each says so.

For `types.ts`, **the 69 discriminant fields are skipped on purpose, and the
enum members are why**. A `type: RequestType.Initialize` field has no noun
phrase that is not its signature restated — but `RequestType.Initialize` has a
great deal to say, and all 70 enum members across the file's five enums were
bare. Documenting those puts the content where a reader following the type
lands, and leaves the field's silence meaning "the contract is at the type"
rather than "nobody wrote one". Count-neutral against the 69 not written, and
the prose is worth reading: that `Idle` waits for durable commits and not merely
for reactive quiescence; that `CellSet` and `CellPush` differ by how a value is
applied rather than by what they carry; that `GetPatternCoverage` distinguishes
a worker with no collector from a collector that saw nothing.

`RuntimeTransport.dispose()` gains the doc its sibling `send()` already had, so
that `WebWorkerRuntimeTransport` can take `/** @inheritDoc */` — the repo's form
for an override needing no further detail, and its only applicable site here —
and have something to inherit.

## Corrections after review

A reviewer running `cf-review` verified the primary charge by a stronger method
than mine — pairing every leaf body across base and head by name (with an
explicit rename map), canonicalizing each assertion into comparison semantics,
and diffing the code outside leaf bodies separately for fixture changes. Result:
zero residue differences and zero assertion-count differences across ~230 paired
tests, plus three mutation ablations confirming the converted suites still grip.

Two of my own measurements were wrong and are corrected above and below.

- **`it()` count is 123, not 122.** One description contains `meta:"cfc"` and so
  is single-quoted; my counting regex required `it("`. Both sides agree either
  way, but the number I published did not match its own population.
- **`assertEquals` → `toEqual` was a loosening**, at 17 sites. `toEqual` ignores
  an explicitly-`undefined` property and an extra `undefined` array item;
  `assertEquals` fails on both. Measured, not assumed. `toStrictEqual` matches
  `assertEquals` exactly and all 17 pass under it, so the strength is restored.

### Behavioral claims corrected

Three doc comments overclaimed, and the class matters more than the count: a
confidently wrong sentence about behavior is the worst thing a change like this
can carry, being invisible to every gate the repo has and more expensive than
the silence it replaced.

- **`CellSet`** said "last write wins, with no compare-and-set", which reads as
  unconditional. A blind write drops the *value-equality* precondition, but
  `applyCellWrite()` threads one structural precondition in its place, on the
  cell's parent — so a concurrent delete of the enclosing document or a reshape
  of an ancestor still rejects it. Cubic caught this.
- **`RegisterSpaceHost`** said an already-accepted route is kept rather than
  replaced. That was lifted from the name of a test about `watchSiteTable`, a
  different mechanism, and is not something this request's path establishes.
  Acceptance is the storage manager's to decide.
- **`SetWriteStackTraceMatchers`** claimed an empty matcher set records nothing,
  which was inference rather than a read.

Five more were found afterwards — three by re-auditing on the strength of the
first, two by the reviewer:

- **The three scheduler collection toggles** (settle stats, action-run tracing,
  trigger tracing) each *discard* what they have collected when set false. None
  of the docs said so; a client that toggles one off and on loses its data.
- **`GetSettleStats`** named one cause for a `null` that has two: recording off,
  and recording on with no settle pass completed.
- **`VDomBatchApplied`** claimed the worker uses the ack to pace what it sends.
  It does not — `acknowledgeBatchApplied()` defers retiring an event handler
  whose node a batch removed until the client confirms that batch landed, and
  `scheduleFlush()` fires on a microtask regardless. That one would have sent a
  reader hunting for backpressure that does not exist.
- **`PageGetAll`** claimed it answers with every piece in a space; it answers
  with a ref to the cell holding the registry.

Eight in all. The pattern is the point: one confirmed overclaim is evidence
about the *method* — here, "read the shape, infer the behavior" — and not just
about the sentence, so the response is to re-audit everything derived the same
way rather than to fix the one that was caught.

### Also from review

The 25 pre-existing `//` blocks that the doc pass left sitting *above* its new
comments — the position `code-comment-style.md` bans — turned out to be worse
than placement. Several said more than what was written beneath them, so the
pass was a net loss of information at those members. All are folded, with the
older text winning wherever it was the better statement, and the two
`TODO(danfuzz)` markers moved inside their doc comments.

Both files now fit 80 columns; the base had three lines that did not.

## Verification

- `deno task check`, `deno lint`, `deno fmt --check`, `check-docs`: green.
- Full workspace `deno task test` at `498ff5e23`: green, 446s, tree clean before
  and after, `deno.lock` untouched.
- **No enum member's name or value moved**: 70 name-value pairs before and
  after, in the same order, compared against `HEAD` rather than eyeballed.
- Final counts: `guards.ts` 17/17 symbols; `types.ts` 146/146 symbols, 246
  members, 70/70 enum members, 0 bare, 69 discriminants skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121sxMwWK139eKHNNGrjygY


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




