### PR TITLE
fix(runner): keep the sync schema table negotiated under contentAddressedSchemas

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -157,11 +157,14 @@ server](#clients-that-are-not-built-alongside-their-server).
   written under it persist, so turning it back off stops emission without
   un-writing anything.
 - **Interaction with `syncSchemaTableV2`.** Both mechanisms dedupe the same
-  link-schema positions, so a flag-on process disables the sync schema
-  table outright (`setSyncSchemaTableConfig(false)` at Runtime
-  construction) rather than running both — a reference-bearing link never
-  needs frame compression, and the table's negotiation simply stops being
-  offered by that process.
+  link-schema positions, and they compose: the table encoder skips
+  reference-only positions (`{ "$ref": "cid:…" }` is already smaller than
+  a table ref), so over reference-bearing frames the table approaches a
+  no-op, while stored links minted before this flag still carry inline
+  schemas that only the table compresses in flight. A Runtime therefore
+  leaves the table's negotiation untouched; the table retires through the
+  spec's Phase 3 — by ceasing to match once reference-bearing links
+  dominate — not by a construction-time switch.
 - **Current default and planned end state.** On by default, everywhere.
   An explicit `false` (env for servers and CLI, build define for the
   shell) is the rollback override: it stops emission without un-writing
@@ -905,20 +908,22 @@ the per-epic implementation notes).
   It changes only the size of the payload, not its meaning. Peers that do not
   advertise the capability keep receiving the historical fully-expanded
   `SessionSync` shape.
-- **Interaction with `contentAddressedSchemas`.** A process with that
-  flag on — its default — disables this table outright: content-addressed
-  references dedupe the same link-schema positions at rest, so the two
-  mechanisms never run together (see that flag's entry).
-- **Current default and planned end state.** On by default at the memory
-  layer, but any process that constructs a Runtime with
-  `contentAddressedSchemas` on (its default) stops offering the table, so
-  it runs only where that flag is rolled back. It is negotiated, so it
-  degrades safely against older peers. The end state is to retire the
-  negotiation and the expanded form once every peer in the fleet speaks the
-  compact form — the content-addressed-schemas spec's Phase 3 covers the
-  link-position half of that retirement.
-- **Status on 2026-08-19.** Implemented; on at the memory layer, disabled
-  in any default-configured Runtime process by `contentAddressedSchemas`.
+- **Interaction with `contentAddressedSchemas`.** The two mechanisms
+  compose (see that flag's entry): the table encoder skips
+  reference-only positions, so it compresses exactly the stored links
+  that still carry inline schemas and approaches a no-op as
+  reference-bearing links take over. Runtime construction leaves the
+  table's negotiation untouched.
+- **Current default and planned end state.** On by default, everywhere;
+  negotiated, so it degrades safely against older peers. The end state is
+  to retire the negotiation and the expanded form once every peer AND the
+  stored stock speak the compact form — the content-addressed-schemas
+  spec's Phase 3 covers the link-position half of that retirement, and it
+  is gated on stored data (reference-bearing links dominating), not on
+  the flag: inline stock outlives every flag flip, and delivering it
+  uncompressed pushes a large space's sync past Deno's 64 MiB inbound
+  websocket frame cap (#6319).
+- **Status on 2026-08-25.** Implemented; on by default everywhere.
 - **Path to removal.** Confirm no peer still needs the expanded payload, then
   delete the negotiation and the expanded-form encoder and always send the
   compact form.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -19,7 +19,6 @@ import {
   serverExecutionEnablerCount,
   setCommitPreconditionsConfig,
   setServerExecutionConfig,
-  setSyncSchemaTableConfig,
 } from "@commonfabric/memory/v2";
 import { RuntimeTelemetry } from "@commonfabric/runner";
 import {
@@ -1254,15 +1253,15 @@ export class Runtime {
     );
     this.experimental.contentAddressedSchemas =
       getContentAddressedSchemasConfig();
-    if (this.experimental.contentAddressedSchemas) {
-      // Content-addressed schema references and the sync schema table dedupe
-      // the same link-schema positions; a reference-bearing link never needs
-      // frame compression, so a flag-on process stops negotiating the table
-      // entirely rather than running both mechanisms. Ambient and one-way
-      // like the flag itself: once any runtime in the realm enables the
-      // flag, the table stays off for the process.
-      setSyncSchemaTableConfig(false);
-    }
+    // The sync schema table stays negotiated under this flag: the two
+    // mechanisms dedupe the same link-schema positions and compose (the
+    // table encoder skips reference-only positions), and stored links
+    // minted before the flag still carry inline schemas that only the
+    // table compresses in flight — delivering that stock uncompressed
+    // pushes a large space's sync past Deno's 64 MiB inbound websocket
+    // frame cap (#6319). The table retires by ceasing to match once
+    // reference-bearing links dominate (content-addressed-schemas.md,
+    // Phase 3), not by a construction-time switch.
     setCommitPreconditionsConfig(this.experimental.commitPreconditions);
     this.experimental.commitPreconditions = getCommitPreconditionsConfig();
     // Propagate only when EXPLICITLY set (stage F): a co-hosted serving

--- a/packages/runner/test/schema-doc-writer.test.ts
+++ b/packages/runner/test/schema-doc-writer.test.ts
@@ -51,9 +51,8 @@ describe("schema-doc-writer", () => {
   });
 
   afterEach(async () => {
-    // The ambient flag is realm-sticky; later test files must see its
-    // default, and the sync schema table (disabled by the flag-on Runtime
-    // construction above) must come back to its own.
+    // The ambient flags are realm-sticky; later test files must see
+    // their defaults.
     resetContentAddressedSchemasConfig();
     resetSyncSchemaTableConfig();
     await writer.dispose();
@@ -301,11 +300,13 @@ describe("schema-doc-writer", () => {
     expect(collectExternalSchemaRefHashes(uiDoc).size).toBe(0);
   });
 
-  it("disables the sync schema table for the process", () => {
-    // Both mechanisms dedupe the same link-schema positions; a flag-on
-    // process must not negotiate the frame table (the Runtime in
-    // beforeEach carries the flag).
-    expect(getSyncSchemaTableConfig()).toBe(false);
+  it("keeps the sync schema table negotiated for the process", () => {
+    // The mechanisms compose: the table encoder skips reference-only
+    // positions, and stored links minted before the flag still carry
+    // inline schemas that only the table compresses in flight. The
+    // flag-on Runtime construction in beforeEach must therefore leave
+    // the table's negotiation untouched.
+    expect(getSyncSchemaTableConfig()).toBe(true);
   });
 
   it("keeps a schema decomposition refuses inline", () => {


### PR DESCRIPTION
## What broke

The topics board on estuary is unloadable for every Deno client (`ConnectionError: Frame too large`), and the 2026-08-25 deploy broke it in browsers too (load timeouts), forcing the rollback. #6319 measured the board's initial sync at 89 MB — for ~115 topics holding ~2 MB of content.

## Mechanism

- Sync frames have interned repeated schemas since #4292 (`syncSchemaTableV2`: hello-negotiated, both ends required — `memory/v2/server.ts` ANDs the client and server capability flags). The board's frame is 88.2% inline schema text (14,066 inline schema objects; roughly one copy of the topics schema family per delivered doc), so the table is an ~8× compressor on this space.
- #5878 added a Runtime-construction side effect: `contentAddressedSchemas` on ⇒ `setSyncSchemaTableConfig(false)`, on the reasoning that a reference-bearing link never needs frame compression.
- #6083 turned `contentAddressedSchemas` on by default, arming that side effect in every default-configured process — clients stopped advertising the table, and any serving process that constructs a Runtime stopped as well.
- The premise holds for links written under the flag (`cid:` refs) but not for the stored stock, which predates the flag and still carries inline schemas — and nothing migrates the stock. Delivery of stock-heavy spaces jumped ~8×: the board's sync went from ~10 MB tabled to 50.8 MB (Aug-18 snapshot) / 89 MB (live) in one websocket message — past Deno's non-configurable 64 MiB inbound frame cap, and past what a browser can move inside the 60 s load deadline on real links.
- Deploys ship the client: deploying main delivered the table-less shell to browsers (board broke in browsers), and the rollback un-shipped it (browsers recovered). Deno clients run checkout code, so they have been broken since #6083 regardless of what is deployed.

## The fix

Delete the side effect. The two mechanisms compose rather than conflict:

- The table encoder already skips reference-only positions (`isSchemaDocumentRefOnly` in `memory/v2/sync-schema-table.ts`): `{ "$ref": "cid:…" }` is smaller than a table ref, so compressing it would grow the frame. Over reference-bearing frames the table approaches a no-op.
- Over the inline stock — which outlives every flag flip — the table is the only in-flight compression that exists.
- The content-addressed-schemas spec already describes this end state: Phase 3 retires the table by it "stopping to match" once reference-bearing links dominate — retirement driven by the data, not by a construction-time switch. This PR restores the spec'd behavior.

Also updated in the same change: both `EXPERIMENTAL_OPTIONS.md` entries now describe the composition (registry obligation), and the runner test that pinned the disable now pins the negotiation staying on.

## Verification

Live against estuary (rolled-back server at `a667cf56a`), same identity, same read, Deno 2.9.4 pinned by absolute path:

| client | result |
| --- | --- |
| main (`737e4a1a5`), defaults | `Frame too large` — board unreadable |
| main + `EXPERIMENTAL_CONTENT_ADDRESSED_SCHEMAS=false` (table restored via the flag's rollback override) | reads fine — 16.8 MB total across 124 messages, dominant frame 9,829,751 B |
| **this branch, defaults** | **reads fine — 10.3 MB total, dominant frame 9,829,877 B, full topic data returned** |

A pin-vintage client (the same memory-client library the deployed shell runs) measures the same tabled shape — 11.3 MB total, identical dominant frame — which is why browsers still work against the rolled-back estuary today while every Deno client fails.

Local gates at open: repo `deno fmt --check` / `deno lint` / `deno task check` green; the changed test file green (13 steps). The full `packages/runner` and `packages/memory` suites were still running locally when this opened — results follow in a comment; CI is authoritative.

## Deploy sequencing

This is the precondition for the next estuary deploy: shipping main without it re-delivers the table-less shell and re-breaks the board in browsers. With it, both directions recover — Deno clients on their next pull, browsers on the next deploy.

## What this does NOT fix

- **The stock is still inline at rest.** ~10 MB of sync for ~2 MB of content, even tabled. The real cure is the one-off stock rewrite (inline → `cid:` refs) discussed in #6319 and on Discord; this PR makes the migration window survivable and deploys safe again, nothing more.
- **Unbounded single-frame sync remains** (#6319's fragmentation work). The dominant tabled frame is ~9.8 MB today and grows with the space — the cap will be met again, especially once blob transfer lands. Worth doing as robustness, decoupled from this incident.
- **Closure size and the client→server direction** (6,093 docs delivered for a 115-topic board; watch specs ship full inline selector schemas with no compression at all — spec surface 2) are separate lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

