### PR TITLE
fix(runner): exempt meta-seam paths from the writer-fit measurement

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -233,6 +233,35 @@ The strict-only delta is:
   transaction with recorded reasons CFC-relevant (`prepare-reasons`), so a
   reasoned tx whose reads never tripped an eager relevance mark cannot slip the
   ladder ([extended-storage-transaction.ts](../../packages/runner/src/storage/extended-storage-transaction.ts)).
+
+  The raw meta seam is outside the check at EVERY rung, so a meta path
+  raises neither a strict reject nor a persist-and-flag diagnostic. The
+  measurement quantifies over paths a schema could have declared a policy
+  at, and no value schema describes the document-root siblings of `value`
+  that `setMetaRaw` addresses. One route does reach a ceiling there: a
+  document-root declared entry resolves at every meta path by longest
+  prefix. It is skipped anyway. That entry sits at logical `[]`, the
+  payload root, and reaches the seam only because canonicalization strips a
+  leading `value` — so it is not a declaration about the seam, and honoring
+  it would make a piece updatable or not according to whether its pattern
+  carries a root `ifc`. Declaring on a single result field, which is how a
+  pattern normally labels one, leaves the seam's ceiling empty, and the
+  piece is then un-updatable under strict because the pattern updater,
+  `setsrc`, and setup over an existing piece all stamp meta.
+
+  The exemption is not a hole. A path counts as meta only while no payload
+  write landed on it too, so a transaction writing both leaves the path
+  measured. The collapse of a deeper path against a covering ancestor runs
+  over the measured paths only, so an exempt meta path cannot shadow a value
+  write beneath it. Meta paths remain flow stamp targets, so the join still
+  persists there and the egress, display, and observation gates read the
+  unchanged label. And the seam sits in the same document, space, and
+  replica set as the value surface beside it, so it reaches no reader that
+  surface did not. One residual comes with it: where a payload field carries
+  a `MetaField` name, an exempt meta write can raise the stored derived
+  label at their shared logical path past what that field declares. The
+  direction is over-taint, so reads stay protected; giving the envelope seam
+  a path space of its own is what removes the collision.
 - **Future strict-only fail-closed cases.** Any new check that wants a
   persist-and-flag grace under explicit puts its reject at the strict level,
   same shape.

--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -304,6 +304,36 @@ clause-subsumption predicate; tests `cfc-writer-fit.test.ts`. Two items stay
 open on the confidentiality side: (a) the standard-profile default, and (d)
 the residency half of the write ceiling, recorded next.
 
+One narrowing landed alongside: the measurement quantifies over paths a
+schema could have declared a policy at, and the raw meta seam is not one.
+`setMetaRaw` lands on a document-root sibling of `value` (`schema`,
+`internal`, `patternIdentity`, and the rest of the `MetaField` union), which
+no value schema describes. The seam is outside the check at every rung, so a
+meta path raises neither a strict reject nor a persist-and-flag diagnostic.
+
+A ceiling can still resolve at a meta path, from a document-root declared
+entry by longest prefix, and that route is skipped too. The entry sits at
+logical `[]`, the payload root, and reaches the seam only because
+canonicalization strips a leading `value`. Honoring it would make a piece
+updatable or not according to whether its pattern carries a root `ifc`.
+Declaring on a single result field, which is how a pattern normally labels
+one, leaves the seam's ceiling empty; the piece is then un-updatable under
+strict, because the pattern updater, `setsrc`, and setup over an existing
+piece all stamp meta.
+
+Nothing is laundered. A path counts as meta only while no payload write
+landed on it too, so a transaction writing both leaves the path measured; the
+ancestor collapse runs over measured paths only, so an exempt meta path
+cannot shadow a value write beneath it; meta paths remain flow-label targets,
+so the join persists there and the egress, display, and observation gates
+read the unchanged label; and the seam shares the document, space, and
+replica set of the value surface beside it, so it reaches no further. The
+residual is the shared namespace: where a payload field carries a `MetaField`
+name, an exempt meta write can raise the stored derived label at their common
+logical path past what that field declares. That is over-taint, so reads stay
+protected, and giving the envelope seam its own path space is the fix. Shares
+the meta-seam predicate with the schema write-policy requirement (#6077).
+
 (d) **[normative] Residency fit — the ceiling a document carries by living
 where it lives.** The fit measurement joins the target's declared policy with
 one RESIDENCY clause, `Space(<the space the document resides in>)`. A flow

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1523,6 +1523,25 @@ const valueWriteTargets = (
   return result;
 };
 
+/**
+ * Whether every write a transaction recorded at `path` on one target arrived
+ * on the raw meta seam — the document-root siblings of `value` that
+ * `setMetaRaw` addresses (`schema`, `internal`, `patternIdentity`, and the
+ * rest of the `MetaField` union).
+ *
+ * No value schema describes that seam, so the two rules that ask a schema
+ * about a path — the write-policy requirement and the §8.12.4 writer-fit
+ * measurement — have nothing to ask about a meta-seam path, and both consult
+ * this one predicate. A meta root and a payload field of the same name share
+ * one logical path, which is why `valueWriteTargets` records the answer per
+ * path across every write that reached it rather than per write: a path is
+ * meta only while no payload write landed there too.
+ */
+const isMetaSeamPath = (
+  metaOnlyByPath: ReadonlyMap<string, boolean> | undefined,
+  path: readonly string[],
+): boolean => metaOnlyByPath?.get(pathKey(path)) === true;
+
 // ---------------------------------------------------------------------------
 // S16 flow labels (default transition): one conservative confidentiality join
 // per transaction — everything the transaction observed taints everything it
@@ -5489,17 +5508,14 @@ export const prepareBoundaryCommit = (
       continue;
     }
     // The schema write-policy requirement quantifies over the paths a
-    // schema could describe. A raw meta-seam write is not one: `setMetaRaw`
-    // lands on a document-root sibling of `value` (`slug`,
-    // `patternIdentity`, and the rest of the `MetaField` union), and no
-    // schema describes that seam, so demanding a policy input for it
-    // rejects every meta write on a labeled document — slug assignment, the
-    // pattern updater's identity swap, setup over an existing piece, and
-    // the source-lifecycle transitions. These paths stay flow-label
-    // targets: the write above still carries the transaction's join onto
-    // the document, so nothing is laundered by skipping them here.
+    // schema could describe. A raw meta-seam write is not one, so demanding
+    // a policy input for it rejects every meta write on a labeled document —
+    // slug assignment, the pattern updater's identity swap, setup over an
+    // existing piece, and the source-lifecycle transitions. These paths stay
+    // flow-label targets: the write above still carries the transaction's
+    // join onto the document, so nothing is laundered by skipping them here.
     const policyPaths = target.paths.filter((path) =>
-      target.metaOnlyByPath.get(pathKey(path)) !== true
+      !isMetaSeamPath(target.metaOnlyByPath, path)
     );
     if (policyPaths.length === 0) {
       continue;
@@ -6508,17 +6524,39 @@ export const prepareBoundaryCommit = (
           structureStampPaths.push(structureContainerPath);
         }
       }
-      for (const path of derivedStampPaths) {
-        // Deeper stamped paths are redundant with a stamped ancestor; only
-        // collapse against paths that actually receive a covering entry.
-        if (
-          derivedStampPaths.some((other) =>
-            other.length < path.length && isPrefix(other, path)
-          )
-        ) {
-          continue;
-        }
-        if (flowConfidentiality.length > 0) {
+      // Writer-fit measures the paths a schema could have declared a policy
+      // at, and the raw meta seam is not one: no value schema describes the
+      // document-root siblings of `value`. The measurement is skipped there
+      // at every rung, so a meta path raises neither a strict reject nor a
+      // persist-and-flag diagnostic.
+      //
+      // A ceiling can still resolve at a meta path, from a document-root
+      // declared entry by longest prefix. The skip is unconditional anyway:
+      // that entry sits at logical `[]`, the PAYLOAD root, and reaches the
+      // seam only because canonicalization strips a leading `"value"`.
+      //
+      // Meta paths stay flow stamp targets in the loop below, so the join
+      // still lands on them as the `derived` component. Where a payload
+      // field carries a `MetaField` name the two share one logical path, so
+      // an exempt meta write can raise the stored derived label there past
+      // what that field declares — over-taint, which leaves the declared
+      // entry untouched and reads protected.
+      if (flowConfidentiality.length > 0) {
+        const measuredPaths = derivedStampPaths.filter((path) =>
+          !isMetaSeamPath(flowTarget?.metaOnlyByPath, path)
+        );
+        for (const path of measuredPaths) {
+          // Deeper paths are covered by the write at a measured ancestor;
+          // collapse against measured paths only, so an exempt meta path
+          // never shadows a value write below it (a payload field named
+          // `schema` shares the meta root's logical path).
+          if (
+            measuredPaths.some((other) =>
+              other.length < path.length && isPrefix(other, path)
+            )
+          ) {
+            continue;
+          }
           // Absent declared entries resolve to the EMPTY ceiling ("public
           // store"), never the undefined "no ceiling" — a tainted write to
           // an undeclared store is the canonical misfit, and fitting it
@@ -6554,6 +6592,17 @@ export const prepareBoundaryCommit = (
               tx.noteCfcDiagnostic(`writer-fit(persist-and-flag): ${misfit}`);
             }
           }
+        }
+      }
+      for (const path of derivedStampPaths) {
+        // Deeper stamped paths are redundant with a stamped ancestor; only
+        // collapse against paths that actually receive a covering entry.
+        if (
+          derivedStampPaths.some((other) =>
+            other.length < path.length && isPrefix(other, path)
+          )
+        ) {
+          continue;
         }
         // C2 persist split (C0 §5/§8): the per-tx join lands as two
         // per-class entries instead of one covering entry. The `value`

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -558,6 +558,309 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
     }
   });
 
+  // The measurement quantifies over paths a schema could have declared a
+  // policy at, and the raw meta seam is not one: `setMetaRaw` lands on a
+  // document-root sibling of `value` (`schema`, `internal`, and the rest of
+  // the `MetaField` union), which no value schema describes.
+  //
+  // One route does reach a ceiling there — a document-root declaration
+  // resolves at every meta path by longest prefix — but it widens the
+  // ceiling over the whole payload, and a declaration on a single result
+  // field, which is how a pattern normally labels one, leaves the seam's
+  // ceiling empty. Such a pattern is then un-updatable: the pattern updater,
+  // `setsrc`, and setup over an existing piece all stamp meta.
+  //
+  // The seam is outside the check at every rung, so these cases assert on
+  // both the strict reject and the persist-and-flag diagnostic below it.
+  describe("meta-seam exemption", () => {
+    // Pinned rather than inherited: this exemption is only observable at the
+    // strictness where the misfit rejects.
+    const strictRuntime = (
+      storageManager: ReturnType<typeof StorageManager.emulate>,
+    ) =>
+      new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-strict",
+        cfcFlowLabels: "persist",
+      });
+
+    /** Seed `cause` as a plain document declaring no store policy. */
+    const seedUndeclaredTarget = async (
+      runtime: Runtime,
+      cause: string,
+      payload: FabricValue = { note: "public" },
+    ) => {
+      const id = runtime.getCell(signer.did(), cause)
+        .getAsNormalizedFullLink().id;
+      const seed = runtime.edit();
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id,
+        path: [],
+      }, { value: payload });
+      expect((await seed.commit()).ok).toBeDefined();
+      return id;
+    };
+
+    it("admits a meta write of a tainted join into an undeclared store", async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-meta-source");
+        const targetId = await seedUndeclaredTarget(runtime, "wf-meta-target");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-meta-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        expect(raw.secret).toBe("s3cr3t");
+        const target = runtime.getCell(
+          signer.did(),
+          "wf-meta-target",
+          undefined,
+          tx,
+        );
+        await target.sync();
+        // The two paths the piece-update flows land on, and the two the
+        // strict measurement used to reject at.
+        target.setMetaRaw("schema", { type: "object" });
+        target.setMetaRaw("internal", { derived: raw.secret });
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error).toBeUndefined();
+        expect(result.ok).toBeDefined();
+        // Not merely "did not reject": no measurement named a meta path at
+        // all, at either rung (a strict reject and an explicit flag carry the
+        // identical reason string).
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+
+        // The taint is not lost with the measurement. The join still lands as
+        // the derived component on the meta paths, so the egress, display,
+        // and observation gates read the unchanged label. (Each path carries
+        // the C2 per-class split — a `value` entry and a `shape` entry — so
+        // the paths are compared as a set.)
+        const stamped = replicaEntries(storageManager, targetId).filter((e) =>
+          e.origin === "derived" &&
+          (e.label.confidentiality ?? []).includes("secret")
+        );
+        expect([...new Set(stamped.map((e) => e.path.join("/")))].sort())
+          .toEqual(["internal", "schema"]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("raises no persist-and-flag diagnostic for a meta write under enforce-explicit", async () => {
+      // The exemption is a statement about what the check can measure, not
+      // about what a rung does with a misfit, so it holds below strict too.
+      // Were it scoped to the reject, the shipped posture would keep flagging
+      // a measurement the strict rung had already declared meaningless.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = newRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-meta-explicit-source");
+        await seedUndeclaredTarget(runtime, "wf-meta-explicit-target");
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-meta-explicit-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const target = runtime.getCell(
+          signer.did(),
+          "wf-meta-explicit-target",
+          undefined,
+          tx,
+        );
+        await target.sync();
+        target.setMetaRaw("slug", `${raw.secret}!`);
+        tx.prepareCfc();
+
+        expect((await tx.commit()).ok).toBeDefined();
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("still rejects an ordinary value write of the same join into the same store", async () => {
+      // The control: the exemption is about paths a schema cannot reach, not
+      // about this transaction's join or this target's store. Swap the meta
+      // write above for a payload write into the same undeclared document and
+      // the misfit is back.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-meta-control-source");
+        const targetId = await seedUndeclaredTarget(
+          runtime,
+          "wf-meta-control-target",
+        );
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-meta-control-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: targetId,
+          path: ["value", "note"],
+        }, `${raw.secret}!`);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error).toBeDefined();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(`for ${targetId} at /note`);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("skips the measurement even where a root declaration resolves at the meta path", async () => {
+      // The skip is unconditional, and this pins that. A document-root
+      // declared entry is a prefix of every meta path, so longest-prefix
+      // resolution hands the meta path a non-empty ceiling — but that
+      // reaches the envelope seam only because canonicalization strips a
+      // leading `"value"`, making the payload root and the document root one
+      // logical path. It says nothing about the seam, and honoring it would
+      // make a piece updatable or not according to whether its pattern
+      // carries a root `ifc`.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-meta-rooted-source");
+
+        // A root declaration that does NOT cover the join the tx will carry.
+        const targetId = runtime.getCell(signer.did(), "wf-meta-rooted-target")
+          .getAsNormalizedFullLink().id;
+        const seed = runtime.edit();
+        writeSeedEnvelopeDoc(seed, signer.did());
+        seed.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: targetId,
+          path: [],
+        }, {
+          value: { note: "public" },
+          cfc: {
+            version: 1,
+            schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                label: { confidentiality: ["unrelated"] },
+              }],
+            },
+          },
+        });
+        expect((await seed.commit()).ok).toBeDefined();
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-meta-rooted-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const target = runtime.getCell(
+          signer.did(),
+          "wf-meta-rooted-target",
+          undefined,
+          tx,
+        );
+        await target.sync();
+        target.setMetaRaw("slug", `${raw.secret}!`);
+        tx.prepareCfc();
+
+        expect((await tx.commit()).ok).toBeDefined();
+        expect(writerFitDiagnostics(tx)).toEqual([]);
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+
+    it("keeps measuring a payload field that shares a meta field's logical path", async () => {
+      // A payload field literally named `schema` lives at raw
+      // `["value","schema"]` and canonicalizes onto the meta root's logical
+      // path. The exemption is recorded per path across every write that
+      // reached it, so writing both in one transaction leaves the path
+      // measured — and an exempt meta path must not collapse a value write
+      // below it out of the measurement either.
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = strictRuntime(storageManager);
+      try {
+        await seedSecretSource(runtime, "wf-meta-collide-source");
+        // The payload carries a `schema` object of its own, so the write
+        // below materializes at its own path instead of at the document root.
+        const targetId = await seedUndeclaredTarget(
+          runtime,
+          "wf-meta-collide-target",
+          { schema: { existing: true } },
+        );
+
+        const tx = runtime.edit();
+        const source = runtime.getCell(
+          signer.did(),
+          "wf-meta-collide-source",
+          undefined,
+          tx,
+        );
+        const raw = source.getRaw() as { secret?: string };
+        const target = runtime.getCell(
+          signer.did(),
+          "wf-meta-collide-target",
+          undefined,
+          tx,
+        );
+        await target.sync();
+        target.setMetaRaw("schema", { type: "object" });
+        tx.writeOrThrow({
+          space: signer.did(),
+          scope: "space",
+          id: targetId,
+          path: ["value", "schema", "leaked"],
+        }, `${raw.secret}!`);
+        tx.prepareCfc();
+
+        const result = await tx.commit();
+        expect(result.error).toBeDefined();
+        expect(result.error?.message).toContain(
+          "writer-fit confidentiality misfit",
+        );
+        expect(result.error?.message).toContain(
+          `for ${targetId} at /schema/leaked`,
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  });
+
   it("leaves untainted writes untouched under enforce-strict", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = newRuntime(storageManager);


### PR DESCRIPTION
The CFC writer-fit check (§8.12.4 `canWrite`) measures a transaction's per-transaction confidentiality flow join against the target document's DECLARED store policy at each path where the join lands, and an absent declaration is the empty "public" ceiling. Under `enforce-strict` a misfit rejects the whole commit.

Raw meta writes are measured by that rule today, and a pattern that labels a result field the ordinary way cannot pass it. `setMetaRaw` lands on a document-root sibling of `value` -- `schema`, `internal`, `patternIdentity`, `slug`, and the rest of the `MetaField` union -- and no value schema describes that seam. One route does reach a ceiling there: a declaration at the schema ROOT is stored at logical `[]` and resolves at every meta path by longest prefix. That route is real, and it is the only one; declaring on a single result field, which is how a pattern normally labels one, leaves the seam's ceiling empty and no §8.12.5 out available -- the write cannot be sent to another store, and the only schema upgrade that would help widens the ceiling over the entire payload.

The consequence is that such a pattern becomes un-updatable once the enforcement dial reaches its strictest rung, because every update route stamps meta -- the pattern updater, `setsrc`, and setup over an existing piece all do. Three cases in
`packages/piece/test/state-continuity.test.ts` fail exactly this way when the suite's runtime is built with `cfcEnforcementMode: "enforce-strict"` and `cfcFlowLabels: "persist"`, rejecting at /schema and /internal on a join carrying a single Resource atom. We are preparing to default every dial to its strictest rung, so this is a blocker for that default.

Skip the measurement at meta-seam paths. This reuses the per-path answer #6077 already records for the neighbouring rule (a meta write requires no schema write-policy input) rather than introducing a second list of field names: both rules now ask the same `isMetaSeamPath` predicate, which reads the `metaOnlyByPath` map `valueWriteTargets` builds. Keeping one predicate matters because the two rules must agree about which paths a schema can speak for; a second list would be free to drift from the first.

The skip covers every rung, not just the reject. Whether a path can be measured is a property of the path, not of what a rung does with a misfit; scoping it to strict would leave the shipped posture flagging a measurement the strict rung had already declared meaningless.

It also covers the root-declaration case, which is a deliberate choice rather than a consequence. A schema's root `ifc` is stored at the PAYLOAD root, and it reaches the envelope seam only because canonicalization strips a leading "value" -- so it is not a statement anyone made about the seam, and honoring it would make a piece's updatability depend on whether its pattern happens to carry a root `ifc`.

Why this cannot launder confidentiality out through a meta surface:

  - The stamp still lands. Meta paths remain flow-label targets, so the join persists on them as the `derived` component exactly as before. Only the measurement is skipped. Every read of a meta path joins the taint, and the egress, display, and observation gates see the unchanged label.

  - The exemption cannot be claimed by a payload write. A leading "value" element is stripped when a path is canonicalized, so the meta root `schema` and a payload field named `schema` share one logical path. `metaOnlyByPath` answers per path across every write that reached it, and a path counts as meta only while no payload write landed there too -- so a transaction that writes both leaves the path measured.

  - An exempt path cannot shadow a value write beneath it. The measurement collapses a deeper path against a shallower one that covers it; that collapse now runs over the measured paths only. Otherwise a meta write at `schema` would suppress the measurement of a payload write at `schema.leaked` in the same transaction.

  - The audience does not widen. The meta seam is a field of the same document, in the same space, reaching the same replicas as the value surface beside it. It is not a route to any reader the value write could not already reach; what distinguishes it is only that a schema cannot describe it.

One residual comes with the exemption, from the shared namespace rather than from this rule. Where a payload field carries a `MetaField` name, an exempt meta write can raise the stored derived label at their common logical path past what that field declares, and no rung reports it. The direction is over-taint: the declared entry is untouched and reads stay protected, but the declared component stops being an upper bound on the derived one at those few names. Giving the envelope seam a path space of its own is what removes the collision.

The measurement moves out of the stamp loop into its own pass so it can run over its own set of paths. It reads a snapshot of the declared policy entries taken before either loop, so separating them changes no order and no value: reasons and diagnostics are recorded in the same sequence, and the stamps are unchanged.

Tests pin each of those at `enforce-strict` with flow labels persisting: a meta write of a tainted join into an undeclared store commits with no writer-fit reason naming a meta path; the derived stamp is still persisted at those paths; the same join written as an ordinary value into the same undeclared store still misfits; a payload field sharing a meta field's logical path is still measured, naming the payload path rather than the meta one; and a document carrying a root declaration the join exceeds still admits the meta write. One more covers `enforce-explicit`, where the meta write must raise no persist-and-flag diagnostic either.

The enforcement matrix's writer-fit section and the SC-18 entry in the spec-changes log record the narrowing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

