### PR TITLE
fix(cli): refuse a `--` on a command that has no section for it to close

### DIFF
--- a/docs/plans/cli-surface-shape.md
+++ b/docs/plans/cli-surface-shape.md
@@ -490,6 +490,26 @@ reader with no edit and no warning.
 **A colon-joined `host:space:piece`.** A handle contains a colon, a DID contains
 two, and a host carries a port, so the token cannot be split from either end.
 
+**A bare `--` before the read options on the commands that have no callable
+section.** Accepting it on `get`, `set` and `wish` would make the marker a
+prefix introducing the read options rather than a boundary closing a section,
+which is one mental model instead of two and lets a line move between `call` and
+`get` unedited. It is refused on both counts it would have to earn.
+
+The model contradicts the one flag it cannot govern: `--help` written past the
+marker reaches the callable, deliberately, so a marker that introduces read
+options would have to except the one flag that is never an unknown one. And the
+marker stays mandatory on `call` and `exec` whatever the markerless commands
+accept, so the rule becomes optional here and required there — weaker than
+*the marker appears exactly where something else owns flags in between*, which
+a caller derives rather than memorizes.
+
+What the markerless commands owe is a refusal rather than acceptance. A `--`
+written on one sets every word after it aside, and an action that reads none of
+them returns an unprojected value and exits zero — the same silent
+reinterpretation as a field named for a read option, and the reason the marker
+is refused where it closes nothing.
+
 ### Precedent worth not re-deriving
 
 Position deciding which entity a flag applies to is well-established.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -842,6 +842,12 @@ schema-derived piece-call flags after `--`, for example
 piece-call JSON file. These rules keep the options before the callable name for
 `cf call` itself and the arguments after the name for the invoked callable.
 
+`--` belongs to the commands that have a callable section to close. `cf get`,
+`cf set` and `cf wish` have none, so a `--` written on one of those is refused
+rather than read: the parser sets every word after it aside, and the command
+would otherwise return a value the caller did not ask for and exit zero. The
+refusal names the words that were set aside and the line that works.
+
 ## Command visibility
 
 Every registered top-level command appears in `cf --help`. The direct

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1530,6 +1530,15 @@ export function withDeprecatedSpellingWarning<
  * they are allowed to differ (test/piece-data-spellings.test.ts pins
  * exactly that).
  */
+export function dataCommandAction<
+  // deno-lint-ignore no-explicit-any
+  F extends (this: any, ...args: any[]) => unknown,
+>(spelling: string, action: F): F {
+  return spelling.startsWith("piece ")
+    ? withDeprecatedSpellingWarning(spelling, action)
+    : action;
+}
+
 /**
  * An action that refuses a `--` before it runs.
  *
@@ -1547,15 +1556,6 @@ export function withNoSectionMarker<
     refuseSectionMarker(spelling, this.getLiteralArgs());
     return action.apply(this, args);
   } as F;
-}
-
-export function dataCommandAction<
-  // deno-lint-ignore no-explicit-any
-  F extends (this: any, ...args: any[]) => unknown,
->(spelling: string, action: F): F {
-  return spelling.startsWith("piece ")
-    ? withDeprecatedSpellingWarning(spelling, action)
-    : action;
 }
 
 /**

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1542,10 +1542,12 @@ export function dataCommandAction<
 /**
  * An action that refuses a `--` before it runs.
  *
- * `get` and `set` have no callable section, so a marker on their line sets
- * words aside that nothing reads. `call` is not wrapped: it declares
- * `stopEarly()` and its action reads what the marker set aside, which is the
- * boundary the marker is for.
+ * `get` and `set` have no callable section, so a marker on their line closes
+ * nothing and sets aside whatever follows it. The raw arguments are what carry
+ * the marker: a trailing one sets nothing aside, so the literal arguments
+ * cannot tell it from a line that wrote none. `call` is not wrapped — it
+ * declares `stopEarly()` and its action reads what the marker set aside, which
+ * is the boundary the marker is for.
  */
 export function withNoSectionMarker<
   // deno-lint-ignore no-explicit-any
@@ -1553,7 +1555,7 @@ export function withNoSectionMarker<
 >(spelling: string, action: F): F {
   // deno-lint-ignore no-explicit-any
   return function (this: any, ...args: any[]) {
-    refuseSectionMarker(spelling, this.getLiteralArgs());
+    refuseSectionMarker(spelling, this.getRawArgs());
     return action.apply(this, args);
   } as F;
 }

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -30,6 +30,7 @@ import {
   runSurvey,
 } from "../lib/bulk.ts";
 import { addressArgument, VerbInputValidationError } from "../lib/callable.ts";
+import { refuseSectionMarker } from "../lib/section-marker.ts";
 import type {
   InvocationIdentity,
   InvocationOutcome,
@@ -1529,6 +1530,25 @@ export function withDeprecatedSpellingWarning<
  * they are allowed to differ (test/piece-data-spellings.test.ts pins
  * exactly that).
  */
+/**
+ * An action that refuses a `--` before it runs.
+ *
+ * `get` and `set` have no callable section, so a marker on their line sets
+ * words aside that nothing reads. `call` is not wrapped: it declares
+ * `stopEarly()` and its action reads what the marker set aside, which is the
+ * boundary the marker is for.
+ */
+export function withNoSectionMarker<
+  // deno-lint-ignore no-explicit-any
+  F extends (this: any, ...args: any[]) => unknown,
+>(spelling: string, action: F): F {
+  // deno-lint-ignore no-explicit-any
+  return function (this: any, ...args: any[]) {
+    refuseSectionMarker(spelling, this.getLiteralArgs());
+    return action.apply(this, args);
+  } as F;
+}
+
 export function dataCommandAction<
   // deno-lint-ignore no-explicit-any
   F extends (this: any, ...args: any[]) => unknown,
@@ -1654,7 +1674,12 @@ the way --input does.`,
       { conflicts: ["select"] },
     )
     .arguments("[addressOrPath:string] [path:string]")
-    .action(dataCommandAction(spelling, getCellValueFromCommand));
+    .action(
+      dataCommandAction(
+        spelling,
+        withNoSectionMarker(spelling, getCellValueFromCommand),
+      ),
+    );
 }
 
 /**
@@ -1704,7 +1729,12 @@ counts, so cf ${spelling} /of:fid1:.../title needs no path argument. A trailing
         '"#argument" reference suffix spells the same selection)',
     )
     .arguments("[addressOrPath:string] [path:string]")
-    .action(dataCommandAction(spelling, setCellValueFromCommand));
+    .action(
+      dataCommandAction(
+        spelling,
+        withNoSectionMarker(spelling, setCellValueFromCommand),
+      ),
+    );
 }
 
 /**

--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -2,6 +2,7 @@ import { Command, ValidationError } from "@cliffy/command";
 import { type DID, isDID } from "@commonfabric/identity";
 import { parseCellPath } from "@commonfabric/runner";
 import { cliText } from "../lib/cli-name.ts";
+import { refuseSectionMarker } from "../lib/section-marker.ts";
 import { render } from "../lib/render.ts";
 import { getDidFromFile } from "../lib/identity.ts";
 import { absPath } from "../lib/utils.ts";
@@ -248,6 +249,9 @@ export const wish = new Command()
     "Return the resolved target's address instead of its contents.",
   )
   .arguments("<target:string>")
-  .action(async (options, target) => {
+  .action(async function (options, target) {
+    // `wish` reads a target directly, so it has no callable section and no
+    // marker to close one. See lib/section-marker.ts.
+    refuseSectionMarker("wish", this.getLiteralArgs());
     await wishAction(options, target);
   });

--- a/packages/cli/commands/wish.ts
+++ b/packages/cli/commands/wish.ts
@@ -252,6 +252,6 @@ export const wish = new Command()
   .action(async function (options, target) {
     // `wish` reads a target directly, so it has no callable section and no
     // marker to close one. See lib/section-marker.ts.
-    refuseSectionMarker("wish", this.getLiteralArgs());
+    refuseSectionMarker("wish", this.getRawArgs());
     await wishAction(options, target);
   });

--- a/packages/cli/lib/section-marker.ts
+++ b/packages/cli/lib/section-marker.ts
@@ -1,0 +1,48 @@
+/**
+ * The `--` marker, on a command that has no section for it to close.
+ *
+ * `--` closes a callable's section, so it is written on the commands that have
+ * one — `call` and `exec` — and nowhere else. A command whose read options
+ * follow the target directly has no such boundary, and Cliffy hands every word
+ * after the marker to the literal arguments instead. An action that reads none
+ * of them discards the words in silence: a projection written that way returns
+ * an unprojected value and exits zero.
+ *
+ * That is the failure this refuses. It is the same shape as a field named for
+ * a read option being read as one — a line that means something else, succeeds,
+ * and says nothing — which is why the marker is refused rather than accepted as
+ * a second spelling.
+ *
+ * The decision, and the alternative of accepting it, are recorded under
+ * "Alternatives, and why they are not the design" in
+ * [CLI surface shape](../../../docs/plans/cli-surface-shape.md).
+ */
+
+import { ValidationError } from "@cliffy/command";
+
+/**
+ * Refuse a `--` written on a command that has no callable section.
+ *
+ * `literalArgs` is what the parser set aside at the marker. Empty means no
+ * marker was written, which is every ordinary line.
+ *
+ * The message names the words that would have been discarded and the line that
+ * works, because every caller who meets it wrote a spelling they expected to
+ * mean something.
+ */
+export function refuseSectionMarker(
+  spelling: string,
+  literalArgs: readonly string[],
+): void {
+  if (literalArgs.length === 0) return;
+  const discarded = literalArgs.join(" ");
+  throw new ValidationError(
+    `\`--\` closes a callable's section, and \`cf ${spelling}\` has none. ` +
+      `The words after it are set aside rather than read, so this line would ` +
+      `return a value you did not ask for.\n\n` +
+      `  written:  cf ${spelling} … -- ${discarded}\n` +
+      `  write:    cf ${spelling} … ${discarded}\n\n` +
+      `\`--\` is written on \`cf call\` and \`cf exec\`, where a callable's ` +
+      `own flags come first and the marker ends them.`,
+  );
+}

--- a/packages/cli/lib/section-marker.ts
+++ b/packages/cli/lib/section-marker.ts
@@ -23,25 +23,38 @@ import { ValidationError } from "@cliffy/command";
 /**
  * Refuse a `--` written on a command that has no callable section.
  *
- * `literalArgs` is what the parser set aside at the marker. Empty means no
- * marker was written, which is every ordinary line.
+ * `rawArgs` is the command's own argument list, marker included. The marker is
+ * read from there rather than from what followed it: a trailing `cf get addr
+ * --` sets no words aside, so the literal arguments are empty and identical to
+ * a line that wrote no marker at all. Judging by what followed would accept the
+ * one spelling that most looks like the caller expected the marker to mean
+ * something.
  *
- * The message names the words that would have been discarded and the line that
+ * The message names the words that would have been set aside and the line that
  * works, because every caller who meets it wrote a spelling they expected to
  * mean something.
  */
 export function refuseSectionMarker(
   spelling: string,
-  literalArgs: readonly string[],
+  rawArgs: readonly string[],
 ): void {
-  if (literalArgs.length === 0) return;
-  const discarded = literalArgs.join(" ");
+  const marker = rawArgs.indexOf("--");
+  if (marker === -1) return;
+
+  const before = rawArgs.slice(0, marker);
+  const after = rawArgs.slice(marker + 1);
+  const written = [...before, "--", ...after].join(" ");
+  const corrected = [...before, ...after].join(" ");
+  const consequence = after.length > 0
+    ? "The words after it are set aside rather than read, so this line would " +
+      "return a value you did not ask for."
+    : "Nothing follows it here, so it closes nothing.";
+
   throw new ValidationError(
     `\`--\` closes a callable's section, and \`cf ${spelling}\` has none. ` +
-      `The words after it are set aside rather than read, so this line would ` +
-      `return a value you did not ask for.\n\n` +
-      `  written:  cf ${spelling} … -- ${discarded}\n` +
-      `  write:    cf ${spelling} … ${discarded}\n\n` +
+      `${consequence}\n\n` +
+      `  written:  cf ${spelling} ${written}\n` +
+      `  write:    cf ${spelling} ${corrected}\n\n` +
       `\`--\` is written on \`cf call\` and \`cf exec\`, where a callable's ` +
       `own flags come first and the marker ends them.`,
   );

--- a/packages/cli/test/section-marker.test.ts
+++ b/packages/cli/test/section-marker.test.ts
@@ -16,17 +16,38 @@ import { wish } from "../commands/wish.ts";
  */
 describe("section-marker", () => {
   describe("refuseSectionMarker()", () => {
-    it("returns for a line that wrote no marker", () => {
+    it("returns for arguments carrying no marker", () => {
       expect(() => refuseSectionMarker("get", [])).not.toThrow();
+      expect(() => refuseSectionMarker("get", ["addr", "items/0"]))
+        .not.toThrow();
+    });
+
+    it("refuses a marker with nothing after it", () => {
+      // The case the literal arguments cannot see: a trailing marker sets no
+      // words aside, so `getLiteralArgs()` is empty and identical to a line
+      // that wrote none. Reading the marker itself is what tells them apart.
+      expect(() => refuseSectionMarker("get", ["addr", "--"]))
+        .toThrow(/closes nothing/);
     });
 
     it("names the words the marker would have set aside", () => {
-      expect(() => refuseSectionMarker("get", ["--select", "title"]))
+      expect(() => refuseSectionMarker("get", ["--", "--select", "title"]))
         .toThrow(/--select title/);
     });
 
+    it("writes the corrected line without the marker", () => {
+      let message = "";
+      try {
+        refuseSectionMarker("get", ["addr", "--", "--select", "title"]);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toContain("written:  cf get addr -- --select title");
+      expect(message).toContain("write:    cf get addr --select title");
+    });
+
     it("names the command the marker was written on", () => {
-      expect(() => refuseSectionMarker("piece get", ["--select", "title"]))
+      expect(() => refuseSectionMarker("piece get", ["--", "--select", "t"]))
         .toThrow(/cf piece get/);
     });
 
@@ -35,7 +56,7 @@ describe("section-marker", () => {
       // spelling does work.
       let message = "";
       try {
-        refuseSectionMarker("wish", ["--select", "name"]);
+        refuseSectionMarker("wish", ["--", "--select", "name"]);
       } catch (error) {
         message = (error as Error).message;
       }
@@ -44,7 +65,8 @@ describe("section-marker", () => {
     });
 
     it("throws a ValidationError, so the CLI reports it as a usage error", () => {
-      expect(() => refuseSectionMarker("get", ["x"])).toThrow(ValidationError);
+      expect(() => refuseSectionMarker("get", ["--", "x"]))
+        .toThrow(ValidationError);
     });
   });
 
@@ -122,6 +144,23 @@ describe("section-marker", () => {
         "name",
       ]);
       expect(text).toContain("closes a callable's section");
+    });
+
+    it("refuses a trailing marker on every command that has no section", async () => {
+      // `cf get addr --` sets no words aside, so the literal arguments are
+      // empty and look exactly like `cf get addr`. Each of these three would
+      // have been accepted by a guard reading what followed the marker.
+      for (
+        const [name, command, args] of [
+          ["get", pieceDataCommand("get"), ["addr", "--"]],
+          ["set", pieceDataCommand("set"), ["addr", "--"]],
+          ["wish", wish, ["#profile", "--"]],
+        ] as const
+      ) {
+        const { text } = await outputFrom(command, [...args]);
+        expect(text, name).toContain("closes a callable's section");
+        expect(text, name).toContain("closes nothing");
+      }
     });
 
     it("leaves a line that writes no marker to its own validation", async () => {

--- a/packages/cli/test/section-marker.test.ts
+++ b/packages/cli/test/section-marker.test.ts
@@ -1,0 +1,149 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { ValidationError } from "@cliffy/command";
+import { refuseSectionMarker } from "../lib/section-marker.ts";
+import { pieceDataCommand } from "../commands/piece.ts";
+import { wish } from "../commands/wish.ts";
+
+/**
+ * `--` closes a callable's section. A command without one sets every word
+ * after the marker aside, and an action reading none of them returns a value
+ * the caller did not ask for and exits zero.
+ *
+ * These hold the refusal to firing at all — the parse tests below are what
+ * prove the words really do reach the literal arguments on a real command,
+ * which is the half a unit test of the helper alone cannot see.
+ */
+describe("section-marker", () => {
+  describe("refuseSectionMarker()", () => {
+    it("returns for a line that wrote no marker", () => {
+      expect(() => refuseSectionMarker("get", [])).not.toThrow();
+    });
+
+    it("names the words the marker would have set aside", () => {
+      expect(() => refuseSectionMarker("get", ["--select", "title"]))
+        .toThrow(/--select title/);
+    });
+
+    it("names the command the marker was written on", () => {
+      expect(() => refuseSectionMarker("piece get", ["--select", "title"]))
+        .toThrow(/cf piece get/);
+    });
+
+    it("names the two commands the marker is written on", () => {
+      // A refusal that only says no leaves the caller to find where the
+      // spelling does work.
+      let message = "";
+      try {
+        refuseSectionMarker("wish", ["--select", "name"]);
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toContain("cf call");
+      expect(message).toContain("cf exec");
+    });
+
+    it("throws a ValidationError, so the CLI reports it as a usage error", () => {
+      expect(() => refuseSectionMarker("get", ["x"])).toThrow(ValidationError);
+    });
+  });
+
+  describe("on the commands that have no callable section", () => {
+    /**
+     * Parse `args` and return what cliffy printed.
+     *
+     * A `ValidationError` reaches the caller as help output plus an exit, so
+     * the refusal is read where a caller reads it — off stderr — rather than
+     * as a thrown value. Same idiom as `wish-command.test.ts`.
+     */
+    async function outputFrom(
+      // deno-lint-ignore no-explicit-any
+      command: { parse: (args: string[]) => Promise<any> },
+      args: string[],
+    ): Promise<{ text: string; exitCode: number | null }> {
+      const originalExit = Deno.exit;
+      const originalLog = console.log;
+      const originalError = console.error;
+      const written: string[] = [];
+      let exitCode: number | null = null;
+      Deno.exit = ((code?: number): never => {
+        exitCode = code ?? 0;
+        throw new Error("exit sentinel");
+      }) as typeof Deno.exit;
+      console.log = (...parts: unknown[]) => written.push(parts.join(" "));
+      console.error = (...parts: unknown[]) => written.push(parts.join(" "));
+      try {
+        await command.parse(args);
+      } catch (error) {
+        if (!(error instanceof Error) || error.message !== "exit sentinel") {
+          written.push(String(error));
+        }
+      } finally {
+        Deno.exit = originalExit;
+        console.log = originalLog;
+        console.error = originalError;
+      }
+      return { text: written.join("\n"), exitCode };
+    }
+
+    it("refuses a marker on `get` rather than discarding the words", async () => {
+      // Without the guard this parse reaches the action with an empty
+      // `--select` and returns an unprojected value — the silent wrong answer
+      // the refusal is for.
+      const { text, exitCode } = await outputFrom(pieceDataCommand("get"), [
+        "addr",
+        "--",
+        "--select",
+        "title",
+      ]);
+      expect(text).toContain("closes a callable's section");
+      expect(text).toContain("--select title");
+      // 2 is cliffy's exit for a validation error, which is what this is —
+      // the point being that it is not 0, which is what the silent discard
+      // returned.
+      expect(exitCode).toBe(2);
+    });
+
+    it("refuses a marker on `set`", async () => {
+      const { text } = await outputFrom(pieceDataCommand("set"), [
+        "addr",
+        "--",
+        "--json",
+        "1",
+      ]);
+      expect(text).toContain("closes a callable's section");
+    });
+
+    it("refuses a marker on `wish`", async () => {
+      const { text } = await outputFrom(wish, [
+        "#profile",
+        "--",
+        "--select",
+        "name",
+      ]);
+      expect(text).toContain("closes a callable's section");
+    });
+
+    it("leaves a line that writes no marker to its own validation", async () => {
+      // The guard must not become the error every incomplete line reports:
+      // this one is refused too, but for the identity and api-url it never
+      // named.
+      const { text } = await outputFrom(pieceDataCommand("get"), ["addr"]);
+      expect(text).not.toContain("closes a callable's section");
+    });
+
+    it("leaves `call` to read what the marker set aside", async () => {
+      // `call` declares stopEarly() and its action reads the literal
+      // arguments, so the marker is the boundary it exists for. A refusal
+      // here would take away the spelling the design prescribes.
+      const { text } = await outputFrom(pieceDataCommand("call"), [
+        "addr",
+        "verb",
+        "--",
+        "--select",
+        "title",
+      ]);
+      expect(text).not.toContain("closes a callable's section");
+    });
+  });
+});


### PR DESCRIPTION
## Why

`cf get addr -- --select title` returns an unprojected value and exits zero.

`--` closes a callable's section, so it is written on `call` and `exec` and
nowhere else. On `get`, `set` and `wish` the parser sets every word after it
aside as literal arguments, and those actions read none of them — so a
projection written that way is discarded in silence. Measured before the fix:

```
$ cf get addr -- --select title
  options   : {}                      # projection lost
  literal   : ["--select","title"]    # into a bucket the action never reads
$ cf get addr -- title
  positional: ["addr"]                # the path is lost too
```

That is the same shape as a field named for a read option being read as one: a
line that means something else, succeeds, and says nothing. It is the failure
class `docs/plans/cli-surface-shape.md` is most careful about, sitting in the
two commands that document describes as the simple case.

The alternative — accepting `--` there, so the marker reads as a prefix
introducing the read options rather than as a boundary closing a section — was
considered and declined. It contradicts the one flag it cannot govern
(`--help` past the marker deliberately reaches the callable), and it leaves the
marker mandatory on `call`/`exec` regardless, so the rule becomes optional here
and required there. Both are now recorded in that document's alternatives
section so the next reader does not re-derive it.

## What Changed

- `lib/section-marker.ts` — `refuseSectionMarker()`, which names the words the
  marker would have set aside and the line that works.
- `get` and `set` wrap their actions with it; `wish` calls it directly.
- `call` is untouched: it declares `stopEarly()` and its action reads what the
  marker set aside, which is the boundary the marker is for.
- The marker is read from the command's own arguments rather than from what
  followed it. A trailing `cf get addr --` sets nothing aside, so the literal
  arguments are empty and identical to a line that wrote no marker — judging by
  what followed accepted exactly the spelling a caller writes when they expect
  the marker to mean something.
- The alternative and its two reasons, recorded in `cli-surface-shape.md`; and
  a paragraph in `packages/cli/README.md`, which taught the marker for
  `cf call` and said nothing about where it is refused.

## Test plan

- `test/section-marker.test.ts` — 15 steps: the helper, then the real commands
  parsed end to end, including a trailing bare marker on all three, that `call`
  still accepts the marker, and that an incomplete line still reports its own
  missing config rather than this.
- Mutation-checked twice: neutering the guard fails 9 steps, and restoring the
  literal-argument reading fails the trailing-marker case specifically.
- End-to-end through the real entrypoint for all four spellings — `get`, `set`
  and `wish` with a trailing marker, and `get` with words after it.
- `deno task test` in `packages/cli` — 210 passed / 0 failed.
- `deno fmt --check`, `deno lint`, `deno task check-docs`,
  `check-skill-facts`, `check-verb-session-sync`, `check-docs-history-index`,
  `check-completion-slots` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)