### PR TITLE
fix(dashboard): wait for connectivity before production checks

### DIFF
--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -321,6 +321,12 @@ surveillance tool.
 | dau | distinct identities active per UTC day on one named service, counted from the `user.did` attribute on the `memory.transact` and `memory.subscriber.sync` spans in SigNoz. The headline is the last day that ran to the end (today is still filling, and a part-day always reads as a drop); the sparkline is the retained history. Gray while the named service has no such spans — which is the resting state until a deployment's tracing is switched on. It counts keypairs rather than people; see [dau](#dau) below | `SIGNOZ_URL`, `SIGNOZ_API_KEY`; optional `PROD_SERVICE`, `DAU_EXCLUDE_DIDS`, `SIGNOZ_UI_URL` |
 | github users | organization members plus outside collaborators, with each roster's size charted over about two months. The headline counts unique users across both rosters | `GH_TOKEN` (with org Members read) |
 
+The **production** tile starts gray and says `waiting for connectivity` until
+the independent **common.tools** check receives an HTTP response. It performs
+no production host checks before that signal. The confirmation lasts for the
+process lifetime, so an unreachable production host is then reported as an
+outage even when every production host is unreachable together.
+
 The **labs ci** and **loom ci** headlines use the most recent completed
 workflow attempt. While GitHub reruns a workflow, the prior attempt's conclusion
 remains visible and the tile marks the activity as **build rerunning**. A new

--- a/packages/dashboard/connectivity.ts
+++ b/packages/dashboard/connectivity.ts
@@ -1,0 +1,26 @@
+/**
+ * Records whether this dashboard process has received a response from a public
+ * host. Production checks wait for that evidence before interpreting their own
+ * failures as outages.
+ */
+
+let confirmed = false;
+
+/** Records that the dashboard has received a response from a public host. */
+export function confirmDashboardConnectivity(): void {
+  confirmed = true;
+}
+
+/** Returns whether this process has confirmed public connectivity. */
+export function dashboardConnectivityConfirmed(): boolean {
+  return confirmed;
+}
+
+/** Sets the connectivity state for a test and returns its restorer. */
+export function setDashboardConnectivityForTest(value: boolean): () => void {
+  const previous = confirmed;
+  confirmed = value;
+  return () => {
+    confirmed = previous;
+  };
+}

--- a/packages/dashboard/tiles/common-tools-up.test.ts
+++ b/packages/dashboard/tiles/common-tools-up.test.ts
@@ -8,6 +8,10 @@
  */
 
 import { assert, assertEquals } from "@std/assert";
+import {
+  dashboardConnectivityConfirmed,
+  setDashboardConnectivityForTest,
+} from "../connectivity.ts";
 import type { Ctx } from "../types.ts";
 import { commonToolsUp } from "./common-tools-up.ts";
 
@@ -42,6 +46,22 @@ const ok = (status: number) => () => new Response(null, { status });
 const unreachable = () => {
   throw new TypeError("error sending request");
 };
+
+Deno.test("common.tools: an HTTP response confirms dashboard connectivity", async () => {
+  const restoreConnectivity = setDashboardConnectivityForTest(false);
+  try {
+    await withFetch(unreachable, () => commonToolsUp.collect(ctx()));
+    assertEquals(dashboardConnectivityConfirmed(), false);
+
+    await withFetch(ok(503), () => commonToolsUp.collect(ctx()));
+    assertEquals(dashboardConnectivityConfirmed(), true);
+
+    await withFetch(unreachable, () => commonToolsUp.collect(ctx()));
+    assertEquals(dashboardConnectivityConfirmed(), true);
+  } finally {
+    restoreConnectivity();
+  }
+});
 
 // Makes Date.now() report the given elapsed span across the two readings the
 // tile takes around fetch.

--- a/packages/dashboard/tiles/common-tools-up.ts
+++ b/packages/dashboard/tiles/common-tools-up.ts
@@ -7,6 +7,7 @@
  * the www host when the apex redirects.
  */
 
+import { confirmDashboardConnectivity } from "../connectivity.ts";
 import type { Status, Tile, TileView } from "../types.ts";
 
 const FAIL_THRESHOLD = 3; // consecutive unreachable checks before declaring "down"
@@ -22,6 +23,7 @@ export const commonToolsUp: Tile = {
     try {
       const t0 = Date.now();
       const res = await fetch(url, { signal: AbortSignal.timeout(8000), redirect: "manual" });
+      confirmDashboardConnectivity();
       const ms = Date.now() - t0;
       try {
         await res.body?.cancel();

--- a/packages/dashboard/tiles/prod-uptime.test.ts
+++ b/packages/dashboard/tiles/prod-uptime.test.ts
@@ -9,6 +9,10 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
+import {
+  confirmDashboardConnectivity,
+  setDashboardConnectivityForTest,
+} from "../connectivity.ts";
 import type { Ctx, TileView } from "../types.ts";
 import type { ProxyStream } from "./prod-uptime.ts";
 import {
@@ -17,6 +21,9 @@ import {
   setProdUptimeHttpClientFactoryForTest,
   setProdUptimeProxyStreamOpenerForTest,
 } from "./prod-uptime.ts";
+
+// Most tests exercise host checks after public connectivity is established.
+confirmDashboardConnectivity();
 
 type ProxyFetchInit = RequestInit & { client?: Deno.HttpClient };
 type DnsReply = readonly string[] | Error;
@@ -167,6 +174,49 @@ async function withLatency(ms: number): Promise<TileView> {
     restore();
   }
 }
+
+Deno.test("prod uptime: waits for public connectivity before checking hosts", async () => {
+  let dnsReachable = true;
+  let fetches = 0;
+  let resolutions = 0;
+  const restoreConnectivity = setDashboardConnectivityForTest(false);
+  const restore = stub(
+    () => {
+      fetches++;
+      throw new TypeError("unreachable");
+    },
+    () => {
+      resolutions++;
+      return dnsReachable
+        ? ["100.64.0.1"]
+        : new Deno.errors.NotFound("no record");
+    },
+  );
+  try {
+    const waiting = await prodUptime.collect(ctx());
+    assertEquals(waiting.status, "unknown");
+    assertEquals(waiting.value, "—");
+    assertEquals(waiting.sub, "waiting for connectivity");
+    assertEquals(waiting.extra, undefined);
+    assertEquals(fetches, 0);
+    assertEquals(resolutions, 0);
+
+    confirmDashboardConnectivity();
+    const partialOutage = await prodUptime.collect(ctx());
+    assertEquals(partialOutage.status, "bad");
+    assertEquals(partialOutage.value, "2 hosts down");
+    assertEquals(fetches, 2);
+    assertEquals(resolutions, 14);
+
+    dnsReachable = false;
+    const outage = await prodUptime.collect(ctx());
+    assertEquals(outage.status, "bad");
+    assertEquals(outage.value, "7 hosts down");
+  } finally {
+    restore();
+    restoreConnectivity();
+  }
+});
 
 Deno.test("prod uptime: healthy servers keep pings while DNS-only hosts disappear", async () => {
   const fetched: string[] = [];

--- a/packages/dashboard/tiles/prod-uptime.ts
+++ b/packages/dashboard/tiles/prod-uptime.ts
@@ -6,6 +6,10 @@
  * and warning states, a red state shows only the hosts that are not good, and
  * a host that answers stays out of the body.
  *
+ * The tile stays unknown until the public-site check has received an HTTP
+ * response. It does not check production hosts before that independent signal
+ * confirms the dashboard's own connectivity.
+ *
  * Both servers are on the tailnet. PROD_PROXY routes the health requests
  * through a proxy when the dashboard cannot reach the tailnet directly.
  * Tailnet names live in Tailscale's MagicDNS, which the resolver of a
@@ -16,6 +20,7 @@
  * from the dashboard itself.
  */
 
+import { dashboardConnectivityConfirmed } from "../connectivity.ts";
 import { escapeHtml } from "../lib.ts";
 import type { Status, Tile, TileView } from "../types.ts";
 
@@ -451,6 +456,14 @@ export const prodUptime: Tile = {
   id: "prod-uptime",
   intervalMs: 30_000,
   async collect(ctx): Promise<TileView> {
+    if (!dashboardConnectivityConfirmed()) {
+      return {
+        label: "production",
+        status: "unknown",
+        value: "—",
+        sub: "waiting for connectivity",
+      };
+    }
     const targets = [
       healthTarget(
         "estuary",


### PR DESCRIPTION
The dashboard can collect before its container network is ready after a restart. Production checks then interpret the local startup failure as an outage across every monitored host.

Use the public common.tools request as an independent, process-lifetime connectivity signal. Keep production gray and skip its HTTP, DNS, and proxy checks until that request receives a response. Once confirmed, production outages, including total outages, continue reporting normally.

The dashboard suite covers the waiting state, the first confirmed check, later outages, raster output, and browser behavior. Repository-wide format, lint, and type checks also pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

