### PR TITLE
Remove the dead whole-program bundle pretransform

### DIFF
--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -4,15 +4,6 @@ import type ts from "typescript";
 import { compilerStack } from "./deferred-compiler-stack.ts";
 import { RuntimeProgram } from "./types.ts";
 
-export function pretransformProgram(
-  program: RuntimeProgram,
-  id: string,
-): RuntimeProgram {
-  program = transformInjectHelperModule(program);
-  program = transformProgramWithPrefix(program, id);
-  return program;
-}
-
 // For each source file in the program, inject the internal helper import used
 // by the AST transformer. Every file is transformed.
 //
@@ -26,7 +17,7 @@ export function pretransformProgram(
 // reach `transformCfDirective`, so the guard never fires for them. Set this
 // ONLY for storage-fetched, Merkle-verified input (the engine's cold
 // recovery path and fabric mounts). Authoring paths
-// (`pretransformProgram(ForModules)`) never set it — authored source
+// (`pretransformProgramForModules`) never set it — authored source
 // containing `__cfHelpers` keeps throwing, so the poison can never be
 // WRITTEN again; tolerance exists only for what history already stored.
 // Skipping `normalizeMixedModuleImports` for these files is safe: the
@@ -69,40 +60,9 @@ export function transformInjectHelperModule(
   };
 }
 
-// Adds `id` as a prefix to all files in the program.
-// Injects a new entry at root `/index.ts` to re-export
-// the entry contents because otherwise `typescript`
-// flattens the output, eliding the common prefix.
-export function transformProgramWithPrefix(
-  program: RuntimeProgram,
-  id: string,
-): RuntimeProgram {
-  const main = program.main;
-  const exportNameds = `export * from "${prefix(main, id)}";`;
-  const exportDefault = `export { default } from "${prefix(main, id)}";`;
-  const hasDefault = !program.mainExport || program.mainExport === "default";
-  const files = [
-    ...program.files.map((source) => ({
-      name: prefix(source.name, id),
-      contents: source.contents,
-    })),
-    {
-      name: `/index.ts`,
-      contents: `${exportNameds}${hasDefault ? `\n${exportDefault}` : ""}`,
-    },
-  ];
-  return {
-    main: `/index.ts`,
-    files,
-    sourceRoots: program.sourceRoots?.map((root) => prefix(root, id)),
-    dataFiles: program.dataFiles?.map((data) => prefix(data, id)),
-  };
-}
-
-// Module-graph variant: inject the helper import and prefix files with `id` to
-// namespace this load's source-map and diagnostic coordinates, but DO NOT add a
-// synthetic `/index.ts` re-export. A per-module graph has no bundle entrypoint
-// to re-export through, so the program entry is simply the prefixed main module.
+// Inject the helper import and prefix every file with `id`, which namespaces
+// this load's source-map and diagnostic coordinates. The program entry is the
+// prefixed main module.
 export function pretransformProgramForModules(
   program: RuntimeProgram,
   id: string,


### PR DESCRIPTION
`pretransform.ts` still carried the pretransform pair that prepared a program for a single whole-program bundle: `pretransformProgram`, and the `transformProgramWithPrefix` it called. That path prefixed every file with the load id and then added a synthetic `/index.ts` whose only job was to re-export the entry module, because the TypeScript emit flattened the output and elided the common prefix otherwise.

Nothing runs that path any more. Module loading resolves and compiles one record per module, so it prefixes the files and takes the prefixed main module as the entry, with no bundle entrypoint to re-export through. That is what `pretransformProgramForModules` does, and it is the only pretransform the engine calls. `docs/specs/module-loading.md` describes the per-module graph and states there is no whole-program `outFile` bundle.

Leaving the pair in place was not free. Every change to the shape of `RuntimeProgram` had to be mirrored into it on the chance that it might one day run: both the `sourceRoots` handling and the `dataFiles` handling were written into `transformProgramWithPrefix` for a caller that does not exist. The lines also counted as uncovered against the coverage debt metric, since no test could reach them.

Both functions are removed. No helper falls out of use with them: `prefix` is still what `pretransformProgramForModules` calls, and `transformInjectHelperModule` is called by that function and directly by tests. Two comments that named the removed function are corrected to name the surviving one and to describe what it does rather than how it differs from the bundle path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

