### PR TITLE
docs(cf-harness): blank lines above doc comments, with `utils` and `piece`

### DIFF
--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -79,6 +79,7 @@ const writeJsonFile = async (path: string, value: unknown): Promise<void> => {
 export interface HarnessArtifactStore {
   readonly artifactRoot: string;
   readonly runRoot: string;
+
   /**
    * Host directory where image-attachment snapshots may be written, for
    * stores backed by a writable filesystem. Stores without a writable

--- a/packages/cf-harness/src/auth/credential-store.ts
+++ b/packages/cf-harness/src/auth/credential-store.ts
@@ -340,6 +340,7 @@ const parseDocument = (text: string): CredentialDocument => {
 
 export interface FileHarnessCredentialStoreOptions {
   path: string;
+
   /** @internal Observability hook used by lock-contention tests. */
   onLockAcquisitionStarted?: () => void;
 }

--- a/packages/cf-harness/src/auth/provider-settings.ts
+++ b/packages/cf-harness/src/auth/provider-settings.ts
@@ -106,6 +106,7 @@ const mutationQueue = new KeyedMutationQueue();
 
 export interface FileHarnessProviderSettingsStoreOptions {
   path: string;
+
   /** @internal Observability hook used by lock-contention tests. */
   onLockAcquisitionStarted?: () => void;
 }

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -352,10 +352,12 @@ export type CfHarnessCliSignalHandler = (
 export interface RunCfHarnessCliDependencies {
   cwd?: string;
   env?: Record<string, string | undefined>;
+
   /** Trusted, fixed binding supplied only by the dedicated local Loom host. */
   loomLocalHostBinding?: LoomLocalHostBinding;
   fetchFn?: HarnessFetch;
   structuredHostFailures?: boolean;
+
   /**
    * What caused this run, reported on every gateway request it makes.
    * Resolved from the process when absent.
@@ -391,6 +393,7 @@ export interface RunCfHarnessCliDependencies {
     handler: CfHarnessCliSignalHandler,
   ) => () => void;
   exit?: (code: number) => never | void;
+
   /**
    * Replaces the Fabric session the engine would build from `--fabric-*`
    * configuration. Tests grant well-known handles without a deployed API.

--- a/packages/cf-harness/src/config.ts
+++ b/packages/cf-harness/src/config.ts
@@ -72,6 +72,7 @@ interface HarnessCommonConfig {
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   browserAccess?: HarnessBrowserAccessLease;
+
   /**
    * Origins where a value materialized from a handle may be sent. Operator
    * configuration, empty or absent by default: a run that names no origin

--- a/packages/cf-harness/src/contracts/handle-table.ts
+++ b/packages/cf-harness/src/contracts/handle-table.ts
@@ -56,6 +56,7 @@ export interface HarnessHandleEntry {
   /** The full token, prefix included (`cfh:a:<suffix>`). */
   token: string;
   kind: HarnessHandleKind;
+
   /**
    * Canonical LLM-friendly link string of the referent — the
    * `/[@did/]<id>[@scope][/path]` form serialized by the runner's
@@ -63,11 +64,13 @@ export interface HarnessHandleEntry {
    * `ref`.
    */
   ref: string;
+
   /**
    * The runner's `addressKey()` of the referent's normalized link. Entry
    * identity: minting the same address twice returns the existing token.
    */
   addressKey: string;
+
   /**
    * Shape of the value at the referent, when a mint knew it — the compiled
    * pattern's result schema behind a `run_pattern` result reference. Absent
@@ -75,6 +78,7 @@ export interface HarnessHandleEntry {
    * no mint reads the cell to fill this in.
    */
   schema?: JSONSchema;
+
   /**
    * Where {@link HarnessHandleEntry.schema} came from. `harness` means a
    * harness step supplied it out of its own work — the schema a pattern WE

--- a/packages/cf-harness/src/contracts/image.ts
+++ b/packages/cf-harness/src/contracts/image.ts
@@ -12,6 +12,7 @@ export interface HarnessImageAttachment {
   mediaType: HarnessImageMediaType;
   bytes: number;
   digest: string;
+
   /**
    * Content-addressed copy of the image taken when the attachment was
    * created. When present, materialization reads this snapshot instead of

--- a/packages/cf-harness/src/contracts/input-cells.ts
+++ b/packages/cf-harness/src/contracts/input-cells.ts
@@ -14,6 +14,7 @@ export interface HarnessInputCellSpec {
    * prose by construction — never text read from the fabric.
    */
   name: string;
+
   /**
    * The reference to mint, as an LLM-friendly link string. The cell's shape
    * and labels are not stated here: both live on the cell's declared schema
@@ -25,8 +26,10 @@ export interface HarnessInputCellSpec {
 /** One input cell, as recorded in run state. */
 export interface HarnessInputCell {
   name: string;
+
   /** The token the model holds. */
   token: string;
+
   /** The canonical reference behind it; never model-facing. */
   ref: string;
 }

--- a/packages/cf-harness/src/contracts/invalid-tool-call.ts
+++ b/packages/cf-harness/src/contracts/invalid-tool-call.ts
@@ -30,12 +30,16 @@ export type HarnessInvalidToolCallReason =
 export interface HarnessInvalidToolCall {
   type: "cf-harness.invalid-tool-call";
   reason: HarnessInvalidToolCallReason;
+
   /** Present when the call named a tool the run offers. */
   toolId?: BuiltinToolId;
+
   /** The argument at fault, when a single one carries the fault. */
   field?: string;
+
   /** What a well-formed call puts there. */
   expected: string;
+
   /** One sentence joining the two above, for a model that reads prose. */
   detail: string;
 }

--- a/packages/cf-harness/src/contracts/policy.ts
+++ b/packages/cf-harness/src/contracts/policy.ts
@@ -26,8 +26,10 @@ export interface HarnessBrowserToolInputSummary {
   action?: string;
   kind?: string;
   ref?: string;
+
   /** A bound handle, carried whole: it names an address, not a value. */
   valueHandle?: string;
+
   /** A bound handle, carried whole: it names an address, not a value. */
   urlHandle?: string;
   timeoutMs?: number;

--- a/packages/cf-harness/src/contracts/run-manifest.ts
+++ b/packages/cf-harness/src/contracts/run-manifest.ts
@@ -55,6 +55,7 @@ export interface LoomRunManifest {
     | "owner-bound-oauth"
     | "cf-harness-local-store";
   credentialOwner?: HarnessCredentialOwnerRef;
+
   /** Opaque digest identifying the canonical host-owned credential home. */
   harnessHomeIdentity?: string;
   workspace?: LoomRunManifestWorkspace;

--- a/packages/cf-harness/src/contracts/run-report.ts
+++ b/packages/cf-harness/src/contracts/run-report.ts
@@ -43,6 +43,7 @@ export interface HarnessToolActivity {
   endedAt: string;
   toolCallId: string;
   toolId: string;
+
   /** Absent when the call named a tool the run offers no descriptor for. */
   effectClass?: HarnessToolEffectClass;
   cfcEnforcementMode: CfcEnforcementMode;
@@ -103,6 +104,7 @@ export interface HarnessRunReport {
   generatedAt: string;
   status: string;
   model: string;
+
   /** Requested effort; provider clients reject routes that cannot apply it. */
   reasoningEffort?: string;
   promptCacheMode?: "implicit" | "explicit";
@@ -112,12 +114,15 @@ export interface HarnessRunReport {
   credentialOwner?: HarnessCredentialOwnerRef;
   harnessHomeIdentity?: string;
   modelTurns: number;
+
   /** Usage from model turns executed directly by this run. */
   usage?: HarnessModelUsage;
+
   /** Direct usage plus usage reported by completed descendant runs. */
   totalUsage?: HarnessModelUsage;
   modelUsage?: HarnessModelTurnUsage[];
   cfcEnforcementMode: CfcEnforcementMode;
+
   /** The fabric session's resolved CFC posture, when the run had a session. */
   fabricSessionCfc?: HarnessFabricSessionCfcPosture;
   createdAt?: string;

--- a/packages/cf-harness/src/contracts/skill.ts
+++ b/packages/cf-harness/src/contracts/skill.ts
@@ -195,6 +195,7 @@ export interface HarnessSkillActivation {
   name: string;
   source: HarnessSkillActivationSource;
   runId: string;
+
   /**
    * The registry paths behind a directory-backed skill. Absent for a
    * `skill-handle` activation, whose text came from a cell rather than a
@@ -208,6 +209,7 @@ export interface HarnessSkillActivation {
   digest: string;
   activatedAt: string;
   cfcPromptRole: HarnessSkillCfcPromptRole;
+
   /**
    * The parent-held handle token a `skill-handle` activation's text was
    * materialized through. Together with {@link digest} this is the

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -24,6 +24,7 @@ export const PATTERN_AUTHOR_SUBAGENT_PROFILE = "pattern-author" as const;
 export const WEB_SEARCH_SUBAGENT_MODEL = "gemini-3.5-flash" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
 export const MAX_SUBAGENT_MAX_MODEL_TURNS = 64;
+
 /**
  * Turn budget of the `pattern-author` profile. Authoring is a write,
  * compile-error, fix loop, and each iteration costs a turn; at the default
@@ -34,6 +35,7 @@ export const MAX_SUBAGENT_MAX_MODEL_TURNS = 64;
 export const PATTERN_AUTHOR_SUBAGENT_MAX_MODEL_TURNS = 24;
 export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
   "summary-and-sanitized-state" as const;
+
 /**
  * Tool surface of the `default` profile. `run_pattern` is gated the same way
  * the parent surface gates it: the prompt loop drops it from a child whose
@@ -60,6 +62,7 @@ export const WEB_FETCH_SUBAGENT_ALLOWED_TOOL_IDS = [
 ] as const satisfies readonly BuiltinToolId[];
 export const WEB_SEARCH_SUBAGENT_ALLOWED_TOOL_IDS =
   [] as const satisfies readonly BuiltinToolId[];
+
 /**
  * Tool surface of the `pattern-author` profile. The child writes pattern source
  * into `run_pattern` arguments rather than into the workspace, so it receives
@@ -88,6 +91,7 @@ export const BROWSER_SUBAGENT_ALLOWED_SKILL_SCRIPTS = [
   { skill: "agent-browser", path: "scripts/form-automation.sh" },
   { skill: "agent-browser", path: "scripts/capture-workflow.sh" },
 ] as const satisfies readonly HarnessAllowedSkillScript[];
+
 /**
  * Skills preloaded into a `pattern-author` child when the run has a skill
  * registry. These are the documents a pattern author would otherwise spend its
@@ -99,6 +103,7 @@ export const PATTERN_AUTHOR_SUBAGENT_SKILL_NAMES = [
   "pattern-dev",
   "pattern-schema",
 ] as const satisfies readonly string[];
+
 /**
  * The vocabulary a child reports a failure in. A code is inert by
  * construction — it is one of a fixed set, carries nothing read out of a
@@ -279,6 +284,7 @@ export interface HarnessSubagentProfileConfig {
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget?: HarnessSkillScriptExecutionTarget;
   maxModelTurns: number;
+
   /**
    * Return contract applied to a delegation to this profile that declares no
    * `returnSchema` of its own. A profile that owns one leaves no delegation
@@ -450,6 +456,7 @@ export interface HarnessSubagentRunStateSummary {
 
 export interface HarnessSubagentStructuredReturn {
   type: "cf-harness.subagent-structured-return";
+
   /**
    * `child-reported-failure` is its own status because a child saying it
    * failed is an answer, not a broken return: the parent gets a failure it can
@@ -457,6 +464,7 @@ export interface HarnessSubagentStructuredReturn {
    * that something went wrong somewhere.
    */
   status: "valid" | "invalid" | "child-reported-failure";
+
   /**
    * Present whenever the child's return says `ok: false`, on either status.
    */
@@ -516,6 +524,7 @@ export interface DelegateTaskToolInput {
   context?: string;
   maxModelTurns?: number;
   returnSchema?: JSONSchema;
+
   /**
    * A handle the PARENT holds, naming a cell whose string value is skill
    * text for the child. Materialized trusted-side at child spawn — the

--- a/packages/cf-harness/src/contracts/transcript.ts
+++ b/packages/cf-harness/src/contracts/transcript.ts
@@ -71,6 +71,7 @@ export type HarnessTranscriptDefect =
 export interface HarnessTranscriptPairing {
   valid: boolean;
   defects: readonly HarnessTranscriptDefect[];
+
   /**
    * Length of the longest prefix that is itself resumable: the prefix ends
    * where no tool call is left outstanding, and never reaches past a

--- a/packages/cf-harness/src/contracts/well-known-grants.ts
+++ b/packages/cf-harness/src/contracts/well-known-grants.ts
@@ -11,8 +11,10 @@ export type HarnessWellKnownGrantName = "piece-registry";
 /** One granted reference, as recorded in run state. */
 export interface HarnessWellKnownGrant {
   name: HarnessWellKnownGrantName;
+
   /** The token the model holds. */
   token: string;
+
   /** The canonical reference behind it; never model-facing. */
   ref: string;
 }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -211,6 +211,7 @@ export interface CreateHarnessEngineOptions
   sandboxRuntime?: SandboxRuntime;
   artifactStore?: HarnessArtifactStore;
   processRunner?: ProcessRunner;
+
   /**
    * Injection seam for the `run_pattern` fabric session, mirroring how
    * `sandboxRuntime` replaces the engine-built sandbox. When absent, a
@@ -219,6 +220,7 @@ export interface CreateHarnessEngineOptions
    * tool surface.
    */
   fabricSessionFactory?: HarnessFabricSessionFactory;
+
   /**
    * Operator input cells to mint handles for at run start; see
    * `establishInputCells`. Requires a fabric session — the cells live in

--- a/packages/cf-harness/src/fabric-observations.ts
+++ b/packages/cf-harness/src/fabric-observations.ts
@@ -26,6 +26,7 @@ export interface FabricActionErrorRecord {
   sequence: number;
   pieceId: string;
   patternId: string;
+
   /** The error's name — the discriminant that tells a policy refusal
    * (`CfcCommitRefusalError`) from a thrown computation (`Error`). */
   name: string;
@@ -34,6 +35,7 @@ export interface FabricActionErrorRecord {
 
 export interface FabricDeferredActionRecord {
   label: string;
+
   /**
    * Comparable entity hash of the piece the deferred action serves, from the
    * marker's observation identity; absent when the action carried none or
@@ -52,11 +54,13 @@ export interface FabricDeferredEpisodeRecord {
 export interface FabricRuntimeObservations {
   /** Monotonic position; capture before starting a piece. */
   sequence(): number;
+
   /** Action errors recorded after `since` for the given piece. */
   errorsSince(
     since: number,
     pieceId: string,
   ): readonly FabricActionErrorRecord[];
+
   /** Convergence-budget episodes recorded after `since`. */
   episodesSince(since: number): readonly FabricDeferredEpisodeRecord[];
 }

--- a/packages/cf-harness/src/gateway/openai-client.ts
+++ b/packages/cf-harness/src/gateway/openai-client.ts
@@ -18,6 +18,7 @@ export interface OpenAICompatibleGatewayClientOptions {
   chatCompletionTransportRetries?: number;
   chatCompletionRetryDelayMs?: number;
   fetchFn?: HarnessFetch;
+
   /**
    * What caused these requests. Resolved from the process when absent.
    */
@@ -76,6 +77,7 @@ export type OpenAIChatMessageContent =
 
 export interface OpenAIChatCompletionMessage {
   role: OpenAIChatMessageRole;
+
   /** Absent on tool-call-only turns from some providers, not just null. */
   content?: OpenAIChatMessageContent;
   tool_calls?: readonly OpenAIChatCompletionToolCall[];
@@ -110,6 +112,7 @@ export interface OpenAIResponsesRequest {
   store?: boolean;
   stream?: boolean;
   include?: readonly string[];
+
   /**
    * Server-side compaction. When rendered tokens cross `compact_threshold`,
    * the provider folds prior context into an encrypted compaction item and

--- a/packages/cf-harness/src/handle-table.ts
+++ b/packages/cf-harness/src/handle-table.ts
@@ -146,6 +146,7 @@ export const createHarnessHandleTable = (
 export interface MintAddressHandleOptions {
   /** Digest seam; defaults to SHA-256. */
   hasher?: HandleTokenHasher;
+
   /**
    * Shape of the value at the address, when the caller already knows it out of
    * its OWN work — the result schema of a pattern this harness compiled and

--- a/packages/cf-harness/src/image-attachments.ts
+++ b/packages/cf-harness/src/image-attachments.ts
@@ -196,6 +196,7 @@ export const createHarnessImageAttachment = async (
     workspaceHostPath: string;
     cwd: string;
     path: string;
+
     /**
      * Directory to snapshot the image bytes into. When provided, the
      * attachment materializes from the snapshot for the rest of the run and

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -64,6 +64,7 @@ export type HarnessInteractiveChatEventListener = (
 
 export interface CreateHarnessInteractiveChatServiceOptions {
   basePromptLoopOptions?: CreateHarnessPromptLoopOptions;
+
   /**
    * The single authenticated owner bound to this service process. Required
    * for openai-codex; interactive requests cannot select or replace it.
@@ -79,12 +80,14 @@ export interface CreateHarnessInteractiveChatServiceOptions {
 
 interface HarnessInteractiveChatSessionRecord {
   status: HarnessChatSessionStatus;
+
   /**
    * The last durable resumable transcript: the model history a following turn
    * is built from. It advances only at a completed turn, so every snapshot
    * persisted alongside an event is one a provider accepts.
    */
   transcript: readonly HarnessTranscriptMessage[];
+
   /**
    * Why a restored session cannot be resumed. Set when the recorded history
    * could not be repaired into valid model history; a turn started on such a
@@ -103,6 +106,7 @@ interface HarnessInteractiveChatSessionRecord {
 interface HarnessInteractiveChatEmitOptions {
   turnRecord?: HarnessChatTurnRecord;
   createTurn?: boolean;
+
   /**
    * A transcript to persist with this event and adopt as the session's durable
    * checkpoint. It replaces `record.transcript` only once the durable write has

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -55,8 +55,10 @@ export interface RunHarnessInteractiveChatStdioOptions {
   output?: WritableStream<Uint8Array>;
   sessionDbPath?: string;
   maxInMemoryEvents?: number;
+
   /** Trusted host injection point for an owner-bound provider client. */
   basePromptLoopOptions?: CreateHarnessPromptLoopOptions;
+
   /** Single authenticated owner for an owner-bound service process. */
   credentialOwner?: HarnessCredentialOwnerRef;
   createPromptLoop?: HarnessInteractivePromptLoopFactory;
@@ -68,6 +70,7 @@ export interface RunHarnessInteractiveChatStdioOptions {
 export interface HarnessInteractiveChatStdioCliOptions {
   sessionDbPath?: string;
   maxInMemoryEvents?: number;
+
   /**
    * Raw `--host-mount` specs, in the batch CLI's grammar, left unresolved.
    *

--- a/packages/cf-harness/src/model/client.ts
+++ b/packages/cf-harness/src/model/client.ts
@@ -46,6 +46,7 @@ export interface HarnessModelTurnRequest {
   cacheAffinityKey?: string;
   promptCacheMode?: "implicit" | "explicit";
   reasoningEffort?: string;
+
   /**
    * Overrides the server-side compaction threshold for this turn. Omitted
    * means the client derives it from the model's input budget; `0` disables
@@ -60,23 +61,29 @@ export interface HarnessModelTurnRequest {
 
 export interface HarnessModelUsage {
   inputTokens?: number;
+
   /** Cache-read tokens included within `inputTokens`, not additional tokens. */
   cachedInputTokens?: number;
+
   /** Cache-write tokens included within `inputTokens`, not additional tokens. */
   cacheWriteTokens?: number;
   outputTokens?: number;
+
   /** Reasoning tokens included within `outputTokens`, not additional tokens. */
   reasoningTokens?: number;
   totalTokens?: number;
+
   /**
    * Provider-reported cost only. The harness does not infer prices when this
    * field is absent.
    */
   costUsd?: number;
+
   /**
    * Estimate based on the harness pricing table, not a provider invoice.
    */
   estimatedCostUsd?: number;
+
   /**
    * Why `estimatedCostUsd` is absent. Aggregate usage reports
    * `incomplete-estimates` when any included turn lacks an estimate.
@@ -120,8 +127,10 @@ export interface HarnessModelCatalogEntry {
   description?: string;
   inputModalities: readonly string[];
   supportedReasoningEfforts: readonly string[];
+
   /** Total context (input + output) advertised by the registry, when known. */
   contextWindow?: number;
+
   /** Maximum output tokens; needed to derive the usable input budget. */
   maxOutputTokens?: number;
   supportsParallelToolCalls: boolean;
@@ -129,6 +138,7 @@ export interface HarnessModelCatalogEntry {
 
 export interface HarnessModelClient {
   readonly providerId: string;
+
   /** Exact authenticated owner binding for owner-bound providers. */
   readonly credentialOwner?: HarnessCredentialOwnerRef;
   complete(request: HarnessModelTurnRequest): Promise<HarnessModelTurnResult>;

--- a/packages/cf-harness/src/model/openai-compatible-gateway.ts
+++ b/packages/cf-harness/src/model/openai-compatible-gateway.ts
@@ -359,8 +359,10 @@ const responsesInputReachesDiscoveryFloor = (
 
 export class OpenAICompatibleGatewayModelClient implements HarnessModelClient {
   readonly providerId = OPENAI_COMPATIBLE_GATEWAY_PROVIDER_ID;
+
   /** Input budgets by model id, keyed from the gateway registry. */
   readonly #compactThresholds = new Map<string, number>();
+
   /** Successful registry discovery is shared and cached per client. */
   #budgetDiscovery?: Promise<void>;
 

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -168,6 +168,7 @@ export interface CreateHarnessPromptLoopOptions
   allowedSubagentProfiles?: readonly HarnessSubagentProfile[];
   nativeModelToolIds?: readonly LLMNativeModelToolId[];
   browserAccess?: HarnessBrowserAccessLease;
+
   /**
    * Stable provider cache affinity. Interactive callers should keep this
    * constant across the turns that replay one append-only transcript.
@@ -208,8 +209,10 @@ export interface HarnessPromptLoopResult {
   finalAssistantText: string;
   transcript: HarnessTranscriptMessage[];
   modelTurns: number;
+
   /** Usage from model turns executed directly by this loop. */
   usage?: HarnessModelUsage;
+
   /** Direct usage plus usage reported by completed descendant loops. */
   totalUsage?: HarnessModelUsage;
   modelUsage?: HarnessModelTurnUsage[];
@@ -1266,6 +1269,7 @@ const createStructuredSubagentReturn = async (
     childRunId: string;
     rawFinalAssistantText: string;
     schema: NonNullable<DelegateTaskToolInput["returnSchema"]>;
+
     /**
      * When present, sealed positions whose raw string is an entity address
      * become handle tokens minted into this table; the updated table comes
@@ -3573,6 +3577,7 @@ export class CfHarnessPromptLoop {
   async #invokeDelegateTaskTool(options: {
     toolCall: HarnessToolCall;
     input: DelegateTaskToolInput;
+
     /** The materialized skillHandle text + token, resolved before dispatch. */
     resolvedSkill?: { text: string; token: string };
     model: string;

--- a/packages/cf-harness/src/provenance.ts
+++ b/packages/cf-harness/src/provenance.ts
@@ -20,21 +20,28 @@ export type HarnessAgent = "claude-code" | "codex";
 
 export interface HarnessProvenance {
   invoker: HarnessInvoker;
+
   /** Stable per-process id, so the requests of one run can be grouped. */
   session: string;
+
   /** A label for the machine, stable across runs. */
   principal: string;
+
   /** The subcommand, passed explicitly by the caller. Never read from argv. */
   command?: string;
+
   /** Continuous-integration run, as `<system>:<job>:<run id>`. */
   ci?: string;
+
   /** The dispatch class a Loom run manifest asked for. */
   dispatch?: string;
+
   /**
    * The coding agent whose session the harness is running inside. Absent when
    * no coding agent is in the picture.
    */
   agent?: HarnessAgent;
+
   /** The service that launched the harness, from its `OTEL_SERVICE_NAME`. */
   service?: string;
 }

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -64,14 +64,17 @@ export type HarnessRunTerminalReason =
  */
 export interface HarnessFabricSessionCfcPosture {
   enforcementMode: "enforce-explicit" | "enforce-strict";
+
   /** `configured` when the operator set the dial; `preset-pin` otherwise. */
   enforcementModeSource: "configured" | "preset-pin";
   flowLabels: "off" | "observe" | "persist";
+
   /**
    * `configured` when the operator set the dial; `posture` when the named
    * bundle below supplied it; `default` otherwise.
    */
   flowLabelsSource: "configured" | "default" | "posture";
+
   /**
    * The named CFC posture bundle the session's runtime opted into, when the
    * operator selected one (`--fabric-cfc-posture`). The bundle sets more

--- a/packages/cf-harness/src/skills/registry.ts
+++ b/packages/cf-harness/src/skills/registry.ts
@@ -65,6 +65,7 @@ export interface HarnessSkillContextLoadResult {
 export interface LoadHarnessSkillContextFromTextOptions {
   /** The skill text a handle resolved to. */
   text: string;
+
   /** The parent-held token the text was materialized through. */
   handleToken: string;
   runId: string;

--- a/packages/cf-harness/src/tools/assign-slug.ts
+++ b/packages/cf-harness/src/tools/assign-slug.ts
@@ -18,8 +18,10 @@ export interface AssignSlugToolInput {
 export interface AssignSlugToolSuccessOutput {
   outputId: string;
   status: "ok";
+
   /** The assigned slug, the caller's own word echoed back. */
   slug: string;
+
   /**
    * Absolute URL for the named piece, composed from the session's API URL
    * and the space's configured name. Absent when the session was configured

--- a/packages/cf-harness/src/tools/browser.ts
+++ b/packages/cf-harness/src/tools/browser.ts
@@ -69,8 +69,10 @@ export interface BrowserToolInput {
 export interface BrowserToolSuccessOutput {
   outputId: string;
   status: "ok";
+
   /** What the action printed, truncated to a bounded length. */
   output: string;
+
   /** Diagnostic text the action printed alongside a success, when any. */
   detail?: string;
 }

--- a/packages/cf-harness/src/tools/describe-handle.ts
+++ b/packages/cf-harness/src/tools/describe-handle.ts
@@ -13,17 +13,22 @@ export interface DescribeHandleToolInput {
 
 export interface DescribeHandleToolOutput {
   outputId: string;
+
   /** The token as asked about, echoed so a reply stands on its own. */
   token: string;
+
   /** Whether this run's handle table holds the token. */
   known: boolean;
+
   /** Whether a schema was found to report, from either source. */
   hasSchema: boolean;
+
   /**
    * The reported schema: fabric-declared, or harness-derived, whichever
    * answered first in that order.
    */
   schema?: JSONSchema;
+
   /**
    * Path segments of the referent within its piece — which field of which
    * piece the token names. Read off the entry's already-parsed reference, so

--- a/packages/cf-harness/src/tools/run-pattern.ts
+++ b/packages/cf-harness/src/tools/run-pattern.ts
@@ -43,8 +43,10 @@ export const RUN_PATTERN_MAX_SOURCE_TEXT_BYTES = 256 * 1024;
 export interface RunPatternToolSuccessOutput {
   outputId: string;
   status: "ok";
+
   /** Canonical LLM-friendly link to the piece's result cell. */
   resultRef: string;
+
   /**
    * The compiled pattern's result schema — the shape of whatever
    * `resultRef` names. Known here for free, since compilation produced it,
@@ -56,6 +58,7 @@ export interface RunPatternToolSuccessOutput {
    * schema.
    */
   resultRefSchema: JSONSchema;
+
   /**
    * Piece id for the persisted tool-output artifact. A bare fabric
    * identifier the handle boundary never swaps, and the piece cell is the
@@ -63,12 +66,15 @@ export interface RunPatternToolSuccessOutput {
    * rendering; only `resultRef` reaches model context.
    */
   pieceId: string;
+
   /** Sanitized result value; present only when `resultSchema` was given. */
   value?: unknown;
   linkedStringCount?: number;
+
   /** Why `value` is absent despite a `resultSchema`: the raw result did not
    * match the schema. */
   valueError?: string;
+
   /**
    * Raw result value for the persisted tool-output artifact. Stripped from
    * the model-facing rendering by the prompt loop, so only the sanitized
@@ -81,12 +87,14 @@ export interface RunPatternToolErrorOutput {
   outputId: string;
   status: "compile-error" | "error" | "cancelled";
   message: string;
+
   /**
    * The durable piece a post-persistence failure leaves behind, for the
    * persisted artifact's run-to-piece provenance. Stripped from the
    * model-facing rendering like the success output's `pieceId`.
    */
   pieceId?: string;
+
   /**
    * The failing computation's own message, retained for the persisted
    * artifact and stripped from the model-facing rendering: a computation
@@ -368,6 +376,7 @@ export const runPatternTool: HarnessToolDefinition<
       status: RunPatternToolErrorOutput["status"],
       message: string,
     ): RunPatternToolErrorOutput => ({ outputId, status, message });
+
     /**
      * `detail` is what the cancellation left behind that the caller would
      * otherwise have to discover by looking: a durable effect the run had

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -31,6 +31,7 @@ export interface HarnessToolContext {
   allowedSkillScripts?: readonly HarnessAllowedSkillScript[];
   skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   browserAccess?: HarnessBrowserAccessLease;
+
   /**
    * Origins a value materialized from a handle may be sent to. Absent or
    * empty means none: materialization is default-deny by destination, and a
@@ -38,6 +39,7 @@ export interface HarnessToolContext {
    * asking the model where it meant.
    */
   handleValueOrigins?: readonly string[];
+
   /**
    * The run's handle table, as it stands at the invocation. Undefined until
    * the run mints its first handle. `describe_handle` is the only tool that
@@ -45,12 +47,14 @@ export interface HarnessToolContext {
    * addresses by the prompt loop.
    */
   handleTable?: HarnessHandleTable;
+
   /**
    * The run's trusted Fabric session, lazy and cached by the engine.
    * Undefined when the run has no fabric session configured, which also
    * keeps `run_pattern` out of the tool surface.
    */
   getFabricSession?: () => Promise<HarnessFabricSession>;
+
   /**
    * The prompt loop's run-level abort signal, when the invocation came
    * through the loop. The only cancellation source a tool may honor — no
@@ -73,6 +77,7 @@ export interface HarnessToolContext {
     path: string,
     options?: { allowMissing?: boolean },
   ): Promise<boolean>;
+
   /**
    * Host directory for image-attachment snapshots (under the artifact
    * root). Undefined when the run has no artifact store; attachments then

--- a/packages/cf-harness/test/describe-handle.test.ts
+++ b/packages/cf-harness/test/describe-handle.test.ts
@@ -505,6 +505,7 @@ describe("describe_handle", () => {
     let storageManager: ReturnType<typeof StorageManager.emulate>;
     let runtime: Runtime;
     let session: HarnessFabricSession;
+
     /** A second space on the same runtime, so a cross-space address in these
      * tests names a document the runtime really could read. */
     let neighbour: PiecesController;

--- a/packages/cf-harness/test/support/chat-fault-fixture.ts
+++ b/packages/cf-harness/test/support/chat-fault-fixture.ts
@@ -35,6 +35,7 @@ export const FAULT_KINDS: readonly ChatFault[] = ["error", "cancel"];
 export interface FaultingToolLoopOptions {
   /** Held by a test that wants to act while the loop sits mid-tool. */
   release?: Promise<void>;
+
   /**
    * Called once the loop has reported everything it ever will. A test that
    * inspects the store while an interrupted turn is still in flight waits on

--- a/packages/cf-harness/test/support/responses-fixture.ts
+++ b/packages/cf-harness/test/support/responses-fixture.ts
@@ -20,6 +20,7 @@
  */
 export interface ChatViewMessage {
   role: string;
+
   /**
    * Text turns project to a plain string. Multimodal turns project to the
    * chat-style content-part array; those few assertions cast to read it.

--- a/packages/piece/src/ops/bulk-diff.ts
+++ b/packages/piece/src/ops/bulk-diff.ts
@@ -40,10 +40,13 @@ export interface PieceDiffRow {
   piece: string;
   phase?: string;
   status: PieceDiffStatus;
+
   /** The reference the plan recorded. */
   before: PatternRef;
+
   /** The reference the after-survey read; absent when the piece is `missing`. */
   after?: PatternRef;
+
   /** The reference the row's operation produces, when the row carries one. */
   target?: PatternRef;
 }
@@ -51,6 +54,7 @@ export interface PieceDiffRow {
 /** A diff over every plan row, plus what the after-survey saw beyond them. */
 export interface PlanDiff {
   rows: readonly PieceDiffRow[];
+
   /** Pieces the after-survey holds that the plan does not. */
   unplanned: readonly string[];
   counts: Readonly<Record<PieceDiffStatus, number>>;

--- a/packages/piece/src/ops/bulk-plan.ts
+++ b/packages/piece/src/ops/bulk-plan.ts
@@ -56,6 +56,7 @@ export interface RegisteredOutside {
 export interface PieceExpect {
   /** The pattern identity the piece is currently on. */
   patternIdentity: string;
+
   /**
    * The export the identity runs. The runtime's executable pointer is the
    * `{identity, symbol}` pair — two patterns exported by one module share an
@@ -63,6 +64,7 @@ export interface PieceExpect {
    * both halves.
    */
   symbol: string;
+
   /**
    * Whether the source behind `patternIdentity` is verifiably retained in
    * the space — the canonical loader can produce its closure — and so is a
@@ -71,12 +73,14 @@ export interface PieceExpect {
    * incident.
    */
   retained: boolean;
+
   /**
    * The revision the piece is at, when it already keeps a source-revision log.
    * A piece with no log yet — a legacy piece — has none until its first
    * transition appends a baseline revision, so a survey cannot read one for it.
    */
   revisionId?: string;
+
   /**
    * The hash of the piece's stored input document, recorded by a repair's
    * dry run. It is the repair row's precondition the way the reference pair
@@ -90,8 +94,10 @@ export interface PieceExpect {
 /** Replace a piece's source with the program a local source closure produces. */
 export interface RetargetOp {
   kind: "retarget";
+
   /** The source closure to apply, as the local-program inputs that name it. */
   source: RetargetSource;
+
   /**
    * A human-facing label for the source's provenance — a git rev, say. Recorded
    * for readers and for diffing two plans; never enforced. The identity is the
@@ -99,10 +105,13 @@ export interface RetargetOp {
    * row if it differs from `patternIdentity`.
    */
   rev?: string;
+
   /** The identity the source produces, computed from the source, not compiled. */
   patternIdentity: string;
+
   /** The export the retarget runs: the source's `mainExport`, or the default. */
   symbol: string;
+
   /**
    * Whether this row may apply with the pattern and retained-link compatibility
    * checks disabled. A field on the row so a reviewer sees which rows ran with
@@ -115,12 +124,16 @@ export interface RetargetOp {
 export interface RetargetSource {
   /** The entry module path. */
   main: string;
+
   /** The source root, when it is not the entry's own directory. */
   root?: string;
+
   /** Test entry paths to include in the closure. */
   testPaths?: readonly string[];
+
   /** Data file paths to attach and classify as data. */
   dataFilePaths?: readonly string[];
+
   /** The entry export to run, when it is not the default. */
   mainExport?: string;
 }
@@ -133,6 +146,7 @@ export interface RetargetSource {
  */
 export interface RestoreOp {
   kind: "restore";
+
   /**
    * The identity the retained revision carries. For a legacy piece whose
    * baseline the retarget itself appended, this is the identity the survey
@@ -140,8 +154,10 @@ export interface RestoreOp {
    * revision retaining that identity's source.
    */
   patternIdentity: string;
+
   /** The export the restored revision runs — the pair's other half. */
   symbol: string;
+
   /**
    * The revision to restore, when the survey read one — a piece that already
    * kept a log at survey time. Absent for a baseline the retarget appends,
@@ -159,8 +175,10 @@ export interface RestoreOp {
  */
 export interface RepairOp {
   kind: "repair";
+
   /** The fixer's name as supplied — a module path or label; never resolved. */
   fixer: string;
+
   /**
    * The content identity of the fixer module's authored closure — the same
    * no-compile identity a retarget's source carries — which is the pin the
@@ -182,6 +200,7 @@ export interface PiecePlanRow {
    * same piece and folds to this form at decode.
    */
   piece: string;
+
   /** A grouping label for reports and for stopping between groups; not a sort key. */
   phase?: string;
   expect: PieceExpect;
@@ -192,8 +211,10 @@ export interface PiecePlanRow {
 export interface PlanEnumeration {
   /** Pieces the selection names: a collection's members, or a list's entries. */
   collection: number;
+
   /** Pieces the space's piece registry lists. */
   registry: number;
+
   /**
    * Registered pieces on an in-scope identity that the collection does not
    * hold. Any above zero is a selection error: the collection read dropped a
@@ -206,13 +227,17 @@ export interface PlanEnumeration {
 export interface PiecePlanHeader {
   kind: "piece-plan";
   v: 1;
+
   /** The space every row's piece lives in. */
   space: string;
+
   /** When the survey behind the plan was taken, as an ISO-8601 string. */
   takenAt: string;
+
   /** Which selector produced the rows: a holder's collection, or a list. */
   selector: "collection" | "list";
   enumerated: PlanEnumeration;
+
   /**
    * Selected pieces the survey could not read into rows. Their absence from
    * `rows` would otherwise be invisible in the artifact, so an incomplete
@@ -220,6 +245,7 @@ export interface PiecePlanHeader {
    * a plan carrying any.
    */
   problems?: readonly SurveyProblem[];
+
   /** Registered in-scope pieces the selection lacks — the same standing. */
   outside?: readonly RegisteredOutside[];
 }

--- a/packages/piece/src/ops/bulk-repair.ts
+++ b/packages/piece/src/ops/bulk-repair.ts
@@ -107,13 +107,17 @@ export type RepairVerdict =
 /** One piece's row in a repair report. */
 export interface RepairRow {
   piece: string;
+
   /** The plan row's phase label, carried as the survey stamped it. */
   phase?: string;
   verdict: RepairVerdict;
+
   /** What a refused, moved, or failed row broke; absent otherwise. */
   problem?: string;
+
   /** The exact changes the fixer would make (or made); absent when none. */
   changes?: readonly DocumentChange[];
+
   /**
    * The hash of the stored document this row's verdict was computed from —
    * the precondition a plan row carries. Absent where no document was read.
@@ -124,14 +128,17 @@ export interface RepairRow {
 /** What one repair run found, and — under `apply` — did. */
 export interface RepairReport {
   rows: readonly RepairRow[];
+
   /**
    * The run as a plan artifact: the survey's header, and one row per
    * evaluated piece carrying its document-hash precondition — with the
    * repair operation stamped when the run was given a fixer name to record.
    */
   plan: PiecePlan;
+
   /** Documents written. Zero on a dry run and on a conforming re-run. */
   applied: number;
+
   /**
    * True when every row is `conforms` or `repaired`: nothing refused,
    * nothing moved, nothing failed, nothing unattempted. A dry run is
@@ -144,12 +151,14 @@ export interface RepairReport {
 export interface RepairOptions {
   selector: PieceSelector;
   fixer: Fixer;
+
   /**
    * The fixer's name as the plan should record it — a module path or a
    * label. With one, the emitted plan's evaluated rows carry the repair
    * operation; without, they carry only the pre-state record.
    */
   fixerName?: string;
+
   /**
    * The content identity of the fixer module's authored closure — the pin
    * the name cannot be. Recorded on every emitted repair op, and held
@@ -158,6 +167,7 @@ export interface RepairOptions {
    * spelled or what it holds today.
    */
   fixerIdentity?: string;
+
   /**
    * A previously emitted plan, which then IS the execution: its rows run
    * in its order, each row's recorded document hash is its precondition,
@@ -169,6 +179,7 @@ export interface RepairOptions {
    * fixer no longer changes is landed, whatever it hashes to now.
    */
   plan?: PiecePlan;
+
   /**
    * Write the documents the fixer produces. Absent, the run is the
    * dry-run report — the exact per-piece diff, and no write at all.
@@ -540,10 +551,12 @@ type RowDecision =
   | {
     kind: "change";
     documentHash: string;
+
     /** The stored document the decision was computed from — what an
      * applied row's changes are measured against, so the write path's own
      * additions show in the report. */
     before: Record<string, unknown>;
+
     /** The evaluated answer — the exact document a write must land, so
      * the report and the write cannot describe two different evaluations
      * of a fixer that lied to the purity probe. */
@@ -626,6 +639,7 @@ export async function repairPieces(
     phase?: string;
     expect: PiecePlanRow["expect"];
     expectedHash?: string;
+
     /** The plan row this one executes, carried into the emitted artifact
      * for every verdict short of landed, so a stopped run's artifact can
      * be supplied straight back. */

--- a/packages/piece/src/ops/bulk-retarget.deno.ts
+++ b/packages/piece/src/ops/bulk-retarget.deno.ts
@@ -76,15 +76,18 @@ export type RetargetVerdict =
 /** One piece's row in a retarget report. */
 export interface RetargetRow {
   piece: string;
+
   /** The plan row's phase label, carried as the plan stamped it. */
   phase?: string;
   verdict: RetargetVerdict;
+
   /**
    * What a moved, refused, or failed row broke; absent otherwise. A row
    * names its own piece's trouble alone — the run's own, a session that
    * would not open or close, is the report's `stopReason`.
    */
   problem?: string;
+
   /**
    * The row's wall-clock cost in milliseconds, present on every row an
    * apply session began work on: a row reclassified as landed, moved, or
@@ -100,8 +103,10 @@ export interface RetargetRow {
 /** What one retarget run found, and — under `apply` — did. */
 export interface RetargetReport {
   rows: readonly RetargetRow[];
+
   /** Sources applied. Zero on a dry run and on a fully landed re-run. */
   applied: number;
+
   /**
    * True when every row is `landed` (or, on a dry run, `outstanding` —
    * that is the dry run's answer, not a defect) and no session boundary
@@ -109,6 +114,7 @@ export interface RetargetReport {
    * unattempted, and every session this run opened was released.
    */
   complete: boolean;
+
   /**
    * Why the run stopped when no piece is at fault: a session that could not
    * be opened, could not be released, or opened onto a space other than the
@@ -123,17 +129,20 @@ export interface RetargetReport {
 
 export interface RetargetOptions {
   plan: PiecePlan;
+
   /**
    * Write the sources the rows resolve. Absent, the run is the preflight
    * classification alone — where every piece stands, and no write at all.
    */
   apply?: boolean;
+
   /**
    * Pieces served by one session before it is replaced. The knob the
    * design requires: warm-up amortizes across a group while the pieces
    * live at once stay bounded by it.
    */
   groupSize?: number;
+
   /**
    * Called as each row settles, for reporting as the run proceeds. A throw
    * from it is the caller's error rather than the run's: it reaches the
@@ -142,6 +151,7 @@ export interface RetargetOptions {
    * `failed`.
    */
   onRow?: (row: RetargetRow) => void;
+
   /** The clock behind `elapsedMs`, injectable for deterministic tests. */
   now?: () => number;
 }
@@ -284,6 +294,7 @@ export async function retargetPieces(
     "landed" | "outstanding" | { blocked: RetargetRow }
   >();
   let startBlocked = false;
+
   /** The run's own trouble, as opposed to any piece's: see `stopReason`. */
   let sessionProblem: string | undefined;
   {

--- a/packages/piece/src/ops/bulk-survey.ts
+++ b/packages/piece/src/ops/bulk-survey.ts
@@ -48,8 +48,10 @@ import type { PiecesController } from "./pieces-controller.ts";
 export type PieceSelector =
   | {
     kind: "collection";
+
     /** The holder piece's address. */
     holder: string;
+
     /** The path to the collection within the chosen document. */
     path: readonly (string | number)[];
     side?: "input" | "result";
@@ -74,6 +76,7 @@ export type PlannedRetarget = Omit<RetargetOp, "kind">;
 /** What {@link surveyPieces} takes beyond the controller. */
 export interface SurveyOptions {
   selector: PieceSelector;
+
   /**
    * Retargets to stamp onto rows, keyed by phase — a collection selector
    * labels members with the collection path and the holder with
@@ -82,6 +85,7 @@ export interface SurveyOptions {
    * unverifiable — so the plan stays a pre-state record for both.
    */
   operations?: Readonly<Record<string, PlannedRetarget>>;
+
   /**
    * A schema to read each piece's result under — a holder's demanded schema
    * is the canonical one. Pieces whose result cannot materialize under it
@@ -91,6 +95,7 @@ export interface SurveyOptions {
    * here exactly as it would for the holder.
    */
   validator?: JSONSchema;
+
   /** The header's `takenAt`; defaults to now. A parameter so tests can pin it. */
   takenAt?: string;
 }
@@ -106,14 +111,19 @@ export interface TallyEntry {
 /** Everything a survey reports beyond the plan itself. */
 export interface SurveyResult {
   plan: PiecePlan;
+
   /** Identity counts by phase — "do these pieces all agree?" at a glance. */
   tally: readonly TallyEntry[];
+
   /** Registered in-scope pieces the selection lacks. Any entry is a stop. */
   outside: readonly RegisteredOutside[];
+
   /** Selected pieces that could not be read into a row. Any entry is a stop. */
   problems: readonly SurveyProblem[];
+
   /** Pieces whose result fails the supplied validator, with the failure. */
   validatorFailures: readonly SurveyProblem[];
+
   /**
    * Whether the plan accounts for everything: no unreadable piece and no
    * registered in-scope piece outside the selection. A write stage must
@@ -356,10 +366,13 @@ export interface PiecePin {
   /** The piece's canonical address. */
   piece: string;
   patternIdentity: string;
+
   /** The entry export the identity runs. */
   symbol: string;
+
   /** The current source revision, when the piece keeps a log. */
   revisionId?: string;
+
   /** Whether the identity's source is retained in the space. */
   retained: boolean;
 }

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -293,6 +293,7 @@ interface OuterCellContract {
 interface PathSchemaContract {
   schema: JSONSchema;
   root: JSONSchema;
+
   /** A valid producer value can omit an ancestor on the localized path. */
   mayBeMissing?: boolean;
 }
@@ -300,12 +301,16 @@ interface PathSchemaContract {
 interface DurableSchemaPath {
   root: JSONSchema;
   path: (string | number)[];
+
   /** Producer-document path corresponding to `path[schemaBaseDepth]`. */
   rawBasePath: (string | number)[];
+
   /** Projection ancestors in `path` that do not exist in the producer doc. */
   schemaBaseDepth: number;
+
   /** Materialized schema root used to validate the complete staged value. */
   validationCell: Cell<unknown>;
+
   /** Path within `validationCell` changed by the producer write. */
   validationPath: (string | number)[];
 }
@@ -340,10 +345,13 @@ interface StoredCellTopology {
 export interface PiecePatternSourceRef {
   /** Immutable in-fabric reference to the verified source closure. */
   ref: string;
+
   /** Optional caller-supplied repository associated with the source tree. */
   repository?: string;
+
   /** Authored entry path within the program's compilation root. */
   entry?: string;
+
   /** Optional mutable/update provenance carried by `patternSource`. */
   origin?: string;
 }
@@ -385,6 +393,7 @@ export interface PieceSourceCompatibilityIssues {
   schema?: string;
   argument?: string;
   retainedLinks?: string;
+
   /**
    * The CFC schema envelope stored on the piece's argument document cannot
    * merge with the candidate's argument schema — or cannot be read at all.
@@ -420,6 +429,7 @@ export interface PieceSourceCompatibilityIssues {
 export interface PatternCompatibilityReport {
   compatible: boolean;
   issues: PieceSourceCompatibilityIssues;
+
   /** Every issue joined, or `undefined` when compatible. */
   message?: string;
   candidate: { identity: string; symbol: string };
@@ -2211,6 +2221,7 @@ export function assertSuppliedLinkSchemasCompatible(
     basePath?: readonly (string | number)[];
     destinationIsStream?: boolean;
     destinationRoot?: JSONSchema;
+
     /**
      * The prior pattern's argument schema, supplied only on a pattern update
      * over existing state. A linked document with no producer-owned metadata —
@@ -2223,6 +2234,7 @@ export function assertSuppliedLinkSchemasCompatible(
      * so a fresh link to an arbitrary contract-less document is still refused.
      */
     priorArgumentSchema?: JSONSchema;
+
     /**
      * The caller writes each supplied link's ORIGINAL envelope back, rather
      * than rebuilding it from a materialized read.

--- a/packages/piece/src/ops/piece-origin.ts
+++ b/packages/piece/src/ops/piece-origin.ts
@@ -42,6 +42,7 @@ export interface PieceOrigin {
   /** The canonical origin URL. */
   url: string;
   kind: PieceOriginKind;
+
   /**
    * The URL as it was recorded on the piece, when normalization changed it. A
    * legacy toolshed-relative path becomes an absolute web URL, so the recorded
@@ -55,22 +56,31 @@ export interface PieceSourceState {
   space: MemorySpace;
   pieceId: string;
   name?: string;
+
   /** The exact executable export the piece runs. */
   pattern?: { identity: string; symbol: string };
+
   /** The identity whose complete setup state was installed. */
   setupPattern?: { identity: string; symbol: string };
+
   /** The pattern identity an in-place update replaced, when one did. */
   displacedPattern?: { identity: string; symbol: string; displacedAt?: number };
+
   /** The active origin, absent when the piece is detached. */
   origin?: PieceOrigin;
+
   /** Descriptive repository locator; never followed. */
   repository?: string;
+
   /** The canonical entry filename of the retained source, when readable. */
   entry?: string;
+
   /** The authored source files of the current pattern, when readable. */
   files: { name: string; contents: string }[];
+
   /** Names among `files` that carry data rather than code. */
   dataFiles?: string[];
+
   /** Ordered, append-only source and origin states accepted by the piece. */
   history: PieceSourceRevisionState[];
   currentRevisionId?: string;
@@ -426,6 +436,7 @@ export async function readPieceSourceState(
 export interface PieceSourceRevisionSource {
   pattern: { identity: string; symbol: string };
   files: { name: string; contents: string }[];
+
   /** Names among `files` that carry data rather than code. */
   dataFiles?: string[];
 }

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -274,8 +274,10 @@ export class PiecesController<T = unknown> {
     }: {
       apiUrl: URL | string;
       identity: Identity;
+
       /** The space to open, as a `did:key:` DID or as a space name. */
       space: string;
+
       /**
        * Open the space's session without syncing the space cell's contents. A
        * caller that reaches pieces by id, and never reads the space record,

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -27,6 +27,7 @@ interface CompatibilityContext {
   targetRoot: JSONSchema;
   role: SchemaRole;
   activePairs: ActivePairsByRoot;
+
   /**
    * Piece evolution deliberately permits a small set of non-subset changes
    * (for example, naming a previously-uncontracted field on an open argument
@@ -34,12 +35,16 @@ interface CompatibilityContext {
    * they must never be used as proof that one conjunct implies another.
    */
   allowEvolutionPolicy: boolean;
+
   /** Whether default-backed evolution remains safe through every ancestor. */
   allowEvolutionDefaults: boolean;
+
   /** Link materialization fills valid target defaults before validation. */
   allowTargetDefaults: boolean;
+
   /** Whether defaults describe a pattern migration or link materialization. */
   defaultComparison: "evolution" | "target";
+
   /**
    * True below a node both contracts mark `asCell: ["stream"]` — a verb, so
    * everything beneath is the verb's EVENT schema. There, a boolean

--- a/packages/piece/test/state-continuity-harness.ts
+++ b/packages/piece/test/state-continuity-harness.ts
@@ -132,6 +132,7 @@ function serverOver(storeDir: string): MemoryV2Server.Server {
 
 export interface VintageRuntime {
   runtime: Runtime;
+
   /**
    * The store behind `runtime`, exposed so another harness can write into the
    * same file. The vintage capture hands this to the pattern-test runner so a
@@ -139,8 +140,10 @@ export interface VintageRuntime {
    * handlers, rather than a bare materialized root with nothing in it.
    */
   storageManager: StorageManager;
+
   /** The PRIMARY space: the signer's own, and the one a fixture is named for. */
   space: string;
+
   /**
    * Every space this runtime was restored WITH, primary and companions alike,
    * sorted. Empty for a fresh store.
@@ -158,6 +161,7 @@ export interface VintageRuntime {
    */
   restoredSpaces: readonly string[];
   storeDir: string;
+
   /**
    * Snapshot EVERY space this runtime wrote — the primary to `destPath`, the
    * rest into its companion directory. Crash-consistent, runs no migrations.
@@ -471,8 +475,10 @@ export const VINTAGE_MANIFEST_CAUSE = {
 export interface VintageManifestEntry {
   identity: string;
   symbol: string;
+
   /** Entry filename, repo-root-relative (`/packages/patterns/system/home.tsx`). */
   main?: string;
+
   /** Entity id of the result cell the pattern was materialized onto. */
   cellId: string;
   space: string;
@@ -941,6 +947,7 @@ export function isReduction(value: unknown): boolean {
  *   indistinguishable here from a key holding nothing. Whatever else changes,
  *   the two must not be allowed to collapse again.
  */
+
 /**
  * Whether one side is a schema written as a content-addressed reference and
  * the other the same schema written out. Representation is not state: a
@@ -1040,6 +1047,7 @@ export interface StateFinding {
   key: string;
   before: unknown;
   after: unknown;
+
   /**
    * The value went from something to nothing, rather than to something else.
    * FAILS the gate; a bare change only warns.
@@ -1379,6 +1387,7 @@ function describeError(error: unknown): string {
 export interface MaterializeOutcome {
   /** The setup-commit rejection, if the candidate could not be applied. */
   error?: string;
+
   /**
    * Set when the refusal is that the candidate module does not define the
    * recorded symbol. A field rather than a message shape, because `error` is
@@ -1388,8 +1397,10 @@ export interface MaterializeOutcome {
    * beside the message instead of inside it.
    */
   missingArtifact?: true;
+
   /** The root's value after a successful materialize. */
   value?: Record<string, unknown>;
+
   /**
    * The candidate's compiled result schema. Handed back so a caller that needs
    * to address the root afterwards reads it off the pattern that was actually
@@ -1397,8 +1408,10 @@ export interface MaterializeOutcome {
    * agree.
    */
   resultSchema: unknown;
+
   /** The candidate's compiled argument schema, for the same reason. */
   argumentSchema: unknown;
+
   /**
    * Identity of the pattern that was materialized — the artifact entry ref's
    * identity, not a hash of the source text. A fixture is NAMED with this, so

--- a/packages/utils/src/equal-ignoring-symbols.ts
+++ b/packages/utils/src/equal-ignoring-symbols.ts
@@ -160,6 +160,7 @@ export interface ExtendedExpected<IsAsync = false> extends Expected<IsAsync> {
   // The modifiers are restated so that they carry the extended type through.
   not: IsAsync extends true ? Async<ExtendedExpected<true>>
     : ExtendedExpected<false>;
+
   /** @inheritDoc */
   resolves: Async<ExtendedExpected<true>>;
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -591,6 +591,7 @@ function getEnvMeasuresEnabled(): boolean {
  * sample — and a reader who does not know that will attribute a whole run from
  * its setup. Raising it has to be reachable from wherever emission is.
  */
+
 /**
  * What `CF_TIMING_MEASURES_CAP` means, separated from reading it.
  *
@@ -745,6 +746,7 @@ export interface GetLoggerOptions {
    * environment, or `info` when it names none.
    */
   level?: LogLevel;
+
   /**
    * How many total calls to go between debug messages summarizing the
    * counts. `0` disables the summaries entirely. Defaults to `100`.

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -125,6 +125,7 @@ export const SANDBOX_WITHHELD_GLOBALS = Object.freeze(
     "self",
   ] as const,
 );
+
 /** Name of a global withheld from a sandbox compartment. */
 export type SandboxWithheldGlobalName =
   (typeof SANDBOX_WITHHELD_GLOBALS)[number];
@@ -146,6 +147,7 @@ export const TRUSTED_BUILDERS = Object.freeze(
     "pattern",
   ] as const,
 );
+
 /** Name of a trusted builder. */
 export type TrustedBuilderName = (typeof TRUSTED_BUILDERS)[number];
 
@@ -167,6 +169,7 @@ export const TRUSTED_DATA_HELPERS = Object.freeze(
     "__cf_data",
   ] as const,
 );
+
 /** Name of a trusted data helper. */
 export type TrustedDataHelperName = (typeof TRUSTED_DATA_HELPERS)[number];
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 230 doc comments across 50 files had no blank line above them; each
gets one. Covered: `packages/cf-harness`, `packages/utils`, and
`packages/piece`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## One thing found, deliberately not fixed here

`packages/utils/src/logger.ts:586` is two doc comments in a row: one describing
"the cap named by `CF_TIMING_MEASURES_CAP`" with no declaration under it, then
the one belonging to `parseTimingMeasureCap()`. TypeScript keeps only the
nearer, so the first is invisible wherever documentation is rendered — the
shape "Where one goes" in the style guide names. This sweep inserts the blank
line the new rule calls for and changes nothing else there; deciding whether
the orphan describes something that still exists is not a whitespace question.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, the three packages' own test
tasks, and `packages/static`'s `check-commonfabric-types`, `check-cfc-types`,
and `check-withheld-globals` all pass locally. The last of those reads
`utils/src/sandbox-contract.ts`, which this sweep touches. GitHub Actions is in
an outage as this is opened, so these are local runs rather than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

