### PR TITLE
docs(ui): blank lines above doc comments, with `ts-transformers`

### DIFF
--- a/packages/ts-transformers/src/ast/call-arguments.ts
+++ b/packages/ts-transformers/src/ast/call-arguments.ts
@@ -7,10 +7,12 @@ import ts from "typescript";
 export interface CallArgumentPosition {
   /** The call whose argument list carries the node. */
   readonly call: ts.CallExpression;
+
   /** The node `call.arguments` lists — the queried node itself, or the
    *  outermost parenthesized wrapper around it. Identity comparisons against
    *  entries of `call.arguments` must use this node, never the queried one. */
   readonly argument: ts.Expression;
+
   /** Index of `argument` within `call.arguments`. */
   readonly index: number;
 }

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -88,6 +88,7 @@ const CELL_SCOPED_CONSTRUCTOR_NAMES = new Set([
 const COMMONFABRIC_CALL_NAMES = COMMONFABRIC_CALL_EXPORT_NAMES;
 const WILDCARD_OBJECT_METHOD_NAMES = new Set(["keys", "values", "entries"]);
 export const FUNCTION_HARDENING_HELPER_PREFIX = "__cfHardenFn";
+
 /**
  * Prefix for the module-scope const a hoisted `lift(...)` call is bound to
  * (CT-1644, Phase 2 of derive→lift→selfcontained). The whole lift call —
@@ -161,6 +162,7 @@ export interface ReactiveCollectionProvenanceOptions {
   readonly sameScope?: ts.FunctionLikeDeclaration;
   readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
   readonly syntheticReactiveCollectionRegistry?: WeakSet<ts.Symbol>;
+
   /**
    * True once the walk has descended into a variable declaration's initializer
    * (CT-1778). The derived-reactive-collection-call recognition is gated on this

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -1066,6 +1066,7 @@ export function inferArrayElementType(
     typeNode: factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
   };
 }
+
 /**
  * Infers the expected type of an expression from its context (e.g., variable assignment).
  */

--- a/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
+++ b/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
@@ -29,6 +29,7 @@ export function buildCapturedHandlerClosureCall(
   options?: {
     readonly eventParamName?: string;
     readonly paramsParamName?: string;
+
     /**
      * The verb's declared result type, carried into `handler`'s third
      * type-argument slot so SchemaInjection can lower it to the module's

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -41,6 +41,7 @@ export class TransformationContext {
   readonly factory: ts.NodeFactory;
   readonly sourceFile: ts.SourceFile;
   readonly options: TransformationOptions;
+
   /**
    * The cross-transformer communication registries every stage in this run
    * shares. Either injected through `options.state` or created here; the same

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -27,6 +27,7 @@ import type {
 export interface NodeTypeLinks {
   /** Cached per-function capability summary (was `capabilitySummaryRegistry`). */
   capabilitySummary?: FunctionCapabilitySummary;
+
   /**
    * Whether SchemaInjection has finalized this builder call/new node (was
    * `schemaInjectedRegistry`). A bare presence flag with NO getOriginalNode
@@ -34,6 +35,7 @@ export interface NodeTypeLinks {
    * pre-injection user call, which must NOT read as injected.
    */
   schemaInjected?: true;
+
   /**
    * For a `toSchema` call SchemaInjection created to describe a pattern's
    * RESULT, the authored node a diagnostic about that schema points at. The
@@ -111,6 +113,7 @@ export class CrossStageState {
   > {
     return this.#policyManifests;
   }
+
   /**
    * Bare cross-package channels (the published boundary contract). Read
    * directly by the schema-generator package as plain WeakMaps; they must NOT

--- a/packages/ts-transformers/src/core/runtime-contract.ts
+++ b/packages/ts-transformers/src/core/runtime-contract.ts
@@ -37,8 +37,10 @@ export interface CfcPolicyCompilerManifestV1 {
 export interface BuilderSourceSite {
   /** Authored line, 1-based. */
   readonly line: number;
+
   /** Authored column, 0-based. */
   readonly col: number;
+
   /** Declaration name visible in authored source, when one exists. */
   readonly bindingName?: string;
 }

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -43,6 +43,7 @@ export type CapabilityParamSummary = {
   readonly opaquePaths?: readonly (readonly string[])[];
   readonly passthrough: boolean;
   readonly wildcard: boolean;
+
   /**
    * Write-exhaustiveness is unverifiable for this parameter — `writePaths`
    * may be incomplete. Set by unrecognized or dynamic method calls on
@@ -75,8 +76,10 @@ export type UnreadableCellArgument = {
 
 export type FunctionCapabilitySummary = {
   readonly params: readonly CapabilityParamSummary[];
+
   /** True when analysis was short-circuited due to recursion. */
   readonly recursive?: boolean;
+
   /** Cell arguments passed to parameters the contract could not classify. */
   readonly unreadableCellArguments?: readonly UnreadableCellArgument[];
 };
@@ -137,6 +140,7 @@ export type TransformationOptions = {
    * its own and stores it back here, so `context.state` is always present.
    */
   readonly state?: CrossStageState;
+
   /**
    * Shared diagnostics collector that accumulates diagnostics across all transformers.
    * If provided, diagnostics are pushed to this array in addition to the local context.
@@ -144,6 +148,7 @@ export type TransformationOptions = {
   readonly diagnosticsCollector?: TransformationDiagnostic[];
   readonly patternCoverage?: PatternCoverageOptions;
   readonly builderSourceSites?: BuilderSourceSiteOptions;
+
   /**
    * Whether an `assert(...)` body records its operands, so that a failing
    * pattern-test assertion can report them. Defaults to true.
@@ -154,8 +159,10 @@ export type TransformationOptions = {
    * debug rendering in its assertion bodies.
    */
   readonly assertDiagnostics?: boolean;
+
   /** Content identity assigned by the compiler for every authored source. */
   readonly moduleIdentities?: ReadonlyMap<string, string>;
+
   /**
    * Compile-name → authored-name mapping for CFC writer-identity file
    * spellings (claim minting, provenance stamping, `PolicyOf` source
@@ -166,6 +173,7 @@ export type TransformationOptions = {
    * verbatim (modulo path-separator normalization).
    */
   readonly canonicalWriterIdentityFile?: (fileName: string) => string;
+
   /**
    * The program is DURABLE STORED pattern source being reloaded — bytes
    * nobody can re-author, recompiled by a toolchain newer than the one that

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -45,6 +45,7 @@ export interface CapabilityAnalysisOptions {
   readonly includeNestedCallbacks?: boolean;
   readonly summaryCache?: WeakMap<ts.Node, FunctionCapabilitySummary>;
   readonly inProgress?: WeakSet<ts.Node>;
+
   /**
    * Transformer-known types for nodes the checker can't resolve. Required for
    * synthetic callbacks (e.g. the destructure-lowered lift-applied param, whose
@@ -53,6 +54,7 @@ export interface CapabilityAnalysisOptions {
    * capability summary mis-shapes or drops inputs. Consulted before the checker.
    */
   readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
+
   /**
    * Optional sink for the read-then-mergeable-`push` misuse check. When set,
    * the analysis reports each `Cell.push` whose receiver collection path the
@@ -79,6 +81,7 @@ interface MutableCapabilityState {
   readonly rawOpaquePaths: Set<string>;
   passthrough: boolean;
   wildcard: boolean;
+
   /** Static path prefixes at which unknown (wildcard) accesses occurred.
    * `[]` means the whole root. Lets the identity-path filter erase only
    * identity paths the unknown access can actually cover, instead of
@@ -87,6 +90,7 @@ interface MutableCapabilityState {
   hasIdentityUse: boolean;
   hasNonIdentityUse: boolean;
   hasNonIdentityRootUse: boolean;
+
   /**
    * Write-exhaustiveness is unverifiable for this parameter. Set by an
    * unrecognized or dynamic (`cell[m]()`) method call on a cell-like

--- a/packages/ts-transformers/src/policy/mergeable-push-classification.ts
+++ b/packages/ts-transformers/src/policy/mergeable-push-classification.ts
@@ -42,10 +42,13 @@ export type MergeablePushMisuseKind =
 export interface MergeablePushMisuse {
   /** The `push(...)` call to point the diagnostic at. */
   readonly node: ts.Node;
+
   /** The collection path that is both read and pushed, relative to its root. */
   readonly path: readonly string[];
+
   /** The analyzed parameter/root the collection belongs to. */
   readonly rootName: string;
+
   /** How the explicit read relates to the push. */
   readonly kind: MergeablePushMisuseKind;
 }
@@ -60,8 +63,10 @@ export interface MergeableCollectionSite {
 export interface MergeablePushClassifierInput {
   /** The analyzed function; the ancestor climb and taint pass stop here. */
   readonly fn: ts.Node;
+
   /** Explicit read sites (`.get()` calls and `for..of` iterables). */
   readonly readSites: readonly MergeableCollectionSite[];
+
   /**
    * Resolves a local identifier to the collection it aliases (from the
    * capability walk's alias bindings), if any.

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -120,6 +120,7 @@ interface HoistableBuilderSpec {
     call: ts.CallExpression,
     context: TransformationContext,
   ) => ts.CallExpression | undefined;
+
   /**
    * Optional: produce the replacement for the visited site once the inner call
    * has been hoisted to `hoistedName`. Omit for applied builders, which take

--- a/packages/ts-transformers/src/transformers/destructuring-lowering.ts
+++ b/packages/ts-transformers/src/transformers/destructuring-lowering.ts
@@ -15,6 +15,7 @@ export interface DestructureBinding {
   readonly localName: string;
   readonly path: readonly PathSegment[];
   readonly directKeyExpression?: ts.Expression;
+
   /** Binding syntax represented by the lowered declaration. */
   readonly bindingNode: ts.Identifier | ts.BindingElement;
 }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
@@ -21,17 +21,20 @@ export interface RewriteParams {
   readonly analysis: DataFlowAnalysis;
   readonly context: TransformationContext;
   readonly analyze: AnalyzeFn;
+
   /**
    * Effective reactive context at the rewrite site.
    */
   readonly reactiveContextKind?: ReactiveContextKind;
   readonly containerKind?: ExpressionContainerKind;
+
   /**
    * True when inside a safe callback wrapper (action, handler, computed, etc.)
    * where opaque reading is allowed. In safe contexts, we still need to apply
    * semantic transformations (&&->when, ||->unless) but NOT lift-applied wrappers.
    */
   readonly inSafeContext?: boolean;
+
   /**
    * When true, reactive compute wrappers introduced during rewriting should
    * be emitted as a lift-applied form bound to its captured inputs

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -216,6 +216,7 @@ function getSymbolTypeAtSource(
 interface CapabilitySummaryMemo {
   /** `{ checker, includeNestedCallbacks: true }` analyses. */
   readonly nested: WeakMap<ts.Node, FunctionCapabilitySummary>;
+
   /** Non-nested analyses (fallback after a recorded-summary miss). */
   readonly fallback: WeakMap<ts.Node, FunctionCapabilitySummary>;
 }

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -2069,6 +2069,7 @@ interface ContractObservation {
   readonly write: ReadonlySet<string>;
   readonly read: ReadonlySet<string>;
   readonly comparable: ReadonlySet<string>;
+
   /** Exact positions whose observed use needs an identity handle even when
    * the authored type is plain — `equals`-style comparison materializes
    * through a comparable cell, not through the value. */

--- a/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/contract-authored-event.input.tsx
@@ -21,8 +21,10 @@ interface PeerNode {
 interface ProbeEvent {
   /** Read by the body. */
   title: string;
+
   /** Declared and never read. */
   done: boolean;
+
   /** A declared, never-read reference. */
   peer: Writable<PeerNode>;
 }

--- a/packages/ts-transformers/test/lineage-regression.test.ts
+++ b/packages/ts-transformers/test/lineage-regression.test.ts
@@ -157,6 +157,7 @@ function findCallbackArgument(
 
 interface BuilderSite {
   readonly tag: string;
+
   /** The builder call whose authored position must be recoverable. For a
    * hoisted `const __cfLift_N = __cfHelpers.lift(...)` this is the INNER
    * call; for a top-level authored builder it is the call itself. */
@@ -255,6 +256,7 @@ function collectRewrittenSites(
 
 async function transformFixtureToAst(): Promise<{
   transformed: ts.SourceFile;
+
   /** The pre-transform source file, whose text the recovered positions index
    * into (it carries the `transformCfDirective` helper-import prelude). */
   original: ts.SourceFile;

--- a/packages/ts-transformers/test/transformed-ast.ts
+++ b/packages/ts-transformers/test/transformed-ast.ts
@@ -261,6 +261,7 @@ export function extractedCallbackBody(
 export interface AssertCapture {
   /** The authored source text the operand was labeled with. */
   src: string;
+
   /** The printed value expression the recording wraps. */
   value: string;
 }

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -21,6 +21,7 @@ export interface TransformOptions {
   types?: Record<string, string>;
   typeCheck?: boolean;
   precomputedDiagnostics?: ts.Diagnostic[];
+
   /** If provided, pipeline diagnostics will be pushed into this array after transformation. */
   pipelineDiagnostics?: TransformationDiagnostic[];
   moduleIdentities?: ReadonlyMap<string, string>;
@@ -33,6 +34,7 @@ export interface TransformOptions {
 export interface BatchTypeCheckResult {
   /** Diagnostics grouped by file path */
   diagnosticsByFile: Map<string, ts.Diagnostic[]>;
+
   /** The TypeScript program used for type-checking (for debugging) */
   program: ts.Program;
 }

--- a/packages/ui/src/v2/components/cf-audio-visualizer/cf-audio-visualizer.ts
+++ b/packages/ui/src/v2/components/cf-audio-visualizer/cf-audio-visualizer.ts
@@ -62,6 +62,7 @@ export class CFAudioVisualizer extends BaseElement {
 
   /** Pre-allocated array for frequency data to avoid GC pressure */
   private _frequencyData?: Uint8Array<ArrayBuffer>;
+
   /** Pre-allocated array for normalized waveform values */
   private _waveformBuffer: number[] = [];
 

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -40,12 +40,16 @@ const AutocompleteItemArraySchema = {
 export interface AutocompleteItem {
   /** Value returned when selected */
   value: string;
+
   /** Display text (defaults to value if not provided) */
   label?: string;
+
   /** Category for grouping/disambiguation */
   group?: string;
+
   /** Additional search terms that match this item */
   searchAliases?: string[];
+
   /**
    * Arbitrary data to pass through with cf-select event.
    *
@@ -76,6 +80,7 @@ const _validateAutocompleteItem: _ValidateAutocompleteItem = true;
  */
 interface ProcessedItem {
   item: AutocompleteItem;
+
   /** All searchable words from label, value, group, and aliases - lowercased */
   words: string[];
 }

--- a/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
+++ b/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
@@ -35,15 +35,18 @@ export class CFAutoLayout extends BaseElement {
     tabNames: { type: Array, attribute: false },
     leftTabName: { type: String, attribute: false },
     rightTabName: { type: String, attribute: false },
+
     /**
      * Position of tabs on mobile: "top" | "bottom".
      * Default is "bottom".
      */
     tabsPosition: { type: String, reflect: true },
+
     /**
      * Whether the left sidebar is open. Reflected to attribute.
      */
     leftOpen: { type: Boolean, reflect: true },
+
     /**
      * Whether the right sidebar is open. Reflected to attribute.
      */

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -177,6 +177,7 @@ const readClaimValue = async (
 
 interface LabelViewResult {
   readonly view: CfcLabelView | undefined;
+
   /**
    * True when the fallback `resolveAsCell()` path read a resolved cell's label
    * and got nothing back. `getCfcLabel` is a pure, non-blocking store read, so

--- a/packages/ui/src/v2/components/cf-chart/types.ts
+++ b/packages/ui/src/v2/components/cf-chart/types.ts
@@ -18,10 +18,13 @@ export type YScaleType = "linear" | "log";
 export interface AxisConfig {
   /** Axis label text */
   label?: string;
+
   /** Tick format: d3-format string (e.g. "$,.0f") or function */
   tickFormat?: string | ((value: unknown) => string);
+
   /** Show grid lines across the plot area */
   grid?: boolean;
+
   /** Number of ticks to display (approximate) */
   tickCount?: number;
 }

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -252,17 +252,20 @@ export class CFCodeEditor extends BaseElement {
   declare placeholder: string;
   declare timingStrategy: InputTimingOptions["strategy"];
   declare timingDelay: number;
+
   /**
    * Mentionable items for @ completion.
    */
   declare mentionable?: CellHandle<MentionableArray> | null;
   declare mentioned?: CellHandle<MentionableArray>;
+
   /**
    * The document's mention references. Its presence selects the reference
    * form for newly minted mentions; wiki-links already in the document keep
    * working either way.
    */
   declare references?: CellHandle<MentionRefMap> | null;
+
   /**
    * Hosts, besides this document's own, whose page URLs name pieces. A pasted
    * URL from anywhere else is a link to a web page.
@@ -868,6 +871,7 @@ export class CFCodeEditor extends BaseElement {
       }
     }
   }
+
   /**
    * The destination behind a reference key, shaped so its name can be read.
    *

--- a/packages/ui/src/v2/components/cf-location/cf-location.ts
+++ b/packages/ui/src/v2/components/cf-location/cf-location.ts
@@ -42,20 +42,28 @@ type LocationState = "idle" | "requesting" | "watching" | "error";
 export interface LocationData {
   /** Unique ID for this location capture */
   id: string;
+
   /** Latitude in decimal degrees */
   latitude: number;
+
   /** Longitude in decimal degrees */
   longitude: number;
+
   /** Accuracy of the position in meters */
   accuracy: number;
+
   /** Altitude in meters above sea level (if available) */
   altitude?: number;
+
   /** Accuracy of altitude in meters (if available) */
   altitudeAccuracy?: number;
+
   /** Direction of travel in degrees (0-360, if available) */
   heading?: number;
+
   /** Speed in meters per second (if available) */
   speed?: number;
+
   /** Unix timestamp in milliseconds when the location was captured */
   timestamp: number;
 }

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.test.ts
@@ -2348,9 +2348,11 @@ function statefulPiece(
   }: {
     result?: Record<string, unknown>;
     argument?: unknown;
+
     /** When set, the argument read also returns this schema-bearing ref. */
     argumentRef?: CellRef;
     getPageFails?: boolean;
+
     /** When true, getPage stays pending until `resolveGetPage()` is called. */
     deferGetPage?: boolean;
     sendFails?: boolean;

--- a/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/cf-piece-menu.ts
@@ -48,6 +48,7 @@ export type Panel = "source" | "origin" | "data" | "actions" | "access";
 /** One entry in the menu, and the panel it opens. */
 interface MenuEntry {
   label: string;
+
   /** Stable hook for tests, exposed as the entry's `test-id`. */
   testId: string;
   panel: Panel;
@@ -212,9 +213,11 @@ function toDisplay(
 /** One dispatchable handler stream found on the piece. */
 export interface PieceAction {
   name: string;
+
   /** Which side of the piece carries it. */
   source: "result" | "argument";
   handle: CellHandle;
+
   /**
    * The event schema the handler declares, when one is known: the schema a
    * stream handle read through the piece's schema carries is the handler's
@@ -2771,10 +2774,13 @@ export function openPieceMenu(
     cell: CellHandle;
     x: number;
     y: number;
+
     /** The element the click came from, whose theme the menu adopts. */
     themeFrom?: Element;
+
     /** The rendered piece to highlight while the menu remains open. */
     highlightedPiece?: Element;
+
     /** A nested pattern root to highlight within the rendered piece. */
     highlightTarget?: Element;
   },

--- a/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
+++ b/packages/ui/src/v2/components/cf-piece-menu/origin-view.ts
@@ -11,6 +11,7 @@ import type { PieceOriginView } from "@commonfabric/runtime-client";
 export interface OriginDescription {
   /** Short label naming the kind of origin. */
   label: string;
+
   /** One sentence on what that origin can do. */
   detail: string;
 }

--- a/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
@@ -18,14 +18,19 @@
 export type IdentitySeal = {
   /** The DID this seal was derived from (normalized). */
   did: string;
+
   /** Primary hue (0–360), the main per-identity differentiator. */
   hue: number;
+
   /** The ring's ordered hues (degrees), used to build the conic aura. */
   hues: readonly number[];
+
   /** Conic-gradient rotation offset, in degrees. */
   angle: number;
+
   /** Ready-to-use CSS `conic-gradient(...)` for the aura ring. */
   ringGradient: string;
+
   /** Accent color (HSL string) for the seal mark when verified. */
   accent: string;
 };

--- a/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
@@ -87,8 +87,10 @@ import { radioGroupStyles } from "./styles.ts";
 export interface RadioItem {
   /** Text shown to the user */
   label: string;
+
   /** Value returned when this option is selected */
   value: unknown;
+
   /** Disabled state for this option */
   disabled?: boolean;
 }

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -54,11 +54,14 @@ export const PIECE_CONTEXT_MENU_EVENT = "cf-piece-context-menu";
 export interface PieceContextMenuDetail {
   /** The space holding the piece. */
   space: DID;
+
   /** The piece's full schemed id. */
   pieceId: string;
+
   /** Client coordinates of the click, for placing the menu. */
   x: number;
   y: number;
+
   /** The variant the piece was rendered at. */
   variant: UIVariant;
 }

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -50,10 +50,13 @@ import {
 export interface SelectItem {
   /** Text shown to the user */
   label: string;
+
   /** Arbitrary JS value returned when this option is selected */
   value: unknown;
+
   /** Disabled state for this option */
   disabled?: boolean;
+
   /**
    * Optional grouping key. When provided, options with
    * identical `group` values will be wrapped in an <optgroup>.
@@ -181,6 +184,7 @@ export class CFSelect extends BaseElement {
   ];
 
   private _select!: HTMLSelectElement;
+
   /** Mapping from stringified option key -> SelectItem */
   private _keyMap = new Map<string, SelectItem>();
 

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -289,14 +289,19 @@ export class CFToolsChip extends BaseElement {
 
   /** Chip label shown in the pill. */
   declare label: string;
+
   /** Show the number of tools next to the label. */
   declare showCount: boolean;
+
   /** If true, hovering/focus opens the panel. */
   declare openOnHover: boolean;
+
   /** If true, clicking toggles the panel. */
   declare toggleOnClick: boolean;
+
   /** Current open state. Reflected to attribute. */
   declare open: boolean;
+
   /** Tools array shown in the panel. Accepts array, record, or CellHandle. */
   @property({ attribute: false })
   accessor tools:

--- a/packages/ui/src/v2/components/form/form-context.ts
+++ b/packages/ui/src/v2/components/form/form-context.ts
@@ -14,6 +14,7 @@ import { createContext } from "@lit/context";
 export interface ValidationResult {
   /** Whether the field value is valid */
   valid: boolean;
+
   /** Optional validation message (shown when invalid) */
   message?: string;
 }
@@ -24,18 +25,25 @@ export interface ValidationResult {
 export interface FieldRegistration {
   /** Reference to the field element */
   element: HTMLElement;
+
   /** Field name for identifying in form submission */
   name?: string;
+
   /** Get the current buffered value */
   getValue: () => unknown;
+
   /** Set the buffered value programmatically */
   setValue: (value: unknown) => void;
+
   /** Write buffered value to bound cell (async to await cell update) */
   flush: () => Promise<void>;
+
   /** Restore to initial value from cell */
   reset: () => void;
+
   /** Validate the current buffered value */
   validate: () => ValidationResult;
+
   /** Check if the field has unsaved changes */
   isDirty: () => boolean;
 }

--- a/packages/ui/src/v2/components/theme-context.ts
+++ b/packages/ui/src/v2/components/theme-context.ts
@@ -30,84 +30,123 @@ export type StatusIntent = "info" | "success" | "warning" | "error";
 export interface CFTheme {
   /** Font family for text content */
   fontFamily: string;
+
   /** Monospace font family for code */
   monoFontFamily: string;
+
   /** Base font size for UI elements */
   fontSize: string;
+
   /** Border radius for UI elements */
   borderRadius: string;
+
   /** Overall density/spacing preference */
   density: "compact" | "comfortable" | "spacious";
+
   /** Color scheme preference */
   colorScheme: ColorScheme;
+
   /** Animation speed preference */
   animationSpeed: "none" | "slow" | "normal" | "fast";
+
   /** Roundness scalar (0-1). Scales all structural radii. */
   roundness: number;
+
   /** Typography scale factor (0.8-1.2). */
   scale: number;
+
   /** Motion scalar (0-1). Scales transition durations. 0 = instant. */
   motion: number;
+
   /** Color palette with semantic tokens that adapt to light/dark */
   colors: {
     /** Primary brand color */
     primary: ColorToken;
+
     /** Primary foreground (text on primary) */
     primaryForeground: ColorToken;
+
     /** Secondary color */
     secondary: ColorToken;
+
     /** Secondary foreground */
     secondaryForeground: ColorToken;
+
     /** Main background color */
     background: ColorToken;
+
     /** Surface color (cards, containers) */
     surface: ColorToken;
+
     /** Surface hover state */
     surfaceHover: ColorToken;
+
     /** Primary text color */
     text: ColorToken;
+
     /** Muted/secondary text color */
     textMuted: ColorToken;
+
     /** Border color */
     border: ColorToken;
+
     /** Muted border color */
     borderMuted: ColorToken;
+
     /** Success color */
     success: ColorToken;
+
     /** Success foreground */
     successForeground: ColorToken;
+
     /** Error color */
     error: ColorToken;
+
     /** Error foreground */
     errorForeground: ColorToken;
+
     /** Warning color */
     warning: ColorToken;
+
     /** Warning foreground */
     warningForeground: ColorToken;
+
     /** Accent color for highlights */
     accent: ColorToken;
+
     /** Accent foreground */
     accentForeground: ColorToken;
+
     /** Brand color (purple) */
     brand: ColorToken;
+
     /** Brand foreground (text on brand) */
     brandForeground: ColorToken;
+
     /** Tertiary text color */
     textTertiary: ColorToken;
+
     /** Disabled text color */
     textDisabled: ColorToken;
+
     /** Disabled surface color */
     surfaceDisabled: ColorToken;
+
     /** Surface pressed state */
     surfacePressed: ColorToken;
+
     /** Tertiary surface color */
     surfaceTertiary: ColorToken;
+
     /** Inverse surface color */
     surfaceInverse: ColorToken;
+
     /** Secondary text on colored backgrounds */
     textOnColorSecondary: ColorToken;
+
     /** Text on inverse surfaces */
     textOnInverse: ColorToken;
+
     /** Pressed text color */
     textPressed: ColorToken;
   };

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -8,16 +8,22 @@ import "../components/cf-cell-link/index.ts";
 export interface DragState {
   /** The CellHandle being dragged */
   cell: CellHandle;
+
   /** Optional type identifier for filtering drop zones */
   type?: string;
+
   /** The source element that initiated the drag */
   sourceElement: HTMLElement;
+
   /** The preview element being shown during drag */
   preview: HTMLElement;
+
   /** Optional cleanup function to call when drag ends */
   previewCleanup?: () => void;
+
   /** Current pointer X position (updated during drag) */
   pointerX: number;
+
   /** Current pointer Y position (updated during drag) */
   pointerY: number;
 }
@@ -173,6 +179,7 @@ export function subscribeToDrag(listener: DragListener): () => void {
 export interface DragPreview {
   /** The preview element (not yet added to the DOM). */
   preview: HTMLElement;
+
   /** Stops the preview's render; pass as {@link DragState.previewCleanup}. */
   cleanup?: () => void;
 }

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -53,11 +53,13 @@ import {
 export interface CellControllerLike<T> {
   getValue(): T;
   setValue(value: T): void;
+
   /**
    * Optional: run any pending (debounced) write immediately, so a following
    * read or commit sees the latest value.
    */
   flush?(): void;
+
   /**
    * Optional method to get the underlying CellHandle for direct async operations.
    * Used by FormFieldController to await cell.set() during flush.

--- a/packages/ui/src/v2/core/mention-refs.ts
+++ b/packages/ui/src/v2/core/mention-refs.ts
@@ -12,6 +12,7 @@ export interface MentionRef {
    * the piece's fields.
    */
   destination: unknown;
+
   /**
    * Whether the label in the document and the destination's name have
    * deliberately diverged. While it is set, a change to the destination's
@@ -43,9 +44,11 @@ export const MentionRefMapSchema = {
 
 /** Length of a freshly minted key. */
 const KEY_LENGTH = 6;
+
 /** Longest key {@link mintRefKey} widens to before it gives up. */
 const MAX_KEY_LENGTH = 10;
 const KEY_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+
 /** Samples drawn at one length before widening. */
 const SAMPLES_PER_LENGTH = 4;
 

--- a/packages/ui/src/v2/core/retired-element.ts
+++ b/packages/ui/src/v2/core/retired-element.ts
@@ -68,6 +68,7 @@ export abstract class RetiredElement extends BaseElement {
 
   /** The tag this stub stands in for. */
   protected abstract retiredTag: string;
+
   /** What to use instead, when there is a successor. */
   protected retiredReplacement?: string;
 

--- a/packages/ui/src/v2/test-utils/mock-vdom-connection.ts
+++ b/packages/ui/src/v2/test-utils/mock-vdom-connection.ts
@@ -22,10 +22,13 @@ import {
 export interface VDomSessionLog {
   /** Cell references passed to `mount`, in order. */
   mounted: CellRef[];
+
   /** Mount ids passed to `unmount`, in order. */
   unmounted: number[];
+
   /** Whether the renderer detached its disposal teardown. */
   detached: boolean;
+
   /** Whether a VDOM session was attached at all. */
   attached: boolean;
 }

--- a/packages/ui/src/v2/utils/file-cell-storage.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.ts
@@ -20,6 +20,7 @@ export interface StoredFile {
 export interface StoreFileOptions {
   file: File;
   runtime: RuntimeClient;
+
   /** The space the file's blob belongs to — part of its address. */
   space: DID;
   width?: number;


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 160 doc comments across 42 files had no blank line above them; each
gets one. Covered: `packages/ui` and `packages/ts-transformers`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

Every other PR in this series leans on `deno fmt` to settle the parenthesized-
list and union carve-outs. Three files here sit in `deno.jsonc`'s `fmt.exclude`
— `ui/src/v2/components/cf-chart/types.ts`,
`ui/src/v2/components/cf-select/cf-select.ts`, and
`ts-transformers/test/fixtures/handler-schema/contract-authored-event.input.tsx`
— so each was copied to a scratch path, formatted there, and came back
byte-identical.

The transformer fixture is an `*.input.tsx` half of a golden pair;
`ts-transformers`' own suite passes against the existing `*.expected.jsx`, so
the insertion does not reach what the pipeline emits.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, both packages' own test
tasks, and `packages/static`'s three generated-asset checks all pass locally.
GitHub Actions is in an outage as this is opened, so these are local runs rather
than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

