### PR TITLE
fix(tasks): stop the batch parse guessing, and name git's reason

### DIFF
--- a/tasks/check-control-characters.test.ts
+++ b/tasks/check-control-characters.test.ts
@@ -203,6 +203,35 @@ describe("check-control-characters", () => {
       expect(parseBatchBlobs(encode("abc missing\ndef blob 2\nhi\n"), 2))
         .toEqual([]);
     });
+
+    it("stops at a size that is not the digits git writes", () => {
+      // An empty field and a negative one both read as a number, so both
+      // would push a record and carry on from an offset nothing lines up
+      // with — the count comes out right and the contents do not.
+      expect(parseBatchBlobs(encode("abc blob \ndef blob 2\nhi\n"), 2))
+        .toEqual([]);
+      expect(parseBatchBlobs(encode("abc blob -1\ndef blob 2\nhi\n"), 2))
+        .toEqual([]);
+    });
+
+    it("stops at a record the output does not carry in full", () => {
+      // The slice clamps to what is there, so a blob short of its declared
+      // size would be scanned as the whole file — and with the count intact,
+      // the caller's fail-closed check would see a tree fully read.
+      expect(parseBatchBlobs(encode("abc blob 2\nhi\ndef blob 9\nnope"), 2))
+        .toEqual([encode("hi")]);
+      expect(parseBatchBlobs(encode("abc blob 100\nhi\n"), 1)).toEqual([]);
+    });
+
+    it("keeps the last record, whose trailing newline ends the output", () => {
+      // The boundary either side of the guard above: a complete final record
+      // reaches exactly to the last byte of the output, and an empty blob
+      // carries nothing between its header and that newline.
+      expect(parseBatchBlobs(encode("abc blob 3\nbye\n"), 1).map(decode))
+        .toEqual(["bye"]);
+      expect(parseBatchBlobs(encode("abc blob 0\n\n"), 1).map(decode))
+        .toEqual([""]);
+    });
   });
 
   describe("scan()", () => {
@@ -315,7 +344,7 @@ describe("check-control-characters", () => {
       );
       await expect(
         blobContents(root, ids),
-      ).rejects.toThrow("git cat-file failed");
+      ).rejects.toThrow("git cat-file failed: fatal: not a git repository");
     });
 
     it("throws when git cannot list the tree", async () => {

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -215,9 +215,18 @@ export function parseBatchBlobs(
     let lineEnd = at;
     while (lineEnd < output.length && output[lineEnd] !== 0x0a) lineEnd++;
     const header = new TextDecoder().decode(output.subarray(at, lineEnd));
-    const size = Number(header.split(" ")[2]);
-    if (!Number.isInteger(size)) break;
+    // Read as the run of digits git writes. `Number` takes an empty field as
+    // 0 and a negative field as itself, and a record pushed at either length
+    // leaves every record after it sliced at the wrong offset.
+    const declared = header.split(" ")[2] ?? "";
+    if (!/^[0-9]+$/.test(declared)) break;
+    const size = Number(declared);
     const start = lineEnd + 1;
+    // A record the output does not carry in full stops the parse too. The
+    // slice would otherwise clamp to what is there, and a blob short of the
+    // size its own header declares would be scanned as though it were the
+    // whole file, with the count still matching what was asked for.
+    if (start + size >= output.length) break;
     contents.push(output.subarray(start, start + size));
     at = start + size + 1;
   }
@@ -246,7 +255,7 @@ export async function blobContents(
     cwd: root,
     stdin: "piped",
     stdout: "piped",
-    stderr: "null",
+    stderr: "piped",
   }).spawn();
 
   // Start draining stdout BEFORE writing the ids. git writes as it reads, and
@@ -265,8 +274,12 @@ export async function blobContents(
     // reports it.
   }
 
-  const { success, stdout } = await output;
-  if (!success) throw new Error("git cat-file failed");
+  const { success, stdout, stderr } = await output;
+  if (!success) {
+    throw new Error(
+      `git cat-file failed: ${new TextDecoder().decode(stderr).trim()}`,
+    );
+  }
 
   return parseBatchBlobs(stdout, ids.length);
 }


### PR DESCRIPTION
The control-character gate reads the stored bytes of every tracked file through one `git cat-file --batch` and slices the output by the size each record's header declares. Its doc comment says a header that does not carry a size stops the parse rather than being guessed at, because a wrong size slices every record after it at the wrong offset and blames violations on the wrong files. Two shapes were being guessed at anyway.

`Number("")` is 0, so a header with an empty size field passed as a zero-length blob, and `Number("-1")` is an integer, so a negative size passed as well. Either one pushes a record and reads the next header from an offset nothing lines up with. Separately, `subarray` clamps, so a record the output did not carry in full came back as whatever bytes were there - a blob announced as 100 bytes arriving as 3 became a 3-byte blob.

Both defeat the check the gate leans on. `scan` refuses a batch that came back shorter than the list it sent, because a blob that went missing would otherwise skip its own file and every file after it. All three of these shapes keep the count intact. So what slips through is the case where the gate declares the tree fully read and then scans bytes it composed rather than bytes git sent, and a control character past the cut is reported as absent.

The size is now read as the run of digits git writes, and a record whose content and trailing newline the output does not hold stops the parse, which turns both into the short batch they really are. Real git ends every record, including the last, with that newline, so the guard cannot clip a complete stream; the boundary is tested from both sides, with a complete final record and with an empty blob.

The failure message is the other half. `git cat-file` writes its fatal to stderr, which was discarded, so the gate could only ever say "git cat-file failed" - seven words that do not include what git said. The realistic trigger is an object git cannot read, where it names the object and the inflate error. Stderr is now piped and the message carries git's own words, matching what the sibling `git ls-files` call has always reported.

deflaked by Hixie's agent (Claude Opus 5)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

