### PR TITLE
feat(cli): cf piece retarget and survey --diff — the apply at the terminal (stage 3, PR 2)

### DIFF
--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -1,8 +1,8 @@
 # Bulk piece operations
 
-**Status:** proposed; stages 1 and 2 — the survey and repair libraries,
-their `cf` entry points, and their coverage in the CI drill and the demo —
-are built. Every later stage is unbuilt. This is the design and build sequence for changing
+**Status:** proposed; stages 1 through 3 — the survey, repair, and retarget
+libraries, their `cf` entry points, and their coverage in the CI drill and
+the demo — are built. Every later stage is unbuilt. This is the design and build sequence for changing
 many pieces in one space as one reviewable, resumable operation. Driven by
 recurring Topics board upgrades.
 
@@ -628,36 +628,36 @@ siblings may run concurrently and whether stage 5 is worth building; and the
 retarget drill. The entry point's spelling follows decision 1: the `piece`
 group.
 
-- [ ] A retarget of a seeded board runs to completion from a checked-in plan.
-- [ ] Preconditions are proved for every row before the first write.
-- [ ] The identity of each row's resolved source is recomputed before the
+- [x] A retarget of a seeded board runs to completion from a checked-in plan.
+- [x] Preconditions are proved for every row before the first write.
+- [x] The identity of each row's resolved source is recomputed before the
       write and must equal `op.patternIdentity`, and the export it runs must
       be `op.symbol`; `rev` is never enforced.
-- [ ] The compatibility override is honored from the row field alone.
-- [ ] Every retarget row carries the `{identity, symbol}` reference its
+- [x] The compatibility override is honored from the row field alone.
+- [x] Every retarget row carries the `{identity, symbol}` reference its
       source produces, the identity computed without compiling, and the
       precondition check classifies each piece as outstanding, landed, or
       moved elsewhere against that row alone — comparing both halves of the
       reference, never the identity by itself.
-- [ ] A run interrupted partway is completed by re-invoking the same command,
+- [x] A run interrupted partway is completed by re-invoking the same command,
       and the pieces that landed are not rewritten. A piece on neither of its
       row's references stops the run by name rather than being skipped or
       rewritten.
-- [ ] A stopped run names every unattempted piece, not a count of them.
-- [ ] The after-survey distinguishes "moved as planned", "still outstanding",
+- [x] A stopped run names every unattempted piece, not a count of them.
+- [x] The after-survey distinguishes "moved as planned", "still outstanding",
       and "moved to something the plan did not ask for" — the third being
       what an upgrade that half-converged looks like.
-- [ ] It composes with the existing space-level checks rather than replacing
+- [x] It composes with the existing space-level checks rather than replacing
       them; those remain the acceptance gate.
-- [ ] Sessions are grouped rather than per-piece or per-run, and the group
+- [x] Sessions are grouped rather than per-piece or per-run, and the group
       size is a knob rather than a constant in the code.
-- [ ] A group boundary is a resume point: a run that dies inside a group
+- [x] A group boundary is a resume point: a run that dies inside a group
       resumes from the start of that group, having lost at most a group's
       worth of warm-up.
-- [ ] Per-piece timing is reported as the run proceeds. A run whose cost per
+- [x] Per-piece timing is reported as the run proceeds. A run whose cost per
       piece is unknown cannot be improved, and the number is the input to
       every decision below about whether to go faster.
-- [ ] The apply and survey-diff acts in
+- [x] The apply and survey-diff acts in
       `packages/cli/integration/bulk-ops-demo.sh` stop being pending: the
       transcript applies a stamped plan and diffs the after-survey against
       it where it now shows the provisional spellings.

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -2,11 +2,17 @@ import { Command, ValidationError } from "@cliffy/command";
 import { Table } from "@cliffy/table";
 import type { CellScope } from "@commonfabric/api";
 import {
+  decodePlan,
+  diffPlan,
   encodePlan,
   type PatternCompatibilityReport,
+  type PatternRef,
+  type PieceDiffStatus,
   type PiecePatternRef,
   type PieceSelector,
+  type PlanDiff,
 } from "@commonfabric/piece/ops";
+import type { RetargetRow } from "@commonfabric/piece/ops/bulk-retarget";
 import ports from "@commonfabric/ports" with { type: "json" };
 import { parseCellPath, UI } from "@commonfabric/runner";
 import {
@@ -20,6 +26,7 @@ import {
   readSourcePin,
   type RepairRunRequest,
   runRepair,
+  runRetarget,
   runSurvey,
 } from "../lib/bulk.ts";
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
@@ -2343,10 +2350,14 @@ export const piece = targetOptions(
     "--validator <path:string>",
     "A JSON-schema file each piece's result is read under; pieces that fail it are named on stderr.",
   )
+  .option(
+    "--diff <plan:string>",
+    "Report this survey against the plan it verifies instead of emitting it: every planned piece as moved as planned, still outstanding, or moved to something the plan did not ask for. Exits nonzero unless every planned row converged.",
+  )
   .option("--out <file:string>", "Write the plan to a file instead of stdout.")
   .option(
     "--json",
-    "Write the full survey result as JSON to stdout instead of the plan.",
+    "Write the full survey result as JSON to stdout instead of the plan, or the diff when --diff names a plan.",
     { conflicts: ["out"] },
   )
   .action(surveyFromCommand)
@@ -2402,6 +2413,39 @@ export const piece = targetOptions(
     { conflicts: ["out"] },
   )
   .action(repairFromCommand)
+  /* piece retarget */
+  .command(
+    "retarget",
+    "Apply a plan's retarget rows: serial, in plan order, each row's precondition proved before its write, stopping at the first failure with every unattempted piece named. Dry by default.",
+  )
+  .usage(spaceUsage)
+  .example(
+    cliText(`cf piece retarget ${EX_ID} ${EX_COMP} --plan plan.jsonl --apply`),
+    "Move every piece the plan names onto the source its row resolves.",
+  )
+  .option(
+    "--plan <file:string>",
+    "The plan this run applies. It is the whole input: it names the pieces, the reference each must still be on, and the source each moves to.",
+    { required: true },
+  )
+  .option(
+    "--apply",
+    "Write each row's source. Without it the run is the classification alone: where every piece stands against its own row, and no write at all.",
+  )
+  .option(
+    "--group-size <count:integer>",
+    "Pieces one session serves before it is replaced, so the warm-up amortizes while the pieces live at once stay bounded. A group boundary is a resume point.",
+  )
+  .option(
+    "--out <file:string>",
+    "Write the report to a file instead of streaming it to stdout, in the canonical FabricValue JSON encoding.",
+  )
+  .option(
+    "--json",
+    "Write the whole report to stdout as one document in the canonical FabricValue JSON encoding, instead of streaming a line per row.",
+    { conflicts: ["out"] },
+  )
+  .action(retargetFromCommand)
   /* piece view */
   .command("view", "Display the rendered view for a piece")
   .usage(pieceUsage)
@@ -3214,16 +3258,85 @@ export function parseRetargetFlag(spec: string): PhaseRetarget {
 export interface SurveyCLIOptions extends BulkSelectionOptions {
   retarget?: string[];
   validator?: string;
+  /** A plan this survey is reported against rather than emitted beside. */
+  diff?: string;
   out?: string;
 }
 
 export interface SurveyCommandDependencies {
   runSurvey?: typeof runSurvey;
   render?: typeof render;
+  readTextFile?: (path: string) => Promise<string>;
   writeTextFile?: typeof Deno.writeTextFile;
   printError?: (message: string) => void;
   printHint?: (message: string) => void;
   exit?: (code: number) => never;
+}
+
+/**
+ * Each diff verdict in the words the design names it in. The three a planned
+ * row can carry lead; the rest belong to a row the plan recorded without an
+ * operation, or to a piece the after-survey no longer holds.
+ */
+const PLAN_DIFF_LABELS: Readonly<Record<PieceDiffStatus, string>> = {
+  landed: "moved as planned",
+  outstanding: "still outstanding",
+  "moved-elsewhere": "moved to something the plan did not ask for",
+  unchanged: "unchanged, with no operation planned",
+  changed: "changed, with no operation planned",
+  missing: "gone from the selection",
+};
+
+/** The verdicts a converged after-survey holds, and only those. */
+const CONVERGED_DIFF_STATUSES: readonly PieceDiffStatus[] = [
+  "landed",
+  "unchanged",
+];
+
+function formatDiffRef(ref: PatternRef | undefined): string {
+  return ref === undefined ? "nothing" : `${ref.patternIdentity}#${ref.symbol}`;
+}
+
+/**
+ * The diff as a person reads it. All three planned verdicts print, whatever
+ * their counts: "still outstanding: 0" is a fact the reader is owed, and an
+ * absent line is one they would have to infer. The remaining classes print
+ * only when a run produced one.
+ */
+export function planDiffLines(diff: PlanDiff): string[] {
+  const lines = (["landed", "outstanding", "moved-elsewhere"] as const).map(
+    (status) => `${PLAN_DIFF_LABELS[status]}: ${diff.counts[status]}`,
+  );
+  for (const status of ["unchanged", "changed", "missing"] as const) {
+    if (diff.counts[status] > 0) {
+      lines.push(`${PLAN_DIFF_LABELS[status]}: ${diff.counts[status]}`);
+    }
+  }
+  if (diff.unplanned.length > 0) {
+    lines.push(
+      `held by the space but not by the plan: ${diff.unplanned.length}`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Every piece whose verdict is not the converged one, named with the
+ * references behind it — a count of them is not something an operator can
+ * act on.
+ */
+export function planDiffFindings(diff: PlanDiff): string[] {
+  return diff.rows.filter((row) =>
+    !CONVERGED_DIFF_STATUSES.includes(row.status)
+  ).map((row) =>
+    `${PLAN_DIFF_LABELS[row.status]}: ${row.piece} ` +
+    `${formatDiffRef(row.before)} -> ${formatDiffRef(row.after)}`
+  );
+}
+
+/** Whether every planned row reached what its plan asked of it. */
+export function planDiffConverged(diff: PlanDiff): boolean {
+  return diff.rows.every((row) => CONVERGED_DIFF_STATUSES.includes(row.status));
 }
 
 /** The selection surface the bulk piece commands share. */
@@ -3381,16 +3494,33 @@ export async function surveyFromCommand(
 
   const print = deps.render ?? render;
   const printHint = deps.printHint ?? hint;
-  if (options.json) {
-    print(result, { json: true });
-  } else {
+  // A diff needs an after-survey that accounts for everything, so an
+  // incomplete one takes the refusal below instead of being compared: a
+  // verdict from a survey that dropped a piece is not a verdict.
+  const diff = options.diff === undefined || !result.complete
+    ? undefined
+    : diffPlan(
+      decodePlan(
+        await (deps.readTextFile ?? Deno.readTextFile)(absPath(options.diff)),
+      ),
+      result.plan,
+    );
+  if (options.out !== undefined) {
+    // The after-survey's own plan, whatever this run reports: it is the
+    // artifact the next run's diff is taken against.
     const plan = encodePlan(result.plan);
-    if (options.out !== undefined) {
-      await (deps.writeTextFile ?? Deno.writeTextFile)(options.out, plan);
-      printHint(`Wrote ${result.plan.rows.length} plan rows to ${options.out}`);
-    } else {
-      print(plan.trimEnd());
-    }
+    await (deps.writeTextFile ?? Deno.writeTextFile)(options.out, plan);
+    printHint(`Wrote ${result.plan.rows.length} plan rows to ${options.out}`);
+  }
+  if (options.json) {
+    print(diff ?? result, { json: true });
+  } else if (diff !== undefined) {
+    for (const line of planDiffLines(diff)) print(line);
+  } else if (options.out === undefined) {
+    print(encodePlan(result.plan).trimEnd());
+  }
+  for (const address of diff?.unplanned ?? []) {
+    printHint(`held by the space but not by the plan: ${address}`);
   }
   for (const entry of result.tally) {
     printHint(
@@ -3414,6 +3544,20 @@ export async function surveyFromCommand(
               `  registered outside the selection: ${outside.piece} on ` +
               `${outside.patternIdentity}#${outside.symbol}`,
           ),
+        ].join("\n"),
+      },
+      deps,
+    );
+  }
+  if (diff !== undefined && !planDiffConverged(diff)) {
+    // A verification that finds work left is not a verification, so it does
+    // not exit zero. The findings ride the message rather than a hint: a
+    // quiet script is the caller most in need of which pieces they are.
+    exitWithDataError(
+      {
+        message: [
+          "The after-survey is not what the plan asked for.",
+          ...planDiffFindings(diff).map((finding) => `  ${finding}`),
         ].join("\n"),
       },
       deps,
@@ -3519,6 +3663,129 @@ export async function repairFromCommand(
             row.verdict !== "conforms" && row.verdict !== "repaired" &&
             (options.apply === true || row.verdict !== "would-change")
           ).map((row) =>
+            `  ${row.verdict}: ${row.piece}` +
+            (row.problem === undefined ? "" : ` ${row.problem}`)
+          ),
+        ].join("\n"),
+      },
+      deps,
+    );
+  }
+}
+
+export interface RetargetCLIOptions extends PieceCLIOptions {
+  /** Inherited from the `piece` mount's global target options. */
+  quiet?: boolean;
+  plan: string;
+  apply?: boolean;
+  groupSize?: number;
+  out?: string;
+}
+
+export interface RetargetCommandDependencies {
+  runRetarget?: typeof runRetarget;
+  render?: typeof render;
+  writeTextFile?: typeof Deno.writeTextFile;
+  printError?: (message: string) => void;
+  printHint?: (message: string) => void;
+  exit?: (code: number) => never;
+}
+
+/**
+ * One report row as a line: the verdict, the piece, its phase, what the row
+ * cost, and what it broke. The cost is on the line rather than in a summary
+ * because a run whose cost per piece is unknown cannot be improved, and the
+ * number has to arrive while there is still a run to reason about.
+ */
+export function formatRetargetRow(row: RetargetRow): string {
+  return [
+    row.verdict,
+    row.piece,
+    ...(row.phase === undefined ? [] : [row.phase]),
+    ...(row.elapsedMs === undefined ? [] : [`${row.elapsedMs}ms`]),
+    ...(row.problem === undefined ? [] : [`- ${row.problem}`]),
+  ].join(" ");
+}
+
+/**
+ * `cf piece retarget`: the plan consumer. The plan is the whole input — it
+ * names the pieces, the reference each must still be on, and the source each
+ * moves to — so this command carries no selection of its own. Dry by
+ * default: without `--apply` the run is the classification alone.
+ *
+ * The report has exactly one destination. Streamed to stdout it arrives a
+ * row at a time, as each row settles; written to a file or emitted as one
+ * JSON document it cannot stream, and each row carries its own cost there
+ * instead. Applying implies no verdict either way: the verification is
+ * `cf piece survey --diff`, a separate invocation by design.
+ */
+export async function retargetFromCommand(
+  options: RetargetCLIOptions,
+  deps: RetargetCommandDependencies = {},
+): Promise<void> {
+  setQuietMode(!!options.quiet);
+  // Every mode reserves stdout for the report — streamed rows, one JSON
+  // document, or nothing at all beside `--out` — and this run starts the
+  // pieces it writes, so the runtime's console goes to stderr whether or not
+  // `--json` is on the line. A pattern's own logging would otherwise land
+  // between two rows of a machine-readable stream.
+  const spaceConfig = { ...parseSpaceOptions(options), jsonOutput: true };
+  const print = deps.render ?? render;
+  const printHint = deps.printHint ?? hint;
+  const streaming = options.json !== true && options.out === undefined;
+  const report = await (deps.runRetarget ?? runRetarget)(spaceConfig, {
+    planPath: absPath(options.plan),
+    ...(options.apply === true ? { apply: true } : {}),
+    ...(options.groupSize === undefined
+      ? {}
+      : { groupSize: options.groupSize }),
+    ...(streaming
+      ? { onRow: (row: RetargetRow) => print(formatRetargetRow(row)) }
+      : {}),
+  });
+  // The canonical FabricValue encoding, as the repair's report uses: one
+  // encoding for one document, whichever destination it goes to.
+  const encoded = jsonFromFabricValue(report as unknown as FabricValue);
+  if (options.out !== undefined) {
+    await (deps.writeTextFile ?? Deno.writeTextFile)(
+      options.out,
+      `${encoded}\n`,
+    );
+    printHint(`Wrote ${report.rows.length} report rows to ${options.out}`);
+  } else if (options.json) {
+    print(encoded);
+  }
+  const tally = new Map<string, number>();
+  for (const row of report.rows) {
+    tally.set(row.verdict, (tally.get(row.verdict) ?? 0) + 1);
+  }
+  printHint(
+    [
+      ...[...tally.entries()].map(([verdict, count]) => `${verdict}: ${count}`),
+      `written: ${report.applied}`,
+    ].join(" · "),
+  );
+  if (!report.complete) {
+    const settled = (row: RetargetRow) =>
+      row.verdict === "landed" || row.verdict === "applied" ||
+      (options.apply !== true && row.verdict === "outstanding");
+    exitWithDataError(
+      {
+        message: [
+          options.apply === true
+            ? "Retarget did not complete; re-running resumes it."
+            : "Retarget found rows an apply would refuse.",
+          // The run's own trouble, as opposed to any piece's: a session that
+          // would not open, would not release, or answered for another space.
+          ...(report.stopReason === undefined
+            ? []
+            : [`  stopped: ${report.stopReason}`]),
+          // Every unattempted piece by name, never a count of them: a count
+          // is not something the operator of a stopped migration can act on.
+          // On the message rather than a hint, for the same reason the
+          // repair puts its problems there — a quiet script is the caller
+          // most in need of them.
+          ...report.rows.filter((row) => !settled(row)).map((row) =>
             `  ${row.verdict}: ${row.piece}` +
             (row.problem === undefined ? "" : ` ${row.problem}`)
           ),

--- a/packages/cli/integration/bulk-ops-demo.sh
+++ b/packages/cli/integration/bulk-ops-demo.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Bulk piece operations as something to watch. What runs today is stages 1
-# and 2 of docs/plans/piece-bulk-operations.md — a board of 113 members
+# through 3 of docs/plans/piece-bulk-operations.md — a board of 113 members
 # surveyed in one process, the plan it emits, the retarget stamp, the
-# containment refusal, and a repair: a fixer run dry, applied from its own
-# plan, and resumed as landed — live rather than asserted. What the later
-# stages add appears as
-# PENDING acts at the end: the eventual shape of the mechanism stays visible
+# containment refusal, a repair (a fixer run dry, applied from its own plan,
+# and resumed as landed), the retarget that plan carries applied over grouped
+# sessions, and the after-survey diffed against the plan it verifies — live
+# rather than asserted. What the later stage adds appears as a
+# PENDING act at the end: the eventual shape of the mechanism stays visible
 # in the transcript, and each stage's checklist in the plan carries the item
 # that converts its act from pending to run, so a landed stage cannot leave
 # this demo describing a smaller tool than the one that exists.
@@ -284,7 +285,43 @@ run_loud cf piece repair -s "$SPACE" --piece board --path items \
   --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply \
   --out "$WORK/applied.jsonl"
 
-act "8 · The refusal the survey exists to make"
+act "8 · The retarget: the plan carried, then applied"
+say "Stage 3, live. The plan is the whole input — it names the pieces, the"
+say "reference each must still be on, and the source each moves to — so the"
+say "command carries no selection of its own. Dry by default: every row"
+say "classified against its own reference pair, and no write at all."
+run_loud cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
+  --out "$WORK/dry.json"
+run sh -c "sed 's/^fvj1://' '$WORK/dry.json' | jq -c '{applied, complete, verdicts: (.rows | map(.verdict) | unique)}'"
+say "--apply writes. Sessions are grouped rather than opened per piece or"
+say "held open for the whole run: the warm-up amortizes across a group while"
+say "the pieces live at once stay bounded by it, and a group boundary is a"
+say "resume point."
+run_loud cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
+  --group-size 25 --apply --out "$WORK/applied.json"
+say "Every row carries what it cost. A run whose cost per piece is unknown"
+say "cannot be improved, and this is the number a decision to run siblings"
+say "concurrently would be made on."
+run sh -c "sed 's/^fvj1://' '$WORK/applied.json' | jq -c '.rows[0:3] | map({piece, verdict, elapsedMs})'"
+say "Re-invoking is the resume: a piece already on its row's target reads as"
+say "landed and is not rewritten, so the same command finishes a run that"
+say "stopped partway."
+run_loud cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" --apply \
+  --out "$WORK/resumed.json"
+run sh -c "sed 's/^fvj1://' '$WORK/resumed.json' | jq -c '{applied, complete, verdicts: (.rows | map(.verdict) | unique)}'"
+
+act "9 · The verification is a second survey, never the apply's exit code"
+say "An apply that exits zero is not a verdict. The verdict is a survey"
+say "taken afterwards and held against the plan the run was made from, and"
+say "the two stay separate invocations on purpose."
+run_loud cf piece survey -s "$SPACE" --piece board --path items \
+  --diff "$WORK/retarget.jsonl"
+say "Three outcomes for a planned piece, and the third is what an upgrade"
+say "that half-converged looks like. The member filed after the plan was"
+say "taken is none of them: it is named as held by the space and not by the"
+say "plan, rather than counted as though the plan had asked for it."
+
+act "10 · The refusal the survey exists to make"
 say "Deploy a member directly, so the registry knows a piece the board's"
 say "collection does not hold. A silent subset is the failure bulk operations"
 say "die of, so the survey stops and names it rather than emitting a plan"
@@ -297,7 +334,7 @@ say "The plan the later stages consume is therefore complete by construction:"
 say "an incomplete survey refuses to produce one, and a serialized plan"
 say "carries the incompleteness so no write stage can consume it either."
 
-act "9 · A list survey claims only what it read"
+act "11 · A list survey claims only what it read"
 say "Naming pieces directly skips the containment check — and says so: the"
 say "header records the selector, so a reader of the plan knows no"
 say "containment claim was made. The orphan is still out there; this survey"
@@ -305,23 +342,14 @@ say "just never claimed otherwise."
 run_loud cf piece survey -s "$SPACE" --list board --out "$WORK/list.jsonl"
 run sh -c "head -1 '$WORK/list.jsonl' | jq -c '{selector, enumerated}'"
 
-act "10 · The rest of the mechanism, by what it waits on"
-say "The plan files this transcript produced are the input to every later"
-say "stage; nothing below needs a different artifact — the paths are the"
-say "ones written above. Each act shows the command a stage adds and what"
-say "it will print — spelled provisionally per the plan, and prefixed »"
+act "12 · The rest of the mechanism, by what it waits on"
+say "The plan files this transcript produced are the input to the stage"
+say "below; it needs no different artifact — the path is the one written"
+say "above. The act shows the command that stage adds and what it will"
+say "print — spelled provisionally per the plan, and prefixed »"
 say "because nothing runs it. A stage that lands converts its act from"
 say "PENDING to run; the plan's checklist for that stage says so, the way"
-say "stages 1 and 2 did."
-
-pending "cf piece apply -s $SPACE $WORK/retarget.jsonl" \
-  "stage 3: the retarget apply — serial, precondition-checked, resumable" \
-"row 1/114 fid1:cey7Ro... I9aHKe...#Member -> WPK2FB...#Member landed
-stopped at row 57: the piece moved since the survey; 57 unattempted, named"
-
-pending "cf piece survey -s $SPACE --piece board --path items --diff $WORK/retarget.jsonl" \
-  "stage 3: verification is a second survey against the plan, never the apply's exit code — the diff itself is stage-1 library code waiting on a spelling" \
-"moved as planned: 56 . still outstanding: 57 planned rows . 1 unplanned piece, named"
+say "stages 1 through 3 did."
 
 pending "cf piece rollback -s $SPACE $WORK/retarget.jsonl" \
   "stage 4: the plan derived in the other direction, restoring each row's recorded revision" \
@@ -331,8 +359,10 @@ retained; restores in plan order"
 printf '\n%s━━ The shape of it %s\n' "$B" "$N"
 say "One process surveyed a board-sized collection and emitted the plan the"
 say "later stages consume; the same command carried a retarget when asked;"
-say "and the one refusal shown is the survey's reason to exist: no plan that"
-say "silently misses a piece."
+say "a second process applied that plan over grouped sessions and reported"
+say "what each piece cost; a third took the survey that says whether it"
+say "worked. And the one refusal shown is the survey's reason to exist: no"
+say "plan that silently misses a piece."
 
 if [ "$UNEXPECTED" != "0" ]; then
   printf '\n%s━━ %d act(s) failed that this demo says work%s\n' \

--- a/packages/cli/integration/bulk-survey-drill.sh
+++ b/packages/cli/integration/bulk-survey-drill.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 # The bulk-operations drill: deploy a board whose members are created
-# through its own verb, survey it, assert the plan — and repair it: a fixer
-# run dry with every plan row recording its precondition and fixer, applied
-# from that plan, resumed as all-landed writing nothing, and a
-# field-dropping fixer refused by name. Stages 1 and 2 of
-# docs/plans/piece-bulk-operations.md, which finishes each stage with a CI
-# drill so "does the migration tooling still work?" stays a CI result.
+# through its own verb, survey it, assert the plan — repair it: a fixer run
+# dry with every plan row recording its precondition and fixer, applied from
+# that plan, resumed as all-landed writing nothing, and a field-dropping
+# fixer refused by name — and retarget it: the stamped plan applied to
+# completion, a run killed midway and finished by re-invocation, an edited
+# source refused with every unattempted piece named, a piece moved elsewhere
+# stopping the run, and the after-survey diffed against the plan it verifies.
+# Stages 1 through 3 of docs/plans/piece-bulk-operations.md, which finishes
+# each stage with a CI drill so "does the migration tooling still work?"
+# stays a CI result.
 #
 # It deploys pattern/bulk-board.tsx (members from pattern/bulk-member.tsx, a
 # separate module so member and board identities differ, the way topic.tsx
-# sits beside the topics board's main.tsx) and stamps a retarget from
-# pattern/bulk-member-v2.tsx, which is never deployed: the survey computes the
-# identity the source produces without writing anything. The fixtures belong
-# to this drill alone.
+# sits beside the topics board's main.tsx) and retargets them onto
+# pattern/bulk-member-v2.tsx — the checked-in fixture pair the design calls
+# for, a trimmed prior generation and a current one, so the drill reds when
+# bulk operations break rather than when a real pattern changes. The fixtures
+# belong to this drill alone.
 #
 # Every step names the property it asserts. A fresh space per run, no prior
 # state, no store access — the survey is API-only.
@@ -28,6 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 API_URL="${API_URL:-http://localhost:8000}"
 BOARD_FIXTURE="$SCRIPT_DIR/pattern/bulk-board.tsx"
+MEMBER_FIXTURE="$SCRIPT_DIR/pattern/bulk-member.tsx"
 RETARGET_FIXTURE="$SCRIPT_DIR/pattern/bulk-member-v2.tsx"
 
 # Prefer a built binary when the harness supplies one; fall back to source.
@@ -287,9 +293,207 @@ RUN3=$($CF piece repair -q --piece "$BOARD" --path items $ARGS \
 check "$(printf '%s\ttrue' "$((MEMBERS_NOW - 2))")" "$RUN3" \
   "the amended fixer completes the remainder by re-invocation"
 
-step "12. A registered in-scope orphan makes the survey refuse"
+step "12. A retarget plan over the whole board, from the fixture pair"
+# The source is a copy, so a later step can edit it and prove the apply
+# refuses a source that no longer produces the reference the plan recorded.
+NEXT_SOURCE="$WORK/member-next.tsx"
+cp "$RETARGET_FIXTURE" "$NEXT_SOURCE"
+RETARGET_PLAN="$WORK/retarget.jsonl"
+if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
+  --retarget "items=$NEXT_SOURCE" --main-export Member \
+  --out "$RETARGET_PLAN" 2>"$WORK/retarget-survey.err"; then
+  ok "the survey stamped the retarget onto every member row"
+else
+  bad "the retarget survey exited nonzero"
+  sed 's/^/  | /' "$WORK/retarget-survey.err"
+  exit 1
+fi
+PLAN_OPS=$(tail -n +2 "$RETARGET_PLAN" | jq -rs \
+  'map(select(has("op"))) | length')
+check "$MEMBERS_NOW" "$PLAN_OPS" "one retarget row per member, the holder none"
+
+step "13. The dry run classifies every row and writes nothing"
+DRY=$($CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --json \
+  2>"$WORK/retarget-dry.err" | sed 's/^fvj1://' |
+  jq -r '[(.applied|tostring), (.complete|tostring),
+    (.rows | map(.verdict) | unique | join(",")),
+    (.rows | length | tostring)] | @tsv')
+check "$(printf '0\ttrue\toutstanding\t%s' "$MEMBERS_NOW")" "$DRY" \
+  "every row reads outstanding against its own reference pair"
+
+step "14. An edited source is refused, and the stop names the remainder"
+# The reviewed plan pins the identity the source produced when it was
+# reviewed. An edited source is a different identity, so the apply refuses
+# the first row rather than landing something the plan's reader never saw.
+printf '\n// edited after the plan was reviewed\n' >> "$NEXT_SOURCE"
+if $CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --apply \
+  --out "$WORK/stop.json" 2>"$WORK/retarget-stop.err"; then
+  bad "an edited source ran under the reviewed plan"
+else
+  ok "an edited source exited nonzero under the reviewed plan"
+fi
+STOP_FACTS=$(sed 's/^fvj1://' "$WORK/stop.json" | jq -r '[(.applied|tostring),
+  (.complete|tostring), (.rows[0].verdict),
+  (.rows | map(select(.verdict == "unattempted") | .piece) | unique | length
+    | tostring)] | @tsv')
+check "$(printf '0\tfalse\trefused\t%s' "$((MEMBERS_NOW - 1))")" "$STOP_FACTS" \
+  "the first row was refused, and every other piece is named unattempted"
+if grep -q "resolves to" "$WORK/retarget-stop.err"; then
+  ok "the refusal names the identity the source resolves to now"
+else
+  bad "the refusal does not name the resolved identity"
+  sed 's/^/  | /' "$WORK/retarget-stop.err"
+fi
+cp "$RETARGET_FIXTURE" "$NEXT_SOURCE"
+
+step "15. A run killed midway is completed by re-invoking the same command"
+# The report streams a row at a time to stdout, so the drill reads rows as
+# they land and kills the run on the sixth — inside the second group, past
+# one group boundary. Nothing is waited on but the rows themselves.
+#
+# The interruption is proved rather than assumed, because a run that finished
+# on its own would satisfy every assertion about the second invocation while
+# exercising none of what this step exists for. Two independent proofs, both
+# required: the first invocation's exit status must be a signal death, and a
+# read-only pass between the two invocations must find real work on both
+# sides of the cut.
+mkfifo "$WORK/progress"
+$CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --apply --group-size 5 \
+  >"$WORK/progress" 2>"$WORK/retarget-killed.err" &
+KILLED_PID=$!
+# The read end stays open past the loop, on its own descriptor: closing it at
+# the break would deliver a broken pipe and end the run before the signal
+# does, which is a different interruption from the one this step claims.
+exec 3<"$WORK/progress"
+WATCHED=0
+while IFS= read -r _row <&3; do
+  WATCHED=$((WATCHED + 1))
+  [ "$WATCHED" -ge 6 ] && break
+done
+if [ "$WATCHED" -ge 6 ]; then
+  ok "watched $WATCHED rows land"
+else
+  bad "the run ended before six rows landed (saw $WATCHED)"
+  sed 's/^/  | /' "$WORK/retarget-killed.err"
+fi
+if kill "$KILLED_PID" 2>/dev/null; then
+  ok "signalled the run partway through its second group"
+else
+  bad "the run was already gone when the drill signalled it, so nothing was \
+interrupted and this step proves nothing"
+fi
+wait "$KILLED_PID"
+KILLED_STATUS=$?
+exec 3<&-
+# 128 plus the signal number: 143 for the SIGTERM sent above, 137 if it
+# escalated. Any other status is a run that reached its own exit — the race
+# this step must go red on rather than pass through.
+if [ "$KILLED_STATUS" = "143" ] || [ "$KILLED_STATUS" = "137" ]; then
+  ok "the first invocation died on the signal (exit $KILLED_STATUS)"
+else
+  bad "the first invocation exited $KILLED_STATUS rather than on the signal: \
+it ran to its own end before the drill could stop it"
+fi
+# What the cut left behind, read without writing: rows on both sides of it.
+# Zero on either side is a run that was never stopped midway, whatever the
+# exit status said.
+MIDWAY=$($CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --json \
+  2>"$WORK/retarget-midway.err" | sed 's/^fvj1://' |
+  jq -r '[(.rows | map(select(.verdict == "landed")) | length | tostring),
+    (.rows | map(select(.verdict == "outstanding")) | length | tostring)]
+    | @tsv')
+MIDWAY_LANDED=$(printf '%s' "$MIDWAY" | cut -f1)
+MIDWAY_OUTSTANDING=$(printf '%s' "$MIDWAY" | cut -f2)
+if [ "${MIDWAY_LANDED:-0}" -ge "$WATCHED" ] &&
+  [ "${MIDWAY_OUTSTANDING:-0}" -gt 0 ]; then
+  ok "the cut left $MIDWAY_LANDED landed and $MIDWAY_OUTSTANDING outstanding"
+else
+  bad "the cut left $MIDWAY_LANDED landed and $MIDWAY_OUTSTANDING \
+outstanding, of $WATCHED rows watched: the run was not stopped midway"
+fi
+check "$MEMBERS_NOW" \
+  "$((${MIDWAY_LANDED:-0} + ${MIDWAY_OUTSTANDING:-0}))" \
+  "between the invocations every row is landed or outstanding, nothing else"
+RESUME=$($CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --apply --json \
+  2>"$WORK/retarget-resume.err" | sed 's/^fvj1://' |
+  jq -r '[(.complete|tostring),
+    (.rows | map(select(.verdict == "landed")) | length | tostring),
+    (.rows | map(select(.verdict == "applied")) | length | tostring)] | @tsv')
+RESUME_COMPLETE=$(printf '%s' "$RESUME" | cut -f1)
+RESUME_LANDED=$(printf '%s' "$RESUME" | cut -f2)
+RESUME_APPLIED=$(printf '%s' "$RESUME" | cut -f3)
+check "true" "$RESUME_COMPLETE" "the re-invocation completed the run"
+check "$MIDWAY_LANDED" "$RESUME_LANDED" \
+  "the rows the killed run landed were read as landed, not rewritten"
+check "$MIDWAY_OUTSTANDING" "$RESUME_APPLIED" \
+  "the re-invocation wrote the remainder, and only the remainder"
+check "$MEMBERS_NOW" "$((${RESUME_LANDED:-0} + ${RESUME_APPLIED:-0}))" \
+  "every member row is accounted for across the two invocations"
+
+step "16. Re-running the completed plan writes nothing"
+SETTLED=$($CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --apply --json \
+  2>/dev/null | sed 's/^fvj1://' | jq -r '[(.applied|tostring),
+    (.complete|tostring), (.rows | map(.verdict) | unique | join(","))]
+    | @tsv')
+check "$(printf '0\ttrue\tlanded')" "$SETTLED" \
+  "a settled plan re-runs as all-landed and writes nothing"
+
+step "17. A piece on neither of its row's references stops the run by name"
+FIRST_MEMBER=$(tail -n +2 "$RETARGET_PLAN" |
+  jq -r 'select(has("op")) | .piece' | head -1)
+SECOND_MEMBER=$(tail -n +2 "$RETARGET_PLAN" |
+  jq -r 'select(has("op")) | .piece' | sed -n 2p)
+# MemberAlias is the same module under a second symbol, so this piece now
+# carries the target row's identity and not its symbol: a check comparing the
+# identity alone would call it landed.
+if $CF piece setsrc -q --piece "$FIRST_MEMBER" --main-export MemberAlias \
+  "$RETARGET_FIXTURE" $ARGS >/dev/null 2>"$WORK/alias.err"; then
+  ok "moved a member to the target identity under another symbol"
+else
+  bad "moving a member to the alias export failed"
+  sed 's/^/  | /' "$WORK/alias.err"
+fi
+if $CF piece retarget -q $ARGS --plan "$RETARGET_PLAN" --apply \
+  --out "$WORK/moved.json" 2>"$WORK/moved.err"; then
+  bad "a piece on neither reference did not stop the run"
+else
+  ok "a piece on neither reference exited nonzero"
+fi
+MOVED_FACTS=$(sed 's/^fvj1://' "$WORK/moved.json" | jq -r '[(.applied|tostring),
+  (.complete|tostring),
+  (.rows | map(select(.verdict == "moved-elsewhere") | .piece) | join(",")),
+  (.rows | map(select(.verdict == "landed")) | length | tostring)] | @tsv')
+check "$(printf '0\tfalse\t%s\t%s' "$FIRST_MEMBER" "$((MEMBERS_NOW - 1))")" \
+  "$MOVED_FACTS" \
+  "the moved piece is named, and nothing was written for any row"
+if grep -q "$FIRST_MEMBER" "$WORK/moved.err"; then
+  ok "the stop names the piece rather than counting it"
+else
+  bad "the stop does not name the moved piece"
+  sed 's/^/  | /' "$WORK/moved.err"
+fi
+
+step "18. The after-survey tells the three outcomes apart"
+# One member back on the prior generation, so the diff has an outstanding row
+# to distinguish from the one that moved somewhere the plan never named.
+$CF piece setsrc -q --piece "$SECOND_MEMBER" --main-export Member \
+  "$MEMBER_FIXTURE" $ARGS >/dev/null 2>"$WORK/revert.err" ||
+  bad "moving a member back to the prior generation failed"
+if $CF piece survey -q --piece "$BOARD" --path items $ARGS \
+  --diff "$RETARGET_PLAN" --json >"$WORK/diff.json" 2>"$WORK/diff.err"; then
+  bad "the diff exited 0 with rows outstanding and moved elsewhere"
+else
+  ok "the diff exited nonzero with rows outstanding and moved elsewhere"
+fi
+DIFF_FACTS=$(jq -r '[(.counts.landed|tostring), (.counts.outstanding|tostring),
+  (.counts["moved-elsewhere"]|tostring), (.counts.unchanged|tostring),
+  (.unplanned | length | tostring)] | @tsv' "$WORK/diff.json")
+check "$(printf '%s\t1\t1\t1\t0' "$((MEMBERS_NOW - 2))")" "$DIFF_FACTS" \
+  "moved as planned, still outstanding, and moved to something unplanned"
+
+step "19. A registered in-scope orphan makes the survey refuse"
 ORPHAN=$($CF piece new --quiet --main-export Member \
-  "$SCRIPT_DIR/pattern/bulk-member.tsx" $ARGS 2>/dev/null |
+  "$MEMBER_FIXTURE" $ARGS 2>/dev/null |
   grep -oE '^fid1:[A-Za-z0-9_-]+' | head -1)
 if [ -n "$ORPHAN" ]; then ok "registered orphan $ORPHAN"; else
   bad "orphan deploy failed"
@@ -306,7 +510,7 @@ else
   bad "the refusal does not name the orphan"
 fi
 
-step "13. A list survey claims no containment"
+step "20. A list survey claims no containment"
 LIST_FACTS=$($CF piece survey -q --list "$BOARD" $ARGS 2>/dev/null |
   head -1 | jq -r '[.selector, (.enumerated.collection|tostring),
     (.enumerated.registeredOutside|tostring)] | @tsv')

--- a/packages/cli/integration/pattern/bulk-member-v2.tsx
+++ b/packages/cli/integration/pattern/bulk-member-v2.tsx
@@ -1,9 +1,14 @@
 /**
- * The "next generation" of `bulk-member.tsx`, for the bulk-survey drill. The
- * drill never deploys it: it is the `--retarget` source whose computed
- * identity the survey stamps onto member rows, and the assertion is that the
- * stamp differs from the identity the members currently run. The only
- * difference from generation one is the field a retarget would change.
+ * The "next generation" of `bulk-member.tsx`, for the bulk-operations drill:
+ * the `--retarget` source whose computed identity the survey stamps onto
+ * member rows, and which the retarget then moves them to. The only difference
+ * from generation one is the field a retarget would change.
+ *
+ * It exports the same pattern twice. A module's identity is its closure's, so
+ * `Member` and `MemberAlias` share one identity and differ only in symbol —
+ * which is what lets the drill move a piece to a reference whose identity
+ * half matches a plan row's target while its symbol half does not, and hold
+ * the classification to comparing both.
  */
 
 import { NAME, pattern, type PatternFactory } from "commonfabric";
@@ -20,6 +25,16 @@ export interface MemberOutput {
 }
 
 export const Member: PatternFactory<MemberInput, MemberOutput> = pattern<
+  MemberInput,
+  MemberOutput
+>(({ title }) => ({
+  [NAME]: title,
+  title,
+  generation: "two",
+}));
+
+/** The same member under a second symbol; see the module comment. */
+export const MemberAlias: PatternFactory<MemberInput, MemberOutput> = pattern<
   MemberInput,
   MemberOutput
 >(({ title }) => ({

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -292,10 +292,12 @@ export async function runRetarget(
       // a wrong-space stop whose session also would not release. Only the
       // message survives, which is all the library reads off this throw.
       throw new Error(
-        settleProblem === undefined ? disposeProblem : settleProblem +
-          (disposeProblem === undefined
-            ? ""
-            : ` Its session could not be disposed either: ${disposeProblem}.`),
+        settleProblem === undefined
+          ? disposeProblem
+          : disposeProblem === undefined
+          ? settleProblem
+          : `${settleProblem.replace(/\.$/, "")}. Its session could not ` +
+            `be disposed either: ${disposeProblem}.`,
       );
     },
   };

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -236,6 +236,22 @@ export interface RetargetRunDependencies {
 }
 
 /**
+ * Run one teardown step, handing back what it broke instead of throwing it.
+ * A session boundary runs every step it has, so an early failure must not
+ * take the later ones with it; what each broke is composed afterwards.
+ */
+async function teardownProblem(
+  step: () => Promise<void>,
+): Promise<string | undefined> {
+  try {
+    await step();
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+/**
  * Run the retarget: decode the plan file and hand the library a session
  * supply that opens a real session per group and disposes its runtime when
  * the group ends, which closes that session's storage — so a group's pieces
@@ -261,8 +277,26 @@ export async function runRetarget(
       // without draining it, so a read still in flight would come back
       // against a closed client — a failure belonging to a session already
       // being released, reported over the rows the group just produced.
-      await pieces.synced();
-      await pieces.dispose();
+      //
+      // The disposal happens whether or not the settling did. A failed
+      // settle is reported as a stop rather than crashing the run, so a
+      // session skipped over here would stay open — with its runtime and
+      // its storage — for as long as the process lives, which is the whole
+      // cost the grouping exists to avoid.
+      const settleProblem = await teardownProblem(() => pieces.synced());
+      const disposeProblem = await teardownProblem(() => pieces.dispose());
+      if (settleProblem === undefined && disposeProblem === undefined) return;
+      // The settle failure leads when both fail: it is why this boundary
+      // cannot be trusted, and the disposal that followed it is named after
+      // it rather than instead of it — the composition the library uses for
+      // a wrong-space stop whose session also would not release. Only the
+      // message survives, which is all the library reads off this throw.
+      throw new Error(
+        settleProblem === undefined ? disposeProblem : settleProblem +
+          (disposeProblem === undefined
+            ? ""
+            : ` Its session could not be disposed either: ${disposeProblem}.`),
+      );
     },
   };
   return await (deps.retargetPieces ?? retargetPieces)(sessions, {

--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -30,6 +30,12 @@ import {
   programEntryIdentity,
   resolveLocalSourceProgram,
 } from "@commonfabric/piece/ops/bulk-local";
+import {
+  retargetPieces,
+  type RetargetReport,
+  type RetargetRow,
+  type RetargetSessions,
+} from "@commonfabric/piece/ops/bulk-retarget";
 import type { JSONSchema, RuntimeProgram } from "@commonfabric/runner";
 
 import { loadPieces, type PieceConfig, type SpaceConfig } from "./piece.ts";
@@ -205,6 +211,68 @@ async function importProgramSnapshot(
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+}
+
+/** What one retarget run is asked to do, parsed off the command line. */
+export interface RetargetRunRequest {
+  /**
+   * The plan file this run consumes. The plan is the whole input: it names
+   * the pieces, the reference each must still be on, and the source each
+   * moves to, so a retarget carries no selection of its own.
+   */
+  planPath: string;
+  /** Write each row's source; absent, the run is the classification alone. */
+  apply?: boolean;
+  /** Pieces one session serves before it is replaced. */
+  groupSize?: number;
+  /** Called as each row settles, for reporting as the run proceeds. */
+  onRow?: (row: RetargetRow) => void;
+}
+
+export interface RetargetRunDependencies {
+  loadPieces?: typeof loadPieces;
+  readTextFile?: (path: string) => Promise<string>;
+  retargetPieces?: typeof retargetPieces;
+}
+
+/**
+ * Run the retarget: decode the plan file and hand the library a session
+ * supply that opens a real session per group and disposes its runtime when
+ * the group ends, which closes that session's storage — so a group's pieces
+ * stop being live at the boundary rather than accumulating across the run.
+ *
+ * Dry by default. Every refusal is the library's, the plan's space among
+ * them: each session answers for the space this command names, and a plan
+ * surveyed elsewhere is refused before a single row is read.
+ */
+export async function runRetarget(
+  config: SpaceConfig,
+  request: RetargetRunRequest,
+  deps: RetargetRunDependencies = {},
+): Promise<RetargetReport> {
+  const plan = decodePlan(
+    await (deps.readTextFile ?? Deno.readTextFile)(request.planPath),
+  );
+  const load = deps.loadPieces ?? loadPieces;
+  const sessions: RetargetSessions = {
+    open: () => load(config),
+    close: async (pieces) => {
+      // Settle first, dispose second. Disposal closes this session's storage
+      // without draining it, so a read still in flight would come back
+      // against a closed client — a failure belonging to a session already
+      // being released, reported over the rows the group just produced.
+      await pieces.synced();
+      await pieces.dispose();
+    },
+  };
+  return await (deps.retargetPieces ?? retargetPieces)(sessions, {
+    plan,
+    ...(request.apply === true ? { apply: true } : {}),
+    ...(request.groupSize === undefined
+      ? {}
+      : { groupSize: request.groupSize }),
+    ...(request.onRow === undefined ? {} : { onRow: request.onRow }),
+  });
 }
 
 /** One `--retarget` flag, parsed: which phase, what source, what label. */

--- a/packages/cli/lib/json-output.ts
+++ b/packages/cli/lib/json-output.ts
@@ -84,7 +84,8 @@ export function reservesStdoutForCommandOutput(
   const subcommand = pieceSubcommand(args);
   return subcommand === "get" || subcommand === "get-label" ||
     subcommand === "set-label" || subcommand === "call" ||
-    subcommand === "survey" || subcommand === "repair";
+    subcommand === "survey" || subcommand === "repair" ||
+    subcommand === "retarget";
 }
 
 export const stderrConsoleHandler: ConsoleHandler = ({ method, args }) => ({

--- a/packages/cli/test/json-command.test.ts
+++ b/packages/cli/test/json-command.test.ts
@@ -52,6 +52,14 @@ describe("JSON command contracts", () => {
       .toBe(true);
     expect(reservesStdoutForCommandOutput(["piece", "set-label", "path"]))
       .toBe(true);
+    // The bulk commands write their plan or their report to stdout, so they
+    // reserve it whether or not --json is on the line.
+    expect(reservesStdoutForCommandOutput(["piece", "survey", "--piece", "b"]))
+      .toBe(true);
+    expect(reservesStdoutForCommandOutput(["piece", "repair", "--piece", "b"]))
+      .toBe(true);
+    expect(reservesStdoutForCommandOutput(["piece", "retarget", "--plan", "p"]))
+      .toBe(true);
     expect(
       reservesStdoutForCommandOutput([
         "piece",

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -177,7 +177,7 @@ describe("piece-retarget", () => {
           runRetarget: (_config, request) => {
             // A single document cannot stream, so no row reporter is handed
             // to the library at all.
-            expect(request.onRow).toBeUndefined();
+            expect(Object.keys(request).sort()).toEqual(["planPath"]);
             return Promise.resolve(REPORT);
           },
           printHint: () => {},
@@ -193,7 +193,7 @@ describe("piece-retarget", () => {
       const out = await captureStdout(() =>
         retargetFromCommand({ ...OPTIONS, out: "report.json" }, {
           runRetarget: (_config, request) => {
-            expect(request.onRow).toBeUndefined();
+            expect(Object.keys(request).sort()).toEqual(["planPath"]);
             return Promise.resolve(REPORT);
           },
           writeTextFile: (path, text) => {
@@ -287,7 +287,10 @@ describe("piece-retarget", () => {
       const out = await captureStdout(() =>
         retargetFromCommand(OPTIONS, {
           runRetarget: (_config, request) => {
-            expect(request.apply).toBeUndefined();
+            expect(Object.keys(request).sort()).toEqual([
+              "onRow",
+              "planPath",
+            ]);
             const dry: RetargetReport = {
               rows: [{
                 piece: "fid1:aaa",
@@ -395,9 +398,12 @@ describe("piece-retarget", () => {
           return Promise.resolve(REPORT);
         },
       });
-      expect(options?.apply).toBeUndefined();
-      expect(options?.groupSize).toBeUndefined();
-      expect(options?.onRow).toBeUndefined();
+      // The key set, not each value: an `apply: undefined` riding along is
+      // a key the library still has to reason about, and every matcher that
+      // asks about one property — `toBeUndefined`, and `toHaveProperty` in
+      // this library too — reads a present-but-undefined key as an absent
+      // one. Only the keys themselves tell the two apart.
+      expect(Object.keys(options ?? {})).toEqual(["plan"]);
     });
 
     it("settles and disposes each session it is handed back", async () => {
@@ -435,6 +441,76 @@ describe("piece-retarget", () => {
       });
       expect(opened.length).toBe(2);
       expect(disposed).toEqual(opened);
+    });
+
+    it("disposes a session whose settle failed, and reports the stop", async () => {
+      let disposed = 0;
+      const report = await runRetarget(
+        {} as never,
+        { planPath: "/plans/upgrade.jsonl" },
+        {
+          readTextFile: () => Promise.resolve(PLAN_TEXT),
+          loadPieces: () =>
+            Promise.resolve(
+              {
+                getSpace: () => "did:key:test",
+                get: () =>
+                  Promise.reject(new Error("this session reads no pieces")),
+                synced: () =>
+                  Promise.reject(new Error("the group's writes never landed")),
+                dispose: () => {
+                  disposed += 1;
+                  return Promise.resolve();
+                },
+              } as unknown as PiecesController,
+            ),
+        },
+      );
+      // A settle that rejects must not take the disposal with it: the
+      // library turns the boundary's failure into a stop rather than a
+      // crash, so a session skipped here would stay open for the rest of
+      // the process.
+      expect(disposed).toBe(1);
+      expect(report.complete).toBe(false);
+      expect(report.applied).toBe(0);
+      expect(report.stopReason).toContain("the group's writes never landed");
+      expect(report.stopReason).toContain(
+        "the preflight session could not be released",
+      );
+      expect(report.stopReason).not.toContain("could not be disposed");
+    });
+
+    it("names the settle failure ahead of a disposal that failed too", async () => {
+      const report = await runRetarget(
+        {} as never,
+        { planPath: "/plans/upgrade.jsonl" },
+        {
+          readTextFile: () => Promise.resolve(PLAN_TEXT),
+          loadPieces: () =>
+            Promise.resolve(
+              {
+                getSpace: () => "did:key:test",
+                get: () =>
+                  Promise.reject(new Error("this session reads no pieces")),
+                synced: () =>
+                  Promise.reject(new Error("the group's writes never landed")),
+                dispose: () =>
+                  Promise.reject(new Error("the runtime would not shut down")),
+              } as unknown as PiecesController,
+            ),
+        },
+      );
+      // The settle failure leads: it is why the boundary cannot be trusted.
+      // The disposal that failed after it is named too, never instead.
+      const stop = report.stopReason ?? "";
+      expect(stop).toContain("the group's writes never landed");
+      expect(stop).toContain(
+        "Its session could not be disposed either: the runtime would not " +
+          "shut down.",
+      );
+      expect(stop.indexOf("never landed")).toBeLessThan(
+        stop.indexOf("could not be disposed"),
+      );
     });
   });
 });

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -503,10 +503,11 @@ describe("piece-retarget", () => {
       // The settle failure leads: it is why the boundary cannot be trusted.
       // The disposal that failed after it is named too, never instead.
       const stop = report.stopReason ?? "";
-      expect(stop).toContain("the group's writes never landed");
+      // One period joins the two sentences: the settle message carries none
+      // of its own, so the composition must supply it.
       expect(stop).toContain(
-        "Its session could not be disposed either: the runtime would not " +
-          "shut down.",
+        "the group's writes never landed. Its session could not be " +
+          "disposed either: the runtime would not shut down.",
       );
       expect(stop.indexOf("never landed")).toBeLessThan(
         stop.indexOf("could not be disposed"),

--- a/packages/cli/test/piece-retarget.test.ts
+++ b/packages/cli/test/piece-retarget.test.ts
@@ -1,0 +1,440 @@
+/**
+ * `cf piece retarget`'s command action and its `runRetarget` seam: the plan
+ * intake, the report's one destination in each of its three modes, the
+ * per-row line as the run proceeds, the exit discipline, and the session
+ * supply the seam hands the library — opened per group and disposed at every
+ * boundary.
+ */
+
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { PiecesController } from "@commonfabric/piece/ops";
+import type {
+  RetargetOptions,
+  RetargetReport,
+  RetargetSessions,
+} from "@commonfabric/piece/ops/bulk-retarget";
+import { decode } from "@commonfabric/utils/encoding";
+
+import { runRetarget } from "../lib/bulk.ts";
+import {
+  formatRetargetRow,
+  piece,
+  retargetFromCommand,
+  setQuietMode,
+} from "../commands/piece.ts";
+
+function captureStdout(fn: () => Promise<void>): Promise<string> {
+  let captured = "";
+  const original = Deno.stdout.writeSync;
+  Deno.stdout.writeSync = (data: Uint8Array): number => {
+    captured += decode(data);
+    return data.length;
+  };
+  return fn().then(() => captured).finally(() => {
+    Deno.stdout.writeSync = original;
+  });
+}
+
+class ExitSentinel extends Error {}
+
+const OPTIONS = {
+  apiUrl: "http://localhost:8000",
+  identity: "/tmp/test-identity.pem",
+  space: "home",
+  quiet: true,
+  plan: "plan.jsonl",
+};
+
+// The 43-character handle length clears the canonical parser's threshold
+// below which an id reads as a human name and is refused.
+const HANDLE = "baedreiabcdefghijklmnopqrstuvwxyz0123456789";
+
+const PLAN_TEXT = [
+  JSON.stringify({
+    kind: "piece-plan",
+    v: 1,
+    space: "did:key:test",
+    takenAt: "2026-08-25T00:00:00.000Z",
+    selector: "collection",
+    enumerated: { collection: 1, registry: 0, registeredOutside: 0 },
+  }),
+  JSON.stringify({
+    piece: `fid1:${HANDLE}`,
+    phase: "items",
+    expect: { patternIdentity: "idA", symbol: "Member", retained: true },
+    op: {
+      kind: "retarget",
+      patternIdentity: "idB",
+      symbol: "Member",
+      source: { main: "/sources/member-v2.tsx", mainExport: "Member" },
+    },
+  }),
+  "",
+].join("\n");
+
+const REPORT: RetargetReport = {
+  rows: [
+    { piece: "fid1:aaa", phase: "items", verdict: "applied", elapsedMs: 412 },
+    { piece: "fid1:bbb", phase: "items", verdict: "landed", elapsedMs: 18 },
+  ],
+  applied: 1,
+  complete: true,
+};
+
+describe("piece-retarget", () => {
+  // The fixtures pass `quiet`, and the action applies it globally.
+  afterEach(() => setQuietMode(false));
+
+  describe("formatRetargetRow()", () => {
+    it("puts the verdict, the piece, its phase, and its cost on one line", () => {
+      expect(formatRetargetRow(REPORT.rows[0])).toBe(
+        "applied fid1:aaa items 412ms",
+      );
+    });
+
+    it("carries what a row broke, and omits what a row does not have", () => {
+      expect(
+        formatRetargetRow({
+          piece: "fid1:ccc",
+          verdict: "refused",
+          problem: "The source resolves to idC, not the idB this row recorded.",
+        }),
+      ).toBe(
+        "refused fid1:ccc - The source resolves to idC, not the idB this " +
+          "row recorded.",
+      );
+    });
+  });
+
+  describe("retargetFromCommand()", () => {
+    it("prints a line per row as each row settles", async () => {
+      const hints: string[] = [];
+      const printed: unknown[] = [];
+      const printedWhenSettled: number[] = [];
+      await retargetFromCommand(OPTIONS, {
+        render: (value) => {
+          printed.push(value);
+        },
+        runRetarget: (_config, request) => {
+          for (const row of REPORT.rows) {
+            request.onRow?.(row);
+            printedWhenSettled.push(printed.length);
+          }
+          return Promise.resolve(REPORT);
+        },
+        printHint: (message) => {
+          hints.push(message);
+        },
+      });
+      expect(printed).toEqual([
+        "applied fid1:aaa items 412ms",
+        "landed fid1:bbb items 18ms",
+      ]);
+      // One line out by the time each row settled: a report assembled first
+      // and printed at the end would satisfy the assertion above and none of
+      // what it exists for.
+      expect(printedWhenSettled).toEqual([1, 2]);
+      expect(hints).toEqual(["applied: 1 · landed: 1 · written: 1"]);
+    });
+
+    it("passes the plan path, the apply flag, and the group size through", async () => {
+      let request: { planPath?: string; apply?: boolean; groupSize?: number } =
+        {};
+      await captureStdout(() =>
+        retargetFromCommand({ ...OPTIONS, apply: true, groupSize: 7 }, {
+          runRetarget: (_config, req) => {
+            request = req;
+            return Promise.resolve(REPORT);
+          },
+          printHint: () => {},
+        })
+      );
+      expect(request.planPath?.endsWith("/plan.jsonl")).toBe(true);
+      expect(request.apply).toBe(true);
+      expect(request.groupSize).toBe(7);
+    });
+
+    it("keeps the runtime's console off stdout in every mode", async () => {
+      let jsonOutput: boolean | undefined;
+      await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: (config) => {
+            jsonOutput = (config as { jsonOutput?: boolean }).jsonOutput;
+            return Promise.resolve(REPORT);
+          },
+          printHint: () => {},
+        })
+      );
+      // Not only under --json: this run starts the pieces it writes, and a
+      // pattern's own logging would land between two rows of the stream.
+      expect(jsonOutput).toBe(true);
+    });
+
+    it("emits the whole report as one canonical document under --json", async () => {
+      const out = await captureStdout(() =>
+        retargetFromCommand({ ...OPTIONS, json: true }, {
+          runRetarget: (_config, request) => {
+            // A single document cannot stream, so no row reporter is handed
+            // to the library at all.
+            expect(request.onRow).toBeUndefined();
+            return Promise.resolve(REPORT);
+          },
+          printHint: () => {},
+        })
+      );
+      expect(out.startsWith("fvj1:")).toBe(true);
+      expect(out).toContain('"elapsedMs":412');
+    });
+
+    it("writes the report to --out and leaves stdout empty", async () => {
+      let written: { path: string; text: string } | undefined;
+      const hints: string[] = [];
+      const out = await captureStdout(() =>
+        retargetFromCommand({ ...OPTIONS, out: "report.json" }, {
+          runRetarget: (_config, request) => {
+            expect(request.onRow).toBeUndefined();
+            return Promise.resolve(REPORT);
+          },
+          writeTextFile: (path, text) => {
+            written = { path: String(path), text: String(text) };
+            return Promise.resolve();
+          },
+          printHint: (message) => {
+            hints.push(message);
+          },
+        })
+      );
+      expect(out).toBe("");
+      expect(written?.path).toBe("report.json");
+      expect(written?.text.startsWith("fvj1:")).toBe(true);
+      expect(written?.text.endsWith("\n")).toBe(true);
+      expect(hints).toContain("Wrote 2 report rows to report.json");
+    });
+
+    it("exits nonzero on a stopped run, naming every unattempted piece", async () => {
+      const errors: string[] = [];
+      const stopped: RetargetReport = {
+        rows: [
+          { piece: "fid1:aaa", verdict: "applied", elapsedMs: 5 },
+          {
+            piece: "fid1:bbb",
+            verdict: "refused",
+            problem: "The source resolves to idC, not the idB this row " +
+              "recorded.",
+            elapsedMs: 3,
+          },
+          { piece: "fid1:ccc", verdict: "unattempted" },
+          { piece: "fid1:ddd", verdict: "unattempted" },
+        ],
+        applied: 1,
+        complete: false,
+      };
+      await expect(
+        captureStdout(() =>
+          retargetFromCommand({ ...OPTIONS, apply: true }, {
+            runRetarget: () => Promise.resolve(stopped),
+            printHint: () => {},
+            printError: (message) => {
+              errors.push(message);
+            },
+            exit: (code) => {
+              expect(code).toBe(1);
+              throw new ExitSentinel();
+            },
+          })
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      const message = errors.join("\n");
+      expect(message).toContain("Retarget did not complete");
+      // Each unattempted piece by name, never a count of them.
+      expect(message).toContain("  unattempted: fid1:ccc");
+      expect(message).toContain("  unattempted: fid1:ddd");
+      expect(message).toContain("  refused: fid1:bbb The source resolves");
+      expect(message).not.toContain("fid1:aaa");
+    });
+
+    it("names the run's own stop reason when no piece is at fault", async () => {
+      const errors: string[] = [];
+      await expect(
+        captureStdout(() =>
+          retargetFromCommand({ ...OPTIONS, apply: true }, {
+            runRetarget: () =>
+              Promise.resolve({
+                rows: [{ piece: "fid1:aaa", verdict: "unattempted" }],
+                applied: 0,
+                complete: false,
+                stopReason: "The plan names space did:key:test; this run " +
+                  "targets did:key:other.",
+              } as RetargetReport),
+            printHint: () => {},
+            printError: (message) => {
+              errors.push(message);
+            },
+            exit: () => {
+              throw new ExitSentinel();
+            },
+          })
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      expect(errors.join("\n")).toContain(
+        "  stopped: The plan names space did:key:test",
+      );
+    });
+
+    it("holds a dry run's outstanding rows against nothing", async () => {
+      const hints: string[] = [];
+      const out = await captureStdout(() =>
+        retargetFromCommand(OPTIONS, {
+          runRetarget: (_config, request) => {
+            expect(request.apply).toBeUndefined();
+            const dry: RetargetReport = {
+              rows: [{
+                piece: "fid1:aaa",
+                phase: "items",
+                verdict: "outstanding",
+              }],
+              applied: 0,
+              complete: true,
+            };
+            request.onRow?.(dry.rows[0]);
+            return Promise.resolve(dry);
+          },
+          printHint: (message) => {
+            hints.push(message);
+          },
+          exit: () => {
+            throw new ExitSentinel();
+          },
+        })
+      );
+      expect(out).toBe("outstanding fid1:aaa items\n");
+      expect(hints).toEqual(["outstanding: 1 · written: 0"]);
+    });
+
+    it("exits nonzero on a dry run that found a row an apply would refuse", async () => {
+      const errors: string[] = [];
+      await expect(
+        captureStdout(() =>
+          retargetFromCommand(OPTIONS, {
+            runRetarget: () =>
+              Promise.resolve({
+                rows: [
+                  { piece: "fid1:aaa", verdict: "outstanding" },
+                  {
+                    piece: "fid1:bbb",
+                    verdict: "moved-elsewhere",
+                    problem: "The piece is on idC#Member.",
+                  },
+                ],
+                applied: 0,
+                complete: false,
+              } as RetargetReport),
+            printHint: () => {},
+            printError: (message) => {
+              errors.push(message);
+            },
+            exit: () => {
+              throw new ExitSentinel();
+            },
+          })
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      const message = errors.join("\n");
+      expect(message).toContain("Retarget found rows an apply would refuse.");
+      expect(message).toContain("  moved-elsewhere: fid1:bbb");
+      // A dry run's outstanding row is that run's answer, not its defect.
+      expect(message).not.toContain("fid1:aaa");
+    });
+
+    it("routes cf piece retarget to retargetFromCommand", () => {
+      const registered = piece.getCommand("retarget") as unknown as {
+        actionHandler?: unknown;
+      };
+      expect(registered?.actionHandler).toBe(retargetFromCommand);
+    });
+  });
+
+  describe("runRetarget()", () => {
+    it("decodes the plan file and passes the run's knobs to the library", async () => {
+      let options: RetargetOptions | undefined;
+      const report = await runRetarget({} as never, {
+        planPath: "/plans/upgrade.jsonl",
+        apply: true,
+        groupSize: 4,
+        onRow: () => {},
+      }, {
+        readTextFile: (path) => {
+          expect(path).toBe("/plans/upgrade.jsonl");
+          return Promise.resolve(PLAN_TEXT);
+        },
+        retargetPieces: (_sessions, given) => {
+          options = given;
+          return Promise.resolve(REPORT);
+        },
+      });
+      expect(report).toBe(REPORT);
+      expect(options?.plan.header.space).toBe("did:key:test");
+      expect(options?.plan.rows[0].op).toEqual({
+        kind: "retarget",
+        patternIdentity: "idB",
+        symbol: "Member",
+        source: { main: "/sources/member-v2.tsx", mainExport: "Member" },
+      });
+      expect(options?.apply).toBe(true);
+      expect(options?.groupSize).toBe(4);
+      expect(options?.onRow).toBeDefined();
+    });
+
+    it("omits the knobs the command did not ask for", async () => {
+      let options: RetargetOptions | undefined;
+      await runRetarget({} as never, { planPath: "/plans/upgrade.jsonl" }, {
+        readTextFile: () => Promise.resolve(PLAN_TEXT),
+        retargetPieces: (_sessions, given) => {
+          options = given;
+          return Promise.resolve(REPORT);
+        },
+      });
+      expect(options?.apply).toBeUndefined();
+      expect(options?.groupSize).toBeUndefined();
+      expect(options?.onRow).toBeUndefined();
+    });
+
+    it("settles and disposes each session it is handed back", async () => {
+      const opened: unknown[] = [];
+      const settled: unknown[] = [];
+      const disposed: unknown[] = [];
+      const config = { space: "home" } as never;
+      await runRetarget(config, { planPath: "/plans/upgrade.jsonl" }, {
+        readTextFile: () => Promise.resolve(PLAN_TEXT),
+        loadPieces: (given) => {
+          expect(given).toBe(config);
+          const controller = {
+            synced: () => {
+              settled.push(controller);
+              return Promise.resolve();
+            },
+            dispose: () => {
+              // Settling comes first: disposal closes the storage this
+              // session's reads are still going through.
+              expect(settled).toContain(controller);
+              disposed.push(controller);
+              return Promise.resolve();
+            },
+          } as unknown as PiecesController;
+          opened.push(controller);
+          return Promise.resolve(controller);
+        },
+        retargetPieces: async (sessions: RetargetSessions) => {
+          // Two groups, each released at its boundary: the run holds one
+          // session at a time rather than accumulating them.
+          await sessions.close(await sessions.open());
+          await sessions.close(await sessions.open());
+          return REPORT;
+        },
+      });
+      expect(opened.length).toBe(2);
+      expect(disposed).toEqual(opened);
+    });
+  });
+});

--- a/packages/cli/test/piece-survey.test.ts
+++ b/packages/cli/test/piece-survey.test.ts
@@ -17,6 +17,7 @@ import {
   inspectPieceFromCommand,
   parseRetargetFlag,
   piece,
+  planDiffLines,
   setQuietMode,
   surveyFromCommand,
 } from "../commands/piece.ts";
@@ -73,6 +74,95 @@ const COMPLETE: SurveyResult = {
   tally: [
     { phase: "members", patternIdentity: "idA", symbol: "default", count: 1 },
   ],
+  outside: [],
+  problems: [],
+  validatorFailures: [],
+  complete: true,
+};
+
+// Canonical addresses, so the plan file, the after-survey, and the diff's
+// own lines all spell one piece the same way.
+const M1 = "fid1:baedreiabcdefghijklmnopqrstuvwxyz0123456788";
+const M2 = "fid1:baedreibbcdefghijklmnopqrstuvwxyz0123456788";
+const M3 = "fid1:baedreicbcdefghijklmnopqrstuvwxyz0123456788";
+const HOLDER = "fid1:baedreidbcdefghijklmnopqrstuvwxyz0123456788";
+const EXTRA = "fid1:baedreiebcdefghijklmnopqrstuvwxyz0123456788";
+
+/** The plan an after-survey is held against: three members, then the holder. */
+const VERIFIED_PLAN = [
+  JSON.stringify({
+    kind: "piece-plan",
+    v: 1,
+    space: "did:key:test",
+    takenAt: "2026-08-24T00:00:00.000Z",
+    selector: "collection",
+    enumerated: { collection: 4, registry: 1, registeredOutside: 0 },
+  }),
+  ...[M1, M2, M3].map((address) =>
+    JSON.stringify({
+      piece: address,
+      phase: "members",
+      expect: { patternIdentity: "idA", symbol: "Member", retained: true },
+      op: {
+        kind: "retarget",
+        patternIdentity: "idB",
+        symbol: "Member",
+        source: { main: "/sources/member-v2.tsx", mainExport: "Member" },
+      },
+    })
+  ),
+  JSON.stringify({
+    piece: HOLDER,
+    phase: "holder",
+    expect: { patternIdentity: "idH", symbol: "default", retained: true },
+  }),
+  "",
+].join("\n");
+
+/**
+ * The survey taken after a run that half-converged: one member where the
+ * plan sent it, one still where it was, one somewhere the plan never named,
+ * the holder untouched, and a member filed since the plan was taken.
+ */
+const AFTER: SurveyResult = {
+  plan: {
+    header: {
+      kind: "piece-plan",
+      v: 1,
+      space: "did:key:test",
+      takenAt: "2026-08-25T00:00:00.000Z",
+      selector: "collection" as const,
+      enumerated: { collection: 5, registry: 1, registeredOutside: 0 },
+    },
+    rows: [
+      {
+        piece: M1,
+        phase: "members",
+        expect: { patternIdentity: "idB", symbol: "Member", retained: true },
+      },
+      {
+        piece: M2,
+        phase: "members",
+        expect: { patternIdentity: "idA", symbol: "Member", retained: true },
+      },
+      {
+        piece: M3,
+        phase: "members",
+        expect: { patternIdentity: "idC", symbol: "Member", retained: true },
+      },
+      {
+        piece: EXTRA,
+        phase: "members",
+        expect: { patternIdentity: "idA", symbol: "Member", retained: true },
+      },
+      {
+        piece: HOLDER,
+        phase: "holder",
+        expect: { patternIdentity: "idH", symbol: "default", retained: true },
+      },
+    ],
+  },
+  tally: [],
   outside: [],
   problems: [],
   validatorFailures: [],
@@ -453,11 +543,216 @@ describe("piece-survey", () => {
       expect(errors.join("\n")).toContain("of:fid1:orphan");
     });
 
+    it("reports the after-survey against the plan --diff names", async () => {
+      const hints: string[] = [];
+      const errors: string[] = [];
+      const out = await captureStdout(() =>
+        expect(
+          surveyFromCommand(
+            { ...OPTIONS, path: "topics", diff: "before.jsonl" },
+            {
+              runSurvey: () => Promise.resolve(AFTER),
+              readTextFile: (path) => {
+                expect(path.endsWith("/before.jsonl")).toBe(true);
+                return Promise.resolve(VERIFIED_PLAN);
+              },
+              printHint: (message) => {
+                hints.push(message);
+              },
+              printError: (message) => {
+                errors.push(message);
+              },
+              exit: (code) => {
+                expect(code).toBe(1);
+                throw new ExitSentinel();
+              },
+            },
+          ),
+        ).rejects.toThrow(ExitSentinel)
+      );
+      // The three verdicts a planned row can carry, in the words the design
+      // names them in, and all three whatever their counts.
+      expect(out.split("\n")).toEqual([
+        "moved as planned: 1",
+        "still outstanding: 1",
+        "moved to something the plan did not ask for: 1",
+        "unchanged, with no operation planned: 1",
+        "held by the space but not by the plan: 1",
+        "",
+      ]);
+      expect(hints).toEqual([
+        `held by the space but not by the plan: ${EXTRA}`,
+      ]);
+      const message = errors.join("\n");
+      expect(message).toContain("The after-survey is not what the plan asked");
+      expect(message).toContain(
+        `still outstanding: ${M2} idA#Member -> idA#Member`,
+      );
+      expect(message).toContain(
+        `moved to something the plan did not ask for: ${M3} ` +
+          `idA#Member -> idC#Member`,
+      );
+      // A row that reached what its plan asked of it is not a finding.
+      expect(message).not.toContain(M1);
+    });
+
+    it("exits zero when every planned row reached its target", async () => {
+      const landed: SurveyResult = {
+        ...AFTER,
+        plan: {
+          ...AFTER.plan,
+          rows: AFTER.plan.rows.filter((row) => row.piece !== EXTRA).map(
+            (row) =>
+              row.piece === HOLDER ? row : {
+                ...row,
+                expect: { ...row.expect, patternIdentity: "idB" },
+              },
+          ),
+        },
+      };
+      const out = await captureStdout(() =>
+        surveyFromCommand(
+          { ...OPTIONS, path: "topics", diff: "before.jsonl" },
+          {
+            runSurvey: () => Promise.resolve(landed),
+            readTextFile: () => Promise.resolve(VERIFIED_PLAN),
+            printHint: () => {},
+            exit: () => {
+              throw new ExitSentinel();
+            },
+          },
+        )
+      );
+      expect(out).toContain("moved as planned: 3");
+      expect(out).toContain("still outstanding: 0");
+    });
+
+    it("prints the diff rather than the survey result under --diff --json", async () => {
+      const out = await captureStdout(() =>
+        expect(
+          surveyFromCommand(
+            { ...OPTIONS, path: "topics", diff: "before.jsonl", json: true },
+            {
+              runSurvey: () => Promise.resolve(AFTER),
+              readTextFile: () => Promise.resolve(VERIFIED_PLAN),
+              printHint: () => {},
+              printError: () => {},
+              exit: () => {
+                throw new ExitSentinel();
+              },
+            },
+          ),
+        ).rejects.toThrow(ExitSentinel)
+      );
+      const diff = JSON.parse(out) as {
+        counts: Record<string, number>;
+        unplanned: string[];
+      };
+      expect(diff.counts).toEqual({
+        landed: 1,
+        outstanding: 1,
+        "moved-elsewhere": 1,
+        unchanged: 1,
+        changed: 0,
+        missing: 0,
+      });
+      expect(diff.unplanned).toEqual([EXTRA]);
+    });
+
+    it("keeps the after-survey plan going to --out beside the diff", async () => {
+      let written: { path: string; text: string } | undefined;
+      await captureStdout(() =>
+        expect(
+          surveyFromCommand(
+            {
+              ...OPTIONS,
+              path: "topics",
+              diff: "before.jsonl",
+              out: "after.jsonl",
+            },
+            {
+              runSurvey: () => Promise.resolve(AFTER),
+              readTextFile: () => Promise.resolve(VERIFIED_PLAN),
+              writeTextFile: (path, text) => {
+                written = { path: String(path), text: String(text) };
+                return Promise.resolve();
+              },
+              printHint: () => {},
+              printError: () => {},
+              exit: () => {
+                throw new ExitSentinel();
+              },
+            },
+          ),
+        ).rejects.toThrow(ExitSentinel)
+      );
+      expect(written?.path).toBe("after.jsonl");
+      expect(written?.text).toContain(M1);
+    });
+
+    it("leaves an incomplete survey uncompared, refusing it instead", async () => {
+      const errors: string[] = [];
+      await expect(
+        captureStdout(() =>
+          surveyFromCommand(
+            { ...OPTIONS, path: "topics", diff: "before.jsonl" },
+            {
+              runSurvey: () =>
+                Promise.resolve({
+                  ...AFTER,
+                  outside: [{
+                    piece: EXTRA,
+                    patternIdentity: "idA",
+                    symbol: "Member",
+                  }],
+                  complete: false,
+                }),
+              readTextFile: () => {
+                throw new Error("an incomplete survey reads no plan to diff");
+              },
+              printHint: () => {},
+              printError: (message) => {
+                errors.push(message);
+              },
+              exit: () => {
+                throw new ExitSentinel();
+              },
+            },
+          )
+        ),
+      ).rejects.toThrow(ExitSentinel);
+      expect(errors.join("\n")).toContain("Survey is incomplete");
+    });
+
     it("routes cf piece survey to surveyFromCommand", () => {
       const registered = piece.getCommand("survey") as unknown as {
         actionHandler: unknown;
       };
       expect(registered.actionHandler).toBe(surveyFromCommand);
+    });
+  });
+
+  describe("planDiffLines()", () => {
+    it("names the classes only a degraded run produces, when it has any", () => {
+      expect(planDiffLines({
+        rows: [],
+        unplanned: ["fid1:extra"],
+        counts: {
+          landed: 2,
+          outstanding: 0,
+          "moved-elsewhere": 0,
+          unchanged: 0,
+          changed: 1,
+          missing: 3,
+        },
+      })).toEqual([
+        "moved as planned: 2",
+        "still outstanding: 0",
+        "moved to something the plan did not ask for: 0",
+        "changed, with no operation planned: 1",
+        "gone from the selection: 3",
+        "held by the space but not by the plan: 1",
+      ]);
     });
   });
 


### PR DESCRIPTION
## Why

The stage-3 engine landed in #6273 but nothing could reach it: a migration still had no way to apply a plan, no verdict on what an apply did, and no standing guarantee that either keeps working. This PR is the rest of stage 3 (docs/plans/piece-bulk-operations.md): the terminal entry point under the decided spelling (`cf piece retarget` — `apply` is taken by the whole-document input write), the after-survey verdict `cf piece survey --diff` over stage-1's `diffPlan`, the drill steps that turn both into a CI guarantee — interrupted-resume included, the property most likely to rot silently — and the demo's two pending stage-3 acts running live. Prior PRs in the arc: #6273 (engine), #6264/#6255 (stage 2), #6214/#6213/#6211 (stage 1), #6246 (demo).

## What Changed

- `cf piece retarget --plan <file>`: dry by default, `--apply` to write, `--group-size` for the session knob, one report destination (streamed per-row lines with `elapsedMs` as each row settles, or `--json`/`--out` as one canonical `fvj1:` document). Nonzero exit whenever the run is incomplete, naming `stopReason` and every non-settled row. Production sessions open via the CLI's controller and close by settling (`synced()`) then really disposing the runtime.
- `cf piece survey --diff <plan>`: the three-way verdict — moved as planned / still outstanding / moved to something the plan did not ask for — plus unplanned pieces; nonzero unless every planned row converged.
- Drill: seven new steps, 53 assertions total — full-board apply from a plan derived from checked-in fixtures, tamper refusal naming all 113 unattempted addresses, a mid-group kill completed by re-invocation (signal exit asserted, landed/outstanding mixture proved between invocations, so an uninterrupted run turns the step red), both-halves classification via a same-identity `MemberAlias` export, and the diff verdict.
- Demo: the stage-3 pending acts are live; stage-4 rollback stays pending.
- Plan doc: all 13 stage-3 checklist items ticked.

Two review criteria were resolved by explicit rebuttal (mpsalisbury): "checked-in plan" reads as derived entirely from checked-in fixtures and script — the artifact necessarily carries the per-run space DID; and the drill's no-store-access design stands as established in #6214/#6264. One checklist item ("composes with the existing space-level checks") is true by construction — the retarget adds no acceptance gate of its own — with no new demonstrating evidence.

## Test plan

- `packages/cli` suite: 205 files / 214 steps green (new `piece-retarget.test.ts`, extended `piece-survey.test.ts`); `packages/piece` untouched and green.
- Drill run end-to-end against an isolated toolshed: 53/53, three consecutive runs; a negative run with the kill stubbed fails exactly the interruption assertions.
- Demo end-to-end: exit 0, render-reparse retypability counters all zero.
- `deno fmt --check`, `deno lint`, `deno task check`, `cfcheck`, `check-docs`, `check-skill-facts`, `check-no-waitfor` all pass. Coverage verified against lcov directly: no net uncovered line added (the one uncovered registration line is the chain-shadow position, same count before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

