### PR TITLE
docs(memory): blank lines above doc comments, with `state-inspector` and `toolshed`

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -108,6 +108,7 @@ export type Result<T extends Unit = Unit, E extends Error = Error> =
 
 export type Ok<T extends Unit> = {
   ok: T;
+
   /**
    * Discriminant to differentiate between Ok and Fail.
    */
@@ -116,6 +117,7 @@ export type Ok<T extends Unit> = {
 
 export type Fail<E extends Error> = {
   error: E;
+
   /**
    * Discriminant to differentiate between Ok and Fail.
    */
@@ -165,6 +167,7 @@ export interface ConnectionError extends Error {
 export interface TransactionError extends Error {
   name: "TransactionError";
   cause: SystemError;
+
   /**
    * The commit being stored when the error occurred.
    */

--- a/packages/memory/test/naive-admission.ts
+++ b/packages/memory/test/naive-admission.ts
@@ -34,6 +34,7 @@ import type { ClientCommit, Operation, PatchOp } from "../v2.ts";
 export interface NaiveOp {
   id: string;
   kind: "set" | "patch";
+
   /** Leaf value paths touched by a patch (unused for `set`). */
   leafPaths: string[][];
 }
@@ -47,6 +48,7 @@ export interface NaiveCommit {
 
 export interface NaiveHistory {
   accepted: NaiveCommit[];
+
   /** sessionId -> localSeq -> resolution seq (accepted commits only). */
   resolution: Map<string, Map<number, number>>;
 }

--- a/packages/memory/test/v2-differential-consistency.test.ts
+++ b/packages/memory/test/v2-differential-consistency.test.ts
@@ -91,8 +91,10 @@ interface SessionState {
   sessionId: string;
   principal: string;
   nextLocalSeq: number;
+
   /** Simulated integration watermark: the read basis this client would use. */
   integratedSeq: number;
+
   /** Own prior localSeqs per entity, newest last (for pending-read stacks). */
   stacks: Map<string, number[]>;
 }
@@ -111,6 +113,7 @@ interface ScheduleStats {
   accepted: number;
   rejected: number;
   pendingReadAccepts: number;
+
   /** Commits whose pending read was sparsely mutated, split by verdict —
    * both sides must stay exercised for the declared-set exclusion to keep
    * differential coverage (see the vacuity guard). */

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -396,18 +396,22 @@ export type StreamEventFiredAt = {
  */
 export type StreamEventEntry = {
   eventId: string;
+
   /** The stream this entry targets — self-describing so the drain, the
    * dropped-notice reader, and compaction never need a reverse map. */
   stream: StreamLinkRef;
   payload?: FabricValue;
   firedAt?: StreamEventFiredAt;
+
   /** Engine-stamped: the appending commit's seq. */
   seq?: number;
+
   /** Runtime-injection provenance for the payload's injected keys,
    * carried so the server-side handler run's closed-world gate judges
    * the payload as the firing client's runtime did (same in-process
    * trust as today's client-side enforcement). */
   runtimeInjectedEventKeys?: string[];
+
   /** The firing RUNTIME's attestation that the sent event was
    * RENDERER-TRUSTED — it carried the process-local renderer-trust mark
    * (`markRendererTrustedEvent`, set by the renderer's dispatch and
@@ -422,15 +426,19 @@ export type StreamEventEntry = {
    * present; a present value must be `true` (admission refuses any
    * other). Absent = not attested. */
   rendererTrusted?: true;
+
   /** Processing-side (SpaceServer-written): consequences committed. */
   consequenced?: boolean;
+
   /** Processing-side: the handler threw — the error IS the consequence
    * (events.md §5). */
   error?: string;
+
   /** Processing-side: the dropped-event notice (events.md §5 T7) —
    * `{ status: "dropped", reason }` on the entry itself. */
   status?: "dropped";
   reason?: string;
+
   /** Processing-side (OW14, protocol.md §2b's LT4 ruling): failure
    * notices for CROSS-SPACE appends this event's handler emitted whose
    * DELIVERY was refused deterministically at the target — written by
@@ -598,6 +606,7 @@ export const identityOfScopeKey = (
   }
   return undefined;
 };
+
 /**
  * The identity annotation on one write WITHIN a derived-class commit's body
  * (protocol.md §1's transaction identity model, §7's closed metadata list).
@@ -760,6 +769,7 @@ export type ConfirmedRead = {
   branch?: BranchName;
   path: ReadPath;
   seq: number;
+
   /**
    * When true, this is a SHALLOW (shape-only) read — the reader observed the
    * container at `path` (its key set / existence) but did NOT depend on the deep
@@ -776,6 +786,7 @@ export type PendingRead = {
   id: EntityId;
   scope?: CellScope;
   path: ReadPath;
+
   /**
    * The reader's pending-stack dependency set for this document. An array
    * lists EVERY pending layer the read's materialized view sat on; each
@@ -789,6 +800,7 @@ export type PendingRead = {
    * lower-layer dependencies).
    */
   localSeq: number | number[];
+
   /**
    * The reader's confirmed basis for THIS document, in the SERVER's
    * space-log seq space (an accepted-commit `seq`, NOT the session's
@@ -815,6 +827,7 @@ export type PendingRead = {
    * docs/specs/memory-v2/09-invariants.md.
    */
   basisSeq?: number;
+
   /** See {@link ConfirmedRead.nonRecursive}. */
   nonRecursive?: boolean;
 };
@@ -822,6 +835,7 @@ export type PendingRead = {
 export type CommitPrecondition =
   | {
     kind: "origin-committed";
+
     /** localSeq of a commit from the SAME session in this space. */
     originLocalSeq: number;
   }
@@ -854,6 +868,7 @@ export type ClientCommit = {
     baseBranch: BranchName;
     baseSeq: number;
   };
+
   /** Server-execution v2 Phase 3 (events.md §1): the commit's declared
    * event appends. Only flag-ON clients produce this; admission under
    * the flag runs the dedupe-horizon CAS and stamps `firedAt` + `seq`
@@ -875,8 +890,10 @@ export type SessionOpenResult = {
 export type MemoryProtocolFlags = {
   modernCellRep: boolean;
   commitPreconditions: boolean;
+
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
+
   /**
    * Server capability (CFC Phase 3.c): commit-folded `sqlite` writes to
    * rule-bearing tables are re-derived through the shared row-label evaluator
@@ -888,6 +905,7 @@ export type MemoryProtocolFlags = {
    * (not configuration), so a server of this version always advertises it.
    */
   sqliteCommitRowLabelEval: boolean;
+
   /**
    * Server capability (CT-1872 1c): pending reads may carry an ARRAY
    * `localSeq` naming every pending layer the read sat on (resolution
@@ -900,6 +918,7 @@ export type MemoryProtocolFlags = {
    * version always advertises it.
    */
   pendingReadStacks: boolean;
+
   /**
    * Server capability (CT-1927): the server stages a `caughtUpLocalSeq`
    * catch-up obligation for every accept and every conflict rejection —
@@ -915,10 +934,13 @@ export type MemoryProtocolFlags = {
    * version always advertises it.
    */
   verdictCatchUpMarkers: boolean;
+
   /** The server can list live space-scoped entity identifiers without values. */
   entityIdListing: boolean;
+
   /** The server can page one stable entity-identifier snapshot. */
   entityIdPagination: boolean;
+
   /** The server can test one entity identifier without loading its value. */
   entityIdLookup: boolean;
 };
@@ -965,6 +987,7 @@ export type SessionDescriptor = {
   sessionId?: SessionId;
   seenSeq?: number;
   sessionToken?: SessionToken;
+
   /**
    * The session-level delegated READ binding (OW31, READ side RULED
    * 2026-08-19: the service identity reads a space's ACL only; every
@@ -998,6 +1021,7 @@ export type SessionOpenRequest = {
 export type GraphQueryRoot = {
   id: EntityId;
   scope?: CellScope;
+
   /**
    * The explicit scope INSTANCE this read names (protocol.md §2's read
    * row; the read half of §1's transaction identity model, ledger LD5).
@@ -1024,6 +1048,7 @@ export type EntitySnapshot = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+
   /**
    * The scope INSTANCE this snapshot is of (server-execution v2 stage A,
    * OW17's wire leg): present ONLY in responses to a lease-holder session
@@ -1037,6 +1062,7 @@ export type EntitySnapshot = {
   scopeKey?: ScopeKey;
   seq: number;
   document: EntityDocument | null;
+
   /** As on {@link SessionSyncUpsert}: the covering commit's class,
    * populated only under the server-execution flag and only for
    * `seq > 0` (a seq-0 snapshot has no covering commit). */
@@ -1086,6 +1112,7 @@ export type SessionSyncUpsert = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+
   /**
    * The scope INSTANCE this upsert is of (server-execution v2 stage A,
    * OW17's wire leg — the ONE write-side addition to the frame shape).
@@ -1102,6 +1129,7 @@ export type SessionSyncUpsert = {
   seq: number;
   doc?: EntityDocument;
   deleted?: true;
+
   /**
    * The commit CLASS of the covering commit — the commit whose write
    * produced this snapshot's `seq` (`commit.seq` is unique, and every
@@ -1123,6 +1151,7 @@ export type SessionSyncRemove = {
   branch: BranchName;
   id: EntityId;
   scope?: CellScope;
+
   /** As on {@link SessionSyncUpsert}: the instance, lease-holder frames only. */
   scopeKey?: ScopeKey;
 };
@@ -1202,6 +1231,7 @@ export type SqliteDbRef = {
   id: string;
   tables?: Record<string, FabricValue>;
   scope?: CellScope;
+
   /** The db's owner — the principal that created the SqliteDb cell. Resolves
    *  the per-row label rule's `dbOwner()` term (CFC Phase 3); a FIXED db
    *  property, captured once at handle creation, never the acting reader. */
@@ -1265,6 +1295,7 @@ export function dbNeedsColumnProvenance(
 
 export type SqliteQueryResult = {
   rows: FabricPlainObject[];
+
   /** Per-result-column origin, present ONLY when the db needs provenance for
    *  CFC labeling — any column declares `ifc` (Phase 2) or any table declares
    *  a per-row label rule (Phase 3); see `dbNeedsColumnProvenance`. An aliased
@@ -1288,8 +1319,10 @@ export type SqliteRegisterDiskSourceRequest = {
   requestId: string;
   space: string;
   sessionId: SessionId;
+
   /** Handle cell id (content-derived from (serviceSpace, absPath); see cf). */
   id: string;
+
   /** Absolute path to the on-disk SQLite file. */
   path: string;
 };
@@ -1348,6 +1381,7 @@ export type V2Error = {
   message: string;
   precondition?: string;
   retryAfterSeq?: number;
+
   /**
    * Present on an `AuthorizationError` that a fresh handshake can heal — the
    * connection-challenge and invocation-freshness anti-replay races (an expired,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -55,6 +55,7 @@ export type MountOptions = {
   sessionId?: string;
   seenSeq?: number;
   sessionToken?: string;
+
   /** The session-level delegated READ binding (OW31; see the wire
    * `SessionDescriptor.actingAs`): only the serving plane's loopback
    * managers set it; the server admits it for delegating-class
@@ -81,6 +82,7 @@ export type SessionOpenAuthFactory = (
 
 export type WatchMutationResult = {
   view: WatchView;
+
   /** Effects delivered before the first watch response, in wire order. */
   precedingSyncs: SessionSync[];
   sync: SessionSync;

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -817,6 +817,7 @@ export type Engine = {
   snapshotRetention: number;
   legacyCommitMetadataRefsRequired: boolean;
   statements: PreparedStatements;
+
   /**
    * Documents already decoded, by the revision each one is.
    *
@@ -835,6 +836,7 @@ export type Engine = {
    * a patched revision costs a base document plus every patch over it.
    */
   documentCache: Map<string, EntityDocument | null>;
+
   /**
    * Where {@link cacheDocumentForRevision} puts entries while a commit is
    * open, so they reach {@link Engine.documentCache} only once its rows are
@@ -903,11 +905,13 @@ export type ApplyCommitOptions = {
   invocationPayload?: FabricValue;
   authorization?: AuthorizationRecord;
   commit: ClientCommit;
+
   /** Map of cell-db id -> attach alias for `sqlite` ops in this commit. The
    *  server attaches these BEFORE applyCommit (ATTACH can't run in a txn); the
    *  apply loop executes the SQL inside the commit's transaction against the
    *  alias. (docs/specs/sqlite-builtin/plans/atomic-writes.md) */
   sqliteAttachments?: ReadonlyMap<string, string>;
+
   /** The commit's class (docs/specs/server-side-execution/protocol.md §1),
    *  determined by the ADMISSION PATH that processed the commit — the
    *  session-facing transact path is `authored` (the default here, since
@@ -917,6 +921,7 @@ export type ApplyCommitOptions = {
    *  client-supplied value: `ClientCommit` cannot express a class, so a field
    *  smuggled into the payload is inert. */
   commitClass?: CommitClass;
+
   /** The producing lease holder of a `derived`-class commit — the DR1
    *  per-process identity the SpaceServer minted at process start
    *  (serving-loop.md §2). Admission compares it against the space's live
@@ -925,6 +930,7 @@ export type ApplyCommitOptions = {
    *  a holder, and no session-facing path supplies one. Meaningless (and
    *  ignored) on other classes. */
   holder?: string;
+
   /** Per-write identity annotations of a `derived`-class commit
    *  (protocol.md §1): the explicit `scope_key` on scoped writes
    *  (ADDRESSING — consumed here to key rows, since the service envelope
@@ -933,6 +939,7 @@ export type ApplyCommitOptions = {
    *  Server-internal like `commitClass`; rejected on any other class
    *  (protocol.md §7's closed list). */
   annotations?: readonly DerivedWriteAnnotation[];
+
   /** Server-internal (the wave path only — applyWaveCommit sets it when
    *  the wave carries outbound append rows): permit a commit with zero
    *  operations. An appends-only wave MUST still commit — its durable
@@ -940,11 +947,13 @@ export type ApplyCommitOptions = {
    *  refusal would lose the appends with nothing to re-emit them. Never
    *  reachable from any session-facing path. */
   allowEmptyOperations?: boolean;
+
   /** The eventIds whose handler consequences this `derived`-class commit
    *  carries (protocol.md §7 — `consequenceOf`, derived only; bounded by
    *  the wave's input, never graph-scaled). Stored on the commit row;
    *  rejected on any other class. */
   consequenceOf?: readonly string[];
+
   /** The watermark this `derived`-class commit is current through
    *  (protocol.md §4, §7 — `derivedThrough`, derived only; every split of
    *  one wave repeats the same value). Stored on the commit row; rejected
@@ -952,6 +961,7 @@ export type ApplyCommitOptions = {
    *  outside a serving loop (tests driving the accumulator directly) has
    *  no watermark to carry, and the column stays NULL. */
   derivedThrough?: number;
+
   /** Server-produced AUTHORED admission (protocol.md §2's delegated row,
    *  §2b — outbox event appends, `.inSpace` provisioning): the commit's
    *  metadata carries the ORIGINATING chain actor + the capability grant,
@@ -965,6 +975,7 @@ export type ApplyCommitOptions = {
     actingPrincipal: string;
     actingSession?: string;
     capabilityRef: string;
+
     /** The Phase-3 floor carve-out for sessionless space-scope emissions
      *  (SHAPE RULED 2026-08-05, protocol.md §2; implemented with Phase
      *  3's events): the completeness floor admits an ABSENT acting
@@ -1000,6 +1011,7 @@ export type AppliedCommit = {
   seq: number;
   branch: BranchName;
   revisions: AppliedRevision[];
+
   /** True when the commit was an exact REPLAY of one this session
    * already applied — the stored result was returned and NOTHING was
    * inserted. Side-effect carriage riding the apply (the wave commit's
@@ -1008,6 +1020,7 @@ export type AppliedCommit = {
    * have been delivered and retired — re-inserting resurrects
    * delivered appends as duplicate delivery work). */
   replayed?: true;
+
   /**
    * Operation indexes whose `cid:` set matched the stored content exactly
    * and applied as a no-op: no revision, no head advance, no dirty mark.
@@ -1023,6 +1036,7 @@ export type ReadOptions = {
   sessionId?: SessionId;
   branch?: BranchName;
   seq?: number;
+
   /** The explicit scope INSTANCE to read (protocol.md §2's read row —
    *  the read half of the transaction identity model). When present it
    *  bypasses the session-identity resolution: the caller (a lease
@@ -1795,13 +1809,16 @@ WHERE branch = :branch AND id LIKE :prefix AND op != 'delete'
  * entry) pruned too. */
 export type RetirableEffectsInstance = {
   scopeKey: string;
+
   /** Entries surviving retirement (unacked intents persist — a reload
    * re-reads and may re-enact them, LT8). */
   remainingEntries: EffectIntentEntry[];
+
   /** Ack marks surviving retirement: acks whose entry still stands
    * (structurally none today — an ack retires its entry — kept exact
    * so the write is a pure prune, never an invention). */
   remainingAcks: Record<string, true>;
+
   /** The acked nonces this retirement consumes (diagnostics). */
   retiredNonces: string[];
 };
@@ -1921,8 +1938,10 @@ export const serverSeq = (engine: Engine): number => {
  * `firedAt` into the clone only. */
 type EventAppendStamp = {
   opIndex: number;
+
   /** Index into the op's `patches` array; absent for a whole-doc `set`. */
   patchIndex?: number;
+
   /** Index into the patch's `values` array (append/add-unique) or the
    * written array value (add/replace/set). */
   valueIndex: number;
@@ -2063,6 +2082,7 @@ const validateEventAppends = (
     principal?: string;
     sessionId: SessionId;
     delegated?: NonNullable<ApplyCommitOptions["delegated"]>;
+
     /** Derived-class scoped-op keys (the annotation ADDRESSING), for the
      * dedupe read of scoped sidecars. */
     scopeKeyByOpIndex: ReadonlyMap<number, string>;
@@ -2973,6 +2993,7 @@ export const applyWaveCommit = (
     waveBasis: {
       /** The wave's input snapshot seq (per-doc CAS basis). */
       basisSeq: number;
+
       /** Per doc-instance key (`${id} ${scopeKey}`): the head the wave's
        * rebase decision observed. Re-verification requires these docs to
        * sit at EXACTLY that head — §3d's re-CAS against the new head; a
@@ -2980,6 +3001,7 @@ export const applyWaveCommit = (
       rebasedHeads: ReadonlyArray<{ doc: string; head: number }>;
     };
     basisInstances?: readonly WaveBasisInstance[];
+
     /** The wave's outbound cross-space appends (serving-loop.md §5,
      * FP1): durable rows written INSIDE this very transaction — the
      * basis-row carriage pattern. Deleted later, on delivery-ack, by
@@ -4220,6 +4242,7 @@ const writeOperation = (
     operation: Exclude<Operation, SqliteOperation>;
     principal?: string;
     sessionId: SessionId;
+
     /** The explicit scope_key of a derived commit's scoped write
      * (protocol.md §1's ADDRESSING): admission validated it against the
      * declared scope; when present it keys the row instead of a

--- a/packages/memory/v2/execution-lease.ts
+++ b/packages/memory/v2/execution-lease.ts
@@ -83,6 +83,7 @@ export const liveExecutionLeaseHolder = (
 export type ExecutionLeaseWrite = {
   space: string;
   holder: string;
+
   /** The caller's clock. The host and the memory server are co-hosted (one
    *  process — serving-loop.md §1), so this is the same clock admission
    *  judges liveness by. Injectable so tests can construct expiry without
@@ -179,9 +180,11 @@ export const releaseExecutionLease = (
 export type ExecutionLeaseCycleOptions = {
   engine: Engine;
   space: string;
+
   /** The DR1 per-process holder identity (`executionLeaseHolder`). */
   holder: string;
   ttlMs?: number;
+
   /** The cycle's clock; injectable for tests. Defaults to `Date.now`. */
   now?: () => number;
 };

--- a/packages/memory/v2/execution-outbox.ts
+++ b/packages/memory/v2/execution-outbox.ts
@@ -37,26 +37,32 @@ import type { StreamLinkRef } from "../v2.ts";
 /** One durable outbound append row (serving-loop.md §5, FP1). */
 export type OutboxAppendRow = {
   targetSpace: string;
+
   /** The target stream SIDECAR doc id (events.md §1: an event is an
    * authored append to a stream document — `streamEntriesDocId`). */
   targetStream: string;
+
   /** The stream link the sidecar stands for — carried into the delivered
    * entry's self-describing `stream` field so the target's drain can
    * reconstruct the scheduler event link (Phase 3; events.md §1).
    * Absent on stage-G-era rows, which fall back to a path-less stream at
    * the sidecar id. */
   targetStreamLink?: StreamLinkRef;
+
   /** The client-durable event id (events.md §1); the target's dedupe
    * horizon keys on it. */
   eventId: string;
+
   /** The event payload, JSON — bounded by the event, never
    * graph-scaled (protocol.md §7's metadata discipline applies to the
    * carried event too). */
   payload: unknown;
+
   /** The ORIGINATING chain actor (events.md §2): absent only for a
    * chain with no acting user (a space-scope derivation's emission). */
   actingPrincipal?: string;
   actingSession?: string;
+
   /** The OW15 declaration (protocol.md §2's Phase-3 floor carve-out,
    * SHAPE RULED 2026-08-05): the chain has NO actor anywhere — a
    * space-scope derivation's emission, a timer — and the target stamps
@@ -65,10 +71,12 @@ export type OutboxAppendRow = {
    * userless without the declaration is refused at the SOURCE
    * (wave.ts's enqueueOutboundAppend) and at the target's floor alike. */
   sessionlessSpaceScope?: boolean;
+
   /** The capability grant the target's admission validates —
    * delegation, never session-identity impersonation (protocol.md §2's
    * server-produced authored row). */
   capabilityRef: string;
+
   /** The SOURCE event whose handler run emitted this append (OW14;
    * protocol.md §2b's LT4 ruling): a deterministic delivery refusal
    * writes its failure notice onto THIS entry before the row retires.
@@ -86,6 +94,7 @@ export type OutboxAppendRow = {
  * for the row's lifetime. */
 export type PendingOutboxRow = OutboxAppendRow & {
   rowId: number;
+
   /** The emitting wave's commit seq (FIFO per source wave → target
    * stream rides insertion-id order; the seq is recorded for
    * diagnostics). */

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -59,12 +59,14 @@ export type QueryDocKey = `${string}/${ScopeKey}/${string}`;
 export type TrackedGraphState = {
   branch: string;
   tracker: MapSetStringToPathSelectors;
+
   /** Value-link dead-ends the query's walks read as ABSENT (see
    * GraphQueryWalkOptions.onMissedDoc): keyed like the tracker, never
    * delivered — a miss keeps the graph reactive to the document's later
    * creation (the wake pass and the dirty refresh consult it) without
    * putting an absence marker on the wire. */
   missed: MapSetStringToPathSelectors;
+
   /** missKey → the REFERRER keys whose links dead-ended on it. A miss
    * lives while any referrer attributes it: a referrer that is
    * re-walked clears its attributions first, so a link edited away
@@ -72,6 +74,7 @@ export type TrackedGraphState = {
    * attribution-less miss — defensive, no known producer — retires
    * only on its own arrival). */
   missedBy: Map<string, Set<string>>;
+
   /** referrerKey → the miss keys it attributed (the reverse index the
    * re-walk clears by). */
   missesOf: Map<string, Set<string>>;
@@ -284,6 +287,7 @@ export type TrackGraphOptions = {
   readSeq?: number;
   principal?: string;
   sessionId?: string;
+
   /**
    * `queryGraph` only (server-execution v2 stage A, OW17's wire leg):
    * annotate every returned snapshot with its scope INSTANCE

--- a/packages/memory/v2/scheduler-basis.ts
+++ b/packages/memory/v2/scheduler-basis.ts
@@ -31,6 +31,7 @@ export type SchedulerBasisEntry = {
   entitySpace: string;
   entity: string;
   entityScopeKey: string;
+
   /** The input's seq at read time, in the entity's own space's sequence;
    * in-wave reads share the wave's own commit seq. */
   seq: number;

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -398,12 +398,14 @@ export type AdmittedCommitNotice = {
   holder?: string;
   sessionId: string;
   writes: Array<{ id: string; scopeKey: ScopeKey }>;
+
   /** Phase 3 (events-down): the commit's admitted event appends —
    * serving-loop.md §3's "if c.class == event-append: enqueue for
    * handler processing" classification input. Ids only (the sidecar
    * doc instance + the eventId); the SpaceServer's drain reads the
    * stamped entries from the store, never from this record. */
   eventAppends?: Array<{ id: string; scopeKey: ScopeKey; eventId: string }>;
+
   /** The EXPLICIT WARM REQUEST (serving-loop.md §1's third activation
    * trigger; RULED 2026-08-21): set only by the serving-side
    * provisioning path — a wave's foreign provisioning batch reported
@@ -429,6 +431,7 @@ export type AdmittedCommitNotice = {
 export type ServerExecutionObserver = {
   commitAdmitted?: (notice: AdmittedCommitNotice) => void;
   sessionOpened?: (space: string) => void;
+
   /** A session's WATCH SET changed (`session.watch.set` / `.add`) —
    * demand may have changed (server-execution v2 fan-out stage B, design
    * §A's arrival re-arm: a demander's FIRST watch of a root whose nodes
@@ -462,6 +465,7 @@ export type DemandedInstanceRow = {
   scope: CellScope;
   scopeKey: ScopeKey;
   identity?: { principal?: string; sessionId?: string };
+
   /** True when the row is a watch ROOT of its session (the structure
    * load's input, unchanged in scope — design §2.8 flag 4). */
   root: boolean;
@@ -1139,6 +1143,7 @@ export class Server {
     readonly options: {
       sessions?: SessionRegistry;
       store?: URL;
+
       /**
        * Coalescing delay for the batched subscription fan-out, in
        * milliseconds. `"manual"` never arms the refresh timer: dirty spaces
@@ -1155,6 +1160,7 @@ export class Server {
         message: SessionOpenRequest,
         context: SessionOpenAuthContext,
       ) => Promise<string | undefined> | string | undefined;
+
       /**
        * Authentication data advertised in `hello.ok` and enforced for
        * `session.open` on this server.
@@ -1162,11 +1168,14 @@ export class Server {
       sessionOpenAuth: {
         /** Audience value clients must sign into `session.open` as `aud`. */
         audience: string;
+
         /** How long a connection challenge may be used, in seconds. */
         challengeTtlSeconds?: number;
+
         /** Current unix time in seconds. Tests may inject this. */
         nowSeconds?: () => number;
       };
+
       /**
        * Space access control. `off` (default) preserves the historical
        * any-authenticated-session-may-do-anything behavior. `observe`
@@ -1193,6 +1202,7 @@ export class Server {
       acl?: {
         mode: MemoryAclMode;
         serviceDids?: readonly string[];
+
         /**
          * Principals whose `session.open` may carry the delegated READ
          * binding `actingAs: "space-owner"` (OW31, READ side RULED
@@ -2201,8 +2211,10 @@ export class Server {
    */
   async commitDelegatedAppend(entry: {
     targetSpace: string;
+
     /** The stream SIDECAR doc id (`streamEntriesDocId`). */
     targetStream: string;
+
     /** The stream link for the delivered entry's self-describing
      * `stream` field; stage-G-era rows fall back to a path-less link
      * at the sidecar id. */
@@ -2211,14 +2223,17 @@ export class Server {
     payload: unknown;
     actingPrincipal?: string;
     actingSession?: string;
+
     /** The OW15 sessionless-space-scope declaration (protocol.md §2's
      * Phase-3 floor carve-out): admits an ABSENT acting principal;
      * the entry stamps `firedAt = { session: "server" }`. */
     sessionlessSpaceScope?: boolean;
     capabilityRef: string;
+
     /** The delivering SpaceServer's service session — the commit's
      * envelope identity (LT5). */
     sessionId: string;
+
     /** From the delivering host's process-lifetime counter (the same
      * replay-keying discipline as the wave sink — engine-wave-sink.ts):
      * unique per (sessionId, localSeq) on the target engine. NOTE: a
@@ -4510,6 +4525,7 @@ export class Server {
   ): Array<{
     id: string;
     scope?: CellScope;
+
     /** The DEMANDING session's identity (server-execution v2 Phase 2,
      * scopes.md §5: a derivation runs per demanded instance and the
      * DEMAND supplies the identity; fan-out stage B, RULED 2026-08-16 —

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -104,10 +104,13 @@ export const wireAuthorizationOf = (
 export type VerifySessionOpenOptions = {
   /** This server's own audience identity. */
   audience: string;
+
   /** The challenge issued to this connection. */
   challenge: SessionOpenChallenge;
+
   /** Current unix time in seconds (defaults to now). Injectable for tests. */
   nowSeconds?: number;
+
   /** Grace window for `exp` to tolerate client/server clock skew. */
   clockSkewSeconds?: number;
 };

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -15,11 +15,13 @@ export type SessionState = {
   trackedIds: Set<string>;
   caughtUpLocalSeq: number;
   pendingCaughtUpLocalSeq: number;
+
   /** Set when delivery-state rollback re-inserted tombstone cache entries
    * for a lost frame's removes: the incremental refresh path never emits
    * removes, so the next sync must run a FULL watch evaluation to re-diff
    * them out (CT-1927 review, round 7). Self-clearing. */
   forceFullResync: boolean;
+
   /** Set once this session was admitted an explicit `entity_scope_key`
    * read (protocol.md §2's read row — lease holders only), and STICKY
    * for the session's life: it selects the session's WIRE VOCABULARY
@@ -33,6 +35,7 @@ export type SessionState = {
    * (`Server.#currentLeaseHolderExemption`); this bit alone never
    * admits one. */
   leaseHolderReads?: boolean;
+
   /** Set by a push pass (or a resume catch-up) that found
    * `leaseHolderReads` armed but no live lease: that pass withheld or
    * retracted the session's foreign instances. The first pass that
@@ -44,6 +47,7 @@ export type SessionState = {
   expiresAt: number | null;
   ownerConnectionId: string | null;
   principal?: string;
+
   /** The delegated READ binding (OW31; `SessionDescriptor.actingAs`):
    * the acting user — the space's ACL owner at open time — this
    * session's READ-class capability decisions resolve as. Never

--- a/packages/memory/v2/sqlite/column-origin.ts
+++ b/packages/memory/v2/sqlite/column-origin.ts
@@ -192,6 +192,7 @@ export function columnOriginUnavailableReason(): string | undefined {
 export type ColumnOrigin = {
   /** Origin table, or null for an expression/computed/compound column. */
   table: string | null;
+
   /** Origin column, or null when there is no single source column. */
   column: string | null;
 };

--- a/packages/memory/v2/sqlite/guard.ts
+++ b/packages/memory/v2/sqlite/guard.ts
@@ -33,12 +33,16 @@ export type StatementKind = "select" | "write" | "other";
 export type StatementClassification = {
   /** Leading-keyword classification. */
   kind: StatementKind;
+
   /** More than one statement (after dropping a trailing `;`). */
   multiple: boolean;
+
   /** A schema-qualified table reference (`db.table`) in a table position. */
   qualified: boolean;
+
   /** Contains a forbidden verb: PRAGMA / ATTACH / DETACH. */
   forbidden: boolean;
+
   /** References a core engine table name. */
   coreRef: boolean;
 };

--- a/packages/memory/v2/sqlite/row-label.ts
+++ b/packages/memory/v2/sqlite/row-label.ts
@@ -30,6 +30,7 @@ export type FieldRef = {
 export type MatchOpts = {
   /** Capture group to extract instead of the whole match. */
   group?: number;
+
   /** Minimum number of matches; fewer fails closed (required anchor). */
   min?: number;
 };

--- a/packages/memory/v2/sqlite/schema.ts
+++ b/packages/memory/v2/sqlite/schema.ts
@@ -13,8 +13,10 @@ import { buildRowLabelSpec, type RowLabelRule } from "./row-label.ts";
 
 export type ColumnSchema = {
   type: string;
+
   /** Verbatim SQLite column type/constraints for DDL, e.g. "integer primary key". */
   sqlType: string;
+
   /** Marks a `_cf_link` column (stored TEXT, surfaced as a Cell). */
   cfLink?: true;
   [key: string]: FabricValue;

--- a/packages/state-inspector/churn.ts
+++ b/packages/state-inspector/churn.ts
@@ -24,6 +24,7 @@ import type { SpaceDb } from "./db.ts";
 export interface ChurnBucket {
   /** Bucket start, UTC, `YYYY-MM-DD HH:MM:SS` (the store's own clock format). */
   start: string;
+
   /** Unix seconds for the bucket start — for plotting without re-parsing. */
   startEpoch: number;
   commits: number;
@@ -41,9 +42,11 @@ export interface ChurnEntity {
 export interface ChurnReport {
   bucketSeconds: number;
   branch: string;
+
   /** First and last bucket start the curve covers (null on an empty window). */
   from: string | null;
   to: string | null;
+
   /**
    * Start of the last bucket that actually holds a commit (null when none do).
    *
@@ -54,6 +57,7 @@ export interface ChurnReport {
    */
   lastCommit: string | null;
   totals: { commits: number; revisions: number };
+
   /**
    * Contiguous, zero-filled from `from` to `to` so gaps read as quiet.
    *
@@ -64,10 +68,13 @@ export interface ChurnReport {
    * stopped.
    */
   buckets: ChurnBucket[];
+
   /** The busiest bucket by commits, or null when the window is empty. */
   peak: ChurnBucket | null;
+
   /** Top writers inside `peak` — what to blame for the busiest minute. */
   peakEntities: ChurnEntity[];
+
   /**
    * Commits whose `created_at` SQLite could not parse as a time, and which are
    * therefore absent from every bucket. Nonzero means the curve is incomplete —
@@ -78,8 +85,10 @@ export interface ChurnReport {
 
 export interface ChurnOptions {
   branch?: string;
+
   /** Bucket width in seconds. Default 60. */
   bucketSeconds?: number;
+
   /**
    * Lower bound on `commit.created_at`, inclusive. `YYYY-MM-DD HH:MM:SS` or ISO.
    *
@@ -87,6 +96,7 @@ export interface ChurnOptions {
    * just the part of it that happened to contain writes.
    */
   since?: string;
+
   /**
    * Upper bound on `commit.created_at`, exclusive.
    *
@@ -95,6 +105,7 @@ export interface ChurnOptions {
    * are reported instead of implied.
    */
   until?: string;
+
   /** How many entities to attribute the peak bucket to. Default 10. */
   top?: number;
 }

--- a/packages/state-inspector/clone.ts
+++ b/packages/state-inspector/clone.ts
@@ -45,6 +45,7 @@ import {
 
 /** Filenames the layout depends on. */
 const MANIFEST = "clone.json";
+
 /**
  * Per-entity baseline hashes, written beside the manifest at clone time.
  *
@@ -61,14 +62,19 @@ const PRISTINE_DIR = "pristine";
 export interface CloneManifest {
   /** Schema version of this file, so a future reader can refuse politely. */
   version: 1;
+
   /** Space DID — the clone keeps it (see the design doc's identity section). */
   space: string;
+
   /** Where the snapshot came from: a path or URL, verbatim, for provenance. */
   source: string;
+
   /** ISO timestamp the clone was taken. */
   createdAt: string;
+
   /** SHA-256 of the pristine snapshot file. */
   snapshotHash: string;
+
   /**
    * SHA-256 of the per-entity baseline sidecar.
    *
@@ -81,6 +87,7 @@ export interface CloneManifest {
    */
   baselineHash?: string;
   snapshotBytes: number;
+
   /** Durable counts at clone time — the cheap half of "did content survive?". */
   counts: {
     commits: number;
@@ -88,6 +95,7 @@ export interface CloneManifest {
     entities: number;
     maxSeq: number;
   };
+
   /**
    * Content fingerprint at clone time, generated cells excluded.
    *
@@ -110,15 +118,19 @@ export interface CloneManifest {
 export interface CreateCloneOptions {
   /** Path to a `.sqlite` snapshot (a server-side `VACUUM INTO` output). */
   source: string;
+
   /** Space DID; determines the on-disk filename the server resolves. */
   space: string;
+
   /** Destination clone directory. Created if absent, must be empty otherwise. */
   targetDir: string;
+
   /**
    * Store directories that must never be written to — normally the live
    * server's. Callers pass what the environment says (`MEMORY_DIR`/`DB_PATH`).
    */
   forbiddenDirs?: string[];
+
   /** Timestamp source, injectable so tests need no clock. */
   now?: () => Date;
 }
@@ -126,6 +138,7 @@ export interface CreateCloneOptions {
 export interface ClonePaths {
   dir: string;
   manifestPath: string;
+
   /** Per-entity baseline hashes (see {@link BASELINE}). */
   baselinePath: string;
   pristinePath: string;
@@ -353,6 +366,7 @@ export interface VerifyResult {
    * so the tool does not guess — see `okAfterMigration`.
    */
   ok: boolean;
+
   /**
    * Relaxed: the baseline is intact and nothing was REMOVED.
    *
@@ -363,13 +377,16 @@ export interface VerifyResult {
    * checked separately.
    */
   okAfterMigration: boolean;
+
   /** The pristine snapshot still hashes to what the manifest recorded. */
   baselineIntact: boolean;
+
   /** Working-copy counts, against the manifest's. */
   counts: {
     manifest: CloneManifest["counts"];
     working: CloneManifest["counts"];
   };
+
   /** Working-copy content fingerprint, and whether it matches the baseline. */
   fingerprint: {
     manifest: string;
@@ -377,6 +394,7 @@ export interface VerifyResult {
     match: boolean;
     excludedGenerated: number;
   };
+
   /**
    * WHAT moved, against the pristine baseline — the part an operator can act on.
    *
@@ -393,10 +411,12 @@ export interface VerifyResult {
     removed: number;
     changed: number;
     added: number;
+
     /** Counts per entity kind, so "74 pieces" reads differently from "74 cells". */
     changedByKind: Record<string, number>;
     removedByKind: Record<string, number>;
   };
+
   /**
    * How much of the store the fingerprint could not speak for, on each side.
    *

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -38,6 +38,7 @@ export interface Writer {
   seq: number;
   commitSeq: number;
   session: string;
+
   /** The writer's identity (principal DID parsed from the session). */
   principal?: string;
   op: string;
@@ -46,20 +47,27 @@ export interface Writer {
 
 export interface ContendedEntity {
   id: string;
+
   /** Distinct writer sessions. */
   sessions: number;
+
   /** Distinct writer IDENTITIES — `>=2` is real cross-user contention vs the
    * same user editing from multiple tabs/devices. */
   principals: number;
+
   /** True when ≥2 distinct identities wrote it (multi-user, not multi-session). */
   multiUser: boolean;
   writes: number;
+
   /** Writer timeline, seq-ordered. */
   writers: Writer[];
+
   /** Sessions alternate (A→B→A) — concurrent back-and-forth, not a handoff. */
   interleaved: boolean;
+
   /** Lost-update reads (attached by the explorer bundle for multi-user cells). */
   staleReads?: StaleRead[];
+
   /** True once stale-read analysis ran for this cell. `false`/absent on a
    * multi-user cell means analysis was SKIPPED (a cap), not that it's clean —
    * the UI must distinguish "no anomaly" from "not analyzed". */
@@ -151,20 +159,27 @@ export interface StaleRead {
   /** The commit that read the entity. */
   readerCommitSeq: number;
   readerSession: string;
+
   /** The seq the reader saw the entity at. */
   readAtSeq: number;
+
   /** The read's declared path within the entity (`[]` = whole document). */
   readPath: string[];
+
   /** The branch the read resolved against (`read.branch ?? readerCommit.branch`). */
   readBranch: string;
+
   /** The resolved scope_key the read targeted (engine `resolveScopeKey`). */
   readScopeKey: string;
+
   /** A conflicting write the engine's own check would have rejected. */
   missedWriteSeq: number;
   missedWriteSession: string;
+
   /** The op of the conflicting write (`set`/`delete` always conflict; `patch`
    * only when its paths overlap the read — `patchOverlapsRead`). */
   missedWriteOp: string;
+
   /** True when the reader ALSO wrote the entity (a real lost-update risk). */
   readerAlsoWrote: boolean;
 }
@@ -173,10 +188,12 @@ export interface EntityConflicts {
   id: string;
   writers: Writer[];
   writerSessions: number;
+
   /** Distinct writer identities — `>=2` is real cross-user contention. */
   writerPrincipals: number;
   multiUser: boolean;
   interleaved: boolean;
+
   /** Stale reads: the reader committed without seeing a prior concurrent write. */
   staleReads: StaleRead[];
 }

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -34,6 +34,7 @@ export interface DecodedLink {
   space?: string;
   path?: readonly string[];
   scope?: string;
+
   /**
    * The schema stored on the link, or `undefined` when it stores none. A
    * stored schema is a JSON Schema, so `true` and `false` are among the values

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -40,14 +40,18 @@ import {
 /** A resolved reference to another entity (or a cross-space target). */
 export interface LinkRef {
   id: string;
+
   /** Resolved label of the target (if in this space). */
   label?: string;
   kind?: EntityKind;
+
   /** Cross-space target space DID. */
   space?: string;
   path?: string[];
+
   /** True when the target is in another space (not resolvable locally). */
   external?: boolean;
+
   /** Where this link sits in the source value (a JSON path), for "links" lists. */
   at?: string;
 }
@@ -75,28 +79,38 @@ export interface EntityDetail {
   kind: EntityKind;
   regime: string;
   owned: boolean;
+
   /** Context-aware label (key-name / import specifier / $NAME / module file). */
   label: string;
+
   /** Short human role, e.g. "input cell", "owned stream", "module import". */
   role: string;
+
   /** The key in the owner piece that names this entity, if any. */
   contextName?: string;
+
   /** Top-level document paths present (the control plane). */
   paths: string[];
   valueShape: string;
+
   /** The annotated value (links/streams normalized; depth-bounded). */
   value: unknown;
   valuePreview: string;
+
   /** The result JSONSchema (annotated), if the entity carries one. Streams and
    * named owned cells get their DECLARED schema resolved from the owner piece. */
   schema?: unknown;
   schemaKeys?: string[];
+
   /** Where `schema` came from when it isn't the entity's own (e.g. owner piece). */
   schemaSource?: string;
+
   /** True when the declared schema is a stream payload (`asCell:["stream"]`). */
   streamPayload?: boolean;
+
   /** IFC labels from a schema-as-value entity, if present. */
   ifc?: unknown;
+
   /** Parsed CFC labels from the `cfc` meta path, if present. */
   cfc?: CfcSummary;
   revisions: number;
@@ -112,11 +126,14 @@ export interface EntityDetail {
     argument?: LinkRef;
     internal?: LinkRef[];
     owner?: LinkRef;
+
     /** Legacy regime: the result cell a process cell produces (`resultRef`). */
     result?: LinkRef;
   };
+
   /** Outgoing data links found in the value, resolved to target labels. */
   outLinks: LinkRef[];
+
   /** Module source (only on module entities). */
   code?: string;
 }
@@ -279,6 +296,7 @@ function linksWithPaths(
 interface DetailContext {
   ownDid: string;
   labelOf: Map<string, { kind: EntityKind; label: string }>;
+
   /** entityId → { ownerId, key } naming it in its owner piece's value. */
   nameOf: Map<string, { owner: string; key: string }>;
   moduleIndex: Map<string, ModuleEntry>;

--- a/packages/state-inspector/fingerprint.ts
+++ b/packages/state-inspector/fingerprint.ts
@@ -90,8 +90,10 @@ function allEntities(
 export interface EntityFingerprint {
   id: string;
   scope: string;
+
   /** Entity classification (`piece`, `cell`, …) as the model reports it. */
   kind: string;
+
   /** `hashOf` the entity's durable `value`, or null when it has no value. */
   hash: string | null;
 }
@@ -99,10 +101,13 @@ export interface EntityFingerprint {
 export interface FingerprintReport {
   /** Hash over every included entity's (id, scope, hash) — the one number. */
   hash: string;
+
   /** Entities included in `hash`. */
   entities: number;
+
   /** Internal cells skipped because a manifest calls them compiler-generated. */
   excludedGenerated: number;
+
   /**
    * Ids some manifest calls generated and another calls named. Counted as
    * generated (rotation-prone wins, so the fingerprint stays stable) but
@@ -110,14 +115,17 @@ export interface FingerprintReport {
    * be silent. Zero on every store observed so far.
    */
   ambiguous: string[];
+
   /** Entities whose value could not be hashed, with the reason. Never silent. */
   unhashable: { id: string; reason: string }[];
+
   /** Per-entity hashes, id-sorted — the input to `diffFingerprints`. */
   perEntity: EntityFingerprint[];
 }
 
 export interface FingerprintOptions {
   branch?: string;
+
   /**
    * Refuse rather than fingerprint a space whose scope enumerates more than
    * this many entities, since the enumeration was truncated. A scope holding
@@ -125,6 +133,7 @@ export interface FingerprintOptions {
    * any real space; raise it only knowingly.
    */
   enumerationCap?: number;
+
   /**
    * Include compiler-generated internal cells. Default false. Turning this on
    * makes the fingerprint change on every pattern update by design; it exists

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -35,12 +35,15 @@ export interface GraphNode {
   /** Unique node key. For external stubs this is space-qualified (`<space>/<id>`)
    * so a cross-space target can't collide with a local entity of the same id. */
   id: string;
+
   /** The bare entity id (for display / navigation); equals `id` for local nodes. */
   entityId: string;
   kind: EntityKind;
   label: string;
+
   /** False for a synthesized stub (a cross-space link target not in this space). */
   present: boolean;
+
   /** Set on external stubs: the space DID the target lives in. */
   space?: string;
 }
@@ -49,8 +52,10 @@ export interface GraphEdge {
   from: string;
   to: string;
   kind: EdgeKind;
+
   /** Optional edge annotation (pattern symbol, link path, …). */
   label?: string;
+
   /** True when `to` lives in another space (a cross-space data link). */
   external?: boolean;
 }
@@ -64,6 +69,7 @@ export interface SpaceGraph {
     edgesByKind: Record<EdgeKind, number>;
     externalEdges: number;
   };
+
   /** How far the entity scan this graph was built from reached. */
   extent: ScanExtent;
 }

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -36,14 +36,19 @@ export type SpaceRole =
 
 export interface SpaceSignals {
   did: string;
+
   /** A home-piece was found here (result keys include profiles + createProfile). */
   isHome: boolean;
+
   /** Profile space DIDs from this home's `profiles[]` cells (cross-space links). */
   profileDids: string[];
+
   /** Session principal DIDs from `commit.session_id` (owners acting here). */
   principals: string[];
+
   /** Dominant (most frequent) session principal, if any. */
   principal: string | null;
+
   /** All cross-space link target space DIDs (space ≠ self). */
   crossSpaceDids: string[];
   commits: number;
@@ -182,12 +187,15 @@ export function analyzeSpaceSignals(
 export interface GroupedSpace {
   did: string;
   role: SpaceRole;
+
   /** A local DB file was found for this DID. */
   present: boolean;
+
   /** Present but with zero commits — a pre-created placeholder. */
   empty: boolean;
   commits?: number;
   entities?: number;
+
   /** Why this space is in the group / has this role. */
   evidence: string[];
 }
@@ -195,6 +203,7 @@ export interface GroupedSpace {
 export interface SpaceGroup {
   /** The owner principal / home DID this group centers on. */
   principal: string;
+
   /** A non-empty home space was found locally for the principal. */
   homePresent: boolean;
   spaces: GroupedSpace[];
@@ -202,6 +211,7 @@ export interface SpaceGroup {
 
 export interface GroupingResult {
   groups: SpaceGroup[];
+
   /** Discovered spaces not attachable to any principal. */
   ungrouped: GroupedSpace[];
 }

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -35,20 +35,26 @@ import {
 export interface InspectorBundle {
   space: string;
   generatedAt: string;
+
   /** Base origin of the live shell, for deep links (`<base>/<space>/<id>`). */
   liveBase: string;
   summary: SpaceSummary;
   details: EntityDetail[];
+
   /** How far the entity scan behind `details` and `graph` reached. */
   extent: ScanExtent;
   graph: SpaceGraph;
   timeline: SpaceTimelineEntry[];
+
   /** Per-identity scopes present (space / user:<DID> / session:<DID>:*). */
   scopes: Scope[];
+
   /** Per-entity scope overlays — only for cells with non-space/multi-scope state. */
   overlays: ScopeOverlay[];
+
   /** Identities that touched this space (committers + per-user/session owners). */
   participants: Participant[];
+
   /** Contested entities (≥2 writer sessions); multi-user ones carry stale reads. */
   conflicts: ContendedEntity[];
 }

--- a/packages/state-inspector/identity.ts
+++ b/packages/state-inspector/identity.ts
@@ -25,8 +25,10 @@ export interface IdentitySpace {
   empty: boolean;
   commits?: number;
   entities?: number;
+
   /** Scopes in this space OWNED BY this identity (user:<DID>, session:<DID>:*). */
   ownedScopes: Scope[];
+
   /** Total per-user + per-session entities this identity has here. */
   scopedEntities: number;
   evidence: string[];
@@ -34,12 +36,14 @@ export interface IdentitySpace {
 
 export interface IdentityWorld {
   did: string;
+
   /** A non-empty home space exists locally for this identity. */
   homePresent: boolean;
   spaces: IdentitySpace[];
   totals: {
     spaces: number;
     presentSpaces: number;
+
     /** Spaces where this identity has per-user/session state. */
     spacesWithScopedState: number;
     scopedEntities: number;

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -91,12 +91,16 @@ export type ValueShape =
 export interface Lineage {
   /** Input cell — a piece's `argument` link target. */
   argument?: string;
+
   /** Pattern pointer + resolved module entity (modern pieces). */
   pattern?: { identity: string; symbol?: string; moduleId?: string };
+
   /** Owning piece — an owned cell's `result` back-link target. */
   owner?: string;
+
   /** Owned child cell ids — a piece's `internal` manifest. */
   internal?: string[];
+
   /**
    * Legacy process/source cell link target.
    * LEGACY-PROCESS-CELL: removed with the process-cell era (top-of-file note).
@@ -109,10 +113,13 @@ export interface EntityModel {
   scope: string;
   kind: EntityKind;
   regime: Regime;
+
   /** True when the entity carries a `result` ownership back-link. */
   owned: boolean;
+
   /** Human label: piece $NAME, module:<file>, stream, schema, or value summary. */
   label: string;
+
   /** Top-level paths present in the document (the control plane, sorted). */
   paths: string[];
   valueShape: ValueShape;
@@ -485,14 +492,17 @@ export function scanLimit(limit: number | undefined): number {
 export interface ScanExtent {
   /** The cap the scan applied. */
   limit: number;
+
   /**
    * Entities this branch and scope can see, before any `kind` filter — the
    * size of the set the scan walked (`visibleEntityRows`), so a complete pass
    * describes exactly this many.
    */
   total: number;
+
   /** True when the scan reached more of what was asked for than `limit`. */
   truncated: boolean;
+
   /**
    * Entities the scan enumerated and could NOT describe — a payload that would
    * not decode, or a reconstruction that threw. A separate count from
@@ -513,6 +523,7 @@ export function isCompleteScan(extent: ScanExtent): boolean {
 export interface EntityScanRow {
   id: string;
   revisions: number;
+
   /**
    * The chain link that owns the visible row. A pass describing an entity's
    * history has to read THIS branch and no other: nearest-branch ownership
@@ -548,6 +559,7 @@ export function visibleEntityRows(
   opts: {
     branch?: string;
     scope?: string;
+
     /** Include entities whose visible head is a `delete`. Default false. */
     includeDeleted?: boolean;
   } = {},
@@ -811,6 +823,7 @@ export function listEntityModels(
 
 export interface PieceCellRef {
   id: string;
+
   /** Classified kind of the owned cell (stream / schema / owned-cell / …). */
   kind: EntityKind;
   label: string;
@@ -821,6 +834,7 @@ export interface PieceModel {
   id: string;
   regime: Regime;
   name: string;
+
   /** The pattern (module) this piece instantiates, resolved via patternIdentity. */
   pattern?: {
     id?: string;
@@ -828,15 +842,20 @@ export interface PieceModel {
     symbol?: string;
     filename?: string;
     codeLines?: number;
+
     /** Full TS source — only populated when `includeCode` is set. */
     code?: string;
   };
+
   /** The piece's input cell (the `argument` link). */
   input?: { id: string; summary: string };
+
   /** Top-level keys of the piece's result value ($UI, $NAME, …pattern outputs). */
   resultKeys: string[];
+
   /** Top-level keys of the result JSONSchema. */
   schemaKeys: string[];
+
   /** The piece's owned child cells (its `internal` manifest, resolved). */
   ownedCells: PieceCellRef[];
 }

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -45,12 +45,16 @@ export interface SpaceEntityView {
   revisions: number;
   lastSession: string | null;
   lastWriteAt: string | null;
+
   /** Annotated value at the requested path (links/streams normalized). */
   value?: unknown;
+
   /** Whether the requested path exists within a present entity. */
   pathExists?: boolean;
+
   /** Canonical key used for clustering equal values. */
   valueKey?: string;
+
   /** Set if reconstruction/decode threw for this space (entity still counts as present). */
   error?: string;
 }
@@ -68,6 +72,7 @@ export interface ValueCluster {
   valueKey: string;
   value: unknown;
   labels: string[];
+
   /** Whether this cluster represents values found at the requested path. */
   pathExists?: boolean;
 }
@@ -86,6 +91,7 @@ export interface ConvergenceResult {
   views: SpaceEntityView[];
   clusters: ValueCluster[];
   caveat: string;
+
   /** Set when a link index is supplied — distinguishes drift from instances. */
   relationship?: ConvergenceRelationship;
 }
@@ -105,6 +111,7 @@ export interface CrossSpaceEdge {
 
 export interface CrossSpaceLinkIndex {
   edges: CrossSpaceEdge[];
+
   /** `${toSpace} ${toId}` for every entity referenced cross-space. */
   targets: Set<string>;
   examinedEntities: number;
@@ -388,10 +395,13 @@ export function classifyRelationship(
 export interface ScanOptions {
   scope?: string;
   branch?: string;
+
   /** Max diverged, partial, or unknown findings to return. */
   limit?: number;
+
   /** Max shared entities to reconstruct (cost guard). */
   examineCap?: number;
+
   /** Build the cross-space link index to classify findings (default true). */
   linkIndex?: boolean;
 }
@@ -401,10 +411,13 @@ export interface ScanResult {
   sharedEntities: number;
   examined: number;
   examineCapped: boolean;
+
   /** Cross-space link edges found across all spaces (0 ⇒ no replica relationships). */
   crossSpaceLinkEdges: number;
+
   /** Findings labeled cross-space-linked (real replica drift). */
   linkedFindings: number;
+
   /** Findings labeled no-cross-space-link (likely independent instances). */
   unlinkedFindings: number;
   findings: ConvergenceResult[];

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -9,6 +9,7 @@ import { decodeStored } from "./decode.ts";
 export interface SpaceSummary {
   path: string;
   hasSchedulerBasisTable: boolean;
+
   /** Scheduler basis rows (0 even when the table exists empty). */
   schedulerBasisRows: number;
   commits: number;

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -46,6 +46,7 @@ export type EntityDocument =
 export interface PathSelection {
   /** Whether every segment selected an own property. */
   found: boolean;
+
   /** The selected value. This can be `undefined` when `found` is true. */
   value: unknown;
 }
@@ -109,6 +110,7 @@ function hasTable(space: SpaceDb, name: string): boolean {
 /** One branch a read consults, and the seq its rows are visible up to. */
 export interface BranchReadLink {
   branch: string;
+
   /** Rows with `seq <= atSeq` on this branch are visible from the read. */
   atSeq: number;
 }
@@ -169,8 +171,10 @@ export function branchReadChain(
 export interface VisibleRevisionRow {
   scope: string;
   id: string;
+
   /** Revisions on the branch that OWNS it — the history a read can reach. */
   revisions: number;
+
   /** The chain link that owns it. */
   link: BranchReadLink;
 }
@@ -367,8 +371,10 @@ export function reconstructDocument(
 
 export interface ValueAtResult {
   exists: boolean;
+
   /** The full reconstructed document (`{ value, source, … }`). */
   document?: EntityDocument;
+
   /** The value navigated to `path` within `document.value`. */
   value?: unknown;
 }

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -41,8 +41,10 @@ export interface Scope {
   /** The raw scope_key as stored (often %-encoded). */
   raw: string;
   kind: ScopeKind;
+
   /** Owning principal DID (user/session scopes). */
   principal?: string;
+
   /** Session uuid (session scopes). */
   sessionId?: string;
   entities: number;
@@ -148,12 +150,15 @@ export function resolveScopeChain(
 
 export interface IdentityValue {
   exists: boolean;
+
   /** The scope the value resolved from (the most specific that held the id). */
   resolvedScope?: string;
   resolvedKind?: ScopeKind;
   value?: unknown;
+
   /** True if a more-general scope ALSO holds this id (i.e. this is an override). */
   overrides?: boolean;
+
   /** Honest reminder this is an approximation, not the runtime read path. */
   approximation: true;
 }
@@ -204,10 +209,13 @@ export function valueAsIdentity(
     sessionId?: string;
     branch?: string;
     atSeq?: number;
+
     /** Exact path segments within the resolved value. */
     path?: string[];
+
     /** Return the resolved document instead of selecting within its value. */
     doc?: boolean;
+
     /** Maximum depth retained in annotated output. Defaults to eight. */
     annotationDepth?: number;
   },
@@ -259,14 +267,19 @@ export function valueAsIdentity(
 export interface Participant {
   /** The identity (user) DID. */
   did: string;
+
   /** True when this DID owns the space (space DID == did → it's their home). */
   isOwner: boolean;
+
   /** Commits whose session principal is this DID. */
   commits: number;
+
   /** Distinct sessions (browser tabs/devices) this DID acted from. */
   sessions: number;
+
   /** Entities this DID has in a `user:<DID>` scope here. */
   userEntities: number;
+
   /** Entities this DID has in `session:<DID>:*` scopes here. */
   sessionEntities: number;
 }
@@ -345,8 +358,10 @@ export interface ScopeVariant {
 export interface ScopeOverlay {
   id: string;
   variants: ScopeVariant[];
+
   /** True when the id appears in >1 scope (a per-identity override exists). */
   overridden: boolean;
+
   /** True when those scopes hold DIFFERENT values (real divergence). */
   divergent: boolean;
 }

--- a/packages/state-inspector/test/scan-extent.test.ts
+++ b/packages/state-inspector/test/scan-extent.test.ts
@@ -58,13 +58,17 @@ const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
 
 interface SeedEntity {
   id: string;
+
   /** The stored document, written once per revision. */
   document: Record<string, unknown>;
   revisions: number;
+
   /** Branch the revisions are written on. Defaults to the space branch. */
   branch?: string;
+
   /** Written after the revisions: the entity's visible head is a tombstone. */
   deleted?: boolean;
+
   /** Scope the revisions are written under. Defaults to the shared scope. */
   scope?: string;
 }
@@ -662,6 +666,7 @@ describe("scan-extent", () => {
 
   describe("a fingerprint of a child branch", () => {
     const MINE = "user:did:key:zBob";
+
     /** A parent entity the child overrides, and a parent-only user scope. */
     const forked = (run: (space: SpaceDb) => void) =>
       withSeeded(
@@ -713,6 +718,7 @@ describe("scan-extent", () => {
 
   describe("an entity deleted in one scope and live in another", () => {
     const MINE = "user:did:key:zBob";
+
     /** Shared value kept; the per-user copy written and then deleted. */
     const halfDeleted = (run: (space: SpaceDb) => void) =>
       withSeeded(

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -53,19 +53,25 @@ export type StoredValueKind =
 export interface ValueChange {
   /** Slash-delimited path of the change. */
   path: string;
+
   /** Exact path segments, e.g. `["value", "items", "0"]`. */
   pathSegments?: string[];
   kind: ChangeKind;
   before?: unknown;
   after?: unknown;
+
   /** Set when `before` is the annotation for a stored `undefined` value. */
   beforeIsUndefined?: true;
+
   /** Set when `after` is the annotation for a stored `undefined` value. */
   afterIsUndefined?: true;
+
   /** Set when different stored values have equal display annotations. */
   annotationCollision?: true;
+
   /** Stored value kind for `before` when display annotations collide. */
   beforeValueKind?: StoredValueKind;
+
   /** Stored value kind for `after` when display annotations collide. */
   afterValueKind?: StoredValueKind;
 }
@@ -416,16 +422,22 @@ export interface TimelineStep {
   commitSeq: number;
   session: string;
   createdAt: string;
+
   /** One-line summary of the entity's value after this write. */
   summary: string;
+
   /** Whether the entity is known to exist after this write. */
   exists: boolean;
+
   /** Number of changes from the preceding state. */
   changes: number;
+
   /** Set when the preceding or current state could not be reconstructed. */
   changesKnown?: false;
+
   /** Set when the entity's state after this write could not be reconstructed. */
   stateKnown?: false;
+
   /** The reconstruction error, when this write could not establish state. */
   error?: string;
 }
@@ -544,10 +556,13 @@ export interface SpaceTimelineEntry {
   commitSeq: number;
   createdAt: string;
   session: string;
+
   /** Entities touched (revisions) in this commit. */
   touched: number;
+
   /** Entities seen here for the first time. */
   created: number;
+
   /** Cumulative distinct entities up to and including this commit. */
   cumulativeEntities: number;
 }

--- a/packages/toolshed/background.ts
+++ b/packages/toolshed/background.ts
@@ -41,8 +41,10 @@ export function backgroundLogFile(): string | undefined {
 export interface LaunchMode {
   /** This process should spawn the server as a child and wait for it. */
   background: boolean;
+
   /** Where the child should write its logs, when the caller named a path. */
   logFile: string | undefined;
+
   /** The arguments the server itself consumes (the port, and so on). */
   serverArgs: string[];
 }

--- a/packages/toolshed/lib/cfc-posture.ts
+++ b/packages/toolshed/lib/cfc-posture.ts
@@ -26,8 +26,10 @@ export interface CfcPostureReport {
   readonly policyEvaluation: string;
   readonly labelMetadataProtection: string;
   readonly declaredMonotonicity: string;
+
   /** Digest of the deployment policy snapshot; `null` when none configured. */
   readonly policyDigest: string | null;
+
   /** Sink names with a declared confidentiality ceiling, sorted. */
   readonly sinkCeilings: string[];
 }

--- a/packages/toolshed/lib/custody-ingest.ts
+++ b/packages/toolshed/lib/custody-ingest.ts
@@ -38,6 +38,7 @@ import type { FabricValue } from "@commonfabric/api";
 export type VouchedChannel = {
   /** The ingest channel — its dedicated space DID. Recorded on every mark. */
   readonly channel: string;
+
   /**
    * The stable per-source identifier the grant was vouched to. Recorded for
    * audit/display; NOT enforced (audience-binding is the federation PR5

--- a/packages/toolshed/lib/rate-limit.ts
+++ b/packages/toolshed/lib/rate-limit.ts
@@ -6,8 +6,10 @@
 export interface RateLimiterOptions {
   /** Burst size — the most a single key may spend at once. */
   capacity: number;
+
   /** Sustained rate. */
   refillPerSecond: number;
+
   /**
    * Hard cap on tracked keys, so the limiter cannot itself become the memory
    * exhaustion it exists to prevent. When full, the least-recently-used key is
@@ -15,6 +17,7 @@ export interface RateLimiterOptions {
    * number of distinct clients you expect.
    */
   maxKeys?: number;
+
   /**
    * Clock source, injectable so refill behavior can be tested by advancing a
    * counter rather than sleeping. A timing-dependent test of a rate limiter is

--- a/packages/toolshed/lib/server-execution.ts
+++ b/packages/toolshed/lib/server-execution.ts
@@ -84,6 +84,7 @@ export function serverExecutionPolicyFromEnv(
     const raw = envGet(name);
     return raw === undefined || raw === "" ? undefined : raw;
   };
+
   /** Positive-int knobs whose absence means the built-in default. */
   const positiveOrDefault = (name: string): number | undefined => {
     const raw = readRaw(name);
@@ -166,6 +167,7 @@ export function ensureSpaceRootsFromEnv(
 export function startServerExecutionHost(options: {
   server: MemoryServer;
   identity: Identity;
+
   /** The patterns/compile base — the serving runtimes' `apiUrl`. */
   apiUrl: URL;
   envGet?: EnvReader;

--- a/packages/toolshed/lib/space-authority.ts
+++ b/packages/toolshed/lib/space-authority.ts
@@ -79,8 +79,10 @@ export type SpaceAuthority =
   | {
     ok: false;
     kind: SpaceDenialKind;
+
     /** Safe to return to the caller. */
     message: string;
+
     /** Never returned to the caller — server-side diagnosis only. */
     logDetail: string;
   };
@@ -90,6 +92,7 @@ export interface SpaceAuthorityDeps {
   runtime: Runtime;
   operatorDid: string;
   serviceDids: readonly string[];
+
   /**
    * The deployment's `MEMORY_ACL_MODE`. Load-bearing for the operator-write
    * PREDICTION only: the memory server short-circuits authorization entirely
@@ -101,6 +104,7 @@ export interface SpaceAuthorityDeps {
    * durable write capabilities to non-owners.
    */
   aclMode?: "off" | "observe" | "enforce";
+
   /** True when this deployment hosts `space`. Defaults to the on-disk store. */
   hostsSpace?: (space: string) => boolean;
 }

--- a/packages/toolshed/routes/ingest-channels/ingest-channels.utils.ts
+++ b/packages/toolshed/routes/ingest-channels/ingest-channels.utils.ts
@@ -100,13 +100,16 @@ export const MAX_LIFETIME_CHANNELS_PER_SPACE = 500;
 
 export interface ControlDeps {
   runtime: Runtime;
+
   /** The toolshed's own space — where registrations live. */
   serviceSpace: string;
   operatorDid: string;
   serviceDids: readonly string[];
   hostsSpace: (space: string) => boolean;
+
   /** See SpaceAuthorityDeps.aclMode — gates the operator-write prediction only. */
   aclMode?: "off" | "observe" | "enforce";
+
   /** Overridable so a test can reach the cap without minting the whole limit. */
   maxChannelsPerOwner?: number;
   maxLifetimeChannelsPerOwner?: number;
@@ -144,6 +147,7 @@ export interface ChannelView {
   revoked?: { at: string; by: string };
   revocations?: { at: string; by: string }[];
   lastSeenAt: string | null;
+
   /**
    * The generation of this registration. Surfaced because `revoke` requires
    * it: it is what binds a revoke to the credential the caller actually looked
@@ -259,8 +263,10 @@ const persist = async (
     existing: IngestRegistration | null;
     callerDid: string;
     ttlDays?: number;
+
     /** The hash being rotated away from, so a stale device can be told to re-pair. */
     rotatedFrom?: string;
+
     /** Consumed atomically with this write, or not at all. */
     requestId: string;
   },

--- a/packages/toolshed/routes/ingest/ingest.utils.ts
+++ b/packages/toolshed/routes/ingest/ingest.utils.ts
@@ -98,12 +98,16 @@ export const isValidPartition = isValidSegment;
 export interface IngestRegistration {
   id: string;
   name: string;
+
   /** The space partition cells are written into (the end user's space). */
   space: string;
+
   /** Cell-cause prefix; a partition cell's cause is `${causePrefix}/${partition}`. */
   causePrefix: string;
+
   /** Stable source identifier: recorded on the mark + the cross-repo join key. */
   installId: string;
+
   /**
    * The sink discriminator. Only `"journal"` (durable, append-only, marked)
    * exists in iteration 1; `"stream"` (today's webhook dispatch) joins the union
@@ -112,6 +116,7 @@ export interface IngestRegistration {
    */
   sink: "journal";
   secretHash: string;
+
   /**
    * The hash of the token this channel most recently rotated AWAY from.
    *
@@ -127,6 +132,7 @@ export interface IngestRegistration {
   createdBy: string;
   createdAt: string;
   enabled: boolean;
+
   /**
    * The VERIFIED DID that minted this channel — a first-party request proof,
    * checked against an explicit OWNER grant on `space` (lib/space-authority.ts).
@@ -135,12 +141,14 @@ export interface IngestRegistration {
    * the operator script before self-serve existed.
    */
   owner?: string;
+
   /**
    * Hard expiry, enforced on the data plane by `processIngest` — not merely
    * stored. A minted token otherwise outlives any later ACL change (the
    * authorization is checked once, at mint), so this is the bound on that.
    */
   expiresAt?: string;
+
   /**
    * CURRENT revocation state — present iff the channel is revoked right now.
    * Revocation is a soft disable, not a deletion, diverging deliberately from
@@ -154,12 +162,14 @@ export interface IngestRegistration {
    * on arrival. The history below is what preserves the audit trail.
    */
   revoked?: { at: string; by: string };
+
   /**
    * Past revocations, oldest first, bounded. Keeping this separate from
    * `revoked` is what lets re-minting restore service without erasing the
    * record that the channel was once revoked, and by whom.
    */
   revocations?: { at: string; by: string }[];
+
   /**
    * Monotonic version, bumped on every write. It exists so lifecycle mutations
    * can be optimistic: a caller states the revision its decisions were based
@@ -515,6 +525,7 @@ export async function getSpaceRegistrationIndex(
 // capability, and silently killing the victim's live token. There is no replay
 // cache on request proofs (docs/specs/toolshed-access-control.md), so this is
 // durable and per-request rather than an in-memory cache with a timer.
+
 /**
  * Replay defense only has to span the first-party proof's freshness window, so
  * claims older than it can be forgotten. `DEFAULT_MAX_PROOF_AGE_SECONDS` in
@@ -575,6 +586,7 @@ export const isValidRequestId = isValidSegment;
  * conflict — which is the whole basis of the claim that a replay can never
  * reach `generateIngestSecret`.
  */
+
 /** The claim a lifecycle write records, atomically with the write itself. */
 export interface ClaimRequest {
   owner: string;

--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.types.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.types.ts
@@ -11,14 +11,19 @@ export interface OAuth2ProviderConfig {
   clientSecret: string;
   authorizationEndpointUri: string;
   tokenUri: string;
+
   /** Endpoint to fetch user profile after token exchange */
   userInfoEndpoint?: string;
+
   /** Map raw user info response to normalized shape */
   userInfoMapper?: (raw: Record<string, unknown>) => UserInfo;
+
   /** Space-separated default scopes */
   defaultScopes: string;
+
   /** Extra query params appended to the authorization URL (e.g. access_type, prompt) */
   extraAuthParams?: Record<string, string>;
+
   /**
    * How to authenticate on the token endpoint.
    * - "body" (default): client_id/secret in POST body
@@ -57,8 +62,10 @@ export interface CallbackResult extends Record<string, unknown> {
 export interface OAuth2HandlerOptions {
   /** Custom function to map OAuth2Tokens to the auth cell data shape */
   tokenMapper?: (token: OAuth2Tokens) => Record<string, unknown>;
+
   /** JSON schema to apply when reading/writing the auth cell */
   authSchema?: JSONSchema;
+
   /** Empty data object used when clearing auth (logout) */
   emptyAuthData?: Record<string, unknown>;
 }

--- a/packages/toolshed/routes/shell/shell-static.ts
+++ b/packages/toolshed/routes/shell/shell-static.ts
@@ -20,6 +20,7 @@ export interface ShellStaticDeps {
 
 export interface ShellStaticOptions {
   deps?: ShellStaticDeps;
+
   /**
    * Build identifier embedded in a compiled toolshed binary. Its immutable
    * `/builds/<id>/` URL namespace aliases the binary's single static graph.

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.ts
@@ -33,8 +33,10 @@ export interface MemWriteOp {
   op?: string;
   id?: unknown;
   scope?: unknown;
+
   /** Present for `set`/`delete`; absent for `patch` (value lives in `patches`). */
   value?: unknown;
+
   /** JSON-patch entries for `patch` ops, each `{ path, value, ... }`. */
   patches?: unknown;
 }

--- a/packages/toolshed/scripts/retire-ingest-channels.ts
+++ b/packages/toolshed/scripts/retire-ingest-channels.ts
@@ -53,8 +53,10 @@ import { plainRevocations } from "@/routes/ingest-channels/ingest-channels.utils
 export interface RetirePlan {
   /** Channels this run would retire (or did, when `confirm`). */
   retired: { id: string; space: string; installId: string; owner: string }[];
+
   /** Already revoked, so left alone. */
   skipped: number;
+
   /**
    * Changed underneath the sweep and therefore NOT retired. Re-running picks
    * them up; reporting them is what keeps the sweep from claiming completeness


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 336 doc comments across 46 files had no blank line above them; each
gets one. Covered: `packages/memory`, `packages/state-inspector`, and
`packages/toolshed`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, the three packages' own test
tasks, and `packages/static`'s three generated-asset checks all pass locally.
GitHub Actions is in an outage as this is opened, so these are local runs rather
than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

