### PR TITLE
docs: plan random space identities and name registry

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -63,6 +63,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
   sequences how long an invocation record is kept and what the runtime knows
   about who caused it — the `AgentActor` mint, trusted ingress, and metadata
   confidentiality. Gated on a CFC review that has not happened.
+- [Random space identities](random-space-identities.md) replaces publicly
+  derived named-space keys with fresh random identities whose authority ends
+  after ACL genesis. It is complete without a public name registry.
 - [CFC runner implementation](runner_cfc_implementation.md) defines the
   commit-boundary enforcement workstreams and rollout.
 - [Bulk piece operations](piece-bulk-operations.md) designs retargeting,
@@ -78,6 +81,9 @@ a record: archive it to `docs/history/plans/` following the procedure in
   [`../development/space-clone-rehearsal.md`](../development/space-clone-rehearsal.md).
   The plan stays live until the practice has been exercised on a real
   migration.
+- [Space name registry](space-name-registry.md) adds an optional
+  deployment-scoped public alias service over canonical space DIDs. It remains
+  independent of space creation and authorization.
 - [Reading Fabric data](fabric-read-model.md) is the umbrella for one model
   across three concerns: everything addressable is a cell, so a verb's result
   and a direct read are the same operation on different cells. It carries the

--- a/docs/plans/random-space-identities.md
+++ b/docs/plans/random-space-identities.md
@@ -1,0 +1,642 @@
+# Random space identities implementation plan
+
+## Status
+
+Proposed. Not started.
+
+This plan is implemented, migrated, and landed enabled in one pull request. It
+has no feature flag, opt-out mode, deprecation period, or mixed old-and-new
+creation path.
+
+That one-shot promise applies to the labs runtime and data migration. The
+conflicting normative CFC text lives in another repository, so its amendment is
+a coordinated specification prerequisite. It lands first and introduces no
+runtime phase or compatibility mode.
+
+The change removes the fixed `"common user"` root from space creation. It does
+not require a global name registry. Friendly names remain personal Home labels,
+and canonical navigation uses space DIDs.
+
+## Decision
+
+Create every new non-home space from fresh cryptographically secure random key
+data. Use the resulting space identity only to authorize the first ACL commit.
+After a valid ACL exists, the space identity has no implicit authority and its
+private key data is discarded.
+
+The initial ACL names the acting user as its only owner:
+
+```json
+{
+  "did:key:<acting-user>": "OWNER"
+}
+```
+
+Do not add the current `"*": "WRITE"` rollout grant to newly created spaces.
+Changing wildcard grants on existing spaces is a separate access-policy
+migration and is not implicit in this plan.
+
+The space's display name is stored beside its DID in the user's Home space. It
+is not an input to key generation and is not globally unique.
+
+## Why
+
+The current named-space algorithm derives a private key from two public strings:
+`"common user"` and the space name. Equal names resolve to one shared space
+across all users, and anyone who knows the name can reconstruct the space's
+implicit-owner key.
+
+Writing the acting user's DID into the ACL does not retire that key. The memory
+server currently grants permanent implicit `OWNER` when a session principal
+equals the space DID. A complete fix therefore has two inseparable parts:
+
+1. stop deriving new space keys from public inputs;
+2. limit a space identity to ACL genesis instead of treating it as a permanent
+   owner.
+
+The
+[`ct-space` recovery design at commit `850bca9ae`](https://github.com/commontoolsinc/labs/blob/850bca9aed74c22773de5caa2b0b81c98713e646/docs/access-recovery.md)
+begins space creation by generating a keypair and then addresses recovery of
+that key. The
+[`ct-space` keyring design at commit `a98c7444b`](https://github.com/commontoolsinc/labs/blob/a98c7444b08a944467171539a1e7baf7082e367d/docs/keyring-architecture.md)
+also puts space-key generation in the local trusted boundary. This plan keeps
+that boundary but takes a smaller route: because the key has no post-genesis
+authority, it does not need long-term backup, synchronization, rotation, or
+recovery.
+
+Do not derive a space from the user's identity. A public user DID is no safer
+than a public display name. A derivation keyed by the user's private identity
+would make that identity a permanent master key and couple space recovery and
+rotation to user-key recovery. Adding a counter would still require durable
+allocation state. Fresh randomness plus an explicit ACL keeps identity,
+authority, and naming independent.
+
+## Specification connections and conflicts
+
+This proposal was checked against the current labs documentation and the full
+`commontoolsinc/specs` document corpus at commit
+[`5fb2c6435`](https://github.com/commontoolsinc/specs/tree/5fb2c64357f643f7344d00cdb049f0d9e5983ef0).
+The other specs projects either treat a space as an opaque `did:key` sharing
+boundary or do not constrain space allocation. The material connections are:
+
+- [Home space and user identity](../common/conventions/HOME_SPACE.md) and
+  [Home runtime internals](../features/home-space-internals.md) define the home
+  space DID as the user DID. They also describe the temporary
+  space-authenticated ACL bootstrap. This proposal preserves the DID equality
+  and makes the resulting explicit self-owner ACL the durable authority.
+- [CFC space principals and role membership](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/03-core-concepts.md#36-spaces-and-role-based-confidentiality)
+  make the space DID a confidentiality principal and make administered
+  membership an ACL-backed fact. That agrees with separating an opaque space DID
+  from its owners.
+- Memory v2 already specifies the required ACL-only genesis shape in
+  [INV-12 and INV-13](../specs/memory-v2/09-invariants.md#inv-12--acl-mutation-commit-shape).
+  Its [protocol](../specs/memory-v2/04-protocol.md#451-current-pass) conflicts
+  only where it says the space DID retains implicit `OWNER` for later repair.
+  Preserve its genesis rule and remove that post-genesis repair authority.
+- [CFC `HasRole` fact generation](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/04-label-representation.md#493-hasrole-fact-generation)
+  and its
+  [formal membership model](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/formal/Cfc/Membership.lean#L101-L113)
+  directly conflict with this proposal. They currently grant reader-or-higher
+  membership when `principal === space`, even without an ACL grant. Before the
+  implementation starts, remove that branch entirely from CFC `HasRole` and
+  formal membership. State that the separate Memory sequence-zero admission rule
+  governs ACL genesis without granting CFC membership. An ordinary principal's
+  `HasRole` must come from the declared ACL. Configured service authority
+  remains the existing separate resolver branch; removing it is not part of this
+  plan. The same assumption is recorded in the historical
+  [CFC render-membership design](../history/specs/cfc-render-membership-lookup.md);
+  retain that file as history rather than treating it as a live contract. Home
+  remains accessible because its ACL explicitly names the same DID.
+- [CFC trusted derived identifiers](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/02-overview.md#24-trusted-derived-identifiers)
+  and
+  [CFC causal addressing](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/17-addressing-and-storage.md#171-causal-id-storage-core-cfc-path)
+  require deterministic coordination identifiers to be typed runtime values, not
+  raw digest-shaped authority. An event-derived creation operation ID must
+  follow that contract. It selects an idempotency record and never determines
+  the random key or grants access to the resulting space.
+- [Server-side provisioning](../specs/server-side-execution/protocol.md#2b-cross-space-writes)
+  currently obtains replay convergence by deriving the destination DID from the
+  creation event. This proposal preserves the convergence property by durably
+  associating that trusted event operation with one random allocation. The
+  protocol and its
+  [runtime map](../specs/server-side-execution/runtime-mapping.md) must replace
+  “re-derive the same DID” with “recover the same recorded allocation.”
+- The current [identity tutorial](../tutorial/10-identity-and-security.md),
+  [FUSE path specification](../specs/fuse-filesystem/2-path-scheme.md),
+  [shell routes](../../packages/shell/README.md#routes),
+  [navigation guide](../common/patterns/navigation.md), and
+  [shared-profile specification](../specs/shared-profile-space.md#profile-space-identity)
+  describe name-derived spaces or name-or-DID routes. They are implementation
+  migration targets, not compatible alternate contracts.
+- [Pattern import resolution](../specs/pattern-imports/README.md#open-questions)
+  already keeps human-readable aliases outside Fabric resolution and treats a
+  DID plus an accepted host hint as the runtime boundary. That is the same
+  separation used here.
+- [Toolshed storage configuration](../development/CONFIGURATION.md#memory-store)
+  currently configures Common Memory as per-space SQLite files or one combined
+  memory file. It does not provide a private control database or key-protection
+  facility. This proposal therefore adds those facilities explicitly instead of
+  assuming they already exist or storing allocator secrets in a Fabric space.
+
+The required CFC amendment is a cross-repository preparation result, not a
+compatibility phase. It must be accepted before the one-shot labs implementation
+pull request. The labs runtime, data migration, and live documentation then land
+consistent with it in the single cutover.
+
+## Invariants
+
+1. Every newly created non-home space gets at least 256 bits of randomness from
+   the platform cryptographic random-number generator.
+2. The display name, user DID, operation identifier, event identifier, clock,
+   and process state do not determine the random key data.
+3. A space DID is the canonical and permanent address of that space.
+4. The space identity may authenticate only a valid ACL-only genesis commit
+   while the space has no ACL and server sequence zero.
+5. After genesis, only the ACL and configured service identities grant access.
+6. The acting user's authenticated DID is the genesis ACL owner. A service
+   executing on the user's behalf is not written into the ACL.
+7. Random key data never appears in Fabric values, URLs, logs, telemetry,
+   errors, or client-visible protocol results.
+8. A failed creation does not add a visible Home entry.
+9. Re-execution after scheduler replay or process loss reuses the allocation
+   recorded for the authenticated principal and logical operation. A
+   deterministic operation identifier is a CFC trusted derived identifier and is
+   never treated as space authority.
+10. A created space's DID-to-host hint is durable before its Home entry becomes
+    visible.
+11. Random space creation and DID resolution do not depend on a global name
+    registry.
+12. A canonical URL binds both the DID and its route: an explicit validated host
+    for a non-default store, or the deployment's fixed default host. Personal
+    Home hints never override that navigation-bound route.
+13. Authorization is checked only after the URL selects that common DID and
+    host, so viewer identity can change access but never the target.
+
+## Space identity authority
+
+Replace the memory authorization rule in the same pull request that introduces
+random creation and migrates legacy data. The replacement lands active; there is
+no runtime switch between the two rules.
+
+For a fresh space with no ACL and server sequence zero, a session whose
+principal equals the space DID may submit one valid ACL-only genesis
+transaction. It cannot perform an ordinary read or any other write. Existing
+genesis validation continues to require a concrete owner and the exact
+whole-document operation shape.
+
+Once a valid ACL exists, `principal === space` no longer grants `OWNER`. The
+principal is evaluated like any other identity against the ACL. This has three
+consequences:
+
+- discarding the random private key is safe;
+- learning old or transient space key data does not confer lasting authority;
+- transferring every ACL grant away from a creator is a real transfer.
+
+Home spaces need no exception. A home space's DID equals the user's DID, and its
+genesis ACL explicitly grants that DID `OWNER`. It therefore retains ordinary
+access through the ACL after the implicit rule is narrowed.
+
+Configured service DIDs retain their separately declared authority. Repair of a
+malformed or ownerless ACL becomes an operator operation through that explicit
+authority or offline storage tooling. Do not preserve an ambient space-key
+repair path; it would recreate the permanent master key this plan removes.
+
+Apply this authorization change to session open, reads, writes, ACL mutation,
+CFC membership, foreign-write authority, and every other place that currently
+special-cases `principal === space`. Add one shared capability function or
+shared rule vocabulary so those decisions cannot drift.
+
+## Creation primitive
+
+Replace name resolution as a creation mechanism with an explicit `createSpace`
+operation. It accepts:
+
+- an operation identifier;
+- an optional target storage host selected through the ordinary routing policy.
+
+The storage authority at the target host owns allocation. Browsers, local
+clients, and served runs call its signed creation endpoint; they never generate
+or retain the space key. The signature binds the method, path, target-host
+audience, operation identifier, and canonical request. The authority obtains the
+owner DID from that authenticated caller or from the served run's verified
+acting-principal proof. The request does not supply an owner field. A missing
+acting principal is an authorization failure; the service identity is never
+substituted.
+
+An interactive caller obtains an opaque operation nonce from the trusted client
+runtime. A replayable event path uses the runtime's typed trusted-derived-ID
+form over its principal-bound frame cause and call ordinal. The allocator
+rejects a raw event digest in that position. Neither form is a capability for
+the resulting DID; request authentication and the genesis rule remain the only
+pre-ACL authority.
+
+The target toolshed stores operation records in a Toolshed-private control
+database, separate from Common Memory's per-space storage and service Fabric
+space. The implementation adds one SQLite file beside the configured memory
+store and runs schema migration before accepting traffic. One allocator process
+owns that file and the spaces it allocates; deployments with several front ends
+route creation to that authority.
+
+Pending key data is encrypted with an authenticated-encryption key supplied by
+deployment secret configuration. The local daemon creates one persistent
+mode-`0600` key file beside its control database when neither exists. It refuses
+to start if only one exists or if the key file is accessible to other users.
+Production does not generate a replacement for a missing key. Browser-only
+memory and test fakes may implement the protocol for tests, but are not
+supported creation authorities.
+
+It returns the new space DID and canonical storage host only after ACL genesis
+is confirmed. The random private key remains inside the target storage
+authority.
+
+Creation proceeds as follows:
+
+1. Verify the signed request, canonicalize the target host, and look up a
+   private durable operation record keyed by the acting principal and operation
+   identifier.
+2. If the record is absent, generate fresh random key data once, construct the
+   space identity, and durably record the host, DID, and encrypted key data
+   before opening the space.
+3. If a record exists, reuse its allocation. Reject the operation identifier if
+   its recorded host or other canonical request fields differ.
+4. Open the empty space as its identity and commit the owner-only genesis ACL
+   naming the acting user.
+5. Atomically mark genesis confirmed and erase the encrypted private key from
+   the operation record and every runtime registry.
+6. Reopen as the acting user and confirm ordinary access.
+7. Return the recorded DID and host.
+
+The operation does not probe for name availability. Two creations with the same
+display name produce distinct DIDs.
+
+The operation record is a transaction journal, not a space-key backup. Protect
+its pending key data with the control-database encryption key and never place it
+in Fabric or a client-visible receipt. Erase the private key as soon as genesis
+is confirmed. Retain the non-secret DID, host, owner, request digest, state, and
+result for the allocator's lifetime. A delayed or repeated delivery therefore
+cannot turn a completed logical operation into a fresh allocation.
+
+A process that stops before genesis resumes with the same pending key. A process
+that stops after genesis resumes with the recorded DID. This preserves the
+ordered cross-space commit guarantee: child data may commit before a parent or
+Home link, but replay addresses the same child space instead of creating a
+populated orphan and repeating its effects.
+
+If replay reaches a space whose genesis commit already landed, reopen it as the
+recorded acting owner and verify the expected genesis ACL and recorded
+allocation before marking the operation confirmed. Allow content authorized
+after genesis, including the server-created default root. An ACL or allocation
+mismatch is a terminal integrity error; do not allocate a replacement under the
+same operation.
+
+Do not add timeouts, sleeps, or automatic retry loops. Completion follows the
+genesis commit result, and re-execution consults the durable operation state.
+
+## Home entries and personal names
+
+Make Home's space list a personal address book whose entries contain:
+
+| Field  | Meaning                                                       |
+| ------ | ------------------------------------------------------------- |
+| `id`   | Stable entry identity, normally the space DID for new entries |
+| `name` | Editable personal display name                                |
+| `did`  | Canonical space address                                       |
+
+Require all three fields in the final schema. The migration converts or
+quarantines every old entry before that schema lands; there is no optional-DID
+read path. Address array entities by `id`, not by `name`, so one user may have
+two spaces with the same display name and may rename either without changing its
+identity.
+
+Home names never participate in URL resolution. They are personal presentation
+and command-selection metadata only. A shared URL must carry a DID or use the
+separate deployment-wide registry, so its target cannot vary with the viewer's
+Home contents.
+
+Keep routing in the existing Home site table rather than adding a host field to
+the display entry. Before making a new display entry visible, append the
+validated `{ did, host }` hint returned by `createSpace` to that table. A replay
+may repeat the same hint and Home mutation, but the principal-bound creation
+record makes them refer to the same space.
+
+The site table helps construct links and route non-URL operations; it does not
+override a route already bound by a URL. Clicking a Home entry navigates to
+`/<space-did>` for the deployment default host or
+`/<space-did>?host=<encoded-origin>` for another host. Deep links retain the
+same query after the piece address. The shell validates the origin and opens
+through that navigation-bound route even when Home contains a conflicting hint.
+
+The shell may display the personal name while the URL remains DID-addressed. A
+shared link contains the DID and the host when non-default, and may carry a
+non-authoritative suggested label as presentation metadata.
+
+Without a global registry, typing an arbitrary name cannot open an unknown
+space. The user selects a Home entry, imports a DID-addressed link, or enters a
+DID explicitly.
+
+## Pattern space selection
+
+Make the Pattern Factory surface unambiguous:
+
+- `inSpace()` creates a fresh space for the logical creation event;
+- `inSpace(spaceDid)` addresses an existing space;
+- `inSpace(cell)` addresses the cell's space;
+- `inSpace("name")` is removed.
+
+Anonymous creation already separates a profile's editable display name from its
+space identity and carries a durable per-event cause. Replace its final
+fixed-passphrase derivation with the random creation primitive. Preserve one
+allocation per acting principal, frame cause, and call ordinal across scheduler
+and process re-execution. Record the returned route through the same site-table
+flow before publishing the parent link.
+
+Persist the resulting DID and host in the parent event's graph state under the
+frame cause and call ordinal. Reevaluation consults that state before calling
+the allocator. The mapping remains for the lifetime of the persisted parent
+event. The allocator also retains its non-secret result record, so a delayed
+delivery still converges after the parent has recorded the mapping.
+
+Migrate every repository-owned pattern in the implementation pull request. Do
+not rewrite persisted user source automatically: changing source can change its
+compiled identity, causes, registrations, and provenance. Preparation lists
+every persisted user pattern using named space selection. Its owner must migrate
+and reinstantiate it while preserving the intended data, or explicitly accept
+that the old instance will stop updating. Given the current negligible user
+population, the cutover requires this list to be empty unless a concrete
+exception is recorded.
+
+There is no runtime compatibility shim. Recompilation of any remaining
+`inSpace("name")` reports a focused error instructing the author to use
+anonymous creation, a DID, or a cell.
+
+A name registry, if separately installed, resolves its alias outside pattern
+construction and supplies the resulting DID. The Pattern Factory never imports
+or calls registry code.
+
+## Shell, CLI, FUSE, and services
+
+Keep the existing `/<space-did>` and `/<space-did>/<piece-address>` path forms.
+For a non-default host, add the validated `?host=<encoded-origin>` query to
+either form. URL navigation uses that host or the fixed deployment default and
+ignores conflicting Home hints.
+
+Remove legacy `/<space-name>` handling entirely. A first path segment that is
+neither a built-in nor a DID returns not found uniformly; it is not retained as
+a dormant registry hook. If the separate registry is installed, the server may
+resolve an exact registered `/<name>` before serving the shell. It can be
+implemented or omitted without changing this parser.
+
+Preparation inventories the negligible set of known legacy name and product
+links and migrates them directly to DID-and-host URLs in the same pull request.
+Arbitrary unrecorded name-only links are accepted breakage rather than a
+personal, dormant, or hidden registry.
+
+Remove `createSession({ spaceName })`. Session creation accepts an explicit
+space DID, while the shell turns Home selections into explicit DIDs and the new
+creation primitive owns random identity generation and genesis.
+
+Replace each other bare-name dependency:
+
+- The shell creates spaces through `createSpace`. It records the returned host
+  hint and Home entry before navigating to the canonical DID URL.
+- CLI commands accept a DID. Commands with an identity may resolve a personal
+  Home display name, and reject ambiguous matches with the matching DIDs.
+- FUSE connects DIDs recorded in `.spaces.json`; an unknown directory name does
+  not synthesize a space.
+- The state inspector accepts a DID, DID prefix, or database path. It does not
+  derive a DID from a name.
+- Background services and system-space configuration carry explicit DIDs.
+- Clone-to-new-space uses `createSpace`, records its returned route, then clones
+  to its returned DID.
+- Host embedding receives a DID for an existing space or invokes the explicit
+  creation operation.
+
+Keep all name handling above the runtime boundary. Once a client selects an
+entry, every request below that boundary contains the DID.
+
+## In-pull-request migration
+
+Existing spaces keep their DIDs and data. This is an address-preserving
+authority migration, not a re-key of stored contents. The implementation pull
+request contains the schema, data, ACL, route, configuration, source, and link
+migrations and removes the old path in the same change. There is no period in
+which both creation algorithms are supported.
+
+Preparation drafts an explicit manifest while the legacy derivation is still
+available. At deployment, the migration quiesces legacy creation and writes,
+drains old server instances and sessions, configures the new server to reject a
+missing or old client protocol version before subsequent reads, takes a final
+authoritative inventory at a fixed storage revision, and reconciles the draft
+before changing data. The terminal incompatibility response instructs the user
+to reload; it does not assume the old client can reload itself. The inventory
+records every known named space's DID, host, verified owner, and personal
+display name. The new binary does not start if a live space is unclassified or
+differs from its reconciled entry.
+
+The migration is a durable, resumable operation because its writes span many
+Fabric spaces, ingest state, and product configuration and cannot share one
+atomic commit. Its toolshed ledger records the fixed source revision, manifest
+digest, each target's expected revision and completion, both security-audit
+results, and a final cutover marker. Every step is idempotent and refuses an
+unexpected revision. A crash leaves the write barrier in place and resumes from
+the ledger; it does not roll back completed repairs.
+
+The new binary serves only after the final marker proves that concrete ACL
+owners, Home DIDs and display names, site-table routes, configuration, and
+security cleanup all completed. Populated spaces that cannot be assigned a
+verified owner are retired rather than kept behind a compatibility exception.
+This is one bounded deployment operation, not a coexistence period.
+
+The implementation also fulfills the current security tripwire. It retires
+ingest channels minted under publicly reconstructible keys, removes explicit ACL
+grants to non-home spaces' own DIDs, preserves legitimate home self-owner
+grants, and checks for unexplained concrete owners. A signature made with the
+old key is not evidence that its grant is legitimate.
+
+After migration, the repository contains no executable production copy of the
+fixed passphrase or its derivation algorithm. Documentation and migration
+records may describe the former behavior.
+
+## Relationship to a name registry
+
+This plan does not define a public name-resolution service. Its only mapping is
+the user's personal Home list, which is sufficient to render and reopen their
+own spaces.
+
+If the separate name-registry plan is already implemented, a caller may claim an
+alias with the returned DID and host after `createSpace` returns. If it is
+implemented later, existing random space routes can be registered without
+migration. If it is never implemented, every operation remains complete through
+DIDs, site-table hints, and Home labels.
+
+There is no shared creation transaction, schema, storage table, capability, or
+fallback between the two plans.
+
+## Preparation
+
+- Amend the CFC `HasRole` specification and formal membership model to remove
+  the `principal === space` branch entirely. Cross-reference Memory's separate
+  sequence-zero ACL-genesis admission rule, which grants no CFC membership.
+  Record the accepted specs commit in the implementation decision record.
+- Catalog every production derivation and every implicit `principal === space`
+  authorization check, including session, storage, CFC, worker, CLI, FUSE,
+  inspector, embedding, test-helper, and Pattern Factory paths.
+- Inventory hosted spaces by ACL state, route, owner, Home entry, and known
+  user-facing name. Produce the explicit migration manifest and identify any
+  populated space that must be retired because it has no verified owner.
+- Run the ingest-channel audit and retirement dry run, and record the exact
+  cleanup required by the derivation tripwire.
+- Select the Toolshed-private control-database path and deployment secret
+  source. Define local key-file creation, permissions, backup, restore, and
+  missing-or-mismatched database and key failure behavior.
+- Inventory repository-owned and persisted user `inSpace("name")` calls,
+  including instantiated patterns. Record the instance identity, cells, links,
+  provenance, and execution registration needed for owner-led migration.
+  Inventory product-operated and known shared bare URLs so their direct
+  replacements are part of the implementation diff.
+
+Preparation produces a decision record and migration manifest as inputs to the
+implementation. They are committed with the implementation, not landed
+separately. Preparation adds no runtime code, schema, flag, or compatibility
+path.
+
+## Implementation
+
+- Land one enabled cutover in one pull request:
+  - Define one shared authorization rule: a space principal may submit only an
+    ACL-only genesis transaction to a sequence-zero space with no ACL; afterward
+    the ACL and configured service identities are the only authority.
+  - Apply that rule consistently to session open, reads, writes, ACL mutation,
+    CFC membership, foreign-write authority, and serving paths, with no home or
+    legacy-name exception.
+  - Add `createSpace` with an owner derived only from authenticated execution
+    context and a canonical target host.
+  - Put allocation behind a signed endpoint owned by the target toolshed. Bind
+    the target-host audience and operation identifier, verify browser identity
+    or served acting-principal proof, and return only the DID and host.
+  - Implement the same endpoint and durable journal contract in the local
+    toolshed daemon; do not make a browser-only runtime a supported allocator.
+  - Add the private SQLite control database, schema migration, single-authority
+    routing, deployment-supplied encryption key, and protected local key-file
+    lifecycle. Keep this store independent of Common Memory and the service
+    Fabric space.
+  - Add the private durable operation record keyed by acting principal and
+    logical operation identifier, with request-digest conflict detection.
+  - Represent event-derived operation identifiers through the CFC trusted
+    derived-ID contract. Reject raw event digests, and keep the operation ID an
+    idempotency key rather than an authorization token.
+  - Generate at least 256 cryptographically random bits once per allocation,
+    protect the pending key at rest, erase it after confirmed genesis, and keep
+    the non-secret DID, host, owner, request digest, state, and result for the
+    allocator's lifetime.
+  - Commit an owner-only genesis ACL, close the bootstrap session, remount as
+    the acting user, and return the recorded DID and host.
+  - For anonymous `inSpace()`, persist the DID and host under the parent frame
+    cause and call ordinal, and consult that graph state on every reevaluation.
+  - Make `id`, `name`, and `did` required in the final Home schema, address
+    entries by `id`, and publish the DID-to-host site-table hint before exposing
+    a new entry.
+  - Remove legacy name parsing. Keep DID path forms and add a validated host
+    query for non-default stores; bind each URL navigation to that explicit host
+    or the fixed deployment default, ignoring conflicting personal hints.
+  - Change Home, hosted authoring, clone-to-new-space, host embedding, CLI,
+    FUSE, state inspection, services, and test helpers to create randomly or
+    open an explicit DID.
+  - Change anonymous `inSpace()` to use the random primitive, remove
+    `inSpace("name")`, migrate every repository caller to an explicit DID or
+    anonymous creation, and emit a focused source error for code that still uses
+    the removed form.
+  - Make deployment enter a write barrier, stop legacy creation, drain every old
+    server instance and session, and reject missing or old client protocol
+    versions before reads with a terminal response instructing reload. Then take
+    the final inventory at a fixed storage revision.
+  - Reconcile the prepared manifest against that revision and refuse to start
+    the new binary while any live space is missing, stale, or still writable by
+    the legacy protocol.
+  - Apply the reconciled manifest before serving with the new rule: install
+    verified ACL owners, preserve home self-owner grants, add Home DIDs and
+    labels, add DID-to-host hints, and retire unowned populated spaces.
+  - Run those cross-store writes through a durable toolshed migration ledger
+    with the fixed source revision, manifest digest, per-target expected
+    revisions, idempotent completion records, security-audit results, and a
+    final cutover marker.
+  - Keep the write barrier after a crash, resume incomplete ledger entries, and
+    make the new binary refuse traffic until the final marker exists.
+  - Migrate product configuration, examples, favorites, durable links, host
+    messages, and every known legacy name URL to explicit DID-and-host URLs.
+  - Run the confirmed ingest-channel retirement, remove unexplained ACL owners
+    and explicit grants to publicly derived non-home space DIDs, and verify both
+    audits are clean.
+  - Delete `createSession({ spaceName })`, runtime name-to-DID derivation and
+    caches, all production copies of `"common user"`, and tests that equate a
+    name with a DID.
+  - Remove the derivation tripwire and its task entry only after its audit,
+    retirement, and ACL obligations have completed in the same change.
+  - Update live identity, Home, URL, FUSE, CLI, embedding, pattern, and security
+    documentation. Historical records may retain the former behavior.
+  - Test same-name creation, user separation, display-name rename stability, ACL
+    genesis and post-genesis denial, home self-access, host-route restart,
+    ambiguous CLI display names, user-independent URL resolution, repository and
+    persisted pattern migration, and absence of a registry dependency for
+    creation and DID navigation.
+  - Kill the creator before genesis, after genesis, after child data, and before
+    parent or Home publication; prove replay converges on the recorded DID
+    without repeating child effects.
+  - Erase a completed record's pending key material, restart, and reevaluate a
+    persisted parent. Prove both its graph mapping and the allocator's retained
+    result select the original child DID.
+  - Add a repository check forbidding the fixed passphrase and derivation in
+    executable production code, configuration, and test vectors. Explanatory
+    documentation and migration records are allowed.
+
+The pull request lands with random creation and the narrowed authorization rule
+active. It contains no dormant implementation, opt-out, dual-read, dual-write,
+or deprecated creation path.
+
+## Acceptance criteria
+
+- Two creations with the same acting identity and display name have different
+  DIDs.
+- Two different users choosing the same display name have different DIDs.
+- Re-executing one active creation operation before completion returns the same
+  DID.
+- Re-executing after a process exit returns the same DID, including when child
+  data committed before its parent link.
+- The Home entry appears only after successful ACL genesis.
+- Before genesis, the space principal can submit only the ACL-only genesis
+  transaction and cannot perform an ordinary read or another write.
+- A non-default-host space reopens after restart through its durable site-table
+  hint.
+- A DID URL selects the same DID and host for every viewer; authorization may
+  grant or deny access only after that target is selected.
+- Two viewers with conflicting Home host hints still open the URL-bound host.
+- Without a registry match, a legacy name URL returns not found uniformly and
+  never allocates a space.
+- Every known legacy name link in the preparation inventory is replaced with a
+  DID-and-host link; no unresolved link is silently retained.
+- A new ACL contains the acting user as `OWNER` and no wildcard grant.
+- The bootstrap key cannot open or mutate the space after genesis unless the ACL
+  explicitly grants its DID access.
+- The actual owner can read, write, and change the ACL after remount.
+- A home space continues to work through its explicit self-owner ACL.
+- Anonymous `inSpace()` remains stable across scheduler re-execution and
+  distinct across logical creation events.
+- Anonymous `inSpace()` selects the same DID after restart and delayed duplicate
+  delivery for the full lifetime of its persisted parent event.
+- A remaining `inSpace("name")` call produces the focused source-migration
+  error; there is no runtime fallback.
+- Every persisted named-pattern instance is either migrated and reinstantiated
+  by its owner with its data relationships verified, or recorded as accepted
+  breakage before deployment.
+- All runtime, storage, and durable links use DIDs.
+- Space creation and DID navigation work with no name-registry service or code.
+- Existing migrated spaces retain their original DIDs and data.
+
+## Out of scope
+
+- A global or deployment-scoped public name registry.
+- Re-keying existing space contents to new DIDs.
+- Long-term recovery, synchronization, or escrow of a space key after genesis.
+- Automatic changes to existing wildcard ACL grants.
+- General user-identity recovery and rotation.
+- Cross-provider name federation or `did:web`.

--- a/docs/plans/space-name-registry.md
+++ b/docs/plans/space-name-registry.md
@@ -1,0 +1,723 @@
+# Space name registry implementation plan
+
+## Status
+
+Proposed. Not started.
+
+If selected, this plan is implemented and landed enabled in one pull request. It
+has no feature flag or opt-out mode. Selecting the plan remains optional: it
+does not participate in space creation, authorization, or storage, and it can be
+implemented before or after
+[random space identities](random-space-identities.md), or not implemented at
+all.
+
+## Decision
+
+Add a deployment-scoped registry that maps a short public name to a canonical
+space DID. A registry name is a convenient, mutable alias. It is not the space's
+identity, an ownership claim about the target, or an authority-bearing input to
+storage.
+
+The registry has one durable fact:
+
+| Field                  | Meaning                                                    |
+| ---------------------- | ---------------------------------------------------------- |
+| `name`                 | Canonical short name within one registry origin            |
+| `space`                | Target space DID                                           |
+| `host`                 | Non-authoritative HTTP origin currently serving the space  |
+| `owner`                | Identity allowed to change or transfer this registry entry |
+| `registrationSequence` | Immutable order assigned by the first successful claim     |
+| `revision`             | Compare-and-set revision for mutations                     |
+| `state`                | `active` or `inactive`                                     |
+
+The toolshed origin and name together identify an entry. `orchard` at one
+deployment is unrelated to `orchard` at another deployment.
+
+A separate namespace table has one create-only row per claimed or reserved name:
+
+| Field  | Meaning                          |
+| ------ | -------------------------------- |
+| `name` | Canonical name, unique in origin |
+| `kind` | `alias` or `reserved`            |
+
+Claiming an alias inserts its namespace row and alias entry in one transaction.
+Deactivation never deletes either row. Fixed product routes use permanent
+`reserved` rows and have no alias entry.
+
+The public alias URL is `/<name>`, with an optional piece address after the
+name. For example, `https://toolshed.example/space` resolves the active `space`
+entry at that toolshed origin. The server resolves registered names before it
+serves the shell, so old cached clients cannot reinterpret a registered name
+through legacy derivation.
+
+The space DID remains the opaque fallback URL. After opening the target and
+reading its ACL, the shell gives the space the URL of the most recently
+registered active name whose registry owner is a current owner of that space. If
+no entry satisfies both conditions, it uses `/<space-did>`. A non-default host
+remains encoded by the existing validated host query.
+
+## Why
+
+A human-readable name and a cryptographic identity have different jobs.
+
+- A DID is stable, globally unambiguous, and suitable for durable links.
+- A display name is local, editable, and may be duplicated.
+- A registry name is public, scarce within one registry, and may be repointed by
+  its owner.
+
+The current named-space path combines all three. The fixed derivation makes a
+name sufficient to calculate both the DID and its private key. A registry
+restores the useful part, a short link, without making the name an authority.
+
+The earlier `ct-space` work reached the same boundary from two directions:
+
+- [`docs/acl.md` at commit `a81a9009f`](https://github.com/commontoolsinc/labs/blob/a81a9009f7adb46eddd96b411e564deba8eaf7d0/docs/acl.md)
+  requires carrying a DID beside a name and proposes an address book for
+  name-to-DID resolution.
+- [`docs/space-petnames.md` at commit `f5c70f5fc`](https://github.com/commontoolsinc/labs/blob/f5c70f5fca70d80a6a58902ea318f3b65fe97d06/docs/space-petnames.md)
+  proposes registering, resolving, and listing petname mappings, with
+  provider-directed resolution.
+
+This plan keeps the small common core and leaves out hierarchical petnames,
+`did:web`, provider chaining, search, and contact management. Those features can
+be added over the same exact-lookup contract if demand appears.
+
+## Specification connections and conflicts
+
+This proposal was checked against the current labs documentation and the full
+`commontoolsinc/specs` document corpus at commit
+[`5fb2c6435`](https://github.com/commontoolsinc/specs/tree/5fb2c64357f643f7344d00cdb049f0d9e5983ef0).
+No CFC rule requires a global space-name registry. The material connections are:
+
+- [CFC space principals](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/03-core-concepts.md#361-space-principals)
+  and
+  [CFC causal addressing](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/17-addressing-and-storage.md#171-causal-id-storage-core-cfc-path)
+  treat the stable identifier and access authority as separate facts. A public
+  alias therefore resolves to a DID but never supplies `HasRole`, a storage
+  capability, or evidence that its registry owner owns the target.
+- [CFC `HasRole` fact generation](https://github.com/commontoolsinc/specs/blob/5fb2c64357f643f7344d00cdb049f0d9e5983ef0/cfc/04-label-representation.md#493-hasrole-fact-generation)
+  establishes one ACL document as the declared membership record. Reverse
+  canonicalization reads its concrete `OWNER` rows. Configured service authority
+  does not qualify unless the service DID also has an explicit row. The registry
+  does not create a second meaning of “space owner.”
+- [Pattern import resolution](../specs/pattern-imports/README.md#open-questions)
+  already requires a DID at the Fabric resolver and places readable aliases in a
+  separate short-link service. It also defines the host as a routing hint, not
+  part of space identity. Registry reverse lookup must consequently select
+  candidates by DID, even when two aliases route that DID through different
+  admitted hosts.
+- The existing [shell route table](../../packages/shell/README.md#routes) and
+  [navigation guide](../common/patterns/navigation.md) parse a first segment as
+  a space name or DID. This proposal replaces the public-name half with a
+  server-owned exact registry lookup. DID routes remain backwards-compatible.
+- The [Home space list](../common/conventions/HOME_SPACE.md#spaces) is personal,
+  while the registry is deployment-wide. The two may display the same text but
+  never resolve each other implicitly.
+- The
+  [FUSE path specification](../specs/fuse-filesystem/2-path-scheme.md#space-name-resolution)
+  currently derives a DID from any directory name. Its replacement is an
+  explicit registry connect operation followed by DID-and-host persistence in
+  `.spaces.json`; directory traversal stays offline.
+- [Toolshed request authentication](../specs/toolshed-access-control.md#request-proof-format)
+  supplies the existing proof vocabulary for mutations. A claim permit and
+  compare-and-set revision add allocation and concurrency control without
+  changing what the proof says about target-space authority.
+- [Toolshed storage configuration](../development/CONFIGURATION.md#memory-store)
+  currently configures Common Memory rather than a general metadata database.
+  Existing control records such as
+  [webhook registrations](../../packages/toolshed/routes/webhooks/webhooks.handlers.ts)
+  use the service Fabric space. This proposal instead adds one private registry
+  database because namespace uniqueness, compare-and-set mutation, and monotonic
+  sequences need a compact transactional authority and are not user Fabric data.
+
+The audit found one conflict inside the earlier draft of this plan. It selected
+canonical aliases by DID and host even though the host is only a route. This
+revision selects every eligible alias whose target DID matches the opened space.
+Each candidate alias must still have a currently admitted target host that
+serves the same validated DID and ACL state. The newest qualifying registration
+wins even when it routes that space through a different admitted host.
+
+## Invariants
+
+1. The resolved DID is the only space identifier passed to the runtime, storage,
+   ACL, CFC, piece, and link layers. The host is a routing hint handled at the
+   existing site-table boundary.
+2. No private key is derived from a registry name or stored in the registry.
+3. A registry entry's owner controls the alias. The entry does not assert that
+   its owner controls the target space.
+4. Durable Fabric data contains DIDs, never registry names. A user's existing
+   site table may retain the resolved DID-to-host hint.
+5. Space creation succeeds or fails without consulting the registry.
+6. Registry mutation succeeds or fails without creating, opening, or writing the
+   target space.
+7. An inactive name returns not found before the shell loads. A name with no
+   registry row may reach the shell's independent ordinary fallback. Neither
+   case denotes an empty space.
+8. A lookup is exact. This plan has no enumeration, prefix search, wildcard,
+   hierarchy, or fallback to another provider.
+9. An alias URL returns the same registry entry and canonical DID-and-host
+   redirect for every viewer. Authentication and ACLs may change whether a
+   viewer can open that target, never which target the URL denotes.
+10. URL canonicalization uses only the target DID, an authoritative ACL owner
+    set and revision read from the opened space's host, and authoritative
+    registry rows whose target hosts serve that same validated space state. It
+    does not use a caller-supplied owner set, viewer identity, cookies, Home
+    contents, or personal routing hints.
+11. Among active entries for the same DID whose registry owner is a current
+    space owner and whose target host serves the same validated space state, the
+    greatest immutable registration sequence wins. If none match, the canonical
+    URL uses the space DID.
+12. Once a name has a namespace row, no shell version handles that path. Active
+    aliases redirect. Inactive aliases and reservations not yet consumed by a
+    fixed route return not found.
+13. A fixed product route may use a name only if that name is reserved before
+    any claim. The namespace table resolves every race between reservation and
+    claim; a later route may not take an alias name.
+14. Forward lookup, reverse lookup, and every host mutation apply the same
+    current host-admission policy. Removing a host immediately makes aliases
+    routed through it unavailable without exposing their names to shell
+    fallback.
+
+The third invariant is deliberate. Making registration depend on a target
+space's ACL would couple this plan to space authorization. It would also make a
+registry claim unsafe while legacy named-space keys remain publicly derivable.
+The registry promises who controls the short link, not who controls the value to
+which the link points.
+
+The host is not part of the space identity. It is the authoritative route for
+the navigation produced by an alias redirect, but the space log remains the
+integrity boundary. A registry response cannot make content under another DID
+valid.
+
+## Names
+
+Registry names contain 1 through 63 ASCII characters. They begin and end with a
+lowercase letter or digit and may contain lowercase letters, digits, and hyphens
+between them.
+
+Reject instead of transforming input. In particular, do not lowercase,
+transliterate, normalize Unicode, collapse punctuation, or trim whitespace. A
+caller that did not submit the canonical name receives a validation error. This
+leaves one byte representation for every name and avoids visually confusable
+aliases.
+
+Reserve names required for deployment operation, product entry points, and shell
+built-ins. A valid DID segment and fixed prefixes such as `api`, `static`, and
+`.embed` are never registry names. Route classification happens before registry
+lookup and uses the shared reserved-name module.
+
+Keep the reserved-name list in one shared module used by validation, API
+documentation, and tests. The initial database migration inserts matching
+`reserved` namespace rows before registry mutations are enabled.
+
+Adding a fixed route is a namespace mutation. Its database migration inserts a
+create-only `reserved` row before the route serves. The same unique constraint
+serializes that insert against every claim, including claims from an older
+registry instance. If an `alias` row wins, the migration fails and the product
+must choose another route. If the reservation wins, every claim sees an existing
+namespace row and fails. A claimed path is permanent.
+
+A space's display name is not subject to these restrictions. It remains a
+user-owned label in Home and may contain Unicode or duplicate another display
+name.
+
+## Ownership and lifecycle
+
+Claiming a name requires an authenticated identity and a one-use allocation
+permit issued through the deployment's abuse-controlled admission boundary. The
+permit binds the canonical name, registry origin, and proposed owner DID. The
+issuer applies a lifetime claim quota to a stable deployment account, not to the
+DID, because identities are free to generate. A deployment without such an
+account boundary uses operator-approved permits; it does not fall back to
+self-service DID claims.
+
+The first successful create-only mutation records the permitted identity as the
+registry owner, inserts the create-only `alias` namespace row, and consumes the
+permit in one transaction. Concurrent claims or a claim racing a reservation use
+the namespace table's unique name constraint; exactly one succeeds. Replaying
+the accepted operation returns its result without consuming another permit. The
+same transaction assigns an immutable, deployment-wide registration sequence
+from the database. Repointing, transfer, deactivation, and reactivation do not
+change that sequence. A later successful claim therefore always sorts after
+every earlier claim without using wall-clock timestamps or requiring a
+tie-breaker.
+
+The owner may:
+
+- repoint the name to another valid space DID and host;
+- update the host hint for the current DID;
+- transfer the entry to another identity;
+- deactivate the entry;
+- reactivate an inactive entry.
+
+Every mutation supplies the revision the caller observed. A stale mutation fails
+with a conflict and reports the current revision. The client presents the
+conflict; it does not retry automatically.
+
+Deactivation does not release a name. Reassigning an old link to an unrelated
+future claimant would turn every saved alias URL into an ambient transfer of
+trust. A transfer is therefore an authenticated mutation by the existing owner.
+Recovery of a lost owner identity is outside this plan.
+
+The registry retains an append-only audit row for every accepted mutation. The
+public read response exposes only the current entry. Operator tooling may read
+the audit log.
+
+Registry ownership and space ownership remain separate facts. Registration and
+mutation do not read the target ACL. Canonicalization asks the target storage
+authority for the current validated ACL and its revision, then compares the
+concrete owner set with registry rows. It does not trust an owner set supplied
+by the browser. If an ACL has several concrete `OWNER` identities, an entry
+owned by any one of them qualifies. An ownerless or malformed ACL has no
+matching registry owner.
+
+## Service boundary
+
+The registry is a small service owned by the toolshed deployment. Store its
+records and audit rows in one Toolshed-private SQLite database, separate from
+Common Memory's per-space storage and the service Fabric space. The
+authoritative registry process owns that file, runs schema migration before
+accepting traffic, and provides the narrow storage interface. Other front ends
+proxy registry requests to that authority.
+
+This gives one authoritative toolshed origin with serializable transactions and
+read-your-writes behavior without inventing a distributed database. Lookup is
+not served from file copies or asynchronous replicas. Backup and restore move
+the database as one unit and must preserve its monotonic registration-sequence
+state. Cross-provider federation is outside this plan.
+
+For reverse canonicalization, the registry service first makes an authenticated
+server-to-server read to the opened space's validated storage origin. The
+response binds the space DID, ACL revision, and complete concrete `OWNER` set.
+Accept only origins admitted by the existing space-routing policy, and do not
+follow redirects.
+
+The registry then takes one authoritative database snapshot and reads active
+same-DID rows owned by that concrete owner set in descending registration
+sequence. A row routed through the opened host is already validated. For a row
+routed through another host, make the same authenticated exact read and require
+the same DID, ACL revision, and concrete owner set. Skip a row only when current
+policy excludes its host or an authoritative response proves that the host
+redirects or serves different state. If the highest remaining candidate cannot
+answer, stop canonicalization and retain the safe DID URL. Do not choose an
+older name based on a transient failure. Evaluating the next authoritatively
+disqualified candidate is part of one bounded selection, not a retry of a failed
+request. The finite owner set and existing per-account lifetime quota bound the
+candidate count.
+
+The first validated row wins. If every candidate is authoritatively
+disqualified, return the canonical DID fallback with the opened ACL revision. A
+named result also carries the selected entry revision. A host-read failure
+returns an incomplete result, which also retains the DID URL but is not evidence
+that no name qualifies. Do not cache owner sets or retry a host read.
+
+Use the existing signed first-party HTTP request format for mutations. The
+signed material binds:
+
+- HTTP method and canonical path;
+- registry audience;
+- canonical request body;
+- expected revision;
+- an operation identifier.
+
+A claim also carries the one-use allocation permit. The target host is part of
+the canonical body. Claim, repoint, and host-update mutations accept only an
+HTTP or HTTPS origin without credentials, path, query, or fragment that is
+admitted by the same configured space-routing policy used for authoritative ACL
+reads. Every accepted host must support that read contract.
+
+An operation identifier makes a repeated delivery return the original result. It
+does not authorize a retry loop. A different body under the same operation
+identifier is a conflict.
+
+## HTTP surface
+
+The HTTP surface contains three public read forms and three mutation forms:
+
+- exact public lookup by canonical name;
+- exact reverse canonical-name lookup by target DID and the opened host, with
+  the service reading current space owners from that host;
+- public `/<name>` navigation, which redirects to a DID-and-host URL before the
+  shell loads;
+- authenticated create-only claim;
+- authenticated compare-and-set update or deactivation;
+- authenticated compare-and-set transfer.
+
+Active exact lookups return the canonical name, target DID, host hint, entry
+owner, registration sequence, and revision, with an `ETag` derived from the
+revision. Reverse lookup accepts only a canonical target DID and the host from
+which that DID was opened. The service validates the opened state, then returns
+only the greatest-sequence active same-DID entry with a matching owner whose
+host serves that same state, or not found. The caller supplies no owner and does
+not choose among returned rows. Reverse responses use `Cache-Control: no-store`,
+so a new claim, transfer, repoint, deactivation, or reactivation affects the
+next canonicalization.
+
+Alias navigation has three outcomes. An active alias on an admitted host
+supplies its target. An inactive alias, reserved name, or alias on a removed
+host is terminally unavailable. An absent namespace row allows ordinary shell
+fallback. Every fresh navigation reads the authoritative database. A successful
+mutation and the following authoritative lookup are read-your-writes, and
+revisions never decrease across backup restore or authority failover.
+Registration sequences are never reused and do not move backward across restore
+or failover. Operator inspection also sees the stored audit state.
+
+Before returning an active target, forward lookup reapplies the configured host
+admission policy. A row whose host is no longer admitted returns a terminal
+route-unavailable result and never falls through to the shell. Reverse lookup
+applies the same policy before contacting the opened or candidate hosts.
+Re-admitting a candidate host makes it eligible only after it serves the same
+validated space state. An owner mutation to a host that does so also restores
+ordinary resolution.
+
+Do not add a public list endpoint. Exact forward lookup and the single-result
+reverse lookup are sufficient for navigation. Enumeration would turn the
+registry into a deployment inventory and make scraping its default use.
+
+Apply body limits and mutation rate limits keyed by the client network address
+before signature verification. Rate limiting limits load; the allocation permit
+and account quota limit permanent namespace use. Require the signed request's
+ordinary expiry and audience checks in addition to the operation identifier.
+Apply a separate, generous lookup limit.
+
+## Shell and navigation
+
+For a request whose first segment is a possible registry name, the toolshed
+server applies route precedence in this order:
+
+1. fixed product, API, static, and embed routes;
+2. a valid explicit space DID;
+3. an exact namespace row;
+4. the shell's ordinary fallback when no namespace row exists.
+
+On an active row with a currently admitted host, the response does not vary with
+cookies, authentication, or Home contents. It returns `302 Found` with
+`Cache-Control: no-store` and a `Location` containing the target DID path, the
+original optional piece address, and a validated host query whenever the host is
+not the deployment default. The redirect prevents a cached legacy shell from
+deriving a different space from the name. The registry entry supplies the route;
+a caller cannot override its host through the alias URL.
+
+An active row whose host is no longer admitted returns route unavailable before
+the shell loads. It remains a claimed name and cannot reach legacy derivation.
+
+On an inactive row, the server returns the ordinary public not-found response
+before it serves any shell version. Deactivation permanently reserves the path,
+so an old client can never reinterpret a former alias through legacy derivation.
+
+A `reserved` namespace row that has no active fixed route also returns not found
+before the shell loads. Registry servers understand this state from the initial
+implementation, so inserting a future reservation immediately prevents old and
+new instances from falling through on that path.
+
+A name with no registry row falls through without registry behavior. If this
+plan lands before random space identities, the existing shell may still use its
+legacy name path. After the random-identity plan removes that path, the same
+fallthrough returns not found. The registry route contains no branch for either
+behavior.
+
+The same resolver gates every name-shaped navigation within the shell, including
+link clicks, application navigation events, browser history, and embed routes.
+It resolves the name before any programmatic history mutation and, in every
+case, before opening a session. An active alias on an admitted host supplies its
+DID and host. An inactive alias, reserved name, or alias on a removed host
+returns a terminal error. An absent namespace row reaches the shell's ordinary
+behavior.
+
+The implementation deployment drains old server instances, closes sessions from
+pre-registry shell versions, and rejects a missing or old protocol version
+before any subsequent space read. An old shell may still derive a name locally
+or change its address bar, but the resulting target never resolves. The terminal
+incompatibility response instructs the user to reload; it does not assume the
+old client can reload itself. This one-shot cutoff prevents an already-open old
+shell from reading a registered name through `common user`.
+
+The shell treats the DID and host selected by the URL as authoritative for the
+navigation. It ignores conflicting Home hints, closes or isolates an existing
+session bound to another host, and fails before reading if it cannot open the
+URL-bound host. After a successful open, it may persist the DID-to-host hint to
+an authenticated writable Home. Navigation never depends on that write and never
+writes the target space.
+
+After the target opens, the shell sends only its DID and canonical host to the
+reverse lookup. The registry service reads the authoritative ACL owner set from
+that host. If the lookup returns an entry, the shell replaces browser history
+with `/<name>` while preserving the piece suffix and dropping the host query
+because the registry entry supplies that route. If it returns not found, the
+shell replaces browser history with `/<space-did>`. The DID form retains the
+validated host query for a non-default store. If the ACL read or reverse lookup
+is unavailable, canonicalization has not completed: the shell keeps the safe DID
+form and never chooses a cached name. This replacement does not reload the space
+or create another history entry.
+
+The rule applies no matter how navigation began. Going directly to a DID,
+following a Home entry, or opening any alias for the space converges on the most
+recently registered active owner-matching name. An alias owned by someone who is
+not a current space owner still resolves to its target, but the resulting URL
+converges to the qualifying name or DID. An older qualifying alias converges to
+the newer qualifying alias.
+
+A registry update or ACL change does not move an already-open runtime. A fresh
+navigation, reload, or explicit canonical-link action performs a new lookup and
+uses current authoritative state. Copy-link actions emit the URL selected by the
+same rule. User interface text states that a named URL may be repointed.
+
+## Home, CLI, and FUSE
+
+Home's `spaces` list remains a personal address book. Its `name` is a display
+label and its `did` is the canonical address. It does not become a mirror of the
+public registry.
+
+Add explicit registry commands under `cf space name`:
+
+- `resolve` reads an exact public name;
+- `claim` creates an entry;
+- `set` repoints an owned entry;
+- `transfer` changes its owner;
+- `disable` makes it inactive;
+- `enable` reactivates it.
+
+Every mutating command requires an identity and an expected revision except a
+create-only claim. Commands print both name and DID. Machine-readable output
+includes owner, registration sequence, state, and revision.
+
+FUSE may accept a registry alias only through an explicit mount or connect
+operation that names the registry origin. Once resolved, `.spaces.json` records
+the resulting DID and host hint. Filesystem traversal never performs an implicit
+network lookup.
+
+## Relationship to random space identities
+
+This plan accepts any valid space DID. It does not know whether the DID came
+from a legacy name derivation, random key data, an imported shared space, or a
+future DID method.
+
+If random space creation is also implemented, the product flow is:
+
+1. create the space and receive its DID and host;
+2. add the DID and a personal display name to Home;
+3. optionally claim a public registry name in a separate operation.
+
+The third step is not part of the creation transaction. A name conflict or
+registry outage leaves the new space intact and usable by DID. Deleting this
+entire registry feature leaves no field, key, branch, or compatibility mode in
+the space-creation path.
+
+If random space creation is not implemented, the registry can map aliases to
+legacy named-space DIDs or any explicitly supplied DID. It neither improves nor
+worsens the target space's authority model.
+
+## Migration and compatibility
+
+Registered aliases deliberately occupy `/<name>`. The server resolves every
+registry row before serving any shell version: an active row redirects, and an
+inactive row returns not found. Only a name with no row falls through to the
+shell. If this plan lands before random space identities, existing legacy name
+creation therefore continues for never-registered names. If the random-identity
+plan lands first or later, its shell returns not found for that same
+fallthrough. Neither implementation contains a compatibility branch or dormant
+hook for the other.
+
+Do not infer an owner merely because a legacy name exists. Preparation
+inventories every known legacy name and gives each retained alias an explicit
+verified owner, target DID, and host. Only names that already satisfy the
+registry grammar may be seeded. Product links with invalid names are rewritten
+to canonical DID-and-host URLs instead of being silently transformed. The
+current negligible population makes this a finite reviewed manifest. The
+implementation seeds valid aliases, including product-operated names, in the
+same pull request. An unowned or invalid name is not imported and returns the
+shell's ordinary result to every viewer. There is no later cutover.
+
+## Preparation
+
+- Select the Toolshed-private registry-database path, single-authority routing,
+  schema migration, backup and restore procedure, and the same-origin forward
+  lookup, single-result reverse lookup, alias-navigation, and mutation API
+  routes.
+- Identify the stable deployment account boundary that issues claim permits. If
+  none exists, specify the operator approval procedure used at launch.
+- Inventory every known legacy and product alias. Record its canonical spelling,
+  owner DID, target space DID, and validated host origin. Mark invalid names for
+  direct DID-and-host link migration instead of registry seeding. Put valid seed
+  entries in their intended registration order.
+- Confirm the signed-request verifier, live host-hint registration, optional
+  Home site-table persistence, target-host ACL read, and FUSE connection format
+  that the implementation will reuse.
+- Inventory every fixed first-segment route and encode its precedence or
+  reservation in the shared route classifier.
+
+Preparation produces a short decision record and reviewed seed manifest as
+inputs to the implementation. They are committed with the implementation, not
+landed separately. Preparation adds no runtime code, schema, flag, or
+compatibility path.
+
+## Implementation
+
+- Add the registry as one enabled feature in one pull request:
+  - Define canonical name validation and the reserved-name set in one package
+    shared by the service and clients.
+  - Seed permanent namespace reservations for the initial fixed routes before
+    enabling claims. Require every future fixed route to insert its create-only
+    reservation before serving and to choose another segment if an alias row
+    wins the unique-name race.
+  - Define lookup and mutation protocol types, stable errors, revisions,
+    immutable registration sequences, operation identifiers, and one-use claim
+    permits.
+  - Connect permit issuance to the prepared deployment account quota or operator
+    approval boundary.
+  - Add the private SQLite registry database, schema migration, and routing to
+    its single authoritative process. Keep it independent of Common Memory and
+    the service Fabric space.
+  - Add the durable storage implementation with atomic create-only claim, unique
+    namespace rows, compare-and-set mutation, consumed permits, append-only
+    audit rows, and an index that selects the greatest registration sequence by
+    target DID and owner.
+  - Add exact authoritative forward lookup, single-result reverse lookup, and
+    authenticated claim, update, transfer, deactivation, and reactivation
+    endpoints.
+  - Reapply current host admission on every forward and reverse lookup. Return a
+    terminal route-unavailable result for an alias whose recorded host was
+    removed from policy; never redirect it or let its name fall through.
+  - Make reverse lookup read the current validated ACL and revision directly
+    from the admitted host where the target was opened. Reject redirects. Check
+    same-DID rows in descending registration sequence and validate a different
+    candidate host against the opened DID, ACL revision, and concrete owner set.
+    Skip removed, redirected, or divergent candidates. If the highest remaining
+    candidate is unavailable, return an incomplete result and retain the DID
+    URL. Otherwise return the first validated entry and its revision, or the
+    canonical DID result, with the opened ACL revision.
+  - Reuse first-party request verification; bind every mutation field into the
+    signature; validate DID; require the same configured host admission used by
+    reverse ACL reads; and reject expired or wrong-audience requests.
+  - Apply body and client-network rate limits before expensive verification,
+    with the permit and account quota enforcing permanent allocation limits.
+  - Return the active, inactive, route-unavailable, reserved, and absent
+    navigation states needed to keep a claimed name out of legacy derivation.
+    Expose mutation history only to operators.
+  - Add `cf space name` commands over the shared protocol types.
+  - Add server-owned `/<name>` interception after fixed routes and explicit DIDs
+    but before serving the shell. Redirect active aliases without using cookies,
+    authentication, or Home state; return not found for inactive aliases and
+    reserved namespace rows; and let absent namespace rows follow the shell's
+    ordinary behavior.
+  - Make the redirect carry the target DID path, original optional piece
+    address, and validated host query for a non-default store. Bind the
+    resulting shell navigation to that route and ignore conflicting personal
+    hints.
+  - Register the resolved host hint live and optionally persist it through the
+    existing Home site-table flow only after the URL-bound space opens.
+  - Gate every same-document name navigation on the same resolver before history
+    mutation or session open. Drain old servers and sessions, reject missing or
+    pre-registry shell protocol versions before reads, and return a terminal
+    incompatibility error instructing those users to reload.
+  - Perform reverse lookup by DID and host after open, then replace browser
+    history with the returned latest-registered name or the DID fallback without
+    reloading. Treat a failed ACL or registry read as incomplete
+    canonicalization and retain the DID URL.
+  - Make Home navigation, intra-space navigation, reload, and copy-link actions
+    use the same canonicalization function.
+  - Add explicit FUSE resolution that records the DID and host in `.spaces.json`
+    without network lookup during traversal.
+  - Create the database schema, seed valid reviewed product aliases, and rewrite
+    managed links with invalid legacy names to canonical DID-and-host URLs as
+    the in-pull-request data migration.
+  - Add dashboards for lookup outcomes, mutation conflicts, and rate-limit
+    decisions without logging private request material.
+  - Document backup, restore, and authoritative-origin recovery without revision
+    rollback.
+  - Test claim races, registration ordering, permit consumption, account quotas,
+    stale revisions, idempotent replay, transfer, repoint, deactivation,
+    reactivation, host routing, authoritative reads, process restart, registry
+    unavailability, and identical redirects for anonymous and differently
+    authenticated viewers.
+  - Test direct DID canonicalization, several current ACL owners, owner
+    mismatch, several aliases for one target, alias and ACL ownership changes,
+    piece-suffix preservation, admitted non-default hosts, rejection of a host
+    that cannot supply authoritative ACL reads, and removal of a formerly
+    admitted host.
+  - Test that conflicting Home hints cannot change an alias target, an old
+    cached or already-open shell cannot interpret a registered or inactive name,
+    fixed routes retain precedence, future routes cannot take any claimed name,
+    and landing this plan alone leaves never-registered legacy name creation
+    unchanged.
+
+The pull request lands with the registry API and all clients enabled on the
+existing toolshed deployment. It has no disabled state: if the registry is
+unavailable, alias resolution fails while canonical DID URLs and space creation
+continue to work.
+
+## Acceptance criteria
+
+- Two registry origins may use the same name for different DIDs.
+- Within one origin, anonymous and differently authenticated viewers receive the
+  same DID-and-host redirect from the same registered `/<name>` URL.
+- A conflicting Home route cannot change the DID or host selected by an alias
+  URL.
+- Every host accepted by claim, repoint, or host update supports authoritative
+  ACL reads for reverse canonicalization.
+- Opening `/<space-did>` for a space with one active alias owned by a current
+  ACL owner replaces the URL with that `/<name>`.
+- If several active aliases for the DID are owned by current ACL owners and
+  their target hosts serve the same validated space state, every navigation
+  converges on the one with the greatest immutable registration sequence, even
+  when it names another host.
+- A newer same-DID alias at a removed, redirected, or divergent host is
+  disqualified, so canonicalization may use the next qualifying alias. If its
+  admitted host is merely unavailable, canonicalization remains incomplete and
+  keeps the safe DID URL rather than choosing an older alias.
+- If no active alias owner is a current ACL owner, every navigation converges on
+  `/<space-did>`, retaining the host query when required.
+- An alias whose owner does not own its target still resolves to that target but
+  does not become the target's canonical URL.
+- Successful canonicalization at the same target ACL revision and authoritative
+  registry state produces the same URL for every viewer who can open the space.
+- If authoritative ACL or registry lookup fails, the navigation remains on its
+  safe DID URL and is explicitly not considered canonically named. It never uses
+  a stale alias.
+- A claim without a valid allocation permit fails, and generating more DIDs does
+  not increase one deployment account's lifetime quota.
+- Two identities racing to claim one name produce one owner and one conflict.
+- An entry owner may repoint or transfer with the current revision.
+- A stale or differently signed mutation changes nothing.
+- An inactive name cannot be claimed by a new identity.
+- An inactive `/<name>` returns not found before any shell version loads and
+  never reaches legacy derivation.
+- A fresh navigation after repoint, transfer, deactivation, reactivation, host
+  update, or ACL owner change observes the new canonical URL. An already-open
+  runtime remains on its bound target.
+- Public lookup never creates or writes a space, and navigation never writes the
+  target space.
+- An anonymous visitor and an authenticated visitor whose Home write fails can
+  open a non-default-host alias through the live route hint.
+- When Home persistence succeeds, a non-default-host space may also reopen from
+  Home after restart. The alias URL does not depend on that persisted hint.
+- Durable Fabric links produced after alias navigation contain the DID.
+- Canonical DID navigation works when the registry database and route are
+  unavailable.
+- Landing this registry alone leaves creation and navigation through names with
+  no namespace row unchanged. Active, inactive, and reserved names resolve
+  before every shell version.
+- Same-document navigation in a pre-registry shell is rejected before it reads a
+  space. Its locally derived URL does not resolve, and the terminal error
+  instructs its user to reload.
+- Removing a host from policy makes every alias routed through it unavailable on
+  the next lookup without exposing the name to legacy derivation.
+- A future fixed route cannot take a segment whose namespace row is an alias.
+- A newly inserted reservation returns not found on old and new registry servers
+  until its fixed route begins serving.
+- Invalid legacy names are migrated to canonical DID-and-host links rather than
+  normalized into registry claims.
+- Removing all registry client and server code requires no change to space
+  creation, storage, or ACL behavior.
+
+## Out of scope
+
+- A global internet namespace.
+- Search, browse, suggestions, and public enumeration.
+- Hierarchical petnames or delegation between registries.
+- `did:web`, DNS, and provider migration.
+- Requiring target ownership to claim or repoint an alias. Target ownership is
+  consulted only when selecting the space's canonical browser URL.
+- Identity recovery for a registry owner.
+- Automatic alias claiming during space creation.
+- Changing legacy named-space derivation.

--- a/docs/plans/space-name-registry.md
+++ b/docs/plans/space-name-registry.md
@@ -4,10 +4,17 @@
 
 Proposed. Not started.
 
-If selected, this plan is implemented and landed enabled in one pull request. It
-has no feature flag or opt-out mode. Selecting the plan remains optional: it
-does not participate in space creation, authorization, or storage, and it can be
-implemented before or after
+If selected, this plan is delivered as one coordinated, enabled cutover. It has
+no product feature flag, opt-out mode, or partially usable phase. The registry
+code belongs in labs, while database provisioning and the current and future
+deployment-wide routes belong in their infrastructure repositories. Those repo
+boundaries require linked implementation changes. Infrastructure may land
+inert, with no public route or accepted registry traffic, but no alias is seeded
+and no user-visible behavior changes until the complete implementation passes
+the compatibility barrier and performs the ordered cutover.
+
+Selecting the plan remains optional: it does not participate in space creation,
+authorization, or storage, and it can be implemented before or after
 [random space identities](random-space-identities.md), or not implemented at
 all.
 
@@ -177,6 +184,11 @@ wins even when it routes that space through a different admitted host.
     current host-admission policy. Removing a host immediately makes aliases
     routed through it unavailable without exposing their names to shell
     fallback.
+15. Every request for one registry origin observes one logical transactional
+    database. The toolshed process or registry frontend that receives the
+    request cannot change the result. Process-local files, caches, and
+    asynchronously replicated databases are never authoritative registry
+    state.
 
 The third invariant is deliberate. Making registration depend on a target
 space's ACL would couple this plan to space authorization. It would also make a
@@ -207,15 +219,16 @@ built-ins. A valid DID segment and fixed prefixes such as `api`, `static`, and
 lookup and uses the shared reserved-name module.
 
 Keep the reserved-name list in one shared module used by validation, API
-documentation, and tests. The initial database migration inserts matching
-`reserved` namespace rows before registry mutations are enabled.
+documentation, and tests. The cutover seed transaction inserts matching
+`reserved` namespace rows after name-route convergence and before registry
+mutations are enabled.
 
 Adding a fixed route is a namespace mutation. Its database migration inserts a
 create-only `reserved` row before the route serves. The same unique constraint
-serializes that insert against every claim, including claims from an older
-registry instance. If an `alias` row wins, the migration fails and the product
-must choose another route. If the reservation wins, every claim sees an existing
-namespace row and fails. A claimed path is permanent.
+serializes that insert against every claim, including claims accepted by
+another registry frontend. If an `alias` row wins, the migration fails and the
+product must choose another route. If the reservation wins, every claim sees an
+existing namespace row and fails. A claimed path is permanent.
 
 A space's display name is not subject to these restrictions. It remains a
 user-owned label in Home and may contain Unicode or duplicate another display
@@ -273,18 +286,63 @@ matching registry owner.
 
 ## Service boundary
 
-The registry is a small service owned by the toolshed deployment. Store its
-records and audit rows in one Toolshed-private SQLite database, separate from
-Common Memory's per-space storage and the service Fabric space. The
-authoritative registry process owns that file, runs schema migration before
-accepting traffic, and provides the narrow storage interface. Other front ends
-proxy registry requests to that authority.
+The registry is a deployment-level service, not state owned by any toolshed
+process. Run a bounded pool of stateless registry frontends and store all
+namespace rows, entries, permits, operation results, and audit rows in one
+PostgreSQL database for the registry origin. Every frontend uses that database's
+current primary. Toolshed processes and per-user toolshed shards call the
+registry service; they do not open the database or retain an authoritative
+copy.
 
-This gives one authoritative toolshed origin with serializable transactions and
-read-your-writes behavior without inventing a distributed database. Lookup is
-not served from file copies or asynchronous replicas. Backup and restore move
-the database as one unit and must preserve its monotonic registration-sequence
-state. Cross-provider federation is outside this plan.
+This boundary is required by the existing deployment. Rapids currently runs
+[21 toolshed processes](https://github.com/commontoolsinc/infra/blob/802ac91ab0e64a427f0fc54d164e7392f1789b10/ansible/vars/toolshed-binary.yml)
+on one VM, while
+[Nginx distributes ordinary HTTP requests among five of them and storage
+connections among another sixteen](https://github.com/commontoolsinc/infra/blob/802ac91ab0e64a427f0fc54d164e7392f1789b10/ansible/roles/nginx/templates/toolshed.conf.j2).
+That co-location makes a shared local file possible today, but does not make one
+process a stable authority. It also does not survive horizontal scaling to
+another host. The planned cluster instead gives
+[each stateful toolshed shard one process and one volume](https://github.com/commontoolsinc/common-cluster/blob/dc70d63f2ce44930a1b23793a998e78eeac863bf/docs/design.md#3-the-serving-model-one-toolshed-per-user),
+so a deployment-wide registry cannot live in a shard's storage.
+
+The database is the one serialization point for a registry origin. Unique
+constraints decide namespace races. Transactions atomically consume permits,
+record operation results, mutate entries, and append audit rows. A database
+sequence assigns a total registration order; gaps from aborted transactions are
+valid, and concurrently started claims may receive either order. After one
+claim has returned success, every subsequently started successful claim receives
+a greater sequence.
+
+Registry frontends may be added or removed without moving registry state. Give
+each frontend a bounded connection pool. Put a deployment-level connection
+pooler between the frontends and PostgreSQL when the sum of their pools would
+exceed the database connection budget. Reject excess work with the registry's
+unavailable response instead of building an unbounded in-process queue.
+
+Serve authoritative forward and reverse lookups from the current primary. Do
+not put asynchronous database replicas or frontend caches in the correctness
+path. Exact indexed lookup is the expected high-volume operation; claims and
+other mutations are comparatively rare. Scale stateless frontends separately
+from the database, and scale the primary for indexed lookup throughput before
+introducing a consistency protocol for caches.
+
+Use a single-primary high-availability database configuration whose failover
+does not acknowledge a transaction before it is durable on the failover path.
+Promotion must fence the former primary from writes before the new primary
+accepts them. Frontends connect through the elected-primary endpoint, and a
+failover invalidates connections to the former primary instead of allowing two
+writable pools. An unavailable or uncertain primary makes registry operations
+unavailable; it never permits a frontend to use a local fallback. Continuous
+database recovery records must cover the last acknowledged transaction. If
+disaster recovery cannot establish that fact, put the whole registry origin in
+recovery mode. Recovery mode serves no lookup, fallback decision, or mutation
+until the missing interval has been reconciled. Canonical DID URLs remain
+usable. This prevents a lost claim or repoint from making an old public URL
+resolve incorrectly or become available to a new owner.
+
+Cross-provider federation is outside this plan. Different registry origins may
+use separate databases or isolated databases in one PostgreSQL service, but
+each origin has separate credentials and one logical primary.
 
 For reverse canonicalization, the registry service first makes an authenticated
 server-to-server read to the opened space's validated storage origin. The
@@ -292,24 +350,48 @@ response binds the space DID, ACL revision, and complete concrete `OWNER` set.
 Accept only origins admitted by the existing space-routing policy, and do not
 follow redirects.
 
-The registry then takes one authoritative database snapshot and reads active
-same-DID rows owned by that concrete owner set in descending registration
-sequence. A row routed through the opened host is already validated. For a row
-routed through another host, make the same authenticated exact read and require
-the same DID, ACL revision, and concrete owner set. Skip a row only when current
-policy excludes its host or an authoritative response proves that the host
-redirects or serves different state. If the highest remaining candidate cannot
-answer, stop canonicalization and retain the safe DID URL. Do not choose an
-older name based on a transient failure. Evaluating the next authoritatively
-disqualified candidate is part of one bounded selection, not a retry of a failed
-request. The finite owner set and existing per-account lifetime quota bound the
-candidate count.
+Reject an ACL response above the configured body or concrete-owner limit as an
+incomplete canonicalization. Otherwise, take one authoritative database
+snapshot and materialize active same-DID rows owned by that concrete owner set
+in descending registration sequence, up to one more than the configured
+candidate limit. End the transaction and release its connection before making
+any host request.
 
-The first validated row wins. If every candidate is authoritatively
-disqualified, return the canonical DID fallback with the opened ACL revision. A
-named result also carries the selected entry revision. A host-read failure
-returns an incomplete result, which also retains the DID URL but is not evidence
-that no name qualifies. Do not cache owner sets or retry a host read.
+A row routed through the opened host is already validated. For a row routed
+through another host, make the same authenticated exact read and require the
+same DID, ACL revision, and concrete owner set. Apply hard per-request limits to
+both examined candidates and distinct contacted hosts. Skip a row only when
+the versioned current policy excludes its host. If a newer candidate's admitted
+host redirects, serves different state, or cannot answer, stop canonicalization
+and retain the safe DID URL as an incomplete result. Do the same if the next
+candidate or host would exceed a limit. Do not choose an older name based on a
+mutable cross-host observation or truncated candidate set. Evaluating the next
+policy-excluded candidate is part of one bounded selection, not a retry of a
+failed request. The first validated row wins.
+
+If every examined candidate is excluded by the versioned host policy and the
+snapshot contained no additional candidate, return the canonical DID fallback
+with the opened ACL revision. An additional candidate beyond the examination
+limit makes the result incomplete.
+
+After the host reads, take a second short primary transaction before returning a
+named or DID result. Repeat the same bounded ordered candidate query. For a named
+result, require the prefix through the selected row, including every row's
+identity, revision, registration sequence, owner, DID, host, and state, to match
+the materialized prefix. For a DID result, require the whole bounded result and
+the absence of an additional candidate to match. Any database change returns an
+incomplete result and retains the DID URL. End the second transaction before
+returning. Carry the opened ACL revision in the response; the shell applies the
+result only while its current opened revision still matches. This check makes
+the registry rows stable across the host observation that selected the name.
+Because no mutable host result disqualifies a newer candidate, that observation
+is the selection's consistency point. A later registry, ACL, policy, or host
+change affects the next navigation. No database connection is held during a host
+read.
+
+A named result carries the selected entry revision. A host-read failure returns
+an incomplete result, which also retains the DID URL but is not evidence that no
+name qualifies. Do not cache owner sets or retry a host read.
 
 Use the existing signed first-party HTTP request format for mutations. The
 signed material binds:
@@ -356,11 +438,14 @@ next canonicalization.
 Alias navigation has three outcomes. An active alias on an admitted host
 supplies its target. An inactive alias, reserved name, or alias on a removed
 host is terminally unavailable. An absent namespace row allows ordinary shell
-fallback. Every fresh navigation reads the authoritative database. A successful
-mutation and the following authoritative lookup are read-your-writes, and
-revisions never decrease across backup restore or authority failover.
-Registration sequences are never reused and do not move backward across restore
-or failover. Operator inspection also sees the stored audit state.
+fallback. Every fresh navigation reads the current database primary. A
+successful mutation and the following authoritative lookup are read-your-writes
+even when different frontend instances handle them. Revisions never decrease
+across ordinary primary failover. Registration sequences are never reused and
+do not move backward across ordinary primary failover. Operator inspection also
+sees the stored audit state. Disaster recovery follows the fail-closed recovery
+rule in the service boundary when it cannot prove that it includes the last
+acknowledged transaction.
 
 Before returning an active target, forward lookup reapplies the configured host
 admission policy. A row whose host is no longer admitted returns a terminal
@@ -374,11 +459,14 @@ Do not add a public list endpoint. Exact forward lookup and the single-result
 reverse lookup are sufficient for navigation. Enumeration would turn the
 registry into a deployment inventory and make scraping its default use.
 
-Apply body limits and mutation rate limits keyed by the client network address
-before signature verification. Rate limiting limits load; the allocation permit
-and account quota limit permanent namespace use. Require the signed request's
-ordinary expiry and audience checks in addition to the operation identifier.
-Apply a separate, generous lookup limit.
+Apply body limits and coarse network rate limits at the deployment ingress
+before frontend selection and signature verification. A limit intended to apply
+across the registry origin must use ingress state or another shared counter; a
+frontend-local counter is only an in-flight resource bound and never an abuse or
+allocation boundary. Rate limiting limits load. The allocation permit and the
+transactional account quota limit permanent namespace use. Require the signed
+request's ordinary expiry and audience checks in addition to the operation
+identifier. Apply a separate, generous lookup limit.
 
 ## Shell and navigation
 
@@ -431,6 +519,30 @@ or change its address bar, but the resulting target never resolves. The terminal
 incompatibility response instructs the user to reload; it does not assume the
 old client can reload itself. This one-shot cutoff prevents an already-open old
 shell from reading a registered name through `common user`.
+
+The deployment-wide HTTP entry point routes every name-shaped first segment and
+every registry API request through the registry frontend pool before any
+per-user toolshed selection. Fixed routes and explicit DIDs retain their earlier
+precedence. The entry point does not route registry traffic to a particular
+frontend by name, user, or operation identifier; any healthy frontend must
+produce the same result.
+
+The one-shot deployment uses one ordered compatibility barrier and cutover. It
+first migrates the empty database and deploys the registry frontends without a
+public route or accepted mutations. It then drains every old shell session and
+replaces every ordinary and storage toolshed process. Each replacement rejects
+old shell protocol versions before any space read.
+
+After every process passes the version barrier, install the name and registry
+API route at every deployment entry point while the namespace remains empty and
+the mutation route remains denied. A name miss still reaches the ordinary shell
+fallback, so this changes no name's meaning. Verify route convergence from every
+entry point. Then commit the initial reservations and aliases. Only after that
+transaction succeeds may the entry point admit mutations. Continuously enforce
+the required toolshed, storage, registry schema, registry protocol,
+reserved-route, and host-admission-policy versions. Once any namespace row is
+live, deployment policy prohibits rollback to an incompatible binary or route;
+recovery rolls forward.
 
 The shell treats the DID and host selected by the URL as authoritative for the
 navigation. It ignores conflicting Home hints, closes or isolates an existing
@@ -524,16 +636,27 @@ verified owner, target DID, and host. Only names that already satisfy the
 registry grammar may be seeded. Product links with invalid names are rewritten
 to canonical DID-and-host URLs instead of being silently transformed. The
 current negligible population makes this a finite reviewed manifest. The
-implementation seeds valid aliases, including product-operated names, in the
-same pull request. An unowned or invalid name is not imported and returns the
-shell's ordinary result to every viewer. There is no later cutover.
+coordinated cutover seeds valid aliases, including product-operated names. An
+unowned or invalid name is not imported and returns the shell's ordinary result
+to every viewer. There is no later migration phase.
 
 ## Preparation
 
-- Select the Toolshed-private registry-database path, single-authority routing,
-  schema migration, backup and restore procedure, and the same-origin forward
-  lookup, single-result reverse lookup, alias-navigation, and mutation API
-  routes.
+- Select the PostgreSQL service for each registry origin. Record
+  its high-availability, synchronous-durability, former-primary fencing, and
+  elected-primary endpoint behavior. Record its connection budget, frontend pool
+  size, credentials boundary, schema migration procedure, continuous recovery
+  procedure, and fail-closed disaster-recovery rule.
+- Record an explicit capacity target for exact lookups, reverse lookups, and
+  mutations at projected peak load with launch headroom. Size the database,
+  connection pooler, and stateless frontend pool against that target. Select
+  hard ACL-owner, reverse-candidate, and distinct-host limits that keep one
+  reverse request within its capacity allocation.
+- Select the deployment-wide route that sends name-shaped first segments and
+  registry APIs to the registry frontend pool before per-user toolshed routing.
+  Specify how a registry miss reaches the ordinary shell fallback and how the
+  route remains unavailable until every serving frontend has the required
+  schema and protocol version.
 - Identify the stable deployment account boundary that issues claim permits. If
   none exists, specify the operator approval procedure used at launch.
 - Inventory every known legacy and product alias. Record its canonical spelling,
@@ -553,7 +676,8 @@ compatibility path.
 
 ## Implementation
 
-- Add the registry as one enabled feature in one pull request:
+- Add the registry as one enabled feature in one coordinated change set. Linked
+  infrastructure changes remain inert until the final compatibility barrier:
   - Define canonical name validation and the reserved-name set in one package
     shared by the service and clients.
   - Seed permanent namespace reservations for the initial fixed routes before
@@ -565,9 +689,21 @@ compatibility path.
     permits.
   - Connect permit issuance to the prepared deployment account quota or operator
     approval boundary.
-  - Add the private SQLite registry database, schema migration, and routing to
-    its single authoritative process. Keep it independent of Common Memory and
-    the service Fabric space.
+  - Provision the selected PostgreSQL service and isolated database credentials
+    for each registry origin as part of the enabled deployment.
+  - Add the private PostgreSQL schema, one-run schema migration, bounded database
+    access layer, and stateless registry frontend service. Keep it independent
+    of Common Memory, per-toolshed storage, and the service Fabric space.
+  - Run schema migration as a dedicated deployment task under a PostgreSQL
+    advisory lock and record the resulting schema version. Frontends never run
+    migrations; they refuse readiness when the recorded version differs from
+    the version they implement.
+  - Add deployment-wide routing through the registry frontend pool before
+    per-user toolshed selection. Do not use path affinity or process-local
+    registry state.
+  - Make frontend readiness report the schema, protocol, reserved-route, and
+    host-admission-policy versions. Route traffic only to the homogeneous
+    version selected by the deployment entry point.
   - Add the durable storage implementation with atomic create-only claim, unique
     namespace rows, compare-and-set mutation, consumed permits, append-only
     audit rows, and an index that selects the greatest registration sequence by
@@ -580,17 +716,24 @@ compatibility path.
     removed from policy; never redirect it or let its name fall through.
   - Make reverse lookup read the current validated ACL and revision directly
     from the admitted host where the target was opened. Reject redirects. Check
-    same-DID rows in descending registration sequence and validate a different
-    candidate host against the opened DID, ACL revision, and concrete owner set.
-    Skip removed, redirected, or divergent candidates. If the highest remaining
-    candidate is unavailable, return an incomplete result and retain the DID
-    URL. Otherwise return the first validated entry and its revision, or the
-    canonical DID result, with the opened ACL revision.
+    bounded same-DID rows in descending registration sequence and validate a
+    different candidate host against the opened DID, ACL revision, and concrete
+    owner set. Release the database snapshot before making host reads. Skip
+    only candidates excluded by the versioned host policy. If an admitted newer
+    candidate redirects, diverges, or is unavailable, or if the owner,
+    candidate, or distinct-host limit is exceeded, return an incomplete result
+    and retain the DID URL. Otherwise repeat the bounded ordered database query
+    in a new short transaction. Return the first validated entry and its
+    revision, or the canonical DID result with the opened ACL revision, only if
+    the relevant candidate rows still match. Return incomplete on any database
+    change.
   - Reuse first-party request verification; bind every mutation field into the
     signature; validate DID; require the same configured host admission used by
     reverse ACL reads; and reject expired or wrong-audience requests.
-  - Apply body and client-network rate limits before expensive verification,
-    with the permit and account quota enforcing permanent allocation limits.
+  - Apply body and client-network rate limits before expensive verification.
+    Enforce origin-wide limits before frontend selection or through shared
+    state. Use frontend-local limits only to bound concurrent work. Enforce
+    permits and account quotas transactionally in PostgreSQL.
   - Return the active, inactive, route-unavailable, reserved, and absent
     navigation states needed to keep a claimed name out of legacy derivation.
     Expose mutation history only to operators.
@@ -607,29 +750,57 @@ compatibility path.
   - Register the resolved host hint live and optionally persist it through the
     existing Home site-table flow only after the URL-bound space opens.
   - Gate every same-document name navigation on the same resolver before history
-    mutation or session open. Drain old servers and sessions, reject missing or
-    pre-registry shell protocol versions before reads, and return a terminal
-    incompatibility error instructing those users to reload.
+    mutation or session open. Implement the ordered deployment barrier across
+    every ordinary and storage toolshed process. Drain old servers and sessions,
+    reject missing or pre-registry shell protocol versions before reads, and
+    return a terminal incompatibility error instructing those users to reload.
+    After the barrier passes, install and verify the name route everywhere with
+    an empty namespace and denied mutation route. Then seed reservations and
+    aliases, admit mutations, and prohibit rollback to an incompatible binary or
+    route.
   - Perform reverse lookup by DID and host after open, then replace browser
     history with the returned latest-registered name or the DID fallback without
-    reloading. Treat a failed ACL or registry read as incomplete
-    canonicalization and retain the DID URL.
+    reloading. Apply the result only while the shell's current opened ACL revision
+    equals the revision in the response. Treat a changed ACL revision or failed
+    ACL or registry read as incomplete canonicalization and retain the DID URL.
   - Make Home navigation, intra-space navigation, reload, and copy-link actions
     use the same canonicalization function.
   - Add explicit FUSE resolution that records the DID and host in `.spaces.json`
     without network lookup during traversal.
-  - Create the database schema, seed valid reviewed product aliases, and rewrite
-    managed links with invalid legacy names to canonical DID-and-host URLs as
-    the in-pull-request data migration.
+  - Run the cutover seed transaction for permanent route reservations and valid
+    reviewed product aliases. Rewrite managed links with invalid legacy names to
+    canonical DID-and-host URLs in the same coordinated data migration.
   - Add dashboards for lookup outcomes, mutation conflicts, and rate-limit
     decisions without logging private request material.
-  - Document backup, restore, and authoritative-origin recovery without revision
-    rollback.
+  - Document primary failover, continuous recovery through the last acknowledged
+    transaction, and fail-closed disaster recovery when that point cannot be
+    proven. Document how operators reconcile the missing interval before any
+    registry traffic resumes.
   - Test claim races, registration ordering, permit consumption, account quotas,
     stale revisions, idempotent replay, transfer, repoint, deactivation,
     reactivation, host routing, authoritative reads, process restart, registry
     unavailability, and identical redirects for anonymous and differently
     authenticated viewers.
+  - Test simultaneous claims through different registry frontends, mutation
+    through one frontend followed by lookup through another, frontend removal
+    and replacement, bounded database connections, and primary failover while
+    the former primary remains network-reachable. Verify that the former primary
+    is fenced and its pooled connections cannot accept writes. Test refusal to
+    resolve or mutate names from an uncertain disaster-recovery state.
+  - Test that distributing requests among frontends cannot multiply a network
+    limit, account quota, permit, or operation identifier, and that a frontend
+    with a mismatched schema, protocol, route, or host-policy version receives
+    no traffic.
+  - Load-test exact and reverse lookup at the prepared peak target while claims
+    and owner mutations are occurring. Verify that overload returns unavailable
+    without divergent redirects, lost audit rows, duplicate permits, or an
+    unbounded queue.
+  - Test the ACL-owner, candidate, and distinct-host limits with more rows and
+    hosts than each limit. Verify that database connections are released before
+    host reads and that truncation returns an incomplete result with the DID URL.
+  - Block a reverse lookup in a host read, then repoint, deactivate, transfer, or
+    supersede a materialized candidate through another frontend. Verify that the
+    second database check detects every change and retains the DID URL.
   - Test direct DID canonicalization, several current ACL owners, owner
     mismatch, several aliases for one target, alias and ACL ownership changes,
     piece-suffix preservation, admitted non-default hosts, rejection of a host
@@ -640,11 +811,19 @@ compatibility path.
     fixed routes retain precedence, future routes cannot take any claimed name,
     and landing this plan alone leaves never-registered legacy name creation
     unchanged.
+  - Test the one-shot deployment barrier against all ordinary and storage
+    processes in the current multi-process topology. Verify that no alias is
+    seeded while an old process or shell session can still serve. Verify the
+    empty-namespace route at every entry point before seeding, keep mutations
+    denied until after the seed transaction, and reject an incompatible binary
+    or route after activation.
 
-The pull request lands with the registry API and all clients enabled on the
-existing toolshed deployment. It has no disabled state: if the registry is
-unavailable, alias resolution fails while canonical DID URLs and space creation
-continue to work.
+The coordinated release activates with the registry API and all clients enabled
+on the existing toolshed deployment. It has no disabled product state: if the
+registry is unavailable, alias resolution fails while canonical DID URLs and
+space creation continue to work. Inert database and routing resources are
+deployment prerequisites, not an alternative runtime mode, and accept no
+traffic before activation.
 
 ## Acceptance criteria
 
@@ -661,10 +840,11 @@ continue to work.
   their target hosts serve the same validated space state, every navigation
   converges on the one with the greatest immutable registration sequence, even
   when it names another host.
-- A newer same-DID alias at a removed, redirected, or divergent host is
+- A newer same-DID alias at a host excluded by the versioned policy is
   disqualified, so canonicalization may use the next qualifying alias. If its
-  admitted host is merely unavailable, canonicalization remains incomplete and
-  keeps the safe DID URL rather than choosing an older alias.
+  admitted host redirects, serves divergent state, or is unavailable,
+  canonicalization remains incomplete and keeps the safe DID URL rather than
+  choosing an older alias.
 - If no active alias owner is a current ACL owner, every navigation converges on
   `/<space-did>`, retaining the host query when required.
 - An alias whose owner does not own its target still resolves to that target but
@@ -674,9 +854,32 @@ continue to work.
 - If authoritative ACL or registry lookup fails, the navigation remains on its
   safe DID URL and is explicitly not considered canonically named. It never uses
   a stale alias.
+- An ACL owner set or reverse candidate list above its configured limit, or a
+  selection that would contact too many distinct hosts, produces an incomplete
+  result and retains the DID URL. No database transaction remains open during a
+  target-host read.
+- A repoint, transfer, deactivation, or newer qualifying registration committed
+  while reverse lookup is reading target hosts is detected by its final short
+  database check. A changed opened ACL revision is detected before the shell
+  changes browser history. The stale candidate is never returned as canonical.
 - A claim without a valid allocation permit fails, and generating more DIDs does
   not increase one deployment account's lifetime quota.
-- Two identities racing to claim one name produce one owner and one conflict.
+- Two identities racing through different registry frontends to claim one name
+  produce one owner and one conflict.
+- A mutation acknowledged by one registry frontend is visible to the next
+  authoritative lookup through any other frontend.
+- Adding, removing, replacing, or load-balancing registry frontends does not
+  change a lookup result or permit two successful uses of one operation
+  identifier.
+- Sustained traffic at the prepared peak capacity target preserves lookup and
+  mutation correctness. Overload fails explicitly and does not create an
+  unbounded in-process queue.
+- Loss of the database primary never causes a frontend to serve process-local,
+  cached, or asynchronously replicated registry state. Lookup, fallback
+  decisions, and mutation remain disabled after an uncertain disaster recovery.
+- A primary promotion fences the former primary before accepting writes. A
+  network-reachable former primary and its existing pooled connections cannot
+  accept a claim, mutation, or authoritative lookup after promotion.
 - An entry owner may repoint or transfer with the current revision.
 - A stale or differently signed mutation changes nothing.
 - An inactive name cannot be claimed by a new identity.
@@ -700,11 +903,17 @@ continue to work.
 - Same-document navigation in a pre-registry shell is rejected before it reads a
   space. Its locally derived URL does not resolve, and the terminal error
   instructs its user to reload.
+- No alias is seeded and no mutation is accepted until every ordinary toolshed,
+  storage toolshed, registry frontend, and old shell session has crossed the
+  compatibility barrier. The empty-namespace name route is verified at every
+  entry point before the seed transaction. Mutations remain denied until that
+  transaction succeeds. An incompatible binary or route cannot be deployed
+  after activation.
 - Removing a host from policy makes every alias routed through it unavailable on
   the next lookup without exposing the name to legacy derivation.
 - A future fixed route cannot take a segment whose namespace row is an alias.
-- A newly inserted reservation returns not found on old and new registry servers
-  until its fixed route begins serving.
+- A newly inserted reservation returns not found on every serving registry
+  frontend until its fixed route begins serving.
 - Invalid legacy names are migrated to canonical DID-and-host links rather than
   normalized into registry claims.
 - Removing all registry client and server code requires no change to space


### PR DESCRIPTION
Space creation currently derives a private key from a fixed public value and the space name. That combines display names, routing, identity, and lasting authority in one mechanism.

Plan a one-shot migration to randomly generated space identities. Limit the generated key to ACL genesis, make the acting user the initial owner, and retain non-secret allocation results so interrupted or delayed creation resumes with the same space. Keep Home names as personal labels and bind browser URLs to a space DID and its storage host.

Separately plan a deployment-scoped public name registry. Resolve direct /<name> URLs before the shell. Keep claims independent from space creation. Choose the newest active name owned by a current space owner as the canonical browser URL, after validating its route against the opened space. Fall back to /<space-did> when no name qualifies or canonicalization is incomplete.

Record the Labs and CFC documentation audit in both plans. Require CFC membership to stop granting access merely because a principal equals a space. Keep the separate sequence-zero ACL bootstrap narrowly in Memory. Link the related Home, URL, FUSE, Pattern Factory, and server-execution contracts and include their migration work.

Give each independent plan an explicit Toolshed-private SQLite control store. Describe the one-pull-request migrations, service contracts, routing, authorization rules, failure behavior, compatibility boundaries, tests, and acceptance criteria.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

