### PR TITLE
refactor(data-model): freeze primitives in `BaseFabricPrimitive`

### DIFF
--- a/packages/data-model/src/fabric-bases/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-bases/BaseFabricPrimitive.ts
@@ -35,10 +35,25 @@ export const EXAMPLE_METHOD: unique symbol = Symbol(
  * `FabricPrimitive` is the pure abstract contract that external code is written
  * against, while `BaseFabricPrimitive` is the designated home for shared
  * implementation. Its counterpart `BaseFabricInstance` carries the
- * `shallowClone()` template method; this class currently carries the static
- * invariant guard and a placeholder seed member (see `[EXAMPLE_METHOD]`).
+ * `shallowClone()` template method; this class carries the construction-time
+ * freeze, the static invariant guard, and a placeholder seed member (see
+ * `[EXAMPLE_METHOD]`).
  */
 export abstract class BaseFabricPrimitive extends FabricPrimitive {
+  /** Constructs an instance. */
+  constructor() {
+    super();
+
+    // Freezing here rather than at the end of each concrete constructor is
+    // sound because a primitive's state is entirely private: private fields
+    // are not properties, so a subclass assigns its own after `super()`
+    // returns regardless of this. A primitive is immutable from birth and has
+    // no mutable phase, so a frozen report is simply true of it -- and the
+    // freeze makes it non-extensible too, which is what turns a stray property
+    // addition into a throw.
+    Object.freeze(this);
+  }
+
   //
   // Instance members
   //

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -50,7 +50,6 @@ export class FabricBytes extends BaseFabricPrimitive {
   constructor(bytes: Uint8Array | ArrayBufferLike, transfer: boolean = false) {
     super();
     this.#bytes = toOwnedUint8Array(bytes, transfer);
-    Object.freeze(this);
   }
 
   //

--- a/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
@@ -35,7 +35,6 @@ export class FabricEpochDay extends BaseFabricPrimitive
   constructor(value: bigint) {
     super();
     this.#value = value;
-    Object.freeze(this);
   }
 
   /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -38,7 +38,6 @@ export class FabricEpochNsec extends BaseFabricPrimitive
   constructor(value: bigint) {
     super();
     this.#value = value;
-    Object.freeze(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -79,7 +79,6 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
     this.#tag = tag;
     this.#justHashString = toUnpaddedBase64url(this.#hash);
     this.#fullStringForm = `${tag}:${this.#justHashString}`;
-    Object.freeze(this);
   }
 
   /** Defensive copy of the raw hash bytes. */

--- a/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
+++ b/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
@@ -139,8 +139,6 @@ export class FabricKeyPair extends BaseFabricPrimitive {
       this.#publicKey = pub;
       this.#privateKey = priv;
     }
-
-    Object.freeze(this);
   }
 
   //

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -108,8 +108,6 @@ export class FabricRegExp extends BaseFabricPrimitive
     this.#value = (this.#flavor === DEFAULT_FLAVOR)
       ? new RegExp(this.#source, this.#flags)
       : undefined;
-
-    Object.freeze(this);
   }
 
   /** The pattern source text. */

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -262,14 +262,13 @@ export function shallowFabricFromNativeValue(
 
     case NATIVE_TAGS.RegExp: {
       // `RegExp` instances are converted to `FabricRegExp`, which rejects extra
-      // enumerable properties and self-freezes in its constructor.
+      // enumerable properties and is frozen at construction.
       return new FabricRegExp(value as RegExp);
     }
 
     case NATIVE_TAGS.Uint8Array: {
       // Native `Uint8Array` instances are wrapped in `FabricBytes`.
-      // `FabricBytes` self-freezes in its constructor (`FabricPrimitive`
-      // contract).
+      // `FabricBytes` is frozen at construction (`FabricPrimitive` contract).
       return new FabricBytes(value as Uint8Array);
     }
 

--- a/packages/data-model/test/fabric-bases/BaseFabricPrimitive.test.ts
+++ b/packages/data-model/test/fabric-bases/BaseFabricPrimitive.test.ts
@@ -28,6 +28,24 @@ import {
 class ProbePrimitive extends BaseFabricPrimitive {}
 
 /**
+ * A `BaseFabricPrimitive` subclass that assigns a private field after
+ * `super()`, which is the shape every concrete primitive has.
+ */
+class StatefulProbe extends BaseFabricPrimitive {
+  readonly #value: bigint;
+
+  constructor(value: bigint) {
+    super();
+
+    this.#value = value;
+  }
+
+  get value(): bigint {
+    return this.#value;
+  }
+}
+
+/**
  * A rogue direct subclass of `FabricPrimitive` that bypasses
  * `BaseFabricPrimitive` -- the shape the invariant forbids. Used only to
  * witness `isInstance()`'s enforcement throw; no production class is built this
@@ -41,6 +59,36 @@ describe("BaseFabricPrimitive", () => {
       const probe = new ProbePrimitive();
       expect(probe instanceof BaseFabricPrimitive).toBe(true);
       expect(probe instanceof FabricPrimitive).toBe(true);
+    });
+  });
+
+  describe("constructor()", () => {
+    it("leaves the instance frozen and non-extensible", () => {
+      const probe = new ProbePrimitive();
+      expect(Object.isFrozen(probe)).toBe(true);
+      expect(Object.isExtensible(probe)).toBe(false);
+    });
+
+    it("refuses a new property, whichever way it is added", () => {
+      // Every path here is strict-mode, which is what a module is. Sloppy-mode
+      // assignment is the one path that fails silently instead of throwing.
+      const probe = new ProbePrimitive() as unknown as Record<string, unknown>;
+
+      expect(() => {
+        probe.extra = 42;
+      }).toThrow(TypeError);
+      expect(() => Object.defineProperty(probe, "extra", { value: 42 }))
+        .toThrow(TypeError);
+      expect(Reflect.set(probe, "extra", 42)).toBe(false);
+    });
+
+    it("freezes without disturbing a subclass's private fields", () => {
+      // The freeze lands before a subclass's own assignments. Private fields
+      // are not properties and so are unaffected, which is what makes freezing
+      // here rather than in each concrete constructor sound.
+      const probe = new StatefulProbe(7n);
+      expect(Object.isFrozen(probe)).toBe(true);
+      expect(probe.value).toBe(7n);
     });
   });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

## What this does

Every concrete `FabricPrimitive` ended its constructor with the same
`Object.freeze(this)` — six copies of one line, across `FabricBytes`,
`FabricEpochDay`, `FabricEpochNsec`, `FabricHash`, `FabricKeyPair`, and
`FabricRegExp`. `BaseFabricPrimitive`'s constructor now does it, and the six go
away.

This is sound for the same reason the instance seal (#6302) is: a primitive's
state is entirely private, and private fields are not properties, so a subclass
assigns its own after `super()` returns whether or not the base has already
frozen.

The two base classes now do opposite things for that one shared reason, and the
asymmetry is the point. An instance has a mutable phase and needs
`Object.isFrozen()` to report on it honestly, which is what its freeze shield
is for. A primitive has no mutable phase, so freezing at birth makes a frozen
report simply true, and no shield is wanted — a primitive carries zero own
properties, where an instance carries one.

## Why it is worth doing

Not the five lines. `isNecessarilyFrozenValue()` in `deep-freeze.ts` reports
every `FabricPrimitive` as deep-frozen **by class rather than by inspection**,
so a subclass that forgot the line would produce a mutable value that the
freeze machinery vouches for anyway. That is a silent, hard-to-test failure
mode: no test necessarily catches it, because the checker never looks. Owning
the freeze in the base removes the chance to forget.

`Object.freeze()` implies non-extensible, so a primitive also now throws on a
stray property addition, as an instance does.

## Verification

The census is uniform — all six constructors write only private `#` fields and
then freeze as their last statement, and the hierarchy is flat, so this is a
clean six-for-one trade with no multi-level subclass to consider.

Every constructor shape was probed against a base-freezing class before the
change: a plain field assignment, `FabricHash`'s several-fields-one-derived
shape, `FabricKeyPair`'s throw-partway shape, and a field with a declared
initializer (which runs *after* `super()` returns, and so after the freeze).
All behave identically.

On the changed tree, each primitive constructs to `isFrozen=true`,
`extensible=false`, zero own property names and zero own symbols — the same as
before.

Three new `constructor()` cases on `BaseFabricPrimitive`, covering the freeze,
refusal of a new property by each strict-mode path, and — the mechanic the
whole change rests on — that a subclass's private field survives a base that
froze before the assignment. Ablating the base freeze fails all three, and
takes the package to 9 failed files.

Suites, all on one stable tree (checksummed before and after to prove it did
not move mid-run): data-model 52, api 26, utils 99, pure-json 1, identity 25,
memory 575, piece 46, runner 1292 — 0 failed. Gates: `deno fmt --check`,
`deno lint`, `deno task check`, `deno task check-docs` all pass.

## Prose swept

Two comments in `native-conversion.ts` said `FabricRegExp` and `FabricBytes`
"self-freezes in its constructor". After this change a reader who opens those
files finds no freeze there, so both now say "frozen at construction".
`BaseFabricPrimitive`'s class doc enumerated what the class carries and was
missing the freeze.

The spec's mentions are deliberately untouched: they say primitives are frozen
"at construction", which is a claim about the model and stays true — and where
the freeze lives is an implementation detail the spec should not fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nngbjm3AjShr7Bqf1YFips


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

