### PR TITLE
fix(cli): complete the slot decisions #6318's new options left open

### DIFF
--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -972,6 +972,13 @@ const OPTION_VALUE_PROVIDERS: Readonly<Record<string, OptionProvider>> = {
   // is the transform; `--plan` reads the rows a survey wrote.
   fixer: () => Promise.resolve(directive({ kind: "files", glob: "*.ts" })),
   plan: () => Promise.resolve(directive({ kind: "files" })),
+  // `cf piece survey --diff` reads the plan a prior survey wrote and reports
+  // what changed. Scoped, because `diff` elsewhere is a subcommand name, not
+  // a file-taking option.
+  diff: onlyOn(
+    ["piece survey"],
+    () => Promise.resolve(directive({ kind: "files" })),
+  ),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -229,6 +229,7 @@ const DIRECTIVE_CASES: Array<[string, string, string | undefined]> = [
   ["cf piece repair --fixer ", "files", "*.ts"],
   ["cf piece repair --plan ", "files", undefined],
   ["cf piece survey --validator ", "files", undefined],
+  ["cf piece survey --diff ", "files", undefined],
   ["cf test --pattern-coverage-dir ", "dirs", undefined],
   ["cf test --timing-measures-out ", "files", undefined],
   ["cf fuse mount --cfc-writeback-state ", "files", undefined],

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -97,6 +97,7 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
   ["attrcache-timeout", "a timeout in seconds, passed to the FUSE child"],
   ["stats-action-limit", "a count"],
   ["stats-threshold", "a threshold"],
+  ["group-size", "a session count per retarget group"],
   ["storage-stats-limit", "a count"],
   ["wait", "a patience in seconds"],
   // Identifiers the caller brings from outside, or coins.


### PR DESCRIPTION
## Why

Main's Check job and Test (8/8) are red on every current branch: #6318 added `cf piece survey --diff` and `cf piece retarget --group-size` without deciding their completion slots, and the slot gate (`check-completion-slots`, which runs in both jobs) fails exactly as designed. This unblocks every open PR branched from current main (e.g. #6333).

## What changed

- `--diff` (piece survey) reads the plan file a prior survey wrote, so it hands the shell the `files` directive like `--plan` and `--validator` beside it — scoped to `piece survey`, since `diff` elsewhere is a subcommand name, not a file-taking option.
- `--group-size` (piece retarget) is a session count per retarget group; nothing enumerates a count, so it joins `NO_OPTION_CANDIDATES` in the numbers cluster.
- The hand-maintained directive-case table in `completion-providers.test.ts` gains the `--diff` probe that the "no slot hands the shell a directive the cases miss" net demands.

## Test plan

- `deno task check-completion-slots` passes (was: 2 uncovered slots).
- `deno test -A tasks/check-completion-slots.test.ts` passes (the Test (8/8) failure).
- Full `packages/cli` suite: 210 passed, 0 failed.
- Repo-wide `deno fmt --check` and `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

