### PR TITLE
A DOM event target value crosses as what the element exposed

### DIFF
--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -5,7 +5,7 @@
  * sent to the worker thread for dispatch to the appropriate handler.
  */
 
-import type { JSONValue } from "@commonfabric/runtime-client";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   type EventProvenance,
   getEventProvenance,
@@ -45,7 +45,7 @@ export interface SerializedEvent {
   target?: SerializedEventTarget;
 
   // Custom event detail
-  detail?: JSONValue;
+  detail?: FabricValue;
 }
 
 export type { EventProvenance };
@@ -56,8 +56,19 @@ export type { EventProvenance };
  */
 export interface SerializedEventTarget {
   name?: string;
-  value?: string;
-  checked?: boolean;
+  /**
+   * The element's current value. A `FabricValue` rather than a string: a custom
+   * element chooses what its `value` is, and a `cf-input`, a `cf-tabs` and a
+   * `cf-calendar` each declare theirs as `CellHandle<string> | string`, which
+   * arrives here as the sigil link the conversion resolved it to.
+   */
+  value?: FabricValue;
+  /**
+   * Whether the element is checked -- or, where the element chose to expose
+   * something else, what it chose. `cf-checkbox` and `cf-switch` each declare
+   * theirs as `CellHandle<boolean> | boolean`.
+   */
+  checked?: FabricValue;
   selected?: boolean;
   selectedIndex?: number;
   selectedOptions?: { value: string }[];
@@ -157,7 +168,13 @@ export function serializeEvent(event: Event): SerializedEvent {
     for (const prop of ALLOWLISTED_TARGET_PROPERTIES) {
       const value = (target as unknown as Record<string, unknown>)[prop];
       if (value !== undefined) {
-        (serializedTarget as unknown as Record<string, unknown>)[prop] = value;
+        // Converted like `detail` below, and for the same reason: a `value` is
+        // a whole value a component chose to expose, not necessarily a string.
+        // A `cf-input`, a `cf-tabs` and a `cf-calendar` each declare theirs as
+        // `CellHandle<string> | string`, and a `CellHandle` reaches the pattern
+        // as the sigil link its `toJSON()` produces, which the worker resolves.
+        (serializedTarget as unknown as Record<string, unknown>)[prop] =
+          toSerializableValue(value);
         hasTargetProps = true;
       }
     }
@@ -186,35 +203,40 @@ export function serializeEvent(event: Event): SerializedEvent {
     }
   }
 
-  // Handle CustomEvent detail - ensure it's JSON-serializable
-  //
   // TODO(danfuzz): a `detail` is a whole value a component chose to hand the
-  // pattern, and the pattern's handler receives it as a `FabricValue`. This
-  // JSON round-trip narrows it to the JSON-compatible subset on the way in: a
+  // pattern, and the pattern's handler receives it as a `FabricValue`. The
+  // conversion below narrows it to the JSON-compatible subset on the way in: a
   // `bigint` throws out of `JSON.stringify()` and lands in the `catch`, which
   // replaces the entire detail with `String(detail)`, and a `FabricBytes`
   // stringifies to `{}`. The crossing is `postMessage`, not JSON text, so
   // `codec-realm` carries the whole domain here; what has to stay is the
-  // separate job this does of turning an unencodable detail into something
-  // rather than failing the event. The outbound half of this seam is marked on
+  // separate job the conversion does of turning an unencodable detail into
+  // something rather than failing the event. The same holds of a target's
+  // `value` and `checked` above. The outbound half of this seam is marked on
   // `SetPropOp` in `../vdom-ops.ts`.
   if ("detail" in event && (event as CustomEvent).detail !== undefined) {
-    const detail = (event as CustomEvent).detail;
-    try {
-      // Use JSON round-trip to get a clean JSON value
-      // This handles: functions (stringify returns undefined), symbols, circular refs
-      const jsonString = JSON.stringify(detail);
-      if (jsonString !== undefined) {
-        serialized.detail = JSON.parse(jsonString);
-      } else {
-        // Functions/symbols return undefined from stringify - convert to string
-        serialized.detail = String(detail);
-      }
-    } catch {
-      // Circular refs or other errors - convert to string representation
-      serialized.detail = String(detail);
-    }
+    serialized.detail = toSerializableValue((event as CustomEvent).detail);
   }
 
   return serialized;
+}
+
+/**
+ * Converts one value a component exposed to the event into a form the VDOM
+ * event notification can carry, substituting a description for anything with
+ * no conversion at all. Handing the pattern something is the point: an event
+ * whose value cannot cross is still an event the handler should see.
+ */
+function toSerializableValue(value: unknown): FabricValue {
+  try {
+    // The round trip resolves whatever `toJSON()` a value defines -- a
+    // `CellHandle` becomes its sigil link -- and drops what JSON has no
+    // representation for. `undefined` comes back from `JSON.stringify()` for a
+    // function or a symbol, and a circular reference or a throwing `toJSON()`
+    // lands in the `catch`.
+    const jsonString = JSON.stringify(value);
+    return jsonString !== undefined ? JSON.parse(jsonString) : String(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -233,10 +233,28 @@ function toSerializableValue(value: unknown): FabricValue {
     // `CellHandle` becomes its sigil link -- and drops what JSON has no
     // representation for. `undefined` comes back from `JSON.stringify()` for a
     // function or a symbol, and a circular reference or a throwing `toJSON()`
-    // lands in the `catch`.
+    // throws out of it.
     const jsonString = JSON.stringify(value);
-    return jsonString !== undefined ? JSON.parse(jsonString) : String(value);
+    if (jsonString !== undefined) return JSON.parse(jsonString);
   } catch {
+    // Described below, as a value with no JSON form at all is.
+  }
+
+  return describeUnconvertible(value);
+}
+
+/**
+ * Renders a value with no JSON form as text, for a description that must be
+ * produced whatever it is handed.
+ *
+ * A value can refuse even to be coerced: `String()` reaches for `toString` and
+ * `valueOf`, and an object made with `Object.create(null)` has no prototype to
+ * find either on. `/unconvertible` is the fixed token for that.
+ */
+function describeUnconvertible(value: unknown): string {
+  try {
     return String(value);
+  } catch {
+    return "/unconvertible";
   }
 }

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -5,7 +5,8 @@
  * on the main thread. They are batched and sent as a single message.
  */
 
-import type { CellRef, JSONValue } from "@commonfabric/runtime-client";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { CellRef } from "@commonfabric/runtime-client";
 
 /**
  * Reserved node ID for the container element. The main thread registers the
@@ -58,14 +59,18 @@ export type SetPropOp = {
   op: "set-prop";
   nodeId: number;
   key: string;
-  // TODO(danfuzz): a prop is whatever a pattern put on a render node, so its
-  // value is a `FabricValue`, and `JSONValue` narrows that to the
-  // JSON-compatible subset. The producer (`transformPropValue()` in
-  // `worker/reconciler.ts`) does not narrow to match: it hands over a
-  // `FabricPrimitive` whole, and structured clone strips one to `{}` on the
-  // way here. `codec-realm` is the mechanism, this batch crossing by
-  // `postMessage` rather than as JSON text.
-  value: JSONValue;
+  /**
+   * The value to set, which is whatever a pattern put on a render node and so
+   * is a `FabricValue` entire. `transformPropValue()` in
+   * `worker/reconciler.ts` produces one: it hands a `FabricPrimitive` over
+   * whole rather than narrowing.
+   *
+   * TODO(danfuzz): the crossing does not yet carry what this declares.
+   * Structured clone strips a `FabricPrimitive` to `{}` between the producer
+   * and the applicator, silently. `codec-realm` is the mechanism, this batch
+   * crossing by `postMessage` rather than as JSON text.
+   */
+  value: FabricValue;
 };
 
 /**

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -206,6 +206,21 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.target?.value, "[object Object]");
   });
 
+  await t.step("describes a target value that refuses coercion too", () => {
+    // `String()` reaches for `toString` and `valueOf`; a null-prototype object
+    // has neither, and a circular one has no JSON form either, so both routes
+    // out of the conversion throw. The event still has to reach the worker.
+    const bare = Object.create(null);
+    bare.self = bare;
+    const event = new MockEvent("input", {
+      target: { value: bare },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.target?.value, "/unconvertible");
+  });
+
   await t.step("captures trusted provenance", () => {
     const event = new MockEvent("click", {
       isTrusted: true,

--- a/packages/html/test/worker-events.test.ts
+++ b/packages/html/test/worker-events.test.ts
@@ -174,6 +174,38 @@ Deno.test("events - serializeEvent", async (t) => {
     assertEquals(serialized.type, "click");
   });
 
+  await t.step("resolves a target's `toJSON()`-bearing value", () => {
+    // A `cf-input`, a `cf-tabs` and a `cf-calendar` each declare `value` as
+    // `CellHandle<string> | string`, and a `CellHandle` renders as its sigil
+    // link. Modelled here rather than imported: `html` does not depend on
+    // `runtime-client`'s class, and what the conversion acts on is `toJSON()`.
+    const link = { "/": { "link@1": { id: "of:fid1:abc" } } };
+    const handle = new (class {
+      toJSON() {
+        return link;
+      }
+    })();
+    const event = new MockEvent("input", {
+      target: { value: handle },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.target?.value, link);
+  });
+
+  await t.step("describes a target value with no JSON form", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const event = new MockEvent("input", {
+      target: { value: circular },
+    }) as unknown as Event;
+
+    const serialized = serializeEvent(event);
+
+    assertEquals(serialized.target?.value, "[object Object]");
+  });
+
   await t.step("captures trusted provenance", () => {
     const event = new MockEvent("click", {
       isTrusted: true,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -779,7 +779,16 @@ export interface ITransactionWriteRequest {
   delete?: boolean;
 }
 
-export interface IMemoryChange {
+/**
+ * One address's before-and-after across a change.
+ *
+ * A type alias rather than an `interface`, and it has to stay one: its members
+ * are `FabricValue`s and it rides the IPC envelope inside a telemetry marker,
+ * so it must be able to satisfy `FabricPlainObject`. An `interface` never can,
+ * however plain its members -- TypeScript grants the implicit index signature
+ * that requires to an anonymous object type and not to an interface.
+ */
+export type IMemoryChange = {
   /**
    * Memory address that was changed.
    */
@@ -792,7 +801,7 @@ export interface IMemoryChange {
    * Value memory address has after change.
    */
   after: FabricValue;
-}
+};
 
 export type StorageTransactionStatus =
   | { status: "ready"; journal: ITransactionJournal }

--- a/packages/runtime-client/src/protocol/types.ts
+++ b/packages/runtime-client/src/protocol/types.ts
@@ -2001,7 +2001,7 @@ export type SerializedDomEvent = {
   /**
    * A custom event's payload.
    */
-  detail?: JSONValue;
+  detail?: FabricValue;
 };
 
 /**
@@ -2013,13 +2013,18 @@ export type SerializedEventTarget = {
    */
   name?: string;
   /**
-   * The element's current value.
+   * The element's current value. A `FabricValue` rather than a string: a custom
+   * element chooses what its `value` is, and a `cf-input`, a `cf-tabs` and a
+   * `cf-calendar` each declare theirs as `CellHandle<string> | string`, which
+   * arrives here as the sigil link the main thread resolved it to.
    */
-  value?: string;
+  value?: FabricValue;
   /**
-   * Whether a checkbox or radio is checked.
+   * Whether a checkbox or radio is checked -- or, where the element chose to
+   * expose something else, what it chose. `cf-checkbox` and `cf-switch` each
+   * declare theirs as `CellHandle<boolean> | boolean`.
    */
-  checked?: boolean;
+  checked?: FabricValue;
   /**
    * Whether an option is selected.
    */


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Prep for the IPC envelope work (#6323): the parts of it that are correct on
their own, so that PR carries only the envelope encoding itself. Nothing here
depends on that change landing.

## A value the element exposed reached the worker as `{}`

`serializeEvent()` converts a `CustomEvent`'s `detail` through a JSON round
trip, and copied the target's allowlisted properties raw. A custom element
chooses what its `value` is, and several do not choose a string: `cf-input`,
`cf-tabs` and `cf-calendar` each declare `value` as `CellHandle<string> |
string`, and `cf-checkbox` and `cf-switch` declare `checked` as
`CellHandle<boolean> | boolean`.

A `CellHandle` keeps its state in private fields, so it has no own enumerable
properties, and the structured clone that carries the VDOM event notification
to the worker delivers `{}`. The value is gone and the handler receives an
empty record in its place -- no error, no log.

Both properties now take the same conversion `detail` takes, which resolves the
handle's `toJSON()` into the sigil link `handleVDomEvent()` already reads, and
which describes a value with no JSON form at all rather than failing the event.
The conversion is a named function now that two callers share it.

Two tests cover it, and both were checked against an ablation: with the
conversion reverted, each fails.

## Three declarations that named a narrower domain than what flows

`SerializedEventTarget.value` was `string` and `checked` was `boolean`, in both
of the places that type is declared. The elements above do not honor either
claim. Both are now `FabricValue`, and `detail` widens with them: `JSONValue`
carries an implication of JSON transport, which is not what this crossing is.

`SetPropOp.value` was `JSONValue`, where a prop is whatever a pattern put on a
render node. `transformPropValue()` already hands a `FabricPrimitive` over
whole rather than narrowing to match, so the declaration was behind its own
producer. It is `FabricValue` now, and the `TODO` that recorded the loss moves
onto the field it is about -- structured clone strips a `FabricPrimitive` to
`{}` between the producer and the applicator, which is a fact about the
crossing rather than about the type.

`IMemoryChange` becomes a type alias. Its members are `FabricValue`s and it
rides the IPC envelope inside a telemetry marker, so it has to be able to
satisfy `FabricPlainObject`; an `interface` never can, however plain its
members, because TypeScript grants the implicit index signature that requires
to an anonymous object type alone. The two types beneath it are already
aliases, so the change is exactly one deep.

## Verification

- `deno fmt --check`, `deno lint`, `deno task check`: green, repo-wide.
- `html` and `runtime-client` package suites: green.
- `IMemoryChange` has no implementor or extender to break; the change is
  compile-time only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ukZJG1bVUK194EAJhtLNu


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

