### PR TITLE
docs(cli): blank lines above doc comments outside `lib`

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -1195,6 +1195,7 @@ export function invocationJson(
  * only the receipt readback. */
 export interface PieceCallWaitControl {
   mode: "settle" | "commit";
+
   /** Caller-chosen patience bound in seconds (`--wait`). Never set for
    * `commit` — the readback the bound would cover is already skipped. */
   boundSeconds?: number;
@@ -3258,6 +3259,7 @@ export function parseRetargetFlag(spec: string): PhaseRetarget {
 export interface SurveyCLIOptions extends BulkSelectionOptions {
   retarget?: string[];
   validator?: string;
+
   /** A plan this survey is reported against rather than emitted beside. */
   diff?: string;
   out?: string;
@@ -3867,6 +3869,7 @@ export interface SetPieceSourceCommandDependencies {
 /** Injectable dependencies for testing `piece setsrc --check`. */
 export interface CheckPieceSourceCommandDependencies {
   checkPiecePattern?: typeof checkPiecePattern;
+
   /** `exitWithDataError`'s seam, so a test can observe the refusal. */
   exit?: Parameters<typeof exitWithDataError>[1];
 }

--- a/packages/cli/integration/pattern/bulk-board.tsx
+++ b/packages/cli/integration/pattern/bulk-board.tsx
@@ -47,8 +47,10 @@ interface BoardInput {
 interface BoardOutput {
   [NAME]: string;
   items: MemberOutput[];
+
   /** File a new member on the board. */
   addMember: Stream<AddMemberEvent, AddMemberResult>;
+
   /** Seed many members in one call. */
   seedMembers: Stream<SeedMembersEvent, SeedMembersResult>;
 }

--- a/packages/cli/integration/pattern/bulk-member-v2.tsx
+++ b/packages/cli/integration/pattern/bulk-member-v2.tsx
@@ -20,6 +20,7 @@ export interface MemberInput {
 export interface MemberOutput {
   [NAME]: string;
   title: string;
+
   /** Which generation of this fixture the member runs. */
   generation: string;
 }

--- a/packages/cli/integration/pattern/bulk-member.tsx
+++ b/packages/cli/integration/pattern/bulk-member.tsx
@@ -17,6 +17,7 @@ export interface MemberInput {
 export interface MemberOutput {
   [NAME]: string;
   title: string;
+
   /** Which generation of this fixture the member runs. */
   generation: string;
 }

--- a/packages/cli/integration/pattern/completion-target.tsx
+++ b/packages/cli/integration/pattern/completion-target.tsx
@@ -46,6 +46,7 @@ interface RecordResult {
 interface ItemInput {
   label?: Writable<string | Default<"">>;
   recorded?: Writable<number | Default<0>>;
+
   /**
    * A callable handed in by the board, so this piece's ARGUMENTS cell carries
    * a name its result cell also carries. The two are different streams, and
@@ -58,6 +59,7 @@ interface ItemOutput {
   [NAME]: string;
   label: string;
   recorded: number;
+
   /** Record one line against this item, and report the running count. */
   record: Stream<RecordEvent, RecordResult>;
 }
@@ -85,6 +87,7 @@ export const Item = pattern<ItemInput, ItemOutput>(
 interface AddItemEvent {
   /** The item's display label. */
   title: string;
+
   /** Whether the item starts pinned. */
   pinned?: boolean;
 }
@@ -92,6 +95,7 @@ interface AddItemEvent {
 interface AddItemResult {
   /** The item this call created. */
   item: ItemOutput;
+
   /** How many items the board holds afterwards. */
   total: number;
 }
@@ -99,8 +103,10 @@ interface AddItemResult {
 interface RenameItemEvent {
   /** Which item to rename, by position. */
   index: number;
+
   /** The label to write. */
   newTitle: string;
+
   /** Leave the old label in place when it is already set. */
   keepExisting?: boolean;
 }
@@ -136,18 +142,23 @@ interface BoardOutput {
   itemCount: number;
   settings: BoardSettings;
   revision: number;
+
   /** Add one item to the board, and report the new total. */
   addItem: Stream<AddItemEvent, AddItemResult>;
+
   /** Rename the item at a position. */
   renameItem: Stream<RenameItemEvent, RenameItemResult>;
+
   /** Bump the revision and return nothing. */
   sweep: Stream<void>;
+
   /**
    * Record against the board rather than one item. Handed to every child as
    * its `record` argument, which is what puts a callable of that name on the
    * child's arguments cell beside the one on its result cell.
    */
   noteAll: Stream<RecordEvent, RecordResult>;
+
   /** @deprecated Use addItem, which reports the new total. */
   legacyAdd: Stream<AddItemEvent>;
 }

--- a/packages/cli/integration/pattern/topic-graph.tsx
+++ b/packages/cli/integration/pattern/topic-graph.tsx
@@ -17,19 +17,24 @@ interface TopicEntry {
   id: string;
   title: string;
   body: string;
+
   /** Attribution, interim `agentName` style (verb contract decision 5). */
   createdBy: string;
+
   /** "" until the body is revised. */
   bodyUpdatedBy: string;
+
   /** Ids of sibling topics this topic's body references. */
   references: string[];
 }
 
 interface CreateTopicEvent {
   title: string;
+
   /** The topic's initial body, part of the create's atomic unit. */
   body: string;
   agentName: string;
+
   /** Ids the body references, recorded as explicit edges. */
   references?: string[];
 }
@@ -65,6 +70,7 @@ interface TopicGraphOutput {
   [NAME]: string;
   topics: TopicEntry[];
   topicCount: number;
+
   /** Reciprocal edges, derived at read time and never persisted — topic id →
    * ids of the topics whose `references` name it. A derived result over a list
    * of children, which is what this fixture exercises the CLI against. */

--- a/packages/cli/integration/pattern/tracker.tsx
+++ b/packages/cli/integration/pattern/tracker.tsx
@@ -32,28 +32,37 @@ import {
 export interface ItemOutput {
   /** File a new item beneath this one. */
   addChild: Stream<AddChildEvent, AddChildResult>;
+
   /** Append a progress note. Notes are append-only; nothing rewrites one. */
   recordNote: Stream<RecordNoteEvent, RecordNoteResult>;
+
   /** Mark this item done. Descendants are left alone — finishing a parent
    * says nothing about its children, which is what `openBelow` reports. */
   finish: Stream<FinishEvent, FinishResult>;
+
   /** Record that this item waits on another. The blocker may be anywhere on
    * the board — this is the edge that makes the tree a graph. */
   blockOn: Stream<BlockOnEvent, BlockOnResult>;
+
   /** Mark this item archived. Declares no result — the value-less shape. */
   archive: Stream<void>;
   [NAME]: string;
   title: string;
+
   /** "open" until a verb changes it — "done" or "archived". */
   status: string;
+
   /** Append-only progress record. Each entry carries a time the caller did not
    * supply and could not have supplied — the pattern reads the clock. */
   notes: Note[];
+
   /** The item this one files under, or null at a root. Carried so a caller can
    * walk up as well as down, per the documented self-reference shape. */
   parent: ItemOutput | null;
+
   /** The tree. */
   children: ItemOutput[];
+
   /** Items this one waits on. These are not descendants — a blocker can live
    * anywhere in the board, which is what turns the tree into a graph and makes
    * one item reachable by two different paths. */
@@ -96,6 +105,7 @@ interface RecordNoteResult {
   /** The note as persisted, including the time the pattern stamped on it. A
    * caller cannot compute `at` — that is the whole reason this comes back. */
   note: Note;
+
   /** How many notes this item now carries, after the append. */
   noteCount: number;
 }
@@ -108,6 +118,7 @@ interface FinishEvent {
 interface FinishResult {
   /** When the item was finished, as persisted. */
   at: number;
+
   /** Descendants still open beneath this item. Zero means the subtree is
    * genuinely done; anything else is the caller's next question, and it takes
    * a walk of the whole subtree to answer. */
@@ -124,10 +135,12 @@ interface BlockOnEvent {
 interface BlockOnResult {
   /** The item that now waits — this one. */
   blocked: ItemOutput;
+
   /** The item it waits on. Still a reference: it arrived as one, is stored as
    * one, and is handed back as one, so the caller gets an address rather than
    * a copy of the target. */
   on: Writable<ItemOutput>;
+
   /** How many items this one waits on, after the edge was written. */
   blockedOnCount: number;
 }
@@ -235,8 +248,10 @@ interface BoardInput {
  * directly. */
 interface BoardOutput {
   [NAME]: string;
+
   /** Root items only. The tree hangs off each one's `children`. */
   items: ItemOutput[];
+
   /** File a new root item on the board. */
   addItem: Stream<AddItemEvent, AddItemResult>;
 }

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -34,8 +34,10 @@ export interface NoteOutput {
   [NAME]: string;
   title: string;
   body: string;
+
   /** Bumped by `append`, so a caller can tell a write happened. */
   revision: number;
+
   /** Append a line to the body. */
   append: Stream<AppendEvent, AppendResult>;
 }
@@ -101,6 +103,7 @@ interface SetLabelResult {
   /** The label as persisted — verbatim, so a caller can confirm the round
    * trip rather than assuming it. */
   label: string;
+
   /** The revision this write produced. A caller cannot compute it: it depends
    * on what was already stored. */
   revision: number;

--- a/packages/cli/test/fixtures/data-files/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/data-files/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Each participant of a multi-user test compiles the pattern in its own
  * worker, so an attachment made where the workers are spawned does not reach

--- a/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/crosswise-markers.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Both participants announce before either crosses the other's marker, so
  * each announces from a replica that predates the other's announcement. Each

--- a/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/false-assertion.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * A false assertion after a marker. Bob reads a note Alice did write, and
  * compares it against something she never wrote, so the value is settled and

--- a/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/marker-barrier.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Crossing `{ await }` delivers what the announcing participant wrote before
  * `{ label }`. Bob's assertion is read once, so it passes only when the

--- a/packages/cli/test/fixtures/multi-user-markers/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/settle-step.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * An explicit `{ settle: true }` step runs for a participant. Every step
  * already settles before the next, so this settles again at a point the author

--- a/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-markers/unannounced-marker.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Bob parks on a marker nobody announces. Alice finishes, leaving Bob the
  * only unfinished participant and nothing left to release him, which the

--- a/packages/cli/test/fixtures/multi-user-steps/event-payload.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-steps/event-payload.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * An action step's `event` payload in a multi-user run. Alice sends an object
  * payload and asserts on what the handler recorded, so the assertion fails if

--- a/packages/cli/test/fixtures/multi-user-steps/invalid-step.test.tsx
+++ b/packages/cli/test/fixtures/multi-user-steps/invalid-step.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Fixture for a step carrying no discriminant in a multi-user run. The
  * orchestrator has to name the step's own keys, so an author can see which

--- a/packages/cli/test/fixtures/view-language/corpus.ts
+++ b/packages/cli/test/fixtures/view-language/corpus.ts
@@ -24,6 +24,7 @@ export interface SelectionCases {
  */
 export interface ViewLanguageFixture {
   readonly languageId: string;
+
   /** Other adapters that deliberately share this fixture's token evidence. */
   readonly highlightingPeers?: readonly string[];
   readonly surveyRepository: string;

--- a/packages/cli/test/ingest-channels.test.ts
+++ b/packages/cli/test/ingest-channels.test.ts
@@ -49,8 +49,10 @@ interface RecordedRequest {
 
 interface StubReply {
   status?: number;
+
   /** Serialized as JSON. */
   body?: unknown;
+
   /** Sent verbatim, for the not-JSON case. */
   raw?: string;
 }

--- a/packages/cli/test/piece-cached-result-fields.test.ts
+++ b/packages/cli/test/piece-cached-result-fields.test.ts
@@ -50,6 +50,7 @@ const FIELDS = ["title", "shout", "loud"];
 interface LivePieceReport {
   cached: CachedResultField[];
   primitive: CachedResultField[];
+
   /** The entity each field's own stored link names, before any is followed. */
   firstHop: Record<string, string>;
 }

--- a/packages/cli/test/piece-call-cyclic-result-live.test.ts
+++ b/packages/cli/test/piece-call-cyclic-result-live.test.ts
@@ -143,6 +143,7 @@ interface Tracker {
     rawArgs: string[],
     extra?: Record<string, unknown>,
   ) => Promise<unknown>;
+
   /** How many times a caller reached for the compiled pattern. The declared
    * result is behind it, so this is what a readback pays to bound itself. */
   patternLoads: () => number;

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -1441,6 +1441,7 @@ function createPieceCallableHarness(options: {
   extraParams?: Record<string, unknown>;
   toolResult?: unknown;
   handlerFailureMessage?: string;
+
   /** Commit settles as an aborted transaction whose error wraps the drop
    * reason (`StorageTransactionAborted.reason`) — the shape a pre-dispatch
    * drop hands the commit callback (a send refused at the event-backlog
@@ -1449,27 +1450,33 @@ function createPieceCallableHarness(options: {
    * the whole signal. */
   abortedWithReason?: string;
   callableScope?: "space" | "user" | "session";
+
   /** Value the handling's receipt cell reads back ({} = value-less verb). */
   receiptValue?: unknown;
+
   /** The receipt's STORED form, when it differs from the materialized
    * `receiptValue` — a proxied instance's codec shape, most usefully.
    * Presence is decided on this, mirroring the production readback. */
   receiptRaw?: unknown;
+
   /** Simulate the create-only receipt collision: commit fails with
    * precondition "receipt-exists" while the link addresses the winner's
    * original receipt. */
   receiptExists?: boolean;
+
   /** Hold settlement open: `send` records the dispatch but never invokes the
    * commit callback, so anything awaiting acknowledgment waits forever.
    * This is how a test proves a path does NOT await the commit — the path
    * completes anyway — or exercises a wait bound against a call that can
    * never beat it. */
   neverCommit?: boolean;
+
   /** Commit with no `handlingReceiptLink` on the transaction, which is what
    * the runner leaves behind when receipts are not being written
    * (`commitPreconditions` off): it stashes the link only when it will
    * create the cell. */
   noReceiptLink?: boolean;
+
   /** Replace the readback receipt cell wholesale — for --show-links tests,
    * whose receipt must support key()/resolveAsCell link traversal. */
   receiptCell?: Cell<any>;
@@ -2993,6 +3000,7 @@ interface MockLinkedDoc {
   id: string;
   space: string;
   scope?: "space" | "user" | "session";
+
   /** Where inside the backing doc the link points (a link below its root). */
   path?: string[];
 }
@@ -3126,6 +3134,7 @@ function recordingReceiptCell(
 describe("collectInvocationResultLinks", () => {
   const receiptDoc = { id: "of:receipt-1", space: "did:key:test-home" };
   const receiptLink = mockLink(receiptDoc);
+
   /** The space the call targeted: an address in it carries no `@did`. */
   const contextSpace = "did:key:test-home" as MemorySpace;
   const receiptRef = "/of:receipt-1";

--- a/packages/cli/test/read-options-four-ways.test.ts
+++ b/packages/cli/test/read-options-four-ways.test.ts
@@ -226,6 +226,7 @@ describe("read options, four ways", () => {
   /** `cf exec <mountedFile>` — the read that arrives through a filesystem
    * mount. A real mount-state file and a real mounted callable path; the
    * runtime under it is the same one the other three read through. */
+
   /** `cf exec`'s whole outcome, so both the selected value and the envelope
    * written around it can be read from one drive of the command. */
   async function execOutcome(

--- a/packages/cli/test/verb-emitted-address.test.ts
+++ b/packages/cli/test/verb-emitted-address.test.ts
@@ -435,16 +435,21 @@ describe("verb-emitted-address", () => {
       /** Dispatch `verb` as `cf piece call` does, `payload` spelled as the
        * one positional JSON argument a caller writes by hand. */
       call: (verb: string, payload: unknown) => Promise<unknown>;
+
       /** The piece's own address, exactly as a read emits it. */
       address: string;
+
       /** How many entries `links` holds. */
       linkCount: () => number;
+
       /** `links[0]` RAW — the sigil link itself where a reference was
        * stored, and the object itself where a copy was. */
       storedRaw: () => unknown;
+
       /** `links[0]` read THROUGH, so it says where the edge landed. */
       linkedLabel: () => string | undefined;
       notes: () => string[];
+
       /** How many times the dispatch path loaded the compiled pattern. */
       patternLoads: () => number;
     }

--- a/packages/cli/test/verb-prose-live.test.ts
+++ b/packages/cli/test/verb-prose-live.test.ts
@@ -159,10 +159,13 @@ const PROGRAM = {
 
 const VERB_PROSE = "File a new root item on the board.";
 const FIELD_PROSE = "One line naming the work.";
+
 /** `Details.note` — one declared reference deep. */
 const NESTED_PROSE = "Free text the caller may attach.";
+
 /** `Details.tags` — the array property, one declared reference deep. */
 const NESTED_ARRAY_PROSE = "Labels to file it under.";
+
 /** `Tag.label` — reached through the inlined `primary`, two deep. */
 const ELEMENT_PROSE = "The tag's visible text.";
 

--- a/packages/cli/test/verb-undeclared-field.test.ts
+++ b/packages/cli/test/verb-undeclared-field.test.ts
@@ -198,6 +198,7 @@ interface Tracker {
     payload: unknown,
     invocationId?: string,
   ) => Promise<{ id: string; status: string; deduplicated?: boolean }>;
+
   /** What the handlers recorded, read off the cell rather than through any
    * rendering, so it says what the handler actually received. */
   entries: () => string[];

--- a/packages/cli/test/view-pager-cov.test.ts
+++ b/packages/cli/test/view-pager-cov.test.ts
@@ -266,6 +266,7 @@ function editableDoc(): {
   doc: typeof DOC;
   source: ReturnType<typeof fileSource>;
   dir: string;
+
   /** How many times the source has been re-parsed — the deferred reparse calls
    * `source.parse`, so this stays 0 unless an edit actually scheduled and ran
    * one. */


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 75 doc comments across 26 files had no blank line above them; each
gets one.

Covered: `packages/cli/test`, `integration`, and `commands`. Together with
#6354, which covers `lib`, this completes the package.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/cli`'s own test
task, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`, and
`check-withheld-globals` all pass locally. GitHub Actions is in an outage as this
is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

