### PR TITLE
docs(cli): blank lines above doc comments in `lib`

### DIFF
--- a/packages/cli/lib/bulk.ts
+++ b/packages/cli/lib/bulk.ts
@@ -88,12 +88,16 @@ async function resolveSelector(
 /** What one repair run is asked to do, parsed off the command line. */
 export interface RepairRunRequest {
   selector: PieceSelector;
+
   /** The fixer module's absolute path, for the import. */
   fixerPath: string;
+
   /** The fixer's name as supplied, recorded in the emitted plan. */
   fixerName: string;
+
   /** A plan file to execute, row for row, under its preconditions. */
   planPath?: string;
+
   /** Write the fixer's documents; absent, the run is the dry report. */
   apply?: boolean;
 }
@@ -102,13 +106,16 @@ export interface RepairRunDependencies {
   loadPieces?: typeof loadPieces;
   resolvePieceAddress?: typeof resolvePieceAddress;
   readTextFile?: (path: string) => Promise<string>;
+
   /**
    * Resolve the fixer's closure snapshot — the one read of the authored
    * sources that both the identity and the execution come from.
    */
   resolveFixerProgram?: (path: string) => Promise<RuntimeProgram>;
+
   /** The snapshot's closure identity. */
   programIdentity?: (program: RuntimeProgram) => Promise<string>;
+
   /** Execute the snapshot — never the path it was read from. */
   importProgram?: (program: RuntimeProgram) => Promise<unknown>;
 }
@@ -221,10 +228,13 @@ export interface RetargetRunRequest {
    * moves to, so a retarget carries no selection of its own.
    */
   planPath: string;
+
   /** Write each row's source; absent, the run is the classification alone. */
   apply?: boolean;
+
   /** Pieces one session serves before it is replaced. */
   groupSize?: number;
+
   /** Called as each row settles, for reporting as the run proceeds. */
   onRow?: (row: RetargetRow) => void;
 }
@@ -322,14 +332,17 @@ export interface PhaseRetarget {
 export interface SurveyRunRequest {
   selector: PieceSelector;
   retargets?: readonly PhaseRetarget[];
+
   /**
    * Stamped onto every retarget row as `op.allowIncompatible` — the plan
    * shows which rows would run with the compatibility gate open, and the
    * apply honors only the row field.
    */
   allowIncompatible?: boolean;
+
   /** Path to a JSON-schema file each piece's result is read under. */
   validatorPath?: string;
+
   /** The plan header's `takenAt`; defaults to now. */
   takenAt?: string;
 }

--- a/packages/cli/lib/callable-command.ts
+++ b/packages/cli/lib/callable-command.ts
@@ -16,8 +16,10 @@ import {
 export interface CallableCommandExecutionResult<TResolved> {
   helpText?: string;
   outputText?: string;
+
   /** Handler invocation outcome, passed through from ExecutedCallable. */
   invocation?: InvocationOutcome;
+
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
@@ -33,6 +35,7 @@ export interface CallableCommandExecutionOptions<
   commandSpec: ExecCommandSpec;
   rawArgs: string[];
   deps?: TDeps;
+
   /** Render the help page, once the parse has established one was asked for.
    *
    * Allowed to be async so a renderer can resolve something it needs ONLY

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -65,6 +65,7 @@ export interface CallableResolution {
   cellKey: string;
   pieces: PiecesController;
   space: MemorySpace;
+
   /** This verb's declared result, resolved on demand.
    *
    * A THUNK rather than a value, because reaching it costs a pattern load and
@@ -78,6 +79,7 @@ export interface CallableResolution {
    * to consult — which says this resolution cannot describe a result rather
    * than promising there is none. */
   declaredResult?: () => Promise<JSONSchema | undefined>;
+
   /** The verb's declared event schema — the input contract as the handler
    * module in the compiled pattern states it, reference markers intact.
    *
@@ -95,6 +97,7 @@ export interface CallableResolution {
    * the same conditions. Only a dispatch the published shape refuses pulls
    * it — the load rides the refusal path, never a clean dispatch. */
   declaredEvent?: () => Promise<JSONSchema | undefined>;
+
   /** The verb's published event schema, when the resolution knows a richer
    * one than the dispatch cell carries.
    *
@@ -141,12 +144,15 @@ export interface InvocationIdentity {
 
 export interface CallableExecutionDeps {
   uuid?: () => string;
+
   /** The id and session naming this call's invocation, for a handler send.
    * Absent for a call that names no invocation, which is then dispatched
    * under a runtime-minted event id and has no receipt to come back for. */
   invocation?: InvocationIdentity;
+
   /** Phase observer for early-exit reporting. */
   onPhase?: (phase: InvocationPhase) => void;
+
   /** `--no-wait`: await this handling's transaction-local commit
    * acknowledgment, then return WITHOUT the receipt readback (sync + read).
    * The commit acknowledgment cannot be skipped: the handler executes in
@@ -161,6 +167,7 @@ export interface CallableExecutionDeps {
    * come back for — and only the handler send path supports it (a tool's
    * result is delivered by this process, not read back from a receipt). */
   skipReadback?: boolean;
+
   /** `--show-links`: annotate the Invocation JSON with a `links` dictionary
    * mapping result paths to their backing cell addresses (verb contract
    * WS-F, F2). Provenance rides BESIDE the value, never inline — an inline
@@ -169,6 +176,7 @@ export interface CallableExecutionDeps {
    * document, so plain JSON inside one doc adds nothing. Rides the receipt
    * readback, which is why it cannot combine with `--no-wait`. */
   showLinks?: boolean;
+
   /** `--filter`/`--select`/`--schema`: the shape the caller asked the result
    * to arrive in. Answered by the same selection step `cf piece get` reads
    * through, so one grammar covers reads and calls.
@@ -185,6 +193,7 @@ export interface CallableExecutionDeps {
    * keeps returning nothing — there is no value for a selection to be
    * about. */
   selection?: CellSelection;
+
   /** @internal Seam for tests, mirroring `getCellValue`'s. */
   deriveSelectedValue?: typeof deriveSelectedValue;
 }
@@ -200,11 +209,13 @@ export type InvocationResultLink = string;
 /** The outcome of a handler invocation made with a caller-supplied id. */
 export interface InvocationOutcome {
   id: string;
+
   /** `"settled"` once receipt readback completed. Otherwise the furthest
    * phase the caller chose to observe: `--no-wait` returns at `"committed"`
    * (commit acknowledged, readback skipped), and a caller-bounded wait
    * reports the phase its bound expired in. */
   status: "settled" | InvocationPhase;
+
   /** Durable address of this handling's receipt — the cell the outcome is
    * written to, and the one `result` is read from.
    *
@@ -229,13 +240,16 @@ export interface InvocationOutcome {
    * off nothing writes a receipt, and an address naming a cell that does not
    * exist is worse than no address. */
   receipt?: InvocationResultLink;
+
   /** The verb's result read back from the handling's receipt, when the
    * receipt carried one (a reactive-bearing return, or a plain return under
    * the plainResultReceipts flag). Absent for value-less verbs. */
   result?: unknown;
+
   /** True when this call collided on the create-only receipt: the handling
    * did not commit again, and `result` is the ORIGINAL outcome. */
   deduplicated?: boolean;
+
   /** Under `--show-links` only: result paths mapped to their backing cell
    * addresses in canonical reference syntax, provenance beside the value the
    * caller can pass straight back to `--piece`. The root `"/"` entry is the
@@ -288,8 +302,10 @@ export function canonicalAddress(ref: CallableResultRef): string {
 
 export interface ExecutedCallable {
   outputText?: string;
+
   /** Present for handler sends carrying a caller-supplied invocation id. */
   invocation?: InvocationOutcome;
+
   /** The tool result cell's address — the handle a caller can revisit later
    * instead of re-running the tool (verb contract Part 2,
    * docs/plans/pattern-verb-contract.md). Handlers gain their equivalent with
@@ -561,6 +577,7 @@ export interface DeclaredEventFields {
    * declared more than once keeps its FIRST account, in declaration order,
    * which is the rule the refusal vocabulary already follows. */
   properties: Record<string, JSONSchema>;
+
   /** Names any member marks required. */
   required: Set<string>;
 }

--- a/packages/cli/lib/cell-selection.ts
+++ b/packages/cli/lib/cell-selection.ts
@@ -918,6 +918,7 @@ function normalizeProjectionSchema(
 /** A field name one concise path segment names, and what it asks for there. */
 interface ConciseSegment {
   name: string;
+
   /** The segment ended in an unescaped {@link CONCISE_ADDRESS_SUFFIX}. */
   marked: boolean;
 }
@@ -1221,6 +1222,7 @@ const DERIVED_PROJECTION_SOURCE = "<the verb's declared result>";
  */
 interface DerivedPosition {
   schema?: unknown;
+
   /** A `$link` marker was emitted at or below this position. */
   cut: boolean;
 }
@@ -1545,6 +1547,7 @@ interface ArrayProjectionMask {
   items: ProjectionMask;
 }
 interface ObjectProjectionMask extends ObjectMask<ProjectionMask> {}
+
 /**
  * Which positions a selection reads. `false` is the rejecting one: the
  * position contributes nothing to the read, and the runner never loads what
@@ -1774,6 +1777,7 @@ function alignConciseMarkers(
  */
 interface UnheldSelectionField {
   key: string;
+
   /**
    * The position the field was named at, spelled the way this boundary spells
    * a projection position everywhere else: `<root>` for the read's own source,
@@ -1781,6 +1785,7 @@ interface UnheldSelectionField {
    * crosses.
    */
   position: string;
+
   /**
    * What the position does hold: the field names it declares, the types it
    * states where it declares no fields, or the stream it is.
@@ -2508,6 +2513,7 @@ interface ResolvedProjection {
   itemProjectionSchema?: JSONSchema;
   itemMask?: ProjectionMask;
   implicitArrayTraversal: boolean;
+
   /** The projection's markers, at the depth the source puts them. */
   markers?: LinkMarkers;
 }
@@ -2642,6 +2648,7 @@ function resolveProjection(
 interface WalkedPosition {
   cell: Cell<unknown>;
   address: RenderedLinkAddress;
+
   /**
    * The space the rendered reference is written relative to: an address in
    * another space carries a `@did` prefix, one in this space does not. It is
@@ -2890,6 +2897,7 @@ function arrayItemProjectionError(flag: ProjectionFlag): CellSelectionError {
 interface TransformReads {
   /** Separates this runtime's transform cells from another runtime's. */
   readonly discriminator: number;
+
   /** The pattern each transform result cell runs, by space-qualified id. */
   readonly patterns: Map<string, Pattern>;
 }

--- a/packages/cli/lib/completion/line.ts
+++ b/packages/cli/lib/completion/line.ts
@@ -28,6 +28,7 @@ export type AnyCommand = Command<any>;
 
 /** What the word under the cursor is a position for. */
 export type CompletionSlot =
+
   /** A subcommand name of `command`. */
   | { readonly kind: "subcommand" }
   /** An option flag (the word starts with `-`). */
@@ -36,6 +37,7 @@ export type CompletionSlot =
   | {
     readonly kind: "option-value";
     readonly option: Option;
+
     /** Set when completing `--name=value`; candidates must carry the prefix. */
     readonly inlinePrefix?: string;
   }
@@ -70,6 +72,7 @@ export type CompletionSlot =
 export interface PreParseGlobal {
   readonly flags: readonly string[];
   readonly description: string;
+
   /** Accepted values, when the flag takes one. */
   readonly values?: readonly string[];
 }
@@ -94,23 +97,30 @@ function findPreParseGlobal(token: string): PreParseGlobal | undefined {
 export interface CompletionLine {
   /** Deepest command the words resolved to. */
   readonly command: AnyCommand;
+
   /** Command path below the program name, e.g. `["piece", "call"]`. */
   readonly path: readonly string[];
   readonly slot: CompletionSlot | null;
+
   /** The partial word under the cursor; `""` at a fresh position. */
   readonly word: string;
+
   /** Long name -> last value, for value-taking options already on the line. */
   readonly options: ReadonlyMap<string, string>;
+
   /** Long names of valueless flags already on the line. */
   readonly flags: ReadonlySet<string>;
+
   /**
    * A canonical reference written in the first positional, in place of
    * `--piece`. It does not count as a positional: the command reads it out
    * before the rest, so `<callable>` is still the argument after it.
    */
   readonly address?: string;
+
   /** Positional words already supplied to `command`. */
   readonly positionals: readonly string[];
+
   /** Words after a `--` separator, excluding the separator itself. */
   readonly passthrough: readonly string[];
 }
@@ -552,8 +562,10 @@ export { longName, takesValue };
 export interface DeclaredPositional {
   /** `<command path>:<argument name>`, the key its provider carries. */
   readonly key: string;
+
   /** The command path, or `<root>` for the root command's own. */
   readonly where: string;
+
   /** Its place in that command's argument order, so a line can reach it. */
   readonly index: number;
 }
@@ -563,6 +575,7 @@ export interface DeclaredSlots {
   /** Option long name -> the command paths declaring it. */
   readonly options: ReadonlyMap<string, readonly string[]>;
   readonly positionals: readonly DeclaredPositional[];
+
   /**
    * The option slots whose value may be omitted, as
    * `<command path>:--<long name>`.

--- a/packages/cli/lib/completion/providers.ts
+++ b/packages/cli/lib/completion/providers.ts
@@ -27,6 +27,7 @@ import ports from "@commonfabric/ports" with { type: "json" };
 
 /** A directive tells the shell to complete something only it can do well. */
 export type Directive =
+
   /** Hand off to the shell's own file completion, filtered by glob. */
   | { readonly kind: "files"; readonly glob?: string }
   /** Hand off to the shell's directory completion. */
@@ -275,10 +276,13 @@ async function callableCandidates(
 export interface VerbListingLike {
   readonly name: string;
   readonly kind: string;
+
   /** The author's doc comment on the verb, where the listing carries one. */
   readonly description?: string;
+
   /** A UI affordance rather than a headless verb. Hidden by `cf piece verbs`. */
   readonly tier?: string;
+
   /** `@deprecated` on the verb. Hidden by `cf piece verbs`. */
   readonly deprecated?: boolean;
 }
@@ -514,10 +518,13 @@ export async function acceptedProjections(
 export function splitSelectPrefix(typed: string): {
   /** Elements already closed, trailing comma included. */
   list: string;
+
   /** Segments already closed within the element being typed. */
   path: string[];
+
   /** Those segments as written, trailing dot included. */
   prefix: string;
+
   /** Whether nothing has been typed yet in this element. */
   atElementStart: boolean;
 } {

--- a/packages/cli/lib/declared-fields.ts
+++ b/packages/cli/lib/declared-fields.ts
@@ -85,6 +85,7 @@ export interface DeclaredFieldSource {
 export interface DeclaredFields {
   sources: DeclaredFieldSource[];
   honorsUndeclared: boolean;
+
   /** Every name any reached member marks required. A conjunction constrains
    * one value from all its members at once, so a name any of them requires is
    * required of the value. A DISJUNCTION contributes none — a value satisfies

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -60,6 +60,7 @@ export interface ProcessOptions {
   verboseErrors?: boolean;
   space?: string;
   patternJson?: boolean;
+
   /** Data file paths to attach, so a pattern that reads one can run here. */
   dataFilePaths?: string[];
 }

--- a/packages/cli/lib/exec-schema.ts
+++ b/packages/cli/lib/exec-schema.ts
@@ -21,6 +21,7 @@ export interface ExecCommandSpec {
   defaultVerb: "invoke" | "run";
   inputSchema: JSONSchema;
   outputSchemaSummary?: JSONSchema;
+
   /**
    * What this callable is FOR, in the author's own words: the doc comment on
    * the pattern property that declares it.
@@ -856,12 +857,16 @@ function fullFlagUsage(flagName: string, schema: JSONSchema): string {
 export interface DeclaredVerbFlag {
   /** The flag's long name, without dashes — `flagNameForKey`'s mapping. */
   readonly name: string;
+
   /** The declared field it fills; absent for a non-object input's own flags. */
   readonly key?: string;
+
   /** That field's schema, for a caller rendering a placeholder or a type. */
   readonly schema?: JSONSchema;
+
   /** Whether the payload door owes this field. */
   readonly required: boolean;
+
   /** Whether `--no-<name>` is accepted beside it. */
   readonly negatable: boolean;
 }

--- a/packages/cli/lib/exec.ts
+++ b/packages/cli/lib/exec.ts
@@ -71,9 +71,11 @@ export interface ExecDependencies {
   readTextInput?: () => Promise<string>;
   readTextFile?: (path: string) => Promise<string>;
   isStdinTerminal?: () => boolean;
+
   /** @internal Seam for tests, the same one `getCellValue` and
    * `CallableExecutionDeps` carry. */
   deriveSelectedValue?: CallableExecutionDeps["deriveSelectedValue"];
+
   /**
    * Each phase the dispatch below reaches, in order. A caller announcing the
    * invocation identity hangs it here: the identity is what a failed call is
@@ -85,8 +87,10 @@ export interface ExecDependencies {
 export interface ExecutedMountedCallableFile {
   helpText?: string;
   outputText?: string;
+
   /** Handler invocation outcome, passed through from ExecutedCallable. */
   invocation?: InvocationOutcome;
+
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
@@ -105,6 +109,7 @@ export interface ExecuteMountedCallableOptions {
    * `cf piece call` and `cf wish` read through — so one grammar covers every
    * arrival, whichever one a caller reached for. */
   selection?: CellSelection;
+
   /** @internal Seam for tests. Production mints a fresh pair per call: see
    * {@link executeMountedCallableFile}. */
   invocation?: InvocationIdentity;

--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -31,6 +31,7 @@ export interface FetchMockEntry {
   contentType?: string;
   body?: string;
   base64Body?: string;
+
   /** Fixed real-time delay (ms) before the mock returns. */
   delayMs?: number;
 }

--- a/packages/cli/lib/fuse-mount-flags.ts
+++ b/packages/cli/lib/fuse-mount-flags.ts
@@ -40,6 +40,7 @@ export interface FuseSupervisorFlags extends FuseMountFlags {
 
 /** How a flag carries its field's value on the command line. */
 type FlagArity =
+
   /** Present with a following value when the field is set. */
   | "value"
   /** Present without a value when the field is true. */
@@ -50,8 +51,10 @@ type FlagArity =
 interface FlagSpec {
   flag: string;
   arity: FlagArity;
+
   /** Single-dash form the supervisor parser also accepts. */
   alias?: string;
+
   /** Placeholder for the value in help output. */
   valueLabel?: string;
   help: string;

--- a/packages/cli/lib/ingest-channels.ts
+++ b/packages/cli/lib/ingest-channels.ts
@@ -50,6 +50,7 @@ export interface ChannelSummary {
   revoked?: { at: string; by: string };
   revocations?: { at: string; by: string }[];
   lastSeenAt: string | null;
+
   /** The generation this summary describes; `revoke` must name it. */
   revision: number;
 }
@@ -61,6 +62,7 @@ export interface MintedChannel {
   causePrefix: string;
   installId: string;
   expiresAt?: string;
+
   /** Shown ONCE. The server keeps only its hash. */
   token: string;
 }

--- a/packages/cli/lib/llm-friendly-ref.ts
+++ b/packages/cli/lib/llm-friendly-ref.ts
@@ -24,12 +24,14 @@ import {
 export interface NormalizedLLMFriendlyRef {
   pieceId: string;
   scope?: CellScope;
+
   /**
    * True when the reference ended in the `#argument` suffix: the caller
    * selected the piece's arguments cell, the same selection `--input`
    * spells as a flag. Only commands that take `--input` accept it.
    */
   input?: boolean;
+
   /**
    * The space DID embedded in the reference, when the command's target
    * space is a name (or absent) rather than a DID. A name only resolves to
@@ -39,6 +41,7 @@ export interface NormalizedLLMFriendlyRef {
    * never sets this field.
    */
   embeddedSpace?: string;
+
   /**
    * Path segments embedded in the reference: a canonical array-index
    * segment is a number, everything else stays a string.

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -62,6 +62,7 @@ import type {
 
 export interface MultiUserParticipantSpec {
   name: string;
+
   /** Identity seed; participants with the same `user` share an identity. */
   user: string;
 }

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -83,6 +83,7 @@ export type StepKind =
 
 export interface StepMeta {
   kind: StepKind;
+
   /** Marker name for label/await steps. */
   marker?: string;
   skip?: boolean;
@@ -121,6 +122,7 @@ let storageManager:
   | { synced(): Promise<void>; close(): Promise<void> }
   | undefined;
 let engine: Engine | undefined;
+
 /** Every participant's marker document, keyed by participant name. */
 const markersCells = new Map<string, Cell<Record<string, boolean>>>();
 let selfParticipant: string | undefined;
@@ -129,6 +131,7 @@ let patternCoverage: PatternCoverageCollector | undefined;
 let patternCoveragePath: string | undefined;
 let patternCoverageRoot: string | undefined;
 const runtimeErrors: string[] = [];
+
 /** Channel 1: console.error/warn captured via the harness console event. */
 const consoleErrors: string[] = [];
 const consoleWarnings: string[] = [];
@@ -138,6 +141,7 @@ let continuousUiCancel: (() => void) | undefined;
 // post-compile point where the channel-2 snapshot is taken, so compile-time
 // module-evaluation console output does not fail tests.
 let consoleCaptureActive = false;
+
 /** Channel 2: logger error/warn count snapshot taken after compile, before run. */
 let loggerCountsBeforeRun: LoggerErrorWarnSnapshot = new Map();
 

--- a/packages/cli/lib/piece-describe.ts
+++ b/packages/cli/lib/piece-describe.ts
@@ -39,12 +39,15 @@ import type { PieceCallableListing, PieceCallablesListing } from "./piece.ts";
  * caller-supplied input. */
 export interface PieceFieldDescription {
   name: string;
+
   /** A compact label for the declared type: a named type keeps its name
    * (`ItemOutput`), an array is its element's label suffixed `[]`, a union
    * joins its members with ` | `. See `schemaTypeLabel`. */
   type: string;
+
   /** Present, and true, only on an input the argument schema requires. */
   required?: boolean;
+
   /** The author's doc comment on the field, verbatim. */
   description?: string;
 }
@@ -56,16 +59,20 @@ export interface PieceDescription {
    * identity is: absent when the piece is unnamed or the cell unreadable. */
   name?: string;
   pattern: PiecePatternRef | null;
+
   /** What the pattern is FOR: the result schema's root description. */
   purpose?: string;
+
   /** Pattern-owned state, in declaration order — the author ordered these
    * fields, and that order is part of the documentation. Absent (never
    * empty-by-default) when the compiled pattern could not be read, so a
    * missing section cannot be mistaken for a pattern that declares none. */
   state?: PieceFieldDescription[];
+
   /** Caller-supplied inputs, in declaration order. Absent on the same terms
    * as `state`. */
   inputs?: PieceFieldDescription[];
+
   /** The callable surface, exactly as `listPieceCallables` returned it. */
   verbs: PieceCallableListing[];
   incomplete?: "pattern-unavailable";

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -127,8 +127,10 @@ export interface EntryConfig {
   mainExport?: string;
   repository?: string;
   rootPath?: string;
+
   /** Test entry paths whose resolved source closures travel with the piece. */
   testPaths?: string[];
+
   /** Data file paths stored with the piece and never compiled. */
   dataFilePaths?: string[];
 }
@@ -139,6 +141,7 @@ export interface SpaceConfig {
   identity: string;
   jsonOutput?: boolean;
   deferSpaceCellSync?: boolean;
+
   /**
    * Space DIDs embedded in LLM-friendly references given to this command,
    * carried here when `space` is a name rather than a DID. A name only
@@ -158,6 +161,7 @@ export interface PieceSearchResult {
 export interface PieceConfig extends SpaceConfig {
   piece: string;
   pieceScope?: CellScope;
+
   /**
    * Path segments embedded in an LLM-friendly `--piece` reference. A command
    * that reads or writes at a path prepends these to its positional path
@@ -165,6 +169,7 @@ export interface PieceConfig extends SpaceConfig {
    * carries them.
    */
   piecePath?: (string | number)[];
+
   /**
    * True when the reference carried the `#argument` suffix: the caller
    * selected the piece's arguments cell. A command that takes `--input`
@@ -353,6 +358,7 @@ async function resultProjectionFailedAtPath(
  */
 export interface ResolvedPieceCallable extends CallableResolution {
   commandSpec: ExecCommandSpec;
+
   /**
    * This verb's documentation, resolved on demand — a thunk for the same
    * reason `declaredResult` is one, and attached under the same condition:
@@ -381,8 +387,10 @@ export interface PieceCallableDependencies extends CallableExecutionDeps {
 export interface ExecutedPieceCallable {
   helpText?: string;
   outputText?: string;
+
   /** Handler invocation outcome, passed through from ExecutedCallable. */
   invocation?: InvocationOutcome;
+
   /** Tool result cell address, passed through from ExecutedCallable. */
   resultRef?: CallableResultRef;
   parsed: ParsedExecArgs;
@@ -1954,6 +1962,7 @@ export interface PieceCallablesListing {
   /** The deployed pattern's source identity; null when the piece exposes
    * none (e.g. harness doubles). */
   pattern: PiecePatternRef | null;
+
   /** Present when the listing is a LOWER BOUND rather than the surface,
    * naming what it could not read. `verbs` is still every callable the
    * listing found, and every row in it is still real.
@@ -1974,16 +1983,20 @@ export interface PieceCallablesListing {
 export interface PieceCallableListing {
   name: string;
   kind: "handler" | "tool";
+
   /** Which cell the callable lives on. `result` shadows `input` on a name
    * collision, matching `cf piece call`'s resolution order. */
   on: "result" | "input";
+
   /** The verb's input schema — the same schema `call <verb> --help --json`
    * serves. `true` means unconstrained. */
   inputSchema: JSONSchema | true;
+
   /** What the verb hands back: a tool's pattern result schema, a handler's
    * declared result. Absent when the verb declares none — the value-less
    * shape, which is the common one. */
   outputSchema?: JSONSchema;
+
   /**
    * What the verb is FOR, in the author's own words: the doc comment on the
    * pattern property declaring it, the same prose `call <verb> --help` prints
@@ -1995,10 +2008,12 @@ export interface PieceCallableListing {
    * caller who wrote it and calls it documentation.
    */
   description?: string;
+
   /** Listing mark: a UI affordance outside the headless contract (inferred
    * from session-scoped handler bindings at compile time). Hidden from the
    * default listing; always callable. */
   tier?: "wrapper";
+
   /** Listing mark: `@deprecated` JSDoc on the verb, lowered to the standard
    * schema annotation. Hidden from the default listing; always callable. */
   deprecated?: boolean;
@@ -2195,6 +2210,7 @@ export interface DeclaredVerbProse {
    * merged into it.
    */
   description?: string;
+
   /**
    * The verb's declared event schema with its `$ref` followed against the
    * result schema's own root, so the field descriptions inside the `$defs`
@@ -2513,13 +2529,16 @@ interface ProseWalk {
  */
 interface ProseWalkState {
   readonly edits: DescriptionEdit[];
+
   /** Paths already recorded, so the first account of a position wins. Two
    * positions sharing one `$defs` target can each reach it now that the guard
    * is path-scoped, and without this the later one would silently overwrite
    * the earlier. */
   readonly written: Set<string>;
+
   /** Served `$defs` names open on the current descent. */
   readonly openDefinitions: string[];
+
   /** Declared references open on the current expansion, each with the scope it
    * was followed in — the same reference in two different scopes is two
    * different targets. */
@@ -3761,6 +3780,7 @@ export async function generateSpaceMap(
 export interface CachedResultField {
   /** The field's name on the piece's result. */
   name: string;
+
   /** The computed documents crossed while resolving the field's value. */
   cells: CachedResultCell[];
 }
@@ -3769,10 +3789,13 @@ export interface CachedResultField {
 export interface CachedResultCell {
   /** The computed entity's id. */
   id: string;
+
   /** The space whose commit sequence contains `derivedAtCommit`. */
   space: MemorySpace;
+
   /** The computed entity's memory scope. */
   scope: CellScope;
+
   /**
    * The commit the entity's document last stood at. Absent when the local
    * replica holds no confirmed version of that document.
@@ -3851,14 +3874,17 @@ export interface PieceInspection {
   patternRef?: PiecePatternRef;
   source?: Readonly<unknown>;
   result: Readonly<unknown> | null | undefined;
+
   /**
    * The commit the argument document behind `source` last stood at. It can be
    * ordered against a {@link CachedResultCell} commit only when both have the
    * same `space`.
    */
   sourceCommit?: number;
+
   /** The space whose commit sequence contains `sourceCommit`. */
   sourceSpace?: MemorySpace;
+
   /** The fields of `result` whose resolution crosses a computed-cell cache. */
   cachedResultFields: CachedResultField[];
   readingFrom: Array<{ id: string; name?: string }>;

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -278,6 +278,7 @@ export interface TestResult {
 export interface NavigationEvent {
   /** Name ($NAME) of the navigation target, if available */
   name?: string;
+
   /** Index of the action that triggered this navigation */
   afterActionIndex: number;
 }
@@ -287,36 +288,46 @@ export interface TestRunResult {
   results: TestResult[];
   totalDurationMs: number;
   error?: string;
+
   /** Navigation events recorded during the test run */
   navigations: NavigationEvent[];
+
   /** Runtime errors captured via errorHandlers during the test run */
   runtimeErrors: string[];
+
   /** If true, runtime errors are expected and should not fail the test */
   allowRuntimeErrors?: boolean;
+
   /** If set, runtime errors are REQUIRED: the run fails when none (or, for a
    * number, a different count) were captured. Like expectNonIdempotent, this
    * asserts the loudness fires — it is not a mere tolerance — so reverting a
    * throwing rejection to a silent return fails the suite. Implies
    * allowRuntimeErrors for the captured errors themselves. */
   expectRuntimeErrors?: boolean | number;
+
   /** Non-idempotent computation names detected by the idempotency check */
   nonIdempotent: string[];
+
   /** If true, non-idempotent computations are expected: detected violations
    * don't fail the test, and detecting NONE fails it (the flag asserts the
    * detector fires; it is not a mere tolerance). */
   expectNonIdempotent?: boolean;
+
   /**
    * console.error() calls captured via the harness console event during the
    * run phase, plus logger-level error activity detected via count deltas.
    */
   consoleErrors: string[];
+
   /** If true, console errors are expected and should not fail the test. */
   allowConsoleErrors?: boolean;
+
   /**
    * console.warn() calls captured via the harness console event during the
    * run phase, plus logger-level warn activity detected via count deltas.
    */
   consoleWarnings: string[];
+
   /** If true, console warnings are expected and should not fail the test. */
   allowConsoleWarnings?: boolean;
 }
@@ -324,35 +335,47 @@ export interface TestRunResult {
 export interface TestRunnerOptions {
   timeout?: number;
   verbose?: boolean;
+
   /**
    * Root directory for resolving imports. If not provided, the nearest
    * ancestor of the test file whose deno.json(c) declares a package name is
    * used, falling back to the test file's directory.
    */
   root?: string;
+
   /**
    * Data file paths to attach, so a pattern under test that reads one with
    * `dataFile` reads here what it will read once deployed.
    */
   dataFilePaths?: string[];
+
   /** Print logger stats for steps slower than this (ms). 0 = every step. Default 5000. Only applies when verbose is true. */
   statsThreshold?: number;
+
   /** Timing categories to always print in verbose stats output. Matched by exact name or prefix. */
   statsInclude?: string[];
+
   /** Number of per-step scheduler action deltas to print. Default 10. */
   statsActionLimit?: number;
+
   /** Override CFC enforcement mode for the test runtime. */
   cfcEnforcementMode?: CfcEnforcementMode;
+
   /** Shared compiled-module-byte cache for direct harness compiles. */
   moduleByteCache?: ModuleByteCache;
+
   /** Print storage-related logger timings and counts after each test file. */
   storageStats?: boolean;
+
   /** Limit for storage timing/count tables when storageStats is enabled. */
   storageStatsLimit?: number;
+
   /** Directory for pattern runtime coverage LCOV artifacts. */
   patternCoverageDir?: string;
+
   /** Keep the test descriptor's `$UI` demanded for the full test run. */
   continuousUI?: boolean;
+
   /**
    * Spool one test record per file run, named by the file's
    * repository-relative path.
@@ -363,6 +386,7 @@ export interface TestRunnerOptions {
    * rather than a test of this repository.
    */
   recordResults?: boolean;
+
   /**
    * Emit a `performance.measure` per logger time span and write them here.
    *
@@ -373,6 +397,7 @@ export interface TestRunnerOptions {
    * count starts multiplying.
    */
   timingMeasuresOut?: string;
+
   /**
    * Run against a caller-supplied identity and storage manager, and observe
    * what the run instantiates.
@@ -397,6 +422,7 @@ export interface TestRunnerOptions {
   storageHost?: {
     identity: Identity;
     storageManager: RuntimeOptions["storageManager"];
+
     /**
      * Cause for the test pattern's result cell, pinning its entity id.
      *
@@ -405,6 +431,7 @@ export interface TestRunnerOptions {
      * differs every run can never be addressed again.
      */
     resultCause?: unknown;
+
     /** Records every pattern the run materializes; see the vintage capture. */
     onPatternInstantiated?: PatternInstantiationObserver;
   };

--- a/packages/cli/lib/trusted-test-event.ts
+++ b/packages/cli/lib/trusted-test-event.ts
@@ -20,6 +20,7 @@ import { isObjectNotArray } from "@commonfabric/utils/types";
 export interface TrustedUiDescriptor {
   /** `data-ui-pattern` / `data-ui-event-integrity` of the trusted surface. */
   surface: string;
+
   /** `data-ui-action` of the control inside the surface. */
   action: string;
 }

--- a/packages/cli/lib/version-check.ts
+++ b/packages/cli/lib/version-check.ts
@@ -56,8 +56,10 @@ export interface VersionCheckDeps {
     serverSha: string,
   ) => Promise<ShaRelation>;
   warn?: (message: string) => void;
+
   /** Registers the process-end hook the deferred note prints from. */
   addUnloadListener?: (handler: () => void) => void;
+
   /** The exit code the process is ending with, read inside that hook. */
   exitCode?: () => number;
 }

--- a/packages/cli/lib/view/ansi.ts
+++ b/packages/cli/lib/view/ansi.ts
@@ -21,6 +21,7 @@ export interface Style {
 
 export const ESC = "\x1b";
 export const CSI = `${ESC}[`;
+
 /** Operating System Command introducer and its BEL terminator. */
 const OSC = `${ESC}]`;
 const BEL = "\x07";
@@ -95,10 +96,12 @@ export const term = {
   clearLine: `${CSI}2K`,
   clearToEol: `${CSI}0K`,
   home: `${CSI}H`,
+
   /** Move the cursor to a 1-based (row, col). */
   moveTo(row: number, col: number): string {
     return `${CSI}${row};${col}H`;
   },
+
   /** Set the terminal's default background color (OSC 11). This is the color
    * the terminal fills the area outside the character grid with — the sub-cell
    * padding below the last row and beside the last column — which no cell can
@@ -107,6 +110,7 @@ export const term = {
     const h = rgb.map((c) => c.toString(16).padStart(2, "0")).join("");
     return `${OSC}11;#${h}${BEL}`;
   },
+
   /** Restore the terminal's own default background color (OSC 111). */
   resetDefaultBg: `${OSC}111${BEL}`,
 };

--- a/packages/cli/lib/view/card.ts
+++ b/packages/cli/lib/view/card.ts
@@ -34,17 +34,22 @@ import {
 export interface CardTarget {
   /** Index into the card's `info` lines (for highlight + reveal). */
   readonly cardLine: number;
+
   /** Destination line/column in the main document. */
   readonly destLine: number;
   readonly destCol: number;
+
   /** Char offset of the declaration to select, when the target is a definition. */
   readonly defOffset?: number;
+
   /** End offset of that declaration. Diff views clamp nested nodes to the same
    * start offset, so the end disambiguates which node to select. */
   readonly defEndOffset?: number;
+
   /** External file to open, when the definition lives outside the blob; with
    * `destLine` the line within that file. */
   readonly filePath?: string;
+
   /** A "… N more" line: selecting it and pressing Enter rebuilds the card with
    * every truncated list shown in full, rather than navigating anywhere. */
   readonly expand?: boolean;

--- a/packages/cli/lib/view/commitmsg.ts
+++ b/packages/cli/lib/view/commitmsg.ts
@@ -51,6 +51,7 @@ const emailCommitAt = (
 export interface CommitMessage {
   /** The commit hash, as printed after `commit `. */
   readonly sha: string;
+
   /** First and last (inclusive) 0-based line indices of the indented message. */
   readonly start: number;
   readonly end: number;
@@ -59,6 +60,7 @@ export interface CommitMessage {
 export interface CommitHeader {
   /** The commit hash, as printed after `commit `. */
   readonly sha: string;
+
   /** The 0-based line index of the `commit` header. */
   readonly line: number;
 }
@@ -246,10 +248,13 @@ export function sameCommit(sha: string, head: string): boolean {
 export interface GitRunner {
   /** The current commit's full hash, or null (not a repo, or git failed). */
   headSha(): string | null;
+
   /** The symbolic ref checked out at HEAD, or `HEAD` when detached. */
   headRef?(): string | null;
+
   /** Resolve an abbreviated commit name to its full object id. */
   resolveCommit?(sha: string): string | null;
+
   /** Whether the old and new blob names in one file diff belong to a commit
    * and its first parent. Paths use Git's repository-relative form. */
   commitMatchesDiff?(
@@ -259,9 +264,11 @@ export interface GitRunner {
     oldObject: string,
     newObject: string,
   ): boolean;
+
   /** Read a file's blob from `commit`, addressed by its absolute workspace
    * path. A path absent from the commit returns null. */
   fileAtCommit(commit: string, path: string): string | null;
+
   /** Apply only the change from `before` to `after` to `committed`. */
   applyFileChanges(
     committed: string,
@@ -269,6 +276,7 @@ export interface GitRunner {
     after: string,
     path: string,
   ): string;
+
   /** Amend HEAD with each file's exact contents. A null message preserves the
    * existing commit message byte for byte. Merge the change from the current
    * HEAD into the real index, preserving staged changes that do not conflict.

--- a/packages/cli/lib/view/diff.ts
+++ b/packages/cli/lib/view/diff.ts
@@ -21,8 +21,10 @@ export type DiffLineKind =
 
 export interface DiffLine {
   readonly kind: DiffLineKind;
+
   /** 0-based line number in the NEW file, for ctx/add lines. */
   readonly newLine?: number;
+
   /** 0-based line number in the OLD file, for ctx/del lines. */
   readonly oldLine?: number;
 }
@@ -30,14 +32,18 @@ export interface DiffLine {
 export interface DiffHunk {
   /** 0-based diff-text line index of the `@@` header. */
   readonly headerLine: number;
+
   /** 0-based diff-text line index of the last body line. */
   readonly endLine: number;
+
   /** 1-based start line in the old file (from the `@@` header). */
   readonly oldStart: number;
   readonly oldCount: number;
+
   /** 1-based start line in the new file (from the `@@` header). */
   readonly newStart: number;
   readonly newCount: number;
+
   /** Trailing context from the header (the enclosing function), if any. */
   readonly context: string;
 }
@@ -45,12 +51,16 @@ export interface DiffHunk {
 export interface DiffFile {
   /** Path on the old side (`a/…` stripped), absent for a created file. */
   readonly oldPath?: string;
+
   /** Path on the new side (`b/…` stripped), absent for a deleted file. */
   readonly newPath?: string;
+
   /** Old blob named by a Git `index old..new` header, when present. */
   readonly oldObject?: string;
+
   /** 0-based diff-text line index where this file's headers begin. */
   readonly headerLine: number;
+
   /** 0-based diff-text line index of the file's last line. */
   readonly endLine: number;
   readonly hunks: readonly DiffHunk[];
@@ -58,6 +68,7 @@ export interface DiffFile {
 
 export interface DiffModel {
   readonly files: readonly DiffFile[];
+
   /** Classification of every diff-text line, indexed by line number. */
   readonly lines: readonly DiffLine[];
 }
@@ -146,6 +157,7 @@ export function parseDiff(text: string): DiffModel | null {
     headerLine: number;
     hunks: DiffHunk[];
     endLine: number;
+
     /** A `diff --cc`/`--combined` merge section: consumed but never emitted —
      * its `@@@` hunks use a three-way format this parser does not model. */
     combined?: boolean;

--- a/packages/cli/lib/view/diffdoc.ts
+++ b/packages/cli/lib/view/diffdoc.ts
@@ -46,16 +46,22 @@ import { flattenStructure } from "./model.ts";
 export interface DiffWorkspace {
   /** Resolve a diff-relative path to an absolute workspace path, or null. */
   resolve(path: string): string | null;
+
   /** Read an absolute path's current content, or null. */
   read(absPath: string): string | null;
+
   /** Report the UTF-8 BOM state recorded by the latest successful read. */
   hasUtf8Bom?(absPath: string): boolean | undefined;
+
   /** Write decoded text back with the encoding observed by {@link read}. */
   write?(absPath: string, text: string): void;
+
   /** Read a Git blob by object name, or null when it is unavailable. */
   readBlob?(object: string): string | null;
+
   /** Report the UTF-8 BOM state recorded for a successfully read Git blob. */
   blobHasUtf8Bom?(object: string): boolean | undefined;
+
   /** Read available Git blobs in one local Git operation. */
   readBlobs?(
     objects: readonly string[],
@@ -295,18 +301,22 @@ export interface DiffEdit {
    * mappings, so the source text is also what makes their HEAD message
    * editable. */
   readonly sourceText?: string;
+
   /** Diff line → the file line it edits, with its marker width (1, or 0 for a
    * trimmed empty context line). */
   readonly lines: ReadonlyMap<
     number,
     { absPath: string; newLine: number; markerLen: number }
   >;
+
   /** The captured new-side content of each touched file, for splicing edited
    * lines back in on save. */
   readonly fileText: ReadonlyMap<string, string>;
+
   /** Complete highlighted old files, aligned with the parsed diff's files.
    * The live highlighter uses these spans when an edit creates a removed line. */
   readonly oldFileLines: readonly (readonly Line[] | null)[];
+
   /** Every hunk, in document order, with the file and new-side range it covers
    * and whether its new side matched the workspace (so the captured content is
    * known to be the hunk's new side). Save matches the edited diff's hunks to
@@ -321,12 +331,16 @@ export interface DiffHunkInfo {
   readonly newStart: number;
   readonly newCount: number;
   readonly verified: boolean;
+
   /** Whether the reconstructed old file is encoded with a UTF-8 BOM. */
   readonly oldFileHasUtf8Bom?: boolean;
+
   /** Whether the captured new file is encoded with a UTF-8 BOM. */
   readonly newFileHasUtf8Bom?: boolean;
+
   /** The original diff marks the old side as having no final newline. */
   readonly oldNoTrailingNewline?: boolean;
+
   /** The original diff marks the new side as having no final newline. */
   readonly newNoTrailingNewline?: boolean;
 }
@@ -335,9 +349,11 @@ export interface DiffHunkInfo {
 export interface DiffMaps {
   /** Absolute paths of the diff's files that exist in the workspace. */
   readonly rootFiles: readonly string[];
+
   /** Diff offset → (file, file offset), when the offset sits on code that is
    * present (and unchanged) in the current workspace file. */
   toFile(diffOffset: number): { path: string; offset: number } | null;
+
   /** File offset → diff offset, when that file line is visible in the diff. */
   fromFile(path: string, fileOffset: number): number | null;
 }
@@ -346,6 +362,7 @@ interface FileMapping {
   readonly absPath: string;
   readonly fileText: string;
   readonly fileLineStarts: number[];
+
   /** new-file line → diff line, for content-verified ctx/add lines. */
   readonly newToDiff: Map<number, number>;
 }
@@ -363,10 +380,13 @@ interface LoadedFile {
   fileText: string | null;
   fileDoc: Document | null;
   fileLineStarts: number[];
+
   /** The encoding state kept outside the BOM-stripped parser text. */
   hasUtf8Bom?: boolean;
+
   /** Syntax-only lines used by complete old files. */
   highlightedLines?: readonly Line[] | null;
+
   /** Alternate rendered lines, computed once when that view is opened. */
   renderedLines?: readonly Line[] | null;
 }
@@ -1000,8 +1020,10 @@ interface MutableLine {
 interface FragmentLine {
   diffLine: number;
   code: string;
+
   /** Whether decoding removed a BOM before parsing this source line. */
   omitsUtf8Bom?: boolean;
+
   /** Context can establish old-side state without replacing new-side colors. */
   render?: boolean;
 }
@@ -1023,11 +1045,13 @@ interface HunkCtx {
   mapping: FileMapping | undefined;
   definitions: Map<string, Definition[]>;
   hunks: DiffHunkInfo[];
+
   /** The languages of the new and old sides (they differ across a rename that
    * changes the extension); each colors its side's fragments and, for the new
    * side, projects the hunk's structure. */
   newLanguage: Language;
   oldLanguage: Language;
+
   /** Paths whose extensions the parsers use to pick a script variant. */
   newFileName: string | undefined;
   oldFileName: string | undefined;

--- a/packages/cli/lib/view/diffedit.ts
+++ b/packages/cli/lib/view/diffedit.ts
@@ -2072,10 +2072,13 @@ interface MutableHunk {
   newFileHasUtf8Bom?: boolean;
   oldNoTrailingNewline?: boolean;
   newNoTrailingNewline?: boolean;
+
   /** The nearest preceding commit header in the source text. */
   commitSha?: string | null;
+
   /** This is the first verified hunk that names its workspace range. */
   writable?: boolean;
+
   /** Removed lines have a workspace-verified insertion point. */
   resurrectable?: boolean;
 }

--- a/packages/cli/lib/view/diffremap.ts
+++ b/packages/cli/lib/view/diffremap.ts
@@ -41,6 +41,7 @@ export interface RemapCtx {
   newToDiff: Map<number, number>;
   diffLineStarts: number[];
   rawLines: string[];
+
   /** Line starts of the source text the nodes were parsed from. */
   sourceLineStarts: number[];
   sourceOmitsUtf8Bom: boolean;

--- a/packages/cli/lib/view/display.ts
+++ b/packages/cli/lib/view/display.ts
@@ -50,6 +50,7 @@ export function displayModeLabel(mode: DisplayMode): string {
 export interface DisplayCell {
   readonly ch: string;
   readonly col: number;
+
   /** Exclusive source column represented by this display cell. */
   readonly sourceEnd: number;
   readonly syntax: Style;
@@ -289,8 +290,10 @@ export function glyphFor(cp: string): string {
 interface CsiMatch {
   /** Number of source code points the whole sequence spans. */
   readonly len: number;
+
   /** The final byte, e.g. "m" for a color (SGR) sequence. */
   readonly final: string;
+
   /** The parameter bytes between `ESC [` and the final byte. */
   readonly params: string;
 }

--- a/packages/cli/lib/view/editbuffer.ts
+++ b/packages/cli/lib/view/editbuffer.ts
@@ -21,20 +21,26 @@ export interface LineEndingProvenance {
 
 export class EditBuffer {
   lines: string[];
+
   /** 0-based cursor line. */
   row = 0;
+
   /** 0-based cursor column, in code points within the line. */
   col = 0;
+
   /** The "goal" column for vertical motion, so up/down keep the column over
    * short lines (Emacs/most editors). -1 means "track the current column". */
   private goalCol = -1;
+
   /** Mark for region operations (C-Space … C-w), or null. */
   mark: { row: number; col: number } | null = null;
 
   /** The kill ring, most-recent first. */
   killRing: string[] = [];
+
   /** Index of the entry the next yank-pop will use; -1 when not yank-popping. */
   private yankIndex = -1;
+
   /** [row, col] span the last yank inserted, for yank-pop to replace. */
   private lastYank:
     | { row: number; col: number; endRow: number; endCol: number }

--- a/packages/cli/lib/view/editsource.ts
+++ b/packages/cli/lib/view/editsource.ts
@@ -51,10 +51,12 @@ export interface ExpandResult {
   cursorLine: number;
   insertedAt: number;
   inserted: number;
+
   /** Exact workspace endings for the rows inserted into `text`. */
   insertedLineEndings: readonly (LineEndingProvenance | undefined)[];
   up: boolean;
   removedAt: number | null;
+
   /** Which lines of the workspace file the reveal showed, as the file numbers
    * them and counting from one: `from` to `to`, both ends included. */
   revealed: { from: number; to: number };
@@ -81,25 +83,32 @@ export interface SaveOptions {
 export interface EditableSource {
   /** A short label for the backing target (the filename), or null. */
   readonly label: string | null;
+
   /** True for a diff view, whether or not it is editable. Absent or false for a
    * plain file or a non-diff pipe. */
   readonly isDiff?: boolean;
+
   /** False when there is no underlying file to edit or the selected language
    * is read-only. `reason` is shown when a cursor move is attempted on a
    * non-editable view. */
   readonly editable: boolean;
   readonly reason?: string;
+
   /** Representation used when the caller did not choose one explicitly. */
   readonly defaultViewMode?: ViewMode;
+
   /** Whether rendered rows retain the source document's line layout. */
   readonly renderLineTopology?: "source" | "independent";
+
   /** Whether an empty decoded input is a complete view. */
   readonly allowsEmptyInput?: boolean;
+
   /** Re-parse edited text into a Document — lines, structure and definitions. */
   parse(
     text: string,
     lineEndings?: readonly (LineEndingProvenance | undefined)[],
   ): Document;
+
   /**
    * Build the alternate rendered representation. Rendered documents retain the
    * source text. Most renderers keep one display line per source line;
@@ -107,11 +116,13 @@ export interface EditableSource {
    * source's languages offer no rendered view.
    */
   render?(source: Document): Document;
+
   /** Re-highlight the edited text into rendered lines only (no structure tree),
    * for live highlighting on every keystroke. A fraction of a full {@link
    * parse}; the structure is refreshed separately when typing pauses. When
    * absent, the session falls back to a full parse. */
   highlight?(text: string): readonly Line[];
+
   /** Build an incremental highlighter seeded with `text`, for live highlighting
    * whose cost tracks the size of each edit rather than the whole document. The
    * session re-baselines it on the deferred re-parse. When present it is used in
@@ -125,10 +136,12 @@ export interface EditableSource {
     seedLines?: readonly Line[],
     lineEndings?: readonly (LineEndingProvenance | undefined)[],
   ): Highlighter;
+
   /** Exact file-ending information for transformed editable rows. */
   lineEndingProvenance?(
     text: string,
   ): readonly (LineEndingProvenance | undefined)[];
+
   /** Attempt to persist the edited text. `lineEndings` carries exact source
    * endings for rows that came from a file. `baseline` is the text at the last
    * successful save. A read-only source returns its refusal reason without
@@ -139,6 +152,7 @@ export interface EditableSource {
     baseline?: string,
     options?: SaveOptions,
   ): string;
+
   /** The clean baseline after a successful save. Most sources persist the
    * whole buffer and omit this method. A commit view that saves files without
    * amending keeps commit-message edits outside the returned baseline, so they
@@ -148,12 +162,14 @@ export interface EditableSource {
     current: string,
     options?: SaveOptions,
   ): string;
+
   /** The labels (filenames) of the targets that differ between `original` and
    * `current` — what a save would actually write. A plain file is its one label
    * when changed; a diff reports just the files whose lines an edit touched, so
    * the quit prompt names them instead of every file the diff spans. Absent →
    * the caller falls back to the single {@link label}. */
   dirtyLabels?(original: string, current: string): string[];
+
   /** Restore part of the text to its `original` form: the hunk or file the
    * cursor (`cursorLine`) is in, or everything. Returns the new full text and
    * where to place the cursor, or null when there is nothing to revert at that
@@ -169,6 +185,7 @@ export interface EditableSource {
     cursorLine: number;
     lineEndings?: readonly (LineEndingProvenance | undefined)[];
   } | null;
+
   /** Reveal more of the underlying file around the hunk `cursorLine` sits in (a
    * diff only). Returns the grown diff text, the matching grown baseline (so
    * revealing context is not itself an edit), and where the cursor moves — or
@@ -182,17 +199,21 @@ export interface EditableSource {
     cursorLine: number,
     up?: boolean,
   ): ExpandResult | null;
+
   /** How much context each hunk of `current` could still reveal, keyed by the
    * line its header sits on. The pager offers Ctrl-L only where the edge the
    * user is looking at has room, and says what stopped it where it has not. */
   expandRoom?(current: string): ReadonlyMap<number, HunkRoom>;
+
   /** Constrains where editing may happen. Present only for a diff, whose lines
    * map to fixed file lines: edits stay within a line, past the diff marker. A
    * plain file has no policy and is edited freely. */
   readonly policy?: EditPolicy;
+
   /** The last editable column on a line when the source gives a trailing
    * carriage return meaning beyond ordinary CRLF transport. */
   logicalEnd?(lines: readonly string[], row: number): number;
+
   /** When changed `git show` output contains the HEAD commit, the commit a save
    * would amend — for the confirmation prompt. Null when no such change is
    * pending. Absent on sources that never edit a commit. */
@@ -200,6 +221,7 @@ export interface EditableSource {
     baseline: string,
     current: string,
   ): { sha: string; subject: string } | null;
+
   /** The path of the backing file, when there is a single one. The file picker
    * opens in its directory. */
   readonly path?: string;
@@ -221,12 +243,14 @@ export interface EditPolicy {
    * Takes the whole set of lines because editability depends on the row's
    * region. */
   editStart(lines: readonly string[], row: number): number | null;
+
   /** A source-specific explanation for refusing an edit at `row`, or null to
    * use the editor's general explanation. */
   notEditableMessage?(
     lines: readonly string[],
     row: number,
   ): string | null;
+
   /** What the row at `row` belongs to: a diff hunk's new side (edited as a
    * removed/added pair), a removed line that can be resurrected, an editable
    * commit message (edited as plain indented text), or neither. Drives how the
@@ -235,17 +259,21 @@ export interface EditPolicy {
     lines: readonly string[],
     row: number,
   ): "hunk" | "removed" | "message" | null;
+
   /** The parsed diff hunk containing a body row. */
   hunkAt?(
     lines: readonly string[],
     row: number,
   ): { model: DiffModel; hunk: DiffHunk } | null;
+
   /** Whether the workspace file for the hunk at `row` uses a UTF-8 BOM. */
   hasUtf8Bom?(lines: readonly string[], row: number): boolean | undefined;
+
   /** The marker a newly inserted line is given inside a hunk (a diff adds an
    * added line, so `"+"`), keeping the diff well-formed as the user adds lines.
    * A commit message uses its own indent instead. */
   readonly insertPrefix: string;
+
   /** The indent a new commit-message line is given (git's four spaces). */
   readonly messageIndent: string;
 }
@@ -253,6 +281,7 @@ export interface EditPolicy {
 export interface FileSourceOptions {
   /** Encoder paired with the bytes read when the source was opened. */
   readonly encode?: (text: string) => Uint8Array;
+
   /** Full byte size information for a bounded rendered preview. */
   readonly renderExtent?: RenderInputExtent;
 }

--- a/packages/cli/lib/view/filegateway.ts
+++ b/packages/cli/lib/view/filegateway.ts
@@ -30,14 +30,19 @@ export interface DirEntry {
 export interface FileGateway {
   /** The working directory the picker opens at when there is no current file. */
   cwd(): string;
+
   /** A directory's entries, or null when it cannot be read. */
   list(absDir: string): DirEntry[] | null;
+
   /** Open a file: its source and decoded buffer, or null on failure. */
   open(absPath: string): { source: EditableSource; text: string } | null;
+
   /** Join a directory and a path segment, normalized. */
   join(dir: string, segment: string): string;
+
   /** The parent directory of a path. */
   parent(path: string): string;
+
   /** The final path segment (for display). */
   base(path: string): string;
 }

--- a/packages/cli/lib/view/fold.ts
+++ b/packages/cli/lib/view/fold.ts
@@ -15,17 +15,21 @@ import { languageForFile } from "./languages/language.ts";
 export interface DiffFileRange {
   /** 0-based index in document order — the stable key for the fold set. */
   readonly index: number;
+
   /** First and last (inclusive) diff-text line of the file (header … last
    * hunk line). */
   readonly headerLine: number;
   readonly endLine: number;
+
   /** The path used for file-category detection (new side, else old side). */
   readonly path: string;
   readonly isTest: boolean;
   readonly isMarkdown: boolean;
+
   /** Added and removed line counts within the file's range. */
   readonly adds: number;
   readonly dels: number;
+
   /** The one-line summary shown when the file is collapsed. */
   readonly summary: Line;
 }
@@ -136,9 +140,11 @@ export interface FoldPlan {
   /** The lines to render: full lines, with each collapsed file's range replaced
    * by one summary line. */
   readonly displayLines: readonly Line[];
+
   /** A document line → the display row it appears on (a line inside a collapsed
    * file maps to that file's summary row). */
   docToDisplay(docLine: number): number;
+
   /** A display row → the document line it stands for (a summary row maps to its
    * file's header line). */
   displayToDoc(displayRow: number): number;

--- a/packages/cli/lib/view/keys.ts
+++ b/packages/cli/lib/view/keys.ts
@@ -20,10 +20,12 @@ export interface Key {
    */
   readonly name: string;
   readonly ctrl?: boolean;
+
   /** Alt/Meta modifier (from `ESC <key>` or a CSI modifier param). For an
    * Alt+letter, `name` is the letter and `char` is unset. */
   readonly alt?: boolean;
   readonly shift?: boolean;
+
   /** The printable character, when the key produced one. */
   readonly char?: string;
 }

--- a/packages/cli/lib/view/languages/decoder.ts
+++ b/packages/cli/lib/view/languages/decoder.ts
@@ -1,6 +1,7 @@
 /** Decoded text plus the matching encoder for later saves. */
 export interface DecodedLanguageSource {
   readonly text: string;
+
   /** Whether the decoded source began with a UTF-8 byte-order mark. */
   readonly hasUtf8Bom: boolean;
   encode(text: string): Uint8Array;

--- a/packages/cli/lib/view/languages/json/json.ts
+++ b/packages/cli/lib/view/languages/json/json.ts
@@ -33,6 +33,7 @@ interface Token {
   readonly start: number;
   readonly end: number;
   readonly cls: TokenClass;
+
   /** Nesting depth for `bracket` tokens, for rainbow coloring. */
   readonly depth?: number;
 }

--- a/packages/cli/lib/view/languages/language.ts
+++ b/packages/cli/lib/view/languages/language.ts
@@ -43,6 +43,7 @@ import type { LineEndingProvenance } from "../editbuffer.ts";
 export interface Highlighter {
   /** The current highlighted lines. */
   readonly lines: readonly Line[];
+
   /** Apply the new full text and return the updated lines. */
   update(
     text: string,
@@ -53,16 +54,22 @@ export interface Highlighter {
 /** A resolved definition site for a referenced symbol (jump-to-definition). */
 export interface DefTarget {
   readonly name: string;
+
   /** Offset within the same document, when the definition is in-document. */
   readonly blobOffset?: number;
+
   /** Real file path, when the definition is in a file outside the document. */
   readonly filePath?: string;
+
   /** Character offset within `filePath`. */
   readonly fileOffset?: number;
+
   /** 0-based line of the definition (document line in-document, file otherwise). */
   readonly line: number;
+
   /** 0-based display column of the definition. */
   readonly col?: number;
+
   /** A trimmed one-line preview of the definition site. */
   readonly preview: string;
 }
@@ -75,15 +82,18 @@ export interface DefTarget {
 export interface Semantics {
   /** The inferred type at a source offset, or `null` when not knowable. */
   typeAt(offset: number): string | null;
+
   /**
    * Where the symbol at a source offset is defined. In-document definitions
    * carry a `blobOffset`; definitions in real files carry a `filePath`. Empty
    * when nothing resolves.
    */
   definitionOf(offset: number): DefTarget[];
+
   /** Read and color an external file (within the workspace) so the pager can
    * show a definition that lives outside the document. Null when unreadable. */
   fileLines(filePath: string): readonly Line[] | null;
+
   /** Build the backing program now (off the interactive path), so the first
    * real query does not pay the one-time cost. Safe to call repeatedly. */
   prewarm(): void;
@@ -93,6 +103,7 @@ export interface Semantics {
 export interface SemanticsOptions {
   /** Working directory, for discovering the workspace / import map. */
   cwd: string;
+
   /** Name for the implicit single section when the text has no headers. */
   fileName?: string;
 }
@@ -101,6 +112,7 @@ export interface SemanticsOptions {
 export interface RenderInputExtent {
   /** Total byte count when {@link complete} is true, otherwise bytes retained. */
   readonly byteLength: number;
+
   /** Whether {@link byteLength} is the complete input size. */
   readonly complete: boolean;
 }
@@ -114,6 +126,7 @@ export interface ByteLanguageDetector {
 interface LanguageInputBase {
   /** How file bytes become the string retained by the view model. */
   readonly decoder: LanguageDecoder;
+
   /** When present, files using this input representation are read-only. */
   readonly readOnlyReason?: string;
 }
@@ -127,14 +140,19 @@ export interface TextLanguageInput extends LanguageInputBase {
 export interface ByteLanguageInput extends LanguageInputBase {
   readonly kind: "bytes";
   readonly readOnlyReason: string;
+
   /** Build a fresh incremental content detector. */
   createDetector(): ByteLanguageDetector;
+
   /** Maximum raw bytes retained for an interactive rendered preview. */
   readonly previewByteLimit: number;
+
   /** Render retained bytes as a bounded whole-file view. */
   renderLines(raw: string, extent?: RenderInputExtent): Line[];
+
   /** Render complete redirected input without retaining it. */
   renderByteStream(chunks: AsyncIterable<Uint8Array>): AsyncIterable<Line>;
+
   /** Number of rows produced for a complete byte count. */
   renderedByteLineCount(byteLength: number): number;
 }
@@ -150,16 +168,21 @@ export type LanguageInput = TextLanguageInput | ByteLanguageInput;
  */
 export interface HunkStructureContext {
   readonly doc: Document;
+
   /** Source line (file or fragment) → diff line, for the lines the hunk shows. */
   readonly lineToDiff: Map<number, number>;
+
   /** Whether UTF-8 decoding removed a BOM before this document was parsed. */
   readonly sourceOmitsUtf8Bom: boolean;
+
   /** Line starts of the source text `doc` was parsed from. */
   readonly sourceLineStarts: number[];
+
   /** Last diff line of the hunk (its extent). */
   readonly hunkEnd: number;
   readonly diffLineStarts: number[];
   readonly rawLines: string[];
+
   /** Name → declaration index the remap contributes to (for `t` peeks). */
   readonly definitions: Map<string, Definition[]>;
 }

--- a/packages/cli/lib/view/languages/typescript/parse.ts
+++ b/packages/cli/lib/view/languages/typescript/parse.ts
@@ -1199,6 +1199,7 @@ interface Desc {
   kind: StructureKind;
   label: string;
   name?: string;
+
   /** Char offset of the declared identifier, when the node names one. */
   nameOffset?: number;
   recurseInto: readonly ts.Node[];
@@ -2091,6 +2092,7 @@ interface SchemaProps {
   properties?: ts.ObjectLiteralExpression;
   required: string[];
   items?: ts.ObjectLiteralExpression;
+
   /** True when the literal spells `items: false` (a closed tuple). */
   itemsFalse?: boolean;
   prefixItems?: ts.ArrayLiteralExpression;

--- a/packages/cli/lib/view/languages/typescript/semantics.ts
+++ b/packages/cli/lib/view/languages/typescript/semantics.ts
@@ -41,6 +41,7 @@ import {
 interface SectionFile {
   /** Virtual file name (the section header path, or `fileName`). */
   name: string;
+
   /** Global offset of the section's first character in the blob. */
   start: number;
   end: number;

--- a/packages/cli/lib/view/languages/typescript/vocab.ts
+++ b/packages/cli/lib/view/languages/typescript/vocab.ts
@@ -29,14 +29,19 @@ export const CALL_NAMES: ReadonlySet<string> = COMMONFABRIC_CALL_EXPORT_NAMES;
 
 /** `packages/ts-transformers/src/core/cf-helpers.ts` `CF_HELPERS_IDENTIFIER`. */
 export const CF_HELPERS_IDENTIFIER = "__cfHelpers";
+
 /** `cf-helpers.ts` `CF_DATA_HELPER_IDENTIFIER`. */
 export const CF_DATA_HELPER_IDENTIFIER = "__cfDataHelper";
+
 /** `ast/call-kind.ts` `SYNTHETIC_LIFT_HOIST_PREFIX` (`const __cfLift_N = …`). */
 export const SYNTHETIC_LIFT_HOIST_PREFIX = "__cfLift";
+
 /** `ast/call-kind.ts` `SYNTHETIC_PATTERN_HOIST_PREFIX` (`const __cfPattern_N = …`). */
 export const SYNTHETIC_PATTERN_HOIST_PREFIX = "__cfPattern";
+
 /** `ast/call-kind.ts` `FUNCTION_HARDENING_HELPER_PREFIX`. */
 export const FUNCTION_HARDENING_HELPER_PREFIX = "__cfHardenFn";
+
 /** `ast/call-kind.ts` `SYNTHETIC_MODULE_CALLBACK_PREFIX`. */
 export const SYNTHETIC_MODULE_CALLBACK_PREFIX = "__cfModuleCallback";
 

--- a/packages/cli/lib/view/loadinput.ts
+++ b/packages/cli/lib/view/loadinput.ts
@@ -11,8 +11,10 @@ const MAX_RETAINED_INPUT_BYTES = 256 * 1024;
 export interface BufferedViewInput {
   readonly kind: "bytes";
   readonly bytes: Uint8Array;
+
   /** A raw-byte language established before the retained preview was decoded. */
   readonly language?: Language;
+
   /** The streamed detector consumed all bytes without selecting a byte
    * language. Later decoding can proceed directly as text. */
   readonly byteLanguageDetectionComplete?: boolean;

--- a/packages/cli/lib/view/mod.ts
+++ b/packages/cli/lib/view/mod.ts
@@ -51,13 +51,17 @@ export interface ViewOptions {
   color: ColorWhen;
   plain: boolean;
   lineNumbers: boolean;
+
   /** Start in the rendered representation when one is available. */
   rendered?: boolean;
   file?: string;
+
   /** Select piped source with this stable language identifier. */
   language?: string;
+
   /** Select piped source as though it had this filename. */
   filename?: string;
+
   /** Force (true) or suppress (false) diff mode; undefined auto-detects. */
   diff?: boolean;
 }

--- a/packages/cli/lib/view/model.ts
+++ b/packages/cli/lib/view/model.ts
@@ -57,12 +57,16 @@ export interface Span {
   readonly col: number;
   readonly text: string;
   readonly cls: TokenClass;
+
   /** Nesting depth for `bracket` spans, used for rainbow coloring. */
   readonly bracketDepth?: number;
+
   /** Symbol name to resolve only at this position, not by matching span text. */
   readonly exactDefinitionName?: string;
+
   /** Single-line spelling used when displaying an exact definition target. */
   readonly exactDefinitionDisplayName?: string;
+
   /** Rich-text modifiers used by rendered document views. */
   readonly bold?: boolean;
   readonly italic?: boolean;
@@ -74,8 +78,10 @@ export interface Span {
 export interface Line {
   readonly text: string;
   readonly spans: readonly Span[];
+
   /** Full-row background tint for diff views (added/removed lines). */
   readonly bg?: "add" | "del";
+
   /** The rendered text omits source content that a changed diff line must show. */
   readonly renderedSourceHidden?: boolean;
 }
@@ -106,9 +112,11 @@ export type StructureKind =
 /** A field of a JSON schema, summarized for display. */
 export interface SchemaField {
   readonly name: string;
+
   /** Compact type, e.g. `string`, `string[]`, `object`, `boolean`. */
   readonly type: string;
   readonly required: boolean;
+
   /** Nested fields for object types / array-of-object item types. */
   readonly fields?: readonly SchemaField[];
 }
@@ -136,19 +144,25 @@ export type NodeMeta =
   | { readonly kind: "schema"; readonly schema: SchemaMeta }
   | {
     readonly kind: "contract";
+
     /** Builder family: `pattern`, `lift`, `handler`, `computed`, … */
     readonly builder: string;
     readonly synthetic: boolean;
+
     /** Callback parameters — the captured input cells, e.g. `{ token }`. */
     readonly captures: readonly string[];
     readonly input?: SchemaMeta;
     readonly output?: SchemaMeta;
+
     /** Keys of the returned object literal, when discernible. */
     readonly returns?: readonly string[];
+
     /** Explicit type arguments, e.g. `fetchJson<{ connections: … }>`. */
     readonly typeArgs?: readonly string[];
+
     /** Keys of the non-schema object argument, e.g. fetchJson's `{ url, … }`. */
     readonly args?: readonly string[];
+
     /** Names of builders/patterns called inside the body. */
     readonly innerBuilders: readonly string[];
   }
@@ -156,6 +170,7 @@ export type NodeMeta =
     readonly kind: "closure";
     readonly params: readonly string[];
     readonly returns?: readonly string[];
+
     /** Syntactic type signature, e.g. `(fn: Function)` or `({ x }) → boolean`,
      * present only when the source carries explicit parameter/return types. */
     readonly signature?: string;
@@ -169,6 +184,7 @@ export type NodeMeta =
     readonly kind: "type";
     readonly form: "interface" | "alias";
     readonly members: readonly TypeMember[];
+
     /** For non-literal type aliases (unions, references), the type text. */
     readonly aliasText?: string;
   }
@@ -185,30 +201,39 @@ export type NodeMeta =
  */
 export interface StructureNode {
   readonly kind: StructureKind;
+
   /** Short human label, e.g. `pattern FetchPage` or `schema {token}`. */
   readonly label: string;
+
   /** Optional binding/identifier name, used for the definition index. */
   readonly name?: string;
+
   /** Char offset of the declared identifier (the `name`), for semantic queries
    * (type-at / definition-at). Absent when the node declares no single name. */
   readonly nameOffset?: number;
   readonly startLine: number;
   readonly endLine: number;
+
   /** 0-based column of the node start on `startLine`. */
   readonly startCol: number;
+
   /** 0-based column of the node end on `endLine`. */
   readonly endCol: number;
+
   /** Character offset of the node start, for definition peeks. */
   readonly startOffset: number;
   readonly endOffset: number;
   readonly depth: number;
   readonly children: StructureNode[];
+
   /** Structured, kind-specific detail for the info card (best-effort). */
   readonly meta?: NodeMeta;
+
   /** The TypeScript AST kind name(s) this node represents. More than one when
    * several nodes share the exact same source range and were merged into one
    * navigable node (e.g. an expression statement and the call it wraps). */
   readonly astKinds?: readonly string[];
+
   /** A human description of why this node is machine-generated, when a language
    * can vouch that it is (e.g. the TypeScript view recognizing a transformer's
    * synthetic helper). Absent means "not known to be generated"; the info card
@@ -247,10 +272,13 @@ export interface Document {
   /** Verbatim source text exactly as piped in, in either view mode. */
   readonly text: string;
   readonly lines: readonly Line[];
+
   /** Root-level structure nodes (sections, or top-level statements). */
   readonly structure: readonly StructureNode[];
+
   /** Flattened, pre-order list of structure nodes for linear navigation. */
   readonly flatStructure: readonly StructureNode[];
+
   /** Map from identifier name to its declaration(s) for peek overlays. */
   readonly definitions: ReadonlyMap<string, Definition[]>;
 }

--- a/packages/cli/lib/view/pager.ts
+++ b/packages/cli/lib/view/pager.ts
@@ -54,14 +54,17 @@ export interface PagerDeps {
   /** Open the controlling terminal for reading; throws when there is none. */
   openTty(): PagerTty;
   write(text: string): void;
+
   /** The terminal size; may throw when there is no console. */
   consoleSize(): { columns: number; rows: number };
   env(key: string): string | undefined;
   addSignalListener(signal: Deno.Signal, handler: () => void): void;
   removeSignalListener(signal: Deno.Signal, handler: () => void): void;
   exit(code: number): never;
+
   /** Schedule `handler` after `ms`; returns a function that cancels it. */
   setTimer(handler: () => void, ms: number): () => void;
+
   /** Resolve after `ms`. Used to hold a frame on screen for a moment on a path
    * that then tears the screen down, where a cancellable timer has nothing left
    * to run in. */

--- a/packages/cli/lib/view/references.ts
+++ b/packages/cli/lib/view/references.ts
@@ -25,8 +25,10 @@ export interface Reference {
   readonly line: number;
   readonly col: number;
   readonly cls: TokenClass;
+
   /** The full source line, for context in the card. */
   readonly lineText: string;
+
   /** True when this occurrence sits inside the node being described. */
   readonly inside: boolean;
 }
@@ -34,10 +36,13 @@ export interface Reference {
 export interface Dependency {
   readonly name: string;
   readonly kind: StructureNode["kind"];
+
   /** 0-based line of the declaration this node depends on. */
   readonly line: number;
+
   /** Char offset of the declaration, to select its node when jumped to. */
   readonly startOffset: number;
+
   /** Char offset of the first use inside the node, for a semantic definition
    * lookup that resolves the exact binding (and reaches other files). */
   readonly useOffset: number;

--- a/packages/cli/lib/view/render.ts
+++ b/packages/cli/lib/view/render.ts
@@ -186,68 +186,94 @@ export interface ViewState {
   width: number;
   height: number;
   color: boolean;
+
   /** Whether the source is a diff. */
   isDiff?: boolean;
   showLineNumbers: boolean;
+
   /** How long logical lines continue on later screen rows. */
   wrapMode: WrapMode;
+
   /** A precomputed wrapping layout for `doc`, when the session has one. */
   wrapPlan?: WrapPlan | null;
+
   /** The number to show in the gutter on each display row, or null there for a
    * blank gutter. Absent → the legacy 1-based display-row number. Only consulted
    * when `showLineNumbers` is set. */
   lineNumbers?: readonly (number | null)[] | null;
+
   /** How the non-printable characters in the content are shown. */
   displayMode: DisplayMode;
+
   /** The selected structure node (WASD navigation), or null. */
   selected: StructureNode | null;
+
   /** All search matches, document-ordered; null when no active search. */
   matches: readonly Match[] | null;
+
   /** Index into `matches` of the focused match. */
   currentMatch: number;
+
   /** Transient status text (e.g. "Pattern not found"). */
   message: string;
+
   /** Command/search input line, e.g. "/token"; null in normal mode. */
   inputLine: string | null;
   overlay: OverlayState | null;
+
   /** A modal prompt drawn as a centered Turbo Vision dialog (the save, revert and
    * amend confirmations). Covers the content like an overlay; the two never
    * coexist. */
   dialog?: DialogState | null;
+
   /** The text cursor, in document coordinates (line + display column), when
    * edit mode has it visible. The pager positions the real terminal cursor. */
   cursor?: { line: number; col: number } | null;
+
   /** Edit-mode key hints, shown on the status line in place of the navigation
    * help while the text cursor is active. */
   editHint?: readonly KeyHint[] | null;
+
   /** Whether Ctrl-L can reveal more context here (a diff), so the navigation
    * help advertises it. */
   canExpand?: boolean;
+
   /** Whether this pager can draw diff annotations. */
   expandMargin?: boolean;
+
   /** Per-line annotations drawn against the right edge. */
   diffAnnotations?: readonly DiffAnnotation[];
+
   /** Whole-diff added/removed totals, drawn at the top right corner of the
    * first line. */
   diffTotals?: DiffTotals | null;
+
   /** Absolute display row of the diff edge the next Ctrl-L will expand. */
   expandRow?: number | null;
+
   /** Whether the marked edge expands upward. False means downward. */
   expandUp?: boolean | null;
+
   /** Absolute display rows occupied by metadata adjacent to the expansion edge. */
   diffMetadataRows?: readonly number[];
+
   /** Whether the view is editable, so the navigation help advertises `e`. */
   canEdit?: boolean;
+
   /** Whether this source offers an alternate rendered representation. */
   canRender?: boolean;
+
   /** The representation currently shown. */
   viewMode?: ViewMode;
+
   /** Whether the content holds non-printable characters, so the navigation help
    * advertises the display-mode key `C`. */
   hasNonPrintables?: boolean;
+
   /** Lines shown just above the status/prompt bar (e.g. the list of files an
    * edited diff would save), overwriting the bottom content rows. */
   notice?: readonly string[] | null;
+
   /** The file currently in view — the diff file or source under the viewport, or
    * the file being edited — shown on the right of the status bar. Null when
    * there is none (a bare pipe). */
@@ -335,8 +361,10 @@ export interface OverlayState {
   readonly lines: readonly Line[];
   readonly scroll: number;
   readonly footer: string;
+
   /** Index into `lines` of the selected (highlighted) reference, if any. */
   readonly selectedLine?: number;
+
   /** The overlay shows source code, so it is drawn as a blue editor window
    * rather than a gray dialog. */
   readonly sourceView?: boolean;
@@ -356,9 +384,11 @@ export interface DialogState {
   readonly title: string;
   readonly body: readonly string[];
   readonly buttons: readonly DialogButton[];
+
   /** Index of the focused button — the one Space and Enter activate, drawn
    * highlighted. When absent, the default button (if any) is highlighted. */
   readonly focus?: number;
+
   /** Index of a button drawn mid-press: shifted one column right with its
    * shadow hidden, for the brief animation after it is activated. */
   readonly pushed?: number;

--- a/packages/cli/lib/view/session.ts
+++ b/packages/cli/lib/view/session.ts
@@ -97,6 +97,7 @@ import {
 export interface SessionOptions {
   color: boolean;
   showLineNumbers: boolean;
+
   /** Initial representation, falling back to source when none is available. */
   viewMode?: ViewMode;
 }
@@ -123,12 +124,16 @@ interface PeekOverlay {
   source?: readonly Line[];
   mode: "info" | "source";
   targets: readonly CardTarget[];
+
   /** Index into `targets` of the highlighted reference, or -1. */
   cardSel: number;
+
   /** The node this card describes (its subject), for `z` to reveal. */
   node?: StructureNode;
+
   /** Footer for overlays without a toggle (e.g. help). */
   staticFooter?: string;
+
   /** The `info` lines are verbatim source (a definition peek, an opened file),
    * not a structured card, so the overlay is drawn as a blue editor window even
    * in "info" mode. */
@@ -167,8 +172,10 @@ interface ExpansionLayoutCache {
 interface ExpandOffer {
   /** Screen row in the undecorated layout. */
   readonly row: number | null;
+
   /** Document line carrying the expansion triangle. */
   readonly markerLine: number | null;
+
   /** Document line passed to the context expander. */
   readonly line: number;
   readonly up: boolean;
@@ -182,6 +189,7 @@ interface ExpandEdge extends ExpandOffer {
 interface FoldAnchor {
   readonly docLine: number;
   readonly sourceCol: number;
+
   /** Display column within a collapsed summary that remains collapsed. */
   readonly syntheticDisplayCol?: number;
 }
@@ -192,10 +200,13 @@ interface JumpEntry {
   /** Document line the jump lands the viewport on (a file header or a `commit`
    * header line). */
   readonly line: number;
+
   /** The styled row shown in the list. */
   readonly display: Line;
+
   /** Lower-cased text the filter matches against. */
   readonly filterText: string;
+
   /** Short name for the "Jumped to …" confirmation. */
   readonly name: string;
 }
@@ -207,14 +218,18 @@ export class Session {
   private viewMode: ViewMode = "source";
   private color: boolean;
   private lineNumberMode: LineNumberMode = "off";
+
   /** How long logical lines continue on later screen rows. */
   private wrapMode: WrapMode = "off";
+
   /** How non-printable characters are shown; edit mode forces the first mode. */
   private displayMode: DisplayMode = DISPLAY_MODES[0];
+
   /** Indices (document order) of the diff files collapsed to a summary line.
    * Cleared when the text cursor is revealed, since hidden lines cannot be
    * edited. `this.top` is a display row while any file is collapsed. */
   private collapsed = new Set<number>();
+
   /** Bumped whenever `collapsed` changes, to invalidate the fold-plan cache. */
   private foldVersion = 0;
   private foldFileCache?: { doc: Document; files: DiffFileRange[] };
@@ -257,6 +272,7 @@ export class Session {
   };
   private nonPrintCache?: { doc: Document; value: boolean };
   private fileLineCache?: { doc: Document; value: (number | null)[] | null };
+
   /** Diff metadata lines, cached against the parsed document. */
   private diffMetadataCache?: { doc: Document; lines: readonly number[] };
 
@@ -268,6 +284,7 @@ export class Session {
   private query = "";
   private matches: Match[] = [];
   private currentMatch = 0;
+
   /** Where an edit-mode search (Ctrl-S) began, so its focused match is the
    * first at or after the cursor and Enter lands the cursor there. Null for a
    * normal-mode `/` search. */
@@ -277,55 +294,67 @@ export class Session {
   private input = "";
   private overlay: PeekOverlay | null = null;
   private overlayScroll = 0;
+
   /** The overlays followed to reach the current one, so Esc walks back through
    * the chain of cards and file peeks. Empty when the current overlay is the
    * first one opened from the main view. */
   private overlayStack: Array<{ overlay: PeekOverlay; scroll: number }> = [];
   private semantics?: Semantics;
   quit = false;
+
   /** An edit patched only the changed lines for speed; a full re-parse (for
    * structure, cross-references, and multi-line token colors) is owed. The
    * driver runs it on a short idle, so typing stays responsive. */
   needsReparse = false;
+
   /** What the last key revealed (Ctrl-L in pager mode), for the driver to walk
    * the lines in a few at a time with {@link revealFrame}: the display row they
    * start at, how many there are, and whether they came from above the hunk (so
    * the viewport holds still) or below it (so it slides as they land). The next
    * key clears it. */
   pendingReveal: { row: number; count: number; up: boolean } | null = null;
+
   /** A prompt button was just activated. Holds the frame that shows it pushed —
    * the dialog with that button drawn mid-press — so the driver can play the
    * press for a moment before the action's result appears. The next key clears
    * it. */
   pendingPush: { doc: Document; view: ViewState } | null = null;
+
   /** The last key set a message that takes itself away again rather than sitting
    * in the bar — Ctrl-L pressed where it is not offered, which changed nothing
    * else. The driver leaves it up for a moment and then calls
    * {@link expireMessage}; the next key takes it away too. */
   transientMessage = false;
+
   /** How much context each hunk can reveal, cached against the document. */
   private roomCache?: { doc: Document; room: ReadonlyMap<number, HunkRoom> };
 
   // --- editing ---
   private source?: EditableSource;
   private buffer?: EditBuffer;
+
   /** Incremental highlighter for the current buffer, created lazily on the first
    * edit and discarded (re-baselined) on each deferred re-parse and file swap. */
   private highlighter?: Highlighter;
+
   /** Row of the added line a context-line split produced, so undoing that edit
    * collapses the pair back — even after moving the cursor away and back — while
    * editing an author-written -/+ pair to match does not. Overwritten by the
    * next split, cleared on a collapse or when the buffer text is replaced. */
   private splitRow: number | null = null;
   private cursorOn = false;
+
   /** Pending C-x prefix (Emacs chord), reset by the next key. */
   private chord: "ctrl-x" | null = null;
+
   /** Which button the active prompt's Tab focus rests on — an index into its
    * button row. Space and Enter activate it; it is reset to the default button
    * each time a prompt opens. */
   private dialogFocus = 0;
+
   /** What the active save prompt does on confirm. */
   private savePromptThen: "quit" | null = null;
+
   /** Filenames a save would write, computed when the quit prompt opens and
    * listed above it. */
   private editedFiles: string[] = [];
@@ -338,6 +367,7 @@ export class Session {
   private pickerSel = 0;
 
   // --- jump list (i) ---
+
   /** Every file and commit in the diff, in document order; the filter narrows
    * this into the shown {@link jumpEntries}. */
   private jumpAll: JumpEntry[] = [];

--- a/packages/cli/lib/view/theme.ts
+++ b/packages/cli/lib/view/theme.ts
@@ -129,24 +129,32 @@ export function bracketStyle(depth: number): Style {
 export const ui = {
   /** The editor background painted behind every content cell. */
   editorBg: C.editorBg,
+
   /** Faint background tint marking a JSON-schema object-literal region. */
   schemaRegionBg: C.schemaBg,
+
   /** Faint background tint marking a closure (arrow/function-expression) body. */
   closureRegionBg: C.closureBg,
+
   /** Background of the line range belonging to the selected structure node. */
   selectionBg: C.selectionBg,
+
   /** The vertical guide bar drawn beside a selected node. */
   guide: { fg: C.cyan, bold: true, bg: C.editorBg } as Style,
+
   /** Continuation and diff-margin markers. The renderer supplies the content
    * row's editor or diff background. */
   wrapMarker: { fg: C.yellow, bold: true } as Style,
+
   /** End-of-document ornament. */
   endMark: { fg: C.fgDim } as Style,
   statusBar: { fg: C.fg, bg: C.panel } as Style,
   statusKey: { fg: C.red, bg: C.panel, bold: true } as Style,
+
   /** The current file name on the status bar. */
   statusFile: { fg: C.fgBright, bg: C.panel, bold: true } as Style,
   statusDim: { fg: C.fgDim, bg: C.panel } as Style,
+
   /** The notice region above the status bar (e.g. the files a save would
    * write), tinted to read as a callout rather than ordinary content. */
   noticeBar: { fg: C.ink, bg: C.cyan } as Style,
@@ -154,26 +162,35 @@ export const ui = {
   lineNumberCurrent: { fg: C.yellow, bg: C.editorBg } as Style,
   searchMatch: { fg: C.ink, bg: C.cyan } as Style,
   searchCurrent: { fg: C.ink, bg: C.yellow, bold: true } as Style,
+
   /** A dialog is a panel a shade lighter than the editor, with a bright frame
    * and a drop shadow, distinct from the content behind it. */
   overlayBg: C.panel,
   overlayBorder: { fg: C.white, bold: true } as Style,
+
   /** Border of an overlay that shows source (an editor window). */
   overlaySourceBorder: { fg: C.cyan, bold: true } as Style,
+
   /** The highlighted (selected) reference line inside a card. */
   overlayHighlightBg: C.panelHi,
+
   /** The drop shadow cast to the right of and below a dialog: the content behind
    * shows through, darkened. */
   overlayShadow: { fg: C.fgDim, bg: C.shadow } as Style,
   overlayTitle: { fg: C.fgBright, bold: true } as Style,
+
   /** Body text inside a modal prompt dialog. */
   dialogText: { fg: C.fg } as Style,
+
   /** A Turbo Vision push-button: dark text on a green face. */
   button: { fg: C.ink, bg: C.button } as Style,
+
   /** The default (Enter) button, drawn in bright white so it stands out. */
   buttonDefault: { fg: C.white, bg: C.button, bold: true } as Style,
+
   /** The highlighted shortcut letter on a button face. */
   buttonKey: { fg: C.yellow, bg: C.button, bold: true } as Style,
+
   /** The drop shadow cast below and right of a button, painted with half-block
    * glyphs so it reads as a thin edge rather than a full cell. */
   buttonShadow: { fg: C.shadow } as Style,

--- a/packages/cli/lib/view/wrap.ts
+++ b/packages/cli/lib/view/wrap.ts
@@ -21,22 +21,31 @@ export type ActiveWrapMode = Exclude<WrapMode, "off">;
 export interface WrappedRow {
   /** Absolute screen row in the complete wrapped document. */
   readonly row: number;
+
   /** Index of the logical line in the displayed document. */
   readonly line: number;
+
   /** Display-column offset where this screen row starts. */
   readonly offset: number;
+
   /** Display-column offset where this logical line's final screen row starts. */
   readonly lastOffset: number;
+
   /** Source cells available on this row. */
   readonly sourceWidth: number;
+
   /** Exclusive display-column end of the source cells drawn on this row. */
   readonly sourceEnd: number;
+
   /** Cells copied from the logical line's prefix before this row's source. */
   readonly prefixWidth: number;
+
   /** Whether source content continues on the following row. */
   readonly continues: boolean;
+
   /** Whether this row has room for a continuation marker. */
   readonly wrapMarker: boolean;
+
   /** Cells reserved at the right edge for a line annotation. */
   readonly suffixWidth: number;
 }
@@ -44,36 +53,50 @@ export interface WrappedRow {
 export interface WrapDecoration {
   /** Cells reserved on the logical line's first screen row. */
   readonly firstWidth: number;
+
   /** Cells reserved on the first screen row after the logical line wraps. */
   readonly firstContinuationWidth?: number;
+
   /** Cells reserved on later screen rows of the logical line. */
   readonly continuationWidth: number;
 }
 
 export interface WrapPlan {
   readonly rowCount: number;
+
   /** Total number of content columns available on each screen row. */
   readonly rowWidth: number;
+
   /** Display columns consumed by each row that carries a continuation marker. */
   readonly rowStride: number;
+
   /** First screen row occupied by each logical line. */
   readonly firstRow: readonly number[];
+
   /** Last screen row occupied by each logical line. */
   readonly lastRow: readonly number[];
+
   /** Source cells consumed by a continued first row. */
   readonly firstSourceWidth: readonly number[];
+
   /** Source cells consumed by each continued row after the first. */
   readonly continuationStride: readonly number[];
+
   /** Source cells consumed by the first continuation when it wraps again. */
   readonly firstContinuationStride: readonly number[];
+
   /** Annotation width on each logical line's first row. */
   readonly firstSuffixWidth: readonly number[];
+
   /** Annotation width on each logical line's first continuation row. */
   readonly firstContinuationSuffixWidth: readonly number[];
+
   /** Annotation width on later rows of each logical line. */
   readonly continuationSuffixWidth: readonly number[];
+
   /** Display width of each logical line. */
   readonly lineWidth: readonly number[];
+
   /** Variable word-wrap boundaries, or null entries for fixed-width rows. */
   readonly wordRows: readonly (WordWrapLine | null)[] | null;
 }

--- a/packages/cli/lib/wish.ts
+++ b/packages/cli/lib/wish.ts
@@ -33,15 +33,19 @@ import { throwOnSpaceAuthorizationError } from "./utils.ts";
 export interface WishReadConfig extends SpaceConfig {
   /** Wish target, e.g. "#profile" or "#profileName". */
   query: string;
+
   /** Extra path segments appended to the resolved target cell. */
   path?: string[];
+
   /** Optional result JSON schema (shapes/labels the projected value). */
   schema?: JSONSchema;
+
   /**
    * Search scope for hashtag queries: "~" (favorites/home), "." (mentionables /
    * current space), "profile" (profile elements), or arbitrary space DIDs.
    */
   scope?: (DID | "~" | "." | "profile")[];
+
   /** `--filter`/`--select`/`--schema`: the shape the caller asked the resolved
    * target to arrive in, read through the same step every other arrival reads
    * through. See {@link WishSpec.selection} for where it applies. */
@@ -51,6 +55,7 @@ export interface WishReadConfig extends SpaceConfig {
 export interface WishReadResult {
   /** The resolved value (dereferenced), or null when the wish produced none. */
   result: unknown;
+
   /** The error message a failed wish surfaced, if any (e.g. no profile yet). */
   error?: string;
 }
@@ -61,6 +66,7 @@ export interface WishSpec {
   path?: string[];
   schema?: JSONSchema;
   scope?: (DID | "~" | "." | "profile")[];
+
   /**
    * The caller's `--filter`/`--select`/`--schema`, applied to the cell the
    * wish resolved to.


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 439 doc comments across 50 files had no blank line above them; each
gets one.

Covered: `packages/cli/lib`. The rest of the package — `test`, `integration`,
and `commands` — follows in its own PR.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/cli`'s own test
task, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`, and
`check-withheld-globals` all pass locally. GitHub Actions is in an outage as this
is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

