### PR TITLE
docs(runner): blank lines above doc comments in `src` (top level and five subtrees)

### DIFF
--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -230,6 +230,7 @@ declare module "@commonfabric/api" {
   export interface Module {
     type: "ref" | "javascript" | "pattern" | "raw" | "isolated" | "passthrough";
     implementation?: ((...args: any[]) => any) | Pattern | string;
+
     /**
      * Content-addressed reference to the module-scope builder artifact whose
      * implementation this module runs: the defining module's content identity
@@ -241,16 +242,22 @@ declare module "@commonfabric/api" {
     argumentSchema?: JSONSchema;
     resultSchema?: JSONSchema;
     propagateInputIfc?: boolean;
+
     /** If true, this module is an effect (side-effectful) rather than a computation */
     isEffect?: boolean;
+
     /** Optional scheduler debounce delay in milliseconds */
     debounce?: number;
+
     /** Opt out of scheduler auto-debounce */
     noDebounce?: boolean;
+
     /** Optional scheduler throttle period in milliseconds */
     throttle?: number;
+
     /** Pull-mode write envelopes for broad/dynamic writable-input materializers */
     materializerWriteEnvelopes?: readonly NormalizedFullLink[];
+
     /**
      * Exhaustive analyzed record of input paths the module may write. Only
      * writable-branded paths become materializer envelopes; stream paths
@@ -259,12 +266,14 @@ declare module "@commonfabric/api" {
      * the opaque-result envelope fallback.
      */
     materializerWriteInputPaths?: readonly (readonly string[])[];
+
     /**
      * Transformer proof that this source-backed lift's cell surface is
      * exhaustively described by its structural bindings.  Absence means
      * unknown/incomplete; raw modules and handlers never receive this marker.
      */
     completeSchedulerScopeSummary?: true;
+
     /** Run this module's result in a specific space. */
     targetSpace?: MemorySpace;
   }
@@ -295,6 +304,7 @@ export type DerivedInternalCellDescriptor = {
   partialCause: JSONValue;
   schema?: JSONSchema;
   scope?: CellScope;
+
   /**
    * Entity kind minted into the cell's id (preimage + visible tag). Set to
    * `"computed"` only when the builder proves the cell is written solely by
@@ -347,6 +357,7 @@ export type Frame = {
   space?: MemorySpace;
   inHandler?: boolean;
   reactives: Set<Reactive<any>>;
+
   /**
    * Positive marker for the kind of authored pattern code running under this
    * frame: "handler" for an event handler, "lift" for a reactive computation
@@ -355,6 +366,7 @@ export type Frame = {
    * — both of which lack `inHandler` — without conflating them.
    */
   frameKind?: "lift" | "handler";
+
   /**
    * The wall-clock instant (ms) bound to the event that opened this handler
    * frame. A handler's ambient clock reads this FROZEN value, coarsened, rather
@@ -366,18 +378,21 @@ export type Frame = {
    */
   eventTime?: number;
   unsafe_binding?: UnsafeBinding;
+
   /**
    * Marks a module-evaluation frame. Its presence is the whole signal: it is
    * how the action-execution guard admits the transformer's module-scope
    * builder mints while an action is suspended.
    */
   moduleEvaluation?: true;
+
   /**
    * Named/anonymous `PatternFactory.inSpace(...)` targets encountered during
    * this frame whose space DID was not yet cached. The runner resolves these
    * after the run and re-runs (see RetryImmediately).
    */
   pendingSpaceNames?: Set<string>;
+
   /** Per-frame counter giving each anonymous `inSpace()` call a stable name. */
   inSpaceCounter?: number;
 };

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -41,6 +41,7 @@ type FetchRequestOptions = {
   headers?: Record<string, string>;
   cache?: RequestCache;
   redirect?: RequestRedirect;
+
   /**
    * How long (ms) a claimed request mutex stays valid before another tab may
    * take it over. Not part of the request itself: stripped before the request
@@ -52,6 +53,7 @@ type FetchRequestOptions = {
 /** The shape of the fetch builtins' input cells (union across all kinds). */
 type FetchInputs = {
   url?: string;
+
   /** fetchJson only. */
   schema?: JSONSchema;
   options?: FetchRequestOptions;

--- a/packages/runner/src/builtins/list-element-rollback.ts
+++ b/packages/runner/src/builtins/list-element-rollback.ts
@@ -17,6 +17,7 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
  */
 export type SetupRecord = {
   needsSetup: boolean;
+
   /** The reconcile that last issued these setup writes. */
   setupIssuance?: object;
 };
@@ -32,10 +33,13 @@ export type ElementRun = SetupRecord & {
 export interface ListSetupRollback {
   /** An entry this reconcile added to the coordinator's element map. */
   created(elementKey: string, entry: ElementRun): void;
+
   /** Setup writes this reconcile staged against a record it already had. */
   setupIssued(record: SetupRecord): void;
+
   /** An index this reconcile moved, with the value it moved away from. */
   indexChanged(entry: ElementRun, previousIndex: number): void;
+
   /** A result container this reconcile installed, with a restore for the old one. */
   resultReplaced(restore: () => void): void;
 }

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -71,12 +71,14 @@ export interface ResumeRepublisher {
 export interface ResumeRepublisherOptions {
   runtime: Runtime;
   logger: Logger;
+
   /**
    * False once the coordinator is torn down. A republish outstanding at that
    * moment has a container nothing owns any more, so it is dropped rather than
    * written.
    */
   isActive: () => boolean;
+
   /**
    * The result container is bound after the builtin's setup, so it is read
    * lazily on each republish rather than captured once.
@@ -87,10 +89,13 @@ export interface ResumeRepublisherOptions {
   resultSchema: JSONSchema;
   elementRuns: ElementRuns;
   contribute: ElementContribution;
+
   /** The aggregate's noun for logs, e.g. "filtered list" / "flatMap result". */
   aggregateNoun: string;
+
   /** The per-element noun for logs, e.g. "predicate" / "result". */
   elementNoun: string;
+
   /**
    * Re-arm the coordinator's reconcile. Only a reconcile can issue an owed
    * element setup (`needsSetup`), and it declines to while that element's

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -663,6 +663,7 @@ type QueryState = {
   result?: unknown[];
   error?: unknown;
   requestHash?: string;
+
   /** CFC Phase 3.b read-time clearance audit: how many rows the acting reader
    *  could not read were withheld (a declared existence release). Absent when
    *  no clearance was requested. */
@@ -699,8 +700,10 @@ type QueryState = {
 export function sqliteQueryMemoDecision(options: {
   stored: { pending?: boolean; requestHash?: string } | undefined;
   hash: string;
+
   /** This node instance holds the RPC in flight right now. */
   inFlightHere: boolean;
+
   /** The evaluation runs as a stamped serving run (a wave run context
    * is present — the serving loop's signature; ON-arm client
    * speculation and the OFF arm are unstamped). */
@@ -725,6 +728,7 @@ export function sqliteQuery(
   let initialized = false;
   let result: Cell<QueryState>;
   let resultScope: CellScope | undefined;
+
   /** Hashes whose RPC this node instance currently has in flight — the
    * in-process half of the memo decision above. */
   const inFlightIssues = new Set<string>();

--- a/packages/runner/src/builtins/sqlite/row-label-read.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-read.ts
@@ -38,19 +38,25 @@ export interface PerRowIfc {
 export interface RowLabelReadArgs {
   /** Declared table schemas (`db.tables`, wire-supplied — re-validated). */
   tables: Record<string, unknown> | undefined;
+
   /** Per-result-column TRUE origins (`res.columns`); undefined when the
    *  server captured none. */
   columns: readonly ResultColumn[] | undefined;
   rows: readonly unknown[];
+
   /** The db's owner (db ref), resolving the rule's `dbOwner()` term. */
   owner?: string;
+
   /** Per-column (Phase 2) confidentiality atoms of the labeled projection —
    *  they ride every row, so they count against the ceiling too. */
   staticConfidentiality?: readonly CfcConfClause[];
+
   /** Declared output ceiling (placeholders already resolved). */
   ceiling?: readonly CfcConfClause[];
+
   /** What to do when a row's label exceeds the ceiling (default "fail"). */
   onExceed?: unknown;
+
   /** CFC Phase 3.b read-time clearance: when set, keep only rows the acting
    *  reader may read (a declared existence release, §8.17/inv-14). Requires the
    *  rule-bearing table to opt in (`rowLabelReadClearance`); never for
@@ -64,9 +70,11 @@ export type RowLabelReadResult =
     /** Per kept-order row: the per-row label for its row entity doc, or
      *  undefined when the row carries no per-row label. */
     labels: (PerRowIfc | undefined)[];
+
     /** Row keep-mask under a declared ceiling and/or read-time clearance
      *  (undefined: neither declared). */
     keep: boolean[] | undefined;
+
     /** CFC Phase 3.b: rows withheld because the acting reader could not read
      *  them (a declared, audited existence release). 0/undefined when no
      *  clearance was requested. */

--- a/packages/runner/src/builtins/sqlite/row-label-write.ts
+++ b/packages/runner/src/builtins/sqlite/row-label-write.ts
@@ -51,16 +51,21 @@ export interface RowLabelWritePolicy {
 
 export interface RowLabelWriteArgs {
   sql: string;
+
   /** Bind values as `.exec()` received them — NOT `SqliteParamsWire`. The
    *  gate runs before encoding, so a value here may still be a `Cell`
    *  (that is what `confidentialityOf` reads a label off). */
   params: ReadonlyArray<unknown> | Record<string, unknown> | undefined;
+
   /** Declared table schemas (`db.tables`, wire-supplied — re-validated). */
   tables: SqliteDbRef["tables"];
+
   /** The db's owner (db ref), resolving the rule's `dbOwner()` term. */
   owner?: string;
+
   /** The confidentiality atoms carried by a bound value ([] if unlabeled). */
   confidentialityOf: (value: unknown) => readonly unknown[];
+
   /** True iff the connected server advertised commit-time re-derivation
    *  (Phase 3.c) — the gate then admits the non-attributable shapes with
    *  unlabeled inputs instead of failing closed. Default false. */

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -249,8 +249,10 @@ type WishContext = {
   parentCell: Cell<any>;
   spaceCell?: Cell<unknown>;
   scope?: ("~" | "." | "profile" | string)[];
+
   /** Cached #now cell to avoid non-idempotent re-runs from Date.now() */
   nowCell?: Cell<unknown>;
+
   /** The wish node's cause, keying the durable one-shot #now capture cell. */
   nowCause?: Cell<any>[];
   usedHomeSpace?: boolean;
@@ -583,6 +585,7 @@ function searchFavoritesForHashtag(
 
 type HashtagSearchResult = {
   matches: BaseResolution[];
+
   /** true when cell data has loaded (even if empty); false when still pending */
   loaded: boolean;
 };
@@ -1705,8 +1708,10 @@ export const wishSidecarDiagnostics = {
   /** Continuations registered on the profile-create fetch (one per launch
    * that found no cached pattern — the duplicate-launch producer). */
   profileCreateFetchContinuations: 0,
+
   /** runSidecarInOwnTx invocations (instantiation attempts). */
   sidecarRunsStarted: 0,
+
   /** Conflict-class losers that yielded to a materialized winner. */
   sidecarRunsRaced: 0,
 };

--- a/packages/runner/src/cancel.ts
+++ b/packages/runner/src/cancel.ts
@@ -6,6 +6,7 @@ export type AddCancel = (cancel: Cancel | undefined | null) => void;
 export type DeferredCancelOwnership = {
   cancel: Cancel;
   isCancelled: () => boolean;
+
   /** Records the exact cancel installed by this attempt; returns cancellation. */
   markInstalled: (installedCancel: Cancel | undefined) => boolean;
 };

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -178,6 +178,7 @@ const logger = getLogger("cell", { level: "warn" });
 
 type SinkOptions = {
   changeGroup?: ChangeGroup;
+
   /**
    * Read the cell's display CFC label as part of the sink's tracked read set
    * and pass it to the callback as a second argument. Reading it on the sink's
@@ -353,6 +354,7 @@ const mintedRuntimeInjectedKeys = new WeakSet<readonly string[]>();
  * is ignored and the closed-world gate judges the key like any other
  * undeclared field.
  */
+
 /** An error-status VIEW of a transaction (the durable-ack coupling;
  * verdict blocker, 2026-08-12): everything passes through except
  * `status()`, which reports the append/consequence failure — so a
@@ -511,6 +513,7 @@ declare module "@commonfabric/api" {
       },
     ): SigilWriteRedirectLink;
     getRaw(options?: RawCellReadOptions): Immutable<T> | undefined;
+
     /**
      * Reads the cell's raw value as a `FabricValue`, bypassing the
      * cell's type parameter `T`. Use this when the stored data may not
@@ -530,6 +533,7 @@ declare module "@commonfabric/api" {
     ): FabricValue;
     getRawUntyped(options?: RawCellReadOptions): FabricValue;
     setRaw(value: (NoInfer<T> & FabricValue) | undefined): void;
+
     /**
      * Sets the raw cell value to any `FabricValue`, bypassing the cell's
      * type parameter `T`. Use this when writing a pre-formed `FabricValue`
@@ -552,6 +556,7 @@ declare module "@commonfabric/api" {
       onlyIfDifferent?: boolean,
       schemaRole?: "output",
     ): void;
+
     /**
      * Applies this cell's CFC schema to its existing stored value without
      * rewriting that value.
@@ -2061,6 +2066,7 @@ export class CellImpl<T extends FabricValue>
   send(
     ...args: T extends void ? [] | [AnyCellWrapping<T>] | [
         AnyCellWrapping<T>,
+
         /**
          * Internal-only commit callback. This runs after the final commit
          * result, including failure, so it must remain non-effectful. Use the
@@ -2075,6 +2081,7 @@ export class CellImpl<T extends FabricValue>
       ]
       : [AnyCellWrapping<T>] | [
         AnyCellWrapping<T>,
+
         /**
          * Internal-only commit callback. This runs after the final commit
          * result, including failure, so it must remain non-effectful. Use the
@@ -2085,6 +2092,7 @@ export class CellImpl<T extends FabricValue>
       ] | [
         AnyCellWrapping<T>,
         ((tx: IExtendedStorageTransaction) => void) | undefined,
+
         /**
          * Internal-only stream-send options (see {@link StreamSendOptions}):
          * `eventId` passes a caller-supplied durable event id through to the

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -455,6 +455,7 @@ export class ContextualFlowControl {
   // the right thing, since those are all at the top level. However, we
   // could have a reference to an anchor (not currently allowed), and
   // for those, if the User is secret, their Address should be too.
+
   /**
    * Resolve a $ref in a schema.
    * This doesn't currently handle $anchor tags or external documents

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -60,6 +60,7 @@ const logger = getLogger("cell-cache");
 export interface ModuleImportRef {
   /** Authored import specifier, e.g. `"./util.ts"`. */
   readonly specifier: string;
+
   /** Content-addressed identity of the imported module's document. */
   readonly identity: string;
 }
@@ -89,10 +90,13 @@ const SOURCE_DELEGATION_PATH = ["delegatedModuleIdentities"] as const;
 interface ModuleDocBase {
   /** Module code: authored TS (source set) or compiled JS (compiled set). */
   readonly code: string;
+
   /** Authored module path, e.g. `/main.tsx`. */
   readonly filename: string;
+
   /** Resolved internal imports; each points at another document by identity. */
   readonly imports: readonly ModuleImportRef[];
+
   /** Predecessor module identities whose writer authority this module inherits. */
   readonly delegatedModuleIdentities?: readonly string[];
 }
@@ -100,6 +104,7 @@ interface ModuleDocBase {
 /** A source-set document (`pattern:<identity>`). */
 export interface SourceDoc extends ModuleDocBase {
   readonly kind: "source";
+
   /**
    * Optional, NON-NORMATIVE product annotations (a name doc, a spec doc,
    * lineage — typically sigil links). The runtime NEVER reads these for
@@ -123,8 +128,10 @@ export interface SourceDoc extends ModuleDocBase {
  */
 export interface CompiledDoc extends ModuleDocBase {
   readonly kind: "compiled" | "data";
+
   /** Per-module source map, if any (registered for authored error stacks). */
   readonly sourceMap?: unknown;
+
   /**
    * Precomputed record surface (Fix B): the direct export names, `export *`
    * target specifiers, and runtime import specifiers derived from `code` at
@@ -135,8 +142,10 @@ export interface CompiledDoc extends ModuleDocBase {
   readonly starTargetSpecs?: readonly string[];
   readonly importSpecs?: readonly string[];
   readonly policyManifests?: readonly unknown[];
+
   /** Debug-only authored builder sites, keyed by runtime artifact symbol. */
   readonly builderSourceSites?: BuilderSourceSitesV1;
+
   /**
    * Authored-line spans for the coverage probes the transformer baked into
    * `code`, keyed by `(fileName, id)`. Present only on documents written by a
@@ -498,10 +507,13 @@ export function buildSourceDocs(
 /** Result of verifying a loaded source-document closure. */
 export interface SourceDocVerification {
   readonly ok: boolean;
+
   /** The entry document's authored filename, when present. */
   readonly entryFilename?: string;
+
   /** Identities whose recomputed Merkle hash does not match their key. */
   readonly mismatches: readonly string[];
+
   /** Import-link target identities absent from the loaded document set. */
   readonly missing: readonly string[];
 }
@@ -1384,6 +1396,7 @@ export function writeCompiledDocs(
   opts: {
     runtimeVersion: string;
     moduleDelegations?: ModuleDelegationMap;
+
     /** See {@link buildSourceDocs}: full-set root links for chunked writes. */
     extraRoots?: readonly string[];
   },
@@ -1489,6 +1502,7 @@ export function writeSourceAndCompiledDocs(
   opts: {
     runtimeVersion: string;
     moduleDelegations?: ModuleDelegationMap;
+
     /** See {@link buildSourceDocs}: full-set root links for chunked writes. */
     extraRoots?: readonly string[];
   },

--- a/packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts
+++ b/packages/runner/src/compilation-cache/compiler-fingerprint.deno.ts
@@ -97,6 +97,7 @@ const FINGERPRINT_LENGTH = 16;
 interface FingerprintFile {
   /** Path relative to the repo root, with forward slashes. */
   readonly path: string;
+
   /** File contents with line endings normalized to `\n`. */
   readonly content: string;
 }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -378,6 +378,7 @@ export type DiffAndUpdateOptions = IReadOptions & {
 export interface DiffWalkState {
   /** Shared-reference / cycle tracking: source value → normalized link. */
   seen: Map<any, NormalizedFullLink>;
+
   /**
    * When present, a plain object sitting in an array that is not already a
    * link gets anchored into an entity document of its own, its id drawn from
@@ -456,6 +457,7 @@ export function diffAndUpdate(
 export type ChangeSet = {
   location: NormalizedFullLink;
   value: FabricValue;
+
   /**
    * When true, the change removes the slot at `location` (object key
    * removal or array hole) instead of writing a value; `value` is

--- a/packages/runner/src/ensure-piece-running.ts
+++ b/packages/runner/src/ensure-piece-running.ts
@@ -84,8 +84,10 @@ function followResultCellChain(
 export type EnsurePieceVerdict = {
   /** The owning piece is (now) running. */
   started: boolean;
+
   /** Why a `started: false` verdict could not start the piece. */
   reason?:
+
     /** Result-metadata cycle, or traversal depth exceeded. */
     | "chain-cycle"
     /** The chain's owning doc carries no `patternIdentity` meta — as
@@ -101,10 +103,12 @@ export type EnsurePieceVerdict = {
      * UNCONFIRMED — no terminal decision; the caller's deferred arm
      * retries next cycle. */
     | "confirm-pull-failed";
+
   /** The owning result doc's id (the chain terminus) where the chain
    * resolved — present for `started`, `no-pattern-meta`, and
    * `pattern-unloadable`. */
   rootId?: string;
+
   /** Every doc id the traversal read (the demanded root plus chain
    * links): the demand cycle's commit-triggered re-arm watches these. */
   observedDocIds: string[];

--- a/packages/runner/src/ensure-space-root.ts
+++ b/packages/runner/src/ensure-space-root.ts
@@ -119,13 +119,16 @@ export type SpaceRootCreationHooks = {
    * extraction.
    */
   stampCreationTx?: (tx: IExtendedStorageTransaction) => void;
+
   /** Phase timing (the controller's `timePiecePhase`); defaults to a
    * pass-through so the serving seat pays nothing. */
   timePhase?: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+
   /** The fetch the program resolve uses. The client passes nothing (the
    * platform fetch, its historical behavior); the serving seat passes
    * `runtime.fetch` so tests can serve pattern sources in-process. */
   fetch?: RuntimeFetch;
+
   /** The space-cell handle the creation transaction's re-check reads
    * through. The controller passes its OWN synced instance (its
    * historical read source — and the piece suite's creation-race test
@@ -258,6 +261,7 @@ export type EnsureSpaceRootResult = {
    * root; this call created it; or this call's creation lost the OCC
    * race and resolved the winner's root. */
   outcome: "resolved-existing" | "created" | "raced-existing";
+
   /** The freshness half's verdict. A root this call created was compiled
    * from the current source moments ago — reconciling it would probe the
    * route to learn what we just compiled — so it is "skipped-fresh"; a
@@ -289,6 +293,7 @@ export async function ensureSpaceRootPattern(
   options: {
     isHomeSpace: boolean;
     stampCreationTx?: (tx: IExtendedStorageTransaction) => void;
+
     /** Per-attempt hook for the freshness half's write arms (threaded
      * into `checkDefaultPattern`): the serving seat passes its
      * owner-snapshot setter so the reconcile's transactions — the

--- a/packages/runner/src/fabric-ref-resolution.ts
+++ b/packages/runner/src/fabric-ref-resolution.ts
@@ -16,6 +16,7 @@ const DID_RE = /^did:[a-z0-9]+:.+$/;
 
 export interface FabricChaseResult {
   entryIdentity: string;
+
   /** Human-readable hops for errors/tooling. */
   chain: string[];
 }

--- a/packages/runner/src/graph-query.ts
+++ b/packages/runner/src/graph-query.ts
@@ -81,8 +81,10 @@ export const createGraphQueryWalkStats = (): GraphQueryWalkStats => ({
 export type GraphQueryWalkOptions = {
   /** Supplies documents by address. */
   manager: ObjectStorageManager;
+
   /** Space the visited documents belong to. */
   space: MemorySpace;
+
   /**
    * Receives one entry per document the walk reached, keyed by
    * `schemaTrackerKey`. Share it across walks to accumulate the reach of a
@@ -90,6 +92,7 @@ export type GraphQueryWalkOptions = {
    * it already covers.
    */
   schemaTracker: MapSetStringToPathSelectors;
+
   /**
    * The acting identity the walk's tracker keys resolve scoped addresses
    * against (key-vocabulary.md §1 sites 5–6): coverage proven for one scope
@@ -98,6 +101,7 @@ export type GraphQueryWalkOptions = {
    * never from ambient state (key-vocabulary.md §3).
    */
   identity: ScopeKeyIdentity;
+
   /**
    * Receives one call per SAME-SPACE document a value-link hop tried to
    * read and found ABSENT: the miss's tracker-style key, the
@@ -124,8 +128,10 @@ export type GraphQueryWalkOptions = {
     selector: SchemaPathSelector,
     referrerKey: string | undefined,
   ) => void;
+
   /** Schema-traversal results reused across walks that share it. */
   memo?: SchemaMemo;
+
   /** Counters to add into. */
   stats?: GraphQueryWalkStats;
 };
@@ -146,6 +152,7 @@ export class GraphQueryWalk {
   readonly #context: TraversalContext;
   readonly #memo: SchemaMemo;
   readonly stats: GraphQueryWalkStats;
+
   /** identity-derived key → the caller-supplied key a visit recorded
    * under (a query root naming an explicit scope INSTANCE — protocol.md
    * §2's read row). Miss attribution consults this so a miss recorded

--- a/packages/runner/src/harness/authored-debug-source.ts
+++ b/packages/runner/src/harness/authored-debug-source.ts
@@ -10,6 +10,7 @@ import { resolveOriginal } from "../builder/pattern-metadata.ts";
 export interface AuthoredDebugSource {
   /** Canonical `cf:module/.../<path>:<line>:<col>` source location. */
   readonly src?: string;
+
   /** Authored declaration name, when the function has one. */
   readonly bindingName?: string;
 }

--- a/packages/runner/src/harness/entry-identity.ts
+++ b/packages/runner/src/harness/entry-identity.ts
@@ -133,6 +133,7 @@ export function computeEntryIdentity(
 export interface EntryIdentityOptions {
   /** Additional entry roots beyond `main`. */
   sourceRoots?: readonly string[];
+
   /** Files stored uninterpreted as data. */
   dataFiles?: readonly string[];
 }

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -59,11 +59,13 @@ export interface ModuleIdentityOptions {
    * identity. Defaults to the empty string.
    */
   runtimeFingerprint?: string;
+
   /** Internal dependency edges that participate in identity without executing. */
   additionalInternalDeps?: ReadonlyMap<
     string,
     readonly { specifier: string; target: string }[]
   >;
+
   /**
    * Paths carrying data rather than code. A data file hashes as a leaf over its
    * own bytes and path: it is never scanned for imports, and never the target of
@@ -75,8 +77,10 @@ export interface ModuleIdentityOptions {
 interface ModuleNode {
   path: string;
   src: string;
+
   /** Imports resolved to another file within the program. */
   internalDeps: { specifier: string; target: string }[];
+
   /** Imports that do not resolve to a program file (bare/runtime modules). */
   externalDeps: string[];
 }
@@ -85,6 +89,7 @@ interface ModuleNode {
 export interface ModuleImportEdges {
   /** Imports resolving to another file in the program (specifier → target path). */
   internalDeps: { specifier: string; target: string }[];
+
   /** Imports that do not resolve to a program file (bare/runtime specifiers). */
   externalDeps: string[];
 }
@@ -279,6 +284,7 @@ function compareIntraDep(
 interface SccResult {
   /** Components in reverse-topological order (dependencies first). */
   components: string[][];
+
   /** Map from each module path to an opaque component id. */
   componentOf: Map<string, number>;
 }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -12,6 +12,7 @@ export type RuntimeProgram = Program & {
   // The named export from the program's entry file to run.
   // Defaults to "default".
   mainExport?: string;
+
   /** Source entry points retained and compiled without being executed. */
   sourceRoots?: string[];
 };
@@ -55,6 +56,7 @@ export interface TypeScriptHarnessProcessOptions {
   // on a miss/partial hit: freshly compiled bodies are always SES-verified.
   // Never set for direct `precompiledModules` injection (untrusted bytes).
   trustedBodies?: boolean;
+
   /**
    * Enables fabric (cf:) imports for this compile: the space whose cell-cache
    * source docs fabric refs are fetched from and verified against. Absent means
@@ -65,6 +67,7 @@ export interface TypeScriptHarnessProcessOptions {
 
 export interface FabricImportOptions {
   space: MemorySpace;
+
   /**
    * Dev-only: resolve unpinned mutable refs by chasing the live pointer.
    * The resulting compile is NOT cacheable — module identity folds the
@@ -88,8 +91,10 @@ export interface CompiledModuleArtifact {
   js: string;
   sourceMap?: unknown;
   patternCoverageSpans?: PatternCoverageSpan[];
+
   /** Debug-only authored sites, keyed by runtime artifact symbol. */
   builderSourceSites?: BuilderSourceSitesV1;
+
   /** Compiler-issued policy manifests, transported separately from JS exports. */
   policyManifests?: readonly unknown[];
 }
@@ -102,12 +107,16 @@ export interface CompiledModuleArtifact {
 export interface CacheableModule extends CompiledModuleArtifact {
   /** Prefix-free content identity (the `cf:module/<hash>` hash, no scheme). */
   identity: string;
+
   /** Normalized authored module path (no `/<id>` prefix; e.g. `/main.tsx`). */
   filename: string;
+
   /** Resolved TypeScript source whose bytes are folded into `identity`. */
   source: string;
+
   /** Internal import edges: specifier → the dependency module's identity. */
   imports: { specifier: string; targetIdentity: string }[];
+
   /**
    * This entry carries data rather than code. A data entry's compiled form is
    * its own bytes, so `js` repeats `source` and the compiled set carries what a
@@ -122,6 +131,7 @@ export type Exports = Record<string, any>;
 export interface EvaluateResult {
   main?: Exports;
   exportMap?: Record<string, Exports>;
+
   /**
    * Per-module namespaces keyed by content identity (the prefix-free
    * `cf:module/<identity>` hash). Lets the runner register every module in a
@@ -131,6 +141,7 @@ export interface EvaluateResult {
    * Populated only on the ESM evaluate paths.
    */
   exportsByIdentity?: Map<string, Exports>;
+
   /**
    * Module content identity → the authored file it came from.
    *
@@ -140,6 +151,7 @@ export interface EvaluateResult {
    * and `PatternManager` stamps it onto each indexed artifact.
    */
   sourcePathByIdentity?: Map<string, string>;
+
   /**
    * Hoist registrations collected during this evaluation (`__cfReg`): module
    * content identity → (symbol → live builder artifact). The PatternManager turns

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -24,8 +24,10 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 export type VerifiedProvenance = {
   /** Module content identity (prefix-free `cf:module/<hash>` hash). */
   identity: string;
+
   /** Export / `__cfReg` symbol of the registered factory (absent: dynamic). */
   symbol?: string;
+
   /**
    * Symbol-less dynamic provenance: in-session-only authority — never
    * serializable to a cross-session `$implRef`. No production writer exists
@@ -35,6 +37,7 @@ export type VerifiedProvenance = {
    * honor.
    */
   dynamic?: true;
+
   /** CT-1665 verified binding identity, when the factory carried one. */
   bindingIdentity?: { sourceFile: string; bindingPath: string[] };
 };

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -58,6 +58,7 @@ type LinkHop = {
   link: NormalizedFullLink;
   source: NormalizedFullLink;
   kind: "value" | "write-redirect";
+
   /**
    * How many of the resolving link's path segments the stored link sits under.
    * Equal to `link.path.length` for a hop found at the full path, and shorter
@@ -121,6 +122,7 @@ const recordDereferenceHop = (
 // directly (`runtime.getCellFromLink` with a multi-segment path) has no
 // recorded caps at all, and removing the floor lets such a read follow a
 // narrower link that main blocks. Pinned by a test.
+
 /**
  * Shift recorded caps onto a link's target after a hop consumed `consumed`
  * leading segments. Caps at or below the hop are dropped (already enforced);
@@ -242,8 +244,10 @@ const kickDocPull = (
 type LinkResolutionRecord = {
   /** The resolved link. Handed out as a copy, never this object. */
   readonly result: NormalizedFullLink;
+
   /** Every hop the walk recorded, in order, ready to be recorded again. */
   readonly traces: readonly CfcDereferenceTrace[];
+
   /**
    * Hop targets in another space. Their sync kick is unreserved, so it fires on
    * every resolution and a memoized one has to fire it too. A same-space kick

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -77,6 +77,7 @@ export type NormalizedLink = {
   scope?: LinkScope;
   schema?: JSONSchema;
   overwrite?: "redirect"; // "this" gets normalized away to undefined
+
   /**
    * Follow caps declared by schemas ABOVE this link's leaf, ascending by
    * depth. `schema` only describes the leaf, so a cap declared mid-path — an
@@ -100,6 +101,7 @@ export type NormalizedLink = {
    * silently lift the caps that boundary is supposed to enforce.
    */
   scopeCaps?: readonly ScopeCapAtDepth[];
+
   /**
    * Link resolution FOLLOWED at least one hop and then dead-ended at a
    * doc the replica cannot serve (the sigil probe reported the DOC
@@ -127,6 +129,7 @@ export type NormalizedLink = {
    * identity; consumers that copy links by spread carry it inertly.
    */
   pendingHopDoc?: true;
+
   /**
    * This link is DATA-DERIVED: parsed from a stored sigil link, or
    * produced by a resolution that followed at least one hop. A handle
@@ -158,6 +161,7 @@ export type ValuePath = readonly ["value", ...string[]];
 export type IMemorySpaceValueAddress = IMemorySpaceAddress & {
   path: ValuePath;
 };
+
 /**
  * Convert a value-relative normalized link into a document-root memory address.
  */

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -28,6 +28,7 @@ export interface RawBuiltinResult {
   debounce?: number;
   noDebounce?: boolean;
   throttle?: number;
+
   /**
    * Receives the Action the runner actually registers with the scheduler —
    * a wrapper around `action`, so `action`'s own identity is not the
@@ -104,12 +105,16 @@ function cloneModuleRecord(module: Module): Module {
 export interface RawModuleOptions {
   /** If true, this module is an effect (side-effectful) rather than a computation */
   isEffect?: boolean;
+
   /** Optional scheduler debounce delay in milliseconds */
   debounce?: number;
+
   /** Opt out of scheduler auto-debounce */
   noDebounce?: boolean;
+
   /** Optional scheduler throttle period in milliseconds */
   throttle?: number;
+
   /**
    * Optional argument schema for the raw module's inputs. Threaded into input
    * binding resolution so the emitted links carry per-key schema annotations

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -57,6 +57,7 @@ type SendValueToBindingOptions = {
 type UnwrapOneLevelOptions = {
   targetSchema?: JSONSchema;
   derivedInternalCells?: readonly DerivedInternalCellDescriptor[];
+
   /**
    * The containing pattern's authored argument schema, used as the source of
    * declared cell scopes when serializing binding aliases (see

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1885,6 +1885,7 @@ export class PatternManager {
    * fails the compile: refs-only pattern JSON makes a durable closure in `space`
    * part of the compilation contract.
    */
+
   /** Attach the trigger's §2b carriage ONLY for a write target FOREIGN
    * to the serving manager's home space (OW31 seat S-A): home-space
    * writebacks and every client writeback stay plain bookkeeping —

--- a/packages/runner/src/pattern-updater.ts
+++ b/packages/runner/src/pattern-updater.ts
@@ -65,6 +65,7 @@ type CheckMode =
   | {
     kind: "default-root";
     officialSource: string;
+
     /** Per-attempt transaction hook for the default-root check's TWO
      * write arms (the provenance repair and the transition — the
      * fabric arm returns "current" for this mode before any write).

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -423,6 +423,7 @@ export function mergeSchemaDefaults<T>(
       schema: JSONSchema,
       fullSchema: JSONSchema,
     ) => boolean;
+
     /** Disambiguate otherwise-valid top-level union default candidates. */
     acceptUnionCandidate?: (candidate: unknown) => boolean;
   } = {},

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -203,6 +203,7 @@ const EAGER_RESULT_BUILTIN_REFS = new Set([
 
 type InternalCellDescriptor = {
   partialCause: JSONValue;
+
   /**
    * Entity kind of the materialized cell's id. Part of the manifest match
    * key alongside `partialCause`: a kind flip across pattern versions must
@@ -813,21 +814,28 @@ type SetupResult<R> = {
 type SetupValidationOptions = {
   /** Optional invariant over the argument stored before setup changes it. */
   validateCurrentArgument?: (argumentCell: Cell<unknown>) => void;
+
   /** Optional layer-specific invariant checked inside the setup transaction. */
   validateArgumentLinks?: (
     argumentCell: Cell<unknown>,
     argumentSchema: JSONSchema,
   ) => void;
+
   /** Optional repository locator written atomically with pattern setup. */
   patternRepository?: string;
+
   /** Source lifecycle change written atomically with pattern setup. */
   pieceSourceTransition?: PieceSourceTransition;
+
   /** Record a detached creation revision when setting up a new piece. */
   initializePieceSourceHistory?: boolean;
+
   /** Mutable source origin recorded with a new piece's creation revision. */
   initialPieceSourceOrigin?: string;
+
   /** Rebuild stored setup state even when patternIdentity already matches. */
   reapplyStoredSetup?: boolean;
+
   /** Keep the next start on the persisted-result dependency-sync path. */
   prepareForResume?: boolean;
 };
@@ -846,9 +854,11 @@ export interface PieceSourceRevision {
   revisionId: string;
   timestamp: number;
   pattern: { identity: string; symbol: string };
+
   /** Link retaining the exact content-addressed source closure. */
   source: SigilLink;
   origin?: string;
+
   /** The legacy origin string, when normalizing it changed its value. */
   recordedOrigin?: string;
   operation: PieceSourceRevisionOperation;
@@ -870,6 +880,7 @@ export interface PieceSourceTransition {
   baseline: PieceSourceTransitionBaseline;
   timestamp: number;
   operation: Exclude<PieceSourceRevisionOperation, "baseline" | "create">;
+
   /** The active origin after the transition. Null means detached. */
   origin: string | null;
   expected: PieceSourceSnapshot;
@@ -878,8 +889,10 @@ export interface PieceSourceTransition {
 
 type RunResult<R> = {
   resultCell: Cell<R>;
+
   /** The exact local cancel registration installed by this invocation. */
   installedCancel?: Cancel;
+
   /**
    * Cancels a start that this invocation deferred until its transaction
    * commits. Before installation it tombstones the pending start; afterwards
@@ -1364,8 +1377,10 @@ export function isStoredArgumentSchemaRefusal(error: unknown): boolean {
 interface SetupStateReuse {
   /** Same pattern as the last run, so stored setup state is this run's own. */
   sameStoredSetup: boolean;
+
   /** Re-point the stored argument at this schema and validate it. */
   restageStoredArgument: boolean;
+
   /**
    * Same stored setup AND a completion marker that POSITIVELY names this
    * pattern. Distinct from `!restageStoredArgument`, which is also true when the
@@ -4533,6 +4548,7 @@ export class Runner {
   // §2 — the resolver also normalizes the raw `undefined:` form the
   // previous string interpolation produced for scope-less links, which
   // merges with `space:`, the same instance by definition).
+
   /** Stage P2-F (the F1 fold-in, RULED 2026-08-13): a piece-start
    * setup/instantiation commit failure is fire-and-forget by design but
    * NEVER silent — loud in every arm, and handed to the serving

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -433,8 +433,10 @@ export function adoptServerExperimentalOptions(
 export interface DeployedClientExperimentalParams {
   /** The deployment this client runs against. */
   apiUrl: URL;
+
   /** Reads this process's environment; pass `Deno.env.get` in Deno contexts. */
   env: EnvReader;
+
   /**
    * Cancels the request. A caller whose startup is cancellable must pass its
    * signal: without one, a deployment that accepts the connection and then
@@ -442,6 +444,7 @@ export interface DeployedClientExperimentalParams {
    * no shutdown can reach it.
    */
   signal?: AbortSignal;
+
   /** Injectable for tests; the real `fetch` otherwise. */
   fetch?: typeof globalThis.fetch;
 }
@@ -592,8 +595,10 @@ export const MAX_ENFORCEMENT_CFC_OPTIONS = Object.freeze(
 interface CoreParams {
   /** Base URL of the memory/API service this runtime talks to. */
   apiUrl: URL;
+
   /** Storage backend — `StorageManager.open(...)` against a deployment, or `.emulate(...)` in-memory. */
   storageManager: IStorageManager;
+
   /**
    * Experimental flags. Required on purpose: pass
    * `experimentalOptionsFromEnv(Deno.env.get)` where the environment should
@@ -602,6 +607,7 @@ interface CoreParams {
    * where an omitted field was silent drift.
    */
   experimental: ExperimentalOptions;
+
   /**
    * Opt this runtime into a named CFC posture bundle
    * ({@link MAX_ENFORCEMENT_CFC_OPTIONS}). Applied in {@link coreOptions},
@@ -617,6 +623,7 @@ interface CoreParams {
  * modes) get flipped HERE, in one reviewed place, for every preset user at
  * once — the constructor defaults then only govern non-preset constructions.
  */
+
 /**
  * The first-party server-execution default for the DEPLOYED-TOPOLOGY
  * presets (server-execution v2, docs/plans/server-execution-v2.md Phase
@@ -683,12 +690,16 @@ export interface ProductionServerPresetParams extends CoreParams {
 export interface RemoteClientPresetParams extends CoreParams {
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
+
   /** Shared compiled-module-byte cache (integration suites). */
   moduleByteCache?: ModuleByteCache;
+
   /** Trust provenance for CFC-relevant writes (pieces controller). */
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
+
   /** Statement-coverage collector for the pattern integration harness. */
   patternCoverage?: PatternCoverageCollector;
+
   /**
    * Host-controlled rollout dials, the browserWorker precedent: a client
    * host (cf-harness's fabric session) may raise enforcement and turn on
@@ -705,10 +716,13 @@ export interface PatternTestPresetParams extends CoreParams {
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
   moduleByteCache?: ModuleByteCache;
+
   /** Per-test laxer mode; defaults to the shared core pin. */
   cfcEnforcementMode?: CfcEnforcementMode;
+
   /** Statement-coverage collector for `cf test` and the pattern harnesses. */
   patternCoverage?: PatternCoverageCollector;
+
   /** Records what a run materializes; see the vintage capture. */
   onPatternInstantiated?: PatternInstantiationObserver;
 }
@@ -716,6 +730,7 @@ export interface PatternTestPresetParams extends CoreParams {
 export interface BrowserWorkerPresetParams extends CoreParams {
   /** Map from space DIDs to HTTP or HTTPS origins selected by the shell host. */
   spaceHostMap?: Record<string, string>;
+
   /** Host-controlled rollout dials, from `InitializationData`. */
   cfcEnforcementMode?: CfcEnforcementMode;
   cfcFlowLabels?: CfcFlowLabelsMode;
@@ -725,6 +740,7 @@ export interface BrowserWorkerPresetParams extends CoreParams {
   errorHandlers?: ErrorHandler[];
   navigateCallback?: NavigateCallback;
   pieceCreatedCallback?: PieceCreatedCallback;
+
   /** Statement-coverage collector, set only on the coverage-collecting shell build. */
   patternCoverage?: PatternCoverageCollector;
 }
@@ -736,6 +752,7 @@ export interface UnitTestPresetParams extends Omit<CoreParams, "experimental"> {
   errorHandlers?: ErrorHandler[];
   moduleByteCache?: ModuleByteCache;
   cfcEnforcementMode?: CfcEnforcementMode;
+
   /** Scheduler tests shrink the backoff/retry window. */
   commitBackpressure?: Partial<CommitBackpressurePolicy>;
 }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -217,6 +217,7 @@ export type PieceCreatedCallback = (piece: Cell<any>) => void;
 export interface ExperimentalOptions {
   /** Enable the modern "cell representation" classes. */
   modernCellRep?: boolean | undefined;
+
   /**
    * Link writers replace inline schemas with references to
    * content-addressed schema documents
@@ -227,8 +228,10 @@ export interface ExperimentalOptions {
    * unconditionally. Defaults to off.
    */
   contentAddressedSchemas?: boolean | undefined;
+
   /** Enforce scheduler-v2 lineage and event-receipt commit preconditions (default on). */
   commitPreconditions?: boolean | undefined;
+
   /**
    * Project a handler's plain JSON return into its per-event receipt cell
    * instead of the empty `{}` witness, so a caller — or a same-id retry that
@@ -242,6 +245,7 @@ export interface ExperimentalOptions {
    * temporary rollback override while the flag exists.
    */
   plainResultReceipts?: boolean | undefined;
+
   /**
    * Mint computed-scheme entity ids (`computed:fid1:<hash>`) for derived
    * internal cells classified as replayable by the builder. Gates minting
@@ -250,6 +254,7 @@ export interface ExperimentalOptions {
    * `docs/specs/computed-cell-identity.md`.
    */
   computedCellIds?: boolean | undefined;
+
   /**
    * Materialize a lift's argument lazily: the body reads the paths it touches
    * and nothing else, instead of the whole of what its schema selects. A
@@ -259,6 +264,7 @@ export interface ExperimentalOptions {
    * `docs/plans/lazy-cell-materialization.md`.
    */
   lazyMaterialization?: boolean | undefined;
+
   /**
    * Roll toolshed-backed patterns forward in place when their source serves a
    * newer content identity. Persisted default roots reconcile before start;
@@ -267,6 +273,7 @@ export interface ExperimentalOptions {
    * docs/specs/pattern-imports/pattern-updates.md.
    */
   systemPatternAutoUpdate?: boolean | undefined;
+
   /**
    * Server-execution v2 (docs/specs/server-side-execution/): one flag, two
    * states. OFF is today's behavior byte-for-byte. ON is the v2 posture as
@@ -335,6 +342,7 @@ export interface PatternInstantiation {
   identity: string;
   symbol: string;
   main?: string;
+
   /** The result cell the pattern was materialized onto. */
   cell: NormalizedFullLink;
 }
@@ -353,14 +361,17 @@ export type PatternInstantiationObserver = (
  */
 export type ServerRunInfo = {
   actionId: string;
+
   /** `bookkeeping` is the sanctioned internal stamp kind
    * (serving-loop.md §3d, RULED 2026-08-05) for runtime-internal commit
    * paths that are neither derivations nor handler runs — the
    * pattern-swap setup write today; the loop's own watermark write uses
    * it directly. */
   kind: "derivation" | "event-handler" | "bookkeeping";
+
   /** The dispatched event's durable id (event-handler runs). */
   eventId?: string;
+
   /** The emitting run's durable event id for a same-wave cascade
    * (C8d; review 2026-08-11 M2): threaded from the emission's
    * dispatch carriage (ServedEventDispatch.parentEventId) through
@@ -368,6 +379,7 @@ export type ServerRunInfo = {
    * requeue closure folds a cascade child into its requeued
    * parent's rollback. */
   parentEventId?: string;
+
   /**
    * The run's PER-RUN DEMANDED identity (M1, scopes.md §5: a derivation
    * runs per demanded instance and the DEMAND supplies the identity).
@@ -381,10 +393,12 @@ export type ServerRunInfo = {
    * the wave-level identity (Phase 1's cardinality-1 fallback).
    */
   scopeKeyIdentity?: ScopeKeyIdentity;
+
   /** The instance key the demanded run serves (resolved from
    * `scopeKeyIdentity` over the demanded root's scope), for basis-row
    * keying (serving-loop.md §3b's `action_scope_key`). */
   actionScopeKey?: ScopeKey;
+
   /** The ACTING identity of an event-handler run (Phase 3, LD1;
    * events.md §2, protocol.md §2): the server-stamped `firedAt` actor
    * the drain resolved from the stream entry — handlers keep the
@@ -392,6 +406,7 @@ export type ServerRunInfo = {
    * attribution annotations. `session` is absent for a sessionless
    * chain (`firedAt.session = "server"`). */
   acting?: { user: string; session?: string };
+
   /** The durable stream entry a drained event-handler run consequences
    * (Phase 3; events.md §4): the serving stamper writes the entry's
    * `consequenced` mark INTO the run's own transaction, so the mark and
@@ -399,6 +414,7 @@ export type ServerRunInfo = {
    * same-transaction atomicity events.md §4 requires; a requeued
    * contribution takes its mark with it). */
   streamEntry?: { sidecarId: string; index: number; seq: number };
+
   /** The LT1 same-space in-process copy's emitter transaction
    * (ServedEventDispatch.lt1; stage C build W3, (α)): the SpaceServer's
    * stamper resolves it to the copy's APPENDING wave (the wave the
@@ -406,6 +422,7 @@ export type ServerRunInfo = {
    * other wave (events.md §4). Absent on the drain's
    * `streamEntry`-bearing copies and on every client-side event. */
   lt1?: { emitterTx: IExtendedStorageTransaction };
+
   /** An EXPLICIT §2b delegated carriage for a `bookkeeping`-kind
    * internal write sanctioned to cross a space boundary (OW31 seat S-A;
    * protocol.md §2b): the compile-cache / program-materialization
@@ -445,6 +462,7 @@ export type ServerRunDemanderResolver = (
 
 export interface RuntimeOptions {
   apiUrl: URL;
+
   /**
    * Optional map from space DIDs to HTTP or HTTPS origins. Space-bound work
    * (LLM calls, fetches, blob uploads) for a mapped space targets
@@ -461,8 +479,10 @@ export interface RuntimeOptions {
   pieceCreatedCallback?: PieceCreatedCallback;
   debug?: boolean;
   telemetry?: RuntimeTelemetry;
+
   /** Optional feature flags for experimental space-model data-layer changes. */
   experimental?: ExperimentalOptions;
+
   /**
    * Server-execution v2 (serving-loop.md §3): mark THIS runtime as the
    * SERVING posture — the SpaceServer's own runtime, whose seal
@@ -477,8 +497,10 @@ export interface RuntimeOptions {
    * (speculation.md; the Phase 2 posture). Ignored in the OFF arm.
    */
   servingPosture?: boolean;
+
   /** Rollout mode for commit-boundary CFC enforcement. Defaults to `enforce-explicit`. */
   cfcEnforcementMode?: CfcEnforcementMode;
+
   /**
    * Called once for every pattern this runtime materializes onto a result
    * cell, with the content-addressed pointer and where it landed.
@@ -496,12 +518,14 @@ export interface RuntimeOptions {
    * caller's bug and is not caught here.
    */
   onPatternInstantiated?: PatternInstantiationObserver;
+
   /**
    * Flow-label propagation dial (S16 default transition). Defaults to `off`.
    * Propagation requires enforcement mode ≥ `observe` to run at the commit
    * boundary; it derives and persists labels but never rejects by itself.
    */
   cfcFlowLabels?: CfcFlowLabelsMode;
+
   /**
    * Write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18, Epic D3).
    * Defaults to `off`. `observe` evaluates the floor and emits diagnostics;
@@ -510,6 +534,7 @@ export interface RuntimeOptions {
    * value's integrity, never the consumed-read set.
    */
   cfcWriteFloor?: CfcWriteFloorMode;
+
   /**
    * Trigger-read gating on the enforcement side (§8.9.2 / SC-3, Epic H5).
    * Defaults to `false`. When true, the addresses whose invalidating writes
@@ -518,6 +543,7 @@ export interface RuntimeOptions {
    * metadata resolution per prepare).
    */
   cfcTriggerReadGating?: CfcTriggerReadGating;
+
   /**
    * Defaults to `false`. When true, the envelope persist path stores the
    * decomposed spelling: the metadata's `schemaHash` names a root document
@@ -528,6 +554,7 @@ export interface RuntimeOptions {
    * setting.
    */
   cfcDecomposedEnvelopes?: CfcDecomposedEnvelopes;
+
   /**
    * Exchange-rule policy evaluation dial (Epic B5, spec §4.4.5). Defaults to
    * `off` (gates decide on raw labels, byte-identical to before the dial).
@@ -536,6 +563,7 @@ export interface RuntimeOptions {
    * rewritten label and fails closed on fuel exhaustion.
    */
   cfcPolicyEvaluation?: CfcPolicyEvaluationMode;
+
   /**
    * Cross-space label-metadata representation dial (inv-12 Stage 1 / SC-25,
    * spec §4.6.4.1; docs/specs/cfc-label-metadata-confidentiality.md §2/§5).
@@ -547,6 +575,7 @@ export interface RuntimeOptions {
    * rejects a commit by itself.
    */
   cfcLabelMetadataProtection?: CfcLabelMetadataProtectionMode;
+
   /**
    * Declared-component monotonicity gate dial (WP5, spec §8.12.1/§8.12.8;
    * docs/specs/cfc-persisted-declassification.md §4 item 3). Defaults to
@@ -559,6 +588,7 @@ export interface RuntimeOptions {
    * derived/link/structure components keep their §8.12.8 disciplines.
    */
   cfcDeclaredMonotonicity?: CfcDeclaredMonotonicityMode;
+
   /**
    * Per-prepare D4 write-prefix precision counters (value-level provenance
    * Stage 0 — docs/specs/cfc-value-level-provenance.md §6, SC-24). Defaults
@@ -570,11 +600,13 @@ export interface RuntimeOptions {
    * byte-identical either way.
    */
   cfcPrefixProvenanceStats?: boolean;
+
   /** Per-sink confidentiality ceilings for the sink-request egress gate. A sink
    *  absent from the map is ungated; a declared ceiling rejects (or, in observe
    *  mode, flags) a request carrying confidentiality outside it. Defaults to
    *  none declared (`DEFAULT_SINK_MAX_CONFIDENTIALITY`). */
   cfcSinkMaxConfidentiality?: SinkMaxConfidentiality;
+
   /**
    * Deployment policy records for the exchange-rule evaluator (Epic B2a,
    * spec §4.3). Validated, digested, and deep-frozen into a `PolicySnapshot`
@@ -583,6 +615,7 @@ export interface RuntimeOptions {
    * configured (evaluation is a no-op).
    */
   cfcPolicyRecords?: readonly CfcPolicyRecordInput[];
+
   /**
    * Deployment trust config for concept-guard satisfaction (Epic B3, spec
    * §4.8): trust statements, verifier delegations, concept edges. Validated,
@@ -594,16 +627,20 @@ export interface RuntimeOptions {
    * guard fails closed).
    */
   cfcTrustConfig?: CfcTrustConfigInput;
+
   /** Deterministic provider for the trust snapshot attached to each new tx. */
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
+
   /** Replace runner-owned frames with `<CF_INTERNAL>` in surfaced stacks. */
   hideInternalStackFrames?: boolean;
+
   /**
    * Tuning for committed-write backpressure under contention. Unset fields fall
    * back to DEFAULT_COMMIT_BACKPRESSURE; tests use this to shrink the backoff
    * and retry window. See scheduler/backpressure.ts.
    */
   commitBackpressure?: Partial<CommitBackpressurePolicy>;
+
   /**
    * Process-level, content-addressed cache of compiled MODULE BYTES, shared
    * across runtimes. When set, the ESM cell-cache compile path consults it before
@@ -614,6 +651,7 @@ export interface RuntimeOptions {
    * {@link ModuleByteCache}.
    */
   moduleByteCache?: ModuleByteCache;
+
   /**
    * Statement-coverage collector for authored patterns. When set, every compile
    * this runtime performs is instrumented — the transformer injects a hit call
@@ -627,6 +665,7 @@ export interface RuntimeOptions {
    * packages/runner/src/pattern-coverage.ts and docs/development/COVERAGE.md.
    */
   patternCoverage?: PatternCoverageCollector;
+
   /**
    * Override for the outbound `fetch` used by network builtins (`fetchJson` et al).
    * Defaults to the host `globalThis.fetch`. Scoped to this runtime instance, so
@@ -638,6 +677,7 @@ export interface RuntimeOptions {
 
 export interface CfcRuntimeStats {
   cfcRelevantTx: number;
+
   /** Stage C tuning T1: flow-label relevance probes actually EVALUATED
    * (`flowLabelWorkExists`) vs answered from the transaction's memoized
    * negative verdict. Measurement only. */
@@ -653,22 +693,31 @@ export interface CfcRuntimeStats {
   // (docs/specs/cfc-value-level-provenance.md §6, SC-24). All zero unless
   // `cfcPrefixProvenanceStats` is enabled. Aggregated over the per-prepare
   // summaries; the per-write detail lists are not retained here.
+
   /** Prepares that measured at least one protected write. */
   prefixProvenanceSummaries: number;
+
   /** Protected writes measured (requiredIntegrity / maxConfidentiality). */
   prefixProtectedWrites: number;
+
   /** Gated reads under the shipped D4 per-write prefix. */
   prefixGatedReads: number;
+
   /** What the pre-D4 transaction-global gate would have counted. */
   prefixTxGlobalGatedReads: number;
+
   /** Writes bounded by a logged overlapping attempt (prefix engaged). */
   prefixBoundReal: number;
+
   /** Writes on the +Infinity fallback (no logged overlapping attempt). */
   prefixBoundInfinityFallback: number;
+
   /** Writes with no ordered write-attempt evidence at all (clock-less). */
   prefixBoundClockLess: number;
+
   /** S7 provenance-only exemption fires within prefixes. */
   prefixS7ExemptionFires: number;
+
   /** Read activities without a clock position (treated at -Infinity). */
   prefixClockLessReads: number;
 }
@@ -799,6 +848,7 @@ export class Runtime {
   readonly navigateCallback?: NavigateCallback;
   readonly pieceCreatedCallback?: PieceCreatedCallback;
   readonly cfcEnforcementMode: CfcEnforcementMode;
+
   /** See `RuntimeOptions.onPatternInstantiated`. */
   readonly onPatternInstantiated?: PatternInstantiationObserver;
   readonly cfcFlowLabels: CfcFlowLabelsMode;
@@ -810,14 +860,18 @@ export class Runtime {
   readonly cfcDeclaredMonotonicity: CfcDeclaredMonotonicityMode;
   readonly cfcPrefixProvenanceStats: boolean;
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
+
   /** Frozen deployment policy snapshot; undefined = no policies configured. */
   readonly cfcPolicySnapshot: PolicySnapshot | undefined;
+
   /** Frozen deployment trust config; undefined = no trust configured. */
   readonly cfcTrustConfig: CfcTrustConfig | undefined;
   readonly staticCache: StaticCache;
   readonly storageManager: IStorageManager;
+
   /** Optional process-level compiled-module-byte cache; see RuntimeOptions. */
   readonly moduleByteCache?: ModuleByteCache;
+
   /** Optional pattern statement-coverage collector; see RuntimeOptions. */
   readonly patternCoverage?: PatternCoverageCollector;
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
@@ -828,18 +882,22 @@ export class Runtime {
   // per-run served snapshots exactly as it does ambient client ones.
   readonly #trustRevision: string;
   readonly telemetry: RuntimeTelemetry;
+
   /** Resolved experimental flags (all properties present with built-in defaults). */
   readonly experimental: ExperimentalOptions;
+
   /** Resolved committed-write backpressure policy (all fields present). */
   readonly commitBackpressure: CommitBackpressurePolicy;
   readonly apiUrl: URL;
   readonly spaceHostMap?: Record<string, string>;
+
   /**
    * Outbound `fetch` used by network builtins (e.g. `fetchJson`). Defaults to
    * the host `globalThis.fetch`; a test harness can inject a mock via
    * `RuntimeOptions.fetch`.
    */
   readonly fetch: RuntimeFetch;
+
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
   // The transaction seal destination (server-execution v2, serving-loop.md
@@ -869,9 +927,11 @@ export class Runtime {
   // the replica's pending overlay through it — the structural removal of
   // the client derivation-commit path. Never created in the OFF arm.
   #speculationOverlay: SpeculationOverlayDestination | undefined;
+
   /** The client-effect channel (server-execution v2 Phase 4,
    * protocol.md §5) — constructed for flag-ON non-serving runtimes. */
   #effectsChannel: EffectsChannel | undefined;
+
   /** The exact spaceOpenObserver closure THIS runtime installed on the
    * (possibly shared) storage manager — dispose clears the manager
    * hook only on identity match, so a later runtime's own hook
@@ -891,6 +951,7 @@ export class Runtime {
   // `derived` for every other owner's in-flight wave commit (the
   // admission plane reads the ambient value).
   #serverExecutionRelease: (() => void) | undefined;
+
   /** Serving posture (RuntimeOptions.servingPosture): true only for the
    * SpaceServer's own runtime. Gates the Phase-2 speculation-overlay
    * default (a serving runtime never speculates). */
@@ -909,6 +970,7 @@ export class Runtime {
   get scopeKeyIdentity(): ScopeKeyIdentity {
     return this.storageManager.scopeKeyIdentity();
   }
+
   /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
   private readonly spaceNameToDid = new Map<string, MemorySpace>();
   private defaultFrame?: Frame;
@@ -2041,6 +2103,7 @@ export class Runtime {
         tx: IExtendedStorageTransaction,
         info: ServerRunInfo,
       ) => void;
+
       /** The per-(action × instance) run SUPPLY (server-execution v2
        * stage P2-F; fan-out stage B): resolves an action's demand roots
        * to the DEMANDERS the SpaceServer's registry holds for them. The

--- a/packages/runner/src/schema-decompose.ts
+++ b/packages/runner/src/schema-decompose.ts
@@ -71,6 +71,7 @@ export const SCHEMA_DOCUMENT_REF_PREFIX = "cid:";
 export type ExternalSchemaRef = {
   /** Tagged hash of the referenced document (the id without `cid:`). */
   readonly taggedHash: string;
+
   /**
    * For a reference into a cyclic-group document: the member definition's
    * name. Absent for a bare reference to a document's own schema.
@@ -86,6 +87,7 @@ export type DecomposedSchema = {
    * the root reduced to a single reference into a cyclic group.
    */
   readonly rootRef: string;
+
   /**
    * Every document in the closure, keyed by tagged hash, values interned.
    * Iteration order is dependency-first: a document precedes every document

--- a/packages/runner/src/schema-format.ts
+++ b/packages/runner/src/schema-format.ts
@@ -14,10 +14,13 @@ import { ContextualFlowControl } from "./cfc.ts";
 export interface SchemaFormatOptions {
   /** Definitions map for resolving $ref references */
   defs?: Record<string, JSONSchema>;
+
   /** Current recursion depth (internal use) */
   depth?: number;
+
   /** Maximum recursion depth before abbreviating (default: 4) */
   maxDepth?: number;
+
   /** Current indentation level (internal use) */
   indent?: number;
 }

--- a/packages/runner/src/schema-walk.ts
+++ b/packages/runner/src/schema-walk.ts
@@ -128,6 +128,7 @@ export function isSubschema(value: unknown): value is JSONSchema {
 export interface SchemaWalkOptions {
   /** Also descend into `$defs` bodies. Default false. */
   readonly includeDefs?: boolean;
+
   /**
    * Also visit subschemas under the keywords we never emit
    * (`UNUSED_SINGLE_SUBSCHEMA_KEYS` / `UNUSED_RECORD_SUBSCHEMA_KEYS`). Default
@@ -135,11 +136,13 @@ export interface SchemaWalkOptions {
    * we emit — chiefly `$ref` discovery, where a missed ref is a fail-open bug.
    */
   readonly includeUnused?: boolean;
+
   /**
    * Also invoke the visitor for boolean subschemas (`true` / `false`). Default
    * false — most callers only care about object schemas.
    */
   readonly visitBooleans?: boolean;
+
   /**
    * Resolve `$ref` while walking. Honored by {@link walkSchema} only
    * (`forEachSubschema` is shallow). At a node carrying a string `$ref`, the
@@ -310,10 +313,13 @@ export function forEachSubschema(
 /** One immediate subschema of a parent, with the edge that reached it. */
 export interface SubschemaEdge {
   readonly schema: JSONSchema;
+
   /** The keyword this subschema hangs off. */
   readonly keyword: SubschemaKeyword;
+
   /** For record-valued keywords: the property / definition name. */
   readonly key?: string;
+
   /** For array-valued keywords: the index. */
   readonly index?: number;
 }
@@ -430,20 +436,26 @@ export function mapSubschemas(
 export interface SchemaNode {
   /** The subschema at this node. */
   readonly schema: JSONSchema;
+
   /**
    * Structural path from the walk root: keyword-segmented, e.g.
    * `["properties", "user", "items"]` or `["allOf", 0, "properties", "id"]`.
    * Empty at the root.
    */
   readonly path: ReadonlyArray<string | number>;
+
   /** The keyword the edge from the parent used; undefined at the root. */
   readonly keyword?: SubschemaKeyword;
+
   /** Record edge: the property / definition name. */
   readonly key?: string;
+
   /** Array edge: the index. */
   readonly index?: number;
+
   /** The parent subschema; undefined at the root. */
   readonly parent?: JSONSchemaObj;
+
   /**
    * True when this node is a `$ref` target reached via
    * {@link SchemaWalkOptions.resolveRef}. Its `path` is the ref site's path
@@ -457,6 +469,7 @@ export interface SchemaNode {
  * (`undefined`) descends into the node's children — the common case.
  */
 export type WalkControl =
+
   /** Do not descend into this node's children; continue with its siblings. */
   | "skip"
   /** Abort the entire walk immediately. */

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1132,14 +1132,17 @@ function readValueAtResolvedLink(
 export interface ValidateAndTransformOptions {
   /** When true, also read into each Cell created for asCell fields to capture dependencies */
   traverseCells?: boolean;
+
   /** When true, cells created during traversal are marked as already synced */
   synced?: boolean;
+
   /**
    * Set by a schema view reading one of its children: a mismatch there is a
    * refusal the reader must be told about, not the `undefined` a root read
    * yields, which a reader cannot tell from an absent value.
    */
   mismatchThrows?: boolean;
+
   /**
    * Set by a schema view reading one of its children: this is a step inside a
    * read the entry point already began, so the entry-point-only work — the

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -118,6 +118,7 @@ export function assertWebhookCellLinkRefPayload(
  */
 export type SigilLink<P extends CellLinkRefPayload = CellLinkRefPayload> =
   LinkRef<P>;
+
 /**
  * A {@link SigilLink} whose payload is a write redirect (an alias) — its
  * `overwrite` is fixed to `"redirect"`.

--- a/packages/runner/src/speculation/doc-notification-listener.ts
+++ b/packages/runner/src/speculation/doc-notification-listener.ts
@@ -44,6 +44,7 @@ export type DocNotificationConsumer = {
    * change at notification time — cheap (a map lookup). `scope` is the
    * change address's normalized scope name (`"space"`, `"session"`, …). */
   wants(space: MemorySpace, id: string, scope: string | undefined): boolean;
+
   /** Called in a microtask, once per (space, id) per burst, with every
    * change path recorded since the previous call. `id === undefined` is
    * a storage RESET for the space: everything the consumer tracks there
@@ -68,6 +69,7 @@ export class CoalescedDocListener {
   readonly #pending = new Map<PendingKey, PendingRecord>();
   #subscription: IStorageNotification | undefined;
   #released = false;
+
   /** DIAGNOSTIC: notifications that touched a wanted doc; microtask
    * checks dispatched. */
   #relevantNotifications = 0;

--- a/packages/runner/src/speculation/effects-channel.ts
+++ b/packages/runner/src/speculation/effects-channel.ts
@@ -72,22 +72,28 @@ const logger = getLogger("effects-channel", {
 
 export class EffectsChannel {
   readonly #runtime: Runtime;
+
   /** The enacted-nonce record (LT8): reload-wiped by construction. A
    * FAILED enactment retracts its nonce (owner review P1-1), so the
    * record holds successes and in-flight attempts only. */
   readonly #enacted = new Set<string>();
+
   /** In-flight enactments by nonce — the outcome every ack must chain
    * on (protocol.md §5's "enacts, THEN commits an authored ack"):
    * resolves true on success (record kept, acks release), false on
    * failure (record retracted; the entry — still unacked in the store
    * — re-enacts on a later delivery). */
   readonly #enactInFlight = new Map<string, Promise<boolean>>();
+
   /** Spaces whose session effects instance this channel watches. */
   readonly #spaces = new Set<MemorySpace>();
+
   /** The ONE storage-notification listener (design (e) item 13). */
   #listener: CoalescedDocListener | undefined;
+
   /** DIAGNOSTIC (tests): reconciles run from notifications / re-reads. */
   #reconciles = 0;
+
   /** In-flight ack writes (`${space}\0${nonce}`) — one authored ack per
    * nonce at a time; a failed ack retries on the next sink delivery
    * (the entry is still unacked there). */

--- a/packages/runner/src/speculation/overlay-destination.ts
+++ b/packages/runner/src/speculation/overlay-destination.ts
@@ -158,10 +158,12 @@ type OverlayEntry = {
   space: MemorySpace;
   localSeq: number;
   resolveVerdict: (verdict: SealedCommitVerdict) => void;
+
   /** The highest confirmed store seq this run's reads sat on — the
    * watermark threshold at which the authoritative derivation covers
    * everything this speculation consumed. */
   confirmedFloor: number;
+
   /** Docs this run read through PENDING (unpromoted) layers: unacked
    * authored origins (the user mid-typing), parked promotions, or
    * earlier speculation entries. The entry stays alive while any
@@ -170,12 +172,14 @@ type OverlayEntry = {
    * layer whose promotion is merely parked no longer blocks: the wave
    * consumed the origin, so the authoritative coverage is real). */
   pendingReadDocs: Array<{ id: URI; scope?: CellScope }>;
+
   /** The localSeqs of the pending layers this run read through — its
    * ORIGINS. Retirement needs each origin ACKED with `W >= ackSeq`
    * (speculation.md §4 step 3); an origin that never acks (a retired
    * lower speculation, a rejected input) contributes no floor — the
    * store won upstream and the confirmed basis governs. */
   originLocalSeqs: number[];
+
   /** The doc instances this run WROTE (speculation.md §4's arrival-gated
    * retirement, RULED 2026-08-16): the entry retires only once every one
    * of them holds a CONFIRMED value at seq ≥ the entry's floor — the
@@ -191,11 +195,13 @@ type OverlayEntry = {
   writtenDocs: Array<{
     id: URI;
     scope?: CellScope;
+
     /** Whether the run's op on the doc is a whole-doc set/delete (the
      * supersede-by-newer rider may drop an OLDER entry's layer under it
      * invisibly) or a patch (path-relative — never dropped under). */
     wholeDoc: boolean;
   }>;
+
   /** The scheduler action whose run sealed this entry (the writer), for
    * the supersede-by-newer rider: a NEWER entry of the same writer whose
    * whole-doc ops cover every doc of an older entry retires the older one
@@ -203,18 +209,21 @@ type OverlayEntry = {
    * invisible — no flip), bounding entry growth for a never-served
    * instance that keeps changing. */
   sourceAction?: object;
+
   /** Resolves when the entry's verdict has been APPLIED (pending
    * dropped). Retirement chains a re-sweep on it: a chained entry
    * blocked on this one unblocks only after the drop, which is async
    * relative to the verdict — and on a quiet space no further
    * watermark event would re-sweep. */
   settled: Promise<unknown>;
+
   /** origin `intent(eventId)` (speculation.md §1): set on event-handler
    * echoes — the fired event's durable id. `retireIntent` withdraws by
    * it when the authoritative consequences (or the dropped-event
    * notice) arrive (speculation.md §4 step 2); the watermark sweep
    * stays the backstop. */
   eventId?: string;
+
   /** The emitting run's event id for a CLIENT CASCADE child's echo (the
    * speculation run context's `parentEventId`, threaded by cell.ts's
    * plain `queueEvent` for a send from within a speculation-stamped
@@ -236,21 +245,26 @@ type OverlayEntry = {
 export class SpeculationOverlayDestination
   implements TransactionSealDestination {
   readonly #runtime: Runtime;
+
   /** space -> localSeq -> entry. */
   readonly #entries = new Map<MemorySpace, Map<number, OverlayEntry>>();
+
   /** space -> cancel fn for the watermark-doc sink driving retirement. */
   readonly #watermarkSinks = new Map<MemorySpace, () => void>();
+
   /** space -> release fn for the origin-accept wake installed on the
    * replica (speculation.md §4; leg-C 2026-08-13): a sweep that ran
    * while an origin's verdict was in flight skipped its entries as
    * blocked, and the covering watermark event has already passed — the
    * ack wake re-sweeps so a then-quiet space cannot strand them. */
   readonly #ackObserverReleases = new Map<MemorySpace, () => void>();
+
   /** space -> release fn for the ARRIVAL wake installed on the replica
    * (ISpaceReplica.speculationArrivalObserver; stage C tuning T2): a
    * frame that moves the confirmed seq of a doc some entry wrote
    * re-sweeps the space. */
   readonly #arrivalObserverReleases = new Map<MemorySpace, () => void>();
+
   /** Intents whose TERMINAL consequence this overlay has observed
    * (consequenced / errored / dropped / refused), keyed by eventId (a
    * per-fire mint — event-identity.ts — unique across spaces), bounded and
@@ -260,6 +274,7 @@ export class SpeculationOverlayDestination
    * (speculation.md §4 step 2) — and is not registered. */
   readonly #terminalIntents = new Set<string>();
   static readonly #MAX_TERMINAL_INTENTS = 4096;
+
   /** The client cascade THREAD (stage C W2.1): cascade child eventId →
    * its emitter's eventId, recorded at the seal of every event-handler
    * echo that carries a `parentEventId` — with or without writes, so a
@@ -271,17 +286,21 @@ export class SpeculationOverlayDestination
    * whose terminal consequence just arrived. A link is needed only for
    * the round trip between a cascade's seal and its root's consequence. */
   readonly #cascadeParents = new Map<string, string>();
+
   /** Walk cap for the ancestry walk — ids are fresh per attempt, so no
    * cycle exists; the cap only bounds a pathological depth. */
   static readonly #MAX_CASCADE_DEPTH = 64;
+
   /** Transactions dropped as late echoes: `deferSealedEffects` owns and
    * DROPS their enactable effects too (the closed-overlay arm's shape) —
    * an optimistic navigation for a run whose writes were discarded must
    * not enact. */
   readonly #droppedLateEchoTxs = new WeakSet<object>();
+
   /** DIAGNOSTIC counters (tests). */
   #arrivalSweeps = 0;
   #lateEchoDrops = 0;
+
   /** Stage C W2.1: cascade-child echoes retired because an ANCESTOR
    * intent's terminal consequence arrived (`retireIntent` walked the
    * cascade thread to them), and the subset retired while NO doc they
@@ -289,6 +308,7 @@ export class SpeculationOverlayDestination
    * flicker witness (see `retireIntent`). */
   #cascadeEchoRetirements = 0;
   #cascadeEchoRetirementsUnarrived = 0;
+
   /** F6 telemetry (combined review 2026-08-19): the silent-strand
    * distinguishers. A `#cascadeParents` eviction at the 4096 bound, or
    * an ancestry walk stopped at the 64-hop depth cap with chain
@@ -298,8 +318,10 @@ export class SpeculationOverlayDestination
    * workload; nonzero is the signal to look. */
   #cascadeThreadEvictions = 0;
   #cascadeWalkDepthCaps = 0;
+
   /** space -> last observed watermark (for registration-time sweeps). */
   readonly #watermarks = new Map<MemorySpace, number>();
+
   /** Fired-intent notice watch (events.md §5, speculation.md §4 step 2,
    * §5): space -> sidecarId -> eventIds awaiting their consequence
    * signal — the OUTSTANDING set, which is the spec's own bound (§5:
@@ -310,6 +332,7 @@ export class SpeculationOverlayDestination
     MemorySpace,
     Map<string, Set<string>>
   >();
+
   /** The intent LISTENER (server-execution v2 stage C design (e), RULED
    * 2026-08-18): ONE non-reactive storage-notification subscription per
    * overlay, installed by `trackIntent` while any intent is outstanding
@@ -322,6 +345,7 @@ export class SpeculationOverlayDestination
    * one raw replica read, ZERO transactions, ZERO probes, ZERO scheduler
    * runs, no demand edge. */
   #intentListener: CoalescedDocListener | undefined;
+
   /** space\0sidecarId -> per-sidecar check state: entry-index HINTS the
    * differential's leaf paths named since the last check (a mark on
    * entry i arrives as `["value","entries","<i>","consequenced"]`),
@@ -329,17 +353,20 @@ export class SpeculationOverlayDestination
    * move (a re-append lands behind concurrent entries; compaction, when
    * built, shifts the tail down), so a hint is never trusted unread. */
   readonly #intentSidecarStates = new Map<string, { hints: Set<number> }>();
+
   /** DIAGNOSTIC counters (tests; the `commonfabric.*` surface reads the
    * logger keys — `speculation-overlay/intent-*`). */
   #intentCheckCount = 0;
   #intentCheckVisits = 0;
   #intentCheckMaxVisits = 0;
   #intentListenerInstalls = 0;
+
   /** Subscribers to terminal intent outcomes — the events.md §5 "the
    * client MUST be signaled so the UI can react" hook. */
   readonly #intentOutcomeSubscribers = new Set<
     (outcome: EventIntentOutcome) => void
   >();
+
   /** Per-intent consequence waiters (verdict blocker, 2026-08-12): the
    * send path's durable-ack coupling awaits an intent's TERMINAL
    * consequence — consequenced (server handling committed), errored,
@@ -352,6 +379,7 @@ export class SpeculationOverlayDestination
     Array<(outcome: IntentConsequence) => void>
   >();
   readonly #intentConsequenceMemo = new Map<string, IntentConsequence>();
+
   /** Resolvers parked by `waitForIntentQuiescence`, flushed by the same
    * untrack step that empties the outstanding-intent set (and by close). */
   #intentQuiescenceWaiters: Array<() => void> = [];
@@ -1543,6 +1571,7 @@ export class SpeculationOverlayDestination
       ) => { confirmedSeq: number; pendingLocalSeqs: number[] })
       | null
       | undefined;
+
     /** The mark frame's seq (the sidecar's confirmed seq at this check);
      * 0 = unknown → the witness does not count. */
     let markSeq: number | undefined;

--- a/packages/runner/src/telemetry-otel-bridge.ts
+++ b/packages/runner/src/telemetry-otel-bridge.ts
@@ -32,6 +32,7 @@ import type {
 export interface OtelBridgeOptions {
   tracer: Tracer;
   meter: Meter;
+
   /**
    * Attributes stamped on every emitted span and metric — the dimensions the
    * markers themselves don't carry. Set here once at attach time from the host's
@@ -39,6 +40,7 @@ export interface OtelBridgeOptions {
    *   { "user.did": principal, "space.did": space, "ct.runtime": "bg-piece" }
    */
   attributes?: Attributes;
+
   /**
    * Attributes stamped on METRICS ONLY, merged over `attributes`. Backends
    * don't map OTel resource attributes onto metric datapoint labels, so pass
@@ -48,6 +50,7 @@ export interface OtelBridgeOptions {
    * bare key ambiguous (resource vs attribute context) in SigNoz queries.
    */
   metricAttributes?: Attributes;
+
   /**
    * Minimum action-run duration that earns a retroactive `scheduler.action.run`
    * span. Measured on the lunch-poll diagnose workload: ~4.4% of runs exceed
@@ -62,6 +65,7 @@ export interface OtelBridgeOptions {
 export interface RuntimeTelemetryOtelBridge {
   /** Translate a single marker into spans/metrics. Safe to call for any type. */
   handleMarker(marker: RuntimeTelemetryMarkerResult): void;
+
   /** Close any spans still open (e.g. storage ops without a completion). */
   shutdown(): void;
 }

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -183,10 +183,13 @@ export type RuntimeTelemetryMarker = {
   writesTruncated?: boolean;
   error?: string;
   permanentRejection?: "origin-committed" | "receipt-exists";
+
   /** Backpressure attempt count (1-based) for a transient-conflict retry. */
   retryAttempt?: number;
+
   /** Backoff delay applied before the next retry, in milliseconds. */
   backoffMs?: number;
+
   /**
    * Set when the commit reached a terminal outcome: `permanent` for a
    * never-retried precondition failure, `convergence` for a transient conflict

--- a/packages/runner/src/traverse-recorder.ts
+++ b/packages/runner/src/traverse-recorder.ts
@@ -46,14 +46,19 @@ export type TraverseFixtureAddress = {
 export type TraverseFixtureInvocation = {
   /** Address passed to `SchemaObjectTraverser.traverse()`. */
   address: TraverseFixtureAddress;
+
   /** Index into the fixture's `selectors` table. */
   selector: number;
+
   /** Index into the fixture's `links` table, when traverse() got a link. */
   link?: number;
+
   /** `TraversalContext.includeMeta` (true on the query path). */
   includeMeta: boolean;
+
   /** Invocations sharing this id shared one `TraversalContext`. */
   context: number;
+
   /** Invocations sharing this id shared one `SchemaMemo`. */
   memo?: number;
 };
@@ -68,6 +73,7 @@ export type TraverseFixture = {
   };
   selectors: SchemaPathSelector[];
   links: NormalizedFullLink[];
+
   /** Full fact values keyed by `space|scope|id|type`. */
   docs: Record<string, FabricValue>;
   invocations: TraverseFixtureInvocation[];

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -613,11 +613,14 @@ type PreparedAnyOfBranch = {
   /** Original option was the `false` schema: counted, never matched. */
   optionIsFalse: boolean;
   merged: JSONSchema;
+
   /** Prefilter verdict known statically (boolean merged / unresolved $ref). */
   constant: boolean | undefined;
   hasAsCell: boolean;
+
   /** Normalized type list of the resolved merged schema, if constrained. */
   types: readonly JSONSchemaTypes[] | undefined;
+
   /** Required property names, when the resolved type admits objects. */
   required: readonly string[] | undefined;
 };
@@ -1242,6 +1245,7 @@ export type PointerCycleTracker = CompoundCycleTracker<
 export type TraversalContext = {
   tracker: PointerCycleTracker;
   schemaTracker: MapSet<string, SchemaPathSelector>;
+
   /**
    * The acting identity this traversal's schema-tracker keys resolve
    * scoped addresses against (key-vocabulary.md §1 sites 5–6): coverage
@@ -1254,6 +1258,7 @@ export type TraversalContext = {
   scopeKeyIdentity: ScopeKeyIdentity;
   includeMeta: boolean;
   metaDocsVisited: Set<string>;
+
   /**
    * Reports a followed link whose target document is absent from the local
    * replica. Cross-space targets (target space !== `sourceSpace`) can never
@@ -1271,6 +1276,7 @@ export type TraversalContext = {
      * the miss so a referrer that changes away retires it. */
     source?: { id: string; scope?: CellScope },
   ) => void;
+
   /**
    * Schema-document tracker keys this traversal has already attempted to
    * load, so one traversal reads each referenced document at most once. A
@@ -1278,6 +1284,7 @@ export type TraversalContext = {
    * (triggered by the arrival) retries.
    */
   schemaDocsLoaded: Set<string>;
+
   /**
    * `\${space}/\${taggedHash}` keys for the schema documents this traversal
    * loaded AND verified, qualified by the space each was collected from —
@@ -1522,6 +1529,7 @@ class StandardObjectCreator implements IObjectCreator<FabricValue> {
   ): FabricValue {
     return defaultValue;
   }
+
   /**
    * When processing queries, we want JSON, so we replace undefined with null.
    *
@@ -3662,6 +3670,7 @@ export class SchemaObjectTraverser<V extends FabricValue>
 
   // Generally handles anyOf
   // TODO(@ubik2): Need to break this up -- it's too long
+
   /**
    * Traverse the doc with the specified schema.
    *


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 309 doc comments across 45 files had no blank line above them; each
gets one.

Covered: the `packages/runner/src` top level, plus `builder/`, `builtins/`,
`compilation-cache/`, `harness/`, and `speculation/`. The rest of `src` and the
`test` tree follow in their own PRs.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

Insertions were placed mechanically and then `deno fmt` was run over
`packages/runner/src`, which is what settles the parenthesized-list exception:
four of the 313 candidate sites turned out to be inside a parameter or argument
list, and the formatter removed those, leaving 309.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/runner`'s own test
task, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`, and
`check-withheld-globals` all pass locally. GitHub Actions is in an outage as this
is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

