### PR TITLE
test(topics): retire the epochHolder guard now the registry-epoch fix landed

### DIFF
--- a/packages/patterns/integration/topic-board-child-contract.test.ts
+++ b/packages/patterns/integration/topic-board-child-contract.test.ts
@@ -61,42 +61,6 @@ function onArmStepSkip(step: string): { ignore: boolean } {
   return { ignore: true };
 }
 
-/**
- * Held across both suites: a live controller keeps a lease on the runner's
- * process-wide schema-document registry, which clears when the last lease in
- * the process releases — and with two suites that each build their own
- * controller, that clear lands exactly between them. The compiled topics
- * pattern is reused across the clear with its binding schemas already
- * externalized to `cid:` references, and nothing re-registers the documents
- * behind them, so the second suite's first sync sends the server a selector
- * naming a schema document no one can supply. The server rejects the query
- * ("Selector references schema document ... which is not stored in this
- * space"), the rejected load makes the scheduler drop the next verb event
- * undispatched, and a wait on that event's consequence hangs. Holding one
- * lease open for the whole file keeps every suite inside the epoch that
- * registered the documents. Remove once serialized-pattern reuse registers
- * its schema documents across registry epochs.
- *
- * This guard settles only that. A second symptom — `crossrefs` serving four
- * rows for three topics, while the durable store holds exactly three — is
- * #6304, not covered here: the pivot suite's baseline case observes it and
- * carries a registered ON-arm step skip
- * (tasks/server-execution-on-skips.ts) until that issue is fixed.
- */
-let epochHolder: PiecesController | undefined;
-
-beforeAll(async () => {
-  epochHolder = await initializePiecesController({
-    space: SPACE_NAME,
-    apiUrl: new URL(API_URL),
-    identity: await Identity.generate({ implementation: "noble" }),
-  });
-});
-
-afterAll(async () => {
-  await epochHolder?.dispose();
-});
-
 describe("topic-board-child-contract", () => {
   let cc: PiecesController;
   let board: PieceController;


### PR DESCRIPTION
## Why

The epochHolder guard in `topic-board-child-contract.test.ts` (landed with #6267) held a file-lifetime controller so the schema-document registry never cleared between the file's two suites — a workaround for #6303, whose own text says to remove it once the runtime fix lands. #6297 landed that fix: the wish sidecar pattern caches drop their compiled pattern on the registry-clear transition, and `externalizeSyncSelector` fails closed on references the target space cannot back. The guard now only hides the code path the fix is supposed to carry, so retiring it also makes this file a standing regression test for the cross-epoch mechanism.

Merging this closes #6303 — the runtime fix landed via #6297 without closing it, and this deletion was the issue's last outstanding item.

## What changed

The 36-line guard block (doc comment, holder, its `beforeAll`/`afterAll`) is deleted; nothing else. The #6304 pointer the comment carried is preserved where it lives: the registered ON-arm step skip in `tasks/server-execution-on-skips.ts` with its own rationale.

## Test plan

- Verified against pure main (ad98dc1ab, carrying #6297): the identical two-suite content with the guard removed, run against a current-vintage toolshed — previously this configuration reproduced the `Selector references schema document cid:fid1:U9rnPVv…` rejection deterministically; on main both suites pass in 5s with zero selector rejections and zero sync-load-failures.
- The pattern-integration CI shards run this exact file in both the default and server-execution lanes.

Fixes #6303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

