### PR TITLE
fix(cli): decide the two completion slots `cf piece retarget` and `survey` left open

### DIFF
--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -972,6 +972,12 @@ const OPTION_VALUE_PROVIDERS: Readonly<Record<string, OptionProvider>> = {
   // is the transform; `--plan` reads the rows a survey wrote.
   fixer: () => Promise.resolve(directive({ kind: "files", glob: "*.ts" })),
   plan: () => Promise.resolve(directive({ kind: "files" })),
+  // A plan file on `cf piece survey`, which reports the survey against it, and
+  // a boolean about the input on `cf view`.
+  diff: onlyOn(
+    ["piece survey"],
+    () => Promise.resolve(directive({ kind: "files" })),
+  ),
   // `cf inspect --dir` is an extra directory to search for space DBs.
   dir: () => Promise.resolve(directive({ kind: "dirs" })),
   // `cf inspect html --out` and `cf check --output` write a file.

--- a/packages/cli/test/completion-providers.test.ts
+++ b/packages/cli/test/completion-providers.test.ts
@@ -229,6 +229,7 @@ const DIRECTIVE_CASES: Array<[string, string, string | undefined]> = [
   ["cf piece repair --fixer ", "files", "*.ts"],
   ["cf piece repair --plan ", "files", undefined],
   ["cf piece survey --validator ", "files", undefined],
+  ["cf piece survey --diff ", "files", undefined],
   ["cf test --pattern-coverage-dir ", "dirs", undefined],
   ["cf test --timing-measures-out ", "files", undefined],
   ["cf fuse mount --cfc-writeback-state ", "files", undefined],
@@ -353,6 +354,7 @@ Deno.test("provider keys report which commands each option provider answers on",
   assertEquals(options.get("to"), ["space clone"]);
   assertEquals(options.get("scope"), ["wish"]);
   assertEquals(options.get("list"), ["piece survey", "piece repair"]);
+  assertEquals(options.get("diff"), ["piece survey"]);
   assertEquals(options.get("select"), ["piece get", "get"]);
   assertEquals(options.get("root"), [
     "check",

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -89,6 +89,7 @@ export const NO_OPTION_CANDIDATES = new Map<string, string>([
   ["depth", "a graph depth"],
   ["seq", "a revision sequence number"],
   ["top", "a result count"],
+  ["group-size", "a piece count"],
   ["bucket", "a time bucket size"],
   ["since", "a timestamp"],
   ["until", "a timestamp"],


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5)

`main` is red on the `Check` and `Test (8/8)` jobs. The completion-slot gate
reports two value-taking option slots with no provider, no enumerated set, and
no allowlist entry:

```
  --diff        (piece survey)
  --group-size  (piece retarget)
```

The gate and the options reached `main` from different branches, neither of
which could see the other. The gate landed first; the branch declaring the two
options had been cut four commits earlier, so its own CI never ran the check
against them. The two changes share no file, so the merge was clean and the
red appeared only once both were on `main`.

## The two decisions

`cf piece survey --diff` takes a plan file — the same artifact a survey writes
and `cf piece repair --plan` reads back. `plan` already answers with a file
directive, so `diff` answers with the same one rather than declining to
complete. It is scoped to `piece survey`: `cf view --diff` is a boolean about
whether to read its input as a unified diff, which is a different thing
wearing the same name. That scoping matches how `list`, `from`, and `to` are
already declared.

The scoping is not load-bearing for the gate today, because `declaredSlots`
skips options that take no value and `cf view --diff` therefore never becomes
a slot. It is load-bearing for the claim: a bare key asserts the name means
one thing across the whole tree, and here it does not.

`cf piece retarget --group-size` is a count of pieces one session serves
before it is replaced. Nothing enumerates a count, so it joins the numbers
block of `NO_OPTION_CANDIDATES` alongside `limit`, `top`, and `depth`.

## Tests

Adding the provider tripped the guard that asserts every slot handing the
shell a directive is pinned by a case — which is the guard doing its job, and
the reason this change is four lines rather than one. The survey probe joins
`DIRECTIVE_CASES`, and `provider keys report which commands each option
provider answers on` gains an assertion holding `diff` to `["piece survey"]`.

Each of the four additions was ablated on its own, and each fails on its own:

- Remove the `diff` provider, and the gate names `--diff (piece survey)`.
- Remove the `group-size` entry, and it names `--group-size (piece retarget)`.
- Remove the `DIRECTIVE_CASES` entry, and the directive-coverage guard fails.
- Unscope `diff` to a bare key, and the provider-keys assertion fails.

Run green: `cli` 1729 + 1 + 210 passed / 0 failed; `tasks` 630 passed / 0
failed; `deno task check`, `fmt --check`, `lint`, `check-completion-slots`,
`check-docs`, `check-skill-facts`, `check-conflict-markers`, and
`check-no-waitfor` all clean. The full workspace suite was still running when
this opened; anything it turns up gets a follow-up commit here.

The slot census is unchanged at 390 option slots over 68 names — both options
were already declared. What changes is that they are now decided.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

