### PR TITLE
feat(runner): the max-enforcement CFC posture is a named opt-in bundle

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -579,6 +579,22 @@ latter's for its fabric session from `--fabric-cfc-enforcement-mode`
 (raise-only: `enforce-explicit` or `enforce-strict`) and
 `--fabric-cfc-flow-labels`, with `CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE` and
 `CF_HARNESS_FABRIC_CFC_FLOW_LABELS` as their environment defaults.
+
+One named bundle sits beside the per-dial rollout: every preset's `CoreParams`
+accepts `cfcPosture: "max-enforcement"`, which spreads
+`MAX_ENFORCEMENT_CFC_OPTIONS` (same file) over the core — flow labels
+`persist`, write floor / policy evaluation / declared monotonicity /
+label-metadata protection at `enforce`, trigger-read gating on, the §10.1
+standard prompt-caveat policy as the deployment's `cfcPolicyRecords`, and
+public-only confidentiality ceilings on the network-fetch sinks
+(`MAX_ENFORCEMENT_SINK_CEILINGS`). The bundle deliberately leaves the
+enforcement-mode pin at `enforce-explicit` (strict stays a per-session host
+raise), and leaves `cfcDecomposedEnvelopes`, `cfcTrustConfig`, and
+`cfcPrefixProvenanceStats` alone. It is opt-in per runtime, never a fleet
+flip: cf-harness exposes it for its fabric session as `--fabric-cfc-posture`
+(`CF_HARNESS_FABRIC_CFC_POSTURE`); toolshed publishes whatever CFC posture its
+Runtime resolved on `/api/meta` (`lib/cfc-posture.ts`), so a deployment's
+enforcement is readable rather than indistinguishable from the default.
 The interactive `cf-harness` and the `fuse` mount expose the enforcement mode
 through `CF_CFC_MODE` for testing. Because these dials are keys of
 `RuntimeOptions`, the exhaustive `RUNTIME_OPTION_KEYS` registry in the same file

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -587,7 +587,11 @@ accepts `cfcPosture: "max-enforcement"`, which spreads
 label-metadata protection at `enforce`, trigger-read gating on, the §10.1
 standard prompt-caveat policy as the deployment's `cfcPolicyRecords`, and
 public-only confidentiality ceilings on the network-fetch sinks
-(`MAX_ENFORCEMENT_SINK_CEILINGS`). The bundle deliberately leaves the
+(`MAX_ENFORCEMENT_SINK_CEILINGS`). The llm sinks carry no ceiling, and a sink
+with no ceiling gets no gate: llm-sink release is ungoverned under this
+posture — pending a boundary-scoped admission mechanism, since an exact-match
+ceiling cannot admit the source-varying material-risk caveats an llm sink
+exists to process. The bundle deliberately leaves the
 enforcement-mode pin at `enforce-explicit` (strict stays a per-session host
 raise), and leaves `cfcDecomposedEnvelopes`, `cfcTrustConfig`, and
 `cfcPrefixProvenanceStats` alone. It is opt-in per runtime, never a fleet

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -937,8 +937,8 @@ space's authorization, and only a healthy session is cached for the run. A
 session that fails to build surfaces as an ordinary tool-output error rather
 than a run failure, and the next tool call retries the construction.
 
-Two further flags set the session runtime's CFC dials, and both need the three
-session flags present. `--fabric-cfc-enforcement-mode`
+Three further flags set the session runtime's CFC dials, and each needs the
+three session flags present. `--fabric-cfc-enforcement-mode`
 (`CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE`) accepts `enforce-explicit` or
 `enforce-strict` — raise-only, since the session's runtime preset already pins
 `enforce-explicit`; under `enforce-strict`, a pattern whose writes carry
@@ -946,15 +946,25 @@ confidentiality its target's declared policy does not admit has its commit
 refused. `--fabric-cfc-flow-labels` (`CF_HARNESS_FABRIC_CFC_FLOW_LABELS`)
 accepts `off`, `observe`, or `persist`; `persist` stamps the derived flow labels
 onto everything a pattern's transaction writes, which is what makes a labelled
-read visible to that refusal. These dials govern the fabric session's runtime
-only — `--cfc-enforcement-mode` remains the harness's own dial for tool policy
-and the sandbox, and the two are set independently.
+read visible to that refusal. `--fabric-cfc-posture`
+(`CF_HARNESS_FABRIC_CFC_POSTURE`) accepts `max-enforcement` and opts the
+session's runtime into the named CFC posture bundle
+(`MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets): every staged
+enforcement dial on, the standard prompt-caveat policy loaded, and public-only
+ceilings on the network-fetch sinks. The two per-dial flags still apply over the
+bundle, so
+`--fabric-cfc-posture max-enforcement
+--fabric-cfc-enforcement-mode enforce-strict`
+is the full-strictness configuration. These dials govern the fabric session's
+runtime only — `--cfc-enforcement-mode` remains the harness's own dial for tool
+policy and the sandbox, and the two are set independently.
 
 A run states both postures rather than leaving them to be inferred: the resolved
 fabric-session posture — each dial's value and whether the operator configured
-it or the preset supplied it — is recorded as `fabricSessionCfc` in
-`run-state.json` and the run report, and the operator summary prints it beside
-the harness's own `cfcMode`.
+it, the named posture bundle supplied it, or the preset's default stood — is
+recorded as `fabricSessionCfc` in `run-state.json` and the run report (with the
+selected bundle, when there is one, as its `posture` field), and the operator
+summary prints it beside the harness's own `cfcMode`.
 
 The tool takes `sourceText` (inline pattern source, at most 256 KiB — an
 over-cap source is a structured tool error), an optional `inputs` object, and an

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -951,8 +951,9 @@ read visible to that refusal. `--fabric-cfc-posture`
 session's runtime into the named CFC posture bundle
 (`MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets): every staged
 enforcement dial on, the standard prompt-caveat policy loaded, and public-only
-ceilings on the network-fetch sinks. The two per-dial flags still apply over the
-bundle, so
+ceilings on the network-fetch sinks (the llm sinks carry no ceiling and are
+ungoverned by the posture, pending a boundary-scoped admission mechanism). The
+two per-dial flags still apply over the bundle, so
 `--fabric-cfc-posture max-enforcement
 --fabric-cfc-enforcement-mode enforce-strict`
 is the full-strictness configuration. These dials govern the fabric session's

--- a/packages/cf-harness/docs/CURRENT_STATE.md
+++ b/packages/cf-harness/docs/CURRENT_STATE.md
@@ -146,11 +146,15 @@ The current package provides:
   `--fabric-cfc-enforcement-mode` (raise-only: `enforce-explicit` or
   `enforce-strict`) and `--fabric-cfc-flow-labels` (`off`/`observe`/`persist`)
   set the session runtime's CFC dials, so with labels persisted a
-  confidentiality-tainted pattern write is refused at commit under strict —
-  these are the fabric session's dials, independent of the harness's own
-  `--cfc-enforcement-mode`, and the resolved posture (each dial's value and
-  source) is recorded as `fabricSessionCfc` in run state and printed in the
-  operator summary;
+  confidentiality-tainted pattern write is refused at commit under strict, and
+  `--fabric-cfc-posture max-enforcement` opts the session runtime into the
+  runner's named posture bundle (every staged enforcement dial on, the standard
+  prompt-caveat policy loaded, public-only ceilings on the network-fetch sinks),
+  with the two per-dial flags applying over it — these are the fabric session's
+  dials, independent of the harness's own `--cfc-enforcement-mode`, and the
+  resolved posture (each dial's value and whether the operator, the named
+  bundle, or the default supplied it) is recorded as `fabricSessionCfc` in run
+  state and the run report, and printed in the operator summary;
 - a `pattern-author` child profile that authors and runs Common Fabric pattern
   source: `run_pattern` under the same fabric-session gate, plus `read_file`,
   `bash`, and `read_skill_resource`, and no workspace writes, so its deliverable

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1368,6 +1368,9 @@ export const parseCfHarnessCliArgs = async (
       CF_HARNESS_FABRIC_CFC_FLOW_LABELS: Deno.env.get(
         "CF_HARNESS_FABRIC_CFC_FLOW_LABELS",
       ),
+      CF_HARNESS_FABRIC_CFC_POSTURE: Deno.env.get(
+        "CF_HARNESS_FABRIC_CFC_POSTURE",
+      ),
       CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
       CF_HARNESS_SANDBOX_DOCKER_RUNTIME: Deno.env.get(
         "CF_HARNESS_SANDBOX_DOCKER_RUNTIME",

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -193,6 +193,7 @@ const CLI_STRING_FLAGS = [
   "fabric-space",
   "fabric-cfc-enforcement-mode",
   "fabric-cfc-flow-labels",
+  "fabric-cfc-posture",
   "host-mount",
   "browser-access-lease-id",
   "browser-access-cdp-url",
@@ -538,6 +539,10 @@ Options:
                                 --cfc-enforcement-mode, which governs the harness)
   --fabric-cfc-flow-labels <mode> off | observe | persist flow-label propagation on
                                 the fabric session's runtime
+  --fabric-cfc-posture <name>   max-enforcement: opt the fabric session's runtime
+                                into the named CFC posture bundle (every staged
+                                enforcement dial on); the two dials above still
+                                apply over the bundle
   --host-mount <spec>           Extra host bind mount (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
@@ -561,6 +566,7 @@ Environment:
   CF_HARNESS_FABRIC_SPACE       Default value for --fabric-space
   CF_HARNESS_FABRIC_CFC_ENFORCEMENT_MODE Default value for --fabric-cfc-enforcement-mode
   CF_HARNESS_FABRIC_CFC_FLOW_LABELS Default value for --fabric-cfc-flow-labels
+  CF_HARNESS_FABRIC_CFC_POSTURE Default value for --fabric-cfc-posture
   CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
   CF_HARNESS_SANDBOX_DOCKER_RUNTIME Default value for --sandbox-docker-runtime
   ${CFC_RESULT_DIR_ENV} Fallback for --cfc-result-dir
@@ -1553,7 +1559,8 @@ export const parseCfHarnessCliArgs = async (
       | "fabric-identity"
       | "fabric-space"
       | "fabric-cfc-enforcement-mode"
-      | "fabric-cfc-flow-labels",
+      | "fabric-cfc-flow-labels"
+      | "fabric-cfc-posture",
     envValue: string | undefined,
   ): string | undefined => {
     const raw = typeof args[flag] === "string"
@@ -1603,6 +1610,17 @@ export const parseCfHarnessCliArgs = async (
       `--fabric-cfc-flow-labels must be off, observe, or persist: ${fabricCfcFlowLabels}`,
     );
   }
+  const fabricCfcPosture = fabricSessionFlagValue(
+    "fabric-cfc-posture",
+    env.CF_HARNESS_FABRIC_CFC_POSTURE,
+  );
+  if (
+    fabricCfcPosture !== undefined && fabricCfcPosture !== "max-enforcement"
+  ) {
+    throw new Error(
+      `--fabric-cfc-posture must be max-enforcement: ${fabricCfcPosture}`,
+    );
+  }
   let fabricSession: HarnessFabricSessionConfig | undefined;
   if (
     fabricApiUrl !== undefined || fabricIdentity !== undefined ||
@@ -1635,12 +1653,16 @@ export const parseCfHarnessCliArgs = async (
       ...(fabricCfcFlowLabels !== undefined
         ? { cfcFlowLabels: fabricCfcFlowLabels }
         : {}),
+      ...(fabricCfcPosture !== undefined
+        ? { cfcPosture: fabricCfcPosture }
+        : {}),
     };
   } else if (
-    fabricCfcEnforcementMode !== undefined || fabricCfcFlowLabels !== undefined
+    fabricCfcEnforcementMode !== undefined ||
+    fabricCfcFlowLabels !== undefined || fabricCfcPosture !== undefined
   ) {
     throw new Error(
-      "--fabric-cfc-enforcement-mode and --fabric-cfc-flow-labels configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
+      "--fabric-cfc-enforcement-mode, --fabric-cfc-flow-labels, and --fabric-cfc-posture configure the fabric session's runtime and need --fabric-api-url, --fabric-identity, and --fabric-space",
     );
   }
   // An allowlisted fabric-session tool with no session to run it against is
@@ -2375,7 +2397,9 @@ export const formatCfHarnessCliResult = (
   if (result.runState.fabricSessionCfc !== undefined) {
     const posture = result.runState.fabricSessionCfc;
     lines.push(
-      `fabricSessionCfc: ${posture.enforcementMode} (${posture.enforcementModeSource}), flow-labels ${posture.flowLabels} (${posture.flowLabelsSource})`,
+      `fabricSessionCfc: ${posture.enforcementMode} (${posture.enforcementModeSource}), flow-labels ${posture.flowLabels} (${posture.flowLabelsSource})${
+        posture.posture !== undefined ? `, posture ${posture.posture}` : ""
+      }`,
     );
   }
   if (

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -3,6 +3,7 @@ import {
   type CfcFlowLabelsMode,
   isCfcEnforcementMode,
 } from "@commonfabric/runner/cfc";
+import type { CfcPosture } from "@commonfabric/runner";
 import type { HarnessCfcEnforcementModeSource } from "./contracts/cfc-policy-snapshot.ts";
 import {
   type HarnessCredentialOwnerRef,
@@ -40,7 +41,9 @@ export type HarnessFabricCfcFlowLabelsMode = CfcFlowLabelsMode;
  * the run offers `run_pattern` in the parent tool surface; when absent, the
  * tool is unavailable. The optional CFC dials reach the session's Runtime;
  * unset means the remoteClient preset's first-party posture
- * (`enforce-explicit`, flow labels off).
+ * (`enforce-explicit`, flow labels off). `cfcPosture` opts the runtime into
+ * a named bundle (`MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets);
+ * the two dials still apply over it.
  */
 export interface HarnessFabricSessionConfig {
   apiUrl: string;
@@ -48,6 +51,7 @@ export interface HarnessFabricSessionConfig {
   space: string;
   cfcEnforcementMode?: HarnessFabricCfcEnforcementMode;
   cfcFlowLabels?: HarnessFabricCfcFlowLabelsMode;
+  cfcPosture?: CfcPosture;
 }
 export type HarnessModelProviderId =
   | "openai-compatible-gateway"

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -9,6 +9,7 @@ import type {
 } from "./policy-trace.ts";
 import { countHarnessPolicyDecisions } from "./policy-trace.ts";
 import type { PromptSlotBinding } from "./prompt-slot.ts";
+import type { HarnessFabricSessionCfcPosture } from "../run-state.ts";
 import type { HarnessSubagentRunRef } from "./subagent.ts";
 import type { HarnessToolEffectClass } from "./tool-descriptor.ts";
 import type { HarnessTranscriptMessage } from "./transcript.ts";
@@ -117,6 +118,8 @@ export interface HarnessRunReport {
   totalUsage?: HarnessModelUsage;
   modelUsage?: HarnessModelTurnUsage[];
   cfcEnforcementMode: CfcEnforcementMode;
+  /** The fabric session's resolved CFC posture, when the run had a session. */
+  fabricSessionCfc?: HarnessFabricSessionCfcPosture;
   createdAt?: string;
   updatedAt?: string;
   endedAt?: string;
@@ -154,6 +157,7 @@ export interface CreateHarnessRunReportOptions {
     endedAt?: string;
     terminalReason?: string;
     cfcEnforcementMode: CfcEnforcementMode;
+    fabricSessionCfc?: HarnessFabricSessionCfcPosture;
     artifactRoot?: string;
     transcriptPath?: string;
     promptSlotBinding?: PromptSlotBinding;
@@ -331,6 +335,9 @@ export const createHarnessRunReport = (
       ? { modelUsage: [...(options.modelUsage ?? [])] }
       : {}),
     cfcEnforcementMode: options.runState.cfcEnforcementMode,
+    ...(options.runState.fabricSessionCfc !== undefined
+      ? { fabricSessionCfc: options.runState.fabricSessionCfc }
+      : {}),
     ...(options.runState.createdAt !== undefined
       ? { createdAt: options.runState.createdAt }
       : {}),

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -566,10 +566,18 @@ export class CfHarnessEngine {
           this.config.fabricSession.cfcEnforcementMode !== undefined
             ? "configured" as const
             : "preset-pin" as const,
-        flowLabels: this.config.fabricSession.cfcFlowLabels ?? "off" as const,
+        flowLabels: this.config.fabricSession.cfcFlowLabels ??
+          (this.config.fabricSession.cfcPosture === "max-enforcement"
+            ? "persist" as const
+            : "off" as const),
         flowLabelsSource: this.config.fabricSession.cfcFlowLabels !== undefined
           ? "configured" as const
+          : this.config.fabricSession.cfcPosture === "max-enforcement"
+          ? "posture" as const
           : "default" as const,
+        ...(this.config.fabricSession.cfcPosture !== undefined
+          ? { posture: this.config.fabricSession.cfcPosture }
+          : {}),
       }
       : undefined;
     this.#runState = options.runState ??

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -584,15 +584,26 @@ export class CfHarnessEngine {
     // config that resolves to a DIFFERENT posture would put the artifacts in
     // contradiction with the Runtime that executes: refuse rather than let
     // either record win silently. A run resumed without a session keeps its
-    // record as history (no runtime exists for it to contradict), and a
-    // legacy record that never captured a posture stays absent rather than
-    // being backfilled.
-    if (
-      options.runState?.fabricSessionCfc !== undefined &&
-      fabricSessionCfc !== undefined
-    ) {
+    // record as history (no runtime exists for it to contradict). A LEGACY
+    // record — one that never captured a posture — stays absent rather than
+    // being backfilled, and stays frozen as history: resuming such a run
+    // with plain session dials is allowed (the flags may simply restate the
+    // original invocation, which the record predates), but resuming it under
+    // the named posture bundle is refused — no legacy run can have run the
+    // bundle, so that resume would execute enforcement the artifacts cannot
+    // attest.
+    if (options.runState !== undefined && fabricSessionCfc !== undefined) {
       const recorded = options.runState.fabricSessionCfc;
-      if (
+      if (recorded === undefined) {
+        if (fabricSessionCfc.posture !== undefined) {
+          throw new Error(
+            `fabric session CFC posture mismatch on resume: run state ` +
+              `records no fabric-session posture, so it cannot attest the ` +
+              `${fabricSessionCfc.posture} bundle the session ` +
+              `configuration resolves`,
+          );
+        }
+      } else if (
         recorded.enforcementMode !== fabricSessionCfc.enforcementMode ||
         recorded.flowLabels !== fabricSessionCfc.flowLabels ||
         recorded.posture !== fabricSessionCfc.posture

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -580,6 +580,30 @@ export class CfHarnessEngine {
           : {}),
       }
       : undefined;
+    // A resumed run keeps its recorded fabric-session posture, so a session
+    // config that resolves to a DIFFERENT posture would put the artifacts in
+    // contradiction with the Runtime that executes: refuse rather than let
+    // either record win silently. A run resumed without a session keeps its
+    // record as history (no runtime exists for it to contradict), and a
+    // legacy record that never captured a posture stays absent rather than
+    // being backfilled.
+    if (
+      options.runState?.fabricSessionCfc !== undefined &&
+      fabricSessionCfc !== undefined
+    ) {
+      const recorded = options.runState.fabricSessionCfc;
+      if (
+        recorded.enforcementMode !== fabricSessionCfc.enforcementMode ||
+        recorded.flowLabels !== fabricSessionCfc.flowLabels ||
+        recorded.posture !== fabricSessionCfc.posture
+      ) {
+        throw new Error(
+          `fabric session CFC posture mismatch on resume: run state records ` +
+            `${JSON.stringify(recorded)} but the session configuration ` +
+            `resolves ${JSON.stringify(fabricSessionCfc)}`,
+        );
+      }
+    }
     this.#runState = options.runState ??
       createHarnessRunState({
         runId,

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -23,6 +23,32 @@ export interface HarnessFabricSession {
 export type HarnessFabricSessionFactory = () => Promise<HarnessFabricSession>;
 
 /**
+ * The `PiecesController.initialize` options a session config resolves to,
+ * identity aside: the space and whichever CFC dials the config carries — an
+ * unset dial stays absent so the remoteClient preset's own posture governs.
+ * Pure so the resolution is testable without touching disk or network.
+ */
+export const harnessFabricSessionControllerOptions = (
+  config: HarnessFabricSessionConfig,
+): {
+  apiUrl: URL;
+  space: string;
+  cfcEnforcementMode?: HarnessFabricSessionConfig["cfcEnforcementMode"];
+  cfcFlowLabels?: HarnessFabricSessionConfig["cfcFlowLabels"];
+  cfcPosture?: HarnessFabricSessionConfig["cfcPosture"];
+} => ({
+  apiUrl: new URL(config.apiUrl),
+  space: config.space,
+  ...(config.cfcEnforcementMode !== undefined
+    ? { cfcEnforcementMode: config.cfcEnforcementMode }
+    : {}),
+  ...(config.cfcFlowLabels !== undefined
+    ? { cfcFlowLabels: config.cfcFlowLabels }
+    : {}),
+  ...(config.cfcPosture !== undefined ? { cfcPosture: config.cfcPosture } : {}),
+});
+
+/**
  * Default factory over `config`: loads the PKCS#8 identity from disk and
  * connects a `PiecesController` to the deployed API. An unauthorized space
  * fails construction rather than yielding a session whose every read is a
@@ -36,18 +62,8 @@ async () => {
     await Deno.readFile(config.identityKeyPath),
   );
   const pieces = await PiecesController.initialize({
-    apiUrl: new URL(config.apiUrl),
+    ...harnessFabricSessionControllerOptions(config),
     identity,
-    space: config.space,
-    ...(config.cfcEnforcementMode !== undefined
-      ? { cfcEnforcementMode: config.cfcEnforcementMode }
-      : {}),
-    ...(config.cfcFlowLabels !== undefined
-      ? { cfcFlowLabels: config.cfcFlowLabels }
-      : {}),
-    ...(config.cfcPosture !== undefined
-      ? { cfcPosture: config.cfcPosture }
-      : {}),
   });
   return { pieces };
 };

--- a/packages/cf-harness/src/fabric-session.ts
+++ b/packages/cf-harness/src/fabric-session.ts
@@ -45,6 +45,9 @@ async () => {
     ...(config.cfcFlowLabels !== undefined
       ? { cfcFlowLabels: config.cfcFlowLabels }
       : {}),
+    ...(config.cfcPosture !== undefined
+      ? { cfcPosture: config.cfcPosture }
+      : {}),
   });
   return { pieces };
 };

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -67,8 +67,18 @@ export interface HarnessFabricSessionCfcPosture {
   /** `configured` when the operator set the dial; `preset-pin` otherwise. */
   enforcementModeSource: "configured" | "preset-pin";
   flowLabels: "off" | "observe" | "persist";
-  /** `configured` when the operator set the dial; `default` otherwise. */
-  flowLabelsSource: "configured" | "default";
+  /**
+   * `configured` when the operator set the dial; `posture` when the named
+   * bundle below supplied it; `default` otherwise.
+   */
+  flowLabelsSource: "configured" | "default" | "posture";
+  /**
+   * The named CFC posture bundle the session's runtime opted into, when the
+   * operator selected one (`--fabric-cfc-posture`). The bundle sets more
+   * dials than the two this record itemizes — the full set is
+   * `MAX_ENFORCEMENT_CFC_OPTIONS` in the runner's presets.
+   */
+  posture?: "max-enforcement";
 }
 
 export interface HarnessRunState {

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -602,6 +602,38 @@ Deno.test("parseCfHarnessCliArgs accepts the fabric CFC posture from the environ
   });
 });
 
+Deno.test("parseCfHarnessCliArgs reads the fabric CFC posture from the process environment", async () => {
+  // Through the DEFAULT env projection (no injected `deps.env`), the path a
+  // real invocation takes: a key missing from that projection reads as unset
+  // even when the process environment carries it.
+  const names = [
+    "CF_HARNESS_FABRIC_API_URL",
+    "CF_HARNESS_FABRIC_IDENTITY",
+    "CF_HARNESS_FABRIC_SPACE",
+    "CF_HARNESS_FABRIC_CFC_POSTURE",
+  ] as const;
+  const previous = new Map(names.map((name) => [name, Deno.env.get(name)]));
+  Deno.env.set("CF_HARNESS_FABRIC_API_URL", "https://toolshed.example/");
+  Deno.env.set("CF_HARNESS_FABRIC_IDENTITY", "/keys/agent.pkcs8");
+  Deno.env.set("CF_HARNESS_FABRIC_SPACE", "my-space");
+  Deno.env.set("CF_HARNESS_FABRIC_CFC_POSTURE", "max-enforcement");
+  try {
+    const parsed = await parseCfHarnessCliArgs(
+      ["--prompt", "hi"],
+      { cwd: "/tmp/project" },
+    );
+    if ("help" in parsed) {
+      throw new Error("expected config result");
+    }
+    assertEquals(parsed.fabricSession?.cfcPosture, "max-enforcement");
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+});
+
 Deno.test("parseCfHarnessCliArgs rejects an unknown fabric CFC posture", async () => {
   await assertRejects(
     () =>

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -549,6 +549,99 @@ Deno.test("parseCfHarnessCliArgs rejects an unknown fabric CFC flow-labels mode"
   );
 });
 
+Deno.test("parseCfHarnessCliArgs carries the fabric CFC posture into the session config", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--fabric-api-url",
+      "https://toolshed.example/",
+      "--fabric-identity",
+      "keys/agent.pkcs8",
+      "--fabric-space",
+      "my-space",
+      "--fabric-cfc-posture",
+      "max-enforcement",
+    ],
+    { cwd: "/tmp/project", env: {} },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/tmp/project/keys/agent.pkcs8",
+    space: "my-space",
+    cfcPosture: "max-enforcement",
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs accepts the fabric CFC posture from the environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: {
+        CF_HARNESS_FABRIC_API_URL: "https://toolshed.example/",
+        CF_HARNESS_FABRIC_IDENTITY: "/keys/agent.pkcs8",
+        CF_HARNESS_FABRIC_SPACE: "my-space",
+        CF_HARNESS_FABRIC_CFC_POSTURE: "max-enforcement",
+      },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.fabricSession, {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcPosture: "max-enforcement",
+  });
+});
+
+Deno.test("parseCfHarnessCliArgs rejects an unknown fabric CFC posture", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--fabric-api-url",
+          "https://toolshed.example/",
+          "--fabric-identity",
+          "keys/agent.pkcs8",
+          "--fabric-space",
+          "my-space",
+          "--fabric-cfc-posture",
+          "maximum",
+        ],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--fabric-cfc-posture must be max-enforcement",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects the fabric CFC posture without a fabric session", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--fabric-cfc-posture",
+          "max-enforcement",
+        ],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "need --fabric-api-url, --fabric-identity, and --fabric-space",
+  );
+});
+
 Deno.test("parseCfHarnessCliArgs rejects fabric CFC dials without a fabric session", async () => {
   await assertRejects(
     () =>

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2247,6 +2247,63 @@ Deno.test("runCfHarnessCli registers and disposes signal handlers around a run",
   ]);
 });
 
+Deno.test("runCfHarnessCli prints the fabric-session posture bundle in the operator summary", async () => {
+  const { io, stdout } = createIoBuffers();
+  const exitCode = await runCfHarnessCli(
+    [
+      "--model-provider",
+      "openai-compatible-gateway",
+      "--prompt",
+      "hello",
+      "--gateway-auth-mode",
+      "none",
+    ],
+    {
+      io,
+      env: {},
+      createPromptLoop: () => ({
+        runPrompt: () =>
+          Promise.resolve(
+            ({
+              model: "gpt-5.4",
+              finalAssistantText: "Done.",
+              transcript: [],
+              modelTurns: 1,
+              runState: {
+                runId: "run-postured-summary",
+                status: "completed",
+                createdAt: "2026-04-16T20:10:00.000Z",
+                updatedAt: "2026-04-16T20:10:01.000Z",
+                cfcEnforcementMode: "enforce-explicit",
+                fabricSessionCfc: {
+                  enforcementMode: "enforce-explicit",
+                  enforcementModeSource: "preset-pin",
+                  flowLabels: "persist",
+                  flowLabelsSource: "posture",
+                  posture: "max-enforcement",
+                },
+                currentDir: "/workspace",
+                policyEvents: [],
+                toolOutputs: [],
+              },
+            }) satisfies HarnessPromptLoopResult,
+          ),
+        runTranscript: () =>
+          Promise.reject(new Error("unexpected resume path")),
+      }),
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  const summary = stdout.join("");
+  assertEquals(
+    summary.includes(
+      "fabricSessionCfc: enforce-explicit (preset-pin), flow-labels persist (posture), posture max-enforcement",
+    ),
+    true,
+  );
+});
+
 Deno.test("runCfHarnessCli executes the prompt loop and prints result metadata", async () => {
   const { io, stdout, stderr } = createIoBuffers();
   let createdOptions: Record<string, unknown> | undefined;

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -189,6 +189,25 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
     flowLabelsSource: "default",
   });
 
+  // The named bundle supplies persist when the operator selects the posture
+  // and leaves the flow-labels dial unset; a configured dial would still win.
+  const postured = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+      cfcPosture: "max-enforcement",
+    },
+  });
+  assertEquals(postured.getRunState().fabricSessionCfc, {
+    enforcementMode: "enforce-explicit",
+    enforcementModeSource: "preset-pin",
+    flowLabels: "persist",
+    flowLabelsSource: "posture",
+    posture: "max-enforcement",
+  });
+
   const sessionless = new CfHarnessEngine({
     workspaceHostPath: "/host/project",
   });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -267,6 +267,35 @@ Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that
     detached.getRunState().fabricSessionCfc?.posture,
     "max-enforcement",
   );
+
+  // A legacy record (no posture ever captured) stays frozen as history:
+  // plain session dials may restate the original invocation, but the named
+  // bundle cannot have been what the run ran, so a posture resume is refused.
+  const legacyState = {
+    ...runState,
+    fabricSessionCfc: undefined,
+  } as typeof runState;
+  const legacyWithDials = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: {
+      apiUrl: posturedSession.apiUrl,
+      identityKeyPath: posturedSession.identityKeyPath,
+      space: posturedSession.space,
+      cfcEnforcementMode: "enforce-strict",
+    },
+    runState: legacyState,
+  });
+  assertEquals(legacyWithDials.getRunState().fabricSessionCfc, undefined);
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: posturedSession,
+        runState: legacyState,
+      }),
+    Error,
+    "records no fabric-session posture",
+  );
 });
 
 Deno.test("CfHarnessEngine grants no well-known handles without a fabric session", async () => {

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -214,6 +214,61 @@ Deno.test("CfHarnessEngine records the fabric session's resolved CFC posture in 
   assertEquals(sessionless.getRunState().fabricSessionCfc, undefined);
 });
 
+Deno.test("CfHarnessEngine refuses to resume under a fabric-session posture that contradicts the recorded one", () => {
+  const posturedSession = {
+    apiUrl: "https://toolshed.example/",
+    identityKeyPath: "/keys/agent.pkcs8",
+    space: "my-space",
+    cfcPosture: "max-enforcement",
+  } as const;
+  const runState = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: posturedSession,
+  }).getRunState();
+
+  // The contradiction: the artifacts claim max-enforcement while the session
+  // the resumed engine would actually build runs the default posture.
+  assertThrows(
+    () =>
+      new CfHarnessEngine({
+        workspaceHostPath: "/host/project",
+        fabricSession: {
+          apiUrl: posturedSession.apiUrl,
+          identityKeyPath: posturedSession.identityKeyPath,
+          space: posturedSession.space,
+        },
+        runState,
+      }),
+    Error,
+    "fabric session CFC posture mismatch on resume",
+  );
+
+  // The same session configuration resumes cleanly, record unchanged.
+  const resumed = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    fabricSession: posturedSession,
+    runState,
+  });
+  assertEquals(resumed.getRunState().fabricSessionCfc, {
+    enforcementMode: "enforce-explicit",
+    enforcementModeSource: "preset-pin",
+    flowLabels: "persist",
+    flowLabelsSource: "posture",
+    posture: "max-enforcement",
+  });
+
+  // A resume with no session at all keeps the record as history: no runtime
+  // exists for it to contradict.
+  const detached = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    runState,
+  });
+  assertEquals(
+    detached.getRunState().fabricSessionCfc?.posture,
+    "max-enforcement",
+  );
+});
+
 Deno.test("CfHarnessEngine grants no well-known handles without a fabric session", async () => {
   const engine = new CfHarnessEngine({
     workspaceHostPath: "/host/project",

--- a/packages/cf-harness/test/fabric-session.test.ts
+++ b/packages/cf-harness/test/fabric-session.test.ts
@@ -3,9 +3,39 @@ import { expect } from "@std/expect";
 import {
   cacheHarnessFabricSessionFactory,
   type HarnessFabricSession,
+  harnessFabricSessionControllerOptions,
 } from "../src/fabric-session.ts";
 
 describe("fabric-session", () => {
+  describe("harnessFabricSessionControllerOptions()", () => {
+    const base = {
+      apiUrl: "https://toolshed.example/",
+      identityKeyPath: "/keys/agent.pkcs8",
+      space: "my-space",
+    };
+
+    it("resolves the space and API URL and carries no dial the config omits", () => {
+      const options = harnessFabricSessionControllerOptions(base);
+      expect(options.apiUrl.href).toBe("https://toolshed.example/");
+      expect(options.space).toBe("my-space");
+      expect("cfcEnforcementMode" in options).toBe(false);
+      expect("cfcFlowLabels" in options).toBe(false);
+      expect("cfcPosture" in options).toBe(false);
+    });
+
+    it("carries every dial the config sets, posture included", () => {
+      const options = harnessFabricSessionControllerOptions({
+        ...base,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+        cfcPosture: "max-enforcement",
+      });
+      expect(options.cfcEnforcementMode).toBe("enforce-strict");
+      expect(options.cfcFlowLabels).toBe("persist");
+      expect(options.cfcPosture).toBe("max-enforcement");
+    });
+  });
+
   describe("cacheHarnessFabricSessionFactory()", () => {
     it("returns the same session promise for every call", async () => {
       let calls = 0;

--- a/packages/cf-harness/test/run-report.test.ts
+++ b/packages/cf-harness/test/run-report.test.ts
@@ -34,6 +34,52 @@ Deno.test("legacy run reports remain readable without provider metadata", async 
   }
 });
 
+Deno.test("run reports carry the fabric session's resolved CFC posture", () => {
+  const fabricSessionCfc = {
+    enforcementMode: "enforce-strict",
+    enforcementModeSource: "configured",
+    flowLabels: "persist",
+    flowLabelsSource: "posture",
+    posture: "max-enforcement",
+  } as const;
+  const report = createHarnessRunReport({
+    runState: {
+      runId: "postured-state",
+      status: "completed",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      cfcEnforcementMode: "enforce-explicit",
+      fabricSessionCfc,
+      policyEvents: [],
+      policyDecisions: [],
+      toolOutputs: [],
+    },
+    model: "postured-model",
+    modelTurns: 1,
+    toolActivity: [],
+  });
+
+  assertEquals(report.fabricSessionCfc, fabricSessionCfc);
+});
+
+Deno.test("run reports omit the fabric-session posture when the run had no session", () => {
+  const report = createHarnessRunReport({
+    runState: {
+      runId: "sessionless-state",
+      status: "completed",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      cfcEnforcementMode: "disabled",
+      policyEvents: [],
+      policyDecisions: [],
+      toolOutputs: [],
+    },
+    model: "sessionless-model",
+    modelTurns: 1,
+    toolActivity: [],
+  });
+
+  assertEquals("fabricSessionCfc" in report, false);
+});
+
 Deno.test("run reports do not invent API-key auth for legacy run state", () => {
   const report = createHarnessRunReport({
     runState: {

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -55,6 +55,7 @@ import {
   setPatternSource,
   type SpaceCellContents,
 } from "@commonfabric/runner";
+import type { CfcPosture } from "@commonfabric/runner";
 import type {
   CfcEnforcementMode,
   CfcFlowLabelsMode,
@@ -269,6 +270,7 @@ export class PiecesController<T = unknown> {
       navigateCallback,
       cfcEnforcementMode,
       cfcFlowLabels,
+      cfcPosture,
     }: {
       apiUrl: URL | string;
       identity: Identity;
@@ -302,6 +304,10 @@ export class PiecesController<T = unknown> {
       // preset; unset means the preset's first-party posture.
       cfcEnforcementMode?: CfcEnforcementMode;
       cfcFlowLabels?: CfcFlowLabelsMode;
+      // Named CFC posture bundle for this controller's runtime (the
+      // remoteClient preset's `cfcPosture` opt-in); the two dials above still
+      // apply over it.
+      cfcPosture?: CfcPosture;
     },
   ): Promise<PiecesController> {
     const api = new URL(apiUrl);
@@ -334,6 +340,7 @@ export class PiecesController<T = unknown> {
       patternCoverage,
       ...(cfcEnforcementMode !== undefined ? { cfcEnforcementMode } : {}),
       ...(cfcFlowLabels !== undefined ? { cfcFlowLabels } : {}),
+      ...(cfcPosture !== undefined ? { cfcPosture } : {}),
       ...(navigateCallback !== undefined ? { navigateCallback } : {}),
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -736,7 +736,17 @@ const resolveSingleUseGrant = (
  */
 export const createTxCfcGrantResolver = (
   tx: IExtendedStorageTransaction,
-  opts: { readonly now?: () => number } = {},
+  opts: {
+    readonly now?: () => number;
+    /**
+     * Invoked when a grant lookup could not be READ (the catch arm below) —
+     * as opposed to resolving to no facts. A boundary decision that consults
+     * this resolver is only a deterministic verdict when no lookup was
+     * unavailable: an unsynced grant might discharge on the attempt that
+     * syncs it, so the caller uses this to withhold the terminal tag.
+     */
+    readonly onUnavailable?: () => void;
+  } = {},
 ): CfcGrantResolver => {
   const now = opts.now ?? Date.now;
   const memo = new Map<string, readonly CfcAtom[]>();
@@ -797,7 +807,12 @@ export const createTxCfcGrantResolver = (
       // unsynced replica, storage failure): the grant does not resolve; the
       // §4.9.3 posture. Nothing is memoized or recorded on this path — a
       // candidate that could not be read never produced a value this
-      // decision could have consumed.
+      // decision could have consumed. Reported as UNAVAILABLE rather than
+      // absent, conservatively covering the deterministic arms too (an
+      // undigestable bound field refuses identically every time): the cost
+      // of over-reporting is a bounded retry, the cost of under-reporting is
+      // a write that never lands.
+      opts.onUnavailable?.();
       return [];
     }
     return facts;

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -739,13 +739,13 @@ export const createTxCfcGrantResolver = (
   opts: {
     readonly now?: () => number;
     /**
-     * Invoked when a grant lookup could not be READ (the catch arm below) —
-     * as opposed to resolving to no facts. A boundary decision that consults
-     * this resolver is only a deterministic verdict when no lookup was
-     * unavailable: an unsynced grant might discharge on the attempt that
-     * syncs it, so the caller uses this to withhold the terminal tag.
+     * Out-record set when a grant lookup could not be READ (the catch arm
+     * below) — as opposed to resolving to no facts. A boundary decision that
+     * consults this resolver is only a deterministic verdict when no lookup
+     * was unavailable: an unsynced grant might discharge on the attempt that
+     * syncs it, so the caller reads this to withhold the terminal tag.
      */
-    readonly onUnavailable?: () => void;
+    readonly availability?: { unavailable: boolean };
   } = {},
 ): CfcGrantResolver => {
   const now = opts.now ?? Date.now;
@@ -812,7 +812,7 @@ export const createTxCfcGrantResolver = (
       // undigestable bound field refuses identically every time): the cost
       // of over-reporting is a bounded retry, the cost of under-reporting is
       // a write that never lands.
-      opts.onUnavailable?.();
+      if (opts.availability !== undefined) opts.availability.unavailable = true;
       return [];
     }
     return facts;

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4943,8 +4943,11 @@ const evaluateGatedConfidentiality = (
     readonly reference: unknown;
     readonly reason: string;
   }[];
+  /** A grant lookup could not be read; see `createTxCfcGrantResolver`. */
+  grantResolutionUnavailable: boolean;
 } => {
   const state = tx.getCfcState();
+  let grantResolutionUnavailable = false;
   const result = evaluateExchangeRules(
     { confidentiality: [...confidentiality] },
     state.policySnapshot,
@@ -4959,7 +4962,11 @@ const evaluateGatedConfidentiality = (
       // consulted address+digest into the prepare state for the B5-style
       // digest binding. Rides the same cfcPolicyEvaluation dial as the rest
       // of this evaluation — this function only runs when the dial is on.
-      grantResolver: createTxCfcGrantResolver(tx),
+      grantResolver: createTxCfcGrantResolver(tx, {
+        onUnavailable: () => {
+          grantResolutionUnavailable = true;
+        },
+      }),
       grantConsumption: consumption,
       modulePolicyResolver: createTxCfcModulePolicyResolver(
         tx,
@@ -4982,6 +4989,7 @@ const evaluateGatedConfidentiality = (
     exhausted: result.exhausted,
     firings: result.firings.length,
     resolutionFailures: result.resolutionFailures,
+    grantResolutionUnavailable,
   };
 };
 
@@ -5035,12 +5043,12 @@ const verifySinkRequestCeilings = (
   for (const [sink, ceiling] of gatedSinks) {
     let effective = consumed.confidentiality;
     // Whether the fits-decision below is a pure function of this
-    // transaction's data — a VERDICT (see verdict-reason.ts). Only one thing
-    // makes it not: an enforce-mode rewrite that could not resolve a module
-    // policy manifest, because the discharge that manifest carries might have
-    // admitted the request on an attempt that resolves it. `off` and
-    // `observe` decide on the raw label every time, so their refusal is
-    // always a verdict.
+    // transaction's data — a VERDICT (see verdict-reason.ts). Two things
+    // make it not, both enforce-mode availability holes in the rewrite: a
+    // module policy manifest that did not resolve, and a grant lookup that
+    // could not be read — either might carry the discharge that admits the
+    // request on an attempt that resolves it. `off` and `observe` decide on
+    // the raw label every time, so their refusal is always a verdict.
     let verdict = true;
     if (mode !== "off") {
       // Boundary context for this release site (spec §8.10.5 / §15.4): the
@@ -5091,7 +5099,8 @@ const verifySinkRequestCeilings = (
           continue;
         }
         effective = outcome.confidentiality;
-        verdict = outcome.resolutionFailures.length === 0;
+        verdict = outcome.resolutionFailures.length === 0 &&
+          !outcome.grantResolutionUnavailable;
       } else {
         // observe: decide exactly as `off` would; diagnose what enforce
         // would have done differently.

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3755,7 +3755,11 @@ const verifyInputRequirements = (
           const fits = outcome.exhausted === false &&
             atomsOutsideCeiling(outcome.confidentiality, maxConfidentiality)
                 .length === 0;
-          if (!fits && outcome.resolutionFailures.length > 0) {
+          if (
+            !fits &&
+            (outcome.resolutionFailures.length > 0 ||
+              outcome.grantResolutionUnavailable)
+          ) {
             // The miss was evaluated over a manifest or grant that did not
             // resolve, so the label kept atoms a rewrite might have cleared:
             // not a verdict (see the return-type note above).
@@ -4947,7 +4951,7 @@ const evaluateGatedConfidentiality = (
   grantResolutionUnavailable: boolean;
 } => {
   const state = tx.getCfcState();
-  let grantResolutionUnavailable = false;
+  const grantAvailability = { unavailable: false };
   const result = evaluateExchangeRules(
     { confidentiality: [...confidentiality] },
     state.policySnapshot,
@@ -4963,9 +4967,7 @@ const evaluateGatedConfidentiality = (
       // digest binding. Rides the same cfcPolicyEvaluation dial as the rest
       // of this evaluation — this function only runs when the dial is on.
       grantResolver: createTxCfcGrantResolver(tx, {
-        onUnavailable: () => {
-          grantResolutionUnavailable = true;
-        },
+        availability: grantAvailability,
       }),
       grantConsumption: consumption,
       modulePolicyResolver: createTxCfcModulePolicyResolver(
@@ -4989,7 +4991,7 @@ const evaluateGatedConfidentiality = (
     exhausted: result.exhausted,
     firings: result.firings.length,
     resolutionFailures: result.resolutionFailures,
-    grantResolutionUnavailable,
+    grantResolutionUnavailable: grantAvailability.unavailable,
   };
 };
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -5034,6 +5034,14 @@ const verifySinkRequestCeilings = (
   const reasons: string[] = [];
   for (const [sink, ceiling] of gatedSinks) {
     let effective = consumed.confidentiality;
+    // Whether the fits-decision below is a pure function of this
+    // transaction's data — a VERDICT (see verdict-reason.ts). Only one thing
+    // makes it not: an enforce-mode rewrite that could not resolve a module
+    // policy manifest, because the discharge that manifest carries might have
+    // admitted the request on an attempt that resolves it. `off` and
+    // `observe` decide on the raw label every time, so their refusal is
+    // always a verdict.
+    let verdict = true;
     if (mode !== "off") {
       // Boundary context for this release site (spec §8.10.5 / §15.4): the
       // sink name plus its class. Every sink in the initial inventory is a
@@ -5083,6 +5091,7 @@ const verifySinkRequestCeilings = (
           continue;
         }
         effective = outcome.confidentiality;
+        verdict = outcome.resolutionFailures.length === 0;
       } else {
         // observe: decide exactly as `off` would; diagnose what enforce
         // would have done differently.
@@ -5123,10 +5132,10 @@ const verifySinkRequestCeilings = (
     if (offending.length > 0) {
       // Name the offending atom(s) so an observe-mode diagnostic identifies the
       // exact (sink, atom) pair that needs a ceiling entry (review on #3993).
-      reasons.push(
-        `sink-request confidentiality exceeds ceiling for ${sink}: ` +
-          offending.map((atom) => JSON.stringify(atom)).join(", "),
-      );
+      const reason = `sink-request confidentiality exceeds ceiling for ` +
+        `${sink}: ` +
+        offending.map((atom) => JSON.stringify(atom)).join(", ");
+      reasons.push(verdict ? verdictReason(reason) : reason);
     }
   }
   return reasons;

--- a/packages/runner/src/cfc/verdict-reason.ts
+++ b/packages/runner/src/cfc/verdict-reason.ts
@@ -33,10 +33,11 @@
 // every reason was a verdict unless marked. A producer audit found that false
 // in both directions — several families are mixed, and several DISCARD an
 // availability reason they received upstream (`verifyWriteFloor` drops
-// `derivePersistedLinkLabel`'s, and the sink-ceiling path collapses
-// `resolutionFailures` into a generic message; the `maxConfidentiality`
-// input gate reports its resolution failures and withholds the tag) — so an
-// untagged
+// `derivePersistedLinkLabel`'s; the `maxConfidentiality` input gate reports
+// its resolution failures and withholds the tag; the sink-ceiling gate tags
+// its refusal only when its enforce-mode rewrite resolved every module
+// policy, since an unresolved manifest might carry the discharge that admits
+// the request) — so an untagged
 // reason cannot be assumed deterministic. Tagging the verdicts is the claim a
 // producer can actually make about itself.
 //

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -28,6 +28,7 @@ export type {
 export {
   ADOPT_SERVER_FLAGS_ENV,
   type BrowserWorkerPresetParams,
+  type CfcPosture,
   type DeployedClientExperimentalParams,
   type EnvReader,
   EXPERIMENTAL_ENV_VARS,
@@ -35,6 +36,8 @@ export {
   type ExperimentalFlagAuthority,
   experimentalOptionsForDeployedClient,
   experimentalOptionsFromEnv,
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
   type PatternTestPresetParams,
   type ProductionServerPresetParams,
   type RemoteClientPresetParams,

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -528,15 +528,20 @@ export type CfcPosture = "max-enforcement";
 /**
  * Confidentiality ceilings of the max-enforcement posture: every network-fetch
  * egress sink is public-only (an empty ceiling admits no confidential atom),
- * so labeled data cannot leave over the network at all.
+ * so labeled data cannot leave through the network-fetch sinks.
  *
- * The llm sinks (`llm`, `llmDialog`, `generateText`, `generateObject`) are
- * deliberately NOT ceilinged. Ceiling membership is exact clause subsumption
- * (`atomsOutsideCeiling`) — a ceiling entry cannot admit "any material-risk
- * caveat regardless of `source`" — and risk-caveated ingested content is
- * exactly what an llm sink exists to process. Those flows are governed by the
- * §10.1 caveat policy this posture also carries, and by the llmDialog CFC
- * gates, not by an enumerable atom allowlist.
+ * The llm sinks (`llm`, `llmDialog`, `generateText`, `generateObject`) carry
+ * no ceiling, and a sink with no ceiling gets NO gate: under this posture,
+ * llm-sink release is ungoverned — any confidentiality, a secret as much as a
+ * risk caveat, reaches the llm sinks without a policy evaluation running for
+ * them. Ungated rather than public-only because ceiling membership is exact
+ * clause subsumption (`atomsOutsideCeiling`) — a ceiling entry cannot admit
+ * "any material-risk caveat regardless of `source`" — while risk-caveated
+ * ingested content is exactly what an llm sink exists to process, so a
+ * public-only ceiling would refuse the flows the sink is for. Governing llm
+ * release needs a boundary-scoped admission mechanism (a public-only ceiling
+ * paired with an exchange rule that admits the material-risk family at
+ * llm-class boundaries), which this posture does not yet carry.
  */
 export const MAX_ENFORCEMENT_SINK_CEILINGS: SinkMaxConfidentiality = Object
   .freeze({

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -112,14 +112,22 @@
  * |                            | toolshed ExecutorHost wiring and the executor    |
  * |                            | test harnesses) marks the serving posture, and   |
  * |                            | it hand-rolls its options deliberately           |
+ *
+ * One named departure a caller can opt into: `cfcPosture: "max-enforcement"`
+ * (a `CoreParams` field) swaps the core-default CFC dial rows above for the
+ * {@link MAX_ENFORCEMENT_CFC_OPTIONS} bundle, for that one runtime. The
+ * per-preset host dials (`cfcEnforcementMode`, `cfcFlowLabels`) still apply
+ * over the bundle, so a session-level raise wins either way.
  */
 
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import type {
   CfcEnforcementMode,
   CfcFlowLabelsMode,
+  SinkMaxConfidentiality,
   TrustSnapshot,
 } from "./cfc/mod.ts";
+import { STANDARD_PROMPT_CAVEAT_POLICY } from "./cfc/mod.ts";
 import type { CommitBackpressurePolicy } from "./scheduler/backpressure.ts";
 import type { PatternCoverageCollector } from "./pattern-coverage.ts";
 import type { IStorageManager } from "./storage/interface.ts";
@@ -507,6 +515,72 @@ export async function experimentalOptionsForDeployedClient(
 }
 
 // ---------------------------------------------------------------------------
+// The max-enforcement CFC posture (CT-2075's named bundle).
+// ---------------------------------------------------------------------------
+
+/**
+ * Names of the CFC posture bundles a preset caller can opt into. One posture
+ * exists today; the type is here so the next one is an addition, not a
+ * redesign.
+ */
+export type CfcPosture = "max-enforcement";
+
+/**
+ * Confidentiality ceilings of the max-enforcement posture: every network-fetch
+ * egress sink is public-only (an empty ceiling admits no confidential atom),
+ * so labeled data cannot leave over the network at all.
+ *
+ * The llm sinks (`llm`, `llmDialog`, `generateText`, `generateObject`) are
+ * deliberately NOT ceilinged. Ceiling membership is exact clause subsumption
+ * (`atomsOutsideCeiling`) — a ceiling entry cannot admit "any material-risk
+ * caveat regardless of `source`" — and risk-caveated ingested content is
+ * exactly what an llm sink exists to process. Those flows are governed by the
+ * §10.1 caveat policy this posture also carries, and by the llmDialog CFC
+ * gates, not by an enumerable atom allowlist.
+ */
+export const MAX_ENFORCEMENT_SINK_CEILINGS: SinkMaxConfidentiality = Object
+  .freeze({
+    fetchBinary: Object.freeze([]),
+    fetchText: Object.freeze([]),
+    fetchJson: Object.freeze([]),
+    fetchJsonUnchecked: Object.freeze([]),
+    fetchProgram: Object.freeze([]),
+    streamData: Object.freeze([]),
+  });
+
+/**
+ * The max-enforcement CFC posture: every staged-rollout enforcement dial at
+ * its enforcing value, as one named opt-in bundle (CT-2075 ran them together
+ * and found they co-exist as one system; this is that experiment's dial set,
+ * landed at the seam it designated). A preset caller opts in through
+ * {@link CoreParams.cfcPosture}; the fleet posture in {@link coreOptions}
+ * is unchanged.
+ *
+ * Deliberately NOT in the bundle:
+ * - `cfcEnforcementMode` — the core pin (`enforce-explicit`) stands; a host
+ *   raises one session to `enforce-strict` through its own preset dial
+ *   (remoteClient/browserWorker), and the bundle's `persist` flow labels are
+ *   what make that raise conform (strict requires persist).
+ * - `cfcDecomposedEnvelopes` — gated on every deployed reader resolving
+ *   stored roots' references, a readiness question, not an enforcement one.
+ * - `cfcTrustConfig` — deployment-specific declarations; nothing generic to
+ *   bundle.
+ * - `cfcPrefixProvenanceStats` — measurement, not enforcement.
+ */
+export const MAX_ENFORCEMENT_CFC_OPTIONS = Object.freeze(
+  {
+    cfcFlowLabels: "persist",
+    cfcWriteFloor: "enforce",
+    cfcTriggerReadGating: true,
+    cfcPolicyEvaluation: "enforce",
+    cfcPolicyRecords: Object.freeze([...STANDARD_PROMPT_CAVEAT_POLICY]),
+    cfcDeclaredMonotonicity: "enforce",
+    cfcLabelMetadataProtection: "enforce",
+    cfcSinkMaxConfidentiality: MAX_ENFORCEMENT_SINK_CEILINGS,
+  } as const,
+) satisfies Partial<RuntimeOptions>;
+
+// ---------------------------------------------------------------------------
 // Gate 4: the shared core all presets compose.
 // ---------------------------------------------------------------------------
 
@@ -523,6 +597,14 @@ interface CoreParams {
    * where an omitted field was silent drift.
    */
   experimental: ExperimentalOptions;
+  /**
+   * Opt this runtime into a named CFC posture bundle
+   * ({@link MAX_ENFORCEMENT_CFC_OPTIONS}). Applied in {@link coreOptions},
+   * under the per-preset host dials, so a host that raises
+   * `cfcEnforcementMode` or `cfcFlowLabels` for one session still wins.
+   * Unset means the fleet posture: the core pin plus constructor defaults.
+   */
+  cfcPosture?: CfcPosture;
 }
 
 /**
@@ -569,7 +651,11 @@ function coreOptions(params: CoreParams): RuntimeOptions {
     // cfcDeclaredMonotonicity / cfcPolicyRecords /
     // cfcTrustConfig / cfcSinkMaxConfidentiality ride the constructor
     // defaults (off / none) — deliberately absent here until a first-party
-    // rollout begins.
+    // rollout begins. A caller that opts into `cfcPosture` gets the named
+    // bundle's values instead, for this one runtime.
+    ...(params.cfcPosture === "max-enforcement"
+      ? MAX_ENFORCEMENT_CFC_OPTIONS
+      : {}),
   };
 }
 

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -1204,7 +1204,10 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
         recordCfcConsultedGrant: (entry: unknown) => consulted.push(entry),
         noteCfcDiagnostic: () => {},
       } as unknown as IExtendedStorageTransaction;
-      const resolver = createTxCfcGrantResolver(throwingTx);
+      let unavailable = 0;
+      const resolver = createTxCfcGrantResolver(throwingTx, {
+        onUnavailable: () => unavailable++,
+      });
       expect(
         resolver({
           kind: "ShareGrant",
@@ -1212,6 +1215,31 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
         }),
       ).toEqual([]);
       expect(consulted).toEqual([]);
+      // Reported as UNAVAILABLE, not as an absent grant: a boundary refusal
+      // that consulted this lookup must stay retryable rather than terminal
+      // (the sink-ceiling verdict tag withholds itself on this signal).
+      expect(unavailable).toBe(1);
+    });
+
+    it("does not report unavailability for a grant that reads as absent", () => {
+      const absentTx = {
+        readOrThrow: () => undefined,
+        recordCfcConsultedGrant: () => {},
+        noteCfcDiagnostic: () => {},
+      } as unknown as IExtendedStorageTransaction;
+      let unavailable = 0;
+      const resolver = createTxCfcGrantResolver(absentTx, {
+        onUnavailable: () => unavailable++,
+      });
+      expect(
+        resolver({
+          kind: "ShareGrant",
+          fields: { owner: ALICE, resource: PHOTO_REF },
+        }),
+      ).toEqual([]);
+      // An absent grant is a real answer — no facts — and a refusal decided
+      // on it is deterministic, so the tag-withholding signal must not fire.
+      expect(unavailable).toBe(0);
     });
 
     it("notes a diagnostic for a malformed stored document", async () => {

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -1204,10 +1204,8 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
         recordCfcConsultedGrant: (entry: unknown) => consulted.push(entry),
         noteCfcDiagnostic: () => {},
       } as unknown as IExtendedStorageTransaction;
-      let unavailable = 0;
-      const resolver = createTxCfcGrantResolver(throwingTx, {
-        onUnavailable: () => unavailable++,
-      });
+      const availability = { unavailable: false };
+      const resolver = createTxCfcGrantResolver(throwingTx, { availability });
       expect(
         resolver({
           kind: "ShareGrant",
@@ -1218,7 +1216,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
       // Reported as UNAVAILABLE, not as an absent grant: a boundary refusal
       // that consulted this lookup must stay retryable rather than terminal
       // (the sink-ceiling verdict tag withholds itself on this signal).
-      expect(unavailable).toBe(1);
+      expect(availability.unavailable).toBe(true);
     });
 
     it("does not report unavailability for a grant that reads as absent", () => {
@@ -1227,10 +1225,8 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
         recordCfcConsultedGrant: () => {},
         noteCfcDiagnostic: () => {},
       } as unknown as IExtendedStorageTransaction;
-      let unavailable = 0;
-      const resolver = createTxCfcGrantResolver(absentTx, {
-        onUnavailable: () => unavailable++,
-      });
+      const availability = { unavailable: false };
+      const resolver = createTxCfcGrantResolver(absentTx, { availability });
       expect(
         resolver({
           kind: "ShareGrant",
@@ -1239,7 +1235,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
       ).toEqual([]);
       // An absent grant is a real answer — no facts — and a refusal decided
       // on it is deterministic, so the tag-withholding signal must not fire.
-      expect(unavailable).toBe(0);
+      expect(availability.unavailable).toBe(false);
     });
 
     it("notes a diagnostic for a malformed stored document", async () => {

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The max-enforcement CFC posture as one running system (CT-2075's follow-on
+ * to the preset goldens in `runtime-presets.test.ts`, which pin the bundle's
+ * SHAPE). CT-2075 found two of the bundle's dials load and run without ever
+ * demonstrably firing in ordinary flows — "on and silent" is not "verified
+ * enforcing" — so each test here makes one of them decide an outcome that
+ * the same flow without the dial would decide the other way:
+ *
+ * - policy evaluation: an egress fits the bundle's public-only network
+ *   ceiling ONLY because the §10.1 value-screened discharge dropped the
+ *   caveat clause first — and refuses without the screening evidence;
+ * - trigger-read gating: a scheduled egress that never re-reads the secret
+ *   that triggered it is still held to the sink ceiling;
+ * - refusal-as-event: the ceiling refusal of a reactive action's commit is
+ *   terminal and reaches the scheduler's error channel with its reasons,
+ *   rather than reading as a healthy, quietly empty piece.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { CFC_CONCEPT_KIND, cfcAtom } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { runtimePresets } from "../src/runtime-presets.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import type { JSONSchema, JSONValue } from "../src/builder/types.ts";
+import type { Cell } from "../src/cell.ts";
+import type { IFCLabel } from "../src/cfc/mod.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import type { Action, ErrorWithContext } from "../src/scheduler.ts";
+
+const signer = await Identity.fromPassphrase("runner-max-enforcement-posture");
+
+const makePostureRuntime = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  errorHandlers?: ((error: ErrorWithContext) => void)[],
+) =>
+  new Runtime(runtimePresets.unitTest({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+    cfcPosture: "max-enforcement",
+    ...(errorHandlers !== undefined ? { errorHandlers } : {}),
+  }));
+
+const SOURCE_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: { secret: { type: "string" } },
+    required: ["secret"],
+  } satisfies JSONSchema,
+  true,
+);
+
+/**
+ * Seed a cell whose `/secret` carries `label` as persisted store-policy
+ * metadata — integrity evidence included, which is how screening evidence
+ * actually travels with a value (a schema `ifc` declaration carries only the
+ * declared components, not per-value evidence). The seed itself commits under
+ * the full bundle, so the posture's metadata-protection and monotonicity
+ * dials sign off on it too.
+ */
+const seedSource = async (
+  runtime: Runtime,
+  id: string,
+  label: IFCLabel,
+): Promise<Cell<{ secret: string }>> => {
+  const tx = runtime.edit();
+  const source = runtime.getCell<{ secret: string }>(
+    signer.did(),
+    id,
+    SOURCE_SCHEMA.schema,
+    tx,
+  );
+  const sourceId = source.getAsNormalizedFullLink().id;
+  tx.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: sourceId,
+    path: [],
+  }, {
+    value: { secret: "rosebud" },
+    cfc: {
+      version: 1,
+      schemaHash: SOURCE_SCHEMA.taggedHashString,
+      labelMap: { version: 1, entries: [{ path: ["secret"], label }] },
+    },
+  });
+  tx.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: `cid:${SOURCE_SCHEMA.taggedHashString}`,
+    path: [],
+  }, { value: SOURCE_SCHEMA.schema });
+  expect((await tx.commit()).error).toBeUndefined();
+  return source;
+};
+
+/**
+ * One egress attempt: read the labeled source, enqueue a `fetchText` sink
+ * request, prepare, and hand back the prepare refusal reasons (empty when
+ * the request fits). Aborts rather than commits — the verdict under test is
+ * prepare's.
+ */
+const readThenEgress = (
+  runtime: Runtime,
+  source: Cell<{ secret: string }>,
+): string[] => {
+  const tx = runtime.edit();
+  expect(source.withTx(tx).get()?.secret).toBe("rosebud");
+  enqueueSinkRequestPostCommitEffect(
+    tx,
+    "fetchText",
+    "fetchText:max-enforcement-posture",
+    createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+    "fetchText-start",
+    () => {},
+  );
+  tx.prepareCfc();
+  const state = tx.getCfcState();
+  const reasons = state.prepare.status === "invalidated"
+    ? [...state.prepare.reasons]
+    : [];
+  tx.abort();
+  return reasons;
+};
+
+const withPostureRuntime = async (
+  body: (runtime: Runtime, space: MemorySpace) => Promise<void>,
+  errorHandlers?: ((error: ErrorWithContext) => void)[],
+): Promise<void> => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = makePostureRuntime(storageManager, errorHandlers);
+  try {
+    await body(runtime, signer.did());
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+};
+
+describe("max-enforcement CFC posture as one system (CT-2075)", () => {
+  describe("policy evaluation decides an egress under the bundle", () => {
+    const source = "of:screened-ingest";
+    const valueScreenedCaveat = cfcAtom.caveat(
+      CFC_CONCEPT_KIND.PromptInjectionRiskValueScreened,
+      source,
+    ) as JSONValue;
+    const freshValueEvidence = cfcAtom.caveatScreened({
+      kind: CFC_CONCEPT_KIND.PromptInjectionRiskValueScreened,
+      source,
+      stage: "value",
+      detector: cfcAtom.builtin("detector"),
+      verdict: "pass",
+      valueRef: { "/": "value-doc" },
+    }) as JSONValue;
+
+    it("admits a screened value: the §10.1 discharge is what fits the public-only ceiling", async () => {
+      await withPostureRuntime(async (runtime) => {
+        const cell = await seedSource(
+          runtime,
+          "posture-screened-source",
+          {
+            confidentiality: [valueScreenedCaveat],
+            integrity: [freshValueEvidence],
+          },
+        );
+        // The raw label carries the caveat, which the empty `fetchText`
+        // ceiling admits nothing of. Fitting is only possible because the
+        // bundle's policy records ran and the value-stage evidence
+        // discharged the clause — the dial demonstrably fired.
+        expect(readThenEgress(runtime, cell)).toEqual([]);
+      });
+    });
+
+    it("refuses the same egress without the screening evidence", async () => {
+      await withPostureRuntime(async (runtime) => {
+        const cell = await seedSource(
+          runtime,
+          "posture-unscreened-source",
+          { confidentiality: [valueScreenedCaveat] },
+        );
+        const reasons = readThenEgress(runtime, cell);
+        expect(reasons.length).toBeGreaterThan(0);
+        expect(reasons.join("\n")).toContain(
+          "exceeds ceiling for fetchText",
+        );
+      });
+    });
+  });
+
+  describe("trigger-read gating decides a scheduled egress under the bundle", () => {
+    it("holds an egress that never re-reads its triggering secret to the sink ceiling", async () => {
+      await withPostureRuntime(async (runtime, space) => {
+        const cell = await seedSource(
+          runtime,
+          "posture-trigger-secret",
+          { confidentiality: ["medical"] },
+        );
+        const secretId = cell.getAsNormalizedFullLink().id;
+        const tx = runtime.edit();
+        runtime.getCell<{ v: string }>(space, "posture-trigger-out", {
+          type: "object",
+          properties: { v: { type: "string" } },
+        }, tx).set({ v: "computed" });
+        // The secret is recorded as what SCHEDULED this run; the run never
+        // reads it again. Without the gating dial the consumed set would not
+        // carry ["medical"] and the public-only ceiling would pass this.
+        tx.addCfcTriggerReads([{
+          space,
+          id: secretId,
+          type: "application/json",
+          path: ["value", "secret"],
+        }]);
+        enqueueSinkRequestPostCommitEffect(
+          tx,
+          "fetchJson",
+          "fetchJson:max-enforcement-posture",
+          createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+          "fetchJson-start",
+          () => {},
+        );
+        tx.prepareCfc();
+        const result = await tx.commit();
+        expect(result.error).toBeDefined();
+        expect(String((result.error as Error).message)).toContain(
+          "exceeds ceiling for fetchJson",
+        );
+      });
+    });
+  });
+
+  describe("a ceiling refusal is a scheduler error event", () => {
+    it("surfaces the refused reactive egress on the error channel with its reasons", async () => {
+      const reported: ErrorWithContext[] = [];
+      await withPostureRuntime(async (runtime, space) => {
+        const cell = await seedSource(
+          runtime,
+          "posture-event-secret",
+          { confidentiality: ["medical"] },
+        );
+        const state = { runs: 0 };
+        const egress: Action = (tx) => {
+          state.runs++;
+          expect(cell.withTx(tx).get()?.secret).toBe("rosebud");
+          runtime.getCell<{ v: string }>(space, "posture-event-out", {
+            type: "object",
+            properties: { v: { type: "string" } },
+          }, tx).set({ v: "derived" });
+          enqueueSinkRequestPostCommitEffect(
+            tx,
+            "fetchText",
+            "fetchText:max-enforcement-event",
+            createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
+            "fetchText-start",
+            () => {},
+          );
+        };
+        runtime.scheduler.subscribe(egress, { isEffect: true });
+        await runtime.scheduler.idleWithPendingCommits();
+        // Terminal, not retried: the refusal is a deterministic verdict.
+        expect(state.runs).toBe(1);
+        expect(reported.length).toBe(1);
+        expect(reported[0].name).toBe("CfcCommitRefusalError");
+        expect(String(reported[0].message)).toContain(
+          "exceeds ceiling for fetchText",
+        );
+      }, [(error) => reported.push(error)]);
+    });
+  });
+});

--- a/packages/runner/test/max-enforcement-posture.test.ts
+++ b/packages/runner/test/max-enforcement-posture.test.ts
@@ -98,23 +98,23 @@ const seedSource = async (
 };
 
 /**
- * One egress attempt: read the labeled source, enqueue a `fetchText` sink
- * request, prepare, and hand back the prepare refusal reasons (empty when
- * the request fits). Aborts rather than commits — the verdict under test is
- * prepare's.
+ * One egress attempt: read the labeled source, enqueue a sink request,
+ * prepare, and hand back the prepare refusal reasons (empty when the request
+ * fits). Aborts rather than commits — the verdict under test is prepare's.
  */
 const readThenEgress = (
   runtime: Runtime,
   source: Cell<{ secret: string }>,
+  sink = "fetchText",
 ): string[] => {
   const tx = runtime.edit();
   expect(source.withTx(tx).get()?.secret).toBe("rosebud");
   enqueueSinkRequestPostCommitEffect(
     tx,
-    "fetchText",
-    "fetchText:max-enforcement-posture",
+    sink,
+    `${sink}:max-enforcement-posture`,
     createFrozenRequestSnapshot({ url: "https://example.com/exfil" }),
-    "fetchText-start",
+    `${sink}-start`,
     () => {},
   );
   tx.prepareCfc();
@@ -186,6 +186,26 @@ describe("max-enforcement CFC posture as one system (CT-2075)", () => {
         expect(reasons.join("\n")).toContain(
           "exceeds ceiling for fetchText",
         );
+      });
+    });
+  });
+
+  describe("the llm sinks are ungoverned by the posture", () => {
+    it("lets a secret-labeled value reach the llm sink with no gate at all", async () => {
+      // Pins the DOCUMENTED gap, not a desired end state: a sink with no
+      // ceiling gets no gate, so under this posture any confidentiality — a
+      // secret as much as a risk caveat — reaches the llm sinks without a
+      // policy evaluation running for them. Governing llm release needs the
+      // boundary-scoped admission mechanism described on
+      // MAX_ENFORCEMENT_SINK_CEILINGS; when that lands, this test flips to
+      // asserting the refusal.
+      await withPostureRuntime(async (runtime) => {
+        const cell = await seedSource(
+          runtime,
+          "posture-llm-secret",
+          { confidentiality: ["medical"] },
+        );
+        expect(readThenEgress(runtime, cell, "llm")).toEqual([]);
       });
     });
   });

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -7,6 +7,8 @@ import {
   EXPERIMENTAL_FLAG_AUTHORITY,
   experimentalOptionsForDeployedClient,
   experimentalOptionsFromEnv,
+  MAX_ENFORCEMENT_CFC_OPTIONS,
+  MAX_ENFORCEMENT_SINK_CEILINGS,
   parseServerExperimentalOptions,
   RUNTIME_OPTION_KEYS,
   type RuntimeOptionKey,
@@ -660,6 +662,90 @@ describe("runtimePresets conformance (CT-1814)", () => {
         expect(warnings.length).toBe(1);
         expect(String(warnings[0][0])).toContain(ADOPT_SERVER_FLAGS_ENV);
       });
+    });
+  });
+
+  describe("cfcPosture: max-enforcement (CT-2075)", () => {
+    const posture = { cfcPosture: "max-enforcement" } as const;
+    const postureOutputs: Record<PresetName, RuntimeOptions> = {
+      productionServer: runtimePresets.productionServer({
+        ...minimalCore,
+        ...posture,
+      }),
+      remoteClient: runtimePresets.remoteClient({ ...minimalCore, ...posture }),
+      patternTest: runtimePresets.patternTest({ ...minimalCore, ...posture }),
+      localDev: runtimePresets.localDev({ ...minimalCore, ...posture }),
+      browserWorker: runtimePresets.browserWorker({
+        ...minimalCore,
+        ...posture,
+      }),
+      unitTest: runtimePresets.unitTest({ apiUrl, storageManager, ...posture }),
+    };
+
+    it("spreads exactly the named bundle over each preset's minimal output", () => {
+      for (const preset of PRESET_NAMES) {
+        expect(postureOutputs[preset], preset).toEqual({
+          ...minimalOutputs[preset],
+          ...MAX_ENFORCEMENT_CFC_OPTIONS,
+        });
+      }
+    });
+
+    it("keeps the shared enforcement-mode pin out of the bundle", () => {
+      // Strict is a per-session host raise, not part of the bundle: the pin
+      // must come through unchanged so the raise below is the only way up.
+      expect(Object.keys(MAX_ENFORCEMENT_CFC_OPTIONS))
+        .not.toContain("cfcEnforcementMode");
+      expect(postureOutputs.remoteClient.cfcEnforcementMode)
+        .toBe("enforce-explicit");
+    });
+
+    it("lets a host session dial apply over the bundle", () => {
+      const output = runtimePresets.remoteClient({
+        ...minimalCore,
+        ...posture,
+        cfcEnforcementMode: "enforce-strict",
+      });
+      expect(output.cfcEnforcementMode).toBe("enforce-strict");
+      // The bundle's persist is what makes the strict raise conform.
+      expect(output.cfcFlowLabels).toBe("persist");
+    });
+
+    it("ceilings every network-fetch sink public-only and no llm sink", () => {
+      expect(MAX_ENFORCEMENT_SINK_CEILINGS).toEqual({
+        fetchBinary: [],
+        fetchText: [],
+        fetchJson: [],
+        fetchJsonUnchecked: [],
+        fetchProgram: [],
+        streamData: [],
+      });
+    });
+
+    it("constructs a working Runtime with the dials and policy resolved", async () => {
+      const emulated = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime(runtimePresets.unitTest({
+        apiUrl: new URL(import.meta.url),
+        storageManager: emulated,
+        ...posture,
+      }));
+      try {
+        expect(runtime.cfcEnforcementMode).toBe("enforce-explicit");
+        expect(runtime.cfcFlowLabels).toBe("persist");
+        expect(runtime.cfcWriteFloor).toBe("enforce");
+        expect(runtime.cfcTriggerReadGating).toBe(true);
+        expect(runtime.cfcPolicyEvaluation).toBe("enforce");
+        expect(runtime.cfcDeclaredMonotonicity).toBe("enforce");
+        expect(runtime.cfcLabelMetadataProtection).toBe("enforce");
+        // The §10.1 records validated and digested at boot (fail-closed
+        // config: a malformed bundle would have thrown in the constructor).
+        expect(runtime.cfcPolicySnapshot).toBeDefined();
+        expect(runtime.cfcSinkMaxConfidentiality)
+          .toEqual(MAX_ENFORCEMENT_SINK_CEILINGS);
+      } finally {
+        await runtime.dispose();
+        await emulated.close();
+      }
     });
   });
 

--- a/packages/toolshed/lib/cfc-posture.ts
+++ b/packages/toolshed/lib/cfc-posture.ts
@@ -1,0 +1,78 @@
+/**
+ * The CFC posture this server runs at, published on `/api/meta` beside the
+ * experimental-flag posture (`experimental-posture.ts`, whose module-state
+ * rationale this mirrors): a deployment whose enforcement dials cannot be
+ * read off it is indistinguishable from a default one, so an operator has no
+ * way to confirm what a runtime is actually enforcing (CT-2075's posture
+ * visibility finding). Reporting only — the values come from the constructed
+ * Runtime's resolved fields, never from a second reading of configuration
+ * that could disagree with the first.
+ *
+ * The base webhook Runtime is the one reported. The per-space serving
+ * runtimes the executor host builds hand-roll their options deliberately and
+ * carry the same CFC dials from the same code path, so a separate override
+ * channel would report nothing the base does not.
+ */
+
+import type { Runtime } from "@commonfabric/runner";
+
+/** What `/api/meta` reports about the deployment's CFC dials. */
+export interface CfcPostureReport {
+  readonly enforcementMode: string;
+  readonly flowLabels: string;
+  readonly writeFloor: string;
+  readonly triggerReadGating: boolean;
+  readonly decomposedEnvelopes: boolean;
+  readonly policyEvaluation: string;
+  readonly labelMetadataProtection: string;
+  readonly declaredMonotonicity: string;
+  /** Digest of the deployment policy snapshot; `null` when none configured. */
+  readonly policyDigest: string | null;
+  /** Sink names with a declared confidentiality ceiling, sorted. */
+  readonly sinkCeilings: string[];
+}
+
+type CfcPostureSource = Pick<
+  Runtime,
+  | "cfcEnforcementMode"
+  | "cfcFlowLabels"
+  | "cfcWriteFloor"
+  | "cfcTriggerReadGating"
+  | "cfcDecomposedEnvelopes"
+  | "cfcPolicyEvaluation"
+  | "cfcLabelMetadataProtection"
+  | "cfcDeclaredMonotonicity"
+  | "cfcPolicySnapshot"
+  | "cfcSinkMaxConfidentiality"
+>;
+
+let posture: CfcPostureReport | null = null;
+
+/**
+ * Record a constructed Runtime's resolved CFC dials. Pass `null` to publish
+ * nothing, which is also the state before any Runtime exists — a client then
+ * reads `cfc: null` as "this deployment said nothing".
+ */
+export function publishCfcPosture(runtime: CfcPostureSource | null): void {
+  if (runtime === null) {
+    posture = null;
+    return;
+  }
+  posture = {
+    enforcementMode: runtime.cfcEnforcementMode,
+    flowLabels: runtime.cfcFlowLabels,
+    writeFloor: runtime.cfcWriteFloor,
+    triggerReadGating: runtime.cfcTriggerReadGating === true,
+    decomposedEnvelopes: runtime.cfcDecomposedEnvelopes === true,
+    policyEvaluation: runtime.cfcPolicyEvaluation,
+    labelMetadataProtection: runtime.cfcLabelMetadataProtection,
+    declaredMonotonicity: runtime.cfcDeclaredMonotonicity,
+    policyDigest: runtime.cfcPolicySnapshot?.digest ?? null,
+    sinkCeilings: Object.keys(runtime.cfcSinkMaxConfidentiality).sort(),
+  };
+}
+
+/** What `/api/meta` reports; `null` until a Runtime has been constructed. */
+export function cfcPosture(): CfcPostureReport | null {
+  return posture;
+}

--- a/packages/toolshed/routes/meta/meta.handlers.ts
+++ b/packages/toolshed/routes/meta/meta.handlers.ts
@@ -1,6 +1,7 @@
 import * as HttpStatusCodes from "stoker/http-status-codes";
 import { z } from "zod";
 import { resolveGitSha, shellServerExecutionDefine } from "@/lib/build-info.ts";
+import { cfcPosture } from "@/lib/cfc-posture.ts";
 import { experimentalPosture } from "@/lib/experimental-posture.ts";
 import { identity } from "@/lib/identity.ts";
 import type { AppRouteHandler } from "@/lib/types.ts";
@@ -26,6 +27,23 @@ export const MetaResponseSchema = z.object({
   // An omitted flag means this server said nothing about it, and `null` means
   // it has no Runtime yet; a client keeps its built-in default for either.
   experimental: z.record(z.string(), z.boolean()).nullable(),
+  // The CFC posture this server's Runtime resolved — the enforcement dials,
+  // the policy-snapshot digest, and which sinks carry a confidentiality
+  // ceiling — so a deployment's enforcement is readable rather than
+  // indistinguishable from the default (lib/cfc-posture.ts). `null` means no
+  // Runtime yet.
+  cfc: z.object({
+    enforcementMode: z.string(),
+    flowLabels: z.string(),
+    writeFloor: z.string(),
+    triggerReadGating: z.boolean(),
+    decomposedEnvelopes: z.boolean(),
+    policyEvaluation: z.string(),
+    labelMetadataProtection: z.string(),
+    declaredMonotonicity: z.string(),
+    policyDigest: z.string().nullable(),
+    sinkCeilings: z.array(z.string()),
+  }).nullable(),
 });
 export type MetaResponse = z.infer<typeof MetaResponseSchema>;
 
@@ -35,6 +53,7 @@ export const index: AppRouteHandler<IndexRoute> = (c) => {
     gitSha: GIT_SHA,
     shellServerExecutionDefine,
     experimental: experimentalPosture(),
+    cfc: cfcPosture(),
   };
   return c.json(response, HttpStatusCodes.OK);
 };

--- a/packages/toolshed/routes/meta/meta.test.ts
+++ b/packages/toolshed/routes/meta/meta.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@commonfabric/runner";
 import env from "@/env.ts";
 import createApp from "@/lib/create-app.ts";
+import { publishCfcPosture } from "@/lib/cfc-posture.ts";
 import { publishExperimentalPosture } from "@/lib/experimental-posture.ts";
 import router from "@/routes/meta/meta.index.ts";
 import * as routes from "@/routes/meta/meta.routes.ts";
@@ -39,8 +40,45 @@ Deno.test("meta routes", async (t) => {
       // rather than assumed: the posture is module state, and another test
       // file in the same process publishes one.
       publishExperimentalPosture(null);
+      publishCfcPosture(null);
       const json = await (await app.request("/api/meta")).json();
       assertEquals(json.experimental, null);
+      assertEquals(json.cfc, null);
+    },
+  );
+
+  await t.step(
+    "GET /api/meta reports the published CFC posture",
+    async () => {
+      publishCfcPosture({
+        cfcEnforcementMode: "enforce-explicit",
+        cfcFlowLabels: "persist",
+        cfcWriteFloor: "enforce",
+        cfcTriggerReadGating: true,
+        cfcDecomposedEnvelopes: false,
+        cfcPolicyEvaluation: "enforce",
+        cfcLabelMetadataProtection: "enforce",
+        cfcDeclaredMonotonicity: "enforce",
+        cfcPolicySnapshot: { records: [], digest: "digest-1" },
+        cfcSinkMaxConfidentiality: { fetchText: [], fetchJson: [] },
+      });
+      try {
+        const json = await (await app.request("/api/meta")).json();
+        assertEquals(json.cfc, {
+          enforcementMode: "enforce-explicit",
+          flowLabels: "persist",
+          writeFloor: "enforce",
+          triggerReadGating: true,
+          decomposedEnvelopes: false,
+          policyEvaluation: "enforce",
+          labelMetadataProtection: "enforce",
+          declaredMonotonicity: "enforce",
+          policyDigest: "digest-1",
+          sinkCeilings: ["fetchJson", "fetchText"],
+        });
+      } finally {
+        publishCfcPosture(null);
+      }
     },
   );
 

--- a/packages/toolshed/runtime-options.test.ts
+++ b/packages/toolshed/runtime-options.test.ts
@@ -3,6 +3,7 @@ import { Identity } from "@commonfabric/identity";
 import { SERVER_EXECUTION_DEFAULT_ENABLED } from "@commonfabric/memory/v2/server-execution-default";
 import type { Runtime, RuntimeOptions } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { cfcPosture, publishCfcPosture } from "@/lib/cfc-posture.ts";
 import {
   experimentalPosture,
   publishExperimentalPosture,
@@ -134,6 +135,13 @@ Deno.test("createToolshedRuntime publishes the posture it resolved", async () =>
       (name) => name === "EXPERIMENTAL_MODERN_CELL_REP" ? "true" : undefined,
     );
     const posture = experimentalPosture();
+    // The CFC posture publishes alongside, from the same constructed Runtime
+    // (lib/cfc-posture.ts): the preset core pin plus constructor defaults.
+    const cfc = cfcPosture();
+    assertEquals(cfc?.enforcementMode, "enforce-explicit");
+    assertEquals(cfc?.flowLabels, "off");
+    assertEquals(cfc?.policyDigest, null);
+    assertEquals(cfc?.sinkCeilings, []);
     assertEquals(posture?.modernCellRep, true);
     // Resolved, not passed: the env reader said nothing about these, and a
     // client adopting the posture needs the values in effect rather than the
@@ -147,5 +155,6 @@ Deno.test("createToolshedRuntime publishes the posture it resolved", async () =>
     await runtime?.dispose();
     await storageManager.close();
     publishExperimentalPosture(null);
+    publishCfcPosture(null);
   }
 });

--- a/packages/toolshed/runtime-options.ts
+++ b/packages/toolshed/runtime-options.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeOptions,
   runtimePresets,
 } from "@commonfabric/runner";
+import { publishCfcPosture } from "@/lib/cfc-posture.ts";
 import { publishExperimentalPosture } from "@/lib/experimental-posture.ts";
 import type { env as ToolshedEnv } from "@/env.ts";
 
@@ -56,6 +57,7 @@ export function createToolshedRuntime(
   // than re-read from the environment, so a client adopting this deployment's
   // posture gets the flags actually in effect here.
   publishExperimentalPosture(runtime.experimental);
+  publishCfcPosture(runtime);
   // Fire-and-forget; the attach itself is exported and unit-tested.
   void attachRuntimeOtelBridge(runtime, config);
   return runtime;


### PR DESCRIPTION
## Summary

CT-2075 (E2 of the CT-2066 experiment ladder) ran every staged CFC enforcement dial together and recommended landing the combination as a named preset — an opt-in bundle, not a fleet flip. This PR executes that recommendation.

**The bundle** (`MAX_ENFORCEMENT_CFC_OPTIONS`, at the `coreOptions` seam in `runtime-presets.ts`, reachable from every preset via `CoreParams.cfcPosture: "max-enforcement"`):
- `cfcFlowLabels: "persist"`, `cfcWriteFloor/cfcPolicyEvaluation/cfcDeclaredMonotonicity/cfcLabelMetadataProtection: "enforce"`, `cfcTriggerReadGating: true`
- `STANDARD_PROMPT_CAVEAT_POLICY` spread into `cfcPolicyRecords` (validated, digested, frozen at boot)
- `MAX_ENFORCEMENT_SINK_CEILINGS`: public-only confidentiality ceilings on the six network-fetch sinks — labeled data cannot leave over the network

Deliberately **not** in the bundle, each documented in place: the `enforce-explicit` pin (strict stays a per-session host raise; the bundle's `persist` is what makes that raise conform), `cfcDecomposedEnvelopes` (reader readiness, not enforcement), `cfcTrustConfig`, `cfcPrefixProvenanceStats`. The llm sinks carry no ceiling: ceiling membership is exact clause subsumption, which cannot admit "any material-risk caveat regardless of `source`", and risk-caveated ingested content is exactly what an llm sink exists to process — those flows are governed by the caveat policy the bundle carries. The principled end state (public-only llm ceilings plus a boundary-scoped admission rule for the material-risk family) is follow-up policy authoring.

**The silent riders now demonstrably fire** (`test/max-enforcement-posture.test.ts`). CT-2075 found policy evaluation and trigger-read gating loaded and ran without ever visibly deciding anything. Each test makes the dial decide an outcome the same flow without it would decide the other way: an egress fits the public-only ceiling *only because* the §10.1 value-screened discharge dropped the caveat clause (and refuses without the evidence, naming sink and atom); a scheduled egress that never re-reads its triggering secret is still held to the ceiling.

**One runner fix, riding #6114**: writing the refusal-as-event test exposed that a sink-ceiling refusal was untagged and therefore retried ten times without ever reaching `scheduler.onError` — CT-2077's legibility gap. The refusal is now tagged as a verdict exactly when the decision was a pure function of the transaction's data; an enforce-mode rewrite that failed to resolve a module policy manifest stays retryable, since that manifest might carry the discharge that admits the request. E4 confirmed no deployed surface carries a ceiling today, so no existing behavior changes.

**Two posture surfaces**:
- cf-harness: `--fabric-cfc-posture max-enforcement` (`CF_HARNESS_FABRIC_CFC_POSTURE`), threaded through `PiecesController.initialize` into the `remoteClient` preset; recorded in `fabricSessionCfc` (new `posture` field, `flowLabelsSource: "posture"`) and printed in the operator summary. The per-dial flags still apply over the bundle, so `--fabric-cfc-posture max-enforcement --fabric-cfc-enforcement-mode enforce-strict` is the full-strictness configuration.
- toolshed: `/api/meta` publishes the Runtime's resolved CFC dials, policy digest, and ceilinged sinks (`lib/cfc-posture.ts`, mirroring `experimental-posture.ts`), so a max-enforcement deployment is readable rather than indistinguishable from a default one. Toolshed has no opt-in selector yet — whether that is an env var or a code-level choice is deliberately left open.

Docs updated in the same change: EXPERIMENTAL_OPTIONS.md's CFC preset section and the cf-harness README.

## Test plan

- New: `runner/test/max-enforcement-posture.test.ts` (7 steps — the two rider-firing pairs and refusal-as-event), preset goldens extended with the posture block (bundle shape, pin kept out, host dial wins over bundle, ceiling map, boot construction), meta + runtime-options coverage of the `cfc` field, harness CLI/engine tests for the flag, env default, rejections, and the posture record.
- Ran: full runner suite (1299 passed / 7534 steps), cf-harness suite (763 passed; only the 3 known macOS-sandbox `makeTempDir` failures, identical on clean main, pass in CI), piece suite (46 passed, re-run after rebasing over #6301's conflict in `pieces-controller.ts`), toolshed meta/runtime-options, all 14 CFC/scheduler suites adjacent to the verdict tagging (135 steps), repo-wide `deno task check` under the pinned Deno, `deno fmt --check`, `deno lint`.

Part of CT-2066 (demo build-list item 5); executes CT-2075's verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

