### PR TITLE
fix(ts-transformers): a stored-source reload demotes the opaque-reserved-key veto

### DIFF
--- a/docs/common/concepts/types-and-schemas/unknown.md
+++ b/docs/common/concepts/types-and-schemas/unknown.md
@@ -88,7 +88,10 @@ and what those get is an empty object.
 
 The compiler refuses that declaration, at the root of a result and only there:
 `pattern-result:opaque-reserved-key`, one diagnostic naming every reserved key
-the result leaves opaque. It covers every key the framework puts on a result —
+the result leaves opaque. The refusal is an authoring gate: when the runtime
+reloads a piece's already-deployed stored source — an identity-pinned
+reconstruction that can admit nothing new — the same diagnostic reports as a
+warning instead, so a pattern accepted before the rule existed keeps loading. It covers every key the framework puts on a result —
 `[TYPE]`, `[NAME]`, `[UI]`, `[TILE_UI]`, `[CHIP_UI]`, `[FS]`, `[TESTS]` — for
 the same reason: a key whose spelling the framework fixed holds a value this
 pattern produced.

--- a/docs/development/debugging/gotchas/unknown-typed-field-reads-a-reference.md
+++ b/docs/development/debugging/gotchas/unknown-typed-field-reads-a-reference.md
@@ -72,7 +72,10 @@ type Right = { [NAME]: string; [UI]: VNode; label: string };
 
 The compiler rejects the first form: `pattern-result:opaque-reserved-key`,
 raised at the `pattern()` call by `reserved-result-keys.ts` in
-`packages/ts-transformers`. It reaches the root of a **result** schema and
+`packages/ts-transformers`. The rejection applies where an author can act —
+`cf check`, deploy, candidate admission; the runtime's identity-pinned reload
+of already-deployed stored source demotes it to a warning, so pieces that
+predate the rule keep loading. It reaches the root of a **result** schema and
 nothing else, which leaves two shapes legal and needed. Below the root, a
 reserved key names a field of another piece, where `unknown` is what keeps the
 field a reference to that piece's own screen rather than a copy, so the

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -898,7 +898,9 @@ report these through the same collector (deduplicated via §2.2's
 - **Error** `pattern-result:opaque-reserved-key`
   (`reserved-result-keys.ts`, called from `schema-generator.ts`) — a pattern's
   own result declares one of the framework's reserved keys `unknown` at its
-  root; see §6.12
+  root; demoted to a **Warning** under `TransformationOptions.storedSource`
+  (an identity-pinned reload of durable stored source admits nothing new, so
+  the report keeps its visibility and loses its veto); see §6.12
 - **Error** `reactive-capture:unknown-type` (`src/ast/type-building.ts:681`) —
   a captured reactive value's inferred type is `unknown`, so its schema would
   be `{ type: "unknown" }` and the runner would not materialize it, reading it
@@ -936,7 +938,13 @@ as a value.
 
 `reportOpaqueReservedResultKeys` (`src/transformers/reserved-result-keys.ts`)
 reports it as **Error** `pattern-result:opaque-reserved-key`, naming every
-offending key in one diagnostic. It runs from SchemaGeneration, which is the
+offending key in one diagnostic. Under `TransformationOptions.storedSource` —
+the runner engine's cold-recovery recompile of durable stored source, where an
+identity pin guarantees the compile reconstructs an already-admitted artifact
+rather than admitting a new one — the same diagnostic reports as a
+**Warning**: a rule added after those bytes were admitted must not brick
+their reload, while authoring paths stay strict because the author is present
+to fix the shape. It runs from SchemaGeneration, which is the
 one place a declared result exists as the schema it generated — whatever type
 the author named, and whichever inference path §10.2 took to reach it.
 SchemaInjection records the result schema calls and the node to point at

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1158,6 +1158,12 @@ export class Engine extends EventTarget {
             .CommonFabricTransformerPipeline)({
             patternCoverage,
             builderSourceSites,
+            // The transformer-level twin of `storedSource` above: pattern
+            // shape gates (opaque reserved result keys) demote to warnings
+            // here, so a rule added after these bytes were admitted cannot
+            // brick their reload. The identity check below already
+            // guarantees this compile reconstructs rather than admits.
+            storedSource: true,
             moduleIdentities: identityByPath,
             // Names on this path are already stored-shaped (no `/<id>`
             // prefix); only mount paths need unmapping to authored spellings.

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -169,6 +169,63 @@ describe("load by module identity (warm + version-bump recovery)", () => {
     });
   });
 
+  it("reconstructs a stored pattern an authoring gate now refuses", async () => {
+    // The 2026-08-25 estuary outage, pinned at its seam. This source's
+    // result declares a reserved key opaque — the shape every pre-`VNode`
+    // pattern stored, and the shape the opaque-reserved-key authoring gate
+    // now refuses. Admission stays refused (the first assertion). But the
+    // cold-recovery path reloads durable stored bytes nobody can re-author,
+    // under an identity pin that admits nothing new — a piece pinned to
+    // such a pattern must keep loading, or a new authoring rule bricks
+    // every deployed piece of an older shape at the next runtime-version
+    // bump: profiles fleet-wide, in the incident.
+    const legacy: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { NAME, pattern, lift } from 'commonfabric';",
+            "const dbl = lift((x:number)=>x*2);",
+            "export default pattern<{ value: number }, { [NAME]?: unknown; result: number }>(({ value }) => {",
+            "  return { result: dbl(value) };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    await expect(engine.compileToRecordGraph(legacy)).rejects.toThrow(
+      "declared `unknown`",
+    );
+
+    const storedSource: Source[] = legacy.files.map((f) => ({
+      name: f.name,
+      contents: f.contents,
+    }));
+    const recovered = await engine.compileResolvedToRecordGraph(
+      storedSource,
+      legacy.main,
+    );
+    // Deterministic under reconstruction: the demoted report changes no
+    // emitted byte, so the identity a second reconstruction computes is the
+    // one the first did — what the caller's stored-identity pin checks.
+    const again = await engine.compileResolvedToRecordGraph(
+      storedSource,
+      legacy.main,
+    );
+    expect(again.entryIdentity).toBe(recovered.entryIdentity);
+
+    const result = await engine.evaluateCachedModules(
+      toCached(recovered.modules),
+      recovered.entryIdentity,
+      { sourceFiles: storedSource },
+    );
+    expect(await runPattern(result.main, 6, "legacy reconstruction")).toEqual({
+      result: 12,
+    });
+  });
+
   it("cold-loads an exact attached source-root package", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -166,6 +166,20 @@ export type TransformationOptions = {
    * verbatim (modulo path-separator normalization).
    */
   readonly canonicalWriterIdentityFile?: (fileName: string) => string;
+  /**
+   * The program is DURABLE STORED pattern source being reloaded — bytes
+   * nobody can re-author, recompiled by a toolchain newer than the one that
+   * accepted them, under an identity pin that guarantees this compile admits
+   * nothing new. Authoring-shape gates report as warnings in this mode
+   * instead of errors, so a new rule cannot retroactively brick every
+   * stored pattern of an older shape (the 2026-08-25 estuary deploy: the
+   * opaque-reserved-key rule refused every piece pinned to a pre-`VNode`
+   * pattern, profiles fleet-wide among them). The transformer-level twin of
+   * the compiler option of the same name (CT-1916). Authoring paths — cf
+   * check, deploy, candidate admission — leave this off and stay strict:
+   * there the author is present and can fix the shape.
+   */
+  readonly storedSource?: boolean;
 };
 
 export type DiagnosticSeverity = "error" | "warning";

--- a/packages/ts-transformers/src/transformers/reserved-result-keys.ts
+++ b/packages/ts-transformers/src/transformers/reserved-result-keys.ts
@@ -70,7 +70,7 @@ function isOpaque(schema: unknown): boolean {
  * value it accepted before — so a consumer seam cannot narrow it either.
  */
 export function reportOpaqueReservedResultKeys(
-  context: Pick<TransformationContext, "reportDiagnosticOnce">,
+  context: Pick<TransformationContext, "reportDiagnosticOnce" | "options">,
   schema: unknown,
   anchor: ts.Node,
 ): void {
@@ -96,7 +96,11 @@ export function reportOpaqueReservedResultKeys(
     : " Name the type the field holds.";
 
   context.reportDiagnosticOnce({
-    severity: "error",
+    // Admission is judged once; reconstruction re-judges nothing. Stored
+    // source already carrying this shape was accepted when it was deployed,
+    // and an identity-pinned reload can admit nothing new — so there the
+    // report keeps its visibility and loses its veto.
+    severity: context.options.storedSource ? "warning" : "error",
     type: "pattern-result:opaque-reserved-key",
     message: `pattern() output ${plural ? "fields" : "field"} ${names} ` +
       `${plural ? "are" : "is"} declared \`unknown\`, so the result schema ` +

--- a/packages/ts-transformers/test/reserved-result-keys.test.ts
+++ b/packages/ts-transformers/test/reserved-result-keys.test.ts
@@ -11,10 +11,13 @@ import { validateSource } from "./utils.ts";
 const DIAGNOSTIC_TYPE = "pattern-result:opaque-reserved-key";
 
 /** The diagnostics one schema draws, reported straight rather than compiled. */
-function diagnosticsFor(schema: unknown): DiagnosticInput[] {
+function diagnosticsFor(
+  schema: unknown,
+  options: { storedSource?: boolean } = {},
+): DiagnosticInput[] {
   const reported: DiagnosticInput[] = [];
   reportOpaqueReservedResultKeys(
-    { reportDiagnosticOnce: (input) => void reported.push(input) },
+    { reportDiagnosticOnce: (input) => void reported.push(input), options },
     schema,
     ts.factory.createIdentifier("anchor"),
   );
@@ -53,6 +56,23 @@ describe("reserved-result-keys", () => {
       expect(diagnosticsFor(null)).toEqual([]);
       expect(diagnosticsFor([OPAQUE_SCREEN])).toEqual([]);
       expect(diagnosticsFor({ type: "object" })).toEqual([]);
+    });
+
+    it("demotes the report to a warning over stored source", () => {
+      // Admission is judged once; reconstruction re-judges nothing. The
+      // identity-pinned reload of durable stored source (the engine's
+      // cold-recovery path) compiles bytes nobody can re-author, so the
+      // report keeps its visibility and loses its veto — the 2026-08-25
+      // estuary deploy is what happens otherwise: every piece pinned to a
+      // pre-`VNode` pattern, profiles fleet-wide among them, refused on
+      // reload. Authoring compiles keep the error (the cases below).
+      const reported = diagnosticsFor(OPAQUE_SCREEN, { storedSource: true });
+      expect(reported.map((d) => [d.type, d.severity])).toEqual([
+        [DIAGNOSTIC_TYPE, "warning"],
+      ]);
+      expect(
+        diagnosticsFor(OPAQUE_SCREEN).map((d) => [d.type, d.severity]),
+      ).toEqual([[DIAGNOSTIC_TYPE, "error"]]);
     });
 
     it("follows a root reference into the definition it names", () => {


### PR DESCRIPTION
Fix for the 2026-08-25 estuary deploy failure (the one after #6221 merged): the deploy shipped, homes loaded, and **every piece pinned to a pre-`VNode` pattern failed to load** — profiles fleet-wide among them — with `Could not load pattern <old-identity>`. Estuary was rolled back again.

## Root cause

A piece runs the pattern it is pinned to, not the source the deploy ships, and a new deploy is a new runtime version: the compiled-module cache misses, and the engine's cold-recovery path recompiles the piece's **stored source**. #6098 (correctly) made a result that declares a reserved key `unknown` a transformer **error** — but applied to stored source it retroactively refuses what the store admitted long ago. Every pre-#6019 pattern declares exactly that shape. Space roots survived because the default-pattern updater moves them to current source; nothing else has an updater.

Proven by single-variable differential on a local two-vintage rig (profile created at the a667 pin, loaded under the failed deploy sha): fails with the outage signature; loads with #6098's rule neutralized; loads with **this** change, rule intact.

## The fix — one flag on a line the engine already draws

`compileResolvedToRecordGraph` is exclusively the identity-pinned reconstruction path, and it already declares this contract twice: it passes the compiler `storedSource` so authoring-hygiene TS diagnostics can't brick a reload (CT-1916), and tolerates the pre-#4158 stored envelope (CT-1838). This PR extends the same contract into the transformer pipeline: `TransformationOptions.storedSource`, set only on that path, demotes `pattern-result:opaque-reserved-key` to a **warning** — visibility kept, veto dropped. Authoring paths (`cf check`, `cfcheck`, candidate admission via `setPattern`/`checkPattern`, the updater's official-source compile) are untouched and stay strict.

**Admission is judged once; reconstruction re-judges nothing** — the compile-time sibling of the contract #6221 landed at the validation seam, and the reconstruction-side floor any piece-upgrade rollout needs anyway (upgrades land per-piece over days; reloads happen now).

Safety: the rule is report-only, so demotion changes no emitted byte; the recompiled entry identity still equals the stored pin, which the caller checks regardless.

## Verification

- **Rule unit differential**: warning under the flag, error by default (both severities pinned; red without the fix).
- **Engine-level pin** (`load-by-identity.test.ts`): a hand-written legacy source — authoring compile still **refuses** it; reconstruction compiles it, identity-stable across runs, and the pattern evaluates and runs (red without the fix).
- **Pattern-vintage gate**: green, and the profile-home `$UI` TransformerErrors previously logged during replay are gone.
- **Rig e2e**: the a667-vintage profile that reproduced the outage byte-for-byte now loads and renders under this branch.
- Full `ts-transformers` (1160), `runner`, `piece` suites; repo `deno task check`, `check-docs` (behavior-spec §6/§6.12 updated in this change), fmt, lint.

## Notes for reviewers (@hixie as #6098's author, @ubik2)

- #6098's gate keeps its full teeth everywhere an author can act. This only stops it from ruling on history.
- The vintage replay's two *remaining* source-miss classes (`cf-cell-context` no longer a JSX intrinsic; `safeDateNow` no longer exported) are TYPE-environment drift — a diagnostic-severity flag can't reach those; they're the adjacent problem the piece-upgrade line (#6273/#6245) owns, and worth keeping on that radar.
- Deploy note: with this on main, the next estuary deploy carries #6221 + this; homes swap forward, old-vintage profiles and pieces reload. The topics board timeout from the failed deploy had no `[UI]: unknown` in its vintage — it may have been congestion from the fleet-wide profile failures; the next deploy attempt should watch it specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

