### PR TITLE
docs: a blank line goes above every doc comment, plus `data-model`

### DIFF
--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -440,9 +440,11 @@ export interface Donut {
 }
 ```
 
-Parentheses are the one construct the rule does not reach past that first
-position: `deno fmt` removes a blank line between two items of a parenthesized
-list, so a documented parameter or argument list runs unbroken.
+Past that first position the rule reaches as far as `deno fmt` will let it,
+which is everywhere but two constructs. The formatter removes a blank line
+between two items of a parenthesized list, and between two arms of a union or
+intersection type. A documented parameter list, argument list, or union
+therefore runs unbroken:
 
 ```ts
 // Shown at module scope.
@@ -454,7 +456,19 @@ export function fry(
   /** Desired fryer temperature, in Kelvin. */
   temperature: number,
 ): void {}
+
+/** What a fryer is doing right now. */
+export type FryerState =
+  /** Idle, at whatever temperature it last held. */
+  | { readonly kind: "idle" }
+  /** Coming up to temperature, with the shortfall in Kelvin. */
+  | { readonly kind: "heating"; readonly shortfall: number }
+  /** Frying, with the count of donuts in the basket. */
+  | { readonly kind: "frying"; readonly count: number };
 ```
+
+Object types, tuple types, array literals, and class and interface bodies all
+keep their blank lines, so the rule holds in full there.
 
 ### What gets one
 

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -403,6 +403,59 @@ see [File headers](#file-headers) below. Everything else in that shape is the
 defect. To title a region of a file or a class, use a section marker, which is
 a `//` block; see [Section markers](#section-markers) above.
 
+### The blank line above
+
+A blank line goes above every doc comment. It is what separates a documented
+declaration from whatever precedes it, and it holds uniformly: a function after
+another function, an interface property after another property, an array
+element after another element.
+
+Two positions have nothing above to separate from, and so take no blank line:
+
+- **The first line of a file**, where a file header opens the file. A shebang
+  or a file-scoped pragma is something above, though, and takes the blank line
+  like anything else.
+- **Directly under an opening bracket** — `{`, `(`, or `[` — where the doc
+  comment belongs to the first member, parameter, or element of the block. The
+  bracket is the separator.
+
+The dense cases are the ones the rule is for. An interface whose properties
+each carry a one-line doc comment reads as an undifferentiated run of lines
+without it, and pairing each comment to its property is work left to the
+reader:
+
+```ts
+// Shown at module scope.
+
+/** Everything known about one donut. */
+export interface Donut {
+  /** Style, such as `cruller` or `fritter`. */
+  readonly style: string;
+
+  /** Desired fryer temperature, in Kelvin. */
+  readonly temperature: number;
+
+  /** Toppings, in the order they are applied. */
+  readonly toppings: readonly string[];
+}
+```
+
+Parentheses are the one construct the rule does not reach past that first
+position: `deno fmt` removes a blank line between two items of a parenthesized
+list, so a documented parameter or argument list runs unbroken.
+
+```ts
+// Shown at module scope.
+
+/** Fries one donut to order. */
+export function fry(
+  /** Style to fry. */
+  style: string,
+  /** Desired fryer temperature, in Kelvin. */
+  temperature: number,
+): void {}
+```
+
 ### What gets one
 
 - Every file, as a header, except for the kinds listed under

--- a/docs/development/code-comment-style.md
+++ b/docs/development/code-comment-style.md
@@ -405,8 +405,12 @@ a `//` block; see [Section markers](#section-markers) above.
 
 ### The blank line above
 
-A blank line goes above every doc comment. It is what separates a documented
-declaration from whatever precedes it, and it holds uniformly: a function after
+A doc comment takes a blank line above it, except where it is the first thing
+in its file or bracketed block, and except in the two constructs `deno fmt`
+will not keep one in.
+
+That blank line is what separates a documented declaration from whatever
+precedes it, and within those bounds it holds uniformly: a function after
 another function, an interface property after another property, an array
 element after another element.
 
@@ -440,11 +444,10 @@ export interface Donut {
 }
 ```
 
-Past that first position the rule reaches as far as `deno fmt` will let it,
-which is everywhere but two constructs. The formatter removes a blank line
-between two items of a parenthesized list, and between two arms of a union or
-intersection type. A documented parameter list, argument list, or union
-therefore runs unbroken:
+Two constructs are exempt because the formatter overrules the rule there.
+`deno fmt` removes a blank line between two items of a parenthesized list, and
+between two arms of a union or intersection type, so a documented parameter
+list, argument list, or union runs unbroken:
 
 ```ts
 // Shown at module scope.

--- a/packages/data-model/bench/fixtures/codec-fixtures.ts
+++ b/packages/data-model/bench/fixtures/codec-fixtures.ts
@@ -359,6 +359,7 @@ export const BYTES = BYTE_SIZES.map(
 export const BIGINTS = BYTE_SIZES.map(
   (size) => [size, makeBigint(size)] as const,
 );
+
 /** Leaf counts for every omnibus series, so the three are read against each other. */
 const OMNIBUS_SIZES = [10, 100, 1000] as const;
 

--- a/packages/data-model/src/api.ts
+++ b/packages/data-model/src/api.ts
@@ -257,14 +257,19 @@ export declare const FabricKeyPair: FabricKeyPairConstructor;
 export type FabricErrorState = {
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
   readonly type: string;
+
   /** The `.name` property. Omit to mean "same as `type`". */
   readonly name?: string | null | undefined;
+
   /** The `.message` property. */
   readonly message: string;
+
   /** The `.stack` property, or `undefined`. */
   readonly stack: string | undefined;
+
   /** The `.cause` value, in `FabricValue` form, or `undefined`. */
   readonly cause: FabricValue | undefined;
+
   /** Custom enumerable own properties, in `FabricValue` form. */
   readonly extras?:
     | Iterable<readonly [string, FabricValue]>

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -62,6 +62,7 @@ const FABRIC_ERROR_RESERVED_KEYS: FrozenSet<string> = new FrozenSet([
 export type FabricErrorState = {
   /** Constructor name of the originating native `Error`, e.g. `TypeError`. */
   readonly type: string;
+
   /**
    * The `.name` property. Pass `null` (or omit) to mean "same as `type`"; the
    * resulting instance's `.name` is always a concrete string (`null` is a
@@ -69,12 +70,16 @@ export type FabricErrorState = {
    * public API).
    */
   readonly name?: string | null | undefined;
+
   /** The `.message` property. */
   readonly message: string;
+
   /** The `.stack` property, or `undefined`. */
   readonly stack: string | undefined;
+
   /** The `.cause` value, in `FabricValue` form, or `undefined`. */
   readonly cause: FabricValue | undefined;
+
   /**
    * Optional iterable of custom enumerable own properties, in `FabricValue`
    * form. Keys must not collide with the fixed-schema slot names or with

--- a/packages/data-model/src/frozen-builtins.ts
+++ b/packages/data-model/src/frozen-builtins.ts
@@ -11,6 +11,7 @@
 
 type MapBacking<K, V> = Map<K, V>;
 type SetBacking<T> = Set<T>;
+
 /** Builder for a `FrozenMap`, which fills it before it is handed out. */
 type MapBuilder<K, V> = {
   /** The map being built. */

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -38,8 +38,10 @@ import { toDebugKindString } from "./value-debug.ts";
 export interface CloneOptions {
   /** Whether the result should be frozen. Default: `true`. */
   frozen?: boolean;
+
   /** Whether to clone deeply or shallowly. Default: `true`. */
   deep?: boolean;
+
   /**
    * Force a copy to be made.
    *

--- a/packages/static/assets/types/commonfabric.d.ts
+++ b/packages/static/assets/types/commonfabric.d.ts
@@ -300,14 +300,19 @@ export declare const FabricKeyPair: FabricKeyPairConstructor;
 export type FabricErrorState = {
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
   readonly type: string;
+
   /** The `.name` property. Omit to mean "same as `type`". */
   readonly name?: string | null | undefined;
+
   /** The `.message` property. */
   readonly message: string;
+
   /** The `.stack` property, or `undefined`. */
   readonly stack: string | undefined;
+
   /** The `.cause` value, in `FabricValue` form, or `undefined`. */
   readonly cause: FabricValue | undefined;
+
   /** Custom enumerable own properties, in `FabricValue` form. */
   readonly extras?:
     | Iterable<readonly [string, FabricValue]>


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

`code-comment-style.md` governs what may not come between a doc comment and the
declaration under it. It says nothing about the space above one, and the tree
answered that question two ways: a doc-commented declaration is usually
separated from whatever precedes it, and inside dense interface and type-literal
member lists it usually is not.

Measured over every tracked `.ts`/`.tsx` file: 18,749 doc comments, of which
4,879 in 564 files have no blank line above them.

## The rule

A new "The blank line above" subsection under "Doc comments". A blank line goes
above every doc comment. Two positions are excepted because there is nothing
above to separate from:

- The first line of a file, where a file header opens the file. A shebang or a
  file-scoped pragma is something above, though, and takes the blank line like
  anything else.
- Directly under an opening `{`, `(`, or `[`, where the doc comment belongs to
  the first member, parameter, or element of the block.

Past that first position the rule reaches as far as `deno fmt` will let it. The
formatter removes a blank line between two items of a parenthesized list, and
between two arms of a union or intersection type, so a documented parameter
list, argument list, or union runs unbroken. Object types, tuple types, array
literals, and class and interface bodies all keep their blank lines, and the
section states that complement rather than leaving a reader to find it in a
formatter diff. Both behaviors were measured with a probe carrying its own
control — a file where the affected construct and an unaffected one sit side by
side.

## `data-model`

Fourteen sites in five files, one blank line inserted at each. The diff removes
no line and adds no non-blank one.

`packages/static/assets/types/commonfabric.d.ts` is generated from
`packages/api/index.ts` with each workspace module it re-exports inlined, and
`data-model`'s `FabricErrorState` is one of those, so five of the fourteen reach
the type module the pattern compiler serves. Regenerated with `deno task
gen-commonfabric-types`; `packages/static`'s own test caught the staleness, and
the same test on clean `main` at the same commit was green, which is what
established causation.

The remaining 559 files are left to per-package sweeps.

## Gates

`deno task check`, `deno lint`, `deno fmt --check`, and `deno task check-docs`
all pass, as does the full workspace test suite (37 packages). GitHub Actions is
in an outage as this is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
