### PR TITLE
docs(runner): blank lines above doc comments in `test` and `integration`

### DIFF
--- a/packages/runner/test/async-work-registration.test.ts
+++ b/packages/runner/test/async-work-registration.test.ts
@@ -1,4 +1,5 @@
 /// <reference path="./clock.d.ts" />
+
 /**
  * Async builtin work must reach `runtime.trackAsyncWork()`, and it must reach
  * it under the run that started it.

--- a/packages/runner/test/bench-write-accounting.ts
+++ b/packages/runner/test/bench-write-accounting.ts
@@ -29,8 +29,10 @@ import type { IAttestation } from "../src/storage/interface.ts";
 export interface WrittenValue {
   /** The document the write landed in. */
   id: string;
+
   /** Where in the document it landed. */
   path: readonly string[];
+
   /** What it put there; undefined when the write removed the slot. */
   value: unknown;
 }
@@ -39,6 +41,7 @@ export interface WrittenValue {
 export interface WriteAccount {
   /** Documents the transaction wrote to. */
   docs: number;
+
   /** JSON bytes it wrote into them. */
   bytes: number;
 }

--- a/packages/runner/test/edit-with-retry-classification.test.ts
+++ b/packages/runner/test/edit-with-retry-classification.test.ts
@@ -248,6 +248,7 @@ const TEST_AUDIENCE = "did:key:z6Mk-runner-retry-classification-audience";
 
 class CountingLoopbackSessionFactory implements SessionFactory {
   readonly supportsAclBootstrap = true;
+
   /** Commits sent for the ACL document, across all sessions. */
   aclCommits = 0;
   #aclDocId: string;
@@ -399,8 +400,10 @@ Deno.test("a server ProtocolError reaches editWithRetry by name, once", async ()
 // in storage/rejection.ts.
 class SessionErrorSessionFactory implements SessionFactory {
   readonly supportsAclBootstrap = true;
+
   /** Mounts created — how many times a session was (re)opened. */
   sessions = 0;
+
   /** transact() calls made after `arm()`. */
   commits = 0;
   #armed = false;

--- a/packages/runner/test/executor-dprime-w0.test.ts
+++ b/packages/runner/test/executor-dprime-w0.test.ts
@@ -296,6 +296,7 @@ describe("W1 (d′): demand = the tracked-ids closure, the walk deleted", () => 
     names: { arg: string; result: string };
     pattern?: string;
     clients: Identity[];
+
     /** Extra ARGUMENT fields seeded beside `{ n: 1 }` (a pin that needs
      * a holder cell or a cross-piece link in the outer piece's arg). */
     argExtras?: (alice: Runtime) => Promise<Record<string, unknown>>;

--- a/packages/runner/test/executor-effect-channel.test.ts
+++ b/packages/runner/test/executor-effect-channel.test.ts
@@ -279,6 +279,7 @@ describe("Phase 4 client-effect channel", () => {
     options: {
       navigations?: string[];
       sessionId?: string;
+
       /** Custom navigate callback (wins over `navigations`) — the
        * enactment-failure tests inject throwing callbacks here. */
       navigate?: (

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -84,6 +84,7 @@ class GatedStorageManager extends EmulatedStorageManager {
   settleGateWhen: (() => boolean) | undefined;
   syncGate: Promise<void> | undefined;
   syncGateWhen: ((id: string) => boolean) | undefined;
+
   /** How many syncs the sync gate has parked (a pin's evidence that a
    * drain WAS held in the window it constructs). */
   syncGateHits = 0;
@@ -105,6 +106,7 @@ class GatedStorageManager extends EmulatedStorageManager {
    * runtime tenures (each with a fresh manager), and the seam must hold
    * across every tenure of the pass under test. */
   static syncThrowWhen: ((id: string) => boolean) | undefined;
+
   /** How many syncs the throw seam refused — each drain pass that
    * touched the failing sidecar counts one. */
   static syncThrowHits = 0;
@@ -266,6 +268,7 @@ describe("Phase 3 events-down (serving side)", () => {
   let clientRuntime: Runtime;
   let extraManagers: EmulatedStorageManager[];
   let extraRuntimes: Runtime[];
+
   /** The live serving runtime/manager (set by newHost's createRuntime)
    * — the C8d raced-cascade test reads sealed state through them and
    * closes the settle gate. */
@@ -2201,6 +2204,7 @@ describe("Phase 3 events-down (serving side)", () => {
     const entriesOf = (sidecarId: string) =>
       ((Engine.read(engine, { id: sidecarId })?.value ??
         {}) as StreamEventsDocValue).entries ?? [];
+
     /** Derived commits whose consequenceOf names `eventId` — the
      * store-side per-event completed-run count (events.md §4: per-event
      * run counts are the signature; `processed == appended` is not). */

--- a/packages/runner/test/executor-outbox.test.ts
+++ b/packages/runner/test/executor-outbox.test.ts
@@ -70,6 +70,7 @@ describe("stage G outbox + sqlite discharge", () => {
   let storageManager: EmulatedStorageManager;
   let runtime: Runtime;
   let engine: Engine.Engine;
+
   /** One process-lifetime counter per test, shared by every sink and
    * outbox (the replay-keying discipline — engine-wave-sink.ts). */
   let localSeqRef: { value: number };

--- a/packages/runner/test/executor-run-supply.test.ts
+++ b/packages/runner/test/executor-run-supply.test.ts
@@ -53,6 +53,7 @@ const bob = { principal: "did:key:p2f-bob", sessionId: "bob-s1" as never };
 describe("stage P2-F per-(action × instance) run supply", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
+
   /** Every ServerRunInfo the production stamping choke points hand the
    * installed stamper, in order. */
   let stamped: ServerRunInfo[];

--- a/packages/runner/test/executor-serving-loop.test.ts
+++ b/packages/runner/test/executor-serving-loop.test.ts
@@ -115,6 +115,7 @@ describe("stage F serving loop", () => {
   let clientRuntime: Runtime;
   let servingRuntime: Runtime | undefined;
   let onServingRuntime: ((runtime: Runtime) => Promise<void>) | undefined;
+
   /** Stage G: the serving runtime's injected fetch (egress stub) —
    * effectful builtins served by the loop call THIS, never the network. */
   let servingFetch:

--- a/packages/runner/test/executor-space-root-ensure.test.ts
+++ b/packages/runner/test/executor-space-root-ensure.test.ts
@@ -104,6 +104,7 @@ describe("SpaceServer space-root ensure (OW45 arm-B stage 1)", () => {
   let mintedTxs: IExtendedStorageTransaction[];
   let stats: ServingLoopStats;
   let cleanups: Array<() => Promise<void>>;
+
   /** ONE localSeq counter across every SpaceServer this test builds —
    * the HOST's contract (host.ts #sinkLocalSeq: the counter is
    * process-lifetime and SURVIVES park/re-activate, because every

--- a/packages/runner/test/executor-space-server.test.ts
+++ b/packages/runner/test/executor-space-server.test.ts
@@ -1381,6 +1381,7 @@ describe("stage G SpaceServer recovery seams", () => {
         probe: string;
         pieceRootId: string;
         actionId: string;
+
         /** The EARLY-EMIT shape (fan-out stage B): send FIRST, read user
          * scope AFTER. */
         emitBeforeRead?: boolean;

--- a/packages/runner/test/executor-warm-request.test.ts
+++ b/packages/runner/test/executor-warm-request.test.ts
@@ -93,6 +93,7 @@ describe("executor-warm-request", () => {
   let clientManager: SharedServerStorageManager;
   let clientRuntime: Runtime;
   let servingRuntime: Runtime | undefined;
+
   /** One-shot activation-failure stub (the post-drain failure pin): the
    * next runtime construction for this space THROWS — the activation
    * dies inside `server.activate()` and lands in the host's

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -1,4 +1,5 @@
 /// <reference path="./clock.d.ts" />
+
 /**
  * Integration tests for generateObject with tool calling support.
  *

--- a/packages/runner/test/handler-overload-types.test.ts
+++ b/packages/runner/test/handler-overload-types.test.ts
@@ -32,6 +32,7 @@ import { handler } from "../src/builder/module.ts";
 
 type MustBeTrue<T extends true> = T;
 type Same<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
 /** Identity equality — distinguishes readonly modifiers, which assignability
  * (and therefore `Same`) ignores. */
 type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends

--- a/packages/runner/test/list-container-link-reissue.test.ts
+++ b/packages/runner/test/list-container-link-reissue.test.ts
@@ -109,6 +109,7 @@ const makeServer = () =>
 /** How one reconcile of the coordinator under test went. */
 type ReconcileRecord = {
   attempt: number;
+
   /** Whether this reconcile called `sendResult`, the container link's only writer. */
   issuedLink: boolean;
   outcome: string;

--- a/packages/runner/test/list-element-issuance-ownership.test.ts
+++ b/packages/runner/test/list-element-issuance-ownership.test.ts
@@ -24,8 +24,10 @@ const space = signer.did();
 type Outcome = {
   rejection: string | undefined;
   aggregate: unknown;
+
   /** Ids of element documents left without a `result` meta. */
   missing: string[];
+
   /** The element the held reconcile created. */
   createdId: string | undefined;
 };

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -69,8 +69,10 @@ class ResumeBatchGate {
   readonly #open: [boolean, boolean] = [false, false];
   readonly #resolve: [(() => void) | undefined, (() => void) | undefined];
   #deliver: (payload: string) => void = () => {};
+
   /** Resolves once a top-level document has been held back. */
   readonly topHeld: Promise<void>;
+
   /** Resolves once a per-element document has been held back. */
   readonly elementsHeld: Promise<void>;
   constructor() {
@@ -109,10 +111,12 @@ class ResumeBatchGate {
       setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
     };
   }
+
   /** How many documents of a stage are currently held back. */
   heldCount(stage: 0 | 1): number {
     return this.#held[stage].length;
   }
+
   /** Open a stage and flush every document it holds. */
   release(stage: 0 | 1): void {
     this.#open[stage] = true;

--- a/packages/runner/test/llm-dialog-message-drop.test.ts
+++ b/packages/runner/test/llm-dialog-message-drop.test.ts
@@ -1,4 +1,5 @@
 /// <reference path="./clock.d.ts" />
+
 /**
  * A message added while a dialog turn is already running is dropped, and how
  * `addMessage` decides a turn is still running depends on who is running it.

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -277,6 +277,7 @@ class RecordingWebSocket extends EventTarget {
       },
     );
   }
+
   /** Resolves once `count` sockets have been dialed — no polling. */
   static whenDialed(count: number): Promise<void> {
     if (RecordingWebSocket.dialed.length >= count) return Promise.resolve();

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -97,6 +97,7 @@ type AppliedRecord = {
 type RejectionError = {
   name: string;
   message: string;
+
   /**
    * Mirrors the real server's retryable-conflict marker: the client attaches
    * `readyToRetry` (the read-repair gate) ONLY when a ConflictError carries a
@@ -116,6 +117,7 @@ type ScriptedOutcome =
     remoteInterleave?: RemoteCommit;
     responseGate?: Promise<void>;
     onReceipt?: () => void;
+
     /**
      * Skip validateReads for this commit. Forces the "impossible" late
      * accept — a server verdict resolving a pending dependency the client
@@ -128,6 +130,7 @@ type ScriptedOutcome =
   | {
     kind: "rejectConflict";
     message?: string;
+
     /** See {@link RejectionError.retryAfterSeq}. */
     retryAfterSeq?: number;
     remoteInterleave?: RemoteCommit;
@@ -564,9 +567,11 @@ type PushSyncOptions = {
     value?: RootValue;
     deleted?: true;
   }>;
+
   /** Wire REMOVES (the watch-scope eviction frame): carry NO seq — the
    * shape whose shadow records the sentinel floor 1. */
   removes?: Array<{ id: URI }>;
+
   /** The server's caught-up marker: resolves client + runner read-repair
    * waiters for every localSeq <= this value. */
   caughtUpLocalSeq?: number;

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -149,8 +149,10 @@ export abstract class ScriptedSessionTransport
     private readonly script: {
       /** Challenge-id prefix; keep unique per transport class. */
       name: string;
+
       /** sessionId confirmed on session.open and stamped on effect frames. */
       sessionId: string;
+
       /** The space effect frames (emitSync) are addressed to. */
       space: MemorySpace;
     },

--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -132,8 +132,10 @@ const noSchema = {
 type BuildOpts = {
   /** number of `$alias` leaves (≈ the cell references in the binding) */
   aliases: number;
+
   /** depth of each alias path into the schema (1..4) */
   pathDepth?: number;
+
   /** put an explicit asCell schema on each alias (as the transformer emits) */
   aliasSchema?: boolean;
 };

--- a/packages/runner/test/resume-append-scenario.ts
+++ b/packages/runner/test/resume-append-scenario.ts
@@ -44,6 +44,7 @@ class Gate {
   #held: string[] = [];
   #deliver: (payload: string) => void = () => {};
   #firstHeldResolve: (() => void) | undefined;
+
   /**
    * Resolves the first time a matching document is held back — the edge that the
    * coordinator has reconciled the resume batch (it has read, and so requested,
@@ -72,10 +73,12 @@ class Gate {
       setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
     };
   }
+
   /** How many matching documents are currently held back. */
   get heldCount(): number {
     return this.#held.length;
   }
+
   /** Open the gate and flush every held document to the client. */
   release(): void {
     this.#open = true;
@@ -133,20 +136,27 @@ export interface AppendScenario {
   readonly space: MemorySpace;
   readonly server: MemoryV2Server.Server;
   readonly program: RuntimeProgram;
+
   /** Result cell id in the space. */
   readonly cellId: string;
+
   /** Result field the aggregate is published under (e.g. "kept"/"values"). */
   readonly resultKey: string;
+
   /** Initial input list. */
   readonly items: readonly unknown[];
+
   /** Element appended during the resume window. */
   readonly appended: unknown;
+
   /** Replace the default append with another input-list update. */
   readonly updateItems?: (current: unknown[]) => unknown[];
+
   /** Extract the comparable aggregate from the result cell for assertions. */
   readonly read: (
     rc: { key: (k: string) => { getAsQueryResult: () => unknown } },
   ) => unknown[];
+
   /** Expected aggregate after the first-runtime build. */
   readonly buildExpected: unknown[];
 }

--- a/packages/runner/test/resume-owned-cells-skip-log.test.ts
+++ b/packages/runner/test/resume-owned-cells-skip-log.test.ts
@@ -141,6 +141,7 @@ const unbindableOutputsPattern = {
 type SkipCase = {
   name: string;
   pattern: Pattern;
+
   /**
    * Seed the result cell with a prior run, so the run under test resumes a
    * stored root whose argument meta link is already written.
@@ -149,8 +150,10 @@ type SkipCase = {
   level: "debug" | "warn";
   message: string;
   node: string;
+
   /** Parts the call carries ahead of the identity payload. */
   leadingParts: number;
+
   /** How the run under test is expected to end. */
   rejectsWith?: RegExp;
 };

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -75,6 +75,7 @@ class LoopbackSessionFactory implements SessionFactory {
  */
 class CountingStorageManager extends StorageManager {
   closeCount = 0;
+
   /** Subscriptions handed to `subscribe` and not yet handed back. Mirrors the
    * calls reaching the manager, which is what the assertions below are about;
    * the relay's own membership is private, and its `hasSubscribers()` would
@@ -121,8 +122,10 @@ class FailingCloseStorageManager extends CountingStorageManager {
 
 describe("runtime.dispose({ closeStorage })", () => {
   let server: MemoryV2Server.Server;
+
   /** The store under test — handed to a runtime that does not own it. */
   let held: CountingStorageManager;
+
   /** An independent view of the same durable state, for witnessing writes. */
   let witness: CountingStorageManager;
   let witnessRuntime: Runtime;

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -87,6 +87,7 @@ const DEPLOYMENT_FACING: PresetName[] = [
 ];
 
 type MinimalTreatment =
+
   /** Equals the sentinel passed in, in every preset. */
   | { treat: "per-site" }
   /** Present in every preset with this exact shared value. */

--- a/packages/runner/test/sandbox-timers.test.ts
+++ b/packages/runner/test/sandbox-timers.test.ts
@@ -1,4 +1,5 @@
 /// <reference path="./clock.d.ts" />
+
 /**
  * The SES pattern compartment endows no timers (part of the structural barrier
  * pinned by security-timing.test.ts). Code that wants a delay in both a host

--- a/packages/runner/test/speculation-intent-listener.test.ts
+++ b/packages/runner/test/speculation-intent-listener.test.ts
@@ -702,6 +702,7 @@ const W21_SIDECAR = "of:stream-events:w21-click";
  * notifications (the production carrier). */
 const cascadeDestination = () => {
   let nextLocalSeq = 10;
+
   /** The confirmed read seq the NEXT seal reports (the entry's floor). */
   let nextFloor = 40;
   const confirmedSeqs = new Map<string, number>();
@@ -744,6 +745,7 @@ const cascadeDestination = () => {
     getCellFromLink: () => ({ sink: () => () => {} }),
   } as never;
   const destination = new SpeculationOverlayDestination(runtime);
+
   /** An event-handler echo's transaction: `writes` are whole-doc sets
    * (the lunch shape: the list doc + the new user's entity doc); an
    * empty list seals NOTHING (a child that only forwards). */
@@ -753,6 +755,7 @@ const cascadeDestination = () => {
       parentEventId?: string;
       writes: string[];
       floor?: number;
+
       /** Hold `sealInto` open until this settles — the mid-seal window
        * (the post-await re-check's subject: a mark landing while the
        * seal is in flight). */
@@ -799,6 +802,7 @@ const cascadeDestination = () => {
     });
     return tx;
   };
+
   /** Land P's append, then its consequenced mark, as two notifications;
    * `landed` sets the confirmed seqs the mark's frame carries (the
    * server's cascade child landing in the same wave, or not). */
@@ -811,6 +815,7 @@ const cascadeDestination = () => {
       })),
     });
   };
+
   /** The mark's frame: the sidecar itself lands at `markSeq` (the mark
    * is written in the consequence commit), and `landed` names the docs
    * that commit — or an earlier one — also moved, with their seqs. */

--- a/packages/runner/test/speculation-intent-test-utils.ts
+++ b/packages/runner/test/speculation-intent-test-utils.ts
@@ -40,20 +40,27 @@ export type ScriptedIntentManager = {
       sync(id: string, selector: unknown, scope?: string): Promise<unknown>;
     };
   };
+
   /** Live subscribers (the relay's set). */
   readonly subscribers: Set<IStorageNotification>;
+
   /** `sync` calls seen: `${space}\0${id}\0${scope}`. */
   readonly syncs: string[];
+
   /** Make the NEXT `sync` resolve `{ error }` (a transient pull failure);
    * later calls succeed again. */
   failNextSync(error?: unknown): void;
+
   /** Raw doc reads seen. */
   readonly reads: string[];
+
   /** Whether a notification dispatch is currently on the stack (a
    * consumer that runs INSIDE `next` sees `true`). */
   readonly dispatching: () => boolean;
+
   /** Set (or replace) a sidecar doc's value without notifying. */
   seed(space: MemorySpace, id: string, value: StreamEventsDocValue): void;
+
   /** Mutate the doc and dispatch ONE notification with the given change
    * paths (default: one whole-doc change at `[]`). Returns synchronously
    * — the overlay's check runs in a MICROTASK. */
@@ -64,6 +71,7 @@ export type ScriptedIntentManager = {
     paths?: string[][],
     type?: "commit" | "integrate" | "pull" | "load",
   ): void;
+
   /** Mutate SEVERAL docs and dispatch ONE notification whose merged
    * changes span them — one frame carrying a wave commit that marks two
    * of this client's sidecars (two streams fired by one client in one
@@ -77,6 +85,7 @@ export type ScriptedIntentManager = {
     }>,
     type?: "commit" | "integrate" | "pull" | "load",
   ): void;
+
   /** Dispatch a storage RESET for the space. */
   reset(space: MemorySpace): void;
 };

--- a/packages/runner/test/sqlite-served-identity.test.ts
+++ b/packages/runner/test/sqlite-served-identity.test.ts
@@ -254,6 +254,7 @@ describe("sqlite-served-identity", () => {
       parent,
       runtime,
     );
+
     /** A SECOND instance of the same query (fresh parent, fresh result
      * cell, fresh per-closure in-flight set) — the determinism pin's
      * probe: nothing per-instance may reach the request hash. */

--- a/packages/runner/test/traverse-replay/profile-driver.ts
+++ b/packages/runner/test/traverse-replay/profile-driver.ts
@@ -11,6 +11,7 @@
 const fixtureName = Deno.args[0] ?? "notebook-test";
 const rounds = Deno.args[1] ?? "2";
 const outPrefix = Deno.args[2] ?? `/tmp/traverse-${fixtureName}`;
+
 /** Optional: forwarded to profile-target to replay a single invocation. */
 const onlyInvocation = Deno.args[3];
 const INSPECT_PORT = 9911;

--- a/packages/runner/test/traverse-replay/profile-target.ts
+++ b/packages/runner/test/traverse-replay/profile-target.ts
@@ -10,6 +10,7 @@ import { loadFixture, replayFixture } from "./replay.ts";
 
 const name = Deno.args[0] ?? "notebook-test";
 const rounds = Number(Deno.args[1] ?? "2");
+
 /** Optional: replay only the invocation at this index (tail analysis). */
 const onlyInvocation = Deno.args[2] !== undefined
   ? Number(Deno.args[2])

--- a/packages/runner/test/traverse-replay/replay.ts
+++ b/packages/runner/test/traverse-replay/replay.ts
@@ -47,16 +47,20 @@ import { readMaybeGzippedText } from "./gzip.ts";
 
 export type ReplayInvocationOracle = {
   ok: boolean;
+
   /** TraverseFailure code when ok is false. */
   code?: string;
+
   /** Truncated structural hash of the returned value ("undefined" if so). */
   hash: string;
 };
 
 export type ReplayOracle = {
   invocations: ReplayInvocationOracle[];
+
   /** Sorted unique read descriptors: `space|scope|id|<json path>|flags`. */
   readSet: string[];
+
   /**
    * Per context id: sorted `trackerKey::selectorHash` entries. Only contexts
    * shared by multiple invocations or with includeMeta (the server query
@@ -100,6 +104,7 @@ export type ReplayLatencySample = {
   ms: number;
   selector: number;
   docId: string;
+
   /** Counter deltas for this single invocation. */
   schemaCalls: number;
   anyOfBranches: number;
@@ -114,6 +119,7 @@ export type ReplayLatencyReport = {
   p999: number;
   max: number;
   mean: number;
+
   /** The N slowest invocations, slowest first. */
   slowest: ReplayLatencySample[];
 };
@@ -251,6 +257,7 @@ export function replayFixture(
   options: {
     collectOracle?: boolean;
     limit?: number;
+
     /** Collect per-invocation latency samples (slight timing overhead). */
     collectLatency?: boolean;
   } = {},


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 81 doc comments across 33 files had no blank line above them; each
gets one.

Covered: `packages/runner/test` and `packages/runner/integration`. The `src`
tree is #6351 and #6352, which completes `runner`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/runner`'s own test
task, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`, and
`check-withheld-globals` all pass locally. GitHub Actions is in an outage as this
is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

