### PR TITLE
register: resolve OW45/#6312 residual (iv) — #6248's post-fill reds are a pre-dispatch served-event drop, not the clobber

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6186,7 +6186,70 @@ supply; OW29/OW32/OW34 closed):
     POST-fill shape (shards 2/6: fill succeeded, click landed,
     `#profile` never resolved) is this same clobber on a later
     surface or another member is undetermined — re-measure on that
-    board at a head carrying this fix.
+    board at a head carrying this fix. **RESOLVED 2026-08-25 (the
+    re-measure: CI failure-path store capture at the lane-flip head,
+    run 32929764230, scratch instrumentation branch
+    `claude/server-exec-v2-postfill-diagnosis` — never merged): NOT
+    this clobber — ANOTHER MEMBER, one mechanism across both shards,
+    store-proven in both captures.** The trusted CreateProfile
+    click's durable entry is healthy (seq 17 in both event spaces:
+    `target.value "Ada Lovelace"`, `rendererTrusted: true`, clean
+    admission), and the served dispatch DROPPED it pre-dispatch: the
+    head-event load park awaited a cross-space replica load of the
+    HOME space's ensured `defaultPattern` quote doc — a doc the
+    server's OWN ensure had durably written ONE second earlier — and
+    the load failed `ConnectionError: memory session revoked:
+    unauthorized` (storage/v2.ts sync-load-failure) because the
+    serving plane's home-space session predated the genesis ACL
+    (activation-before-genesis, the recorded boot order) and the ACL
+    landing revoked it (`#revokeDeauthorizedSessions`,
+    memory/v2/server.ts — by design, heal-on-next-mount; a HOME
+    genesis is `{user: OWNER}` with no `"*"`, so the pre-genesis
+    session is de-authorized the moment it lands);
+    `failHeadEventLoadPark` (scheduler/facade.ts) maps ANY load-park
+    failure to the TERMINAL drop arm, and the drain sealed
+    `{status: "dropped", consequenced: true}` with the watermark
+    advanced (seq 18, `consequence_of` naming the eventId) —
+    at-least-once discharged, nothing ever re-runs the event, the
+    authoritative handler never executes, and the surface starves
+    the full 300 s net. This VIOLATES events.md §5's T3 drop
+    predicate ("no runnable handler", never "the run raced"): the
+    handler was runnable and the input doc existed durably; the
+    spec-conforming disposition for an unreachable input is
+    `deferred` (no consequence; re-drain) — the same code's own
+    docstring names the split. Negative discriminators, both stores
+    swept whole: clobber patch signature 0, `sidecarError` 0,
+    `sidecar-run-raced` 0 (this fix HOLDS — no hole); not the
+    read-side r01 member (an error account exists and the
+    consequence is absent, not present-but-unread); not residual
+    (i)'s basis-row gap (the entry is consequenced-dropped, and the
+    only dropped contributions — 3× `compile-cache/writeback` in the
+    speculative profile space's first waves — re-ran and healed in
+    the same second); not OW54's give-up arm (no CFC rejection, no
+    commit attempted) and not OW58's notice wedge (the notice sealed
+    cleanly). A NEW served-event-family member: the pre-dispatch
+    load-park failure arm. Rates at this base: shard 2 red 2/2 CI
+    boards, shard 6 red 2/2, local control 0/12 — the click must
+    land inside the [pre-genesis session open → revocation →
+    re-mount] window with a cross-space read at preflight; slow CI
+    runners do, the local box did not. Shard 9
+    (`cfc-staged-publish`, `TrustedSaveDraft` → `#saved-title`) red
+    1/2 and GREEN on the capture board — UNHARVESTED: symptom-
+    compatible with this member, no store evidence, classification
+    open. Observability, recorded: a terminally dropped served event
+    is invisible in serving stats (`events.*` has no dropped
+    counter; only the scheduler WARN line and the entry's
+    `status: "dropped"` field carry it). Product exposure: ANY ACL
+    change revokes serving sessions by design (sharing is a normal
+    operation), so under ON a served dispatch's cross-space load
+    racing a revocation permanently and silently discards a user's
+    trusted action; the fix direction (load-park failure →
+    `deferred`/re-park) touches the seal-adjacent path — OW58's
+    "(α)-critical, its own deliberate pass" caution applies, and the
+    disposition (fix-before-flip vs. narrow honest step-skips naming
+    shared-profile's, profile-embed's, and staged-publish's steps
+    with an owed row) is the owner's call, deliberately not taken by
+    the diagnosis seat.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6239,11 +6239,14 @@ supply; OW29/OW32/OW34 closed):
     open. Observability, recorded: a terminally dropped served event
     is invisible in serving stats (`events.*` has no dropped
     counter; only the scheduler WARN line and the entry's
-    `status: "dropped"` field carry it). Product exposure: ANY ACL
-    change revokes serving sessions by design (sharing is a normal
-    operation), so under ON a served dispatch's cross-space load
-    racing a revocation permanently and silently discards a user's
-    trusted action; the fix direction (load-park failure →
+    `status: "dropped"` field carry it). Product exposure: an ACL change
+    that REMOVES the serving session's authority or changes its
+    delegated owner revokes that session by design
+    (`#revokeDeauthorizedSessions` — authority-PRESERVING grants
+    leave the session valid; Cubic P2 on this PR scoped the claim),
+    so under ON a served dispatch's cross-space load racing such a
+    revocation permanently and silently discards a user's trusted
+    action; the fix direction (load-park failure →
     `deferred`/re-park) touches the seal-adjacent path — OW58's
     "(α)-critical, its own deliberate pass" caution applies, and the
     disposition (fix-before-flip vs. narrow honest step-skips naming


### PR DESCRIPTION
## Why

The #6312 record's residual (iv) left the #6248 ensure-ON board's POST-fill starvation (shards 2/6: fill worked, trusted click landed, resolution never came) undetermined — it had to be re-measured at a head carrying the clobber-yield fix, with server-side evidence CI job logs do not carry. That re-measure ran: a scratch instrumentation branch captured the failing shards' stores + toolshed logs at the lane-flip head (run 32929764230). The answer changes what #6248 is waiting on, so the register must carry it: the reds are NOT the clobber (its yield holds — zero signatures in both stores) but a distinct, store-proven served-event-family member.

## What Changed

One tight hunk appending the RESOLVED record to residual (iv) of the #6312 entry in `docs/specs/server-side-execution/verification-coverage.md`:

- **The member, store-proven in both captures:** the trusted CreateProfile click's durable entry is healthy (seq 17, `target.value "Ada Lovelace"`, `rendererTrusted: true`); the served dispatch's head-event load park awaited a cross-space replica load of the HOME space's ensured `defaultPattern` quote doc (durably written by the server's own ensure one second earlier); the load failed `memory session revoked: unauthorized` (the genesis-ACL landing revokes the serving plane's pre-genesis session — by design, heal-on-next-mount); `failHeadEventLoadPark` (scheduler/facade.ts) maps any load-park failure to the TERMINAL drop arm; the drain sealed `{status: "dropped", consequenced: true}` and advanced the watermark (seq 18) — at-least-once discharged, nothing re-runs the event, the surface starves 300 s.
- **Spec violation named:** events.md §5's T3 drop predicate ("no runnable handler", never "the run raced") — the handler was runnable; the spec-conforming disposition is `deferred` (re-drain).
- **Negative discriminators recorded:** not the clobber, not the read-side r01 member, not residual (i)'s basis-row gap, not OW54's give-up arm, not OW58's notice wedge.
- **Rates:** shards 2/6 red 2/2 CI boards at this base, 0/12 local; shard 9 red 1/2, green on the capture board — unharvested, classification open.
- **Observability gap:** a terminally dropped served event is invisible in serving stats (no dropped counter).
- **Disposition left to the owner:** fix-before-flip (load-park failure → `deferred`; seal-adjacent, OW58's (α)-critical caution) vs. narrow honest step-skips + owed row on #6248.

The scratch instrumentation branch (`claude/server-exec-v2-postfill-diagnosis`, PR #6344) is diagnosis-only and is NEVER merged; this PR carries only the register hunk, on a branch off origin/main.

## Test plan

Docs-only register append (one hunk inside an existing record). No behavior change; CI docs lanes cover formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

