### PR TITLE
refactor(data-model): reconcile api.ts with interface.ts

### DIFF
--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -7,8 +7,13 @@
  * The canonical implementations live in this module's siblings --
  * `interface.ts`, `fabric-primitives/FabricHash.ts`,
  * `fabric-primitives/FabricEpochNsec.ts`, and the rest -- and these
- * declarations mirror their public surface. The two must agree: where they
- * drift, pattern type-checking diverges from runtime behavior.
+ * declarations mirror their public surface. Each of those files asserts beside
+ * its own definition that its implementation satisfies the declaration here,
+ * so a declaration that no implementation meets stops the build. That check
+ * runs one way only: a public member an implementation gains without a
+ * declaration here is simply unreachable from a pattern, and no gate reports
+ * it. `interface.ts` asserts both directions for the three base classes, whose
+ * protocol carries no symbol-keyed members to hold apart.
  *
  * Every concrete `FabricPrimitive` subclass needs an instanceof-capable
  * declaration here, that being an interface, a constructor interface, and a
@@ -58,6 +63,17 @@ export declare const FabricSpecialObject:
  * one -- a spread, `Object.keys()`, a naive walk -- therefore sees nothing.
  */
 export interface FabricInstance extends FabricSpecialObject {
+  /**
+   * Returns a new deep clone of this instance with equivalent data but no
+   * shared structure for any unfrozen data in the original. When `frozen ===
+   * true`, produces a frozen instance with maximal structural sharing,
+   * including returning `this` if it is already deep-frozen. When `frozen ===
+   * false`, produces a deeply-mutable instance with no visible shared
+   * reference structure with the original.
+   */
+  deepClone(frozen: boolean): FabricInstance;
+
+  /** Returns a shallow clone of this instance with the requested frozenness. */
   shallowClone(frozen: boolean): FabricInstance;
 }
 
@@ -312,7 +328,29 @@ export declare const FabricError: FabricErrorConstructor;
 // absence is a decision, not an oversight; revisit once that rework lands.
 
 /**
- * The full set of values that the fabric storage layer can represent.
+ * The full set of values that the fabric storage layer can represent. This is
+ * the strongly-typed "middle layer" of the three-layer architecture:
+ *
+ *     JavaScript "wild west" (`unknown`)
+ *       <-> `FabricValue`
+ *       <-> serialized (`Uint8Array`)
+ *
+ * Most native JS object types enter the fabric layer via wrapper classes that
+ * extend `FabricInstance`; other special values extend `FabricPrimitive`. Both
+ * of those reach `FabricValue` through the common `FabricSpecialObject` arm.
+ * The non-object values (`bigint` and the other scalars) are direct members of
+ * the union instead, not routed through that arm. Some native types are
+ * converted to `FabricPrimitive`s during conversion.
+ *
+ * `undefined` is preserved.
+ *
+ * `symbol` values are restricted at runtime to **registry-interned** symbols --
+ * those for which `Symbol.keyFor(s)` returns a string. These are portable
+ * across realms and processes via their registry key. Unique symbols
+ * (`Symbol(desc)`) are not portable and are rejected at the fabric boundary.
+ * TypeScript's `symbol` type cannot distinguish the two, so the gate is a
+ * runtime one, and it is the same gate at every point a symbol is admitted or
+ * refused: `Symbol.keyFor(value) !== undefined`.
  *
  * From a typesystem perspective, all `FabricValue`s are immutable (deeply
  * read-only), _except_ members of the `FabricInstance` tree. `FabricInstance`s
@@ -320,6 +358,18 @@ export declare const FabricError: FabricErrorConstructor;
  * changing the set of outgoing references from the instance. This is an
  * _intentional_ hole, because TypeScript has no ergonomic/pithy way to express
  * the desired semantics. (To be clear, it _can_ be done, just not cleanly.)
+ *
+ * **Deep-frozen honesty (mandatory).** A `FabricValue` must report its frozen
+ * state truthfully and permanently. In particular, a `FabricPlainObject` or
+ * `FabricArray` is data-only: it must not expose an own accessor
+ * (getter/setter) whose result can contradict, or change after, the value's
+ * frozen state -- once a `FabricValue` graph is deeply frozen, its contents are
+ * fixed. (For a `FabricInstance`, the analogous obligation is on its
+ * `[IS_DEEP_FROZEN]` report; see `BaseFabricInstance`.) The rest of the system
+ * -- the data model in general and `isDeepFrozen()` specifically, but also the
+ * entire codebase that _uses_ the data model -- relies on this to cache
+ * deep-frozen proofs by root identity without re-validating; a value that
+ * violates it can corrupt data-model invariants, as any broken contract can.
  */
 export type FabricValue =
   | null
@@ -348,6 +398,16 @@ export type NonNullableFabricValue = NonNullable<FabricValue>;
 /** Read-only array of `FabricValue`s. */
 export interface FabricArray extends ReadonlyArray<FabricValue> {}
 
-/** Read-only object/record of `FabricValue`s. */
+/**
+ * Object/record of `FabricValue`s.
+ *
+ * The names `__proto__` and `constructor` are refused at the boundaries where
+ * values enter or leave storage, so no `FabricPlainObject` carries one. The
+ * type cannot say as much -- a string index signature admits every string --
+ * so the guarantee is the boundary's, not TypeScript's. Note the internal copy
+ * loops are unguarded and rely on it: they rebuild records by assignment,
+ * which for `__proto__` would repoint the copy's prototype rather than
+ * creating a property.
+ */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -372,16 +372,16 @@ export declare const FabricError: FabricErrorConstructor;
  * violates it can corrupt data-model invariants, as any broken contract can.
  */
 export type FabricValue =
-  | null
+  | bigint
   | boolean
+  | null
   | number
   | string
-  | bigint
   | symbol
-  | FabricSpecialObject
+  | undefined
   | FabricArray
   | FabricPlainObject
-  | undefined;
+  | FabricSpecialObject;
 
 /**
  * The container types that are part of `FabricValue`. Note that

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -16,7 +16,7 @@
 import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
@@ -528,9 +528,9 @@ export class FabricError extends FabricNativeWrapper<Error>
 }
 
 // Compile-time check that the exported `FabricError` constructor matches the
-// `FabricErrorConstructor` declared in `@commonfabric/api`. This catches a
-// declared member that is missing here or has the wrong type. It does NOT
-// catch the other direction: `satisfies` is an assignability check, so a
-// public member on this class that the declaration omits passes silently.
-// Members added here need adding there by hand.
+// `FabricErrorConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricError satisfies ApiFabricErrorConstructor;

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -16,7 +16,7 @@
 import type {
   FabricError as ApiFabricError,
   FabricErrorConstructor as ApiFabricErrorConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
@@ -528,7 +528,7 @@ export class FabricError extends FabricNativeWrapper<Error>
 }
 
 // Compile-time check that the exported `FabricError` constructor matches the
-// `FabricErrorConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricErrorConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -1,7 +1,7 @@
 import type {
   FabricLink as ApiFabricLink,
   FabricLinkConstructor as ApiFabricLinkConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import type { FabricPlainObject, FabricValue } from "@/interface.ts";
@@ -178,6 +178,9 @@ function assertValidPayload(
 }
 
 // Compile-time check that the exported `FabricLink` constructor matches the
-// `FabricLinkConstructor` declared in `@commonfabric/api`. This catches drift
-// between the public type contract and this implementation.
+// `FabricLinkConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricLink satisfies ApiFabricLinkConstructor;

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -1,7 +1,7 @@
 import type {
   FabricLink as ApiFabricLink,
   FabricLinkConstructor as ApiFabricLinkConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import type { FabricPlainObject, FabricValue } from "@/interface.ts";
@@ -178,7 +178,7 @@ function assertValidPayload(
 }
 
 // Compile-time check that the exported `FabricLink` constructor matches the
-// `FabricLinkConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricLinkConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -4,6 +4,10 @@ import {
 } from "@commonfabric/utils/base64url";
 import { toOwnedUint8Array } from "@commonfabric/utils/buffers";
 
+import type {
+  FabricBytes as ApiFabricBytes,
+  FabricBytesConstructor as ApiFabricBytesConstructor,
+} from "../api.ts";
 import type { FabricValue } from "@/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { BaseFabricPrimitive } from "@/fabric-bases/BaseFabricPrimitive.ts";
@@ -31,7 +35,7 @@ import {
  * instance owns its bytes outright, holding a buffer no other code can reach.
  * (JS cannot freeze `ArrayBuffer` contents, so sole ownership is the defense.)
  */
-export class FabricBytes extends BaseFabricPrimitive {
+export class FabricBytes extends BaseFabricPrimitive implements ApiFabricBytes {
   /**
    * Private byte storage. Guaranteed to be backed by an exact-sized and
    * unshared `ArrayBuffer`.
@@ -236,3 +240,11 @@ export class FabricBytes extends BaseFabricPrimitive {
     return this.#realmCodec;
   }
 }
+
+// Compile-time check that the exported `FabricBytes` constructor matches the
+// `FabricBytesConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
+FabricBytes satisfies ApiFabricBytesConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -7,7 +7,7 @@ import { toOwnedUint8Array } from "@commonfabric/utils/buffers";
 import type {
   FabricBytes as ApiFabricBytes,
   FabricBytesConstructor as ApiFabricBytesConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import type { FabricValue } from "@/interface.ts";
 import { ProblematicValue } from "@/codec-common/ProblematicValue.ts";
 import { BaseFabricPrimitive } from "@/fabric-bases/BaseFabricPrimitive.ts";
@@ -242,7 +242,7 @@ export class FabricBytes extends BaseFabricPrimitive implements ApiFabricBytes {
 }
 
 // Compile-time check that the exported `FabricBytes` constructor matches the
-// `FabricBytesConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricBytesConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
@@ -1,7 +1,7 @@
 import type {
   FabricEpochDay as ApiFabricEpochDay,
   FabricEpochDayConstructor as ApiFabricEpochDayConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import {
   bigintFromUnpaddedBase64url,
   bigintToUnpaddedBase64url,
@@ -126,7 +126,7 @@ export class FabricEpochDay extends BaseFabricPrimitive
 }
 
 // Compile-time check that the exported `FabricEpochDay` constructor matches the
-// `FabricEpochDayConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricEpochDayConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDay.ts
@@ -1,7 +1,7 @@
 import type {
   FabricEpochDay as ApiFabricEpochDay,
   FabricEpochDayConstructor as ApiFabricEpochDayConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import {
   bigintFromUnpaddedBase64url,
   bigintToUnpaddedBase64url,
@@ -125,7 +125,10 @@ export class FabricEpochDay extends BaseFabricPrimitive
   }
 }
 
-// Compile-time check that the exported `FabricEpochDay` constructor matches
-// the `FabricEpochDayConstructor` declared in `@commonfabric/api`. This
-// catches drift between the public type contract and this implementation.
+// Compile-time check that the exported `FabricEpochDay` constructor matches the
+// `FabricEpochDayConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricEpochDay satisfies ApiFabricEpochDayConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -1,7 +1,7 @@
 import type {
   FabricEpochNsec as ApiFabricEpochNsec,
   FabricEpochNsecConstructor as ApiFabricEpochNsecConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import {
   bigintFromUnpaddedBase64url,
   bigintToUnpaddedBase64url,
@@ -133,7 +133,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
 }
 
 // Compile-time check that the exported `FabricEpochNsec` constructor matches the
-// `FabricEpochNsecConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricEpochNsecConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -1,7 +1,7 @@
 import type {
   FabricEpochNsec as ApiFabricEpochNsec,
   FabricEpochNsecConstructor as ApiFabricEpochNsecConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import {
   bigintFromUnpaddedBase64url,
   bigintToUnpaddedBase64url,
@@ -132,7 +132,10 @@ export class FabricEpochNsec extends BaseFabricPrimitive
   }
 }
 
-// Compile-time check that the exported `FabricEpochNsec` constructor matches
-// the `FabricEpochNsecConstructor` declared in `@commonfabric/api`. This
-// catches drift between the public type contract and this implementation.
+// Compile-time check that the exported `FabricEpochNsec` constructor matches the
+// `FabricEpochNsecConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricEpochNsec satisfies ApiFabricEpochNsecConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -1,7 +1,7 @@
 import type {
   FabricHash as ApiFabricHash,
   FabricHashConstructor as ApiFabricHashConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import {
   fromBase64url,
   toUnpaddedBase64url,
@@ -280,6 +280,9 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 }
 
 // Compile-time check that the exported `FabricHash` constructor matches the
-// `FabricHashConstructor` declared in `@commonfabric/api`. This catches drift
-// between the public type contract and this implementation.
+// `FabricHashConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricHash satisfies ApiFabricHashConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -1,7 +1,7 @@
 import type {
   FabricHash as ApiFabricHash,
   FabricHashConstructor as ApiFabricHashConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import {
   fromBase64url,
   toUnpaddedBase64url,
@@ -280,7 +280,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 }
 
 // Compile-time check that the exported `FabricHash` constructor matches the
-// `FabricHashConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricHashConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
+++ b/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
@@ -1,4 +1,4 @@
-import type { FabricKeyPair as ApiFabricKeyPair } from "@commonfabric/api";
+import type { FabricKeyPair as ApiFabricKeyPair } from "../api.ts";
 import {
   fromBase64url,
   toUnpaddedBase64url,
@@ -493,7 +493,7 @@ export class FabricKeyPair extends BaseFabricPrimitive {
   }
 }
 
-// Compile-time drift guards against the `@commonfabric/api` declarations, in
+// Compile-time drift guards against the `../api.ts` declarations, in
 // two halves.
 //
 // The instance surface compares directly. Assignability is covariant on member

--- a/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
+++ b/packages/data-model/src/fabric-primitives/FabricKeyPair.ts
@@ -1,4 +1,4 @@
-import type { FabricKeyPair as ApiFabricKeyPair } from "../api.ts";
+import type { FabricKeyPair as ApiFabricKeyPair } from "@/api.ts";
 import {
   fromBase64url,
   toUnpaddedBase64url,
@@ -493,7 +493,7 @@ export class FabricKeyPair extends BaseFabricPrimitive {
   }
 }
 
-// Compile-time drift guards against the `../api.ts` declarations, in
+// Compile-time drift guards against the `@/api.ts` declarations, in
 // two halves.
 //
 // The instance surface compares directly. Assignability is covariant on member

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -1,7 +1,7 @@
 import type {
   FabricRegExp as ApiFabricRegExp,
   FabricRegExpConstructor as ApiFabricRegExpConstructor,
-} from "../api.ts";
+} from "@/api.ts";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
@@ -333,7 +333,7 @@ function rejectExtraRegExpProperties(regex: RegExp): void {
 }
 
 // Compile-time check that the exported `FabricRegExp` constructor matches the
-// `FabricRegExpConstructor` declared in `../api.ts`. This catches a declared member
+// `FabricRegExpConstructor` declared in `@/api.ts`. This catches a declared member
 // that is missing here or has the wrong type. It does NOT catch the other
 // direction: `satisfies` is an assignability check, so a public member on this
 // class that the declaration omits passes silently. Members added here need

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -1,7 +1,7 @@
 import type {
   FabricRegExp as ApiFabricRegExp,
   FabricRegExpConstructor as ApiFabricRegExpConstructor,
-} from "@commonfabric/api";
+} from "../api.ts";
 import { backtickQuote } from "@commonfabric/utils/markdown";
 import { isPlainObject } from "@commonfabric/utils/types";
 
@@ -333,9 +333,9 @@ function rejectExtraRegExpProperties(regex: RegExp): void {
 }
 
 // Compile-time check that the exported `FabricRegExp` constructor matches the
-// `FabricRegExpConstructor` declared in `@commonfabric/api`. This catches a
-// declared member that is missing here or has the wrong type. It does NOT
-// catch the other direction: `satisfies` is an assignability check, so a
-// public member on this class that the declaration omits passes silently.
-// Members added here need adding there by hand.
+// `FabricRegExpConstructor` declared in `../api.ts`. This catches a declared member
+// that is missing here or has the wrong type. It does NOT catch the other
+// direction: `satisfies` is an assignability check, so a public member on this
+// class that the declaration omits passes silently. Members added here need
+// adding there by hand.
 FabricRegExp satisfies ApiFabricRegExpConstructor;

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -1,16 +1,27 @@
 /**
- * Type-only declarations, the `FabricInstance` base class, and the protocol
- * symbols keyed on a fabric class, for the fabric data model. This file is
- * intentionally free of runtime imports from other data-model modules (only
- * `import type` is used) so that it can be imported by any module without
- * creating circular dependencies.
+ * The `FabricSpecialObject` class hierarchy and the conversion-layer types of
+ * the fabric data model, together with the pattern-visible value types that
+ * `api.ts` declares, re-exported here so that this module carries the whole
+ * `FabricValue` vocabulary. It is intentionally free of runtime imports (only
+ * `import type` is used) so that any module can import it without creating a
+ * circular dependency.
  *
- * NOTE: `api.ts` mirrors these types (and those from
- * `fabric-primitives/FabricHash.ts`, `fabric-primitives/FabricEpochNsec.ts`)
- * for the pattern compiler, which reaches them through `@commonfabric/api`.
- * Changes here must be kept in sync with the corresponding declarations
- * there.
+ * The classes here and the declarations in `api.ts` describe the same shapes,
+ * and the assertions at the end of this file stop compiling when they drift.
+ * The concrete classes under `fabric-primitives/` and `fabric-instances/`
+ * carry the same kind of guard, each beside its own definition.
  */
+
+import type {
+  FabricArray,
+  FabricContainerValue,
+  FabricInstance as ApiFabricInstance,
+  FabricPlainObject,
+  FabricPrimitive as ApiFabricPrimitive,
+  FabricSpecialObject as ApiFabricSpecialObject,
+  FabricValue,
+  NonNullableFabricValue,
+} from "./api.ts";
 
 //
 // `FabricSpecialObject`
@@ -33,9 +44,10 @@
  *
  * It is a well-known string key rather than a `unique symbol` because that
  * would require importing a symbol *value*, and this file is deliberately free
- * of runtime imports (see the file header). `api.ts` declares the
- * identical member; the two must agree exactly, or a value branded by one will
- * not satisfy the other.
+ * of runtime imports (see the file header). `api.ts` declares the identical
+ * member, and the assertions at the end of this file stop compiling if the two
+ * stop agreeing; a value branded by one would otherwise not satisfy the
+ * other.
  */
 export abstract class FabricSpecialObject {
   declare readonly "@commonfabric/FabricSpecialObject": true;
@@ -128,82 +140,19 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
 //
 
 /**
- * The full set of values that the fabric storage layer can represent. This is
- * the strongly-typed "middle layer" of the three-layer architecture:
- *
- *     JavaScript "wild west" (`unknown`)
- *       <-> `FabricValue`
- *       <-> serialized (`Uint8Array`)
- *
- * Most native JS object types enter the fabric layer via wrapper classes that
- * extend `FabricInstance`; other special values extend `FabricPrimitive`. Both
- * of those reach `FabricValue` through the common `FabricSpecialObject` arm.
- * The non-object values (`bigint` and the other scalars) are direct members of
- * the union instead, not routed through that arm. Some native types are
- * converted to `FabricPrimitive`s during conversion.
- *
- * `undefined` is preserved.
- *
- * `symbol` values are restricted at runtime to **registry-interned** symbols --
- * those for which `Symbol.keyFor(s)` returns a string. These are portable
- * across realms and processes via their registry key. Unique symbols
- * (`Symbol(desc)`) are not portable and are rejected at the fabric boundary.
- * TypeScript's `symbol` type cannot distinguish the two, so the gate is a
- * runtime one, and it is the same gate at every point a symbol is admitted or
- * refused: `Symbol.keyFor(value) !== undefined`.
- *
- * **Deep-frozen honesty (mandatory).** A `FabricValue` must report its frozen
- * state truthfully and permanently. In particular, a `FabricPlainObject` or
- * `FabricArray` is data-only: it must not expose an own accessor
- * (getter/setter) whose result can contradict, or change after, the value's
- * frozen state -- once a `FabricValue` graph is deeply frozen, its contents are
- * fixed. (For a `FabricInstance`, the analogous obligation is on its
- * `[IS_DEEP_FROZEN]` report; see `BaseFabricInstance`.) The rest of the system
- * -- the data model in general and `isDeepFrozen()` specifically, but also the
- * entire codebase that _uses_ the data model -- relies on this to cache
- * deep-frozen proofs by root identity without re-validating; a value that
- * violates it can corrupt data-model invariants, as any broken contract can.
+ * The pattern-visible fabric value types, declared in `api.ts` and re-exported
+ * here so that this module carries the whole `FabricValue` vocabulary. `api.ts`
+ * is where they have to be declared: it reaches patterns by being inlined into
+ * the type module the pattern compiler serves, and so may name no import,
+ * which makes it the leaf of this pair.
  */
-export type FabricValue =
-  | bigint
-  | boolean
-  | null
-  | number
-  | string
-  | symbol
-  | undefined
-  | FabricArray
-  | FabricPlainObject
-  | FabricSpecialObject;
-
-/**
- * The container types that are part of `FabricValue`. Note that
- * `FabricSpecialObject` is a combination of container and non-container.
- */
-export type FabricContainerValue =
-  | FabricArray
-  | FabricInstance // One of the two direct subclasses of `FabricSpecialObject`.
-  | FabricPlainObject;
-
-/** A `FabricValue` other than `null` or `undefined`. */
-export type NonNullableFabricValue = NonNullable<FabricValue>;
-
-/** Read-only array of `FabricValue`s. */
-export interface FabricArray extends ReadonlyArray<FabricValue> {}
-
-/**
- * Object/record of `FabricValue`s.
- *
- * The names `__proto__` and `constructor` are refused at the boundaries where
- * values enter or leave storage, so no `FabricPlainObject` carries one. The
- * type cannot say as much -- a string index signature admits every string --
- * so the guarantee is the boundary's, not TypeScript's. Note the internal copy
- * loops are unguarded and rely on it: they rebuild records by assignment,
- * which for `__proto__` would repoint the copy's prototype rather than
- * creating a property.
- */
-export interface FabricPlainObject
-  extends Readonly<Record<string, FabricValue>> {}
+export type {
+  FabricArray,
+  FabricContainerValue,
+  FabricPlainObject,
+  FabricValue,
+  NonNullableFabricValue,
+};
 
 /**
  * Single "layer" of fabric conversion -- the result of shallow conversion
@@ -280,3 +229,29 @@ export type FabricConvertibleValue =
   | FabricNativeObject
   | readonly FabricConvertibleValue[]
   | { readonly [key: string]: FabricConvertibleValue };
+
+//
+// Agreement with the pattern-visible declarations
+//
+
+/** Whether `A` and `B` are mutually assignable. */
+type Same<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/** Compiles only when its argument is `true`. */
+type MustBeTrue<T extends true> = T;
+
+// Compile-time checks that the abstract base classes above and the
+// declarations in `api.ts` -- which is what a pattern compiles against --
+// describe the same shape.
+//
+// Mutual assignability, not `satisfies`. A one-way check passes when the class
+// carries a member the declaration omits, since the extra member only makes
+// the class more assignable; that is the direction a pattern feels, because
+// the member it cannot reach is the one missing from the declaration. Both
+// directions have to be asserted for a member added on either side alone to
+// fail here.
+type _SpecialObjectAgrees = MustBeTrue<
+  Same<FabricSpecialObject, ApiFabricSpecialObject>
+>;
+type _InstanceAgrees = MustBeTrue<Same<FabricInstance, ApiFabricInstance>>;
+type _PrimitiveAgrees = MustBeTrue<Same<FabricPrimitive, ApiFabricPrimitive>>;

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -50,8 +50,13 @@ type Mutable<T> = T extends ReadonlyArray<infer U> ? Mutable<U>[]
  * The canonical implementations live in this module's siblings --
  * `interface.ts`, `fabric-primitives/FabricHash.ts`,
  * `fabric-primitives/FabricEpochNsec.ts`, and the rest -- and these
- * declarations mirror their public surface. The two must agree: where they
- * drift, pattern type-checking diverges from runtime behavior.
+ * declarations mirror their public surface. Each of those files asserts beside
+ * its own definition that its implementation satisfies the declaration here,
+ * so a declaration that no implementation meets stops the build. That check
+ * runs one way only: a public member an implementation gains without a
+ * declaration here is simply unreachable from a pattern, and no gate reports
+ * it. `interface.ts` asserts both directions for the three base classes, whose
+ * protocol carries no symbol-keyed members to hold apart.
  *
  * Every concrete `FabricPrimitive` subclass needs an instanceof-capable
  * declaration here, that being an interface, a constructor interface, and a
@@ -101,6 +106,17 @@ export declare const FabricSpecialObject:
  * one -- a spread, `Object.keys()`, a naive walk -- therefore sees nothing.
  */
 export interface FabricInstance extends FabricSpecialObject {
+  /**
+   * Returns a new deep clone of this instance with equivalent data but no
+   * shared structure for any unfrozen data in the original. When `frozen ===
+   * true`, produces a frozen instance with maximal structural sharing,
+   * including returning `this` if it is already deep-frozen. When `frozen ===
+   * false`, produces a deeply-mutable instance with no visible shared
+   * reference structure with the original.
+   */
+  deepClone(frozen: boolean): FabricInstance;
+
+  /** Returns a shallow clone of this instance with the requested frozenness. */
   shallowClone(frozen: boolean): FabricInstance;
 }
 
@@ -355,7 +371,29 @@ export declare const FabricError: FabricErrorConstructor;
 // absence is a decision, not an oversight; revisit once that rework lands.
 
 /**
- * The full set of values that the fabric storage layer can represent.
+ * The full set of values that the fabric storage layer can represent. This is
+ * the strongly-typed "middle layer" of the three-layer architecture:
+ *
+ *     JavaScript "wild west" (`unknown`)
+ *       <-> `FabricValue`
+ *       <-> serialized (`Uint8Array`)
+ *
+ * Most native JS object types enter the fabric layer via wrapper classes that
+ * extend `FabricInstance`; other special values extend `FabricPrimitive`. Both
+ * of those reach `FabricValue` through the common `FabricSpecialObject` arm.
+ * The non-object values (`bigint` and the other scalars) are direct members of
+ * the union instead, not routed through that arm. Some native types are
+ * converted to `FabricPrimitive`s during conversion.
+ *
+ * `undefined` is preserved.
+ *
+ * `symbol` values are restricted at runtime to **registry-interned** symbols --
+ * those for which `Symbol.keyFor(s)` returns a string. These are portable
+ * across realms and processes via their registry key. Unique symbols
+ * (`Symbol(desc)`) are not portable and are rejected at the fabric boundary.
+ * TypeScript's `symbol` type cannot distinguish the two, so the gate is a
+ * runtime one, and it is the same gate at every point a symbol is admitted or
+ * refused: `Symbol.keyFor(value) !== undefined`.
  *
  * From a typesystem perspective, all `FabricValue`s are immutable (deeply
  * read-only), _except_ members of the `FabricInstance` tree. `FabricInstance`s
@@ -363,6 +401,18 @@ export declare const FabricError: FabricErrorConstructor;
  * changing the set of outgoing references from the instance. This is an
  * _intentional_ hole, because TypeScript has no ergonomic/pithy way to express
  * the desired semantics. (To be clear, it _can_ be done, just not cleanly.)
+ *
+ * **Deep-frozen honesty (mandatory).** A `FabricValue` must report its frozen
+ * state truthfully and permanently. In particular, a `FabricPlainObject` or
+ * `FabricArray` is data-only: it must not expose an own accessor
+ * (getter/setter) whose result can contradict, or change after, the value's
+ * frozen state -- once a `FabricValue` graph is deeply frozen, its contents are
+ * fixed. (For a `FabricInstance`, the analogous obligation is on its
+ * `[IS_DEEP_FROZEN]` report; see `BaseFabricInstance`.) The rest of the system
+ * -- the data model in general and `isDeepFrozen()` specifically, but also the
+ * entire codebase that _uses_ the data model -- relies on this to cache
+ * deep-frozen proofs by root identity without re-validating; a value that
+ * violates it can corrupt data-model invariants, as any broken contract can.
  */
 export type FabricValue =
   | null
@@ -391,7 +441,17 @@ export type NonNullableFabricValue = NonNullable<FabricValue>;
 /** Read-only array of `FabricValue`s. */
 export interface FabricArray extends ReadonlyArray<FabricValue> {}
 
-/** Read-only object/record of `FabricValue`s. */
+/**
+ * Object/record of `FabricValue`s.
+ *
+ * The names `__proto__` and `constructor` are refused at the boundaries where
+ * values enter or leave storage, so no `FabricPlainObject` carries one. The
+ * type cannot say as much -- a string index signature admits every string --
+ * so the guarantee is the boundary's, not TypeScript's. Note the internal copy
+ * loops are unguarded and rely on it: they rebuild records by assignment,
+ * which for `__proto__` would repoint the copy's prototype rather than
+ * creating a property.
+ */
 export interface FabricPlainObject
   extends Readonly<Record<string, FabricValue>> {}
 

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -415,16 +415,16 @@ export declare const FabricError: FabricErrorConstructor;
  * violates it can corrupt data-model invariants, as any broken contract can.
  */
 export type FabricValue =
-  | null
+  | bigint
   | boolean
+  | null
   | number
   | string
-  | bigint
   | symbol
-  | FabricSpecialObject
+  | undefined
   | FabricArray
   | FabricPlainObject
-  | undefined;
+  | FabricSpecialObject;
 
 /**
  * The container types that are part of `FabricValue`. Note that


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`packages/data-model/src/api.ts` and `src/interface.ts` both described the
fabric value surface — `api.ts` in the `interface` + `declare const` form
patterns compile against, `interface.ts` in the class form the runtime
implements — and nothing checked that they agreed.

## The redundancy

Five types were declared identically in both: `FabricValue`,
`FabricContainerValue`, `NonNullableFabricValue`, `FabricArray` and
`FabricPlainObject`. They now live in `api.ts` alone, and `interface.ts`
re-exports them, so the package's own consumers — some fifty modules importing
`FabricValue` from `@/interface.ts` — reach them exactly where they always
have.

`api.ts` is the leaf of the pair by necessity: it reaches patterns by being
inlined verbatim into the type module the pattern compiler serves, and the
generator refuses a module that names any import.

**No doc comment was dropped.** Where the two files described the same type
differently, `api.ts` now carries both accounts — `FabricValue` gains the
three-layer framing, the registry-interned-symbol rule and the deep-frozen
honesty contract from `interface.ts`, and keeps the immutability-hole paragraph
that only `api.ts` had. Checked as a property: all 42 doc lines removed from
`interface.ts` appear in `api.ts`.

## The divergence

`FabricInstance` declared `deepClone()` in `interface.ts` and not in `api.ts`,
so a pattern holding one could not call it. That was unintentional. The
declaration is added, and it is the **only semantic** change to what a pattern
sees.

The `FabricValue` union's arms are also reordered, taking `interface.ts`'s
sorted order — scalars alphabetically, then containers — in place of the ad hoc
order they carried over from `api/index.ts`. A union is a set, so that changes
no type; it is listed here because it does show up in the generated file's
diff.

Those two are the whole of the non-comment change to the shipped type module:

    BASE=$(git merge-base origin/main HEAD)
    git diff $BASE -- packages/static/assets/types/commonfabric.d.ts \
      | grep -E "^[-+]" | grep -vE "^(\+\+\+|---)" \
      | grep -vE "^[-+][[:space:]]*(//|\*|/\*\*|\*/)" \
      | grep -vE "^[-+][[:space:]]*$"

prints the added `deepClone` line and the four reordered arms, and nothing
else. Everything remaining in that file's diff is comment prose.

## Making the agreement checkable

The three base classes now assert agreement with their declarations at the foot
of `interface.ts`, using the `MustBeTrue` / `Same` idiom already in the tree.

The assertion is **mutual assignability, not `satisfies`**. A one-way check
passes when the class carries a member the declaration omits — which is the
direction a pattern feels, and the direction `deepClone` went missing in. I
confirmed this rather than assumed it: with a `satisfies` guard in place,
deleting `deepClone` from `api.ts` left `deno check` green. Both ablations were
then re-run against the mutual form on the final tree, and both exit non-zero:
removing `deepClone` from either file stops the build.

Mutual assignability is the right instrument here only because `interface.ts`'s
`FabricInstance` is the pure protocol, carrying no symbol-keyed members. It is
the wrong instrument for the concrete classes, which inherit
`BaseFabricInstance`'s `[DEEP_FREEZE]` and siblings — measured: all eight fail
mutual assignability, every one of them in the direction that would demand
exposing internals. Their one-way guards are correct as they stand.

## The guards on the concrete classes

They imported their declarations from `@commonfabric/api` — a package away, and
around the allowlisted `api` ↔ `data-model` cycle — to check against a
declaration that now lives one directory from them. They name `../api.ts` now,
which removes seven reverse edges.

`FabricBytes` carried no guard at all. That was an oversight rather than a
decision, so it gains the `implements` + `satisfies` pair its siblings carry.
`FabricKeyPair` keeps its split guard, which exists for a contravariance reason
its own comment sets out, and is untouched.

Five of the eight guard comments said they catch "drift between the public type
contract and this implementation", which overstates an assignability check.
They now carry the wording the other two already used, naming which direction
is covered and which is not. The same correction applies to `api.ts`'s own
header.

## Verification

Green on this branch: `deno task check`, `deno task cfcheck` (420 pattern
files), `deno fmt --check`, `deno lint`, `check-commonfabric-types`,
`check-package-cycles`, `check-single-copy-deps`, `check-unused-deps`,
`check-skill-facts`, `check-docs`, `check-conflict-markers`,
`check-control-characters`, `check-no-waitfor`; and the `api`, `data-model`,
`static`, `js-compiler`, `schema-generator`, `ts-transformers` and `runner`
(1298 tests / 7522 steps) suites.

## Not in this change

A public member added to a concrete class without a matching declaration in
`api.ts` is unreachable from a pattern and no gate reports it. That is now
stated where the guards are rather than left to be discovered, but it is not
fixed — closing it means deciding, per member across eight classes, what
belongs on the pattern surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4ZveCDJ2ZWBQJ11Pt98G7


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


