### PR TITLE
ci: mark server-execution test records

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1008,6 +1008,7 @@ jobs:
         uses: ./.github/actions/test-records-ship
         with:
           artifact: package-integration-server-execution-on-${{ matrix.suite_name }}
+          variant: server-execution
           job: >-
             Package Integration Tests / server-execution ON
             (${{ matrix.suite_name }})
@@ -1512,6 +1513,7 @@ jobs:
         uses: ./.github/actions/test-records-ship
         with:
           artifact: pattern-integration-server-execution-on-${{ matrix.shard }}
+          variant: server-execution
           job: >-
             Pattern Integration Tests / server-execution ON
             (${{ matrix.shard }}/${{ matrix.total }})

--- a/docs/specs/server-side-execution/testing.md
+++ b/docs/specs/server-side-execution/testing.md
@@ -71,6 +71,16 @@ the runner integration files that serve toolshed's `app.ts` in-process)
 are not arms of this contract: they have no serving host and run the
 derive-and-commit model by construction (EXPERIMENTAL_OPTIONS.md).*
 
+Test-record identity follows the [test-run record
+contract](../test-records.md). The current default arm leaves the shipping
+action's `variant` input unset. The explicit ON package and pattern jobs set
+it to `server-execution`, so results from the two configurations keep separate
+histories. Any additional non-default arm uses its own stable variant. The
+workflow tests assert both that non-default arms carry their exact marker and
+that the default arm remains unmarked. When ON becomes the default, remove its
+marker and mark the surviving explicit OFF arm as `server-execution-off`; new
+default runs then continue the existing unmarked history.
+
 ## 3. The watermark replaces polling
 
 `waitForSettled(space, seq)` — new test helper: resolves when the

--- a/tasks/ci-workflow.test.ts
+++ b/tasks/ci-workflow.test.ts
@@ -701,7 +701,7 @@ Deno.test("test-records-ship forwards its optional variant input", async () => {
   assertStringIncludes(action, 'args+=(--variant "$SHIP_VARIANT")');
 });
 
-Deno.test("server-execution variant rollout waits for relay support", async () => {
+Deno.test("server-execution ON jobs ship records under their variant", async () => {
   const contents = withoutComments(await workflow("deno.yml"));
   const packageJob = jobBlock(
     contents,
@@ -730,17 +730,22 @@ Deno.test("server-execution variant rollout waits for relay support", async () =
   );
 
   for (
+    const jobId of ["package-integration-test", "pattern-integration-test"]
+  ) {
+    const ship = stepBlock(jobBlock(contents, jobId), "📤 Ship test records");
+    assert(
+      !ship.includes("variant:"),
+      `${jobId}: the default configuration must remain unmarked`,
+    );
+  }
+
+  for (
     const jobId of [
-      "package-integration-test",
-      "pattern-integration-test",
       "package-integration-test-server-execution-on",
       "pattern-integration-test-server-execution-on",
     ]
   ) {
     const ship = stepBlock(jobBlock(contents, jobId), "📤 Ship test records");
-    assert(
-      !ship.includes("variant:"),
-      `${jobId}: variants start only after relay support reaches main`,
-    );
+    assertStringIncludes(ship, "variant: server-execution");
   }
 });


### PR DESCRIPTION
The server-execution ON integration jobs run the same tests as the default jobs under a different configuration. Their records otherwise share an identity and combine histories with the default runs.

Pass the stable server-execution variant to the shared shipping action for the package and pattern ON jobs. Keep the default jobs unmarked so their existing history remains continuous when server execution becomes the default configuration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

