### PR TITLE
feat(cli): decide the two slots #6318 added

### DIFF
--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -972,6 +972,9 @@ const OPTION_VALUE_PROVIDERS: Readonly<Record<string, OptionProvider>> = {
   // is the transform; `--plan` reads the rows a survey wrote.
   fixer: () => Promise.resolve(directive({ kind: "files", glob: "*.ts" })),
   plan: () => Promise.resolve(directive({ kind: "files" })),
+  // `cf piece survey --diff` reads the plan the survey is checked against,
+  // which is the file `--out` wrote.
+  diff: () => Promise.resolve(directive({ kind: "files" })),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -229,6 +229,7 @@ const DIRECTIVE_CASES: Array<[string, string, string | undefined]> = [
   ["cf piece repair --fixer ", "files", "*.ts"],
   ["cf piece repair --plan ", "files", undefined],
   ["cf piece survey --validator ", "files", undefined],
+  ["cf piece survey --diff ", "files", undefined],
   ["cf test --pattern-coverage-dir ", "dirs", undefined],
   ["cf test --timing-measures-out ", "files", undefined],
   ["cf fuse mount --cfc-writeback-state ", "files", undefined],

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -99,6 +99,7 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
   ["stats-threshold", "a threshold"],
   ["storage-stats-limit", "a count"],
   ["wait", "a patience in seconds"],
+  ["group-size", "how many pieces one session serves; a count"],
   // Identifiers the caller brings from outside, or coins.
   ["did", "a DID, pasted from elsewhere"],
   ["as", "a DID whose view to approximate, pasted from elsewhere"],


### PR DESCRIPTION
## Why

`deno task check-completion-slots` is failing on `main`. #6318 added
`cf piece survey --diff` and `cf piece retarget --group-size`, and both reached
the command tree with no entry in either provider table — which is exactly the
drift the gate from #6254 exists to catch, arriving within hours of it landing.

Until this lands, every PR branched off `main` inherits the red gate.

A slot with no entry is not neutral: it is indistinguishable at the prompt from
one whose fabric is unreachable, because completion swallows every error by
design. Both offer nothing.

## What Changed

- `--diff` reads the plan the survey is checked against — the file `--out`
  wrote — so it takes what `piece repair --plan` takes: a `files` directive.
- `--group-size` is a count, and nothing enumerates one, so it is recorded in
  `NO_OPTION_CANDIDATES` with that reason beside the other counts.
- A directive case for `cf piece survey --diff`. The derived net added in #6254
  demanded it the moment the provider appeared, which is the mechanism working
  rather than a chore.

## Test plan

- `deno task check-completion-slots` — was failing on `main`, now
  `Completion slots OK (390 option slot(s) over 68 name(s), 70 positional(s))`.
- `deno task test` in `packages/cli` — 210 passed / 0 failed.
- `deno test -A tasks/check-completion-slots.test.ts` — 1 passed (24 steps).
- `deno fmt --check`, `deno lint` — clean.

Verified the derived net actually demanded the new case: adding the `--diff`
provider without a case fails `no slot hands the shell a directive the cases
miss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

