### PR TITLE
docs(runner): blank lines above doc comments in five `src` subtrees

### DIFF
--- a/packages/runner/src/cfc/exchange-eval.ts
+++ b/packages/runner/src/cfc/exchange-eval.ts
@@ -84,11 +84,14 @@ export const DEFAULT_EXCHANGE_FUEL = 64;
 export type RuleFiring = {
   readonly recordId: string;
   readonly ruleId: string;
+
   /** Index of the rewritten clause in the label AT FIRING TIME. */
   readonly clauseIndex: number;
   readonly kind: "add" | "drop";
+
   /** Alternatives added by an `add` firing. */
   readonly added?: readonly unknown[];
+
   /** The alternative removed by a `drop` firing. */
   readonly dropped?: unknown;
 };
@@ -118,6 +121,7 @@ export type CfcGrantConsumptionContext = "consuming" | "observing";
 export type CfcGrantResolverQuery = {
   readonly kind: string;
   readonly fields: Readonly<Record<string, unknown>>;
+
   /**
    * The evaluation site's consumption context, stamped from
    * {@link ExchangeEvalContext.grantConsumption}. ABSENT means observing
@@ -157,16 +161,20 @@ export type ExchangeEvalContext = {
    * pool is `label.integrity ∪ ctx.integrity`.
    */
   readonly integrity?: readonly CfcAtom[];
+
   /** Boundary-context atoms minted for this evaluation site (B5). */
   readonly boundary?: readonly CfcAtom[];
+
   /** Trust closure for concept-valued integrity guards (B3). */
   readonly trustResolver?: TrustResolver;
   readonly actingPrincipal?: string;
+
   /**
    * Grant lookup for `policyState` guards (route 2a). Absent → every
    * policyState guard is unsatisfied and its rule never fires (fail closed).
    */
   readonly grantResolver?: CfcGrantResolver;
+
   /**
    * Consuming vs observing evaluation site (single-use releases, design
    * §2.2) — stamped onto every resolver query. Absent = observing (fail
@@ -175,6 +183,7 @@ export type ExchangeEvalContext = {
    * the same prepare pass. See {@link CfcGrantConsumptionContext}.
    */
   readonly grantConsumption?: CfcGrantConsumptionContext;
+
   /**
    * Exact module-manifest lookup. Absent or unsuccessful lookup fails the
    * whole evaluation closed when the label selects a module policy.

--- a/packages/runner/src/cfc/external-ingest.ts
+++ b/packages/runner/src/cfc/external-ingest.ts
@@ -16,12 +16,16 @@ import type { CellScope } from "../builder/types.ts";
 export type CfcExternalIngestMeta = {
   /** The ingest channel (its dedicated space DID). */
   readonly channel: string;
+
   /** The presenter the grant was vouched to (recorded, not enforced). */
   readonly audience: string;
+
   /** Operator wall-clock receive time (ISO 8601), captured before the write. */
   readonly receivedAt: string;
+
   /** Digest of the payload bytes the helper actually wrote. */
   readonly valueDigest: string;
+
   /**
    * The document + path the mark anchors to — the cell the ingest writes into.
    * Declared explicitly (rather than inferred from the write diff) so the mark

--- a/packages/runner/src/cfc/grants.ts
+++ b/packages/runner/src/cfc/grants.ts
@@ -90,10 +90,13 @@ export const CFC_GRANT_ABSENT_DIGEST = "absent";
 export type CfcGrantIdentity = {
   /** Governing space the document lives in (== `owner` in this PR). */
   readonly space: string;
+
   /** Grant kind matched by `policyState` guards ("ShareGrant", …). */
   readonly kind: string;
+
   /** DID whose release authority this grant spends. */
   readonly owner: string;
+
   /** What it releases: a doc reference (URI string) or an atom-pattern
    * scope record (design §2.1 `Reference | AtomPattern`). */
   readonly resource: unknown;
@@ -102,13 +105,16 @@ export type CfcGrantIdentity = {
 /** A verified grant record (design doc §2.1 shape). */
 export type CfcGrant = CfcGrantIdentity & {
   readonly version: typeof CFC_GRANT_VERSION;
+
   /** Principal-like atoms (§3.1.8-validated) the release extends to. */
   readonly audience: readonly unknown[];
   readonly grantedAt: number;
   readonly expiresAt?: number;
+
   /** §6 intent attribution once the intent substrate exists. */
   readonly sourceIntentId?: string;
   readonly revoked?: { readonly at: number; readonly by: string };
+
   /**
    * Single-use release (design §2.2 "Single-use releases", spec §6.5.1-.2):
    * the grant satisfies a `policyState` guard only while its consumption
@@ -130,13 +136,16 @@ export type CfcGrantWriteInput = {
   readonly owner: string;
   readonly resource: unknown;
   readonly audience: readonly unknown[];
+
   /** Defaults to `owner` — the v1 governing-space posture (module doc). */
   readonly space?: string;
+
   /** Defaults to the runner clock at write time. */
   readonly grantedAt?: number;
   readonly expiresAt?: number;
   readonly sourceIntentId?: string;
   readonly revoked?: { readonly at: number; readonly by: string };
+
   /** See {@link CfcGrant.singleUse}: boolean-true or absent, else refused. */
   readonly singleUse?: true;
 };
@@ -204,8 +213,10 @@ export const cfcGrantConsumedReceiptId = (grantId: string): URI =>
 export type CfcGrantConsumptionReceipt = {
   readonly version: typeof CFC_GRANT_VERSION;
   readonly grantConsumed: { readonly grantId: string };
+
   /** Governing space (== the grant's space; the receipt lives beside it). */
   readonly space: string;
+
   /** Runner clock at claim time — captured once per transaction so repeated
    * prepares of the same tx stage a byte-identical receipt. */
   readonly consumedAt: number;
@@ -738,6 +749,7 @@ export const createTxCfcGrantResolver = (
   tx: IExtendedStorageTransaction,
   opts: {
     readonly now?: () => number;
+
     /**
      * Out-record set when a grant lookup could not be READ (the catch arm
      * below) — as opposed to resolving to no facts. A boundary decision that

--- a/packages/runner/src/cfc/label-field-classification.ts
+++ b/packages/runner/src/cfc/label-field-classification.ts
@@ -40,6 +40,7 @@ export type LabelAtomFamily =
 
 export type LabelFieldClassificationEntry = {
   readonly family: LabelAtomFamily;
+
   /**
    * Path of the classified field inside the atom, e.g. `["source"]` or
    * `["identity", "sourceFile"]`. Family-scoped: a Caveat's `source` is

--- a/packages/runner/src/cfc/label-introspection.ts
+++ b/packages/runner/src/cfc/label-introspection.ts
@@ -125,6 +125,7 @@ export type ConfLabelConsumedObservation = {
 
 export type ConfLabelQueryEvaluation = {
   result: InspectConfLabelResult;
+
   /**
    * Joined population-rule confidentiality of every labeled metadata
    * observation the evaluation consumed (per-field consultations and
@@ -133,6 +134,7 @@ export type ConfLabelQueryEvaluation = {
    * the shared constant), so nothing protected flowed to the caller.
    */
   consumedConfidentiality: readonly CfcConfClause[];
+
   /**
    * The same consumption, one record per consulted concrete metadata path
    * (paths are unique by construction — clause/alternative indices plus
@@ -378,6 +380,7 @@ const QUERY_PREDICATES: Record<
   keyof ConfLabelQuery,
   {
     readonly field: string;
+
     /** Absent = family-generic. Input is the record atom's `type` field. */
     readonly familyTypes?: readonly (string | undefined)[];
   }

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -42,6 +42,7 @@ export type LabelMetadataObservationClass = "labelMetadata";
 export type CfcLabelViewEntry = {
   path: readonly string[];
   label: IFCLabel;
+
   /**
    * EFFECTIVE consumption class (C4): unlike the persisted
    * `LabelMapEntry.observes`, view entries resolve the implicit

--- a/packages/runner/src/cfc/policy.ts
+++ b/packages/runner/src/cfc/policy.ts
@@ -42,8 +42,10 @@ export const cfcPolicyManifestDocId = (
 export type ExchangeRule = {
   /** Stable identifier: diagnostics, canonical evaluation order, digests. */
   readonly id: string;
+
   /** Target pattern selecting the clause alternative this rule rewrites. */
   readonly appliesTo: AtomPattern;
+
   /**
    * Conjunctive guards (spec §4.3.2 preCondition). `confidentiality` are the
    * non-target side conditions; `integrity` match against available
@@ -62,6 +64,7 @@ export type ExchangeRule = {
     readonly boundary?: readonly AtomPattern[];
     readonly policyState?: readonly AtomPattern[];
   };
+
   /**
    * Scope for the non-target confidentiality side conditions. Default
    * `targetClause`: they must match alternatives of the SAME clause as the
@@ -69,6 +72,7 @@ export type ExchangeRule = {
    * label.
    */
   readonly preConfScope?: "targetClause" | "anywhere";
+
   /**
    * Effect when the rule fires on a matched clause alternative. Exactly one
    * of the two forms (validated): `addAlternatives` instantiates patterns
@@ -130,6 +134,7 @@ export type CfcPolicyRecordInput = {
   readonly id: string;
   readonly rules: readonly ExchangeRule[];
   readonly digest?: string;
+
   /** Scope mode (see {@link CfcPolicySelection}); defaults to `ambient`. */
   readonly selection?: CfcPolicySelection;
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -267,6 +267,7 @@ const effectiveReadLabel = (
   read: {
     nonRecursive: boolean | undefined;
     consumes: ReadClassSelection;
+
     /**
      * Entries excluded from this read's consumption on top of class
      * selection. Sole current user is `deriveFlowJoin`'s pair of template
@@ -3196,6 +3197,7 @@ type WritePrefixBounds = {
     },
     path: readonly string[],
   ): number;
+
   /**
    * Stage-0 instrumentation only (docs/specs/cfc-value-level-provenance.md
    * §6): whether the transaction logged ANY value-surface write attempt.
@@ -3282,6 +3284,7 @@ const buildWritePrefixBounds = (
 
 /** How a protected write's activity-clock bound was obtained. */
 export type CfcPrefixBoundSource =
+
   /** A logged overlapping write attempt — the prefix engaged. */
   | "real"
   /**
@@ -3302,6 +3305,7 @@ export type CfcPrefixBoundSource =
 export type CfcPrefixProvenanceWrite = {
   /** Document id of the protected write's target. */
   id: string;
+
   /**
    * Protected schema-entry path as an RFC 6901 JSON pointer (e.g. "/out";
    * "" is the root; "~"/"/" in property names escape as "~0"/"~1"), so
@@ -3309,10 +3313,13 @@ export type CfcPrefixProvenanceWrite = {
    */
   path: string;
   boundSource: CfcPrefixBoundSource;
+
   /** Gated reads within this write's D4 prefix (post-S7-exemption). */
   prefixGatedReads: number;
+
   /** What the pre-D4 transaction-global gate would have counted. */
   txGlobalGatedReads: number;
+
   /** Provenance-only reads within the prefix the S7 exemption excluded. */
   s7ExemptionFires: number;
 };
@@ -3326,18 +3333,23 @@ export type CfcPrefixProvenanceWrite = {
 export type CfcPrefixProvenanceSummary = {
   /** Protected writes measured (may exceed writes.length — see the cap). */
   protectedWrites: number;
+
   /** Sum of per-write prefix-gated read counts. */
   prefixGatedReads: number;
+
   /** Sum of per-write pre-D4 transaction-global gated-read counts. */
   txGlobalGatedReads: number;
+
   /** Bound-source classification counts across protected writes. */
   boundSources: {
     real: number;
     infinityFallback: number;
     clockLess: number;
   };
+
   /** Total S7 provenance-only exemption fires within prefixes. */
   s7ExemptionFires: number;
+
   /**
    * Non-internal read activities without an activity-clock position,
    * treated at -Infinity (joining every prefix). Deliberate -Infinity
@@ -3345,6 +3357,7 @@ export type CfcPrefixProvenanceSummary = {
    * write, so this is per-prepare, not per-write.
    */
   clockLessReads: number;
+
   /** Per-write detail, capped at CFC_PREFIX_PROVENANCE_MAX_WRITES. */
   writes: CfcPrefixProvenanceWrite[];
 };
@@ -4947,6 +4960,7 @@ const evaluateGatedConfidentiality = (
     readonly reference: unknown;
     readonly reason: string;
   }[];
+
   /** A grant lookup could not be read; see `createTxCfcGrantResolver`. */
   grantResolutionUnavailable: boolean;
 } => {

--- a/packages/runner/src/cfc/render-ceiling.ts
+++ b/packages/runner/src/cfc/render-ceiling.ts
@@ -88,6 +88,7 @@ const STANDARD_RENDER_SNAPSHOT: PolicySnapshot = buildCfcPolicySnapshot([{
 export type RenderConfidentialityResolverConfig = {
   /** The display audience — the acting user whose HasRole facts are minted. */
   readonly actingPrincipal?: string;
+
   /**
    * Deployment trust config (B3), for any render rule with a `Concept`-valued
    * integrity guard. The standard SpaceReaderAccess rule uses a plain HasRole
@@ -95,6 +96,7 @@ export type RenderConfidentialityResolverConfig = {
    * sink gate and future concept-guarded render rules.
    */
   readonly trustConfig?: CfcTrustConfig;
+
   /**
    * The acting user's VERIFIED reader spaces (§4.9.3): spaces for which the
    * runtime mints `HasRole(actingPrincipal, space, reader)` membership facts,
@@ -110,6 +112,7 @@ export type RenderConfidentialityResolverConfig = {
    * broader cross-space membership arrives with the §4.9.3 membership lookup.
    */
   readonly memberSpaces?: readonly string[];
+
   /**
    * The §4.9.3 membership lookup: a per-space capability oracle consulted for
    * each `Space(id)` atom in the label being rendered. When it verifies the
@@ -127,6 +130,7 @@ export type RenderConfidentialityResolverConfig = {
    * blocked.
    */
   readonly membershipProvider?: SpaceMembershipProvider;
+
   /**
    * Grant lookup for `policyState`-guarded render rules (§8.12.7 route 2a).
    * The standard SpaceReaderAccess rule carries no policyState guard, so this

--- a/packages/runner/src/cfc/schema-label-view.ts
+++ b/packages/runner/src/cfc/schema-label-view.ts
@@ -11,6 +11,7 @@ export interface CfcSchemaEntry {
   readonly path: readonly string[];
   readonly label: IFCLabel;
   readonly schema: JSONSchema;
+
   /** The schema document that resolves local references inside `.schema`. */
   readonly root: JSONSchema;
 }

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -695,6 +695,7 @@ export const mergeCfcSchemaEnvelopes = (
 export interface CfcSchemaMergeIssue {
   /** The merge's own human-readable reason, verbatim. */
   message: string;
+
   /**
    * True when the rejection is the additive-required migration class — an old
    * document predating a now-required field that declares no default. This is

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -46,6 +46,7 @@ type SchemaDefinitions = NonNullable<JSONSchemaObj["$defs"]>;
 type SchemaRefSummary = {
   /** All refs below this fragment, excluding dormant `$defs` bodies. */
   all: ReadonlySet<string>;
+
   /** Local definition names resolved by this fragment's definition scope. */
   localDefinitions: ReadonlySet<string>;
 };

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -812,6 +812,7 @@ const strictConstraintDefinitionIssue = (
 interface SchemaDefinitionContext {
   activeByRoot: WeakMap<object, WeakSet<object>>;
   activeRefsByRoot: WeakMap<object, Set<string>>;
+
   /**
    * Definition maps whose bodies this call already walks under a given root.
    * `resolveCfcSchemaRef()` re-attaches the owning `$defs` object to every
@@ -820,12 +821,14 @@ interface SchemaDefinitionContext {
    * instead of a DAG and node visits grow as (definition count)^(ref depth).
    */
   walkedDefinitionsByRoot: WeakMap<object, WeakSet<object>>;
+
   /**
    * Schemas that proved out completely under a given root, so a schema reached
    * again through another path costs a lookup instead of a full re-walk. Only
    * recorded for subtrees that no recursion guard cut short (see `cuts`).
    */
   provenByRoot: WeakMap<object, WeakSet<object>>;
+
   /**
    * How many times a recursion guard returned "no issue" for a subtree it did
    * not actually walk. A cut result is only sound while the schema that caused
@@ -833,6 +836,7 @@ interface SchemaDefinitionContext {
    * count moved must not be memoized as proven.
    */
   cuts: number;
+
   /**
    * Every `provenByRoot` record, in the order it was made. A schema proven
    * while a definition map was merely claimed may have skipped that map on the
@@ -1244,6 +1248,7 @@ interface SchemaValidationOptions {
     fullSchema: JSONSchema,
   ) => boolean;
   optionalUndefinedIsAbsent?: boolean;
+
   /**
    * Property names an object may carry without the schema modelling them —
    * the reserved keys of whatever produced the value, whose NAMES are fixed by
@@ -1294,6 +1299,7 @@ export interface SchemaValueValidationOptions {
     schema: JSONSchema,
     fullSchema: JSONSchema,
   ) => boolean;
+
   /**
    * Read an OPTIONAL property whose value is `undefined` as absent instead of
    * measuring it against the property's declared type.

--- a/packages/runner/src/cfc/space-membership.ts
+++ b/packages/runner/src/cfc/space-membership.ts
@@ -89,6 +89,7 @@ export interface SpaceMembershipProvider {
    * over-block to an admit.
    */
   readerRole(space: string): SpaceRole | null;
+
   /**
    * Subscribe to a space's ACL doc; `onChange` fires when it later syncs or
    * changes — NOT synchronously at subscribe time (the initial snapshot is

--- a/packages/runner/src/cfc/structured-result.ts
+++ b/packages/runner/src/cfc/structured-result.ts
@@ -13,6 +13,7 @@ import {
 export interface SchemaOpaqueLinkSanitizationResult {
   value: unknown;
   linkedStringCount: number;
+
   /**
    * The paths of the positions THIS sanitization sealed, in walk order. A
    * caller-provided opaque link the schema admits is preserved, not sealed,

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -254,6 +254,7 @@ export type LabelMapEntry = {
   path: readonly string[];
   label: IFCLabel;
   origin?: LabelEntryOrigin;
+
   /**
    * Payload consumption classes, or — on `origin:"label-metadata"`
    * population templates only (Stage B) — the `labelMetadata` class, which
@@ -308,6 +309,7 @@ export type ConsumedRead =
   & Immutable<{
     meta?: Metadata;
     nonRecursive?: boolean;
+
     /**
      * Position on the transaction's activity clock (shared with write
      * attempts — see `OrderedWriteAttempt`). Part of the prepared digest:
@@ -375,12 +377,14 @@ export type ImplementationIdentity =
   | { kind: "builtin"; builtinId: string }
   | {
     kind: "verified";
+
     /**
      * Content-addressed module identity (prefix-free `cf:module/<hash>`
      * hash) — reload-stable and robust to unrelated module changes in the
      * same program.
      */
     moduleIdentity?: string;
+
     /** Export/`__cfReg` symbol of the registered factory, when module-scope. */
     symbol?: string;
     sourceFile?: string;
@@ -415,6 +419,7 @@ export type WritePolicyInput =
     readonly target: CfcAddress;
     readonly schemaHash?: string;
     readonly schema?: JSONSchema;
+
     /**
      * Present only when this schema describes a generated output of the
      * running module. Such outputs may introduce required fields without
@@ -490,6 +495,7 @@ export type PreparedDigestInput = {
   readonly consumedReads: readonly ConsumedRead[];
   readonly attemptedWrites: readonly AttemptedWrite[];
   readonly writes: readonly AttemptedWrite[];
+
   /**
    * The ordered write-attempt log (see `OrderedWriteAttempt`). Mandatory in
    * the digest: `consumedReads`/`writes` are canonicalized by address-sort,
@@ -505,6 +511,7 @@ export type PreparedDigestInput = {
   readonly writePolicyInputs: readonly WritePolicyInput[];
   readonly implementationIdentity?: ImplementationIdentity;
   readonly trustSnapshot?: TrustSnapshot;
+
   /** Update-authority aliases consulted by writeAuthorizedBy verification. */
   readonly moduleDelegations?: readonly ModuleDelegationSnapshotEntry[];
   // Digest of the policy snapshot the boundary decisions evaluated under
@@ -530,6 +537,7 @@ export type PostCommitSideEffect = {
   id: string;
   kind: string;
   idempotencyKey?: string;
+
   /** The client-effect nonce this enactment carries (server-execution v2
    * Phase 4, protocol.md §5) — set by `navigateTo` under the flag so the
    * speculation overlay's OPTIMISTIC enactment records the SAME nonce the

--- a/packages/runner/src/executor/engine-wave-sink.ts
+++ b/packages/runner/src/executor/engine-wave-sink.ts
@@ -96,14 +96,17 @@ export class EngineWaveCommitSink implements WaveCommitSink {
   constructor(options: {
     /** The co-hosted engine per space (memory server's own engines). */
     engineFor: (space: MemorySpace) => Engine;
+
     /** The service session framing the wave's commits are recorded
      * under (replay detection keys on it — see the constructor doc).
      * The SpaceServer passes the DR1 holder identity. */
     sessionId: string;
     principal?: string;
+
     /** The shared, process-lifetime localSeq counter (see the
      * constructor doc). Mutated in place. */
     localSeqRef?: { value: number };
+
     /** The sqlite attachment hook (stage G — the memory server's
      * `attachWaveCommitSqliteDbs`): attach the cell-db file(s) a home
      * batch's folded `sqlite` ops target, keyed by the accumulator's

--- a/packages/runner/src/executor/host.ts
+++ b/packages/runner/src/executor/host.ts
@@ -64,10 +64,12 @@ const failureParkBackoffDelayMs = (
 
 export type ExecutorHostOptions = {
   server: MemoryServer;
+
   /** The service identity (DID) DR1 holders are minted from — also the
    * loopback sessions' principal (the read-row admission matches it,
    * protocol.md §2). */
   serviceIdentity: string;
+
   /** Build a serving runtime for one space over the loopback plane. The
    * factory owns auth and runtime options; it MUST pass
    * `experimental: { serverExecution: true, systemPatternAutoUpdate:
@@ -78,6 +80,7 @@ export type ExecutorHostOptions = {
     dispose: () => Promise<void>;
   }>;
   policy?: SpaceServerPolicy;
+
   /** The RULED test switch for the tenure's space-root ensure (OW45
    * arm-B stage 1, RULED 2026-08-24 — see SpaceServerOptions.
    * ensureSpaceRoots): default ON (production posture); `false`
@@ -91,11 +94,13 @@ export class ExecutorHost {
   readonly #options: ExecutorHostOptions;
   readonly #spaces = new Map<string, SpaceServer>();
   readonly #activating = new Map<string, Promise<void>>();
+
   /** Records admitted while a space's activation is still in flight
    * (before its SpaceServer registers): buffered here, drained into the
    * feed at registration — an admission racing activation must never be
    * dropped (its seq may pass the activation's scan head). */
   readonly #pendingNotices = new Map<string, AdmittedCommitNotice[]>();
+
   /** The ONE process-lifetime localSeq counter for every sink this host
    * builds (the replay keying — engine-wave-sink.ts): survives
    * park/re-activate, shared across ALL spaces. It must be
@@ -114,11 +119,13 @@ export class ExecutorHost {
    * in every store (the engine keys replay by equality, never
    * contiguity). */
   readonly #sinkLocalSeq = { value: 0 };
+
   /** Consecutive `loop-failed` parks per space (the re-activation
    * backoff's streak). Incremented at each failure park, cleared by a
    * successfully committed wave — real served progress, not merely a
    * runtime that got built (every crash-loop tenure builds one). */
   readonly #failureParkStreaks = new Map<string, number>();
+
   /** Wakers for in-flight backoff sleeps — close() flushes them so a
    * delayed re-activation never stalls shutdown. */
   readonly #backoffWakers = new Set<() => void>();

--- a/packages/runner/src/executor/outbox.ts
+++ b/packages/runner/src/executor/outbox.ts
@@ -75,9 +75,11 @@ export type OutboxBudgetPolicy = {
    * path never produces it (the toolshed bootstrap maps a literal env
    * `0` to ABSENT — `serverExecutionPolicyFromEnv`). */
   maxOutstandingEffects?: number;
+
   /** Egress pacing: network-effect dispatches per second (token bucket
    * with burst = one second's tokens, minimum 1). */
   egressRatePerSecond?: number;
+
   /** Test clock (defaults to Date.now). */
   now?: () => number;
 };
@@ -96,6 +98,7 @@ export class SpaceOutbox {
   readonly #sessionId: string;
   readonly #space?: string;
   readonly #localSeqRef: { value: number };
+
   /** In-flight effect entries per effect key — §4's in-flight dedupe,
    * scoped per (memo key, result target): a second admit of a live key
    * is the SAME node's request re-issued (a wave re-run, a
@@ -108,6 +111,7 @@ export class SpaceOutbox {
    * completion commit readable — see #retireBarriers), which is what
    * `settle()` awaits. */
   readonly #inflight = new Map<string, Promise<void>>();
+
   /** Run-context carriage per in-flight effect id (§4's miss rule),
    * consumed by the completion committer; retired with the entry
    * (every completion write of an effect happens inside its tracked
@@ -115,6 +119,7 @@ export class SpaceOutbox {
    * back to the wave-level identity, which is the same identity in
    * Phase 1). */
   readonly #carriage = new Map<string, WaveRunContext>();
+
   /** Read-consistency barriers per in-flight effect id (serving-loop.md
    * §4; the stage-G review's B-1): each completion commit of a served
    * effect registers a promise that resolves when its writes are
@@ -127,6 +132,7 @@ export class SpaceOutbox {
    * reads — not yet showing the completion — pass the hash guard and
    * egress a second time. */
   readonly #retireBarriers = new Map<string, Array<Promise<unknown>>>();
+
   /** Sync-span capture target for the runtime's async-work observer:
    * while an effect's flush runs its SYNCHRONOUS prefix, work the
    * builtin registers via trackAsyncWork lands here — that work IS the
@@ -136,12 +142,15 @@ export class SpaceOutbox {
   // Per-space egress budgets (Phase 6, serving-loop.md §5).
   readonly #budget: OutboxBudgetPolicy | undefined;
   readonly #now: () => number;
+
   /** DISPATCHED-but-unsettled network effects (the outstanding cap's
    * subject; local kinds bypass the gate and are never counted). */
   #outstanding = 0;
+
   /** FIFO of admitted-but-held dispatch starters, woken one per freed
    * slot (and drained wholesale on close — the park path). */
   readonly #dispatchWaiters: Array<() => void> = [];
+
   /** Token bucket for the egress rate (burst = one second's tokens). */
   #egressTokens = 0;
   #egressRefilledAt = 0;
@@ -150,17 +159,22 @@ export class SpaceOutbox {
   constructor(options: {
     stats: ServingLoopStats;
     server: MemoryServer;
+
     /** The HOME space's engine — where the durable append rows live. */
     engine: Engine;
+
     /** The HOME space did — the OW14 failure notice commits into it as
      * a derived-class commit, whose lease admission needs the space. */
     space?: string;
+
     /** The delivering service session (LT5's envelope) — the DR1
      * holder, same as the wave sink's. */
     sessionId: string;
+
     /** The host's process-lifetime localSeq counter, shared with the
      * wave sink (the replay-keying discipline — engine-wave-sink.ts). */
     localSeqRef: { value: number };
+
     /** Per-space egress budgets (Phase 6); absent = unbounded. */
     budget?: OutboxBudgetPolicy;
   }) {

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -180,13 +180,16 @@ export type SpaceServerPolicy = {
    * 50–100 ms; a policy knob tuned in Phase 6 — the toolshed bootstrap
    * reads SERVER_EXECUTION_FLUSH_DEADLINE_MS). */
   flushDeadlineMs?: number;
+
   /** Phase 6 (serving-loop.md §5's per-space budgets; README §3.8):
    * cap on dispatched-but-unsettled NETWORK effects per space —
    * "outstanding LLM calls". Undefined = unbounded. */
   maxOutstandingEffects?: number;
+
   /** Phase 6: per-space network-effect egress pacing (dispatches per
    * second, token bucket). Undefined = unpaced. */
   egressRatePerSecond?: number;
+
   /** OW45 arm-B stage 1 (review F2): the bound on the tenure's
    * awaited space-root ensure. The ensure's resolve path fetches with
    * no timeout of its own and can point at a remote host, and the
@@ -200,21 +203,25 @@ export type SpaceServerPolicy = {
    * UPDATE arm by OCC refusal (the transition's stillMatches baseline
    * refuses a moved root, so stale-over-new is impossible). */
   rootEnsureDeadlineMs?: number;
+
   /** serving-loop.md §1's IDLE_PARK_MS. */
   idleParkMs?: number;
   renewIntervalMs?: number;
+
   /** The execution lease's TTL (serving-loop.md §2; production takes the
    * wire default EXECUTION_LEASE_TTL_MS). A knob so tests can pin the
    * mid-wave renew (stage C tuning T3) with a short tenure instead of
    * waiting out the 15-s default; the mid-wave renew fires once a wave
    * has run longer than TTL/3 without a renewal. */
   leaseTtlMs?: number;
+
   /** Deadline on the park's runtime dispose (park LIVENESS): a serving
    * runtime killed mid-wave can hang `runtime.dispose()` forever, and a
    * park gated on it never resolves `whenParked` — wedging every
    * chained recovery. On overrun the dispose is abandoned (loudly,
    * counted) and the park completes anyway. */
   parkDisposeTimeoutMs?: number;
+
   /** The host's failure-park re-activation backoff (read by the
    * ExecutorHost, not the SpaceServer): after N consecutive
    * `loop-failed` parks of one space, its next re-activation is delayed
@@ -229,10 +236,12 @@ export type SpaceServerOptions = {
   space: MemorySpace;
   server: MemoryServer;
   engine: Engine.Engine;
+
   /** The service identity (DID) the DR1 holder is minted from — also the
    * loopback session's principal, which is what the read-row admission
    * matches (protocol.md §2). */
   serviceIdentity: string;
+
   /** Build the serving runtime over the LOOPBACK storage plane
    * (serving-loop.md §1 plane (a)). The factory owns auth and options;
    * the SpaceServer asserts the posture (flag ON) and flips the
@@ -242,11 +251,14 @@ export type SpaceServerOptions = {
     runtime: Runtime;
     dispose: () => Promise<void>;
   }>;
+
   /** The process-lifetime localSeq counter for this space's wave sink
    * (engine-wave-sink.ts's replay keying — the host owns it). */
   localSeqRef: { value: number };
+
   /** The host's shared counters (serving-loop.md §7). */
   stats: ServingLoopStats;
+
   /** OW45 arm-B stage 1, RULED 2026-08-24 (the owner, verbatim in the
    * stage-1 report): production spaces always get a default pattern —
    * "in production there is no reason for a space to not have a
@@ -260,6 +272,7 @@ export type SpaceServerOptions = {
   ensureSpaceRoots?: boolean;
   policy?: SpaceServerPolicy;
   onParked?: (reason: string) => void;
+
   /** Fired on each successfully committed wave — the host's
    * failure-streak reset signal (real served progress, as opposed to an
    * activation that merely got as far as building a runtime). */
@@ -321,6 +334,7 @@ export async function selectForeignStaleInstances(
  * structurally futile. Remaining `of:` ids are NOT distinguishable by
  * id class (a not-yet-created piece and a never-a-piece value doc look
  * alike) — the complete terminal-state design is the owed follow-up. */
+
 /** The dedupe key of a demanding (principal, session) pair in the
  * registry (stage B): both components, so two sessions of one user are
  * two demanders (a node beneath the root may narrow to session for that
@@ -361,11 +375,13 @@ export class SpaceServer implements TransactionSealDestination {
   #disposeRuntime: (() => Promise<void>) | undefined;
   #sink: EngineWaveCommitSink | undefined;
   #renewTimer: ReturnType<typeof setInterval> | undefined;
+
   /** Wall-clock of the last successful acquire/renew (stage C tuning T3):
    * the mid-wave renew fires from the scheduler's cooperative yield once
    * `now − lastRenewAt ≥ TTL/3`, i.e. exactly when the interval timer
    * would have fired had the wave's settle let it. */
   #lastRenewAt = 0;
+
   /** The drain's IN-FLIGHT copies (stage C tuning, T3's companion guard
    * — see `events.drainInFlightSkips`): eventId → phase. A re-drain must
    * not queue a SECOND copy of an entry whose first copy is still queued,
@@ -399,6 +415,7 @@ export class SpaceServer implements TransactionSealDestination {
   // never dropped between cycles.
   #pendingShadowFlipWake = false;
   #inputHead = 0;
+
   /** Highest NON-self-echo seq drained — the watermark's advance
    * target. The loop's own derived commits return on the feed above W
    * and must not count as coverage-owed input, or every wave commit
@@ -411,6 +428,7 @@ export class SpaceServer implements TransactionSealDestination {
    * commits, never by its own bookkeeping-only commit. */
   #coverageHead = 0;
   #watermark = 0;
+
   /** S1 (RULED 2026-08-19): this loop's own committed wave seqs still
    * ABOVE the watermark — the drain-settle quiescence advance's
    * contiguity domain. The advance walks upward from its coverage base
@@ -429,6 +447,7 @@ export class SpaceServer implements TransactionSealDestination {
    * the bound is never reached. */
   readonly #ownWaveSeqs = new Set<number>();
   static readonly #MAX_OWN_WAVE_SEQS = 4096;
+
   /** S1's once-per-quiescence-transition latch: armed when a wave with
    * CONTENT contributions (derivation/event-handler kinds — commits
    * whose seq can enter a client read basis) lands; consumed when the
@@ -443,6 +462,7 @@ export class SpaceServer implements TransactionSealDestination {
   readonly #parked = Promise.withResolvers<void>();
   #idleSince: number | undefined;
   #demandedRoots = new Set<string>();
+
   /** Demanded roots whose `ensurePieceRunning` has not yet SUCCEEDED —
    * it returned false (typically the creation race: the demand cycle
    * ran before the piece's `patternIdentity` meta applied to the
@@ -455,6 +475,7 @@ export class SpaceServer implements TransactionSealDestination {
    * never started server-side (waves committed watermark-only while
    * `waitForSettled` claimed the derivation current). */
   readonly #pendingStructureLoads = new Set<string>();
+
   /** The TERMINAL not-loadable roots (stage P2-F, the OW19 demand-cycle
    * design — RULED direction 2026-08-07): a demanded root whose doc is
    * confirmed SYNCED from the durable store and still carries no
@@ -468,6 +489,7 @@ export class SpaceServer implements TransactionSealDestination {
    * classes out of piece demand entirely; this covers the remaining
    * `of:` ids, which id classes cannot split. */
   readonly #terminalStructureLoads = new Map<string, ReadonlySet<string>>();
+
   /** Consecutive deferral streak per demanded root (keyed by demand
    * key), feeding `stats.structureLoadStuck` and the
    * `structure-load-stuck` WARN once a streak crosses
@@ -480,10 +502,12 @@ export class SpaceServer implements TransactionSealDestination {
    * again); left untouched by the THROW arm, whose failures are
    * already loud (`structureLoadFailures` + warn per attempt). */
   readonly #structureLoadDeferralStreaks = new Map<string, number>();
+
   /** The single-flighted demand-structure load pass (stage P2-F): the
    * wave cycle races it against the flush deadline; a pass outliving
    * its wave keeps running and later cycles join it. */
   #structureLoadPass: Promise<void> | undefined;
+
   /** Re-armed roots whose retry waits for the CURRENT cycle's settle
    * (frame application) before re-entering `#pendingStructureLoads` —
    * retrying inside the re-arming cycle reads the replica's stale
@@ -491,10 +515,12 @@ export class SpaceServer implements TransactionSealDestination {
    * settle boundary; the promotion latches a wake so a then-quiet
    * space retries promptly instead of sitting out the idle window. */
   readonly #rearmedAwaitingSettle = new Set<string>();
+
   /** Level-converted wake for the promotion above (the same latch
    * shape as the shadow-flip wake): set when re-armed roots became
    * retryable mid-cycle, consumed by the next #waitForInput. */
   #pendingStructureRetryWake = false;
+
   /** Level-converted demand wake (stage B): a session's watch set
    * changed (or a session opened) and the grace elapsed; consumed by the
    * next #waitForInput. */
@@ -509,8 +535,10 @@ export class SpaceServer implements TransactionSealDestination {
   // costs one extra pass; steady state (no notes) never re-latches.
   #demandNoteGeneration = 0;
   #passDemandNoteGen = 0;
+
   /** The demand wake's grace timer (see noteDemandChanged). */
   #demandWakeTimer: ReturnType<typeof setTimeout> | undefined;
+
   /** WARM DEMAND (the explicit warm request's demand half —
    * serving-loop.md §1's third activation trigger, RULED 2026-08-21):
    * the staged doc instances of warm-marked feed notices, captured at
@@ -566,6 +594,7 @@ export class SpaceServer implements TransactionSealDestination {
     }
     | undefined;
   #growthAwaitingLanding = false;
+
   /** Wave-bound seals CHAINED but not yet applied (the F4 fix, as a
    * LEVEL): seal() returns after arming the seal chain, so a seal
    * landing in a cycle's last microtasks — after the closing wave
@@ -579,10 +608,12 @@ export class SpaceServer implements TransactionSealDestination {
    * deterministic wake the removed host fan-out had provided
    * incidentally. */
   #pendingWaveSeals = 0;
+
   /** The activation scan's head: records at or below it are covered
    * by the basis re-mark and never drained (activation filters the
    * queued feed the same way). Late-arrival accounting keys off it. */
   #activationScanHead = 0;
+
   /** Exact-once guard for LATE records (seq ≤ inputHead at drain —
    * the two-producer notice race documented in #drainFeed): recently
    * drained seqs, insertion-ordered, pruned at a bound that far
@@ -591,6 +622,7 @@ export class SpaceServer implements TransactionSealDestination {
   // (d′): `#demandSinks` (the per-key demand WALK effects,
   // `demand-walk:<space>/<root>`) is DELETED — demand is the tracked-ids
   // closure and its writers are standing demand roots (design §2.7).
+
   /** The DEMANDERS per demand key (server-execution v2 Phase 2, M1's
    * demand carriage — scopes.md §5: the demand supplies the run
    * identity; fan-out stage B: identity on SPACE-scoped demand rows too
@@ -610,6 +642,7 @@ export class SpaceServer implements TransactionSealDestination {
    * the key — structure and walk — but own no instance and are not
    * demanders. */
   readonly #demandersByKey = new Map<string, Map<string, ScopeKeyIdentity>>();
+
   /** Demand key → the piece root doc id its structure load RESOLVED to
    * (stage P2-F): a demanded root may be an argument/derived doc whose
    * owning piece `ensurePieceRunning` discovers by following the result
@@ -617,16 +650,20 @@ export class SpaceServer implements TransactionSealDestination {
    * PIECE's actions too, not only when the demand names the piece root
    * itself. Entries retire with their demand key. */
   readonly #pieceRootByDemandKey = new Map<string, string>();
+
   /** The stage-G effect channel (serving-loop.md §4–§5). */
   #outbox: SpaceOutbox | undefined;
+
   /** A drain left undelivered rows behind (transport-class failure):
    * the next wave cycle re-drains even without fresh appends. */
   #outboxDrainOwed = false;
+
   /** Phase 3 (events-down): an event-append admission (or a wave's
    * requeue) owes the next wave a stream-sidecar scan — the drain
    * input (serving-loop.md §3's event-append classification; §6
    * step 4's reprocess scan is the same move at activation). */
   #eventScanOwed = false;
+
   /** OW45 arm-B server-ensure stage 1 (design PR #6209 §1, seat A2):
    * activation owes the tenure ONE space-root ensure — existence +
    * freshness, no start — run as the first serialized step of the wave
@@ -643,6 +680,7 @@ export class SpaceServer implements TransactionSealDestination {
    * creation transaction's OCC re-read plus the cause-derived root
    * address converge every race on one root. */
   #rootEnsureOwed = false;
+
   /** The fail-closed skip's SAME-TENURE retry arm (stage-1 measurement
    * r01's boot-order finding): the host activates on SESSION-OPEN,
    * which precedes the client bootstrap's genesis ACL commit (the
@@ -657,11 +695,13 @@ export class SpaceServer implements TransactionSealDestination {
    * admission, and the ensure re-sets it only from another no-owner
    * skip. */
   #rootEnsureAwaitingOwner = false;
+
   /** F6 (log hygiene): the no-owner WARN fires once per tenure — a
    * permanently-ownerless space whose ACL doc keeps getting written
    * would otherwise warn 1:1 with the re-arm; the counter carries the
    * per-event record either way. */
   #rootEnsureNoOwnerWarned = false;
+
   /** Phase 4 (protocol.md §5): an effects-doc-touching authored commit
    * (an ack) — or activation (a crash between ack and retirement must
    * still retire) — owes the next wave the acked-entry retirement scan.
@@ -669,9 +709,11 @@ export class SpaceServer implements TransactionSealDestination {
    * retirement write (the bookkeeping conflict class's drop-whole arm,
    * serving-loop.md §3d) self-heals on the following cycle. */
   #effectsRetirementOwed = false;
+
   /** Consequence-notice seals in flight (the error/drop/skip arms):
    * awaited before the wave closes so their marks ride THIS wave. */
   readonly #eventNoticeWork = new Set<Promise<unknown>>();
+
   /** Consecutive DEFERRALS per eventId (cold-view piece loads). The
    * deferral arm exists for the creation race (OW19's conflation
    * caution: a not-yet-created piece and a never-startable one are
@@ -682,11 +724,13 @@ export class SpaceServer implements TransactionSealDestination {
    * park). Cleared on activation (a fresh runtime re-tries from
    * scratch) and on any non-deferred outcome. */
   readonly #eventDeferrals = new Map<string, number>();
+
   /** The deferral backstop timer (see EVENT_DEFERRAL_REARM_MS): armed
    * when a drain pass left deferred/transient work behind, so the scan
    * re-arms after a REAL wait even when no input ever arrives. Input
    * arriving first promotes the owed scan immediately (#drainFeed). */
   #deferredRescanTimer: ReturnType<typeof setTimeout> | undefined;
+
   /** Consecutive pre-queue barrier deferrals per blocking key (the
    * view-lagged entry's eventId; the failing sidecar's doc id; a
    * queue-time thrower's `queue\0`-prefixed eventId — its own namespace,
@@ -694,6 +738,7 @@ export class SpaceServer implements TransactionSealDestination {
    * attempt). Cleared when the key passes ITS arm's check; see
    * EVENT_PREQUEUE_STUCK_AFTER. */
   #preQueueDeferralStreaks = new Map<string, number>();
+
   /** Post-commit effects of sealed transactions, deferred per wave
    * (serving-loop.md §3: effects hand to the outbox POST-commit, never
    * at seal). Admitted to the outbox after the wave's commit step;
@@ -703,10 +748,12 @@ export class SpaceServer implements TransactionSealDestination {
     WaveAccumulator,
     SealedEffectBatch[]
   >();
+
   /** Which wave each sealed tx closed into — set at seal, consumed by
    * deferSealedEffects (which runs after the seal resolved, when the
    * wave may already have rotated). */
   readonly #waveByTx = new WeakMap<object, WaveAccumulator>();
+
   /** The APPENDING wave of each LT1 same-space in-process copy's run
    * (stage C build W3, (α); events.md §4's RULED one-entry-one-
    * completed-run sentence): tx of the copy's handler run → the wave
@@ -2901,6 +2948,7 @@ export class SpaceServer implements TransactionSealDestination {
    * `#pendingStructureLoads` for the next input-driven cycle — the
    * missing meta arrives as a commit, and that commit fires the cycle
    * that retries. */
+
   /** Fold the demand-root enter/leave delta SINCE THE LAST FOLD into the
    * space-lived `stats.demand` accumulators (MINOR-2). Called at the end
    * of every demand pass AND before park disposes the runtime, so a
@@ -3433,6 +3481,7 @@ export class SpaceServer implements TransactionSealDestination {
    * commit ONE derived transaction carrying the wave's writes, the
    * watermark doc write, and `derivedThrough`.
    */
+
   /**
    * The LT1 leftover PURGE (stage C build W3, (α1); events.md §4's RULED
    * sentence: "the serving loop purges unrun in-process leftovers at the

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -39,6 +39,7 @@ export type ServingLoopStats = {
   authoredSeen: number;
   effectAcks: number;
   derivedCommits: number;
+
   /** `derivedCommits`, attributed per space (the space DID as the key).
    * The process-wide total cannot scope a delta to the space under test
    * on a shared host — another space's serving activity in the window
@@ -54,14 +55,17 @@ export type ServingLoopStats = {
    * {@link bumpDerivedCommits} only, which keeps total and row in
    * lockstep. */
   derivedCommitsBySpace: Record<string, number>;
+
   /** Counts folded out of `derivedCommitsBySpace` by the cap eviction
    * (never a lost commit — the process-wide total keeps them). */
   derivedCommitsBySpaceDropped: number;
+
   /** Demanded-structure loads that THREW (serving-loop.md §1: a value
    * the server cannot serve is counted AND surfaced here, not just
    * logged). Counted per attempt; the loop retries the root on each
    * subsequent input-driven demand cycle until the load lands. */
   structureLoadFailures: number;
+
   /** Demanded-structure ensure attempts that returned FALSE — the root
    * carried no loadable pattern identity yet, typically the creation
    * race (the demand cycle ran before the piece's instantiation
@@ -72,6 +76,7 @@ export type ServingLoopStats = {
    * loadable (e.g. a plain value doc demanded as if it owned a
    * piece). */
   structureLoadDeferred: number;
+
   /** Demanded roots whose consecutive-deferral streak crossed
    * `STRUCTURE_LOAD_STUCK_AFTER` (space-server.ts) — counted ONCE per
    * crossing, so a nonzero value names roots that are effectively
@@ -86,6 +91,7 @@ export type ServingLoopStats = {
    * lifetime. The companion WARN log (`structure-load-stuck`) fires
    * at the crossing and at each doubling while the streak grows. */
   structureLoadStuck: number;
+
   /** Demanded roots that reached the TERMINAL not-loadable state
    * (server-execution v2 stage P2-F, the OW19 demand-cycle design): the
    * root's doc is confirmed synced from the durable store and carries
@@ -95,12 +101,14 @@ export type ServingLoopStats = {
    * Counted per terminalization, so a root that re-arms and
    * terminalizes again counts again. */
   structureLoadTerminal: number;
+
   /** Terminal roots RE-ARMED by a commit touching one of their observed
    * docs (the OW19 re-arm half): the root returns to the pending set
    * and the next cycle retries its load — this is what keeps the
    * terminal state safe for the creation race (a not-yet-created
    * piece's instantiation commit re-arms and then loads). */
   structureLoadRearmed: number;
+
   /** Waves whose W advance was CLAMPED below the input batch head
    * because inbound foreign novelty was still shadowed by a parked own
    * write (the settle input barrier, Phase 2 revisit (a):
@@ -108,6 +116,7 @@ export type ServingLoopStats = {
    * not a failure — W catches up the wave after the shadow clears — but
    * a count that grows without settling flags a wedged marker channel. */
   watermarkClamped: number;
+
   /** Write-carrying transactions REFUSED at the wave's seal because no
    * run context was stamped (serving-loop.md §3d, RULED 2026-08-05).
    * Structurally zero when every server-side commit path declares its
@@ -117,6 +126,7 @@ export type ServingLoopStats = {
    * landing, so the demanded derivation never materialized). Counted
    * here so the storm is a health-stats fact, not a log-grep. */
   unstampedSealRefusals: number;
+
   /** Served navigate-intent transactions whose seal FAILED — resolved
    * `{ error }` or rejected (navigate-to.ts's intent-commit arms,
    * independent review NOTE-b). Every failure requeues the owning
@@ -126,16 +136,19 @@ export type ServingLoopStats = {
    * the loop is burning re-drains on them, never that navigations are
    * being lost. */
   servedIntentSealFailures: number;
+
   /** Park-time runtime disposes that overran their deadline and were
    * abandoned (park LIVENESS, the lunch-wall containment): a hung
    * dispose must never wedge `whenParked` and every recovery chained
    * behind it. Nonzero says a serving runtime refused to tear down —
    * loud in logs, counted here. */
   parkDisposeTimeouts: number;
+
   /** Failure-park re-activations delayed by the host's streak backoff
    * (a permanently-failing space must reactivate at a bounded rate,
    * not as fast as admissions arrive). */
   reactivationBackoffs: number;
+
   /** Foreign-space writes refused at wave ACCUMULATION (serving-loop.md
    * §3d, RULED 2026-08-14 (c); Phase 5 keeps the counter for the
    * accept gate's refusals): action-scoped — the writing action fails,
@@ -145,6 +158,7 @@ export type ServingLoopStats = {
    * (an acting identity reaching for a space it holds no structural
    * grant on — protocol.md §2b's authorization predicate). */
   foreignWriteRefusals: number;
+
   /** Foreign co-hosted ENGINE resolutions that FAILED at the wave's
    * commit step (Phase 5, the F1b isolation): the failing space's
    * contributions withdraw action-scoped (events requeue, derivations
@@ -154,6 +168,7 @@ export type ServingLoopStats = {
    * cannot open (disk trouble, or a provisioning target with an
    * unusable path). */
   foreignEngineFailures: number;
+
   /** EXPLICIT WARM REQUESTS issued (serving-loop.md §1's third
    * activation trigger; RULED 2026-08-21): one per foreign provisioning
    * batch a wave durably committed — the serving-side provisioning path
@@ -163,6 +178,7 @@ export type ServingLoopStats = {
    * residual). Counted at issue; an already-active target consumes the
    * request as a demand-union no-op. */
   warmRequests: number;
+
   /** Server-execution v2 fan-out stage B (design §B5, RULED 2026-08-16
    * accept-and-count): derivation runs under the wave-level FALLBACK
    * identity — an action NOBODY demands with an identity — that
@@ -173,6 +189,7 @@ export type ServingLoopStats = {
    * (the service identity runs NO demanded work); a growing count names
    * an eager/idle-scheduled narrowing node no principal watches. */
   undemandedNarrowingRuns: number;
+
   /** Fan-out stage B's early-emit guard (design §F risk 4, RULED
    * 2026-08-16 fail-closed): a demanded derivation run that EMITTED an
    * event before its scope ratchet had moved — the emission carried a
@@ -181,12 +198,15 @@ export type ServingLoopStats = {
    * has learned the scope, so the retry emits correctly attributed.
    * Never silently sessionless. Counted per refusal. */
   earlyEmitRefusals: number;
+
   /** Fan-out stage B's ARRIVAL RE-ARMS (design §A): demand-registry
    * passes that found a new (principal, session) demander for a root
    * and re-armed the narrowed nodes beneath it for that demander. */
   demandArrivals: number;
+
   /** max over active spaces of (store head seq − W). */
   watermarkLag: number;
+
   /** The (d′) `demand` counter block (serving-loop.md §7; stage-C design
    * §6 W4). Demand is memory v2's tracked-ids closure and the demand walk
    * is deleted, so there is NO `walkRuns` counter — its absence is T9′'s
@@ -228,6 +248,7 @@ export type ServingLoopStats = {
     demandPassMs: number;
     pushGrowthWakes: number;
     watchWakes: number;
+
     /** Demand-pass wakes from WARM captures (the explicit warm
      * request's staged instances entering the tenure's warm demand,
      * serving-loop.md §1; RULED 2026-08-21) — counted apart so
@@ -236,6 +257,7 @@ export type ServingLoopStats = {
      * coalescing. */
     warmWakes: number;
   };
+
   /** SERVER SETTLE per authored input (serving-loop.md §7; stage-C design
    * §6 W4's metric): from the authored commit's ADMISSION on the server
    * (its seq, `enqueueCommit`) to W COVERING it (the wave commit whose
@@ -260,6 +282,7 @@ export type ServingLoopStats = {
       waves: number;
       cycles: number;
       growthWakes: number;
+
       /** VALUE-ONLY at coverage; promoted to STRUCTURAL-GROWTH (by
        * ADJACENCY — the most recently covered input) when a push-growth
        * wake fires AFTER this input's coverage and a later derived commit
@@ -267,21 +290,26 @@ export type ServingLoopStats = {
        * promoted entry). */
       class: "value-only" | "structural-growth";
       eventAppend: boolean;
+
       /** ms from admission to the structural-growth LANDING (the derived
        * commit after the growth wake); present only when promoted. */
       msGrowth?: number;
+
       /** waves from admission through the growth landing; present only
        * when promoted. */
       growthWaves?: number;
+
       /** ms from the growth WAKE to its landing (the demand-wake grace +
        * derive); present only when promoted and a wake time was seen. */
       graceMs?: number;
+
       /** performance.now() of the growth landing; present only when
        * promoted. */
       growthLandedAt?: number;
     }>;
     dropped: number;
   };
+
   /** S1 — DRAIN-SETTLE QUIESCENCE ADVANCES (RULED 2026-08-19,
    * protocol.md §4's amendment; stage-c/swatch-stall-rootcause.md §4):
    * W covering the space's own committed derived tail at quiescence,
@@ -292,9 +320,11 @@ export type ServingLoopStats = {
    * bookkeeping commit. */
   settleAdvances: {
     count: number;
+
     /** The last advance's step: advancedTo − the coverage it advanced
      * from (how many tail-derivation seqs the quiescence covered). */
     lastDelta: number;
+
     /** Bounded series (same discipline as settle.series): one row per
      * quiescence advance, so W4 can split advance-only waves out of
      * the per-input settle timings. */
@@ -306,6 +336,7 @@ export type ServingLoopStats = {
     processed: number;
     coalescedPerWaveMax: number;
     skippedIdempotent: number;
+
     /** Stage C tuning (T3's companion guard): drain passes that found a
      * pending entry whose EARLIER drain copy is still queued or in flight
      * in the serving scheduler (its dispatch has not reached its commit
@@ -318,6 +349,7 @@ export type ServingLoopStats = {
      * that grows without `processed` settling names a drain copy that
      * never completes. */
     drainInFlightSkips: number;
+
     /** OW45 arm-B round: entries stuck at the drain's PRE-QUEUE
      * deferral barrier (a lagging sidecar view, a failing sidecar
      * sync, or a queue-time throw — the third under its own
@@ -333,6 +365,7 @@ export type ServingLoopStats = {
      * order-preserved — the §5 pattern the queued class has) is the
      * register's owed follow-up on the OW45 row. */
     preQueueDeferralStuck: number;
+
     /** Stage C build W3, (α1) — events.md §4's RULED one-entry-one-
      * completed-run sentence: LT1 same-space in-process copies (`served
      * !== undefined && served.streamEntry === undefined`) the flush
@@ -342,6 +375,7 @@ export type ServingLoopStats = {
      * drain delivers it ONCE, with a `streamEntry`. Routine under short
      * waves; grows with `wavesBudgetExhausted`. */
     lt1LeftoversPurged: number;
+
     /** Stage C build W3, (α1b) — the in-flight residue the purge cannot
      * reach: LT1 in-process copies that were RUNNING at the deadline and
      * sealed OUTSIDE their appending wave (the wave their emitter sealed
@@ -361,6 +395,7 @@ export type ServingLoopStats = {
      * `processed` never settles names a handler whose in-process copy
      * keeps missing its wave. */
     lt1LateSealsRefused: number;
+
     /** Stage C build W3, (α3) — the orphan REFUSAL (events.md §4's third
      * clause): event-handler runs of an LT1 cascade whose durable entry
      * rode an emitter write the wave WITHDREW (a derivation's superseded
@@ -377,6 +412,7 @@ export type ServingLoopStats = {
     queued: number;
     completed: number;
     failed: number;
+
     /** Phase 6 (serving-loop.md §5's per-space budgets): dispatch
      * holds — an admitted network effect waiting on the outstanding
      * cap or an egress-rate token. Growth under load is the budget
@@ -384,6 +420,7 @@ export type ServingLoopStats = {
     budgetDeferrals: number;
   };
   lease: { held: number; lost: number };
+
   /** OW45 arm-B server-ensure stage 1 (design PR #6209 §10): the
    * SpaceServer's space-root ensure — one lease-guarded owed step per
    * tenure (existence + freshness, no start). Counting caveat (review
@@ -401,16 +438,20 @@ export type ServingLoopStats = {
   rootEnsure: {
     /** Completed ensure runs, any outcome. */
     runs: number;
+
     /** Runs whose creation transaction materialized the root. */
     created: number;
+
     /** Runs whose freshness reconcile moved the root ("updated" or
      * "repaired-provenance" from the awaited default-root check). */
     reconciled: number;
+
     /** Fail-closed skips: the space's ACL resolved no concrete owner
      * (missing, invalid, retracted, ANYONE-only). The tenure serves
      * without a root ensure and NEVER substitutes the service DID
      * (OW53's ruled shape); the next tenure retries. */
     skippedNoOwner: number;
+
     /** Ensure attempts that threw (source resolve, compile, creation,
      * or resolution failure). Counted AND warned; cleared for the
      * tenure — the next tenure retries — so a deterministic failure

--- a/packages/runner/src/executor/wave.ts
+++ b/packages/runner/src/executor/wave.ts
@@ -115,22 +115,27 @@ export interface WaveRunContext {
    * restart-stable, never per-process. */
   actionId: string;
   kind: WaveRunKind;
+
   /** ATTRIBUTION — the acting identity, one per action run, where the run
    * has one. A run with no acting identity (a space-scope derivation
    * before any narrowing) carries none (protocol.md §1). */
   acting?: { user: string; session?: string };
+
   /** The event this handler run consequences (`consequenceOf` carriage). */
   eventId?: string;
+
   /** The durable stream entry this handler run is processing (Phase 3;
    * OW14's source-event carriage): a cross-space append the run emits
    * records `{sidecarId, eventId}` on its outbox row so a
    * deterministic delivery refusal can write its failure notice onto
    * the SOURCE entry (protocol.md §2b's LT4 ruling). */
   streamEntry?: { sidecarId: string; index: number; seq: number };
+
   /** The same-wave parent event of a cascade-minted event: a requeued
    * parent folds this contribution into the requeue set (§3d; the
    * model's C8d rollback closure). */
   parentEventId?: string;
+
   /** This handler run is the LT1 same-space IN-PROCESS copy of an event
    * some contribution of this wave emitted (cell.ts's serving-arm send;
    * stage C build W3, (α3)): its durable entry rides the EMITTER's
@@ -141,6 +146,7 @@ export interface WaveRunContext {
    * clause). Never set on a drain copy (which carries a `streamEntry`)
    * or a plain in-process event on the serving runtime. */
   lt1?: true;
+
   /** The scope INSTANCE this run ran as, for basis rows'
    * action_scope_key. Typed as the shared `ScopeKey` vocabulary so a
    * caller cannot hand the basis index a scope NAME or a hand-rolled
@@ -148,6 +154,7 @@ export interface WaveRunContext {
    * pre-narrowing instance; stage F's serving loop supplies per-run
    * demanded instances. */
   actionScopeKey?: ScopeKey;
+
   /** M1 — the PER-RUN identity this run's scoped reads and writes
    * resolve their instance keys against (scopes.md §5, §7 M1): the
    * demand-supplied instance identity for a derivation, the event's
@@ -156,11 +163,13 @@ export interface WaveRunContext {
    * cardinality-1 posture, and pre-narrowing space-scope runs, which
    * resolve no scoped addresses at all). */
   scopeKeyIdentity?: ScopeKeyIdentity;
+
   /** The capability grant a provisioning run's FOREIGN writes are
    * admitted under (protocol.md §2's server-produced authored row, §2b):
    * carried with the acting identity into the foreign commit's metadata
    * for the target's delegated-capability admission. */
   capabilityRef?: string;
+
   /** Server-execution v2 fan-out stage B (RULED 2026-08-16, design §F):
    * this DERIVATION run's `acting`/`capabilityRef` are DERIVED FROM THE
    * SCOPE IT DISCOVERS — space → none; user → the user; session → the
@@ -171,6 +180,7 @@ export interface WaveRunContext {
    * pair. Absent on handler runs (explicit `firedAt` actor — LD1),
    * bookkeeping, and every context off the serving posture. */
   attributionFromScope?: boolean;
+
   /** The BROADEST scope any emission from this run was attributed at
    * (the early-emit guard's evidence): set by {@link actingForEmission};
    * a seal whose final discovered scope is NARROWER than it refuses the
@@ -379,46 +389,57 @@ export interface WaveBasisInstanceRows {
 /** The batched commit the wave hands the sink, per space. */
 export interface WaveSpaceCommit {
   space: MemorySpace;
+
   /** Same-space emitted event entries this batch appends (LT1,
    * events.md §2): their declarations, so the engine's event-append
    * admission stamps each entry's stream `seq` (a derived append must
    * be DECLARED — seq stamping cannot be skipped by a plumbing bug). */
   eventAppends?: Array<{ id: string; scope?: CellScope; eventId: string }>;
+
   /** True for the home space's derived-class commit; false for a foreign
    * space's authored-class provisioning commit (protocol.md §2b). */
   home: boolean;
+
   /** The wave's read basis: the store seq of the wave's input snapshot.
    * The sink's re-verification compares doc heads against it. */
   basisSeq: number;
+
   /** Per doc-instance key (`${id} ${scopeKey}`): the head the wave's
    * REBASE decision observed (§3d's "re-CAS against the new head"). The
    * sink's re-verification MUST require these docs' heads to EQUAL the
    * recorded value — a head that moved past the decision invalidates the
    * field-level merge, and the wave re-decides against the new head. */
   rebasedHeads: ReadonlyArray<{ doc: string; head: number }>;
+
   /** Surviving operations, in seal order — the commit step never reorders
    * (§3's sealing-order MUST binds the loop's processing order; this step
    * preserves what it was handed). */
   operations: Operation[];
   preconditions: CommitPrecondition[];
+
   /** Owning contribution index per precondition — home batch only; lets a
    * reported precondition failure resolve per write class. */
   preconditionOwners?: number[];
   annotations: WaveWriteAnnotation[];
+
   /** Every eventId whose handler consequences ride this commit. */
   consequenceOf: string[];
+
   /** Basis rows to write INSIDE the same store transaction (§3b's
    * carriage rule — never own commits, never commit metadata), already
    * grouped into overwrite units: per (action, instance), the LAST
    * contributing run's set. */
   basisInstances: WaveBasisInstanceRows[];
+
   /** The DR1 lease holder identity the derived-class admission checks. */
   holder: string | undefined;
+
   /** The watermark this home commit is current through (protocol.md §4);
    * every split of one wave repeats the same value. Absent for waves
    * driven outside a serving loop (no watermark exists to carry) and on
    * foreign batches. */
   derivedThrough?: number;
+
   /** Foreign provisioning batches only (protocol.md §2's server-produced
    * authored row, §2b): the ORIGINATING chain actor + the capability
    * grant the target's admission validates — delegation, never
@@ -428,6 +449,7 @@ export interface WaveSpaceCommit {
     actingSession?: string;
     capabilityRef: string;
   };
+
   /** Per-op resolved scope keys for the batch's folded `sqlite` ops
    * (stage G, discharging the stage-D sqlite bound): the accumulator
    * resolves each op's db scope against its RUN's identity (M1 — the
@@ -436,6 +458,7 @@ export interface WaveSpaceCommit {
    * transaction. Ops whose db declares the space scope carry `"space"`
    * explicitly — every sqlite op in the batch has an entry. */
   sqliteScopeKeys?: ReadonlyArray<{ op: number; scopeKey: ScopeKey }>;
+
   /** The wave's outbound cross-space event appends (serving-loop.md §5,
    * FP1): durable rows the sink writes INSIDE the wave's own store
    * transaction, from surviving contributions only — a withdrawn
@@ -487,6 +510,7 @@ export interface WaveCommitSink {
     space: MemorySpace,
     docs: ReadonlyArray<{ id: string; scope?: CellScope; scopeKey: string }>,
   ): Promise<ReadonlyMap<string, number>>;
+
   /** The value paths written to a doc-instance by commits after `sinceSeq`
    * — the field-level merge input for the rebase of non-re-derivable
    * writes (§3d). */
@@ -516,9 +540,11 @@ export interface WaveLease {
 interface WaveContribution {
   index: number;
   context: WaveRunContext;
+
   /** Per-space sealed commits, in the tx's commit order (children first,
    * home last — protocol.md §2b). */
   spaces: SealedSpaceContribution[];
+
   /** Doc-instance keys read in spaces this run WROTE NOTHING to (the
    * sealSpaceReads handoff — stage F, discharging the stage-D bound):
    * `${space}\0${docInstanceKey}`, folded into the withdrawn-read
@@ -528,12 +554,14 @@ interface WaveContribution {
    * spaces) — over-dropping a derivation is sound, committing one
    * derived from withdrawn state is not (§3d). */
   readOnlyReadKeys: Set<string>;
+
   /** Cross-space event appends this run emitted (serving-loop.md §5,
    * FP1): folded into the home batch's durable rows iff the
    * contribution survives — a withdrawn contribution's appends never
    * ride (its event replays and re-emits, the model's committed-only
    * `cascadesCross` fold). */
   outboundAppends: OutboxAppendRow[];
+
   /** The run's DISCOVERED scope at seal (scopes.md §2 S1 — the
    * transaction's read-scope ratchet, learned by running): the narrowest
    * scope of anything the run read, its diff bases and redirect slots
@@ -570,20 +598,25 @@ export interface WaveCommitOutcome {
    * commit or aborted. */
   seq?: number;
   aborted?: "lease-lost" | "abandoned" | "foreign-commit-failed" | "rejected";
+
   /** Superseded pure-derivation writes dropped at the per-doc CAS —
    * §7's `supersededWrites` counter feeds from this. */
   supersededWrites: number;
+
   /** Pure-derivation ops dropped because they read a withdrawn
    * contribution's sealed writes — re-derivable, and re-run through
    * their own reads when fresh state lands (§3d, RULED 2026-08-05).
    * Counted apart from `supersededWrites` so that counter keeps §3d's
    * exact meaning (doc head advanced past the basis). */
   dependencyDroppedWrites: number;
+
   /** Events rolled back to unconsequenced, in seal order — the serving
    * loop retries them in a later wave. */
   requeuedEventIds: string[];
+
   /** Events whose consequences committed (the commit's `consequenceOf`). */
   committedEventIds: string[];
+
   /** Event-handler contributions REFUSED as orphans (server-execution v2
    * stage C build W3, (α3); events.md §4's third clause): runs of an
    * LT1 same-wave cascade whose durable entry rode an emitter write
@@ -594,6 +627,7 @@ export interface WaveCommitOutcome {
    * loop's `events.orphanDeliveriesRefused` feeds from this. */
   orphanDeliveriesRefused: number;
   dispositions: ContributionDisposition[];
+
   /** Foreign provisioning batches this wave DURABLY COMMITTED, in commit
    * order — the serving loop's input for the EXPLICIT WARM REQUEST
    * (serving-loop.md §1's third activation trigger; RULED 2026-08-21).
@@ -731,11 +765,13 @@ export class WaveAccumulator
       acting: { user: string; session?: string },
     ) => ForeignWriteGrantResult | Promise<ForeignWriteGrantResult>)
     | undefined;
+
   /** Grant verdicts per (space, acting user) for THIS wave — one probe
    * per crossing pair, not per sealed tx. A new wave re-probes (grants
    * can change between waves; a transient probe failure must not stick
    * beyond the wave that observed it). */
   readonly #foreignGrantVerdicts = new Map<string, Promise<boolean>>();
+
   /** The grant ARM each admitted crossing resolved through, per
    * (space, acting user) — retained for the commit step (OW31 B4,
    * protocol.md §2b): a `creation`-granted foreign target's genesis
@@ -755,6 +791,7 @@ export class WaveAccumulator
   #assembly: PendingAssembly | undefined;
   #closed = false;
   #derivedThrough: number | undefined;
+
   /** Events one of whose EVENT-STAMPED transactions failed its seal
    * (owner review P1-2, 2026-08-12): the served navigateTo issues its
    * intent as a SEPARATE event-handler-stamped tx (builtins.md §4),
@@ -767,6 +804,7 @@ export class WaveAccumulator
    * for the re-drain. Store-owned idempotency (the engine's nonce
    * dedupe) absorbs the re-run's re-issue. */
   readonly #sealFailedEventIds = new Set<string>();
+
   /** Foreign spaces whose co-hosted ENGINE failed to resolve for this
    * wave's commit step (Phase 5, the F1b fix): commitWave withdraws
    * exactly the contributions that sealed into these spaces (requeue
@@ -779,6 +817,7 @@ export class WaveAccumulator
    * until this isolation. Marked by the serving loop's
    * per-space-caught foreign-engine resolution (failForeignSpace). */
   readonly #failedForeignSpaces = new Map<MemorySpace, string>();
+
   /** Outbound appends staged per transaction before its seal
    * (enqueueOutboundAppend); folded (by copy) into the contribution at
    * seal so only surviving contributions' appends ride the wave (FP1).
@@ -793,10 +832,12 @@ export class WaveAccumulator
   constructor(options: {
     /** The home space this wave derives for. */
     space: MemorySpace;
+
     /** Store seq of the wave's input snapshot: the per-doc CAS basis
      * (serving-loop.md §3b's snapshot discipline — mid-wave commits are
      * the NEXT wave's input). */
     basisSeq: number;
+
     /** The acting identity scoped writes resolve their instance keys
      * against, via the shared scope_key constructor — never a caller-
      * supplied format (key-vocabulary.md §3/§4). At OFF-arm cardinality 1
@@ -806,21 +847,25 @@ export class WaveAccumulator
     scopeKeyIdentity: ScopeKeyIdentity;
     replicaFor: (space: MemorySpace) => ISpaceReplica;
     lease?: WaveLease;
+
     /** Counted observation of §3d's unstamped-seal refusal (the
      * serving loop feeds its §7 `unstampedSealRefusals` counter):
      * called once per refused write-carrying transaction, right
      * before the refusal throws. The refusal semantics are unchanged
      * — this only makes the storm a counter fact. */
     onUnstampedSeal?: () => void;
+
     /** Counted observation of fan-out stage B's early-emit guard (the
      * serving loop feeds its §7 `earlyEmitRefusals` counter): called
      * once per contribution refused for an under-attributed emission. */
     onEarlyEmitRefusal?: () => void;
+
     /** Counted observation of design §B5's accept-and-count residual
      * (the serving loop feeds `undemandedNarrowingRuns`): a derivation
      * run under the wave-level fallback identity that discovered a
      * scope narrower than `space`. */
     onUndemandedNarrowing?: () => void;
+
     /** Foreign-space writes at ACCUMULATION (serving-loop.md §3d, RULED
      * 2026-08-14 (c) — the lunch-wall trigger's ruled seat): on
      * `"refuse"` (the pre-Phase-5 default), a sealing tx carrying a
@@ -841,6 +886,7 @@ export class WaveAccumulator
      * refusing action-scoped and counted. The commit-step guard stays
      * as backstop. */
     foreignWrites?: "refuse" | "accept";
+
     /** The authorization predicate of the accept gate (Phase 5;
      * protocol.md §2b): whether `acting` holds a structural write
      * grant for `space`. REQUIRED with `foreignWrites: "accept"` — an
@@ -856,6 +902,7 @@ export class WaveAccumulator
       space: MemorySpace,
       acting: { user: string; session?: string },
     ) => ForeignWriteGrantResult | Promise<ForeignWriteGrantResult>;
+
     /** Fired once per refused foreign-space write (above): the serving
      * loop counts it into §7's `foreignWriteRefusals`. */
     onForeignWriteRefusal?: (
@@ -1529,6 +1576,7 @@ export class WaveAccumulator
     const homeWrites = this.#contributions.map((contribution) =>
       this.#homeDocInstances(contribution)
     );
+
     /** Per SPACE: sealed localSeq → contribution index. LocalSeqs are
      * per-space replica counters, so the mapping must be per-space too —
      * a pending read in a FOREIGN sealed commit resolves its layers
@@ -1557,6 +1605,7 @@ export class WaveAccumulator
     const conflicted = new Set<string>();
     const requeued = new Set<number>();
     const droppedWhole = new Set<number>();
+
     /** Event-handler contributions refused as ORPHANS (stage C build W3,
      * (α3)) — a subset of `droppedWhole`, kept apart for the
      * disposition message; the outcome COUNT is per EVENT
@@ -1564,6 +1613,7 @@ export class WaveAccumulator
      * same-eventId siblings down with it (the sibling fold below). */
     const orphanRefused = new Set<number>();
     const orphanRefusedEvents = new Set<string>();
+
     /** eventId → the contribution (and its home sidecar doc-instance
      * key) whose sealed ops APPEND that event's durable entry in THIS
      * wave — the LT1 same-wave emitters (cell.ts's serving-arm send
@@ -1571,13 +1621,16 @@ export class WaveAccumulator
      * of the requeue closure keys on it: a cascade child whose emitter
      * write is withdrawn has no durable entry behind it. */
     const emitterOf = this.#lt1EmittersByEventId();
+
     /** per contribution: home doc-instance keys whose ops are dropped */
     const droppedDocs: Set<string>[] = this.#contributions.map(() => new Set());
+
     /** per contribution: conflicted docs whose non-re-derivable ops
      * rebase — the disposition is PER (contribution, doc): one handler's
      * commuting patches never absolve another contribution's writes to
      * the same doc from their own drop/rebase/requeue check. */
     const rebasedDocs: Set<string>[] = this.#contributions.map(() => new Set());
+
     /** per rebased doc: the head every rebase decision on it observed
      * (§3d's "re-CAS against the new head" — the sink re-verifies the
      * doc still sits exactly there inside its store transaction). */

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -77,8 +77,10 @@ export interface BindingInfo {
 export interface ModuleItemClassificationOptions {
   /** Canonical shadow-guard statements that MUST be present, or none. */
   requiredGuards: ReadonlySet<string>;
+
   /** Reserved wrapper bindings authored code may not declare, or none. */
   reservedBindings: ReadonlySet<string>;
+
   /** Source offset used for the "missing required shadow guards" error. */
   missingGuardsErrorAt: number;
 }

--- a/packages/runner/src/sandbox/esm-module-loader.ts
+++ b/packages/runner/src/sandbox/esm-module-loader.ts
@@ -21,8 +21,10 @@ import { verifyModuleGraph } from "./module-record-verifier.ts";
 export interface VirtualModuleRecord {
   /** Specifiers this module imports (as written in the module). */
   imports: string[];
+
   /** Names this module exports. */
   exports: string[];
+
   /**
    * Maps each of this module's import specifiers to the absolute
    * (content-addressed) specifier it resolves to. When omitted, an import
@@ -30,6 +32,7 @@ export interface VirtualModuleRecord {
    * are already absolute).
    */
   resolutions?: Record<string, string>;
+
   /**
    * Populate `moduleExports`. Use `compartment.importNow(resolvedImports[spec])`
    * to obtain an imported module's namespace.
@@ -62,10 +65,13 @@ interface SesCompartmentCtor {
 export interface SesModuleLoaderOptions {
   /** Records keyed by absolute (content-addressed) specifier. */
   records: Map<string, VirtualModuleRecord>;
+
   /** Global endowments for the compartment. */
   globals?: Record<string, unknown>;
+
   /** Optional compartment name, for diagnostics. */
   name?: string;
+
   /**
    * Run structural graph verification before loading. Default true. The deep
    * SES classification port is still pending (see module-record-verifier.ts).

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -9,13 +9,16 @@ const DID_RE = /^did:[a-z0-9]+:.+$/;
 export interface FabricRef {
   /** Toolshed host (authority); only present in the cf://host/... form. */
   host?: string;
+
   /** Space name or DID; absent = the compiling space. */
   space?: string;
   ref:
     | { kind: "slug"; slug: string }
     | { kind: "uri"; scheme: EntityUriScheme | "pattern"; hash: string };
+
   /** Path inside the target program. */
   subpath?: string;
+
   /** Trailing @<hash> pin. */
   pin?: string;
 }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -384,12 +384,14 @@ export interface CompileSourcesOptions {
    */
   runtimeModules?: Record<string, string[]>;
   runtimeFingerprint?: string;
+
   /**
    * Attached data files as `[authored path, bytes]`, carried onto the graph for
    * the modules that read them. They are not sources: nothing here compiles,
    * parses, or records them.
    */
   dataFiles?: Iterable<readonly [string, string]>;
+
   /**
    * Pre-compiled CommonJS body per source name. When provided (e.g. from
    * `TypeScriptCompiler.compileToModules`, which runs the full CF transformer
@@ -398,14 +400,17 @@ export interface CompileSourcesOptions {
    * generation, `__cf_data` wrapping) cannot be produced by transpileModule.
    */
   precompiledBodies?: Map<string, string>;
+
   /**
    * Per-source source map (from `compileToModules`), keyed by source name. Used
    * to compose per-load maps so error stacks resolve back to the original
    * authored files.
    */
   precompiledSourceMaps?: Map<string, SourceMap>;
+
   /** Debug-only authored builder sites per source name. */
   precompiledBuilderSourceSites?: Map<string, BuilderSourceSitesV1>;
+
   /**
    * Whole-program path prefix (`/<id>`, no trailing slash) to strip from each
    * module's path *for content-addressed identity only*. The compile path
@@ -420,6 +425,7 @@ export interface CompileSourcesOptions {
    * error-stack mapping) keeps the prefixed path untouched.
    */
   idPrefix?: string;
+
   /**
    * Precomputed per-path module identities (from {@link computeModuleIdentities}).
    * When the caller already derived these (e.g. the Engine, for its cache-hit
@@ -427,11 +433,13 @@ export interface CompileSourcesOptions {
    * be consistent with `idPrefix` / `runtimeFingerprint`.
    */
   identityByPath?: Map<string, string>;
+
   /**
    * Maps an authored import specifier to a concrete file already present in the
    * program. Used for scheme-prefixed fabric refs mounted under reserved paths.
    */
   specifierAliases?: ReadonlyMap<string, string>;
+
   /**
    * The stored path for a resolved source name — the spelling `dataFiles` is
    * keyed by, with the per-load `idPrefix` and any fabric mount root taken off.
@@ -444,20 +452,26 @@ export interface CompileSourcesOptions {
 
 export interface CompiledModuleGraph {
   records: Map<string, VirtualModuleRecord>;
+
   /** Content-addressed specifier for each original file path. */
   specifierByPath: Map<string, string>;
+
   /** Compiled CommonJS body per specifier — the text the verifier classifies. */
   compiledBodies: Map<string, string>;
+
   /** Per-specifier source map (compiled body → original source), when available. */
   moduleSourceMaps: Map<string, SourceMap>;
+
   /** Debug-only authored builder sites per content-addressed module identity. */
   builderSourceSitesByIdentity: Map<string, BuilderSourceSitesV1>;
+
   /**
    * Hoist registrations, populated as the graph's modules evaluate (`__cfReg`).
    * Empty until `importNow` runs each module's `execute`. The engine reads it
    * after evaluation; the PatternManager assigns `{ identity, symbol }` refs.
    */
   registrationSink: HoistRegistrationSink;
+
   /**
    * Specifiers of modules the VERIFIER approved for hoist registration (a valid
    * top-level `__cfReg({ … })` call). The engine fills this during the verify
@@ -466,6 +480,7 @@ export interface CompiledModuleGraph {
    * missed fails closed at runtime instead of registering attacker values.
    */
   registrationApproved: Set<string>;
+
   /**
    * Verbatim bytes of every attached data file in this graph, keyed by the
    * data entry's authored path. These are carried alongside the records rather
@@ -579,8 +594,10 @@ export const FABRIC_MOUNT_ROOT = "/~cf/";
 export interface FabricMount {
   /** Terminal identity the subtree was fetched by and must hash back to. */
   entryIdentity: string;
+
   /** Mounted path of the subtree's entry file. */
   entryPath: string;
+
   /** The fabric specifiers that resolve to this mount. */
   specifiers: string[];
 }
@@ -980,19 +997,25 @@ export function compileSourcesToRecords(
 export interface CachedCompiledModule {
   /** Prefix-free content identity (the `cf:module/<hash>` hash, no scheme). */
   identity: string;
+
   /** Normalized authored path (e.g. `/main.tsx`); used for the eval sourceURL. */
   filename: string;
+
   /** Compiled CommonJS body, or the verbatim bytes of a data entry. */
   code: string;
+
   /** Internal import edges: require specifier → dependency module identity. */
   imports: { specifier: string; targetIdentity: string }[];
+
   /**
    * This entry carries data rather than code, so `code` is its authored bytes.
    * A data entry never becomes a module record and is never parsed as one.
    */
   isData?: boolean;
+
   /** Per-module source map, if cached. */
   sourceMap?: SourceMap;
+
   /**
    * Precomputed record surface (Fix B), derived from `code` at compile time via
    * {@link deriveModuleRecordFields} and persisted on the compiled doc: the
@@ -1005,6 +1028,7 @@ export interface CachedCompiledModule {
   exportNames?: readonly string[];
   starTargetSpecs?: readonly string[];
   importSpecs?: readonly string[];
+
   /**
    * Authored-line spans for the coverage probes baked into `code`, carried from
    * the cached document. The engine registers them with the collector it
@@ -1012,6 +1036,7 @@ export interface CachedCompiledModule {
    * resolve to source lines. Absent whenever `code` is uninstrumented.
    */
   patternCoverageSpans?: readonly PatternCoverageSpan[];
+
   /** Debug-only authored builder sites carried from the cached document. */
   builderSourceSites?: BuilderSourceSitesV1;
 }

--- a/packages/runner/src/sandbox/result-normalization.ts
+++ b/packages/runner/src/sandbox/result-normalization.ts
@@ -17,6 +17,7 @@ import { isCellLink } from "../link-utils.ts";
 export interface NormalizedSandboxResult {
   /** The host/Fabric graph that may safely leave the sandbox boundary. */
   value: unknown;
+
   /** Whether the result graph contains a Reactive leaf. */
   hasReactive: boolean;
 }

--- a/packages/runner/src/scheduler/backpressure.ts
+++ b/packages/runner/src/scheduler/backpressure.ts
@@ -27,8 +27,10 @@ export interface CommitBackpressurePolicy {
    * curve only grows into real spacing once a conflict persists.
    */
   baseDelayMs: number;
+
   /** Ceiling on the per-retry delay, in milliseconds. */
   maxDelayMs: number;
+
   /**
    * Fraction of the computed delay subtracted at random, in [0, 1]. 0.5 spreads
    * each delay across the lower 50% of the capped value so concurrent writers
@@ -36,6 +38,7 @@ export interface CommitBackpressurePolicy {
    * delay never exceeds maxDelayMs.
    */
   jitter: number;
+
   /**
    * Total wall-clock time a transient conflict may be retried before the write
    * surfaces a terminal error, in milliseconds. Measured from the first

--- a/packages/runner/src/scheduler/cooperative-yield.ts
+++ b/packages/runner/src/scheduler/cooperative-yield.ts
@@ -54,6 +54,7 @@ export class CooperativeYield {
   readonly #sliceMs: number;
   #sliceStart = performance.now();
   #yields = 0;
+
   /** The mid-wave hook (the SpaceServer's lease renew): called
    * synchronously at every yield, BEFORE the macrotask turn. */
   onYield: (() => void) | undefined;

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -650,6 +650,7 @@ export interface SchedulerEventExecutionState {
     deps: ReactivityLog,
     invalidDeps: Set<Action>,
   ) => boolean;
+
   /** The transient-demander preflight (fan-out stage B, review F2):
    * re-arm the fanned-out nodes in a served handler's closure whose
    * instance for the actor is not current. Undefined off the serving
@@ -701,6 +702,7 @@ export function preflightQueuedEventDependencies(state: {
     deps: ReactivityLog,
     invalidDeps: Set<Action>,
   ) => boolean;
+
   /** The transient-demander preflight (server-execution v2 fan-out
    * stage B, review F2): re-arm the fanned-out nodes in a served
    * handler's closure whose instance for the ACTOR is not current, so
@@ -1836,6 +1838,7 @@ type CommitDisposition =
  * way — a stale basis is bounded by the retry window, and a non-stale-basis
  * rejection drops on the first attempt.
  */
+
 /** Whether a served event's commit error is the serving loop's
  * LT1-late-seal refusal (stage C build W3, (α)) — carried as the
  * `reason` Error's message, the sentinel `LT1_LATE_SEAL_REFUSED`. */

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -148,13 +148,17 @@ export type SchedulerSettleResult = {
   maxSettleIterations: number;
   backoffApplied: boolean;
   backoffActionCount: number;
+
   /** Actions deferred by convergence backoff in this settle pass. */
   backoffActions: readonly Action[];
   backoffUntil?: number;
+
   /** Iterations that actually ran work (excludes the final settled check). */
   iterationsRun: number;
+
   /** Wall-clock of the settle loop, measured unconditionally. */
   settleDurationMs: number;
+
   /** Number of actions in the final non-empty settle work set. */
   workSetSize: number;
   settleStats?: SettleStats;
@@ -181,6 +185,7 @@ export interface SchedulerSettleLoopState {
     IMemorySpaceAddress[]
   >;
   readonly collectPullIterationSeeds: (seeds: Set<Action>) => void;
+
   /** Refresh transient demand such as a head event's current invalid closure. */
   readonly refreshPassScopedDemand?: (demand: Set<Action>) => void;
   readonly getActionId: (action: Action) => string;
@@ -190,6 +195,7 @@ export interface SchedulerSettleLoopState {
   readonly clearComputationDebounceState: (action: Action) => void;
   readonly isLiveAction: (action: Action) => boolean;
   readonly runAction: (action: Action) => Promise<unknown>;
+
   /** The serving posture's cooperative macrotask yield between runs
    * (server-execution v2 stage C tuning T3, cooperative-yield.ts):
    * returns a promise to await when the current slice is spent, else
@@ -268,6 +274,7 @@ export interface BudgetBackoffPlan {
 
 export function planBudgetBackoff(state: {
   readonly workSet: ReadonlySet<Action>;
+
   /** Transient demand roots, such as a head event's preflight closure. */
   readonly passScopedDemand?: ReadonlySet<Action>;
   readonly nodes: NodeRegistry;

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -388,6 +388,7 @@ export class Scheduler {
   private subscriptionState!: SchedulerSubscriptionState;
   private subscribeActionState!: SchedulerSubscribeActionState;
   private unsubscribeState!: SchedulerUnsubscribeActionState;
+
   /** The storage subscriber registered in the constructor, kept so `dispose`
    * can hand it back. */
   readonly #storageSubscription: IStorageSubscription;
@@ -1066,6 +1067,7 @@ export class Scheduler {
    * and `user:bob`, name ONE entity whose one node writes both). The
    * count is the number of registry instance keys naming the entity. */
   private readonly demandedEntityRefs = new Map<SpaceScopeAndURI, number>();
+
   /** Per-runtime enter/leave/re-arm tallies. The SpaceServer reads the
    * enter/leave DELTA per pass and folds it into its space-lived
    * `stats.demand` accumulators (these reset with the runtime on a
@@ -1291,6 +1293,7 @@ export class Scheduler {
       eventId?: string;
       originTx?: IExtendedStorageTransaction;
       time?: number;
+
       /**
        * Payload keys the RUNTIME itself injected into `event`'s value —
        * provenance for the closed-world gate, forwarded from the send's
@@ -1298,11 +1301,13 @@ export class Scheduler {
        * `StreamSendOptions` (cell.ts).
        */
       runtimeInjectedEventKeys?: readonly string[];
+
       /** Server-execution v2 Phase 3: the serving drain's per-event
        * carriage — acting identity, the durable stream entry, and the
        * failure hook (QueuedEvent.served). Passed only by the
        * SpaceServer's drain; absent everywhere client-side. */
       served?: ServedEventDispatch;
+
       /** The client-echo cascade thread (QueuedEvent.parentEventId):
        * the emitting run's event id, passed by cell.ts's plain
        * queueEvent for a send from within a speculation-stamped

--- a/packages/runner/src/scheduler/fan-out.ts
+++ b/packages/runner/src/scheduler/fan-out.ts
@@ -42,6 +42,7 @@ export interface FanOutInstance {
    * REPRESENTATIVE one (the smallest demanded session of that principal)
    * — resolution scaffolding, never attribution. */
   readonly identity: ScopeKeyIdentity;
+
   /** The instance key the run is stamped with: `space` for the probe,
    * `user:<p>` / `session:<p>:<s>` at the ratchet's depth for `p`. */
   readonly key: ScopeKey;
@@ -56,19 +57,23 @@ export interface FanOutNodeState {
   /** The top hop: some run discovered a scope narrower than `space`.
    * Structural (the shared redirect), so node-level. */
   narrowed: boolean;
+
   /** Principals whose discovered depth is SESSION (ragged; per principal;
    * only ever grows). A principal outside it runs once, as its user
    * instance, while `narrowed`. */
   readonly sessionPrincipals: Set<string>;
+
   /** Every instance key this node has run (or is running) at the current
    * ratchet, with its resolution identity and its LAST COMMITTED
    * reactivity log — the union of the logs is the node's subscription
    * (B7: skipped instances keep their reads registered). */
   readonly instances: Map<ScopeKey, InstanceRecord>;
+
   /** Instance keys whose last run is CURRENT (B7): a change dirties only
    * the instances whose reads covered it; everything not in here runs on
    * the next pass. Emptied by an untargeted invalidation. */
   readonly clean: Set<ScopeKey>;
+
   /** Per-key dirtiness generation: a run marks its key clean at finalize
    * only if no cause dirtied it since the run started (a change that
    * lands mid-run must not be absorbed by the run that predates it). */

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -22,6 +22,7 @@ export class SpeculationLineage {
     private readonly hooks: {
       /** Drop and settle a not-yet-dispatched event from the queue. */
       dropQueuedEvent: (event: QueuedEvent, reason: string) => void;
+
       /** Wake the scheduler (parked cross-space events become ready). */
       queueExecution: () => void;
       onError: (error: unknown) => void;

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -13,6 +13,7 @@ export interface SchedulerGateState {
   throttleReadyAt?: number;
   backoffUntil?: number;
   backoffStreak: number;
+
   /** Backoff passes charged to the current idle-wait episode. */
   convergenceHoldPasses: number;
 }
@@ -38,6 +39,7 @@ export interface SchedulerNode {
   provisionalDemandPass?: number;
   gate: SchedulerGateState;
   passRuns: number;
+
   /** Server-execution v2 fan-out stage B: the node's known-scope
    * ratchet and per-instance record (scheduler/fan-out.ts). Present ONLY
    * once the serving loop's demand registry supplied demanders for this
@@ -66,6 +68,7 @@ export class NodeRegistry {
 
   readonly effects: ReadonlySet<Action> = this.activeEffects;
   readonly computations: ReadonlySet<Action> = this.activeComputations;
+
   /** (d′) — the STANDING, refcounted `demandedWriters` root
    * kind (design §2.4; serving-loop.md §1's "a demanded instance's
    * writers hold demand … while any session tracks the instance"): the

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -511,6 +511,7 @@ export async function runSchedulerAction(
   ): Promise<{
     result: unknown;
     log: ReactivityLog | undefined;
+
     /** The run ended in `RetryImmediately` (an unresolved inSpace name):
      * its retry — if any budget is left — is QUEUED, never re-run in the
      * calling pass (see the fan-out loop's deferred set). */
@@ -727,6 +728,7 @@ interface FanOutRunArgs {
   readonly instance: FanOutInstance;
   readonly startGen: number;
   readonly collectLog: (log: ReactivityLog) => void;
+
   /** The run ended in `RetryImmediately`: tell the loop not to offer this
    * instance again in the current pass (its retry, if any budget is
    * left, is queued — never re-run in-loop). */

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -19,6 +19,7 @@ export type TelemetryAnnotations = {
   writes: NormalizedFullLink[];
   materializerWriteEnvelopes?: NormalizedFullLink[];
   ignoredSchedulingWrites?: NormalizedFullLink[];
+
   /**
    * Concrete structural surface for a transformer-proven complete source lift.
    * This is runner-owned metadata; raw modules, handlers, and unresolved
@@ -40,12 +41,14 @@ export type SchedulerObservationIdentity = {
   branch?: string;
   pieceId: string;
   processGeneration?: number;
+
   /** The piece root's RAW doc id (no scope-key prefix — `pieceId` above
    * is instance-keyed for shaper buckets). The per-(action × instance)
    * run supply (server-execution v2 stage P2-F) resolves an action's
    * demanded instances through this id at the reactive-action choke
    * point. */
   pieceRootId?: string;
+
   /** The DEMAND roots this action's instances resolve through (Phase 7):
    * `pieceRootId` plus every ANCESTOR piece root that instantiated it —
    * a nested pattern node's or a result-as-pattern child's actions are
@@ -76,6 +79,7 @@ export type EventHandler =
       tx: IExtendedStorageTransaction,
       event: any,
     ) => void;
+
     /**
      * Optional callback to ensure the handler's input docs are locally
      * available before the handler body runs. A handler reads its asCell
@@ -106,6 +110,7 @@ export type AnnotatedEventHandler = EventHandler & TelemetryAnnotations;
  */
 export type ReactivityLog = {
   reads: IMemorySpaceAddress[];
+
   /** Reads that should not invalidate on child writes unless they add a new key */
   shallowReads: IMemorySpaceAddress[];
   writes: IMemorySpaceAddress[];
@@ -130,6 +135,7 @@ export type SettleIterationStats = {
   workSetSize: number;
   orderSize: number;
   actionsRun: number;
+
   /** Action IDs in the work set (truncated to top entries) */
   actions: { id: string; type: "effect" | "computation" }[];
   durationMs: number;
@@ -157,6 +163,7 @@ export type ActionRunTraceEntry = {
   durationMs: number;
   declaredWrites: ActionRunTraceAddress[];
   actualWrites: ActionRunTraceAddress[];
+
   /** Server-execution v2 fan-out stage B: the instance key a fanned-out
    * run was stamped with (`space` for the probe, `user:…`/`session:…`
    * otherwise); absent on every other run. */
@@ -227,6 +234,7 @@ export const LT1_LATE_SEAL_REFUSED = "lt1-late-seal-refused";
 export type ServedEventDispatch = {
   firedAt?: { user?: string; session?: string };
   streamEntry?: { sidecarId: string; index: number; seq: number };
+
   /** The EMITTING run's durable event id for a same-wave cascade
    * (C8d; review 2026-08-11 M2): cell.ts's LT1 same-space emission
    * queues the emitted event in-process with the emitter's own
@@ -237,6 +245,7 @@ export type ServedEventDispatch = {
    * eventId to fold on; a requeued derivation withdraws the entry
    * with its own contribution). */
   parentEventId?: string;
+
   /** The LT1 same-space in-process copy's APPENDING-WAVE identity
    * (server-execution v2 stage C build W3, (α); events.md §4's RULED
    * one-entry-one-completed-run sentence): the EMITTING run's
@@ -271,6 +280,7 @@ export type ServedEventDispatch = {
 export type QueuedEvent = {
   /** Durable event id minted at send (spec §7.5). */
   readonly id: string;
+
   /** The EMITTING run's event id for a CLIENT-side same-wave cascade
    * echo (independent review M1, 2026-08-11): cell.ts's plain
    * queueEvent threads it when the send came from within a
@@ -282,6 +292,7 @@ export type QueuedEvent = {
    * deferred-vs-dropped (the drain's cold-view deferral), and a
    * client echo must keep today's dropped shape. */
   readonly parentEventId?: string;
+
   /**
    * Whether `id` was supplied by the caller rather than minted at enqueue. A
    * caller-supplied id is a durable delivery id: the handling's receipt
@@ -291,6 +302,7 @@ export type QueuedEvent = {
    * (spec §7.6, the backlog-cap exclusions).
    */
   readonly callerSuppliedId?: boolean;
+
   /**
    * Monotonic stamp minted at first enqueue and carried unchanged across
    * requeues (backoff, name-resolution). Commits are not awaited, so several
@@ -300,6 +312,7 @@ export type QueuedEvent = {
    * before it.
    */
   readonly enqueueSeq: number;
+
   /**
    * The wall-clock instant (ms) bound to this event, captured at its causal
    * origin: carried forward unchanged from the emitting handler's frame, or a
@@ -310,12 +323,14 @@ export type QueuedEvent = {
    * reads the instant of the event that actually dispatches.
    */
   time?: number;
+
   /** The transaction whose handler sent this event, when transactional. */
   readonly originTx?: IExtendedStorageTransaction;
   eventLink: NormalizedFullLink;
   action: Action;
   handler: EventHandler;
   event: any;
+
   /**
    * Payload keys the RUNTIME itself injected into `event`'s value (send's
    * internal `runtimeInjectedEventKeys` option — the LLM tool-call path's
@@ -326,14 +341,17 @@ export type QueuedEvent = {
    * newest event's payload, and the marker must describe THAT payload.
    */
   runtimeInjectedEventKeys?: readonly string[];
+
   /**
    * The FIFO slot was reserved before its handler's piece finished loading.
    * A loading head parks the whole event queue so later, already-registered
    * handlers cannot overtake it.
    */
   handlerLoadPending?: boolean;
+
   /** Internal exactly-once guard for terminal pre-dispatch drops. */
   finalOutcomeNotified?: boolean;
+
   /**
    * Whether a transient failure for this event should be retried. `true` routes
    * a transient commit failure through the exponential-backoff window and lets
@@ -346,6 +364,7 @@ export type QueuedEvent = {
    */
   retry: boolean;
   onCommit?: (tx: IExtendedStorageTransaction) => void;
+
   /**
    * Server-execution v2 Phase 3 (events-down): the serving drain's
    * per-event carriage. `firedAt` is the server-stamped acting identity
@@ -361,12 +380,14 @@ export type QueuedEvent = {
    */
   served?: ServedEventDispatch;
   notBefore?: number;
+
   /**
    * Number of transient commit failures this intent has hit. Drives the
    * exponential backoff exponent; carried across backoff retries. Covers every
    * transient commit failure, not only conflicts.
    */
   retryAttempts?: number;
+
   /**
    * Wall-clock deadline (performance.now()) after which a still-failing intent
    * surfaces a terminal error instead of retrying. Set from the first transient

--- a/packages/runner/src/scheduler/wake-shaping.ts
+++ b/packages/runner/src/scheduler/wake-shaping.ts
@@ -86,10 +86,13 @@ export const CELL_GROUP_PREFIX = "cell:";
 /** One shaped wake. See the module comment for the per-field semantics. */
 export interface WakeHold {
   groupKey: string;
+
   /** Coalescing unit within the group; omitted, the wake is kept FIFO. */
   itemKey?: string;
+
   /** Same key as the group's last charged hold ⇒ ride that token. */
   chargeKey?: object;
+
   /** Deliver the leading edge on a fresh macrotask instead of synchronously. */
   defer?: boolean;
   deliver: () => void;
@@ -100,16 +103,20 @@ export interface WakeHold {
 // activity; an idle, fully refilled bucket is closed.
 interface ThrottleGroup {
   tokens: number;
+
   /** itemKey -> deliver thunk; unique keys preserve FIFO, shared keys coalesce. */
   pending: Map<string, () => void>;
   timer: ReturnType<typeof setTimeout> | undefined;
+
   /** Deferred leading-edge deliveries scheduled but not yet run. */
   inFlight: number;
+
   /**
    * The charge key of the hold that most recently took a burst token. Holds
    * carrying the same key ride that token instead of spending their own.
    */
   lastBurstCharge: object | undefined;
+
   /** Source of unique item keys for keep-all (FIFO) holds. */
   uniqueSeq: number;
 }
@@ -269,16 +276,19 @@ export interface DeliverOpts {
   eventId?: string;
   originTx?: IExtendedStorageTransaction;
   time?: number;
+
   /** Runtime-injection provenance, carried through a held delivery unchanged
    * so shaping can never strip the closed-world gate's exemption. Renderer
    * events (the only shapable class) are never injection sites, so this is
    * defensive plumbing, not a live path. */
   runtimeInjectedEventKeys?: readonly string[];
+
   /** The serving drain's per-event carriage (Phase 3), carried through a
    * held delivery unchanged — same defensive plumbing as above (drained
    * store entries are never renderer-trusted, so shaping never holds
    * them in practice). */
   served?: ServedEventDispatch;
+
   /** The client-echo cascade thread (QueuedEvent.parentEventId), carried
    * through a held delivery unchanged — defensive plumbing like `served`
    * (a cascade send from a handler frame is never renderer-trusted). */

--- a/packages/runner/src/scheduler/work-oracle.ts
+++ b/packages/runner/src/scheduler/work-oracle.ts
@@ -122,12 +122,14 @@ export function isIdleMaterializerRunnable(
 export interface PullWorkAssessment {
   /** A seed the settle loop would run right now exists. */
   readonly runnableNow: boolean;
+
   /**
    * Earliest future eligibility among deferred idle-relevant work (effects,
    * materializers, demanded computations, awaited first runs). Feeds the
    * single wake timer.
    */
   readonly nextWakeAt?: number;
+
   /**
    * Some deferred node's eventual run is one an idle() waiter must observe:
    * effects and materializers (side effects), and a never-ran demanded

--- a/packages/runner/src/storage/event-append-queue.ts
+++ b/packages/runner/src/storage/event-append-queue.ts
@@ -64,15 +64,19 @@ const logger = getLogger("event-append-queue", {
 export type QueuedEventAppend = {
   /** The stream's sidecar doc ({@link streamEntriesDocId}). */
   sidecarId: string;
+
   /** The stream link the entry self-describes (events.md §1). */
   stream: StreamLinkRef;
+
   /** The durable client-minted event id (event-identity). */
   eventId: string;
   payload?: FabricValue;
+
   /** The one client-minted firedAt component (events.md §1): orders
    * this session's own appends and steers nothing. */
   clientSeq: number;
   runtimeInjectedEventKeys?: string[];
+
   /** See StreamEventEntry.rendererTrusted (fan-out stage B). */
   rendererTrusted?: true;
 };
@@ -134,8 +138,10 @@ const RETRY_CAP_MS = 10_000;
 export type EventAppendPacing = {
   /** Sustained sends per second, per stream. */
   ratePerSecond: number;
+
   /** Bucket capacity: sends that pass immediately after a quiet spell. */
   burst: number;
+
   /** Clock seam (tests). Defaults to `Date.now`. */
   now?: () => number;
 };
@@ -173,6 +179,7 @@ export class EventAppendQueue {
   readonly #nextLocalSeq: () => number;
   readonly #onRefused?: (append: QueuedEventAppend, reason: string) => void;
   readonly #queue: QueuedEventAppend[] = [];
+
   /** Keyed PER ENTRY OBJECT, not per eventId: duplicate-eventId fires
    * are a DESIGNED flow (events.md §5's duplicate submission), and a
    * per-id map would leak the first fire's outcome forever — wedging
@@ -186,26 +193,32 @@ export class EventAppendQueue {
   #draining = false;
   #closed = false;
   #retryTimer: ReturnType<typeof setTimeout> | undefined;
+
   /** Resolves the drain loop's in-flight backoff wait — close() must
    * settle it (clearing the timer alone would leave the loop's await
    * pending forever, wedging dispose-time sanitizers). */
   #retryRelease: (() => void) | undefined;
+
   /** OW27 pacing: the per-stream token buckets (keyed by sidecar doc id
    * — one per stream), or undefined when pacing is disabled. */
   readonly #pacing: EventAppendPacing | undefined;
   readonly #buckets = new Map<string, { tokens: number; refilledAt: number }>();
+
   /** DIAGNOSTIC (tests): sends held by pacing so far. */
   #pacedHolds = 0;
   #loaded: Promise<void>;
+
   /** The tail of the save chain — `persisted` awaits it (tests, and
    * any caller that must observe durability before proceeding). */
   #lastPersist: Promise<void> = Promise.resolve();
 
   constructor(options: {
     space: string;
+
     /** Sends one ClientCommit; resolves on accept, rejects with the
      * (name-carrying) wire error otherwise. */
     transact: (commit: ClientCommit) => Promise<unknown>;
+
     /** Allocated at SEND time, per attempt — the increasing-localSeq
      * send-order discipline (04-protocol §3.9) forbids holding one
      * across other commits, and a session-replacement resubmit needs a
@@ -213,6 +226,7 @@ export class EventAppendQueue {
     nextLocalSeq: () => number;
     store?: EventAppendQueueStore;
     onRefused?: (append: QueuedEventAppend, reason: string) => void;
+
     /** OW27 per-stream send pacing; absent = the default posture,
      * `false` = unpaced. */
     pacing?: EventAppendPacing | false;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -143,6 +143,7 @@ const createOnlyMarkKey = (
 
 type CfcInstrumentationHooks = {
   onRelevantTx?(): void;
+
   /** Stage C tuning T1: one flow-label probe was evaluated (`computed`) or
    * answered from the memoized negative verdict (`memo`). Measurement
    * only. */

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -91,12 +91,14 @@ export interface Metadata extends Record<PropertyKey, unknown> {}
  */
 export interface IReadOptions {
   meta?: Metadata;
+
   /**
    * When true, register the read in transaction activity but skip loading
    * from storage. Use when caller already has the value and only needs
    * dependency tracking.
    */
   trackReadWithoutLoad?: boolean;
+
   /**
    * When true, the read is tracked as non-recursive for scheduler invalidation:
    * parent/same-path writes invalidate, child writes invalidate only on key
@@ -143,6 +145,7 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * space.
    */
   open(space: MemorySpace): IStorageProvider;
+
   /**
    * Whether SPACE's replica holds server-confirmed verified content for
    * `cid:<hash>` — the write-side elision seam for schema-document
@@ -231,6 +234,7 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * @returns Promise that resolves when all pending syncs are complete.
    */
   synced(): Promise<void>;
+
   /** INBOUND settlement only (server-execution v2 stage F): outstanding
    * watch refreshes/pulls, EXCLUDING commit settlement AND update
    * processing — the serving loop's wave-settle barrier. Both exclusions
@@ -485,6 +489,7 @@ export interface IStorageProvider {
    * @returns Promise that resolves when all pending syncs are complete.
    */
   synced(): Promise<void>;
+
   /** INBOUND settlement only (server-execution v2 stage F): outstanding
    * watch refreshes/pulls, EXCLUDING commit settlement AND update
    * processing — the serving loop's wave-settle barrier. Both exclusions
@@ -651,10 +656,12 @@ export interface ICommitNotification {
    * The space into which changes were made.
    */
   space: MemorySpace;
+
   /**
    * Set of changes merged.
    */
   changes: IMergedChanges;
+
   /**
    * Transaction that committed changes. If legacy API is used it will not have
    * a source transaction.
@@ -673,6 +680,7 @@ export interface IRevertNotification {
    * The space into which changes were made.
    */
   space: MemorySpace;
+
   /**
    * Set of changes merged. Note that this is not necessary resetting every
    * change commit made to a state it had pre-commit as things may have changed
@@ -725,6 +733,7 @@ export interface IIntegrateNotification {
   type: "integrate";
   space: MemorySpace;
   changes: IMergedChanges;
+
   /**
    * Present ONLY on the flip a SPECULATION retirement produces
    * (server-execution v2, speculation.md §4's arrival-gated retirement,
@@ -775,6 +784,7 @@ export interface IWriteOptions {
 export interface ITransactionWriteRequest {
   address: IMemorySpaceAddress;
   value: FabricValue;
+
   /** See {@link IWriteOptions.delete}. */
   delete?: boolean;
 }
@@ -793,10 +803,12 @@ export type IMemoryChange = {
    * Memory address that was changed.
    */
   address: IMemoryAddress;
+
   /**
    * Value memory address had before change.
    */
   before: FabricValue;
+
   /**
    * Value memory address has after change.
    */
@@ -855,11 +867,13 @@ export interface IStorageTransaction {
    * Optional change group used to associate commits with scheduler actions.
    */
   changeGroup?: ChangeGroup;
+
   /**
    * When true, the transaction bypasses batch-signing debounce and flushes
    * immediately. Set for user-interactive paths (editWithRetry, events).
    */
   immediate?: boolean;
+
   /**
    * The scheduler action whose run opened this transaction (spec scheduler-v2
    * P5). Change records derived from this transaction must not re-trigger this
@@ -867,6 +881,7 @@ export interface IStorageTransaction {
    * across instances.
    */
   sourceAction?: object;
+
   /**
    * The scope INSTANCE identity this transaction's scoped reads and writes
    * resolve against when it is NOT the storage manager's own session
@@ -881,6 +896,7 @@ export interface IStorageTransaction {
    * transaction per instance run — `runOnce`).
    */
   scopeKeyIdentity?: ScopeKeyIdentity;
+
   /**
    * Opt the transaction into writing to more than one memory space. By default
    * a transaction may write to a single space only. When enabled, commit()
@@ -909,6 +925,7 @@ export interface IStorageTransaction {
    * failures are logged).
    */
   enableMultiSpaceWrites?(order?: readonly MemorySpace[]): void;
+
   /**
    * Confirm that every replica supplying this transaction's read basis is
    * still the active replica for its space. Storage calls this immediately
@@ -916,6 +933,7 @@ export interface IStorageTransaction {
    * computed from the old replica into another space.
    */
   validateReplicaRoutes?(): Result<Unit, IStorageTransactionInconsistent>;
+
   /**
    * Optional read-only mode hook used by runtime-generated fallback read
    * transactions.
@@ -923,6 +941,7 @@ export interface IStorageTransaction {
   setReadOnly?(reason?: string): void;
   clearReadOnly?(): void;
   isReadOnly?(): boolean;
+
   /**
    * The transaction journal containing all read and write activities.
    * Provides access to transaction operations and dependency tracking.
@@ -1101,6 +1120,7 @@ export interface IStorageTransaction {
    * instead of materializing novelty/history attestations.
    */
   getWriteDetails?(space: MemorySpace): Iterable<TransactionWriteDetail>;
+
   /**
    * The manager's `isSchemaDocPersisted`, reachable from the transaction
    * (the staging scan runs inside one). Optional the same way; absent
@@ -1297,6 +1317,7 @@ export interface ITransactionSealSink {
     native: NativeStorageCommit,
     source: IStorageTransaction,
   ): Promise<Result<Unit, CommitError>>;
+
   /**
    * The read set of a space this transaction READ but wrote nothing to
    * (stage F, discharging a stage-D bound): a tx seals only spaces it
@@ -1461,8 +1482,10 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;
   setCfcFlowLabelsMode(mode: CfcFlowLabelsMode): void;
+
   /** Set the write-side `requiredIntegrity` floor dial (§8.12.4.1 / SC-18). */
   setCfcWriteFloorMode(mode: CfcWriteFloorMode): void;
+
   /**
    * Enable trigger-read gating on the enforcement side (§8.9.2 / SC-3).
    * Anti-downgrade pinned: once enabled, disabling throws.
@@ -1470,11 +1493,13 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   setCfcTriggerReadGating(enabled: CfcTriggerReadGating): void;
 
   setCfcDecomposedEnvelopes(enabled: CfcDecomposedEnvelopes): void;
+
   /**
    * Set the exchange-rule policy evaluation dial (Epic B5, spec §4.4.5).
    * Anti-downgrade pinned: once `enforce`, weakening throws.
    */
   setCfcPolicyEvaluationMode(mode: CfcPolicyEvaluationMode): void;
+
   /**
    * Set the cross-space label-metadata representation dial (inv-12 Stage 1 /
    * SC-25, spec §4.6.4.1). Anti-downgrade pinned: once `enforce`, weakening
@@ -1483,11 +1508,13 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   setCfcLabelMetadataProtectionMode(
     mode: CfcLabelMetadataProtectionMode,
   ): void;
+
   /**
    * Set the declared-component monotonicity gate dial (WP5, §8.12.1).
    * Anti-downgrade pinned: once `enforce`, weakening throws.
    */
   setCfcDeclaredMonotonicityMode(mode: CfcDeclaredMonotonicityMode): void;
+
   /**
    * Exempt exactly one (doc, path, clauseDigest) triple from the
    * declared-monotonicity gate for this transaction — the §8.12.7 route 2b
@@ -1498,12 +1525,14 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   setCfcDeclaredWideningExemption(
     exemption: CfcDeclaredWideningExemption,
   ): void;
+
   /**
    * Record the addresses whose invalidating writes scheduled this run
    * (§8.9.2 trigger reads). Their labels join the flow-label derivation
    * even when the run never re-reads them.
    */
   addCfcTriggerReads(reads: readonly IMemorySpaceAddress[]): void;
+
   /**
    * The flow-label relevance probe (`cfc/prepare.ts`'s
    * `flowLabelWorkExists`) evaluated ONCE per transaction activity epoch
@@ -1520,6 +1549,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * caller falls back to the free function.
    */
   probeFlowLabelWork?(): boolean;
+
   /**
    * Run `fn` with `meta` merged into every read issued within (explicit
    * per-read meta wins). Lets scheduling machinery tag its reads without
@@ -1994,6 +2024,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
  */
 export interface IStorageTransactionAborted extends IStorageError {
   readonly name: "StorageTransactionAborted";
+
   /**
    * Reason provided when transaction was aborted.
    */
@@ -2089,6 +2120,7 @@ export interface INotFoundError extends IStorageError {
   readonly name: "NotFoundError";
   readonly source: IAttestation;
   readonly address: IMemoryAddress;
+
   /** Path to the non-existent key, or `[]` if the document doesn't exist. */
   readonly path: readonly MemoryAddressPathComponent[];
   from(space: MemorySpace): INotFoundError;
@@ -2145,15 +2177,18 @@ export type IMemoryAddress = {
    * URI to an entity. It corresponds to `of` field in the memory protocol.
    */
   id: URI;
+
   /**
    * Media type of the addressed value. Document addresses omit this; storage
    * boundaries use application/json.
    */
   type?: MediaType;
+
   /**
    * Declared scoped cell instance. Storage defaults omitted scope to `space`.
    */
   scope?: CellScope;
+
   /**
    * The explicit scope INSTANCE this address names (server-execution v2
    * stage A — OW17's instance-keyed replica and wire; key-vocabulary.md
@@ -2174,6 +2209,7 @@ export type IMemoryAddress = {
    * scope NAMES; instances resolve at the reader).
    */
   scopeKey?: ScopeKey;
+
   /**
    * Intra-value path to the {@link FabricValue} being referenced by this
    * address. It is a path within the `is` field of the state in the memory
@@ -2221,19 +2257,24 @@ export interface ISpace {
 export type EventAppendRequest = {
   /** The stream's sidecar doc id (`streamEntriesDocId`). */
   sidecarId: string;
+
   /** The stream link the entry self-describes (events.md §1). */
   stream: { id: string; path: readonly string[]; scope?: CellScope };
+
   /** The durable client-minted event id (event-identity). */
   eventId: string;
+
   /** The event payload — a FabricValue (round-2 thread T23): the type
    * is the admission boundary's own domain, so a payload the memory
    * protocol cannot represent is refused at the CALL SITE'S type check
    * instead of failing (or endlessly retrying) at delivery. */
   payload?: FabricValue;
+
   /** Client-minted append order within this session; allocated by the
    * queue when absent. */
   clientSeq?: number;
   runtimeInjectedEventKeys?: string[];
+
   /** The runtime's attestation that the sent event was renderer-trusted
    * (server-execution v2 fan-out stage B; the sister of
    * `runtimeInjectedEventKeys` — see `StreamEventEntry.rendererTrusted`).
@@ -2323,6 +2364,7 @@ export interface ISpaceReplica extends ISpace {
        * (reset sweeps and origin-drop cascades reach it) — is the
        * ordinary sealed-commit machinery. */
       readonly speculative?: boolean;
+
       /** Server-execution v2 stage A (OW17's tx→replica identity seam):
        * the sealing run's identity when it is not the replica's own. Its
        * operations apply to — and its verdict promotes or rolls back —
@@ -2501,11 +2543,13 @@ export type SealedCommitVerdict =
 export interface SealedNativeCommit {
   /** The replica-local seq the sealed pending writes are keyed by. */
   localSeq: number;
+
   /** The built commit — operations plus the read set (confirmed reads carry
    * the store versions the wave's per-doc CAS and basis rows are computed
    * from; pending reads name earlier sealed commits by localSeq, the
    * in-wave read edges). */
   commit: ClientCommit;
+
   /** Resolves when the verdict has been applied locally (promotion or
    * rollback complete). */
   settled: Promise<Result<Unit, StorageTransactionRejected>>;
@@ -2551,6 +2595,7 @@ export interface TransactionWriteDetail {
   address: IMemorySpaceAddress;
   value?: FabricValue;
   previousValue?: FabricValue;
+
   /**
    * Pre-transaction slot presence at `address.path` — distinguishes an
    * absent slot from a present slot holding `undefined`, which
@@ -2592,6 +2637,7 @@ export type NativeStorageCommitOperation =
 export interface NativeStorageCommit {
   operations: readonly NativeStorageCommitOperation[];
   preconditions?: readonly CommitPrecondition[];
+
   /**
    * Folded SQLite write ops, applied in the same wire commit as `operations`
    * (appended last). They are NOT entity revisions and stay out of the
@@ -2608,6 +2654,7 @@ export type Activity = Variant<{
 export interface IReadActivity extends IMemorySpaceAddress {
   meta: Metadata;
   nonRecursive?: boolean;
+
   /**
    * Position of this read on the transaction's activity clock — a single
    * per-transaction monotonic counter shared with write attempts

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -40,6 +40,7 @@ const cacheHitLogger = getLogger("attestation-hit", {
   enabled: false,
   level: "debug",
 });
+
 /**
  * Cache for parsed data URIs to avoid redundant parsing.
  * Key format: `${address.id}::${address.type}`

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -17,6 +17,7 @@ export const newLoopbackServer = (options?: {
   audience?: string;
   subscriptionRefreshDelayMs?: number | "manual";
   store?: URL;
+
   /** The session registry's detached-session TTL (tests): how long a
    * closed connection's sessions — and their watches, i.e. their DEMAND
    * — linger before pruning. Default 30 s (the server's resume window). */

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -872,6 +872,7 @@ class V2TransactionJournal implements ITransactionJournal {
 export class V2StorageTransaction implements IStorageTransaction {
   changeGroup?: ChangeGroup;
   immediate?: boolean;
+
   /**
    * The scope INSTANCE identity this transaction's scoped reads and
    * writes resolve against (IStorageTransaction.scopeKeyIdentity —

--- a/packages/runner/src/storage/v2-watch.ts
+++ b/packages/runner/src/storage/v2-watch.ts
@@ -35,6 +35,7 @@ type ScopedWatchAddress = {
   id: URI;
   type: MIME;
   scope?: CellScope;
+
   /** The explicit scope INSTANCE an instance-named load targets
    * (server-execution v2 stage A); absent = the session's own. */
   scopeKey?: ScopeKey;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -258,6 +258,7 @@ function conflictAdmissionMode(): ConflictAdmissionMode {
     return "off";
   }
 }
+
 /**
  * Identity of one data-URI pull: the URI, the schema it was read against, the
  * path into it, and where it lives.
@@ -354,6 +355,7 @@ type PendingVersion =
 
 type ConfirmedVersion = MaterializedVersion & {
   seq: number;
+
   /**
    * The class of the covering commit — the commit whose write produced
    * `seq` (speculation.md §4's arrival-witness predicate, RULED
@@ -399,6 +401,7 @@ type PendingCommitRead = {
   id: URI;
   scope?: CellScope;
   path: DocumentPath;
+
   /**
    * Every pending layer the read's materialized view sat on, as an array —
    * each must resolve to an accepted commit (server pending-dependency
@@ -412,6 +415,7 @@ type PendingCommitRead = {
    * commit the client cascade-rejects.
    */
   localSeq: number | number[];
+
   /**
    * The reader's confirmed basis for THIS document, in the SERVER's seq
    * space — the same value the confirmed branch emits as `seq`, which the
@@ -573,6 +577,7 @@ const dropMaterializedSuffix = (
 
 export interface Options {
   as: Signer;
+
   /**
    * Base URL of the default memory host. The storage endpoint path
    * (`/api/storage/memory`) is joined internally — pass the host, not
@@ -580,6 +585,7 @@ export interface Options {
    * WebSocket, or secure WebSocket.
    */
   memoryHost: URL;
+
   /**
    * Optional map from space DIDs to HTTP or HTTPS origin overrides. A space
    * listed here opens its storage connection against that host; absent map or
@@ -591,9 +597,11 @@ export interface Options {
   spaceHostMap?: Record<string, string>;
   id?: string;
   settings?: IRemoteStorageProviderSettings;
+
   /** Space authority used only for fresh named-space ACL genesis. The durable
    *  replica session still authenticates as `as`. */
   spaceIdentity?: Signer;
+
   /** The event-intent queue's store seam (server-execution v2 Phase 3;
    *  events.md §5; LT9 re-ruled 2026-08-15: PROCESS-LIFETIME — reload
    *  survival is a non-goal this round). Absent = one in-memory store per
@@ -601,12 +609,14 @@ export interface Options {
    *  replacement carries the predecessor's undischarged intents to the
    *  successor. Tests inject their own to observe or fail the store. */
   eventAppendQueueStore?: EventAppendQueueStore;
+
   /** OW27 (server-execution v2 Phase 7): the client event-append queue's
    *  per-stream send pacing — pace-never-drop, README §3.8. Absent = the
    *  default posture (`DEFAULT_EVENT_APPEND_PACING`); `false` = unpaced.
    *  Lives only in the flag-gated append path (the OFF arm never
    *  constructs the queue). */
   eventAppendPacing?: EventAppendPacing | false;
+
   /** Server-execution v2 Phase 5: declares this manager a SERVING
    *  manager whose home space is `servingHomeSpace`. Providers opened
    *  for OTHER spaces refuse scoped (user/session) reads fail-closed
@@ -851,26 +861,34 @@ export class StorageManager implements IStorageManager {
   #sessionFactory: SessionFactory;
   #eventAppendQueueStore?: EventAppendQueueStore;
   #eventAppendPacing?: EventAppendPacing | false;
+
   /** Phase 5: the serving manager's home space (Options.servingHomeSpace). */
   #servingHomeSpace?: MemorySpace;
   #spaceIdentities = new Map<MemorySpace, Signer>();
+
   /** Genesis ACL owners registered beside a space identity (OW31): the
    * ACTING user a serving-side provisioning run supplied. Keyed apart so
    * the client path (no owner registered) stays byte-identical. */
   #spaceGenesisOwners = new Map<MemorySpace, string>();
+
   /** Seed map from Options — fixed for the manager's lifetime. */
   #seedHosts: Record<string, string>;
+
   /** Late-bound host hints; see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
+
   /** Base URL the default storage route is resolved from, held as text so a
    *  caller mutating their URL object cannot move the route. */
   #memoryHost: string;
+
   /** WebSocket storage endpoint used by an unseeded, unhinted space; read it
    *  through #resolveDefaultStorageRoute(). */
   #defaultStorageRoute?: string;
+
   /** Whether #defaultStorageRoute holds the result of a resolution attempt.
    *  Separate from the value, which is undefined when resolution failed. */
   #defaultStorageRouteResolved = false;
+
   /** Late-bound marker sink (the Runtime's telemetry bus); see setTelemetry. */
   #telemetry?: TelemetrySink;
 
@@ -1618,6 +1636,7 @@ export class StorageManager implements IStorageManager {
       space: MemorySpace;
       scope: CellScope;
       id: URI;
+
       /** The explicit instance an instance-named load targets (stage A);
        * the key — and the address the scheduler's park machinery
        * cross-matches — is then per THAT instance. */
@@ -2056,6 +2075,7 @@ type ProviderOptions = {
   space: MemorySpace;
   settings: IRemoteStorageProviderSettings;
   subscription: IStorageSubscription;
+
   /**
    * The owning manager's authenticated session identity
    * (IStorageManager.scopeKeyIdentity) — what the replica's notification
@@ -2070,12 +2090,16 @@ type ProviderOptions = {
   syncReplayDependencies: (
     document: EntityDocument | undefined,
   ) => Promise<Error | undefined>;
+
   /** Late-bound: resolves to the Runtime's telemetry bus once attached. */
   getTelemetry?: () => TelemetrySink | undefined;
+
   /** The LT9 event-intent persistence seam (see Options). */
   eventAppendQueueStore?: EventAppendQueueStore;
+
   /** OW27 per-stream send pacing (see Options). */
   eventAppendPacing?: EventAppendPacing | false;
+
   /** Server-execution v2 Phase 5 (protocol.md §2's grant-scoped read
    * design, RULED 2026-08-13 — the delegated-scoped-read fail-closed
    * precondition): set on a SERVING manager's FOREIGN-space providers.
@@ -2096,6 +2120,7 @@ type ProviderSyncRequest = {
   uri: URI;
   selector: SchemaPathSelector;
   scope?: CellScope;
+
   /** The explicit instance an instance-named load targets (stage A). */
   instance?: ScopeKey;
 };
@@ -2342,6 +2367,7 @@ type WatchAddress = {
   id: URI;
   type: MIME;
   scope?: CellScope;
+
   /** The explicit instance an instance-named load targets (stage A). */
   scopeKey?: ScopeKey;
 };
@@ -2396,6 +2422,7 @@ class StorageTransactionRejectionError extends Error {
  */
 type InFlightCommit = {
   readonly localSeq: number;
+
   /**
    * The unique localSeqs named by `commit.reads.pending` — every in-flight
    * commit this one's read view sits on (resolution-only lower-layer reads
@@ -2405,22 +2432,26 @@ type InFlightCommit = {
   readonly operations: NativeCommitOperation[];
   readonly source?: IStorageTransaction;
   readonly commit: ClientCommit;
+
   /** The identity the commit's operations were applied under (a served
    * per-instance run's; absent = the replica's own) — its verdict
    * promotes or drops exactly those instances' pending layers. */
   readonly identity?: ScopeKeyIdentity;
+
   /**
    * Resolves when a rejection is fabricated locally for this commit (a
    * pending dependency was dropped, or the replica reset). Raced against the
    * server verdict in `pushCommit`.
    */
   readonly localRejection: PromiseWithResolvers<StorageTransactionRejected>;
+
   /**
    * Set synchronously BEFORE `localRejection` resolves, so `pushCommit`'s
    * pre-send checkpoints can observe the rejection without racing the
    * microtask queue. `undefined` means "not locally rejected".
    */
   localRejectionValue?: StorageTransactionRejected;
+
   /** True once `pushCommit`'s finally ran — the outcome is finalized and the
    * entry can no longer be cascaded. */
   settled: boolean;
@@ -2453,6 +2484,7 @@ class SpaceReplica implements ISpaceReplica {
   readonly #space: MemorySpace;
   readonly #subscription: IStorageSubscription;
   readonly #scopeKeyIdentity: () => ScopeKeyIdentity;
+
   /** The replica's OWN instance keys per scope name, resolved once (the
    * manager's identity is stable for the manager's live span — `close()`
    * ends it and the replicas with it): the doc-key hot path resolves an
@@ -2467,9 +2499,11 @@ class SpaceReplica implements ISpaceReplica {
     client: MemoryV2Client.Client;
     session: MemoryV2Client.SpaceSession;
   }>;
+
   /** The client of the last RESOLVED session handle — for synchronous
    *  capability reads (`sqliteServerCommitRowLabelEval`). */
   #sessionClient?: MemoryV2Client.Client;
+
   /** The session of the last RESOLVED handle — read synchronously so
    *  `authorizationError()` can observe a denial that terminated the session
    *  during reconnect, which closes its watch view without a fresh watch result
@@ -2530,6 +2564,7 @@ class SpaceReplica implements ISpaceReplica {
   );
   #watchedIds = new Set<string>();
   #nextLocalSeq = 1;
+
   /** The Phase-3 event-intent queue (events.md §5, LT9), created on the
    * first fire into this space. Owns fired-order discharge and the
    * duplicate-as-delivered classification; its entries are the client's
@@ -2537,6 +2572,7 @@ class SpaceReplica implements ISpaceReplica {
   #eventAppendQueue?: EventAppendQueue;
   #eventAppendQueueStore?: EventAppendQueueStore;
   #eventAppendPacing?: EventAppendPacing | false;
+
   /** Phase 5's producer-side foreign-scoped-read refusal (see
    * ProviderOptions.refuseForeignScopedReads). */
   #refuseForeignScopedReads = false;
@@ -2556,6 +2592,7 @@ class SpaceReplica implements ISpaceReplica {
   #parkedAccepts = new Map<number, {
     operations: NativeCommitOperation[];
     applied: AppliedCommit;
+
     /** Resolves when the parked application runs — the commit promise's
      * resolution point (CT-1950): the caller may then act on its
      * subscribed view as one reflecting the committed write. */
@@ -3153,6 +3190,7 @@ class SpaceReplica implements ISpaceReplica {
    * decision) runs inside settlement, so consulting the parked set
    * before settlement would race it.
    */
+
   /**
    * Queue one event append for this space (server-execution v2 Phase 3;
    * events.md §1, §5): the client's ONLY computational commit under the


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 443 doc comments across 47 files had no blank line above them; each
gets one.

Covered: `packages/runner/src/cfc`, `executor`, `sandbox`, `scheduler`, and
`storage`. The `src` top level and its remaining subtrees are #6351; the `test`
tree follows in its own PR.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

Sweeping this group is what turned up the union carve-out now stated in the
rule: five of the 448 candidate sites were doc comments on the arms of a union
type, where `deno fmt` removes the blank line. The formatter took those five
back out, leaving 443.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/runner`'s own test
task, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`, and
`check-withheld-globals` all pass locally. GitHub Actions is in an outage as this
is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

