### PR TITLE
fix(runner): drop the wish sidecar pattern caches with the schema-registry epoch

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -33,6 +33,7 @@ import {
   toMemorySpaceAddress,
 } from "../link-utils.ts";
 import { setRunnableName } from "../runner-utils.ts";
+import { onSchemaRegistryClear } from "../schema-registry.ts";
 import { type Runtime, spaceCellSchema } from "../runtime.ts";
 import { type Action, type ReactivityLog } from "../scheduler.ts";
 import { RetryImmediately } from "../scheduler/retry-immediately.ts";
@@ -1541,6 +1542,21 @@ export function createSidecarPatternCache(options: {
   let fetchPromise: Promise<Pattern | undefined> | undefined;
   let fetchUrl: string | undefined;
   let pattern: Pattern | undefined;
+
+  // A compiled pattern's binding schemas are externalized to `cid:`
+  // references whose documents live in the realm schema registry for the
+  // epoch that compiled it. This cache outlives runtimes, so on the
+  // registry-clear transition (last lease out) the cached pattern's
+  // references would dangle — every cell its next instantiation minted
+  // would carry a schema nobody can resolve, and the first sync built from
+  // one would be rejected by the server (#6303). Drop the cache with the
+  // epoch; the next launch recompiles (cheap — the compile caches are
+  // content-addressed and survive) and registers its documents afresh.
+  onSchemaRegistryClear(() => {
+    fetchPromise = undefined;
+    fetchUrl = undefined;
+    pattern = undefined;
+  });
 
   // Resolved lazily (not at module load): in the browser worker this module
   // is imported before the runtime calls `setPatternEnvironment` with the

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1518,12 +1518,31 @@ function releaseSharedHashtagResolver(runtime: Runtime, key: string): void {
   resolvers?.delete(key);
 }
 
+// The schema-registry epoch every sidecar cache compares against: a compiled
+// pattern's binding schemas are externalized to `cid:` references whose
+// documents live in the realm schema registry only for the epoch that
+// compiled it. A sidecar cache outlives runtimes, so a pattern reused past
+// the registry-clear transition (last lease out) would mint cells carrying
+// schemas nobody can resolve, and the first sync built from one would be
+// rejected by the server (#6303). One shared counter, bumped by one shared
+// listener, instead of a listener per cache: caches compare their recorded
+// epoch on read, so an abandoned cache (tests create them freely) holds
+// nothing in the registry's listener set.
+let sidecarPatternEpoch = 0;
+onSchemaRegistryClear(() => {
+  sidecarPatternEpoch++;
+});
+
 // Fetch-and-compile cache for one sidecar pattern (suggestion /
 // profile-create / profile-picker), shared across all wish invocations. The
 // cache tracks the URL each fetch was started for: `setPatternEnvironment`
 // can change the apiUrl while a fetch is in flight, so a launch for a
 // different URL starts a fresh fetch, and a superseded fetch leaves the cache
-// untouched and resolves to undefined when it settles.
+// untouched and resolves to undefined when it settles. The schema-registry
+// epoch supersedes the same way (see `sidecarPatternEpoch`): a pattern
+// fetched in an earlier epoch is never served or recorded, and the next
+// launch recompiles (cheap — the compile caches are content-addressed and
+// survive) and registers its schema documents afresh.
 //
 // The cache is keyed only on the URL, not the user identity, even with
 // `compileInUserSpace`. A same-apiUrl identity switch reuses the prior user's
@@ -1541,22 +1560,8 @@ export function createSidecarPatternCache(options: {
 }) {
   let fetchPromise: Promise<Pattern | undefined> | undefined;
   let fetchUrl: string | undefined;
+  let fetchEpoch = -1;
   let pattern: Pattern | undefined;
-
-  // A compiled pattern's binding schemas are externalized to `cid:`
-  // references whose documents live in the realm schema registry for the
-  // epoch that compiled it. This cache outlives runtimes, so on the
-  // registry-clear transition (last lease out) the cached pattern's
-  // references would dangle — every cell its next instantiation minted
-  // would carry a schema nobody can resolve, and the first sync built from
-  // one would be rejected by the server (#6303). Drop the cache with the
-  // epoch; the next launch recompiles (cheap — the compile caches are
-  // content-addressed and survive) and registers its documents afresh.
-  onSchemaRegistryClear(() => {
-    fetchPromise = undefined;
-    fetchUrl = undefined;
-    pattern = undefined;
-  });
 
   // Resolved lazily (not at module load): in the browser worker this module
   // is imported before the runtime calls `setPatternEnvironment` with the
@@ -1604,13 +1609,17 @@ export function createSidecarPatternCache(options: {
   }
 
   return {
-    // Pattern from a completed fetch for the current environment's URL.
+    // Pattern from a completed fetch for the current environment's URL and
+    // the current schema-registry epoch.
     cached(): Pattern | undefined {
-      return fetchUrl === patternUrl() ? pattern : undefined;
+      return fetchUrl === patternUrl() && fetchEpoch === sidecarPatternEpoch
+        ? pattern
+        : undefined;
     },
     // Memoized fetch for the current environment's URL, started by this call
-    // when none is in flight for that URL. When this call starts the fetch,
-    // `onSuccess` runs once it resolves with a pattern, unless a later fetch
+    // when none is in flight for that URL in the current schema-registry
+    // epoch. When this call starts the fetch, `onSuccess` runs once it
+    // resolves with a pattern, unless a later fetch or an epoch transition
     // superseded it. A superseded fetch resolves to undefined.
     fetch(
       runtime: Runtime,
@@ -1618,18 +1627,27 @@ export function createSidecarPatternCache(options: {
       compileSpace?: Cell<unknown>["space"],
     ): Promise<Pattern | undefined> {
       const url = patternUrl();
-      if (!fetchPromise || fetchUrl !== url) {
+      if (
+        !fetchPromise || fetchUrl !== url || fetchEpoch !== sidecarPatternEpoch
+      ) {
         fetchUrl = url;
+        const startedEpoch = sidecarPatternEpoch;
+        fetchEpoch = startedEpoch;
         pattern = undefined;
         const started: Promise<Pattern | undefined> = fetchPattern(
           runtime,
           url,
           compileSpace,
         ).then((fetched) => {
-          // Only the fetch the cache currently points to records and reports
-          // its result; launches chained on a superseded fetch get undefined
-          // so a stale pattern is never run.
-          if (fetchPromise !== started) return undefined;
+          // Only the fetch the cache currently points to, settling in the
+          // epoch it started in, records and reports its result; launches
+          // chained on a superseded fetch get undefined so a stale pattern
+          // is never run.
+          if (
+            fetchPromise !== started || startedEpoch !== sidecarPatternEpoch
+          ) {
+            return undefined;
+          }
           pattern = fetched;
           if (fetched) {
             onSuccess?.(fetched);

--- a/packages/runner/src/schema-decompose.ts
+++ b/packages/runner/src/schema-decompose.ts
@@ -102,6 +102,24 @@ export class SchemaNotDecomposableError extends Error {
   }
 }
 
+/**
+ * The refusal for an external ref whose document the resolver cannot
+ * supply — the one {@link SchemaNotDecomposableError} that is about
+ * availability rather than the input's structure. Callers that treat a
+ * locally unresolvable reference differently from a structural refusal (a
+ * structural one is harmless inline; an unresolvable reference reaches the
+ * server unverified) catch this subtype; everything catching the base
+ * class keeps seeing both.
+ */
+export class SchemaDocumentNotAtHandError extends SchemaNotDecomposableError {
+  constructor(readonly taggedHash: string) {
+    super(
+      `references a schema document that is not at hand: \`${taggedHash}\``,
+    );
+    this.name = "SchemaDocumentNotAtHandError";
+  }
+}
+
 /** Formats an external schema reference from its parts. */
 export function formatExternalSchemaRef(
   taggedHash: string,
@@ -456,9 +474,7 @@ export function decomposeSchema(
       if (documents.has(hash)) continue;
       const supplied = options.resolveDocument?.(hash);
       if (supplied === undefined) {
-        throw new SchemaNotDecomposableError(
-          `references a schema document that is not at hand: \`${hash}\``,
-        );
+        throw new SchemaDocumentNotAtHandError(hash);
       }
       const sah = internSchema(supplied, true);
       if (sah.taggedHashString !== hash) {

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -13,6 +13,7 @@ import type {
 } from "@commonfabric/memory/v2";
 
 import type { JSONSchemaObj } from "@commonfabric/api";
+import { getLogger } from "@commonfabric/utils/logger";
 
 import { pruneCfcSchemaDefinitions } from "../cfc/schema-refs.ts";
 import {
@@ -28,6 +29,11 @@ import {
 } from "../schema-registry.ts";
 import type { PullError, Result, Unit, URI } from "./interface.ts";
 import { SelectorTracker } from "./selector-tracker.ts";
+
+const logger = getLogger("storage.v2-watch", {
+  enabled: true,
+  level: "error",
+});
 
 const DOCUMENT_MIME = "application/json" as const;
 type ScopedWatchAddress = {
@@ -73,10 +79,14 @@ export const normalizeSyncSelector = (
  *   recomposes to the fully inline form through the realm registry, which
  *   holds every document behind a locally created reference.
  *
- * A decomposition refusal keeps the selector exactly as given; so does a
- * ref-bearing schema whose documents the registry cannot supply — that
- * reference was unresolvable locally too, and the server's diagnostic is
- * the loudest signal available.
+ * A decomposition refusal keeps the selector exactly as given. An
+ * inline-only schema goes to the wire inline, which every server accepts.
+ * A ref-bearing schema whose documents the registry cannot supply also
+ * passes through — but that selector names a document this client could
+ * not resolve either, so a current server rejects it and the failed load
+ * surfaces as a dropped event far from this cause. The error log below
+ * names the missing document at the point where the inconsistency is
+ * first detectable (#6303).
  */
 export const externalizeSyncSelector = (
   selector: SchemaPathSelector,
@@ -111,7 +121,17 @@ export const externalizeSyncSelector = (
       ),
     });
   } catch (error) {
-    if (error instanceof SchemaNotDecomposableError) return selector;
+    if (error instanceof SchemaNotDecomposableError) {
+      if (carriesRefs) {
+        logger.error("unresolvable-selector-schema-ref", () => [
+          "sync selector schema carries a `cid:` reference this client",
+          "cannot resolve; the server will reject the query and the",
+          "pending load will fail:",
+          error.message,
+        ]);
+      }
+      return selector;
+    }
     throw error;
   }
 };

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -20,6 +20,7 @@ import {
   containsExternalSchemaRef,
   decomposeSchema,
   recomposeSchema,
+  SchemaDocumentNotAtHandError,
   SchemaNotDecomposableError,
 } from "../schema-decompose.ts";
 import { getContentAddressedSchemasConfig } from "../schema-doc-config.ts";
@@ -79,14 +80,16 @@ export const normalizeSyncSelector = (
  *   recomposes to the fully inline form through the realm registry, which
  *   holds every document behind a locally created reference.
  *
- * A decomposition refusal keeps the selector exactly as given. An
- * inline-only schema goes to the wire inline, which every server accepts.
- * A ref-bearing schema whose documents the registry cannot supply also
- * passes through — but that selector names a document this client could
- * not resolve either, so a current server rejects it and the failed load
- * surfaces as a dropped event far from this cause. The error log below
- * names the missing document at the point where the inconsistency is
- * first detectable (#6303).
+ * A decomposition refusal keeps the selector exactly as given. A
+ * structural refusal (nested `$defs`, an `$id`, and the rest) is harmless
+ * on the wire — the schema rides inline, refs and all, and the server
+ * verifies only the referenced closure. A ref whose DOCUMENT the registry
+ * cannot supply also passes through — but that selector names a document
+ * this client could not resolve, so the server rejects it unless the
+ * space happens to persist the document, and the failed load surfaces as
+ * a dropped event far from this cause. The error log below names the
+ * missing document for exactly that refusal, at the point where the
+ * inconsistency is first detectable (#6303).
  */
 export const externalizeSyncSelector = (
   selector: SchemaPathSelector,
@@ -122,11 +125,12 @@ export const externalizeSyncSelector = (
     });
   } catch (error) {
     if (error instanceof SchemaNotDecomposableError) {
-      if (carriesRefs) {
+      if (error instanceof SchemaDocumentNotAtHandError) {
         logger.error("unresolvable-selector-schema-ref", () => [
-          "sync selector schema carries a `cid:` reference this client",
-          "cannot resolve; the server will reject the query and the",
-          "pending load will fail:",
+          "sync selector schema references a `cid:` schema document this",
+          "client cannot resolve; unless the space persists the document,",
+          "the server will reject the query and the pending load will",
+          "fail:",
           error.message,
         ]);
       }

--- a/packages/runner/test/schema-decompose.test.ts
+++ b/packages/runner/test/schema-decompose.test.ts
@@ -11,6 +11,7 @@ import {
   isExternalSchemaRef,
   parseExternalSchemaRef,
   recomposeSchema,
+  SchemaDocumentNotAtHandError,
   SchemaNotDecomposableError,
 } from "../src/schema-decompose.ts";
 
@@ -398,6 +399,38 @@ describe("schema-decompose", () => {
           properties: { x: { $ref: "cid:fid1:abc" } },
         })
       ).toThrow(SchemaNotDecomposableError);
+    });
+
+    it("throws the not-at-hand subtype naming the missing document's hash", () => {
+      let thrown: unknown;
+      try {
+        decomposeSchema({
+          type: "object",
+          properties: { x: { $ref: "cid:fid1:abc" } },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(SchemaDocumentNotAtHandError);
+      expect((thrown as SchemaDocumentNotAtHandError).taggedHash).toBe(
+        "fid1:abc",
+      );
+    });
+
+    it("throws the base refusal, not the not-at-hand subtype, for a structural refusal", () => {
+      let thrown: unknown;
+      try {
+        decomposeSchema({
+          type: "object",
+          properties: {
+            nested: { type: "object", $defs: { Inner: { type: "string" } } },
+          },
+        });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(SchemaNotDecomposableError);
+      expect(thrown).not.toBeInstanceOf(SchemaDocumentNotAtHandError);
     });
 
     it("includes the resolved closure behind a pre-existing external ref", () => {

--- a/packages/runner/test/v2-watch-selector-externalize.test.ts
+++ b/packages/runner/test/v2-watch-selector-externalize.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 
 import type { JSONSchemaObj } from "@commonfabric/api";
 import { internSchemaAsTaggedHashString } from "@commonfabric/data-model/schema-hash";
+import { getLogger } from "@commonfabric/utils/logger";
 
 import { decomposeSchema } from "../src/schema-decompose.ts";
 import { registerSchemaDocument } from "../src/schema-registry.ts";
@@ -128,6 +129,64 @@ describe("v2-watch", () => {
       expect(externalizeSyncSelector(refused as never, () => true)).toBe(
         refused as never,
       );
+    });
+
+    /** Capture `storage.v2-watch` error logs around `fn`, resolving thunked
+     * message parts to their values. */
+    const captureErrorLogs = (fn: () => void): unknown[][] => {
+      const logger = getLogger("storage.v2-watch") as unknown as {
+        error(...args: unknown[]): void;
+      };
+      const captured: unknown[][] = [];
+      logger.error = (...args: unknown[]) => {
+        captured.push(
+          args.map((arg) => (typeof arg === "function" ? arg() : arg)),
+        );
+      };
+      try {
+        fn();
+      } finally {
+        delete (logger as { error?: unknown }).error;
+      }
+      return captured;
+    };
+
+    it("logs the missing document when a ref-bearing selector passes through unresolved", () => {
+      // The pass-through sends the server a selector naming a document this
+      // client could not resolve; without this line the failure surfaces as
+      // a dropped event far from the cause (#6303).
+      setContentAddressedSchemasConfig(true);
+      const doc: JSONSchemaObj = {
+        type: "string",
+        title: "never-registered-6303",
+      };
+      const hash = internSchemaAsTaggedHashString(doc);
+      const selector = { path: [], schema: { $ref: `cid:${hash}` } };
+      const captured = captureErrorLogs(() => {
+        expect(externalizeSyncSelector(selector, () => true)).toBe(selector);
+      });
+      expect(captured.length).toBe(1);
+      expect(captured[0][0]).toBe("unresolvable-selector-schema-ref");
+      expect(JSON.stringify(captured[0])).toContain(hash);
+    });
+
+    it("stays silent when an inline-only schema refuses decomposition", () => {
+      setContentAddressedSchemasConfig(true);
+      const refused = {
+        path: [],
+        schema: {
+          type: "object",
+          properties: {
+            nested: { type: "object", $defs: { Inner: { type: "string" } } },
+          },
+        },
+      } as const;
+      const captured = captureErrorLogs(() => {
+        expect(externalizeSyncSelector(refused as never, () => true)).toBe(
+          refused as never,
+        );
+      });
+      expect(captured).toEqual([]);
     });
   });
 });

--- a/packages/runner/test/v2-watch-selector-externalize.test.ts
+++ b/packages/runner/test/v2-watch-selector-externalize.test.ts
@@ -170,6 +170,43 @@ describe("v2-watch", () => {
       expect(JSON.stringify(captured[0])).toContain(hash);
     });
 
+    it("stays silent when a ref-bearing schema refuses for a structural reason", () => {
+      // The server verifies only the referenced closure, so a selector whose
+      // refusal is structural — here a nested `$defs` beside a resolvable
+      // reference — is served fine when the document is persisted; logging
+      // it would announce a rejection that never comes.
+      setContentAddressedSchemasConfig(true);
+      const doc: JSONSchemaObj = {
+        type: "string",
+        title: "registered-beside-structural-refusal",
+      };
+      const hash = internSchemaAsTaggedHashString(doc);
+      registerSchemaDocument(hash, doc);
+      const probed: string[] = [];
+      const mixed = {
+        path: [],
+        schema: {
+          type: "object",
+          properties: {
+            referenced: { $ref: `cid:${hash}` },
+            nested: { type: "object", $defs: { Inner: { type: "string" } } },
+          },
+        },
+      } as const;
+      const captured = captureErrorLogs(() => {
+        expect(
+          externalizeSyncSelector(mixed as never, (probedHash) => {
+            probed.push(probedHash);
+            return true;
+          }),
+        ).toBe(mixed as never);
+      });
+      expect(captured).toEqual([]);
+      // The structural refusal fires before the persistence probe runs, so
+      // nothing about the referenced closure was ever checked.
+      expect(probed).toEqual([]);
+    });
+
     it("stays silent when an inline-only schema refuses decomposition", () => {
       setContentAddressedSchemasConfig(true);
       const refused = {

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -18,6 +18,7 @@ import {
   getPatternEnvironment,
   setPatternEnvironment,
 } from "../src/builder/env.ts";
+import { acquireSchemaRegistryLease } from "../src/schema-registry.ts";
 
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
@@ -4928,5 +4929,57 @@ describe("createSidecarPatternCache", () => {
     // The winning env-b fetch reports through onSuccess; the superseded env-a
     // fetch does not.
     expect(recorded).toEqual([{ source: "source from env-b.test" }]);
+  });
+
+  it("drops the cached pattern when the last schema-registry lease releases", async () => {
+    // A compiled pattern's binding schemas reference `cid:` documents that
+    // live only for the registry epoch that compiled it; a cache entry
+    // surviving the last-lease-out clear is #6303's silent event drop.
+    const { calls } = installFetchMock();
+    const fakeRuntime = makeFakeRuntime();
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    const cache = createSidecarPatternCache({
+      name: "profile-create.tsx",
+      retryOnFailure: true,
+    });
+
+    const release = acquireSchemaRegistryLease();
+    expect(await cache.fetch(fakeRuntime)).toEqual({
+      source: "source from env-a.test",
+    });
+    expect(cache.cached()).toEqual({ source: "source from env-a.test" });
+
+    release();
+    expect(cache.cached()).toBeUndefined();
+    // The next launch compiles afresh in the new epoch instead of reusing
+    // the pattern whose references died with the old one.
+    expect(await cache.fetch(fakeRuntime)).toEqual({
+      source: "source from env-a.test",
+    });
+    expect(calls).toEqual(["env-a.test", "env-a.test"]);
+  });
+
+  it("resolves a fetch that outlives its registry epoch to undefined", async () => {
+    const { release: releaseGate } = installFetchMock({ gate: "env-a.test" });
+    const fakeRuntime = makeFakeRuntime();
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    const cache = createSidecarPatternCache({
+      name: "profile-create.tsx",
+      retryOnFailure: true,
+    });
+
+    const recorded: unknown[] = [];
+    const releaseLease = acquireSchemaRegistryLease();
+    const inFlight = cache.fetch(
+      fakeRuntime,
+      (pattern) => recorded.push(pattern),
+    );
+    // The epoch ends while the fetch is pending; when it settles it must
+    // record nothing — its pattern was compiled for a registry that is gone.
+    releaseLease();
+    releaseGate();
+    expect(await inFlight).toBeUndefined();
+    expect(cache.cached()).toBeUndefined();
+    expect(recorded).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

Fixes #6303: serialized-pattern reuse across a schema-registry epoch left
`cid:` refs unresolvable, and the failure was a silent event drop — two
28-minute CI shard timeouts during #6267's investigation.

The carrier is now pinned, and it is **not** the compile byte cache — a
byte-cache hit still re-evaluates the module graph in a fresh SES
compartment, and re-evaluation re-serializes and re-registers every
binding-schema document. The carrier is the wish builtin's module-level
sidecar pattern caches (`createSidecarPatternCache`: `suggestion.tsx`,
`profile-create.tsx`, `profile-picker.tsx`). They hold a compiled
`Pattern` keyed only by URL for the whole process. A pattern's `$alias`
binding schemas are externalized to `cid:` references whose documents
live in the realm schema registry for the epoch that compiled it, and are
by design never persisted to the space. When the registry cleared at
last-lease-out (two sequential suites in one process, each with its own
controller), the next suite's `wish("#profile")` launch ran the previous
epoch's cached `Pattern` directly — no re-serialization, so nothing
re-registered the documents. Every cell that instantiation minted carried
a schema nobody could resolve; the first sync selector built from one was
rejected by the server, and the scheduler dropped the queued verb event
with no retry.

Pinned empirically: diffing per-suite factory serializations showed the
second suite lacked exactly the profile-create/profile-home factory runs,
and the deterministic missing document
(`cid:fid1:U9rnPVv…`) is profile-create's `profiles` binding schema.
`compile-cache-hit` in the CI logs was correlation, not the carrier.

## What changed

- `createSidecarPatternCache` hooks `onSchemaRegistryClear` — the same
  mechanism every other resolution-success memo already uses — and drops
  its pattern, URL, and in-flight fetch with the epoch. The next launch
  recompiles (cheap: the content-addressed compile caches survive) and
  registers its documents afresh. A fetch that outlives its epoch
  resolves to `undefined` instead of recording a dead pattern.
- Independently (the issue's second ask): `externalizeSyncSelector`'s
  silent pass-through now logs
  `unresolvable-selector-schema-ref` naming the missing document when a
  ref-bearing schema cannot be decomposed — the point where the
  inconsistency is first detectable, instead of a server rejection
  surfacing later as a silent event drop. An inline-only refusal stays
  silent; inline selectors are fine on the wire.

Not built here: the general closure-carrying epoch-aware artifact
mechanism (#6303's first fix direction). The sidecar caches are the only
cross-epoch `Pattern` holders in the tree today (the other module-level
schema cache in wish.ts, `schemaAsCellCache`, is a content-preserving
spelling transform keyed by the same content, so it cannot extend an
artifact's availability across epochs). If a second carrier of this shape
appears, that mechanism is the fix to reach for; the design call belongs
to the content-addressed-schemas owner.

Once this merges, #6267 can delete its `epochHolder` workaround.

## Test plan

- New unit tests:
  - `wish.test.ts`: the sidecar cache drops its pattern when the last
    schema-registry lease releases, and a fetch that outlives its epoch
    resolves to `undefined` and records nothing.
  - `v2-watch-selector-externalize.test.ts`: the ref-bearing pass-through
    logs the missing document; an inline-only refusal stays silent.
- End-to-end verification (not committed): the exact two-suite
  topic-board integration file from #6267 with the `epochHolder` guard
  removed, against a current-vintage toolshed built from this branch —
  previously reproduced the `Selector references schema document
  cid:fid1:U9rnPVv…` rejection deterministically; with this fix both
  suites pass in 5s with zero rejections, and the second suite registers
  the document itself.
- `deno task check`, repo-wide `deno fmt --check` and `deno lint`, and
  the full `packages/runner` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

