### PR TITLE
test(patterns): the dictionary check reads details directly

### DIFF
--- a/packages/patterns/scrabble/scrabble.test.tsx
+++ b/packages/patterns/scrabble/scrabble.test.tsx
@@ -130,7 +130,7 @@ export default pattern(() => {
     const lastEvent = scrabble.gameEvents.at(-1);
     return scrabble.board.length === 7 &&
       lastEvent?.type === "word" &&
-      lastEvent?.details?.includes("ANODES") === true &&
+      lastEvent.details.includes("ANODES") &&
       scrabble.message.startsWith("Scored ");
   });
 


### PR DESCRIPTION
`assert()` used to hide a field that a check only ever called a method on, so `lastEvent.details.includes(...)` was handed an event with no `details` and threw. Two checks in this file worked around it by reaching the field through an optional chain instead, which sidesteps the recording entirely: the rewrite leaves the receiver of an optional call alone, so `lastEvent?.details?.includes(...)` stayed a plain field read and kept `details` in the schema.

The first of the two lost its workaround when the underlying bug was fixed. This one was written while that fix was in flight, so it still carries it. The field is in the schema now, and the check reads it the way the one above it does.

Dropping the `=== true` that went with the optional chain also improves what a failure says. `assert()` records the operands of a comparison, so `lastEvent?.details?.includes("ANODES") === true` recorded only the `false` that the call returned. A bare call has its receiver recorded instead, so a failure now reports the details string the board actually produced, which is what tells you whether the word scored differently or did not score at all.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

