### PR TITLE
fix(runner): prepareTxForCommit takes no work on a settled transaction

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2423,6 +2423,14 @@ export class Runtime {
   }
 
   prepareTxForCommit(tx: IExtendedStorageTransaction): void {
+    // A transaction that is no longer open takes no prepare work, because it
+    // can no longer commit. Everything below reaches storage through the
+    // transaction: the flow probe reads stored metadata, and prepareCfc reads
+    // and writes the derived label map. A settled transaction refuses both,
+    // and its commit reports the terminal state as the result.
+    if (tx.status().status !== "ready") {
+      return;
+    }
     const state = tx.getCfcState();
     if (state.enforcementMode === "disabled") {
       // A vouched ingest still needs its provenance mark minted even where CFC

--- a/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
+++ b/packages/runner/test/runtime-prepare-tx-for-commit.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { CfcFlowLabelsMode } from "../src/cfc/types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "runner-prepare-tx-for-commit",
+);
+const space = signer.did();
+
+const LABELED_SCHEMA = {
+  type: "object",
+  properties: {
+    secret: {
+      type: "string",
+      ifc: { confidentiality: ["secret"] },
+    },
+  },
+  required: ["secret"],
+} as const;
+
+// `prepareTxForCommit` reaches storage through the transaction it prepares,
+// by two routes: the flow-labels relevance probe reads stored metadata, and
+// `prepareCfc` reads and writes the derived label map. A settled transaction
+// refuses both, and cannot commit either, so prepare on one returns without
+// touching it and leaves the terminal state to the commit result.
+describe("Runtime.prepareTxForCommit()", () => {
+  const started: {
+    runtime: Runtime;
+    storageManager: ReturnType<typeof StorageManager.emulate>;
+  }[] = [];
+
+  // The flow dial is the one thing that varies between the cases below, so
+  // each test names its own rather than sharing one from `beforeEach`.
+  const makeRuntime = (cfcFlowLabels?: CfcFlowLabelsMode): Runtime => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      ...(cfcFlowLabels === undefined ? {} : { cfcFlowLabels }),
+    });
+    started.push({ runtime, storageManager });
+    return runtime;
+  };
+
+  afterEach(async () => {
+    for (const { runtime, storageManager } of started.splice(0)) {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  // At `persist` the probe runs for every prepared transaction, so a plain
+  // unlabeled write is enough to reach the metadata read. An aborted
+  // transaction keeps its journal, so the probe finds that write and goes on
+  // to read the document's stored metadata.
+  it("leaves an aborted transaction unprepared when its write is unlabeled and the flow dial is `persist`", () => {
+    const runtime = makeRuntime("persist");
+    const tx = runtime.edit();
+    const cell = runtime.getCell<{ note: string }>(
+      space,
+      "prepare-aborted-flow-probe",
+      undefined,
+      tx,
+    );
+    cell.set({ note: "discarded" });
+    tx.abort("scheduler retry discarded this attempt");
+    expect(tx.status().status).toBe("error");
+
+    expect(() => runtime.prepareTxForCommit(tx)).not.toThrow();
+    expect(tx.getCfcState().relevant).toBe(false);
+    expect(tx.getCfcState().prepare.status).toBe("unprepared");
+  });
+
+  // The flow dial defaults to `off`, which skips the probe. A labeled write
+  // marks the transaction relevant on its own, so prepare reaches `prepareCfc`
+  // instead, which also reads and writes through the transaction.
+  it("leaves an aborted transaction unprepared when it is already CFC-relevant and the flow dial is at its default", () => {
+    const runtime = makeRuntime();
+    const tx = runtime.edit();
+    const cell = runtime.getCell(
+      space,
+      "prepare-aborted-relevant",
+      LABELED_SCHEMA,
+      tx,
+    );
+    cell.set({ secret: "value" });
+    expect(tx.getCfcState().relevant).toBe(true);
+    tx.abort("scheduler retry discarded this attempt");
+    expect(tx.status().status).toBe("error");
+
+    expect(() => runtime.prepareTxForCommit(tx)).not.toThrow();
+    expect(tx.getCfcState().prepare.status).toBe("unprepared");
+  });
+
+  // A committed transaction releases its journal, so the probe finds no writes
+  // to check and reaches no read. This pins the contract rather than a throw.
+  it("returns without throwing when the transaction has already committed", async () => {
+    const runtime = makeRuntime("persist");
+    const tx = runtime.edit();
+    const cell = runtime.getCell<{ note: string }>(
+      space,
+      "prepare-committed",
+      undefined,
+      tx,
+    );
+    cell.set({ note: "durable" });
+    expect((await tx.commit()).ok).toBeDefined();
+    expect(tx.status().status).toBe("done");
+
+    expect(() => runtime.prepareTxForCommit(tx)).not.toThrow();
+  });
+
+  it("prepares a ready transaction whose write is CFC-relevant", async () => {
+    const runtime = makeRuntime("persist");
+    const tx = runtime.edit();
+    const cell = runtime.getCell(
+      space,
+      "prepare-ready-relevant",
+      LABELED_SCHEMA,
+      tx,
+    );
+    cell.set({ secret: "value" });
+
+    runtime.prepareTxForCommit(tx);
+
+    expect(tx.getCfcState().prepare.status).toBe("prepared");
+    expect((await tx.commit()).ok).toBeDefined();
+  });
+});


### PR DESCRIPTION
`prepareTxForCommit` reaches storage through the transaction it prepares, by two routes. The flow-labels relevance probe reads stored metadata, and `prepareCfc` reads and writes the derived label map. A transaction that is no longer open refuses both, so preparing one throws the storage error out of the prepare call, at a point where the caller is holding a transaction it has already finished with.

Both routes are reachable at shipped settings. The `prepareCfc` route needs no dial at all: an aborted transaction keeps the `relevant` flag a labeled write set, so prepare falls through to it even with the flow dial at its default of "off". The probe route needs `cfcFlowLabels: "persist"`, which shell hosts already run by default, and there a plain unlabeled write is enough, because the probe then runs for every prepared transaction.

The reactive-commit path contains such a throw itself, converting it into a failed commit rather than letting it escape. Most callers do not: `editWithRetry` prepares outside the block that guards the action it just ran, so a throw escapes it synchronously and defeats its `Result` return type, and the event path prepares with nothing around it. `ensurePieceRunning` prepares an already-committed transaction outright in its error path.

Early-return when the transaction's status is no longer "ready". A settled transaction cannot commit, so there is nothing to prepare for, and its commit reports the terminal state as the result. The check races nothing: status transitions are one-way, and every state the wrapper overrides moves toward "error", so a transaction that reads as "ready" here is one that can still commit and still gets prepared in full. Skipping prepare fails closed rather than open, because `commit()` re-derives relevance itself and refuses a relevant but unprepared transaction under an enforcing mode.

This matches the boundary-verification model in the CFC specification (§8.10.1). Verification is per attempt and gates that attempt's commit, a retry runs on a fresh transaction with both phases rerun from scratch, and the reference algorithm abandons an attempt at the point it aborts rather than doing further boundary work on it. An abandoned attempt has no effective writes and can reach no side-effect commit point, since abort clears the outbox, so it produces no observable state transition and owes no derived label persistence.

The regression test covers both routes, each with an aborted transaction that wrote. A third case covers preparing an already-committed transaction; that one pins the contract rather than a throw, because a completed commit releases the journal and the probe then finds no writes to check. A fourth covers a still-ready relevant transaction, which prepares as before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

