### PR TITLE
A losing duplicate sidecar instantiation yields instead of clobbering the create surface

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6052,7 +6052,7 @@ supply; OW29/OW32/OW34 closed):
     entry's own gate evidence at the merged head, 10/10, never by
     inference from the default-app gate.**
     **THE ENSURE-ON PROFILE-SURFACE MEMBER ROOT-CAUSED AND FIXED
-    2026-08-25 — the n=3 side probe's "create surface never renders"
+    2026-08-25 (PR #6312) — the n=3 side probe's "create surface never renders"
     shape and the #6248 board's profile-shard family, reproduced
     locally: a WRITE-side SELF-CLOBBER of the wish's create-surface
     sidecar — neither recorded read-side member, and not a

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6108,10 +6108,13 @@ supply; OW29/OW32/OW34 closed):
     and superseded derivations stay quiet; both are expected
     recovery): the r05/p11 cascades each surfaced exactly ONE logged
     symptom before this.
-    Live at the fix head: 6/6 GREEN in 23-27 s (shared-profile ×2,
-    profile-embed ×2, probe ×2; same harness, fresh store + posture
-    probe per run) against 6/11 red pre-fix on the same box — the
-    all-green outcome has ~0.8% probability under the pre-fix rate.
+    Live evidence, by head: 6/6 GREEN in 23-27 s at the ORIGINAL fix
+    head `bcd816b8a` (shared-profile ×2, profile-embed ×2, probe ×2)
+    and 3/3 GREEN in 20-22 s re-run at the review-round head
+    `95734a5b0` (one of each) — same harness, fresh store + posture
+    probe per run, against 6/11 red pre-fix on the same box; the
+    9-green record has well under 1% probability at the pre-fix
+    rate.
     Residuals recorded, NOT owed by this fix: (i) in red r05 the wish
     action held a durable `scheduler_basis` row on its ready-cell
     read (seq 0, user-instance-keyed), the ready flip landed at

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6077,25 +6077,37 @@ supply; OW29/OW32/OW34 closed):
     below), the client faithfully renders the durable error box, the
     create input never exists, and the run is SILENT — the register's
     "fail EARLIER at the host's create" prediction, mechanized. FIX
-    (red-first): the conflict-class loser now YIELDS to the winner's
-    surface — loud `sidecar-run-raced` warn per serving-loop.md §3d's
-    failure-arm contract; the error UI is reserved for real
-    fetch/compile/run failures; the thrown arm classifies
-    identically. No local dedupe latch: the pin drives the duplicate
-    from a second runtime instance of the same node (cause-derived
+    (red-first): a conflict-class failure (commit-refused or thrown
+    mid-run) now checks the RESULT CELL — a materialized value there
+    means a sibling instantiation won, and the loser YIELDS, loudly
+    (`sidecar-run-raced`, serving-loop.md §3d's failure-arm
+    contract); an EMPTY cell means the conflict came from an input
+    doc (e.g. the home `profiles` list moving), and the run RE-RUNS
+    against fresh state (bounded, three attempts) rather than
+    abandoning the only instantiation; the error UI is reserved for
+    real fetch/compile/run failures and the bounded-retry terminal.
+    No local dedupe latch: the pin drives the duplicate from a
+    second runtime instance of the same node (cause-derived
     convergence is the design), so yield-on-conflict — the OCC
     discipline `createSpaceRootIfAbsent` already uses — is the fix,
     not dedupe. Pin: `wish-sidecar-duplicate-launch.test.ts` (two
     runtimes, one store, the same compiled `#profile` piece → one
     wish-node cause → one sidecar cell; a gated fetch holds the
-    duplicate window open deterministically; watched red at
-    `$NAME` undefined with the conflict text durable; removing only
-    the conflict-class yield reds it again). The sidecar run also now
-    awaits its wave settlement and warns (`sidecar-run-withdrawn`)
-    when a committed instantiation is withdrawn, and the wave
-    accumulator names every DROPPED contribution
-    (`contribution-dropped` — requeues stay quiet): the r05/p11
-    cascades each surfaced exactly ONE logged symptom before this.
+    duplicate window open, a registration-counted witness — the
+    `wishSidecarDiagnostics` test seam, this package's stand-in for
+    the missing logger-capture idiom — proves the duplicate
+    continuation is chained before release, and a runs-delta
+    assertion kills the vacuous-green path; watched red at `$NAME`
+    undefined with the conflict text durable; removing only the
+    conflict-class yield reds it again). The sidecar run also now
+    observes its wave settlement OUTSIDE the tracked launch (an
+    awaited settlement would make `idle()` wait on the wave that
+    waits on quiescence) and warns (`sidecar-run-withdrawn`) when a
+    committed instantiation is withdrawn, and the wave accumulator
+    names DROPPED contributions (`contribution-dropped` — requeues
+    and superseded derivations stay quiet; both are expected
+    recovery): the r05/p11 cascades each surfaced exactly ONE logged
+    symptom before this.
     Live at the fix head: 6/6 GREEN in 23-27 s (shared-profile ×2,
     profile-embed ×2, probe ×2; same harness, fresh store + posture
     probe per run) against 6/11 red pre-fix on the same box — the

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6051,6 +6051,82 @@ supply; OW29/OW32/OW34 closed):
     program-materialization loss. The lift bar is UNCHANGED: this
     entry's own gate evidence at the merged head, 10/10, never by
     inference from the default-app gate.**
+    **THE ENSURE-ON PROFILE-SURFACE MEMBER ROOT-CAUSED AND FIXED
+    2026-08-25 — the n=3 side probe's "create surface never renders"
+    shape and the #6248 board's profile-shard family, reproduced
+    locally: a WRITE-side SELF-CLOBBER of the wish's create-surface
+    sidecar — neither recorded read-side member, and not a
+    provisioning loss.** Reproduced 6/11 at main `35ab29c38` (true
+    topology, ensure defaulting ON, fresh store + posture probe per
+    run; shared-profile, profile-embed, and a probe driver): every
+    red's store shows the served `#profile` wish's profile-create
+    sidecar materialize DURABLY and then — inside the SAME wave
+    commit — a patch removing `/value/$NAME` and
+    `/value/createProfile` and replacing `$UI` with an error span
+    carrying a conflict message. Mechanism: every pre-resolve launch
+    of the sidecar chains its OWN instantiation continuation on the
+    memoized fetch (`createSidecarPatternCache.fetch` — by design,
+    for cross-slot joiners), so a wish node that runs twice before
+    the fetch resolves instantiates the sidecar twice into the same
+    cause-derived result cell; the losing duplicate's commit fails on
+    the conflict class (`StorageTransactionInconsistent` /
+    `ConflictError` — its snapshot predates the winner) and
+    `runSidecarInOwnTx`'s error arm wrote the ERROR UI over the
+    winner's surface (`commitPatternErrorUI`). Nothing re-issues (the
+    continuation is one-shot; the wish never re-ran — residual (i)
+    below), the client faithfully renders the durable error box, the
+    create input never exists, and the run is SILENT — the register's
+    "fail EARLIER at the host's create" prediction, mechanized. FIX
+    (red-first): the conflict-class loser now YIELDS to the winner's
+    surface — loud `sidecar-run-raced` warn per serving-loop.md §3d's
+    failure-arm contract; the error UI is reserved for real
+    fetch/compile/run failures; the thrown arm classifies
+    identically. No local dedupe latch: the pin drives the duplicate
+    from a second runtime instance of the same node (cause-derived
+    convergence is the design), so yield-on-conflict — the OCC
+    discipline `createSpaceRootIfAbsent` already uses — is the fix,
+    not dedupe. Pin: `wish-sidecar-duplicate-launch.test.ts` (two
+    runtimes, one store, the same compiled `#profile` piece → one
+    wish-node cause → one sidecar cell; a gated fetch holds the
+    duplicate window open deterministically; watched red at
+    `$NAME` undefined with the conflict text durable; removing only
+    the conflict-class yield reds it again). The sidecar run also now
+    awaits its wave settlement and warns (`sidecar-run-withdrawn`)
+    when a committed instantiation is withdrawn, and the wave
+    accumulator names every DROPPED contribution
+    (`contribution-dropped` — requeues stay quiet): the r05/p11
+    cascades each surfaced exactly ONE logged symptom before this.
+    Live at the fix head: 6/6 GREEN in 23-27 s (shared-profile ×2,
+    profile-embed ×2, probe ×2; same harness, fresh store + posture
+    probe per run) against 6/11 red pre-fix on the same box — the
+    all-green outcome has ~0.8% probability under the pre-fix rate.
+    Residuals recorded, NOT owed by this fix: (i) in red r05 the wish
+    action held a durable `scheduler_basis` row on its ready-cell
+    read (seq 0, user-instance-keyed), the ready flip landed at
+    commit 31, waves kept running through 44 — and the wish action
+    provably never re-ran (wish-state doc frozen; greens re-run it
+    within 60 ms and heal everything). When that re-run fires, every
+    one-shot loss heals; when it does not, any one-shot loss is
+    permanent. Gear undetermined — its own seat. Related, from code
+    reading: a DROPPED contribution leaves NO basis rows
+    (`#basisRowsFor` covers survivors only), so "its own reads re-run
+    it when fresh state lands" is structurally false for a first-ever
+    run that gets dropped. (ii) The client and server auto-updaters
+    ping-pong the ensure-created root's summary-index child between
+    its closure-embedded pattern identity and the standalone compile
+    of the same source (alternating authored/derived
+    `pieceSourceHistory` + `/value` replaces;
+    `pattern-swap-setup-withdrawn` fires in greens and reds alike) —
+    the contention population that multiplies pre-resolve wish
+    re-runs; its own defect, untouched. (iii) The lunch FILE entry's
+    third member (ensure-OFF: the guest's ~98-101-op
+    program-materialization commit never landing) is a DIFFERENT,
+    post-click stage and is untouched — the entry and its lift bar
+    stand exactly as written. (iv) Whether the #6248 board's
+    POST-fill shape (shards 2/6: fill succeeded, click landed,
+    `#profile` never resolved) is this same clobber on a later
+    surface or another member is undetermined — re-measure on that
+    board at a head carrying this fix.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1633,6 +1633,43 @@ export function createSidecarPatternCache(options: {
   };
 }
 
+/** What a failed sidecar instantiation attempt does next — the OW45
+ * discrimination, shared verbatim by the commit-error arm and the
+ * thrown-error arm of `runSidecarInOwnTx` (a thrown conflict is the same
+ * object shape as a commit-refused one, so one function decides both):
+ *
+ * - a CONFLICT-CLASS failure (`ConflictError` /
+ *   `StorageTransactionInconsistent`) with the result cell already
+ *   materialized means a racing sibling instantiation won → `"yield"`
+ *   (never clobber the winner with an error UI — the OW45
+ *   profile-starvation defect);
+ * - a conflict-class failure with the cell still EMPTY means an INPUT doc
+ *   moved under the run (no winner exists) → `"retry"` against fresh
+ *   state while attempts remain — abandoning the only instantiation
+ *   leaves the surface permanently blank;
+ * - anything else — and the bounded-retry terminal — → `"error-ui"`, the
+ *   surface's loud account of why it never came up. The winner probe is
+ *   consulted ONLY for conflict-class failures: the real-failure path
+ *   performs no reads.
+ *
+ * Exported for the unit half of `wish-sidecar-duplicate-launch.test.ts`:
+ * the thrown arm is not deterministically drivable through the public
+ * flow (it needs a third-party write between a transaction's snapshot
+ * and its own reads), so the discrimination itself is pinned here and
+ * each arm reduces to a mechanical consume.
+ */
+export async function sidecarRunFailureDisposition(
+  error: { name?: string } | undefined | null,
+  winnerPresent: () => Promise<boolean> | boolean,
+  lastAttempt: boolean,
+): Promise<"yield" | "retry" | "error-ui"> {
+  if (isConflictRejection(error) || isStorageTransactionInconsistent(error)) {
+    if (await winnerPresent()) return "yield";
+    if (!lastAttempt) return "retry";
+  }
+  return "error-ui";
+}
+
 // Test seam (this package has no logger-capture idiom — the OW45 register's
 // F9 note): process-global counts of sidecar launch activity, so a pin that
 // must WITNESS a duplicate launch can assert it happened instead of passing
@@ -2372,13 +2409,10 @@ export function wish(
     // every pre-resolve launch chains its own continuation on the memoized
     // fetch — another runtime/instance of the node, or the serving loop's
     // re-run), or concurrent traffic on an INPUT doc (e.g. the home
-    // `profiles` list). Only the sibling case has a winner to yield to;
-    // the input case must re-run, not abandon. Discriminator: the result
-    // cell's own post-conflict state. Loud either way, per
-    // serving-loop.md §3d's failure-arm contract; pinned by
+    // `profiles` list). The decision is `sidecarRunFailureDisposition`
+    // (module level, unit-pinned); loudness per serving-loop.md §3d's
+    // failure-arm contract; the flow pin is
     // wish-sidecar-duplicate-launch.test.ts.
-    const isRaceClass = (error: { name?: string } | undefined | null) =>
-      isConflictRejection(error) || isStorageTransactionInconsistent(error);
     const yieldToRacingWinner = (error: { name?: string }) => {
       wishSidecarDiagnostics.sidecarRunsRaced += 1;
       wishFlowLogger.warn("sidecar-run-raced", () => [
@@ -2425,13 +2459,16 @@ export function wish(
         runtime.prepareTxForCommit(runTx);
         const { error } = await runTx.commit();
         if (error) {
-          if (isRaceClass(error)) {
-            if (await winnerInCell()) {
-              yieldToRacingWinner(error);
-              return;
-            }
-            if (!lastAttempt) continue;
+          const disposition = await sidecarRunFailureDisposition(
+            error,
+            winnerInCell,
+            lastAttempt,
+          );
+          if (disposition === "yield") {
+            yieldToRacingWinner(error);
+            return;
           }
+          if (disposition === "retry") continue;
           await commitPatternErrorUI(resultCell, toCompactDebugString(error));
           return;
         }
@@ -2465,14 +2502,17 @@ export function wish(
         return;
       } catch (error) {
         // The same conflict classes surface as THROWS from the run/prepare
-        // path (a stale read met mid-run) — same discrimination.
-        if (isRaceClass(error as { name?: string })) {
-          if (await winnerInCell()) {
-            yieldToRacingWinner(error as { name?: string });
-            return;
-          }
-          if (!lastAttempt) continue;
+        // path (a stale read met mid-run) — same shared discrimination.
+        const disposition = await sidecarRunFailureDisposition(
+          error as { name?: string },
+          winnerInCell,
+          lastAttempt,
+        );
+        if (disposition === "yield") {
+          yieldToRacingWinner(error as { name?: string });
+          return;
         }
+        if (disposition === "retry") continue;
         await commitPatternErrorUI(resultCell, errorMessage(error));
         return;
       }

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -18,8 +18,9 @@ import { extractHashtags } from "@commonfabric/utils/hashtags";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import { h } from "../builder/h.ts";
-// DIAGNOSTIC import (profile-starvation seat, 2026-08-25): observe the wave
-// settlement of the sidecar instantiation commit.
+// The sidecar instantiation observes its wave settlement (a serving-wave
+// commit can be withdrawn AFTER commit() resolves — runner.ts's pattern-swap
+// settlement precedent) so a withdrawn one-shot is at least named.
 import { waveSettlementOf } from "../executor/wave.ts";
 import {
   type CellScope,
@@ -2341,6 +2342,27 @@ export function wish(
     pattern: Pattern,
     inputForTx: (tx: IExtendedStorageTransaction) => unknown,
   ): Promise<void> {
+    // A conflict-class failure means ANOTHER instantiation of the same
+    // cause-derived sidecar won the race on these very docs — the same
+    // node launched again before the fetch resolved (every pre-resolve
+    // launch chains its own continuation on the memoized fetch), another
+    // runtime/instance of the node converged on the same cause, or the
+    // serving loop re-ran the wish. The winner's surface IS the outcome:
+    // yield and leave it standing. Writing the error UI here instead
+    // REPLACED the winner's materialized create surface with a dead
+    // error box — the profile-resolution starvation's reproduced member
+    // (OW45; the create surface is the only route to a first profile,
+    // and nothing re-issues it). Loud per serving-loop.md §3d's
+    // failure-arm contract; pinned by
+    // wish-sidecar-duplicate-launch.test.ts.
+    const yieldToRacingWinner = (error: { name?: string }) => {
+      wishFlowLogger.warn("sidecar-run-raced", () => [
+        `sidecar run for ${resultCell.sourceURI} lost a same-cell race ` +
+        `and yields to the winner's surface: ${error.name}: ${
+          (error as { message?: string }).message ?? ""
+        }`,
+      ]);
+    };
     try {
       const runTx = runtime.edit();
       // Sidecar run from a cache-fetch continuation — no scheduler run
@@ -2358,28 +2380,44 @@ export function wish(
       );
       runtime.prepareTxForCommit(runTx);
       const { error } = await runTx.commit();
-      // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
-      wishFlowLogger.warn("sidecar-run-committed", () => [
-        `sidecar run for ${resultCell.sourceURI}: commit ` +
-        `${error ? `ERROR ${toCompactDebugString(error)}` : "ok"}`,
-      ]);
       if (error) {
+        if (
+          isConflictRejection(error) || isStorageTransactionInconsistent(error)
+        ) {
+          yieldToRacingWinner(error);
+          return;
+        }
         await commitPatternErrorUI(resultCell, toCompactDebugString(error));
         return;
       }
+      // Under a serving wave, commit() resolving ok is not durability: the
+      // commit step can still withdraw the contribution (runner.ts's
+      // pattern-swap settlement precedent). Nothing re-issues a withdrawn
+      // sidecar instantiation, so at least SAY so — the silent one-shot
+      // loss class this row keeps producing. Recovery is deliberately not
+      // attempted here (re-running against a withdrawn basis is its own
+      // design question, flagged in the register).
       const settlement = waveSettlementOf(runTx);
       if (settlement !== undefined) {
         const settled = await settlement;
-        wishFlowLogger.warn("sidecar-run-settled", () => [
-          `sidecar run for ${resultCell.sourceURI}: wave settlement ` +
-          `${
-            settled.error !== undefined
-              ? `WITHDRAWN ${settled.error.message}`
-              : "durable"
-          }`,
-        ]);
+        if (settled.error !== undefined) {
+          wishFlowLogger.warn("sidecar-run-withdrawn", () => [
+            `sidecar run for ${resultCell.sourceURI} committed but the ` +
+            `wave withdrew it; nothing re-issues this instantiation: ` +
+            `${settled.error.message}`,
+          ]);
+        }
       }
     } catch (error) {
+      // The same conflict classes surface as THROWS from the run/prepare
+      // path (a stale read met mid-run) — same race, same yield.
+      if (
+        isConflictRejection(error as { name?: string }) ||
+        isStorageTransactionInconsistent(error as { name?: string })
+      ) {
+        yieldToRacingWinner(error as { name?: string });
+        return;
+      }
       await commitPatternErrorUI(resultCell, errorMessage(error));
     }
   }
@@ -2452,14 +2490,6 @@ export function wish(
     };
 
     const cachedProfileCreatePattern = profileCreatePatternCache.cached();
-    // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
-    if (!sidecarIsServed && runtime.servingPosture === true) {
-      wishFlowLogger.warn("profile-create-launch", () => [
-        `profile-create launch for ${sidecarUser}: cached=` +
-        `${cachedProfileCreatePattern !== undefined} cancelled=${cancelled} ` +
-        `resultCell=${slot.resultCell?.sourceURI ?? "<none>"}`,
-      ]);
-    }
     if (sidecarIsServed) {
       // The SpaceServer fetches/instantiates the create surface for this
       // demander and flips its ready cell; this speculative run only
@@ -2491,14 +2521,6 @@ export function wish(
         }
       }, runtime.servingPosture ? parentCell.space : undefined).then(
         (pattern) => {
-          // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
-          if (runtime.servingPosture === true) {
-            wishFlowLogger.warn("profile-create-fetch-resolved", () => [
-              `profile-create fetch resolved for ${sidecarUser}: pattern=` +
-              `${pattern !== undefined} cancelled=${cancelled} resultCell=` +
-              `${slot.resultCell?.sourceURI ?? "<none>"}`,
-            ]);
-          }
           if (cancelled || !slot.resultCell) return;
           if (pattern) {
             return runSidecarInOwnTx(

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -18,6 +18,9 @@ import { extractHashtags } from "@commonfabric/utils/hashtags";
 import { getLogger } from "@commonfabric/utils/logger";
 
 import { h } from "../builder/h.ts";
+// DIAGNOSTIC import (profile-starvation seat, 2026-08-25): observe the wave
+// settlement of the sidecar instantiation commit.
+import { waveSettlementOf } from "../executor/wave.ts";
 import {
   type CellScope,
   type JSONSchema,
@@ -2355,8 +2358,26 @@ export function wish(
       );
       runtime.prepareTxForCommit(runTx);
       const { error } = await runTx.commit();
+      // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
+      wishFlowLogger.warn("sidecar-run-committed", () => [
+        `sidecar run for ${resultCell.sourceURI}: commit ` +
+        `${error ? `ERROR ${toCompactDebugString(error)}` : "ok"}`,
+      ]);
       if (error) {
         await commitPatternErrorUI(resultCell, toCompactDebugString(error));
+        return;
+      }
+      const settlement = waveSettlementOf(runTx);
+      if (settlement !== undefined) {
+        const settled = await settlement;
+        wishFlowLogger.warn("sidecar-run-settled", () => [
+          `sidecar run for ${resultCell.sourceURI}: wave settlement ` +
+          `${
+            settled.error !== undefined
+              ? `WITHDRAWN ${settled.error.message}`
+              : "durable"
+          }`,
+        ]);
       }
     } catch (error) {
       await commitPatternErrorUI(resultCell, errorMessage(error));
@@ -2431,6 +2452,14 @@ export function wish(
     };
 
     const cachedProfileCreatePattern = profileCreatePatternCache.cached();
+    // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
+    if (!sidecarIsServed && runtime.servingPosture === true) {
+      wishFlowLogger.warn("profile-create-launch", () => [
+        `profile-create launch for ${sidecarUser}: cached=` +
+        `${cachedProfileCreatePattern !== undefined} cancelled=${cancelled} ` +
+        `resultCell=${slot.resultCell?.sourceURI ?? "<none>"}`,
+      ]);
+    }
     if (sidecarIsServed) {
       // The SpaceServer fetches/instantiates the create surface for this
       // demander and flips its ready cell; this speculative run only
@@ -2462,6 +2491,14 @@ export function wish(
         }
       }, runtime.servingPosture ? parentCell.space : undefined).then(
         (pattern) => {
+          // DIAGNOSTIC (profile-starvation seat, 2026-08-25).
+          if (runtime.servingPosture === true) {
+            wishFlowLogger.warn("profile-create-fetch-resolved", () => [
+              `profile-create fetch resolved for ${sidecarUser}: pattern=` +
+              `${pattern !== undefined} cancelled=${cancelled} resultCell=` +
+              `${slot.resultCell?.sourceURI ?? "<none>"}`,
+            ]);
+          }
           if (cancelled || !slot.resultCell) return;
           if (pattern) {
             return runSidecarInOwnTx(

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1670,6 +1670,17 @@ export async function sidecarRunFailureDisposition(
   return "error-ui";
 }
 
+/** Whether a sidecar result cell's raw value is a RACING WINNER a
+ * conflict-class loser may yield to. An error ACCOUNT written by
+ * `commitPatternErrorUI` is NOT a winner (Cubic P2 on the review round:
+ * yielding to a stale error account makes the surface permanently red and
+ * defeats the heal path) — it carries the `sidecarError` marker for exactly
+ * this discrimination. Exported for the unit pin. */
+export function sidecarValueIsWinner(raw: unknown): boolean {
+  if (raw === undefined) return false;
+  return !(typeof raw === "object" && raw !== null && "sidecarError" in raw);
+}
+
 // Test seam (this package has no logger-capture idiom — the OW45 register's
 // F9 note): process-global counts of sidecar launch activity, so a pin that
 // must WITNESS a duplicate launch can assert it happened instead of passing
@@ -2371,7 +2382,13 @@ export function wish(
       actionId: `wish/pattern-error-ui/${resultCell.sourceURI}`,
       kind: "bookkeeping",
     });
-    resultCell.withTx(errorTx).set({ [UI]: errorUI(message) });
+    // The `sidecarError` marker is the winner predicate's discriminator
+    // (sidecarValueIsWinner): a conflict-class loser must never yield to
+    // this account as if it were a materialized surface.
+    resultCell.withTx(errorTx).set({
+      [UI]: errorUI(message),
+      sidecarError: message,
+    });
     runtime.prepareTxForCommit(errorTx);
     const { error } = await errorTx.commit();
     // The account of the failure failed to land, so the surface stays blank
@@ -2434,7 +2451,7 @@ export function wish(
       } catch {
         // The local replica view still answers below.
       }
-      return fresh.getRaw() !== undefined;
+      return sidecarValueIsWinner(fresh.getRaw());
     };
     // Bounded: an input-doc conflict converges by re-reading fresh state;
     // three attempts outlasts any plausible burst, and the terminal arm is

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1633,6 +1633,21 @@ export function createSidecarPatternCache(options: {
   };
 }
 
+// Test seam (this package has no logger-capture idiom — the OW45 register's
+// F9 note): process-global counts of sidecar launch activity, so a pin that
+// must WITNESS a duplicate launch can assert it happened instead of passing
+// vacuously when a timing window closes early. Monotonic; consumers compare
+// deltas, never absolutes.
+export const wishSidecarDiagnostics = {
+  /** Continuations registered on the profile-create fetch (one per launch
+   * that found no cached pattern — the duplicate-launch producer). */
+  profileCreateFetchContinuations: 0,
+  /** runSidecarInOwnTx invocations (instantiation attempts). */
+  sidecarRunsStarted: 0,
+  /** Conflict-class losers that yielded to a materialized winner. */
+  sidecarRunsRaced: 0,
+};
+
 const suggestionPatternCache = createSidecarPatternCache({
   name: "suggestion.tsx",
   compileInUserSpace: true,
@@ -2333,29 +2348,39 @@ export function wish(
     }
   }
 
-  // Run a just-fetched sidecar pattern (profile create / picker) into its result
-  // cell on its own committed transaction, surfacing any commit failure as an
-  // error UI in that cell. Shared by launchProfileCreatePattern and
-  // launchProfilePickerPattern so the commit/error lifecycle lives in one place.
+  // Run a just-fetched sidecar pattern (profile create / picker) into its
+  // result cell on its own committed transaction. Shared by
+  // launchProfileCreatePattern and launchProfilePickerPattern so the
+  // commit/failure lifecycle lives in one place. Failure semantics, per arm:
+  // a CONFLICT-CLASS failure with the result cell already materialized means
+  // a racing sibling instantiation won — yield to it (never clobber it with
+  // an error UI; that was the OW45 profile-starvation defect); a
+  // conflict-class failure with the cell still EMPTY means an INPUT doc
+  // moved under the run — re-run against fresh state (bounded), because
+  // abandoning the only instantiation leaves the surface permanently blank;
+  // every other failure writes the error UI into the cell (the surface's
+  // account of why it never came up).
   async function runSidecarInOwnTx(
     resultCell: Cell<any>,
     pattern: Pattern,
     inputForTx: (tx: IExtendedStorageTransaction) => unknown,
   ): Promise<void> {
-    // A conflict-class failure means ANOTHER instantiation of the same
-    // cause-derived sidecar won the race on these very docs — the same
-    // node launched again before the fetch resolved (every pre-resolve
-    // launch chains its own continuation on the memoized fetch), another
-    // runtime/instance of the node converged on the same cause, or the
-    // serving loop re-ran the wish. The winner's surface IS the outcome:
-    // yield and leave it standing. Writing the error UI here instead
-    // REPLACED the winner's materialized create surface with a dead
-    // error box — the profile-resolution starvation's reproduced member
-    // (OW45; the create surface is the only route to a first profile,
-    // and nothing re-issues it). Loud per serving-loop.md §3d's
-    // failure-arm contract; pinned by
+    wishSidecarDiagnostics.sidecarRunsStarted += 1;
+    // A conflict-class failure means SOME other writer advanced a doc this
+    // run's basis read: a sibling instantiation of the same cause-derived
+    // sidecar (the same node launched again before the fetch resolved —
+    // every pre-resolve launch chains its own continuation on the memoized
+    // fetch — another runtime/instance of the node, or the serving loop's
+    // re-run), or concurrent traffic on an INPUT doc (e.g. the home
+    // `profiles` list). Only the sibling case has a winner to yield to;
+    // the input case must re-run, not abandon. Discriminator: the result
+    // cell's own post-conflict state. Loud either way, per
+    // serving-loop.md §3d's failure-arm contract; pinned by
     // wish-sidecar-duplicate-launch.test.ts.
+    const isRaceClass = (error: { name?: string } | undefined | null) =>
+      isConflictRejection(error) || isStorageTransactionInconsistent(error);
     const yieldToRacingWinner = (error: { name?: string }) => {
+      wishSidecarDiagnostics.sidecarRunsRaced += 1;
       wishFlowLogger.warn("sidecar-run-raced", () => [
         `sidecar run for ${resultCell.sourceURI} lost a same-cell race ` +
         `and yields to the winner's surface: ${error.name}: ${
@@ -2363,62 +2388,94 @@ export function wish(
         }`,
       ]);
     };
-    try {
-      const runTx = runtime.edit();
-      // Sidecar run from a cache-fetch continuation — no scheduler run
-      // stamps it; bookkeeping per serving-loop.md §3d.
-      runtime.stampServerRun(runTx, {
-        actionId: `wish/sidecar-run/${resultCell.sourceURI}`,
-        kind: "bookkeeping",
-      });
-      runtime.runner.run(
-        runTx,
-        pattern,
-        inputForTx(runTx),
-        resultCell.withTx(runTx),
-        sidecarRunOptions,
+    // Whether a sibling's materialization (or its error account) is already
+    // in the cell — read through a fresh handle so no stale bound tx is
+    // consulted; sync errors fall through to the local view.
+    const winnerInCell = async (): Promise<boolean> => {
+      const fresh = runtime.getCellFromLink(
+        resultCell.getAsNormalizedFullLink(),
       );
-      runtime.prepareTxForCommit(runTx);
-      const { error } = await runTx.commit();
-      if (error) {
-        if (
-          isConflictRejection(error) || isStorageTransactionInconsistent(error)
-        ) {
-          yieldToRacingWinner(error);
+      try {
+        await fresh.sync();
+      } catch {
+        // The local replica view still answers below.
+      }
+      return fresh.getRaw() !== undefined;
+    };
+    // Bounded: an input-doc conflict converges by re-reading fresh state;
+    // three attempts outlasts any plausible burst, and the terminal arm is
+    // the loud error UI, never a silent drop.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const lastAttempt = attempt === 2;
+      try {
+        const runTx = runtime.edit();
+        // Sidecar run from a cache-fetch continuation — no scheduler run
+        // stamps it; bookkeeping per serving-loop.md §3d.
+        runtime.stampServerRun(runTx, {
+          actionId: `wish/sidecar-run/${resultCell.sourceURI}`,
+          kind: "bookkeeping",
+        });
+        runtime.runner.run(
+          runTx,
+          pattern,
+          inputForTx(runTx),
+          resultCell.withTx(runTx),
+          sidecarRunOptions,
+        );
+        runtime.prepareTxForCommit(runTx);
+        const { error } = await runTx.commit();
+        if (error) {
+          if (isRaceClass(error)) {
+            if (await winnerInCell()) {
+              yieldToRacingWinner(error);
+              return;
+            }
+            if (!lastAttempt) continue;
+          }
+          await commitPatternErrorUI(resultCell, toCompactDebugString(error));
           return;
         }
-        await commitPatternErrorUI(resultCell, toCompactDebugString(error));
-        return;
-      }
-      // Under a serving wave, commit() resolving ok is not durability: the
-      // commit step can still withdraw the contribution (runner.ts's
-      // pattern-swap settlement precedent). Nothing re-issues a withdrawn
-      // sidecar instantiation, so at least SAY so — the silent one-shot
-      // loss class this row keeps producing. Recovery is deliberately not
-      // attempted here (re-running against a withdrawn basis is its own
-      // design question, flagged in the register).
-      const settlement = waveSettlementOf(runTx);
-      if (settlement !== undefined) {
-        const settled = await settlement;
-        if (settled.error !== undefined) {
-          wishFlowLogger.warn("sidecar-run-withdrawn", () => [
-            `sidecar run for ${resultCell.sourceURI} committed but the ` +
-            `wave withdrew it; nothing re-issues this instantiation: ` +
-            `${settled.error.message}`,
-          ]);
+        // Under a serving wave, commit() resolving ok is not durability:
+        // the commit step can still withdraw the contribution (runner.ts's
+        // pattern-swap settlement precedent). Nothing re-issues a withdrawn
+        // sidecar instantiation, so at least SAY so — the silent one-shot
+        // loss class this row keeps producing. Observed OUTSIDE this
+        // launch's awaited chain: the launch promise is tracked into
+        // idle(), and a wave's settlement can resolve only at the commit
+        // step — awaiting it here would make idle() wait on the wave that
+        // waits on quiescence (stalling cold sidecars until the flush
+        // deadline). Recovery is deliberately not attempted (re-running
+        // against a withdrawn basis is its own design question, flagged in
+        // the register).
+        const settlement = waveSettlementOf(runTx);
+        if (settlement !== undefined) {
+          void settlement.then((settled) => {
+            if (settled.error !== undefined) {
+              wishFlowLogger.warn("sidecar-run-withdrawn", () => [
+                `sidecar run for ${resultCell.sourceURI} committed but ` +
+                `the wave withdrew it; nothing re-issues this ` +
+                `instantiation: ${settled.error.message}`,
+              ]);
+            }
+          }, () => {
+            // A settlement rejection is the wave's own failure account;
+            // nothing to add here.
+          });
         }
-      }
-    } catch (error) {
-      // The same conflict classes surface as THROWS from the run/prepare
-      // path (a stale read met mid-run) — same race, same yield.
-      if (
-        isConflictRejection(error as { name?: string }) ||
-        isStorageTransactionInconsistent(error as { name?: string })
-      ) {
-        yieldToRacingWinner(error as { name?: string });
+        return;
+      } catch (error) {
+        // The same conflict classes surface as THROWS from the run/prepare
+        // path (a stale read met mid-run) — same discrimination.
+        if (isRaceClass(error as { name?: string })) {
+          if (await winnerInCell()) {
+            yieldToRacingWinner(error as { name?: string });
+            return;
+          }
+          if (!lastAttempt) continue;
+        }
+        await commitPatternErrorUI(resultCell, errorMessage(error));
         return;
       }
-      await commitPatternErrorUI(resultCell, errorMessage(error));
     }
   }
 
@@ -2495,6 +2552,10 @@ export function wish(
       // demander and flips its ready cell; this speculative run only
       // references the served cells (read above for the re-run trigger).
     } else if (!cachedProfileCreatePattern) {
+      // Each entry here chains one instantiation continuation on the
+      // (possibly in-flight, memoized) fetch — the duplicate-launch
+      // producer the pin's witness counts at REGISTRATION time.
+      wishSidecarDiagnostics.profileCreateFetchContinuations += 1;
       const launch = profileCreatePatternCache.fetch(runtime, () => {
         // The pattern arrived: re-arm EVERY demander's create surface —
         // the fetch is node-shared (memoized), so the ready signal must

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -1433,20 +1433,27 @@ export class WaveAccumulator
   }
 
   #withdraw(contribution: WaveContribution, message: string): void {
-    // DIAGNOSTIC (profile-starvation seat, 2026-08-25): every withdrawal
-    // named, because a withdrawn ONE-SHOT contribution (bookkeeping
-    // continuation, sidecar instantiation) has no reactive reads to
-    // re-run it and a quiet space never re-triggers it — the silent
-    // permanent-loss class this seat is hunting.
-    logger.warn("contribution-withdrawn", () => [
-      `wave ${this.#space} withdrew contribution action=` +
+    for (const space of contribution.spaces) {
+      space.resolveVerdict({ withdrawn: { message } });
+    }
+  }
+
+  /** Name a DROPPED contribution out loud (profile-starvation seat,
+   * 2026-08-25). A dropped contribution's writes vanish with no basis
+   * rows behind them (#basisRowsFor covers survivors only), so a
+   * ONE-SHOT contribution — a bookkeeping continuation, a sidecar
+   * instantiation — that gets dropped has nothing to re-run it, and on
+   * a space that then goes quiet the loss is permanent and previously
+   * INVISIBLE (the r05/p11 profile-starvation stores each carried one
+   * such cascade with a single logged symptom). Requeued events stay
+   * quiet — at-least-once redelivery is that class's normal path. */
+  #warnDropped(contribution: WaveContribution, message: string): void {
+    logger.warn("contribution-dropped", () => [
+      `wave ${this.#space} dropped contribution action=` +
       `${contribution.context.actionId ?? "<unstamped>"} kind=` +
       `${contribution.context.kind ?? "<none>"} eventId=` +
       `${contribution.context.eventId ?? "<none>"}: ${message}`,
     ]);
-    for (const space of contribution.spaces) {
-      space.resolveVerdict({ withdrawn: { message } });
-    }
   }
 
   /**
@@ -2832,17 +2839,16 @@ export class WaveAccumulator
       }
       if (droppedWhole.has(idx)) {
         outcome.dispositions[idx] = { kind: "dropped" };
-        this.#withdraw(
-          contribution,
-          orphanRefused.has(idx)
-            ? "orphan delivery refused: the event's durable entry rode an " +
-              "emitter write this wave withdrew, so no entry exists behind " +
-              "this run and nothing re-emits it (events.md §4 — one " +
-              "durable entry, one completed run; stage C build W3, (α3))"
-            : "pure derivation dropped: derived from a withdrawn " +
-              "contribution; its own reads re-run it when fresh state " +
-              "lands (serving-loop.md §3d)",
-        );
+        const message = orphanRefused.has(idx)
+          ? "orphan delivery refused: the event's durable entry rode an " +
+            "emitter write this wave withdrew, so no entry exists behind " +
+            "this run and nothing re-emits it (events.md §4 — one " +
+            "durable entry, one completed run; stage C build W3, (α3))"
+          : "pure derivation dropped: derived from a withdrawn " +
+            "contribution; its own reads re-run it when fresh state " +
+            "lands (serving-loop.md §3d)";
+        this.#warnDropped(contribution, message);
+        this.#withdraw(contribution, message);
         continue;
       }
       if (droppedDocs[idx].size > 0) {
@@ -2858,6 +2864,13 @@ export class WaveAccumulator
         outcome.dispositions[idx] = allDropped
           ? { kind: "dropped" }
           : { kind: "partially-dropped", droppedOps };
+        if (allDropped) {
+          this.#warnDropped(
+            contribution,
+            "superseded pure derivation writes dropped from the wave " +
+              "commit (serving-loop.md §3d)",
+          );
+        }
         // Any surviving ops rode the wave commit; the sealed commit's own
         // overlay rolls back whole and reconverges from the wave commit
         // (or, all-dropped, from the superseding authored commit) arriving
@@ -2892,11 +2905,15 @@ export class WaveAccumulator
   #abortAfterForeignFailure(outcome: WaveCommitOutcome): void {
     for (const contribution of this.#contributions) {
       const idx = contribution.index;
-      this.#withdraw(
-        contribution,
+      const message =
         "foreign provisioning commit failed; home commit withheld — the " +
-          "event stays unconsequenced and replays (protocol.md §2b)",
-      );
+        "event stays unconsequenced and replays (protocol.md §2b)";
+      if (contribution.context.kind !== "event-handler") {
+        // The event-handler arm requeues (at-least-once); everything else
+        // drops with nothing to re-run it — say so (see #warnDropped).
+        this.#warnDropped(contribution, message);
+      }
+      this.#withdraw(contribution, message);
       outcome.dispositions[idx] = contribution.context.kind === "event-handler"
         ? { kind: "requeued" }
         : { kind: "dropped" };

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -1433,6 +1433,17 @@ export class WaveAccumulator
   }
 
   #withdraw(contribution: WaveContribution, message: string): void {
+    // DIAGNOSTIC (profile-starvation seat, 2026-08-25): every withdrawal
+    // named, because a withdrawn ONE-SHOT contribution (bookkeeping
+    // continuation, sidecar instantiation) has no reactive reads to
+    // re-run it and a quiet space never re-triggers it — the silent
+    // permanent-loss class this seat is hunting.
+    logger.warn("contribution-withdrawn", () => [
+      `wave ${this.#space} withdrew contribution action=` +
+      `${contribution.context.actionId ?? "<unstamped>"} kind=` +
+      `${contribution.context.kind ?? "<none>"} eventId=` +
+      `${contribution.context.eventId ?? "<none>"}: ${message}`,
+    ]);
     for (const space of contribution.spaces) {
       space.resolveVerdict({ withdrawn: { message } });
     }

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -2864,13 +2864,10 @@ export class WaveAccumulator
         outcome.dispositions[idx] = allDropped
           ? { kind: "dropped" }
           : { kind: "partially-dropped", droppedOps };
-        if (allDropped) {
-          this.#warnDropped(
-            contribution,
-            "superseded pure derivation writes dropped from the wave " +
-              "commit (serving-loop.md §3d)",
-          );
-        }
+        // No #warnDropped here: a superseded pure derivation is the
+        // EXPECTED recovery path — the superseding authored commit is the
+        // fresh state its readers reconverge from — not the one-shot loss
+        // class the warn exists for.
         // Any surviving ops rode the wave commit; the sealed commit's own
         // overlay rolls back whole and reconverges from the wave commit
         // (or, all-dropped, from the superseding authored commit) arriving

--- a/packages/runner/test/clock-preload.ts
+++ b/packages/runner/test/clock-preload.ts
@@ -136,5 +136,12 @@ installFakeClock({
     // interval and flush deadline; auto-advance turns the renew cadence
     // into a runaway (the guard names SpaceServer.activate's timers).
     "executor-warm-request",
+    // Holds the sidecar pattern fetch on an explicit test-side gate while
+    // the duplicate launch registers, with a short test-armed pump inside
+    // the held window (the gate, not the pump, carries correctness). A
+    // test-armed wall-clock sleep deadlocks under auto-advance, so this
+    // file stays on the real clock; it waits on the gate and on
+    // runtime.idle(), never on a bare delay for its verdict.
+    "wish-sidecar-duplicate-launch",
   ],
 });

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -5,7 +5,10 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
-import { wishSidecarDiagnostics } from "../src/builtins/wish.ts";
+import {
+  sidecarRunFailureDisposition,
+  wishSidecarDiagnostics,
+} from "../src/builtins/wish.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 import { NAME, UI } from "../src/builder/types.ts";
@@ -173,6 +176,7 @@ describe("wish profile-create sidecar duplicate launch", () => {
       const continuationsBefore =
         wishSidecarDiagnostics.profileCreateFetchContinuations;
       const runsBefore = wishSidecarDiagnostics.sidecarRunsStarted;
+      const racedBefore = wishSidecarDiagnostics.sidecarRunsRaced;
 
       await rt1.patternManager.flushCompileCacheWrites();
       await rt1.storageManager.synced();
@@ -224,6 +228,12 @@ describe("wish profile-create sidecar duplicate launch", () => {
       // single launch that raced nothing.
       expect(wishSidecarDiagnostics.sidecarRunsStarted - runsBefore)
         .toBeGreaterThanOrEqual(2);
+      // And the losing duplicate took the WINNER-CHECKED YIELD path (the
+      // fix's central arm), not a clean serialize or a silent drop: the
+      // raced counter increments exactly when a conflict-class loser
+      // yields to a materialized winner.
+      expect(wishSidecarDiagnostics.sidecarRunsRaced - racedBefore)
+        .toBeGreaterThanOrEqual(1);
 
       const surface = createCell.get() as Record<string | symbol, unknown>;
       const raw = JSON.stringify(createCell.getRaw());
@@ -236,5 +246,74 @@ describe("wish profile-create sidecar duplicate launch", () => {
       await rt2.dispose();
       await rt1.dispose();
     }
+  });
+});
+
+// The discrimination itself, exhaustively — this is the shared decision both
+// the commit-error arm AND the thrown-error arm of runSidecarInOwnTx consume
+// (a thrown conflict carries the same object shape as a commit-refused one).
+// The thrown arm is not deterministically drivable through the public flow
+// (it needs a third-party write to land between a transaction's snapshot and
+// its own reads), so the semantics are pinned here and each arm reduces to a
+// mechanical consume of this function; the flow-level pin above covers the
+// commit arm end to end.
+describe("sidecarRunFailureDisposition", () => {
+  const conflict = { name: "ConflictError" };
+  const inconsistent = { name: "StorageTransactionInconsistent" };
+  const aborted = { name: "StorageTransactionAborted" };
+
+  it("yields to a materialized winner on either conflict spelling", async () => {
+    expect(await sidecarRunFailureDisposition(conflict, () => true, false))
+      .toBe("yield");
+    expect(await sidecarRunFailureDisposition(inconsistent, () => true, false))
+      .toBe("yield");
+    // A winner outranks the attempt budget: yield even on the last attempt.
+    expect(await sidecarRunFailureDisposition(conflict, () => true, true))
+      .toBe("yield");
+    // The probe may be async (the real winnerInCell is).
+    expect(
+      await sidecarRunFailureDisposition(
+        inconsistent,
+        () => Promise.resolve(true),
+        true,
+      ),
+    ).toBe("yield");
+  });
+
+  it("re-runs an input-doc conflict (no winner) while attempts remain", async () => {
+    expect(await sidecarRunFailureDisposition(conflict, () => false, false))
+      .toBe("retry");
+    expect(await sidecarRunFailureDisposition(inconsistent, () => false, false))
+      .toBe("retry");
+  });
+
+  it("ends a winnerless conflict on the last attempt with the error UI", async () => {
+    expect(await sidecarRunFailureDisposition(conflict, () => false, true))
+      .toBe("error-ui");
+    expect(await sidecarRunFailureDisposition(inconsistent, () => false, true))
+      .toBe("error-ui");
+  });
+
+  it("routes real failures to the error UI without consulting the winner probe", async () => {
+    const probeNotConsulted = () => {
+      throw new Error("winner probe must not run for non-conflict failures");
+    };
+    expect(
+      await sidecarRunFailureDisposition(aborted, probeNotConsulted, false),
+    )
+      .toBe("error-ui");
+    expect(
+      await sidecarRunFailureDisposition(
+        { name: "WishError" },
+        probeNotConsulted,
+        true,
+      ),
+    ).toBe("error-ui");
+    expect(
+      await sidecarRunFailureDisposition(undefined, probeNotConsulted, false),
+    ).toBe("error-ui");
+    expect(
+      await sidecarRunFailureDisposition(null, probeNotConsulted, false),
+    ).toBe("error-ui");
   });
 });

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+import { NAME, UI } from "../src/builder/types.ts";
+import {
+  getPatternEnvironment,
+  setPatternEnvironment,
+} from "../src/builder/env.ts";
+
+// The profile-resolution starvation family's reproduced member (2026-08-25,
+// OW45 residue): when the `#profile` wish node's create-surface sidecar is
+// launched MORE THAN ONCE before its pattern fetch resolves, every launch
+// chains its own instantiation continuation on the module-global memoized
+// fetch, and the resolve runs the sidecar repeatedly into the SAME
+// cause-derived result cell. One run wins; a duplicate's commit fails on the
+// conflict class (StorageTransactionInconsistent / ConflictError — its
+// snapshot predates the winner), and its error arm then REPLACED the winner's
+// materialized surface with an error UI (`commitPatternErrorUI`), removing
+// `$NAME`/`createProfile` and leaving the only route to a first profile a
+// dead error box. On a serving runtime the wave folds winner-then-clobber
+// into one commit, so the durable state is the error box from birth; live
+// evidence: the #6248 ensure-ON board's profile shards and 6/11 local reds at
+// main 35ab29c38 — every red store carries the `remove /value/$NAME` +
+// error-span patch on the create surface's cell.
+//
+// The duplicate here is driven the way the live one is: two runs of the same
+// content-addressed pattern (two runtimes over one store — the serving loop's
+// re-runs of one wish node are the same shape) share the module-global fetch
+// AND the cause-derived sidecar cell, so both continuations instantiate into
+// one address. The contract pinned: the materialized create surface survives
+// the losing duplicate.
+const signer = await Identity.fromPassphrase("wish-sidecar-duplicate-launch");
+const homeSpace = signer.did();
+
+const read = (name: string) =>
+  Deno.readTextFileSync(
+    fromFileUrl(new URL("../../patterns/system/", import.meta.url)) + name,
+  );
+
+const WISH_SRC = [
+  "import { pattern, wish } from 'commonfabric';",
+  "export default pattern(() => ({",
+  "  profile: wish({ query: '#profile' }),",
+  "}));",
+].join("\n");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{ name: "/main.tsx", contents: WISH_SRC }],
+};
+
+const RESULT_CAUSE = "wish-sidecar-duplicate-launch-result";
+
+describe("wish profile-create sidecar duplicate launch", () => {
+  let server: MemoryV2Server.Server;
+  let managerA: EmulatedStorageManager;
+  let managerB: EmulatedStorageManager;
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnvironment: ReturnType<typeof getPatternEnvironment>;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    managerA = EmulatedStorageManager.connectTo(server, { as: signer });
+    managerB = EmulatedStorageManager.connectTo(server, { as: signer });
+    originalFetch = globalThis.fetch;
+    originalEnvironment = getPatternEnvironment();
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    setPatternEnvironment(originalEnvironment);
+    await managerA?.close();
+    await managerB?.close();
+    await server?.close();
+  });
+
+  it("a duplicate pre-fetch launch does not clobber the materialized create surface", async () => {
+    // A unique pattern-environment origin keys this test's entry in the
+    // module-global sidecar cache (the cache memoizes per URL).
+    setPatternEnvironment({
+      apiUrl: new URL("https://sidecar-duplicate-launch.test/"),
+    });
+
+    // Serve the REAL profile-create.tsx (+ its profile-home.tsx import). The
+    // ENTRY response is gated: it signals when the first launch's fetch is in
+    // flight and releases only once BOTH runtimes' launches have registered
+    // their continuations on the shared memoized fetch — the duplicate-launch
+    // window, held open deterministically.
+    const entryRequested = Promise.withResolvers<void>();
+    const entryGate = Promise.withResolvers<void>();
+    globalThis.fetch = ((input: Request | URL | string) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes("profile-create.tsx")) {
+        entryRequested.resolve();
+        return entryGate.promise.then(() =>
+          new Response(read("profile-create.tsx"), { status: 200 })
+        );
+      }
+      if (url.includes("profile-home.tsx")) {
+        return Promise.resolve(
+          new Response(read("profile-home.tsx"), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }) as typeof fetch;
+
+    const rt1 = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: managerA,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager: managerB,
+    });
+    try {
+      // Home space with a profile-less default pattern: `#profile` resolves
+      // to the missing-profile state, whose UI is the create surface.
+      const setupTx = rt1.edit();
+      const homeSpaceCell = rt1.getSpaceCell(homeSpace);
+      const homeDefault = rt1.getCell(
+        homeSpace,
+        "duplicate-launch-home-default",
+        undefined,
+        setupTx,
+      );
+      homeDefault.key("marker").set("home");
+      // deno-lint-ignore no-explicit-any
+      (homeSpaceCell.withTx(setupTx) as any).key("defaultPattern").set(
+        homeDefault,
+      );
+      rt1.prepareTxForCommit(setupTx);
+      const setupCommit = await setupTx.commit();
+      expect(setupCommit.error).toBeUndefined();
+      await rt1.storageManager.synced();
+
+      // Both runtimes compile the same source — content-addressed, so the
+      // wish node (and with it the sidecar slot cells) shares one cause.
+      const tx1 = rt1.edit();
+      const pattern1 = await rt1.patternManager.compilePattern(PROGRAM, {
+        space: homeSpace,
+        tx: tx1,
+      });
+      const result1 = rt1.getCell<Record<string, unknown>>(
+        homeSpace,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const run1 = rt1.run(tx1, pattern1 as any, {}, result1);
+      rt1.prepareTxForCommit(tx1);
+      const commit1 = await tx1.commit();
+      expect(commit1.error).toBeUndefined();
+
+      // Demand drives the compiled piece's wish action (which fires the
+      // launch); the pull itself may then park behind the gated fetch, so it
+      // is raced against the entry witness rather than awaited.
+      const demand1 = run1.pull().catch(() => {});
+      await Promise.race([demand1, entryRequested.promise]);
+      // The first launch's fetch is in flight (the entry request is the
+      // witness); the gate keeps the window open while the SAME piece —
+      // hence the same wish node, the same cause-derived sidecar cells —
+      // starts in the second runtime. Its launch joins the shared memoized
+      // fetch and registers the duplicate continuation.
+      await entryRequested.promise;
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      const piece2 = rt2.getCellFromLink(run1.getAsNormalizedFullLink());
+      await piece2.sync();
+      const started = await rt2.start(piece2);
+      expect(started).toBe(true);
+      // Demand drives rt2's wish action too (the launch that registers the
+      // duplicate continuation); its pull may also park behind the gate, so
+      // it is left racing. The pump is generosity for rt2's scheduler — the
+      // held gate means it cannot lose a race.
+      const demand2 = piece2.pull().catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      void demand2;
+
+      // Release the fetch: every registered continuation instantiates into
+      // the same cause-derived cell; idle() covers the tracked launches.
+      entryGate.resolve();
+      await Promise.all([rt1.idle(), rt2.idle()]);
+      await run1.pull();
+      await rt1.idle();
+      await rt2.idle();
+
+      // The wish UI names the create-surface cell the launches filled.
+      await run1.pull();
+      const createCell = run1.key("profile").key(UI).key("props").key("$cell")
+        .resolveAsCell();
+      await createCell.sync();
+      await createCell.pull();
+
+      // The contract: the materialized create surface survives the duplicate.
+      // Pre-fix, the losing duplicate's conflict-class commit error wrote an
+      // error UI over the winner (remove $NAME/createProfile, $UI -> an error
+      // span carrying "Transaction consistency violated").
+      const surface = createCell.get() as Record<string | symbol, unknown>;
+      const raw = JSON.stringify(createCell.getRaw());
+      // Both conflict-class spellings the loser's error arm can carry.
+      expect(raw).not.toContain("Transaction consistency violated");
+      expect(raw).not.toContain("stale confirmed read");
+      expect(surface?.[NAME]).toBe("Create Profile");
+      expect(Object.keys(surface ?? {})).toContain("createProfile");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   sidecarRunFailureDisposition,
+  sidecarValueIsWinner,
   wishSidecarDiagnostics,
 } from "../src/builtins/wish.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
@@ -315,5 +316,26 @@ describe("sidecarRunFailureDisposition", () => {
     expect(
       await sidecarRunFailureDisposition(null, probeNotConsulted, false),
     ).toBe("error-ui");
+  });
+});
+
+// The winner predicate itself (Cubic P2, review round): an error ACCOUNT
+// left by commitPatternErrorUI must NOT count as a racing winner — yielding
+// to it would leave the surface permanently red and defeat the heal path.
+describe("sidecarValueIsWinner", () => {
+  it("an empty cell is no winner", () => {
+    expect(sidecarValueIsWinner(undefined)).toBe(false);
+  });
+  it("a materialized surface is a winner", () => {
+    expect(sidecarValueIsWinner({ [NAME]: "Create Profile", [UI]: {} }))
+      .toBe(true);
+    // Marker-less values stay winners — only the explicit error account is
+    // excluded (a legit UI-only surface must never be mistaken for one, or
+    // the loser retries against the real winner and clobbers it terminally).
+    expect(sidecarValueIsWinner({ [UI]: {} })).toBe(true);
+  });
+  it("an error account is NOT a winner", () => {
+    expect(sidecarValueIsWinner({ [UI]: {}, sidecarError: "fetch failed" }))
+      .toBe(false);
   });
 });

--- a/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
+++ b/packages/runner/test/wish-sidecar-duplicate-launch.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { Runtime } from "../src/runtime.ts";
+import { wishSidecarDiagnostics } from "../src/builtins/wish.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import { newSharedServer } from "./memory-v2-test-utils.ts";
 import { NAME, UI } from "../src/builder/types.ts";
@@ -169,6 +170,9 @@ describe("wish profile-create sidecar duplicate launch", () => {
       // starts in the second runtime. Its launch joins the shared memoized
       // fetch and registers the duplicate continuation.
       await entryRequested.promise;
+      const continuationsBefore =
+        wishSidecarDiagnostics.profileCreateFetchContinuations;
+      const runsBefore = wishSidecarDiagnostics.sidecarRunsStarted;
 
       await rt1.patternManager.flushCompileCacheWrites();
       await rt1.storageManager.synced();
@@ -176,13 +180,24 @@ describe("wish profile-create sidecar duplicate launch", () => {
       await piece2.sync();
       const started = await rt2.start(piece2);
       expect(started).toBe(true);
-      // Demand drives rt2's wish action too (the launch that registers the
-      // duplicate continuation); its pull may also park behind the gate, so
-      // it is left racing. The pump is generosity for rt2's scheduler — the
-      // held gate means it cannot lose a race.
+      // Demand drives rt2's wish action too; its pull may also park behind
+      // the gate, so it is left racing.
       const demand2 = piece2.pull().catch(() => {});
-      await new Promise((resolve) => setTimeout(resolve, 400));
       void demand2;
+      // STRUCTURAL WITNESS: wait until rt2's launch has chained the
+      // duplicate continuation on the shared in-flight fetch (counted at
+      // registration in wish.ts's diagnostics seam). The gate is held, so
+      // this wait cannot lose a race; the bound only converts a hung
+      // scheduler into a loud failure instead of a hang.
+      for (let attempt = 0; attempt < 500; attempt++) {
+        if (
+          wishSidecarDiagnostics.profileCreateFetchContinuations >
+            continuationsBefore
+        ) break;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(wishSidecarDiagnostics.profileCreateFetchContinuations)
+        .toBeGreaterThan(continuationsBefore);
 
       // Release the fetch: every registered continuation instantiates into
       // the same cause-derived cell; idle() covers the tracked launches.
@@ -203,6 +218,13 @@ describe("wish profile-create sidecar duplicate launch", () => {
       // Pre-fix, the losing duplicate's conflict-class commit error wrote an
       // error UI over the winner (remove $NAME/createProfile, $UI -> an error
       // span carrying "Transaction consistency violated").
+      // Vacuity killer: the duplicate instantiation actually RAN (rt1's
+      // and rt2's continuations both invoked runSidecarInOwnTx) — without
+      // this, a timing miss would green the contract assertions on a
+      // single launch that raced nothing.
+      expect(wishSidecarDiagnostics.sidecarRunsStarted - runsBefore)
+        .toBeGreaterThanOrEqual(2);
+
       const surface = createCell.get() as Record<string | symbol, unknown>;
       const raw = JSON.stringify(createCell.getRaw());
       // Both conflict-class spellings the loser's error arm can carry.


### PR DESCRIPTION
## Why

The PROFILE-RESOLUTION STARVATION family is the biggest remaining ensure-ON
flip blocker (OW45's residue; PR #6248's shards 2/6 fail on it, and the
register's n=3 lunch side probe found ensure-ON "strictly worse — the host's
profile-create surface never renders", 3/3). This PR root-causes and fixes the
reproduced member red-first.

Reproduced 6/11 at main `35ab29c38` at the true topology (ON-built binary,
ensure defaulting ON, fresh store + posture probe per run,
`shared-profile.test.ts` / `profile-embed.test.ts` / a probe driver): the
create surface never renders, the fill probes "no-element" for the full 300 s,
zero browser errors, zero quarantines — the family's silent signature.

**The discrimination** (deliverable 1, from the red stores): this member is
NEITHER recorded read-side residue member and NOT a provisioning loss — it is a
**write-side SELF-CLOBBER**. Every red store shows the served `#profile` wish's
profile-create sidecar materialize DURABLY, and then — inside the SAME wave
commit — a patch that removes `/value/$NAME` and `/value/createProfile` and
replaces `$UI` with an error span carrying a conflict message. The client
faithfully renders the durable error box; the create input never exists.

**Root cause**: every pre-resolve launch of the sidecar chains its own
instantiation continuation on the memoized fetch
(`createSidecarPatternCache.fetch` — per-caller continuations are by design,
for cross-slot joiners), so a wish node that runs twice before the fetch
resolves runs `runSidecarInOwnTx` twice into the same cause-derived result
cell. One run wins; the duplicate's commit fails on the conflict class
(`StorageTransactionInconsistent` / `ConflictError` — its snapshot predates the
winner), and the error arm treated that as "the sidecar failed", committing an
error UI **over the winner's surface**. Nothing re-issues a one-shot
continuation, so the error box is permanent — the register's "fail EARLIER at
the host's create" prediction, mechanized.

## What Changed

- `packages/runner/src/builtins/wish.ts` — `runSidecarInOwnTx`: a
  conflict-class commit failure (and the same classes on the thrown arm) now
  YIELDS to the racing winner's surface with a loud `sidecar-run-raced` warn,
  instead of clobbering it with an error UI. The error UI is reserved for real
  fetch/compile/run failures. This is the OCC-convergence discipline
  `createSpaceRootIfAbsent` already uses; a local dedupe latch is deliberately
  NOT the fix — the pin drives the duplicate from a second runtime instance of
  the same node, where no per-closure latch can reach (cause-derived
  convergence is the design). The sidecar run also awaits its wave settlement
  and warns (`sidecar-run-withdrawn`) when a committed instantiation is
  withdrawn — observability only, no re-issue (recovery for withdrawn
  one-shots is flagged in the register, not filled).
- `packages/runner/src/executor/wave.ts` — the wave accumulator names every
  DROPPED contribution (`contribution-dropped`, action + kind + eventId +
  reason). Dropped contributions leave no basis rows (`#basisRowsFor` covers
  survivors only), so a dropped one-shot has nothing to re-run it and was
  previously invisible: the red runs' cascades each surfaced exactly ONE
  logged symptom. Requeued events stay quiet (at-least-once redelivery is that
  class's normal path).
- `packages/runner/test/wish-sidecar-duplicate-launch.test.ts` — the red-first
  pin: two runtimes over one store run the same compiled `#profile` piece
  (same wish-node cause → same sidecar cell); a gated fetch holds the
  duplicate-launch window open deterministically. Watched red at the pre-fix
  code (`$NAME` undefined, the conflict text durable in the surface cell);
  green with the fix; removing only the conflict-class yield reds it again
  (mutation check).
- `docs/specs/server-side-execution/verification-coverage.md` — OW45 row
  append: the discrimination, the root cause, the fix, the live gate, and four
  recorded residuals — (i) the wish action not re-running despite a durable
  stale `scheduler_basis` row (r05: ready-flip landed, waves continued, no
  re-run — gear undetermined, its own seat), (ii) the client↔server
  auto-updater identity ping-pong on the ensure-created root's children (the
  contention population), (iii) the lunch FILE entry's ensure-OFF third member
  (different stage, untouched — the entry and its lift bar stand), (iv)
  whether #6248's post-fill shards-2/6 shape is this clobber on a later
  surface (re-measure at a head carrying this fix).

## Test plan

- Red-first pin (above), watched red, mutation-checked.
- Live gate at the fix head: **6/6 GREEN in 23–27 s** (shared-profile ×2,
  profile-embed ×2, probe ×2; fresh store + posture probe per run, ensure
  defaulting ON) against **6/11 red pre-fix** on the same box — ~0.8%
  probability under the pre-fix rate.
- Batteries green locally: wish.test.ts + profile-create-real-card-add +
  profile-owner-cfc; executor-serving-loop; executor-events-down;
  executor-fan-out; the new pin. `deno check` / `fmt` / `lint` clean on the
  changed files.

Evidence (off-repo, on the measuring box):
`/Users/berni/labs-worktrees/profile-starvation-evidence/` (per-run ledgers,
test+toolshed logs, fresh stores — the red stores carry the clobber patch),
report `/Users/berni/labs-worktrees/profile-starvation-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Cubic P2 adjudication (round 3, coordinator) — CONFIRMED, fixed at `d1167b8cd`

Cubic's P2 (wish.ts, "treating any existing raw value as the racing winner") is the independent review's R2 residual with a concrete kill path: a conflict-class loser yielded to the **error account** an earlier real failure had written, leaving the surface permanently red and defeating the heal. Fixed red-first: `commitPatternErrorUI` stamps a `sidecarError` marker; the winner predicate (`sidecarValueIsWinner`, unit-pinned — the error-account case watched FAILED against the coarse semantics) excludes marked values and nothing else (a legit marker-less UI-only surface must stay a winner, or the loser would retry against the real winner and clobber it terminally — the original defect back). No legacy window: marker and predicate ship in the PR the account shape was born in. Tests: 8 files / 141 steps green at the head.
