### PR TITLE
docs(tasks): blank lines above doc comments in `tasks` and `scripts`

### DIFF
--- a/scripts/bench-setup.ts
+++ b/scripts/bench-setup.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env deno run -A
+
 /**
  * bench-setup.ts — CT-1409+ benchmark space deployer
  *

--- a/scripts/fuse-bench.ts
+++ b/scripts/fuse-bench.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env deno run -A
+
 /**
  * FUSE benchmark harness — CT-1408
  *

--- a/scripts/topics-export.ts
+++ b/scripts/topics-export.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-write
+
 /**
  * Export every topic's authored content from a Topics space snapshot,
  * offline. The export is the restore payload `topics-restore.ts` consumes,

--- a/scripts/topics-rehearsal-lib.ts
+++ b/scripts/topics-rehearsal-lib.ts
@@ -95,6 +95,7 @@ export interface TopicExportRow {
   patternIdentity: string;
   argumentId: string;
   content: TopicContent;
+
   /** The argument document exactly as stored, links unresolved — the
    * forensic copy. Restore consumes `content`, never this. */
   rawArgument: unknown;
@@ -109,11 +110,13 @@ export interface TopicsExport {
     fid: string;
     patternIdentity: string;
     argumentId: string;
+
     /** Stored membership links of the board's `topics` array, in order —
      * evidence of membership and order, never a restore payload. */
     topicsLinks: unknown[];
   } | null;
   topics: TopicExportRow[];
+
   /** Every piece in the snapshot, so "did I select the right ones?" is
    * answerable from the export alone. */
   manifest: { fid: string; patternIdentity: string; resultKeys: string[] }[];
@@ -122,6 +125,7 @@ export interface TopicsExport {
 /** The known link-valued argument fields a restore handles specially:
  * `mentionable` is re-established with `cf piece link` after the write, and
  * the deprecated `myName` stays retired. */
+
 /**
  * The link-valued argument fields a restore re-establishes with
  * `cf piece link` rather than writing as data, mapped to the board path each
@@ -145,8 +149,10 @@ export const LEGACY_LINK_FIELDS = ["myName"] as const;
 export interface RestoreDocument {
   /** The complete input document a restore applies. */
   doc: Record<string, unknown>;
+
   /** Link fields present in the raw argument that the caller re-links. */
   structural: string[];
+
   /** Deprecated link fields present in the raw argument, left retired. */
   legacy: string[];
 }

--- a/scripts/topics-restore.ts
+++ b/scripts/topics-restore.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-env
+
 /**
  * Restore one topic's authored content from a `topics-export.ts` export,
  * against a live server — never through verbs, which stamp their own write

--- a/tasks/check-baselines-append-only.ts
+++ b/tasks/check-baselines-append-only.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run=git
+
 /**
  * The pattern-update gate's safety argument is that `--update` can only ADD a
  * baseline — a command that could remove one could remove the very baseline

--- a/tasks/check-completion-slots.ts
+++ b/tasks/check-completion-slots.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-sys --allow-ffi
+
 /**
  * Fails when a slot the CLI accepts has not been decided about for completion.
  *
@@ -173,10 +174,13 @@ export interface SlotReport {
    * enumerated set, and no allowlist entry.
    */
   readonly undecidedOptions: string[];
+
   /** Positionals with no provider and no allowlist entry. */
   readonly undecidedPositionals: string[];
+
   /** Provider entries matching no slot on the tree. */
   readonly unreachableProviders: string[];
+
   /** Allowlist entries that decide no slot on the tree. */
   readonly staleAllowlist: string[];
 }

--- a/tasks/check-conflict-markers.ts
+++ b/tasks/check-conflict-markers.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run=git
+
 /**
  * Fails when a tracked file contains an unresolved merge-conflict marker.
  *

--- a/tasks/check-control-characters.ts
+++ b/tasks/check-control-characters.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run=git
+
 /**
  * Fails when a tracked source file contains a control codepoint below 0x20
  * other than newline.
@@ -98,8 +99,10 @@ export function isGovernedPath(path: string): boolean {
 export interface ControlViolation {
   file: string;
   line: number;
+
   /** The offending codepoint, e.g. `0x00`. */
   code: number;
+
   /** How many times it occurs in the file, so a CRLF file reports once. */
   count: number;
 }

--- a/tasks/check-docs-history-index.ts
+++ b/tasks/check-docs-history-index.ts
@@ -29,6 +29,7 @@ const HISTORY_DIR = "docs/history";
 export interface IndexEntry {
   /** 1-based line number in the index. */
   readonly lineNumber: number;
+
   /** Link targets on that line, relative to docs/history/. */
   readonly targets: readonly string[];
 }
@@ -140,6 +141,7 @@ export function coversPath(target: string, documentPath: string): boolean {
 export interface HistoryTree {
   /** Every archived document, excluding README.md and INDEX.md. */
   readonly documents: readonly string[];
+
   /** Every path an entry may point at: those documents and every directory. */
   readonly paths: ReadonlySet<string>;
 }

--- a/tasks/check-local-program.ts
+++ b/tasks/check-local-program.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-run=git
+
 /**
  * Fails when a `FileSystemProgramResolver` is constructed outside the one
  * operation that builds a program from local files.

--- a/tasks/check-no-waitfor.ts
+++ b/tasks/check-no-waitfor.ts
@@ -158,6 +158,7 @@ export function isIntegrationTestFile(relPath: string): boolean {
 export interface ScanResult {
   /** In-scope files importing the polling `waitFor` that are not allowlisted. */
   violations: string[];
+
   /** In-scope files importing the polling `waitFor` that are allowlisted. */
   allowlisted: string[];
 }

--- a/tasks/check-package-cycles.ts
+++ b/tasks/check-package-cycles.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run=git
+
 /**
  * Fails CI when the workspace packages import each other in a circle.
  *
@@ -60,6 +61,7 @@ const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
 export interface AllowedCycle {
   /** Package directory names, sorted, exactly as the cycle stands today. */
   readonly packages: readonly string[];
+
   /** What the two sides take from each other. */
   readonly reason: string;
 }
@@ -186,6 +188,7 @@ export function resolveRelative(fromPath: string, specifier: string): string {
 export interface Workspace {
   /** Every member's directory under `packages/`, which may itself be nested. */
   readonly members: readonly string[];
+
   /** Package name to member directory, for the members that declare a name. */
   readonly names: ReadonlyMap<string, string>;
 }
@@ -391,6 +394,7 @@ export function isExcused(
 export interface ScanResult {
   /** Cycles present in the tree that the allowlist does not cover. */
   readonly unexpected: string[][];
+
   /** Allowlist entries that no longer describe a cycle in the tree. */
   readonly resolved: AllowedCycle[];
   readonly edges: readonly Edge[];

--- a/tasks/check-skill-facts.ts
+++ b/tasks/check-skill-facts.ts
@@ -243,6 +243,7 @@ export interface SkillDoc {
 export interface Drift {
   /** Repo-relative path of the doc making the citation. */
   file: string;
+
   /** 1-based line within that doc. */
   line: number;
   message: string;

--- a/tasks/check-test-aliases.ts
+++ b/tasks/check-test-aliases.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-run=git
+
 /**
  * Guards tasks/test-identity-aliases.jsonl, the append-only file that
  * bridges test-identity renames for readers of the test-run record store

--- a/tasks/check-tripwires.ts
+++ b/tasks/check-tripwires.ts
@@ -29,12 +29,16 @@ const banner = (lines: string[]): string => {
 
 export interface Tripwire {
   name: string;
+
   /** The unit test that must remain present and intact. */
   testFile: string;
+
   /** A marker the test file must still contain, so gutting it is caught. */
   sentinel: string;
+
   /** True while the weakness is still present. Resolving it fails the check. */
   stillWeak: () => Promise<boolean>;
+
   /** Printed when the weakness is resolved: what the resolver must now do. */
   obligation: string[];
 }

--- a/tasks/check-unused-deps.ts
+++ b/tasks/check-unused-deps.ts
@@ -258,6 +258,7 @@ async function readSourceFiles(
 interface Entry {
   /** Repo-relative path of the declaring deno.jsonc. */
   config: string;
+
   /** The declaring member, or undefined for the root config. */
   member: string | undefined;
   alias: string;
@@ -272,6 +273,7 @@ export interface UnusedEntry extends Entry {
 export interface ScanResult {
   /** Unused entries that are not allowlisted. */
   unused: UnusedEntry[];
+
   /** Unused entries that are allowlisted, with their reasons. */
   allowlisted: UnusedEntry[];
 }

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read
+
 /**
  * Fails when a verb-session document drifts from the demo that runs it.
  *

--- a/tasks/ci-check-lib.ts
+++ b/tasks/ci-check-lib.ts
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------
 
 export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
+
 /** Where the repository is hosted; a workflow run names it. */
 export const SERVER_URL = Deno.env.get("GITHUB_SERVER_URL") ??
   "https://github.com";
@@ -69,13 +70,17 @@ export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
 export interface CoverageCommentPayload {
   prNumber: number;
   state: "regressed" | "resolved";
+
   /** Present when `state` is "regressed". */
   body?: string;
+
   /** Present when `state` is "resolved". */
   improvedLines?: number;
+
   /** Present when `state` is "resolved": the changed source groups and where
    * this PR left each one's uncovered-line count. */
   groups?: CoverageResolvedGroup[];
+
   /** Present when `state` is "resolved": true when the gate passed because a
    * changed group's debt was accepted with a per-group acceptance or the reset
    * marker, not because the new code is covered. */
@@ -184,8 +189,10 @@ export type CompileCacheStates = Partial<
 export interface CacheStateRecord {
   family: string;
   shard: string;
+
   /** The cache key `actions/cache` restored from; empty on a full miss. */
   matchedKey: string;
+
   /** True only when the primary key matched exactly. */
   exactHit: boolean;
 }
@@ -194,6 +201,7 @@ export interface CoverageBaselineFile {
   version: 1;
   generatedAt: string;
   metrics: MetricRecord[];
+
   /**
    * Per-family compile cache states for the run this file describes. Absent
    * when no cache-state artifact recorded for the run.
@@ -211,8 +219,10 @@ export interface PRInfo {
 
 export interface PRFile {
   filename: string;
+
   /** Old path for renamed files; the fingerprint classifier needs both. */
   previous_filename?: string;
+
   /** Unified diff for this file. Absent for binary or oversized changes. */
   patch?: string;
 }
@@ -236,6 +246,7 @@ export interface BaselineOverrides {
    * reads the number off the current pull request alone.
    */
   metrics: Map<string, number>;
+
   /** Reset all coverage-debt metrics at the commit carrying this marker. */
   coverageBaselineReset: boolean;
 }
@@ -465,6 +476,7 @@ function metricsToRecords(
 /** Parsed coverage baseline plus the run's compile cache states, when tagged. */
 export interface CoverageBaselineDetailed {
   metrics: Map<string, BaselineSample>;
+
   /** Null when the file recorded no compile cache states. */
   compileCacheStates: CompileCacheStates | null;
 }
@@ -854,8 +866,10 @@ export function parseAddedLinesFromPatch(patch: string): Map<number, string> {
 /** A changed source group whose uncovered-line count regressed. */
 export interface CoverageSuggestionGroup {
   group: string;
+
   /** Uncovered-line count from latest `main`; the PR must not exceed it. */
   target: number;
+
   /** Uncovered-line count this PR produced. */
   current: number;
 }
@@ -870,8 +884,10 @@ export interface CoverageSuggestionFileLines {
 /** A changed source group and where this PR left its uncovered-line count. */
 export interface CoverageResolvedGroup {
   group: string;
+
   /** Uncovered-line count from latest `main`. */
   baseline: number;
+
   /** Uncovered-line count this PR produced. */
   current: number;
 }
@@ -1081,6 +1097,7 @@ export interface CoverageUnattributedFile {
 export interface CoverageMeasurement {
   /** The run's page on GitHub. */
   runUrl?: string;
+
   /** The base-branch commit the run merged the pull request into. */
   baseSha?: string;
 }
@@ -1089,6 +1106,7 @@ export interface CoverageMeasurement {
 export interface CoverageRunIdentity {
   /** The run's page on GitHub. */
   runUrl?: string;
+
   /** The commit that run measured. */
   sha?: string;
 }
@@ -1101,12 +1119,14 @@ export interface CoverageUnattributedGroup extends CoverageSuggestionGroup {
 export interface CoverageDebtUnattributedInput {
   groups: CoverageUnattributedGroup[];
   files: CoverageUnattributedFile[];
+
   /** The run whose coverage report the affected lines were read from. */
   measurement?: CoverageMeasurement;
 }
 
 /** How many affected files the comment names before it starts counting. */
 const MAX_UNATTRIBUTED_FILES = 20;
+
 /** How many line numbers one file contributes before the rest are counted. */
 const MAX_UNATTRIBUTED_LINES_PER_FILE = 20;
 

--- a/tasks/coverage-check.ts
+++ b/tasks/coverage-check.ts
@@ -345,8 +345,10 @@ export async function fetchAncestorRanks(
 export interface BaselineRunReading {
   /** The run's uncovered-line count per metric, from its baseline artifact. */
   samples: Map<string, BaselineSample>;
+
   /** What the run's merged pull request accepted, when it has one. */
   overrides: BaselineOverrides | null;
+
   /** True when the run compiled patterns from scratch. */
   cold: boolean;
 }
@@ -357,10 +359,13 @@ export interface WalkBaselineRunsOptions {
    * because a one-shot iterator would leave a second pass over it empty.
    */
   metrics: readonly string[];
+
   /** Recent `main` runs, newest first. */
   runs: WorkflowRun[];
+
   /** Reads one run. Called only for the runs the walk reaches. */
   readRun: (run: WorkflowRun) => Promise<BaselineRunReading>;
+
   /**
    * How far back from the base-branch commit this run merged each recent commit
    * sits, or null when there is no base-branch commit to measure against.
@@ -538,8 +543,10 @@ export function isComparableBaseline(
 
 export interface MetricBaseline {
   sample?: BaselineSample;
+
   /** Whether the ratchet may fail this metric against that sample. */
   comparable: boolean;
+
   /**
    * The base-branch commit the comparison was judged against: the commit this
    * run merges the pull request into. Absent on a `main` push run, and when
@@ -551,8 +558,10 @@ export interface MetricBaseline {
 export interface SelectBaselinesOptions {
   /** The metrics to gate; an array, as in {@link WalkBaselineRunsOptions}. */
   metrics: readonly string[];
+
   /** Recent `main` runs, newest first. */
   runs: WorkflowRun[];
+
   /** Reads one baseline run; called only for the runs the walk reaches. */
   readRun: (run: WorkflowRun) => Promise<BaselineRunReading>;
   isPullRequest: boolean;
@@ -562,6 +571,7 @@ export interface SelectBaselinesOptions {
     baselineSha: string,
     baseSha: string,
   ) => Promise<Set<string>>;
+
   /** Wraps the GitHub calls made here so a rate limit skips the check. */
   guard?: <T>(description: string, operation: () => Promise<T>) => Promise<T>;
   log?: (message: string) => void;
@@ -1142,14 +1152,19 @@ export interface Row {
   metric: string;
   status: Status;
   current: number;
+
   /** Uncovered lines the chosen `main` run measured for this metric. */
   baseline?: number;
+
   /** Head SHA of the run that baseline came from. */
   baselineSha?: string;
+
   /** Id of the run that baseline came from. */
   baselineRunId?: number;
+
   /** Id of the run that measured `current`. */
   measuredRunId?: number;
+
   /**
    * The base-branch commit that run merged this pull request into. A
    * `pull_request` run measures `refs/pull/<number>/merge`, so this is the
@@ -1178,14 +1193,17 @@ export interface BuildCoverageRowsOptions {
   currentMetrics: Map<string, BaselineSample>;
   baselineByMetric: Map<string, MetricBaseline>;
   overrides: BaselineOverrides;
+
   /** Undefined when the PR's changed files could not be read. */
   changedCoverageGroups: Set<string> | undefined;
 }
 
 export interface CoverageRows {
   rows: Row[];
+
   /** The subset of `rows` that fails the gate. */
   failures: Row[];
+
   /** Groups whose baseline could not be held against this run. */
   ungatedGroups: Set<string>;
 }
@@ -1497,6 +1515,7 @@ export interface UnattributedRegressionOptions {
   groups: CoverageSuggestionGroup[];
   coverageFailures: Row[];
   prFiles: PRFile[];
+
   /** LCOV from this run. */
   lcov: string;
   readBaselineLcov: (runId: number) => Promise<string | null>;

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -193,12 +193,16 @@ export interface RegressedSourceLines {
 
 export interface RegressedLinesOptions {
   rootDir: string;
+
   /** LCOV from the run being gated. */
   lcov: string;
+
   /** LCOV from the `main` run its ratchet baseline came from. */
   baselineLcov: string;
+
   /** Metric groups to inspect; every other group is left alone. */
   groups: Set<string>;
+
   /** Repository-relative POSIX paths the pull request changed. */
   changedFiles: Set<string>;
 }

--- a/tasks/lcov.ts
+++ b/tasks/lcov.ts
@@ -13,8 +13,10 @@ export interface LcovFileCoverage {
    * `mapPath` turned it into the key this entry is stored under.
    */
   sourcePath: string;
+
   /** The `TN:` name from the first record for this file that carried one. */
   testName?: string;
+
   /** Execution count per line number, summed over every record read. */
   lineHits: Map<number, number>;
 }

--- a/tasks/lint-bench-console.ts
+++ b/tasks/lint-bench-console.ts
@@ -107,8 +107,10 @@ function calledName(node: BenchNode): string | undefined {
 interface Scope {
   /** Names this body calls as plain `name(...)` calls. */
   readonly calls: Set<string>;
+
   /** The `console` calls written directly in this body. */
   readonly consoleCalls: { node: Deno.lint.Node; method: string }[];
+
   /** True when this function was written inside a `Deno.bench(...)` call. */
   readonly inBench: boolean;
 }

--- a/tasks/pattern-break-registry-guards.ts
+++ b/tasks/pattern-break-registry-guards.ts
@@ -55,8 +55,10 @@ const REPO_ROOT = fromFileUrl(new URL("..", import.meta.url)).replace(
 export interface BreakRegistryEntry {
   /** Which registry the entry sits in, for reporting. */
   registry: string;
+
   /** Pattern key: the path relative to `packages/patterns`. */
   pattern: string;
+
   /** Repo-relative path of the entry's decision record. */
   record: string;
 }
@@ -230,6 +232,7 @@ export function guardUnevaluableExemptions(options: {
 export function reportBreakRegistryFindings(options: {
   requiredPatternKeys: ReadonlySet<string>;
   recordExists: (repoRelativePath: string) => boolean;
+
   /**
    * Tier 1's unevaluable list, when the caller is the gate it exempts from.
    * Omitted by Tier 2, which does not consult it.

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -40,15 +40,19 @@
 export interface AcceptedContractBreak {
   /** Pattern key: the path relative to `packages/patterns`. */
   pattern: string;
+
   /** Baseline labels (filename stems) this pattern may fail to apply over. */
   baselines: readonly string[];
+
   /**
    * Schema paths this break may blame, spelled as the compatibility proof
    * spells them. A finding blaming anything else stands.
    */
   paths: readonly string[];
+
   /** Why the break was accepted. */
   reason: string;
+
   /**
    * Repo-relative path of the decision record under `docs/history/` — the
    * deliberation behind this entry's declaration. Its existence is enforced

--- a/tasks/pattern-compat-lib.ts
+++ b/tasks/pattern-compat-lib.ts
@@ -48,6 +48,7 @@ export interface Baseline {
 }
 
 export type Finding =
+
   /** The current contract is not recorded, so nothing pins it for the next PR. */
   | { kind: "missing-baseline"; pattern: string; hash: string }
   /** The current contract cannot be applied over a deployed one. */

--- a/tasks/pattern-compat.ts
+++ b/tasks/pattern-compat.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run -A
+
 /**
  * Tier 1 pattern-update gate. Compiles every authored pattern, then proves its
  * argument/result contract can still be applied over every contract recorded
@@ -117,6 +118,7 @@ async function main() {
   const cwd = Deno.cwd();
 
   const contracts = new Map<string, PatternContract>();
+
   /**
    * Files that yielded no contract, and why. Most of `packages/patterns` is not
    * a pattern entry — `schemas.tsx`, `auth-types.ts`, client helpers — and a
@@ -126,6 +128,7 @@ async function main() {
    * and can no longer roll forward. That case is `checkPattern`'s `retired`.
    */
   const unavailable = new Map<string, string>();
+
   /** Skips that are an evaluation error rather than "not a pattern entry". */
   const evaluationErrors: { pattern: string; error: string }[] = [];
 

--- a/tasks/pattern-vintage-accepted-drops.test.ts
+++ b/tasks/pattern-vintage-accepted-drops.test.ts
@@ -17,6 +17,7 @@ describe("pattern-vintage-accepted-drops", () => {
       record: "docs/history/topics-crossref-identity-break.md",
     },
   ];
+
   /** A capture from inside the window the entry was granted over. */
   const within = "2026-07-30T21-43-16.977Z";
 

--- a/tasks/pattern-vintage-accepted-drops.ts
+++ b/tasks/pattern-vintage-accepted-drops.ts
@@ -41,11 +41,13 @@
 export interface AcceptedStateDrop {
   /** Pattern key: the path relative to `packages/patterns`. */
   pattern: string;
+
   /**
    * Dotted paths into the pattern's result state that it no longer holds.
    * A segment ending in `[]` steps through every element of that list.
    */
   paths: readonly string[];
+
   /**
    * Capture stamp of the newest vintage this entry forgives, as
    * `VintageRef.stamp` spells one (ISO-8601 with `:` replaced, so it sorts as
@@ -60,8 +62,10 @@ export interface AcceptedStateDrop {
    * exemption covers the removal it was granted for and stops there.
    */
   capturedThrough: string;
+
   /** Why the removal was accepted. */
   reason: string;
+
   /**
    * Repo-relative path of the decision record under `docs/history/` — shared
    * with the matching Tier 1 entry where there is one. Existence is enforced

--- a/tasks/pattern-vintage-lib.ts
+++ b/tasks/pattern-vintage-lib.ts
@@ -102,12 +102,16 @@ export interface VintageRef {
    * test instantiates, which is routinely several patterns.
    */
   testKey: string;
+
   /** `pinned` or `auto`. */
   tier: string;
+
   /** Capture timestamp, ISO-8601 with `:` replaced (filenames). */
   stamp: string;
+
   /** Identity of the pattern version that WROTE this state. */
   identity: string;
+
   /** Repo-relative path to the fixture file. */
   path: string;
 }
@@ -472,6 +476,7 @@ export function uncoveredRequiredPatterns(
 export interface ReplayFailure {
   /** The TEST whose fixture this failure came from. */
   testKey: string;
+
   /** Repo-relative fixture path. */
   path: string;
   detail: string;

--- a/tasks/pattern-vintage-run.ts
+++ b/tasks/pattern-vintage-run.ts
@@ -58,10 +58,13 @@ import {
 export interface GateRoots {
   /** Repo root, used only to shorten paths in reports. */
   repoRoot: string;
+
   /** Directory pattern keys are resolved against. */
   patternsRoot: string;
+
   /** Directory fixtures live under. */
   vintagesRoot: string;
+
   /** Signer every capture and replay runs as. */
   signer: Identity;
 }
@@ -142,6 +145,7 @@ export function snippet(value: unknown): string {
 /** Which test's fixture records a pattern, and whether it can credit it. */
 export interface VintageAttribution {
   testKey: string;
+
   /**
    * PINNED is the only tier coverage counts. It breaks TIES over which test to
    * name, and selects a remedy: `reportUncovered` scopes by whether the
@@ -154,10 +158,13 @@ export interface VintageAttribution {
 /** What replaying ONE fixture found, kept per fixture rather than summed. */
 export interface VintageOutcome {
   ref: VintageRef;
+
   /** Recorded instantiations that are legitimate upgrade targets. */
   targets: number;
+
   /** Of those, the ones whose source moved since this fixture was captured. */
   changed: number;
+
   /** Whether replaying this fixture produced any failure at all. */
   failed: boolean;
 }
@@ -218,8 +225,10 @@ export function staleTestKeys(
 export interface ReplayReport {
   /** Instantiations the fixture recorded. Zero means it proved nothing. */
   candidates: number;
+
   /** Recorded instantiations that are legitimate upgrade targets. */
   targets: number;
+
   /**
    * Recorded instantiations that cannot be mapped to a file to apply.
    *
@@ -231,12 +240,16 @@ export interface ReplayReport {
    * failure mode. Kept as a count for the tests that pin that behavior.
    */
   unmappable: number;
+
   /** Targets whose source CHANGED since capture — the actual migrations. */
   changed: number;
+
   /** Changed targets that applied cleanly. */
   updated: number;
+
   /** Keys an applied update stopped being able to read back. */
   stranded: number;
+
   /**
    * Targets recorded under a SERVED route rather than a repo path.
    *
@@ -245,6 +258,7 @@ export interface ReplayReport {
    * read as thorough coverage.
    */
   servedRoute: number;
+
   /**
    * Pattern keys this fixture actually replayed a target for.
    *
@@ -254,6 +268,7 @@ export interface ReplayReport {
    * "X was replayed" — and the second is the one that matters.
    */
   covered: Set<string>;
+
   /**
    * Pattern keys this fixture's manifest NAMES, whether or not each was
    * credited as coverage.
@@ -270,6 +285,7 @@ export interface ReplayReport {
    * since `uncovered` is exactly the required keys ABSENT from `covered`.
    */
   recorded: Set<string>;
+
   /**
    * Accepted-drop entries that actually removed something from a vintage here.
    *
@@ -278,6 +294,7 @@ export interface ReplayReport {
    * unless the run counts where each was used. Keyed by the entry's pattern.
    */
   dropsApplied: Set<string>;
+
   /**
    * Derived-hoist targets held back from failing, each entry tagged with the
    * rule that held it. Two refusal shapes qualify: STORED ARGUMENTS today's
@@ -335,6 +352,7 @@ export async function replayVintage(
     capturesSuperseded: [],
     failures: [{ ...where, detail }],
   });
+
   /** Every pattern key a manifest names, for attributing a failed fixture. */
   const recordedFrom = (entries: readonly VintageManifestEntry[]) =>
     new Set(
@@ -931,6 +949,7 @@ export async function replayAll(
     stranded: number;
     servedRoute: number;
     covered: Set<string>;
+
     /**
      * Which TEST's fixture RECORDS each pattern, and whether that fixture is
      * the tier that credits coverage.
@@ -951,6 +970,7 @@ export async function replayAll(
      * fixture can need.
      */
     coveredBy: Map<string, VintageAttribution>;
+
     /**
      * What each fixture individually found, in walk order.
      *
@@ -963,8 +983,10 @@ export async function replayAll(
      * with the one that produced the verdict.
      */
     perVintage: VintageOutcome[];
+
     /** Accepted-drop entries that forgave something somewhere in this run. */
     dropsApplied: Set<string>;
+
     /**
      * Derived-hoist targets held back, each tagged with the rule that held
      * it — a superseded stored argument, or a hoist no longer emitted.

--- a/tasks/pattern-vintage.ts
+++ b/tasks/pattern-vintage.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run -A
+
 /**
  * Tier 2's gate: replay every pinned vintage under TODAY's pattern source.
  *

--- a/tasks/run-recorded.ts
+++ b/tasks/run-recorded.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env --allow-net
+
 /**
  * Runs a command and spools one record from its exit code:
  *

--- a/tasks/server-execution-on-skips.ts
+++ b/tasks/server-execution-on-skips.ts
@@ -42,10 +42,13 @@ export type ServerExecutionOnSkip = {
   /** Test file, relative to the suite's package root (the directory the
    * suite's `deno test` runs from), e.g. "integration/counter.test.ts". */
   file: string;
+
   /** The plan phase that, once landed, unskips this file (or step). */
   phase: ServerExecutionPhase;
+
   /** Why the ON arm cannot run this file (or step) before that phase. */
   reason: string;
+
   /**
    * STEP-LEVEL entry (Phase 7 fixer, 2026-08-16): the exact name of ONE
    * `it`/step inside `file` that the ON arm skips while the REST of the
@@ -126,6 +129,7 @@ const SUITE_PACKAGE_DIR: Record<ServerExecutionSuite, string> = {
  * residual; its sibling `cfc-group-chat-demo-two-browsers` was
  * un-skipped by fan-out stage B (2026-08-17, 3/3 green).
  */
+
 /**
  * The two-browser gates' Phase-7 reason (the client-side
  * `scheduler-non-settling` loop, verification-coverage.md OW32) RETIRED

--- a/tasks/test-records-agent-config.ts
+++ b/tasks/test-records-agent-config.ts
@@ -21,8 +21,10 @@ import { type Environment, readEnv } from "@commonfabric/test-support/records";
 export interface AgentHarness {
   /** What the harness is called, for what the tool prints. */
   name: string;
+
   /** The directory whose presence means the harness is installed. */
   home: (home: string) => string;
+
   /** The configuration file, which need not exist yet. */
   config: (home: string) => string;
 }
@@ -53,6 +55,7 @@ export type ConfigWriter = (
 
 /** What one harness configuration's update did. */
 export type AgentConfigOutcome =
+
   /** The variable was written into the configuration. */
   | "added"
   /** The configuration already carries the variable with this value. */
@@ -68,6 +71,7 @@ export interface AgentConfigUpdate {
   harness: string;
   path: string;
   outcome: AgentConfigOutcome;
+
   /** The value already there, for a conflict. */
   existing?: string;
 }

--- a/tasks/test-records-compact.ts
+++ b/tasks/test-records-compact.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
+
 /**
  * The compactor: rewrites each closed day of raw records as one rollup
  * object under the dataset's aggregated/ area, so full-history consumers
@@ -67,6 +68,7 @@ export interface CompactOptions {
   plan: boolean;
   bucket: string;
   rawPrefix: string;
+
   /** Required unless plan is set. */
   token?: string;
   fetchImpl?: typeof fetch;

--- a/tasks/test-records-crypto.ts
+++ b/tasks/test-records-crypto.ts
@@ -24,10 +24,13 @@ const HKDF_INFO = "common-fabric test-records key delivery v1";
 
 export interface SealedBox {
   v: 1;
+
   /** Ephemeral sender public key, base64url raw. */
   epk: string;
+
   /** AES-GCM nonce, base64url. */
   iv: string;
+
   /** Ciphertext with tag, base64url. */
   ct: string;
 }
@@ -35,6 +38,7 @@ export interface SealedBox {
 export interface KeyDeliveryIdentity {
   /** The recipient string to paste into the minting workflow. */
   recipient: string;
+
   /** X25519 private key, base64url PKCS#8. */
   privateKey: string;
 }

--- a/tasks/test-records-gather.ts
+++ b/tasks/test-records-gather.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env
+
 /**
  * The credential-free shipping step every CI test job ends with: gather the
  * job's spooled record fragments and its JUnit files into one artifact

--- a/tasks/test-records-janitor.ts
+++ b/tasks/test-records-janitor.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
+
 /**
  * The activity lease. A key's validity window cannot be extended, so the
  * one-month lifetime is enforced here instead of by key expiry: daily, with

--- a/tasks/test-records-key.test.ts
+++ b/tasks/test-records-key.test.ts
@@ -164,11 +164,14 @@ function mintRun(
 interface StubOptions {
   login?: string;
   loginStatus?: number;
+
   /** What the token endpoint says about the installed key. */
   keyStatus?: number;
+
   /** One page of runs per listing call; the last repeats. */
   runPages?: Record<string, unknown>[][];
   runsStatus?: number;
+
   /** GitHub's clock, as the runs listing reports it. */
   listDate?: string;
   artifacts?: { id: number; name: string; expired?: boolean }[];

--- a/tasks/test-records-key.ts
+++ b/tasks/test-records-key.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run=gh
+
 /**
  * The personal key tool, in one command that finishes the job and two that
  * split it.
@@ -98,6 +99,7 @@ export interface KeyToolDeps {
   env: Environment;
   fetchImpl: typeof fetch;
   githubToken: () => Promise<string | undefined>;
+
   /** Waits out one polling interval. */
   pause: () => Promise<void>;
 }
@@ -261,6 +263,7 @@ function mintWorkflowUrl(): string {
 interface DispatchResult {
   dispatched: boolean;
   username?: string;
+
   /** GitHub's clock at the dispatch, which bounds the run's creation. */
   at?: number;
 }
@@ -337,6 +340,7 @@ interface MintRun {
 /** A minting run this requester's, and the delivery it published. */
 interface RunMatch {
   run: MintRun;
+
   /** The delivery artifact, when one identified the run. */
   artifact?: number;
 }
@@ -347,6 +351,7 @@ interface RunSearch {
   recipient: string;
   artifactName: string;
   login: string;
+
   /**
    * GitHub's clock at the moment this attempt began, bounding how far
    * back a run can be and still be this attempt's. Unset examines every
@@ -358,6 +363,7 @@ interface RunSearch {
 
 interface RunSearchResult {
   match?: RunMatch;
+
   /** GitHub's clock at the listing, for bounding later searches. */
   serverDate?: number;
 }

--- a/tasks/test-records-mint.ts
+++ b/tasks/test-records-mint.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net
+
 /**
  * Mints a personal test-records key. Runs inside the dispatch-gated minting
  * workflow with the broker's federated token: dispatching a workflow takes
@@ -74,6 +75,7 @@ export function usernameOfDisplayName(displayName: string): string | undefined {
 export interface GcpClient {
   token: string;
   fetchImpl: typeof fetch;
+
   /**
    * Waits out the window in which a just-created service account is not
    * yet visible to the other services that name it. Tests pass a no-op.
@@ -334,6 +336,7 @@ export interface MintRunOptions {
   username: string;
   out: string;
   client: GcpClient;
+
   /** GITHUB_OUTPUT file to append the fingerprint line to, when set. */
   githubOutput?: string;
 }

--- a/tasks/test-records-relay.ts
+++ b/tasks/test-records-relay.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
+
 /**
  * The relay: the one CI principal that writes to the store. Runs in the
  * workflow_run follower with base-repository credentials, walks the
@@ -49,8 +50,10 @@ export interface RunFacts {
   headSha: string;
   headBranch?: string;
   runStartedAt: string;
+
   /** True when the head repository differs from the base repository. */
   fork: boolean;
+
   /** Numeric id of the user whose push or pull request ran, when known. */
   actorId?: string;
 }

--- a/tasks/test-records-report.ts
+++ b/tasks/test-records-report.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-env --allow-net
+
 /**
  * The reader-side reports over the record store: name collisions,
  * high-churn identities, and tests over the sixty-second rule. Reads only

--- a/tasks/test-records-shell-config.ts
+++ b/tasks/test-records-shell-config.ts
@@ -24,6 +24,7 @@ export type ShellKind = "zsh" | "bash" | "fish" | "posix";
 
 /** What one profile file's update did. */
 export type ProfileOutcome =
+
   /** The line was appended. */
   | "added"
   /** The variable is already exported with this value. */
@@ -45,6 +46,7 @@ export type ProfileOutcome =
 export interface ProfileUpdate {
   path: string;
   outcome: ProfileOutcome;
+
   /** The line already in the file, for a conflict or an unexported set. */
   existing?: string;
 }
@@ -53,8 +55,10 @@ export interface ProfileUpdate {
 export interface ProfileSetting {
   /** The line, as the profile carries it. */
   line: string;
+
   /** Whether the assignment reaches the programs the shell starts. */
   exported: boolean;
+
   /** The path it names, read the way the shell reads it. */
   value: string;
 }
@@ -403,6 +407,7 @@ export async function exportFromProfiles(
 
 /** What one profile file's removal did. */
 export type RemovalOutcome =
+
   /** The line this tool wrote was taken out. */
   | "removed"
   /** The variable is set by a line this tool did not write. */
@@ -411,6 +416,7 @@ export type RemovalOutcome =
 export interface ProfileRemoval {
   path: string;
   outcome: RemovalOutcome;
+
   /** The line left in place, for one this tool did not write. */
   existing?: string;
 }

--- a/tasks/test-records.ts
+++ b/tasks/test-records.ts
@@ -66,8 +66,10 @@ async function git(
 interface CheckoutFacts {
   /** Output of `git rev-parse HEAD`; absent outside a repository. */
   commit?: string;
+
   /** Output of `git branch --show-current`; empty on a detached checkout. */
   branch?: string;
+
   /** Output of `git status --porcelain`; empty when the tree is clean. */
   status?: string;
 }

--- a/tasks/test-timing-weights.ts
+++ b/tasks/test-timing-weights.ts
@@ -1,5 +1,6 @@
 // Relative weights from successful CI runs. Only tests whose cost materially
 // affects placement need an entry; selectors use a default for the long tail.
+
 /**
  * Relative weights for the `agents-host` test files. The debug-view suite
  * dominates the package, which is why it spans several files; the rest are

--- a/tasks/test.ts
+++ b/tasks/test.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-run --allow-env --allow-net
+
 /**
  * Entry point for the root `deno task test`. The implementation lives in
  * workspace-tests.ts because `deno coverage` skips files whose names end in

--- a/tasks/typecheck.ts
+++ b/tasks/typecheck.ts
@@ -229,6 +229,7 @@ export interface TypecheckOptions {
   list?: boolean;
   reload?: boolean;
   check?: typeof checkGroup;
+
   /**
    * Spool one typecheck record per scope.
    *

--- a/tasks/vintage-adopt.ts
+++ b/tasks/vintage-adopt.ts
@@ -59,16 +59,21 @@ export interface AdoptRoots {
 
 export interface AdoptOptions {
   snapshotPath: string;
+
   /** The pattern identity the capture reported for the root. */
   expectedIdentity: string;
+
   /** Fixture directory key, e.g. `system/home.test.tsx`. */
   testKey: string;
+
   /** Repo path replay resolves today's source from,
    * e.g. `/packages/patterns/system/home.tsx`. */
   main: string;
+
   /** Capture cause of the root cell. Defaults to `"home-pattern"`, the cause
    * `ensureDefaultPattern` mints the home root with. */
   cause?: string;
+
   /**
    * Sub-pattern roots to record alongside the entry root, addressed by the
    * entity id the capture minted them at (a child's id is position-derived,
@@ -82,6 +87,7 @@ export interface AdoptOptions {
    */
   children?: readonly { cellId: string; main: string }[];
   roots: AdoptRoots;
+
   /** Capture stamp; injectable so a test is deterministic. */
   now?: Date;
   log?: (line: string) => void;

--- a/tasks/weighted-shards.ts
+++ b/tasks/weighted-shards.ts
@@ -2,8 +2,10 @@
 export interface WeightedShardItem {
   /** Stable identifier used for assignment and tie-breaking. */
   name: string;
+
   /** Relative processing cost. */
   weight: number;
+
   /** Items in one group prefer different shards. */
   group?: string;
 }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 179 doc comments across 51 files had no blank line above them; each
gets one — 46 files under `tasks/` and 5 under `scripts/`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Gates

These files are the repository's own gate and build scripts, so every mechanical
gate was run against the result rather than only the four pre-push commands:
`check-no-waitfor`, `check-docs`, `check-docs-history-index`,
`check-conflict-markers`, `check-control-characters`, `check-skill-facts`,
`check-verb-session-sync`, `check-single-copy-deps`, `check-unused-deps`,
`check-deno-pins`, `check-package-cycles`, `check-local-program`,
`check-baselines-append-only`, and `check-test-aliases` all pass, as do
`deno fmt --check`, `deno lint`, `deno task check`, `tasks`' own test task, and
`packages/static`'s three generated-asset checks.

GitHub Actions is in an outage as this is opened, so these are local runs rather
than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

