### PR TITLE
fix(runner): the output-spot scan takes a derived cell's cause-only id as it stands instead of reading through it

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -578,6 +578,37 @@ const recordRawBuiltinResultSchemaPolicyInput = (
 };
 
 /**
+ * The kind-free ids of a pattern's derived internal cells on `resultCell` —
+ * the ids a manifest-blind binding conversion mints for a `partialCause`
+ * alias (pattern-binding's descriptor-miss fallback), which is how the
+ * identity bind (CT-1943) renders such an alias. Cause-only by contract:
+ * the coordinates ARE the position-derived identity, and nothing may read
+ * through them — where the descriptor carries a kind, the data lives at the
+ * KINDED entity, so a read here asks about bytes that are never there and
+ * ties the asking transaction to replication state.
+ * {@link firstResolvedOutputRedirect} takes this set to return such links
+ * parsed rather than resolved. The kind is omitted from the mint on
+ * purpose: the hash preimage is kind-free, so one kindless mint per
+ * descriptor names the id the fallback produces whatever the descriptor's
+ * kind is.
+ */
+function causeOnlySpotIds(
+  resultCell: Cell<any>,
+  descriptors: Pattern["derivedInternalCells"],
+): ReadonlySet<string> | undefined {
+  if (descriptors === undefined || descriptors.length === 0) return undefined;
+  const ids = new Set<string>();
+  for (const descriptor of descriptors) {
+    ids.add(
+      getDerivedInternalCellLink(resultCell, {
+        partialCause: descriptor.partialCause,
+      }).id,
+    );
+  }
+  return ids;
+}
+
+/**
  * Find the first write-redirect link within an output binding and return its
  * FULLY RESOLVED normalized link (`id` and `space` populated). The output spot
  * a pattern node writes through is reserved for that node, so its resolved
@@ -586,6 +617,15 @@ const recordRawBuiltinResultSchemaPolicyInput = (
  * pattern object (which drags in the session-varying `program`). Returns
  * undefined if the binding contains no write redirect.
  *
+ * A link whose id is in `causeOnlyIds` (a derived internal cell's kind-free
+ * id — see {@link causeOnlySpotIds}) is returned PARSED, never resolved:
+ * its coordinates are already the identity the caller wants, resolution of
+ * a loaded spot stops there anyway (a stored plain link is not followed
+ * under `writeRedirect`), and reading an absent one ties the scan to
+ * replication state while kicking a doc pull nothing can satisfy — for a
+ * kinded descriptor, the data lives at the KINDED entity and this id is
+ * never written.
+ *
  * Exported for tests only.
  */
 export function firstResolvedOutputRedirect(
@@ -593,6 +633,7 @@ export function firstResolvedOutputRedirect(
   tx: IExtendedStorageTransaction,
   binding: unknown,
   baseCell: Cell<any>,
+  causeOnlyIds?: ReadonlySet<string>,
 ): NormalizedFullLink | undefined {
   if (isWriteRedirectLink(binding) || isAliasBinding(binding)) {
     // A partialCause alias denotes a DERIVED INTERNAL cell — of the child
@@ -610,18 +651,21 @@ export function firstResolvedOutputRedirect(
       return undefined;
     }
     const bindingBase = baseCell.getAsNormalizedFullLink();
-    return resolveLink(
-      runtime,
-      tx,
-      isAliasBinding(binding)
-        ? parseAliasBinding(binding, bindingBase)
-        : parseLink(binding, bindingBase),
-      "writeRedirect",
-    );
+    const parsed = isAliasBinding(binding)
+      ? parseAliasBinding(binding, bindingBase)
+      : parseLink(binding, bindingBase);
+    if (causeOnlyIds?.has(parsed.id)) return parsed;
+    return resolveLink(runtime, tx, parsed, "writeRedirect");
   }
   if (Array.isArray(binding)) {
     for (const child of binding) {
-      const found = firstResolvedOutputRedirect(runtime, tx, child, baseCell);
+      const found = firstResolvedOutputRedirect(
+        runtime,
+        tx,
+        child,
+        baseCell,
+        causeOnlyIds,
+      );
       if (found) return found;
     }
     return undefined;
@@ -633,7 +677,13 @@ export function firstResolvedOutputRedirect(
   // pre-sync keyed off it.
   if (isObjectOrArray(binding) && !isCellLink(binding)) {
     for (const child of Object.values(binding)) {
-      const found = firstResolvedOutputRedirect(runtime, tx, child, baseCell);
+      const found = firstResolvedOutputRedirect(
+        runtime,
+        tx,
+        child,
+        baseCell,
+        causeOnlyIds,
+      );
       if (found) return found;
     }
   }
@@ -4934,11 +4984,14 @@ export class Runner {
           argumentLink,
           resultCell,
         );
+        // The same cause-only skip instantiatePatternNode's spot
+        // derivation applies, so the two derive identical coordinates.
         spotLink = firstResolvedOutputRedirect(
           this.runtime,
           tx,
           unwrappedOutputs,
           resultCell,
+          causeOnlySpotIds(resultCell, pattern.derivedInternalCells),
         );
       } catch (error) {
         // A node whose outputs cannot be bound (e.g. they alias the argument
@@ -7986,11 +8039,17 @@ export class Runner {
         argumentCellLink,
         resultCell,
       );
+      // The manifest-blind bind above renders a partialCause alias as its
+      // derived cell's kind-free id, which is cause-only — resolving it
+      // would read an entity the kinded data never lives at (and kick a
+      // doc pull nothing can satisfy), so the scan is told to take those
+      // coordinates as they stand.
       const outputRedirect = firstResolvedOutputRedirect(
         this.runtime,
         tx,
         mappedOutputBindings,
         resultCell,
+        causeOnlySpotIds(resultCell, pattern.derivedInternalCells),
       );
       if (!outputRedirect) {
         throw new Error(

--- a/packages/runner/test/resume-output-redirect-partialcause.test.ts
+++ b/packages/runner/test/resume-output-redirect-partialcause.test.ts
@@ -5,6 +5,10 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { firstResolvedOutputRedirect } from "../src/runner.ts";
+import {
+  createSigilLinkFromParsedLink,
+  getDerivedInternalCellLink,
+} from "../src/link-utils.ts";
 
 // Seen live on estuary home spaces (2026-07-29): a sub-pattern node whose
 // stored outputs carry a DEFERRED partialCause alias unwraps to a bare
@@ -67,6 +71,43 @@ describe("firstResolvedOutputRedirect vs partialCause aliases", () => {
     const found = firstResolvedOutputRedirect(rt, tx, outputs, base);
     tx.abort("test: read-only");
     expect(found?.id).toBe(spot.getAsNormalizedFullLink().id);
+  });
+
+  it("returns a cause-only spot link parsed, with no read of its doc", () => {
+    // The identity bind (CT-1943) renders a partialCause alias as its
+    // derived cell's kind-free id — a cause-only coordinate whose data,
+    // for a computed-kind descriptor, lives at the KINDED entity, so
+    // nothing is ever written under this id. Resolving it reads that
+    // never-written doc, tying the scan to replication state and kicking
+    // a pull no store can satisfy. Given the id in `causeOnlyIds`, the
+    // scan returns the parsed coordinates and the transaction records no
+    // read of the doc.
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-spot-base",
+      undefined,
+      tx,
+    );
+    const twin = getDerivedInternalCellLink(base, {
+      partialCause: { "$generated": 0 },
+      scope: "space",
+    });
+    const binding = createSigilLinkFromParsedLink(twin, {
+      overwrite: "redirect",
+    });
+
+    const found = firstResolvedOutputRedirect(
+      rt,
+      tx,
+      { generated: binding },
+      base,
+      new Set([twin.id]),
+    );
+    expect(found?.id).toBe(twin.id);
+    const reads = tx.getReactivityLog?.().reads ?? [];
+    expect(reads.filter((read) => read.id === twin.id)).toEqual([]);
+    tx.abort("test: read-only");
   });
 
   it("returns undefined (not a throw) when outputs hold ONLY such aliases", () => {

--- a/packages/runner/test/resume-output-redirect-partialcause.test.ts
+++ b/packages/runner/test/resume-output-redirect-partialcause.test.ts
@@ -110,6 +110,72 @@ describe("firstResolvedOutputRedirect vs partialCause aliases", () => {
     tx.abort("test: read-only");
   });
 
+  it("keeps a scoped cause-only link's scope while skipping its read", () => {
+    // Cross-scope id matching is deliberate: the id hashes parent+cause
+    // while scope rides the link, so a per-principal instance of the same
+    // derived cell is recognized by the same set entry — and its scope
+    // must survive untouched, because downstream consumers (the resultFor
+    // cause, the owned-cell pre-sync) address the instance through it.
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-scoped-base",
+      undefined,
+      tx,
+    );
+    const twin = getDerivedInternalCellLink(base, {
+      partialCause: { "$generated": 1 },
+      scope: "user",
+    });
+    const binding = createSigilLinkFromParsedLink(twin, {
+      overwrite: "redirect",
+    });
+
+    const found = firstResolvedOutputRedirect(
+      rt,
+      tx,
+      { generated: binding },
+      base,
+      new Set([twin.id]),
+    );
+    expect(found?.id).toBe(twin.id);
+    expect(found?.scope).toBe("user");
+    const reads = tx.getReactivityLog?.().reads ?? [];
+    expect(reads.filter((read) => read.id === twin.id)).toEqual([]);
+    tx.abort("test: read-only");
+  });
+
+  it("still resolves a spot whose id is not in the cause-only set", () => {
+    // The set bounds the skip: an ordinary reserved spot resolves exactly
+    // as before, even when a cause-only id is supplied for a different
+    // cell of the same pattern.
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-other-base",
+      undefined,
+      tx,
+    );
+    const spot = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-other-spot",
+      undefined,
+      tx,
+    );
+    const twin = getDerivedInternalCellLink(base, {
+      partialCause: { "$generated": 2 },
+    });
+    const found = firstResolvedOutputRedirect(
+      rt,
+      tx,
+      { result: spot.getAsWriteRedirectLink({ base }) },
+      base,
+      new Set([twin.id]),
+    );
+    tx.abort("test: read-only");
+    expect(found?.id).toBe(spot.getAsNormalizedFullLink().id);
+  });
+
   it("returns undefined (not a throw) when outputs hold ONLY such aliases", () => {
     const tx = rt.edit();
     const base = rt.getCell<Record<string, unknown>>(

--- a/packages/runner/test/resume-output-redirect-partialcause.test.ts
+++ b/packages/runner/test/resume-output-redirect-partialcause.test.ts
@@ -176,6 +176,43 @@ describe("firstResolvedOutputRedirect vs partialCause aliases", () => {
     expect(found?.id).toBe(spot.getAsNormalizedFullLink().id);
   });
 
+  it("returns a cause-only first entry of an ARRAY binding as the spot", () => {
+    // Output bindings are usually objects, so the array descent otherwise
+    // goes unexercised: a list-shaped binding is scanned in order, and a
+    // cause-only first entry IS the found spot — taken as parsed, never
+    // read — with the ordinary spot after it left alone.
+    const tx = rt.edit();
+    const base = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-array-base",
+      undefined,
+      tx,
+    );
+    const spot = rt.getCell<Record<string, unknown>>(
+      space,
+      "cause-only-array-spot",
+      undefined,
+      tx,
+    );
+    const twin = getDerivedInternalCellLink(base, {
+      partialCause: { "$generated": 3 },
+    });
+    const binding = [
+      createSigilLinkFromParsedLink(twin, { overwrite: "redirect" }),
+      spot.getAsWriteRedirectLink({ base }),
+    ];
+
+    const found = firstResolvedOutputRedirect(
+      rt,
+      tx,
+      binding,
+      base,
+      new Set([twin.id]),
+    );
+    tx.abort("test: read-only");
+    expect(found?.id).toBe(twin.id);
+  });
+
   it("returns undefined (not a throw) when outputs hold ONLY such aliases", () => {
     const tx = rt.edit();
     const base = rt.getCell<Record<string, unknown>>(


### PR DESCRIPTION
A sub-pattern node's partialCause output alias is rendered two ways at instantiation. The **value bind** resolves it with the derived-internal manifest, landing on the descriptor's kinded entity (`computed:fid1:<hash>` for a classifier-proven cell) — where the child's data actually lives. The **identity bind** (CT-1943) deliberately omits the manifest, so pattern-binding's descriptor-miss fallback renders the same alias as the kind-free `of:fid1:<hash>` — same hash preimage, different scheme, and by CT-1943's own comment a coordinate that is "used purely as the `resultFor` cause — never read for a value."

`firstResolvedOutputRedirect` broke that contract: handed the identity-bound mapping, it resolved the kind-free link like any ordinary reserved spot, reading an entity that is never written where the descriptor carries a kind. That ties the scan's outcome to replication state and kicks a doc pull no store can satisfy, once per sub-pattern instantiation. The misread was surfaced by the pattern-vintage gate under #6245's converge-then-validate: the spurious provisional miss postponed every home vintage's child validation on first attempt (probe-traced from the dead-end read to this exact call).

## The fix

The scan takes the caller's set of **cause-only ids** — the kind-free mints of the pattern's `derivedInternalCells`, one per descriptor since the hash preimage is kind-free — and returns such links **parsed, never resolved**. Coordinates are unchanged in every replication state: a dead-end resolution returned the link as given, and a loaded spot's stored plain link is not followed under `writeRedirect` anyway — so no existing piece re-identifies; the only delta is no read, no kick. Both spot-derivation sites pass the set (`instantiatePatternNode`'s identity bind and the resume owned-cell walk), keeping their derived coordinates identical.

## Verification

- New tests: a cause-only spot link comes back parsed with the transaction recording no read of its doc; a scoped (per-principal) instance keeps its scope through the skip — cross-scope id matching is deliberate, since the id hashes parent+cause while scope rides the link; an ordinary spot still resolves when a cause-only id for a different cell rides along; the existing partialCause-alias scan tests still pass.
- Repo-wide `deno task check`, fmt, lint clean; full `runner` suite green.
- On #6245 (where the strict validator makes the misread loud), the same change removes all three home-vintage postponements from the vintage gate, leaving only the known pattern-side schema-honesty refusals. That branch currently carries an equivalent commit and will dedupe on its next main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
