### PR TITLE
Warn when an outbound memory frame approaches the 64 MiB client cap

### DIFF
--- a/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   attachMemorySocketPipeline,
   bufferTextMessagesUntilNegotiated,
+  warnOnOversizedOutboundFrame,
 } from "./memory.handlers.ts";
 import { memoryServer } from "@/routes/storage/memory.ts";
 
@@ -89,6 +90,61 @@ describe("memory.handlers", () => {
       await runHelloThroughPipeline(fake, WebSocket.CLOSED);
 
       expect(fake.sent).toEqual([]);
+    });
+  });
+
+  describe("warnOnOversizedOutboundFrame", () => {
+    const captureWarn = () => {
+      const calls: { key: string; args: unknown[] }[] = [];
+      const warn = (key: string, lazyArgs: () => unknown[]) => {
+        calls.push({ key, args: lazyArgs() });
+      };
+      return { calls, warn };
+    };
+
+    it("stays silent for a frame at or under the byte threshold", () => {
+      const { calls, warn } = captureWarn();
+
+      warnOnOversizedOutboundFrame("a".repeat(30), {}, 30, warn);
+
+      expect(calls).toEqual([]);
+    });
+
+    it("warns past the threshold with the byte size, type, and space", () => {
+      const { calls, warn } = captureWarn();
+
+      warnOnOversizedOutboundFrame(
+        "a".repeat(31),
+        { type: "session/effect", space: "did:key:zExample" },
+        30,
+        warn,
+      );
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].key).toBe("oversized-outbound-frame");
+      expect(calls[0].args).toContain(31);
+      expect(calls[0].args).toContain("session/effect");
+      expect(calls[0].args).toContain("did:key:zExample");
+    });
+
+    it("measures bytes, not code units, for non-ASCII content", () => {
+      // Eight emoji are 16 code units but 32 UTF-8 bytes: under a
+      // code-unit reading of the 30-byte threshold, over a byte reading.
+      const { calls, warn } = captureWarn();
+
+      warnOnOversizedOutboundFrame("😀".repeat(8), {}, 30, warn);
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].args).toContain(32);
+    });
+
+    it("names an absent type and space as unknown", () => {
+      const { calls, warn } = captureWarn();
+
+      warnOnOversizedOutboundFrame("a".repeat(31), {}, 30, warn);
+
+      expect(calls.length).toBe(1);
+      expect(calls[0].args).toContain("unknown");
     });
   });
 });

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -152,8 +152,10 @@ const frameSizeLogger = getLogger("memory-socket", {
 // approaching that cap is an outage in the making, not a curiosity — and a
 // payload regression looks like timeouts from the outside (labs#6319).
 // Warning at a quarter of the cap surfaces the growth while every client
-// still loads.
-const OUTBOUND_FRAME_WARN_CODE_UNITS = 16 * 1024 * 1024;
+// still loads. The cap is in bytes, so the check measures encoded bytes;
+// a string's UTF-8 byte length falls in [length, 3 × length], and the
+// cheap code-unit bound below spares ordinary frames the encode pass.
+const OUTBOUND_FRAME_WARN_BYTES = 16 * 1024 * 1024;
 
 export const attachMemorySocketPipeline = (
   socket: WebSocket,
@@ -182,16 +184,19 @@ export const attachMemorySocketPipeline = (
       return;
     }
     const encoded = encodeMemoryBoundary(message);
-    if (encoded.length > OUTBOUND_FRAME_WARN_CODE_UNITS) {
-      frameSizeLogger.warn("oversized-outbound-frame", () => [
-        "outbound memory frame at",
-        encoded.length,
-        "code units approaches the 64 MiB client cap;",
-        "type:",
-        (message as { type?: string }).type ?? "unknown",
-        "space:",
-        (message as { space?: string }).space ?? "unknown",
-      ]);
+    if (encoded.length * 3 > OUTBOUND_FRAME_WARN_BYTES) {
+      const frameBytes = TEXT_ENCODER.encode(encoded).byteLength;
+      if (frameBytes > OUTBOUND_FRAME_WARN_BYTES) {
+        frameSizeLogger.warn("oversized-outbound-frame", () => [
+          "outbound memory frame at",
+          frameBytes,
+          "bytes approaches the 64 MiB client cap;",
+          "type:",
+          (message as { type?: string }).type ?? "unknown",
+          "space:",
+          (message as { space?: string }).space ?? "unknown",
+        ]);
+      }
     }
     socket.send(encoded);
   });

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -154,8 +154,33 @@ const frameSizeLogger = getLogger("memory-socket", {
 // Warning at a quarter of the cap surfaces the growth while every client
 // still loads. The cap is in bytes, so the check measures encoded bytes;
 // a string's UTF-8 byte length falls in [length, 3 × length], and the
-// cheap code-unit bound below spares ordinary frames the encode pass.
+// cheap code-unit bound spares ordinary frames the encode pass.
 const OUTBOUND_FRAME_WARN_BYTES = 16 * 1024 * 1024;
+
+export const warnOnOversizedOutboundFrame = (
+  encoded: string,
+  message: unknown,
+  warnBytes: number = OUTBOUND_FRAME_WARN_BYTES,
+  warn: (key: string, lazyArgs: () => unknown[]) => void = (key, lazyArgs) =>
+    frameSizeLogger.warn(key, lazyArgs),
+): void => {
+  if (encoded.length * 3 <= warnBytes) {
+    return;
+  }
+  const frameBytes = TEXT_ENCODER.encode(encoded).byteLength;
+  if (frameBytes <= warnBytes) {
+    return;
+  }
+  warn("oversized-outbound-frame", () => [
+    "outbound memory frame at",
+    frameBytes,
+    "bytes approaches the 64 MiB client cap;",
+    "type:",
+    (message as { type?: string }).type ?? "unknown",
+    "space:",
+    (message as { space?: string }).space ?? "unknown",
+  ]);
+};
 
 export const attachMemorySocketPipeline = (
   socket: WebSocket,
@@ -184,20 +209,7 @@ export const attachMemorySocketPipeline = (
       return;
     }
     const encoded = encodeMemoryBoundary(message);
-    if (encoded.length * 3 > OUTBOUND_FRAME_WARN_BYTES) {
-      const frameBytes = TEXT_ENCODER.encode(encoded).byteLength;
-      if (frameBytes > OUTBOUND_FRAME_WARN_BYTES) {
-        frameSizeLogger.warn("oversized-outbound-frame", () => [
-          "outbound memory frame at",
-          frameBytes,
-          "bytes approaches the 64 MiB client cap;",
-          "type:",
-          (message as { type?: string }).type ?? "unknown",
-          "space:",
-          (message as { space?: string }).space ?? "unknown",
-        ]);
-      }
-    }
+    warnOnOversizedOutboundFrame(encoded, message);
     socket.send(encoded);
   });
   const closeConnection = () => {

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -1,5 +1,6 @@
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
+import { getLogger } from "@commonfabric/utils/logger";
 
 import type * as Routes from "./memory.routes.ts";
 import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
@@ -141,6 +142,19 @@ export const bufferTextMessagesUntilNegotiated = (
 // `memwrite-trace.ts`.
 let memwriteConnSeq = 0;
 
+const frameSizeLogger = getLogger("memory-socket", {
+  enabled: true,
+  level: "warn",
+});
+
+// Deno's WebSocket client rejects any incoming message over 64 MiB
+// ("Frame too large") and closes the connection, so an outbound frame
+// approaching that cap is an outage in the making, not a curiosity — and a
+// payload regression looks like timeouts from the outside (labs#6319).
+// Warning at a quarter of the cap surfaces the growth while every client
+// still loads.
+const OUTBOUND_FRAME_WARN_CODE_UNITS = 16 * 1024 * 1024;
+
 export const attachMemorySocketPipeline = (
   socket: WebSocket,
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
@@ -167,7 +181,19 @@ export const attachMemorySocketPipeline = (
     if (socket.readyState !== WebSocket.OPEN) {
       return;
     }
-    socket.send(encodeMemoryBoundary(message));
+    const encoded = encodeMemoryBoundary(message);
+    if (encoded.length > OUTBOUND_FRAME_WARN_CODE_UNITS) {
+      frameSizeLogger.warn("oversized-outbound-frame", () => [
+        "outbound memory frame at",
+        encoded.length,
+        "code units approaches the 64 MiB client cap;",
+        "type:",
+        (message as { type?: string }).type ?? "unknown",
+        "space:",
+        (message as { space?: string }).space ?? "unknown",
+      ]);
+    }
+    socket.send(encoded);
   });
   const closeConnection = () => {
     connection.close();


### PR DESCRIPTION
## Why

Deno WebSocket clients hard-reject any incoming message over 64 MiB (`Frame too large`) and close the connection, so an oversized sync response presents from the outside as timeouts and dead connections — never as "this response is huge". That is exactly how the 2026-08-25 topics-board outage (#6319) stayed invisible: a flag side effect (#6083) grew every table-less sync ~8×, and nothing surfaced payload size as the failing dimension until a proxy was put on the wire. #6337 fixed that regression; this adds the early warning that would have caught it weeks earlier, and will catch the next one — whether from another compression regression or from plain content growth — while every client still loads.

## What Changed

One warning in the toolshed memory socket's outbound path, at the single point every server→client frame passes: when an encoded frame exceeds 16 Mi code units (a quarter of the cap), log its size, message type, and space. No behavior change; the frame is sent regardless.

## Test plan

`deno fmt --check`, `deno lint`, `deno check` on the touched file, and `deno task test` in packages/toolshed (146 passed / 0 failed). The warning path itself is log-only and threshold-gated; no test asserts on log output, matching how the neighboring `[memwrite]` trace is treated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

