### PR TITLE
fix(data-model): seal `FabricInstance`s over a freeze shield

### DIFF
--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1564,9 +1564,9 @@ for legacy-data migration/import (see the decode-only tag discussion in Section
 ### 2.2 Symbols
 
 The encoding symbols live with the codec vocabulary; the in-process
-lifecycle symbols, along with the one that keys an instance's freeze shield,
-live on the implementation base class `BaseFabricInstance` (Section 2.3), kept
-off the pure-protocol `FabricInstance` interface as implementation plumbing.
+lifecycle symbols live on the implementation base class `BaseFabricInstance`
+(Section 2.3), kept off the pure-protocol `FabricInstance` interface as
+implementation plumbing.
 
 There is one encoding symbol per wire format, plus the format-neutral
 `CODEC` (Section 2.4). A registry reads the format's own symbol through a
@@ -1633,18 +1633,6 @@ export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol(
   'data-model.shallowUnfrozenClone',
 );
 
-/**
- * Well-known symbol for the sole own property every fabric instance carries.
- * Unlike the symbols above, this one keys a property rather than a member:
- * it is what keeps `Object.isFrozen()` an honest report of an instance's
- * frozen state, given that an instance is sealed and holds everything else
- * privately (Section 2.3). It is non-enumerable, so no structural view of an
- * instance sees it, and its value is never read.
- */
-export const FREEZE_SHIELD: unique symbol = Symbol(
-  'data-model.freezeShield',
-);
-
 // Protocol evolution: a further exported symbol, e.g.
 // `Symbol('data-model.codec@2')`.
 ```
@@ -1678,13 +1666,12 @@ class-side `[CODEC]` (Section 2.4).
  * scaffolding (such as `shallowClone()`) lives.
  *
  * An instance holds all of its state privately and makes it reachable only
- * through members. Its one own property is the non-enumerable
- * `[FREEZE_SHIELD]` that `BaseFabricInstance` installs, so a structural
- * view of an instance — a spread, `Object.keys()`, a naive walk — still
- * sees nothing. Mutable state is exposed as an accessor pair over a
- * private field, whose setter is responsible for honoring the instance's
- * frozen state: `Object.freeze()` bears only on own properties and so
- * cannot enforce that on its own.
+ * through members, so it has no own properties at all. A structural view
+ * of one — a spread, `Object.keys()`, a naive walk — therefore sees
+ * nothing. Mutable state is exposed as an accessor pair over a private
+ * field, whose setter is responsible for honoring the instance's frozen
+ * state: `Object.freeze()` bears only on own properties and so cannot
+ * enforce that on its own.
  *
  * Subclasses must implement:
  * - `[DEEP_FREEZE](subFreeze)` -- deeply freezes this instance in place.
@@ -1770,34 +1757,6 @@ export abstract class FabricInstance extends FabricSpecialObject {
  */
 export abstract class BaseFabricInstance extends FabricInstance {
   /**
-   * Constructs an instance, installing `[FREEZE_SHIELD]` and sealing.
-   *
-   * The seal is what makes an attempt to add a property to an instance
-   * throw, rather than quietly attach data that no structural view,
-   * encoder, or hash will ever see again. The shield is what keeps
-   * `Object.isFrozen()` honest across that seal: an instance keeps its
-   * state in private fields, and a sealed object with no own properties is
-   * vacuously frozen, so without the shield a freshly built mutable
-   * instance would report as frozen and every thaw would short-circuit to
-   * identity. `Object.freeze()` clears the shield's `writable` bit, so
-   * `Object.isFrozen()` tracks frozen state exactly.
-   *
-   * Private fields are not properties, so a subclass's state is untouched
-   * by the seal. A subclass that declares a public field, or assigns one
-   * after `super()`, throws here by design.
-   */
-  constructor() {
-    super();
-    Object.defineProperty(this, FREEZE_SHIELD, {
-      value: false,
-      writable: true,
-      enumerable: false,
-      configurable: false,
-    });
-    Object.seal(this);
-  }
-
-  /**
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */
@@ -1845,6 +1804,20 @@ export abstract class BaseFabricInstance extends FabricInstance {
 > therefore stable against changes to the template-method scaffolding, and the
 > `instanceof FabricInstance` brand check still catches every concrete
 > `FabricInstance` value.
+
+> **An aside on sealing instances.** Nothing in this model requires it, and an
+> implementation is free to skip it, but a JavaScript implementation may want
+> to seal an instance so that adding a property to one throws rather than
+> silently attaching data that no structural view, encoder, or hash will read.
+> Doing so takes one wrinkle. `Object.isFrozen()` reports `true` for any sealed
+> object with no own properties, so an instance holding all of its state
+> privately would report as frozen from the moment it was built, and a request
+> for a mutable copy would hand back the original. Giving the instance a single
+> writable own property, keyed by a symbol and non-enumerable, is enough to fix
+> that: `Object.freeze()` clears the property's `writable` bit, so
+> `Object.isFrozen()` again tracks the instance's frozen state. Such a property
+> is invisible to a spread, `Object.keys()`, and `JSON.stringify()` alike, so
+> instances still present no properties to a client.
 
 ### 2.4 Codec Protocol
 

--- a/docs/specs/space-model-formal-spec/1-fabric-values.md
+++ b/docs/specs/space-model-formal-spec/1-fabric-values.md
@@ -1564,9 +1564,9 @@ for legacy-data migration/import (see the decode-only tag discussion in Section
 ### 2.2 Symbols
 
 The encoding symbols live with the codec vocabulary; the in-process
-lifecycle symbols live on the implementation base class `BaseFabricInstance`
-(Section 2.3), kept off the pure-protocol `FabricInstance` interface as
-implementation plumbing.
+lifecycle symbols, along with the one that keys an instance's freeze shield,
+live on the implementation base class `BaseFabricInstance` (Section 2.3), kept
+off the pure-protocol `FabricInstance` interface as implementation plumbing.
 
 There is one encoding symbol per wire format, plus the format-neutral
 `CODEC` (Section 2.4). A registry reads the format's own symbol through a
@@ -1633,6 +1633,18 @@ export const SHALLOW_UNFROZEN_CLONE: unique symbol = Symbol(
   'data-model.shallowUnfrozenClone',
 );
 
+/**
+ * Well-known symbol for the sole own property every fabric instance carries.
+ * Unlike the symbols above, this one keys a property rather than a member:
+ * it is what keeps `Object.isFrozen()` an honest report of an instance's
+ * frozen state, given that an instance is sealed and holds everything else
+ * privately (Section 2.3). It is non-enumerable, so no structural view of an
+ * instance sees it, and its value is never read.
+ */
+export const FREEZE_SHIELD: unique symbol = Symbol(
+  'data-model.freezeShield',
+);
+
 // Protocol evolution: a further exported symbol, e.g.
 // `Symbol('data-model.codec@2')`.
 ```
@@ -1666,12 +1678,13 @@ class-side `[CODEC]` (Section 2.4).
  * scaffolding (such as `shallowClone()`) lives.
  *
  * An instance holds all of its state privately and makes it reachable only
- * through members, so it has no own properties at all. A structural view
- * of one — a spread, `Object.keys()`, a naive walk — therefore sees
- * nothing. Mutable state is exposed as an accessor pair over a private
- * field, whose setter is responsible for honoring the instance's frozen
- * state: `Object.freeze()` bears only on own properties and so cannot
- * enforce that on its own.
+ * through members. Its one own property is the non-enumerable
+ * `[FREEZE_SHIELD]` that `BaseFabricInstance` installs, so a structural
+ * view of an instance — a spread, `Object.keys()`, a naive walk — still
+ * sees nothing. Mutable state is exposed as an accessor pair over a
+ * private field, whose setter is responsible for honoring the instance's
+ * frozen state: `Object.freeze()` bears only on own properties and so
+ * cannot enforce that on its own.
  *
  * Subclasses must implement:
  * - `[DEEP_FREEZE](subFreeze)` -- deeply freezes this instance in place.
@@ -1756,6 +1769,34 @@ export abstract class FabricInstance extends FabricSpecialObject {
  * implementations live.
  */
 export abstract class BaseFabricInstance extends FabricInstance {
+  /**
+   * Constructs an instance, installing `[FREEZE_SHIELD]` and sealing.
+   *
+   * The seal is what makes an attempt to add a property to an instance
+   * throw, rather than quietly attach data that no structural view,
+   * encoder, or hash will ever see again. The shield is what keeps
+   * `Object.isFrozen()` honest across that seal: an instance keeps its
+   * state in private fields, and a sealed object with no own properties is
+   * vacuously frozen, so without the shield a freshly built mutable
+   * instance would report as frozen and every thaw would short-circuit to
+   * identity. `Object.freeze()` clears the shield's `writable` bit, so
+   * `Object.isFrozen()` tracks frozen state exactly.
+   *
+   * Private fields are not properties, so a subclass's state is untouched
+   * by the seal. A subclass that declares a public field, or assigns one
+   * after `super()`, throws here by design.
+   */
+  constructor() {
+    super();
+    Object.defineProperty(this, FREEZE_SHIELD, {
+      value: false,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
+    Object.seal(this);
+  }
+
   /**
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.

--- a/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
@@ -39,9 +39,8 @@ import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 export const DEEP_FREEZE: unique symbol = Symbol("data-model.deepFreeze");
 
 /**
- * Well-known symbol for the sole own property every `FabricInstance` carries:
- * the one that keeps `Object.isFrozen()` an honest report of the instance's
- * frozen state.
+ * Key for the sole own property every `FabricInstance` carries: the one that
+ * keeps `Object.isFrozen()` an honest report of the instance's frozen state.
  *
  * An instance keeps its contents in private fields, and a sealed object with no
  * own properties is *vacuously* frozen: `Object.isFrozen()` would answer `true`
@@ -54,7 +53,7 @@ export const DEEP_FREEZE: unique symbol = Symbol("data-model.deepFreeze");
  * spread, `Object.keys()`, `JSON.stringify()`, and a naive walk all see
  * nothing. Its value is never read; existing is the whole of its job.
  */
-export const FREEZE_SHIELD: unique symbol = Symbol("data-model.freezeShield");
+const FREEZE_SHIELD: unique symbol = Symbol("data-model.freezeShield");
 
 /**
  * Well-known symbol for checking whether a `FabricInstance` is already deeply

--- a/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
@@ -10,6 +10,9 @@
  * inside it. Dispatch is generic in the base class, so nothing here enumerates
  * concrete subclasses.
  *
+ * That same privacy is why an instance is sealed at construction over a single
+ * non-enumerable own property; `[FREEZE_SHIELD]` covers the pair.
+ *
  * This module and the freeze utility import each other. The cycle is
  * deliberate, and is safe only because each side reaches the other from inside
  * a function body; a dereference during module evaluation would break it.
@@ -34,6 +37,24 @@ import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
  * in place; `deepClone()` constructs a new instance.
  */
 export const DEEP_FREEZE: unique symbol = Symbol("data-model.deepFreeze");
+
+/**
+ * Well-known symbol for the sole own property every `FabricInstance` carries:
+ * the one that keeps `Object.isFrozen()` an honest report of the instance's
+ * frozen state.
+ *
+ * An instance keeps its contents in private fields, and a sealed object with no
+ * own properties is *vacuously* frozen: `Object.isFrozen()` would answer `true`
+ * for a freshly built, fully mutable instance, and every thaw would then
+ * short-circuit to identity. One writable own property is what gives the
+ * predicate something to bear on -- `Object.freeze()` clears its `writable`
+ * bit, so `Object.isFrozen()` tracks the instance's frozen state exactly.
+ *
+ * The property is non-enumerable, so it stays out of every structural view: a
+ * spread, `Object.keys()`, `JSON.stringify()`, and a naive walk all see
+ * nothing. Its value is never read; existing is the whole of its job.
+ */
+export const FREEZE_SHIELD: unique symbol = Symbol("data-model.freezeShield");
 
 /**
  * Well-known symbol for checking whether a `FabricInstance` is already deeply
@@ -93,6 +114,30 @@ export const DEEP_CLONE_CORE: unique symbol = Symbol(
  * freeze-protocol plumbing (`[DEEP_FREEZE]()`, `[IS_DEEP_FROZEN]()`) live.
  */
 export abstract class BaseFabricInstance extends FabricInstance {
+  /**
+   * Constructs an instance: installs the `[FREEZE_SHIELD]` property, then
+   * seals. The seal makes an attempt to add a property to an instance throw,
+   * where it would otherwise attach data that no structural view, encoder, or
+   * hash goes on to see. The shield must precede the seal, for the reason its
+   * own doc gives.
+   *
+   * A subclass keeps its state in private fields, which are not properties and
+   * so are untouched by the seal. A subclass that declares a public field, or
+   * assigns one after `super()`, throws here by design.
+   */
+  constructor() {
+    super();
+
+    Object.defineProperty(this, FREEZE_SHIELD, {
+      value: false,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
+
+    Object.seal(this);
+  }
+
   //
   // Subclass contract
   //

--- a/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-bases/BaseFabricInstance.ts
@@ -10,9 +10,6 @@
  * inside it. Dispatch is generic in the base class, so nothing here enumerates
  * concrete subclasses.
  *
- * That same privacy is why an instance is sealed at construction over a single
- * non-enumerable own property; `[FREEZE_SHIELD]` covers the pair.
- *
  * This module and the freeze utility import each other. The cycle is
  * deliberate, and is safe only because each side reaches the other from inside
  * a function body; a dereference during module evaluation would break it.
@@ -113,20 +110,18 @@ export const DEEP_CLONE_CORE: unique symbol = Symbol(
  * freeze-protocol plumbing (`[DEEP_FREEZE]()`, `[IS_DEEP_FROZEN]()`) live.
  */
 export abstract class BaseFabricInstance extends FabricInstance {
-  /**
-   * Constructs an instance: installs the `[FREEZE_SHIELD]` property, then
-   * seals. The seal makes an attempt to add a property to an instance throw,
-   * where it would otherwise attach data that no structural view, encoder, or
-   * hash goes on to see. The shield must precede the seal, for the reason its
-   * own doc gives.
-   *
-   * A subclass keeps its state in private fields, which are not properties and
-   * so are untouched by the seal. A subclass that declares a public field, or
-   * assigns one after `super()`, throws here by design.
-   */
+  /** Constructs an instance. */
   constructor() {
     super();
 
+    // The shield goes on before the seal, not after: sealing an instance that
+    // has no own properties leaves it reporting as frozen, which is what
+    // `FREEZE_SHIELD` covers. The seal is then what turns a stray property
+    // addition into a throw, rather than data that no structural view,
+    // encoder, or hash goes on to see. A subclass's state lives in private
+    // fields, which are not properties and so are untouched by any of this; a
+    // subclass that declares a public field, or assigns one after `super()`,
+    // throws here by design.
     Object.defineProperty(this, FREEZE_SHIELD, {
       value: false,
       writable: true,

--- a/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
@@ -22,7 +22,6 @@ import {
   BaseFabricInstance,
   DEEP_CLONE_CORE,
   DEEP_FREEZE,
-  FREEZE_SHIELD,
   IS_DEEP_FROZEN,
   SHALLOW_UNFROZEN_CLONE,
 } from "@/fabric-bases/BaseFabricInstance.ts";
@@ -182,9 +181,8 @@ describe("BaseFabricInstance", () => {
     });
 
     it("reports an unfrozen instance as not frozen", () => {
-      // The case the `[FREEZE_SHIELD]` property exists for: sealing an object
-      // with no own properties would make this `true`, and every thaw would
-      // then short-circuit to identity.
+      // Sealing an object that has no own properties would make this `true`,
+      // and every thaw would then short-circuit to identity.
       const probe = new Probe("t");
       expect(Object.isFrozen(probe)).toBe(false);
     });
@@ -200,11 +198,6 @@ describe("BaseFabricInstance", () => {
       expect(Object.keys(probe)).toEqual([]);
       expect({ ...probe }).toEqual({});
       expect(JSON.stringify(probe)).toBe("{}");
-    });
-
-    it("installs `[FREEZE_SHIELD]` as the sole own symbol", () => {
-      const probe = new Probe("t");
-      expect(Object.getOwnPropertySymbols(probe)).toEqual([FREEZE_SHIELD]);
     });
   });
 

--- a/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-bases/BaseFabricInstance.test.ts
@@ -22,6 +22,7 @@ import {
   BaseFabricInstance,
   DEEP_CLONE_CORE,
   DEEP_FREEZE,
+  FREEZE_SHIELD,
   IS_DEEP_FROZEN,
   SHALLOW_UNFROZEN_CLONE,
 } from "@/fabric-bases/BaseFabricInstance.ts";
@@ -37,13 +38,20 @@ import { deepFreeze, isDeepFrozen } from "@/deep-freeze.ts";
 class Probe extends BaseFabricInstance {
   readonly #tag;
 
+  readonly #counter: { calls: number };
+
   constructor(
     tag: string,
-    readonly counter: { calls: number } = { calls: 0 },
+    counter: { calls: number } = { calls: 0 },
   ) {
     super();
 
     this.#tag = tag;
+    this.#counter = counter;
+  }
+
+  get counter(): { calls: number } {
+    return this.#counter;
   }
 
   get wireTypeTag(): string {
@@ -80,12 +88,22 @@ class Probe extends BaseFabricInstance {
  * independence (which the payload-less `Probe` cannot express).
  */
 class DeepProbe extends BaseFabricInstance {
-  state: { n: number };
+  readonly #state: { n: number };
+  readonly #counter: { calls: number };
 
-  constructor(state: { n: number }, readonly counter = { calls: 0 }) {
+  constructor(state: { n: number }, counter = { calls: 0 }) {
     super();
 
-    this.state = state;
+    this.#state = state;
+    this.#counter = counter;
+  }
+
+  get counter(): { calls: number } {
+    return this.#counter;
+  }
+
+  get state(): { n: number } {
+    return this.#state;
   }
 
   get wireTypeTag(): string {
@@ -138,6 +156,55 @@ describe("BaseFabricInstance", () => {
       const probe = new Probe("t");
       expect(probe instanceof BaseFabricInstance).toBe(true);
       expect(probe instanceof FabricInstance).toBe(true);
+    });
+  });
+
+  describe("constructor()", () => {
+    it("leaves the instance sealed and non-extensible", () => {
+      const probe = new Probe("t");
+      expect(Object.isSealed(probe)).toBe(true);
+      expect(Object.isExtensible(probe)).toBe(false);
+    });
+
+    it("refuses a new property, whichever way it is added", () => {
+      // Every path here is strict-mode, which is what a module is. Sloppy-mode
+      // assignment is the one path that fails silently instead of throwing.
+      const probe = new Probe("t") as unknown as Record<string, unknown>;
+
+      expect(() => {
+        probe.extra = 42;
+      }).toThrow(TypeError);
+      expect(() => Object.defineProperty(probe, "extra", { value: 42 }))
+        .toThrow(TypeError);
+      expect(() => Object.assign(probe, { extra: 42 })).toThrow(TypeError);
+      expect(Reflect.set(probe, "extra", 42)).toBe(false);
+      expect(Object.getOwnPropertyNames(probe)).toEqual([]);
+    });
+
+    it("reports an unfrozen instance as not frozen", () => {
+      // The case the `[FREEZE_SHIELD]` property exists for: sealing an object
+      // with no own properties would make this `true`, and every thaw would
+      // then short-circuit to identity.
+      const probe = new Probe("t");
+      expect(Object.isFrozen(probe)).toBe(false);
+    });
+
+    it("reports a frozen instance as frozen", () => {
+      const probe = new Probe("t");
+      expect(Object.isFrozen(Object.freeze(probe))).toBe(true);
+    });
+
+    it("keeps the instance absent from every structural view", () => {
+      const probe = new Probe("t");
+      expect(Object.getOwnPropertyNames(probe)).toEqual([]);
+      expect(Object.keys(probe)).toEqual([]);
+      expect({ ...probe }).toEqual({});
+      expect(JSON.stringify(probe)).toBe("{}");
+    });
+
+    it("installs `[FREEZE_SHIELD]` as the sole own symbol", () => {
+      const probe = new Probe("t");
+      expect(Object.getOwnPropertySymbols(probe)).toEqual([FREEZE_SHIELD]);
     });
   });
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -25,6 +25,7 @@ import { expect } from "@std/expect";
 import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
+  FREEZE_SHIELD,
   IS_DEEP_FROZEN,
 } from "@/fabric-bases/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-interface/interface.ts";
@@ -60,7 +61,7 @@ describe("FabricError", () => {
     const se = FabricError.fromNativeError(new Error("test"));
     se.setExtra("extra", 1);
     expect(Object.getOwnPropertyNames(se)).toEqual([]);
-    expect(Object.getOwnPropertySymbols(se)).toEqual([]);
+    expect(Object.getOwnPropertySymbols(se)).toEqual([FREEZE_SHIELD]);
     expect({ ...se }).toEqual({});
   });
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -25,7 +25,6 @@ import { expect } from "@std/expect";
 import { FabricInstance, type FabricValue } from "@/interface.ts";
 import {
   DEEP_FREEZE,
-  FREEZE_SHIELD,
   IS_DEEP_FROZEN,
 } from "@/fabric-bases/BaseFabricInstance.ts";
 import { CODEC } from "@/codec-interface/interface.ts";
@@ -61,7 +60,6 @@ describe("FabricError", () => {
     const se = FabricError.fromNativeError(new Error("test"));
     se.setExtra("extra", 1);
     expect(Object.getOwnPropertyNames(se)).toEqual([]);
-    expect(Object.getOwnPropertySymbols(se)).toEqual([FREEZE_SHIELD]);
     expect({ ...se }).toEqual({});
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## What this does

A `FabricInstance` keeps all of its state in private fields. A property
accidentally added to one is therefore data that no structural view, encoder,
or hash ever reads again — it is lost at the moment it is written, and nothing
says so. `BaseFabricInstance`'s constructor now seals, which turns that into a
throw at the site of the write.

Sealing on its own does not work, and the reason is the interesting part: an
object with no own properties is *vacuously* frozen once sealed, so
`Object.isFrozen()` answers `true` for a freshly built, fully mutable instance,
and every thaw short-circuits to identity. Measured on a bare seal: 8 failing
test files, every one a `frozen=false` clone reporting frozen.

The constructor therefore installs one non-enumerable, writable, symbol-keyed
own property — `[FREEZE_SHIELD]` — and seals after it. `Object.freeze()` clears
that property's `writable` bit, so `Object.isFrozen()` goes on tracking an
instance's frozen state exactly. The shield does not defeat `Object.isFrozen()`
on instances; it gives the predicate something honest to bear on, which is why
no frozen-state reporting has to move off it and no call site in
`value-clone.ts` or `deep-freeze.ts` changes.

Non-enumerable is required rather than merely tidy. An enumerable shield rides
along in `{...instance}`, and the resulting plain object then fails
`isInertPlainObject()`, which rejects any object carrying own symbols.

## The behavior change to weigh

This converts a class of silent corruption into a throw. That is the intent,
and it is also the risk: a production caller that adds a property to an
instance now fails loudly where it used to fail invisibly.

- `cloneWithValueAtPath()` is the one confirmed such site. Before: own props
  `["extra"]`, spreading as `{"extra":42}` on a `FabricError`. After:
  `TypeError: Cannot add property extra, object is not extensible`. That
  latent bug is now visible rather than fixed — worth its own change.
- `cloneWithoutValueAtPath()` was already safe: its pre-walk gates the final
  parent on `isPlainContainer`.
- `runner/src/storage/transaction/mutable-path-write.ts` and
  `runner/src/cfc/prepare.ts` both looked guarded on reading — the first
  refuses a non-plain container, the second writes into a freshly built one —
  and the runner suite passing is the running evidence for that.

## Cost

~116 ns per instance construction, flat across every workload measured
(A/B against a clean worktree, 1000 constructions per iteration):

| bench | baseline | with shield | added per instance |
| --- | --- | --- | --- |
| `FabricMap` | 3.3 µs | 118.8 µs | +115.5 ns |
| `FabricSet` | 3.3 µs | 118.4 µs | +115.1 ns |
| `FabricError.fromNativeError()` | 43.8 µs | 161.3 µs | +117.5 ns |
| `shallowClone(false)` | 3.3 µs | 119.7 µs | +116.4 ns |

`Object.seal()` is essentially free; the whole of the cost is the one
`Object.defineProperty()` call, and no descriptor or lock combination buys any
of it back (a control installing the property and *not* locking measured
123.8 µs against 124.1 µs for property-plus-seal). The machine was not quiet
during these runs.

## Tests

Five new `constructor()` cases in `BaseFabricInstance.test.ts`, covering the
seal, refusal of a new property by each strict-mode path, the unfrozen and
frozen `Object.isFrozen()` reports, and structural invisibility. They test the
behavior the shield enables, not the shield itself — `FREEZE_SHIELD` is
module-private, and a property no structural view can see is not a thing to
assert on directly.

Both mechanisms were ablated to confirm the cases have grip. Removing
`Object.seal()` fails exactly the two seal cases. Removing the shield fails
`reports an unfrozen instance as not frozen` and reproduces the original 8
thaw-path failures.

`DeepProbe`'s public `state` field became a private field behind a getter: the
seal forbids a public field on a subclass, and every production
`FabricInstance` is already all-private, so this makes the test double match
the shape it stands in for. Its setter was dead and is gone.

## Spec

`docs/specs/space-model-formal-spec/1-fabric-values.md` gains one aside and no
normative change — the diff is additions only, all inside a blockquote. From a
client's perspective an instance still presents no properties, and sealing is
a tactic available to a JavaScript implementation rather than a property of the
model, so the spec notes it without mandating it.

## Verification

`deno fmt --check`, `deno lint`, `deno task check`, `check-docs` (566 blocks),
`check-skill-facts`, `check-docs-history-index`, `check-conflict-markers`,
`check-no-waitfor` — all pass. Suites: data-model 52, api 26, utils, pure-json,
identity, memory 574, piece 45, runner 1292 — all 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nngbjm3AjShr7Bqf1YFips


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


