### PR TITLE
docs(schema-generator): blank lines above doc comments, with four more packages

### DIFF
--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -236,6 +236,7 @@ export interface WritePath {
   jsonPath: (string | number)[];
   isJsonFile: boolean;
   piece: PieceController;
+
   /** Set when the file is an [FS] projection index file. */
   fsProjection?: "markdown" | "json";
 }
@@ -250,15 +251,18 @@ export interface HandlerTarget {
 export interface SourceWritePath {
   spaceName: string;
   pieceName: string;
+
   /** Relative path within .src/, e.g. "main.tsx" or "utils/helper.tsx". */
   relPath: string;
   piece: PieceController;
+
   /** Inode of the .src/ directory (for error.log lookups). */
   srcIno: bigint;
 }
 
 /** Callback to invalidate kernel cache entries (by name under a parent). */
 export type InvalidateCallback = (parentIno: bigint, names: string[]) => void;
+
 /** Callback to invalidate cached attrs/data for an inode (forces readdir refresh). */
 export type InvalidateInodeCallback = (ino: bigint) => void;
 
@@ -281,14 +285,18 @@ export interface SpaceState {
     string,
     { summary: string; patternRef?: PiecePatternRef }
   >;
+
   /** Per-piece subscription cancellers, keyed by piece name. */
   pieceSubs: Map<string, Cancel[]>;
   did: string;
   unsubscribes: Cancel[];
+
   /** Used names set for collision resolution. */
   usedNames: Set<string>;
+
   /** Map from piece name to the inode of its .src/ directory. */
   srcInos: Map<string, bigint>;
+
   /** Map from piece name to the inode of the synthetic error.log file in .src/. */
   srcErrorLogInos: Map<string, bigint>;
 }
@@ -351,19 +359,24 @@ interface PropRebuildJob {
 export class CellBridge {
   tree: FsTree;
   spaces: Map<string, SpaceState> = new Map();
+
   /** Known space name → DID mapping (for .spaces.json). */
   knownSpaces: Map<string, string> = new Map();
+
   /** Callback for kernel cache invalidation (set by mod.ts after mount). */
   onInvalidate: InvalidateCallback | null = null;
   onInvalidateInode: InvalidateInodeCallback | null = null;
   private identity: string = "";
   private apiUrl: string = "";
   private connecting = new Map<string, Promise<SpaceState>>();
+
   /** In-flight piece-list synchronization keyed by space name. */
   private pieceSyncs = new Map<string, Promise<void>>();
+
   /** Flag: re-run sync after current pass completes. */
   private syncAgain: Set<string> = new Set();
   private pendingPieceHydrations = new Map<string, Promise<void>>();
+
   /** Coalesced subtree rebuilds keyed by piece inode + prop name. */
   private pendingPropRebuilds = new Map<
     string,
@@ -414,11 +427,14 @@ export class CellBridge {
   private entitySubscriptions = new Map<bigint, Cancel[]>();
   private piecePropRoots = new Map<bigint, PiecePropRootInfo>();
   private hydratedPieceProps = new Map<bigint, Set<"input" | "result">>();
+
   /** In-flight hydration promises keyed by `${pieceIno}-${propName}`. */
   private pendingHydrations = new Map<string, Promise<boolean>>();
   private pendingPropRebuildQueues = new Map<string, Promise<void>>();
+
   /** Monotonic invalidation epoch per hydration key. */
   private hydrationEpochs = new Map<string, number>();
+
   /**
    * Tracks root-level entries created by [FS] projections so they can be
    * cleared when the result switches back to the default result/ tree.
@@ -433,6 +449,7 @@ export class CellBridge {
   private maxEntityProjections: number;
 
   private startedAt = new Date().toISOString();
+
   /**
    * Set to true when a write fails due to a transport/connection error.
    * Once disconnected, all files appear read-only (EACCES on write)

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -40,6 +40,7 @@ export interface HandleState {
   writeTarget?: unknown;
   cfcAuthorizedOperations: Set<CfcExistingWritebackOperation>;
   cfcAuthorizationAnnotation?: CfcNodeAnnotation;
+
   /**
    * For a read-only snapshot of a generated file, when its bytes were
    * published. A getattr on this handle reports it so the size and the

--- a/packages/fuse/invalidation.ts
+++ b/packages/fuse/invalidation.ts
@@ -31,14 +31,19 @@ export interface ReverseInvalidationDeps {
     nameBuf: Uint8Array<ArrayBuffer>,
     nameLen: bigint,
   ): NotifyResult;
+
   /** Issue notify_inval_inode off the isolate thread (whole inode). */
   invalidateInode(ino: bigint): NotifyResult;
+
   /** Whether the mount is tearing down; queued work is dropped once true. */
   isUnmounting(): boolean;
+
   /** Emit per-call diagnostics when set. */
   debug: boolean;
+
   /** Diagnostic sink; defaults to console.log. */
   log?: (message: string) => void;
+
   /** Failure sink; defaults to console.warn. */
   warn?: (message: string) => void;
 }

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -13,6 +13,7 @@ export interface StatOpts {
   size: number;
   uid?: number;
   gid?: number;
+
   /** Modification time in milliseconds since the epoch. */
   mtime?: number;
 }
@@ -32,6 +33,7 @@ export interface FileInfo {
 
 export interface MountHandle {
   session: Deno.PointerValue;
+
   /** Channel pointer on macOS (FUSE v2), session pointer on Linux (FUSE v3). */
   notifyTarget: Deno.PointerValue;
 }
@@ -165,8 +167,10 @@ export interface FusePlatform {
   OPS_SIZE: number;
   OPS_OFFSETS: Readonly<Record<string, number>>;
   FUSE_ARGS_STRUCT_SIZE: number;
+
   /** Byte offset of st_size within struct stat. */
   STAT_ST_SIZE_OFFSET: number;
+
   /** Byte offset of st_mtim(espec) within struct stat. */
   STAT_ST_MTIM_OFFSET: number;
 
@@ -190,6 +194,7 @@ export interface FusePlatform {
   ENOSYS: number;
   ENODATA: number;
   ENOTSUP: number;
+
   /** Byte offset of fh within fuse_file_info. */
   FH_OFFSET: number;
 

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -292,6 +292,7 @@ interface JsonTreeBuild {
     key: string,
     value: unknown,
   ) => CallableKind | null;
+
   /**
    * Nodes to project, in the order their entries will be created. A slot is
    * emptied as its node is taken, so a build holds only the nodes still

--- a/packages/fuse/tree.ts
+++ b/packages/fuse/tree.ts
@@ -64,12 +64,15 @@ export class FsTree {
   inodes: Map<bigint, FsNode> = new Map();
   parents: Map<bigint, bigint> = new Map();
   paths: Map<string, bigint> = new Map();
+
   /** Reverse map: inode → path string (O(1) lookup). */
   private inoPaths: Map<bigint, string> = new Map();
+
   /**
    * Reverse map from inode to registered child name for constant-time lookup.
    */
   private inoNames: Map<bigint, string> = new Map();
+
   /** Renderers for inodes added by `addGeneratedFile`. */
   private generated: Map<bigint, () => Uint8Array | string> = new Map();
   private cfcEntryIndexes = new Map<bigint, Map<string, number>>();

--- a/packages/html/src/in-process.ts
+++ b/packages/html/src/in-process.ts
@@ -18,10 +18,13 @@ import { WorkerReconciler } from "./worker/reconciler.ts";
 export interface InProcessRenderOptions {
   /** The document to create nodes in. Defaults to the ambient document. */
   document?: Document;
+
   /** Custom property setter, as for a browser render. */
   setProp?: SetPropHandler;
+
   /** Called for reconciliation and application errors. */
   onError?: (error: Error) => void;
+
   /**
    * Called after each batch of operations has been applied, so a host that
    * watches the rendered result learns when the container changed. Several
@@ -39,6 +42,7 @@ export interface InProcessRender {
    * container calls this to fix the point it is reading.
    */
   flush(): void;
+
   /** Unmount the tree and drop the applicator's nodes and listeners. */
   cancel: Cancel;
 }

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -105,1318 +105,1824 @@ declare namespace CFDOM {
   interface CSSStyleDeclaration {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/accent-color) */
     accentColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content) */
     alignContent: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-items) */
     alignItems: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-self) */
     alignSelf: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/alignment-baseline) */
     alignmentBaseline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/all) */
     all: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation) */
     animation: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-composition) */
     animationComposition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-delay) */
     animationDelay: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-direction) */
     animationDirection: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-duration) */
     animationDuration: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode) */
     animationFillMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count) */
     animationIterationCount: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-name) */
     animationName: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-play-state) */
     animationPlayState: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-timing-function) */
     animationTimingFunction: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/appearance) */
     appearance: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio) */
     aspectRatio: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backdrop-filter) */
     backdropFilter: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backface-visibility) */
     backfaceVisibility: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background) */
     background: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-attachment) */
     backgroundAttachment: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-blend-mode) */
     backgroundBlendMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-clip) */
     backgroundClip: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-color) */
     backgroundColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-image) */
     backgroundImage: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-origin) */
     backgroundOrigin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position) */
     backgroundPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position-x) */
     backgroundPositionX: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position-y) */
     backgroundPositionY: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-repeat) */
     backgroundRepeat: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-size) */
     backgroundSize: string;
     baselineShift: string;
     baselineSource: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/block-size) */
     blockSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border) */
     border: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block) */
     borderBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-color) */
     borderBlockColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end) */
     borderBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-color) */
     borderBlockEndColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-style) */
     borderBlockEndStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-width) */
     borderBlockEndWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start) */
     borderBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-color) */
     borderBlockStartColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-style) */
     borderBlockStartStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-width) */
     borderBlockStartWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-style) */
     borderBlockStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-width) */
     borderBlockWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom) */
     borderBottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-color) */
     borderBottomColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius) */
     borderBottomLeftRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius) */
     borderBottomRightRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-style) */
     borderBottomStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-width) */
     borderBottomWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-collapse) */
     borderCollapse: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-color) */
     borderColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius) */
     borderEndEndRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius) */
     borderEndStartRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image) */
     borderImage: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-outset) */
     borderImageOutset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-repeat) */
     borderImageRepeat: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-slice) */
     borderImageSlice: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-source) */
     borderImageSource: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-width) */
     borderImageWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline) */
     borderInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-color) */
     borderInlineColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end) */
     borderInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color) */
     borderInlineEndColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style) */
     borderInlineEndStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width) */
     borderInlineEndWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start) */
     borderInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color) */
     borderInlineStartColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style) */
     borderInlineStartStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width) */
     borderInlineStartWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-style) */
     borderInlineStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-width) */
     borderInlineWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left) */
     borderLeft: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-color) */
     borderLeftColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-style) */
     borderLeftStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-width) */
     borderLeftWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-radius) */
     borderRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right) */
     borderRight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-color) */
     borderRightColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-style) */
     borderRightStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-width) */
     borderRightWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-spacing) */
     borderSpacing: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius) */
     borderStartEndRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius) */
     borderStartStartRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-style) */
     borderStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top) */
     borderTop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-color) */
     borderTopColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius) */
     borderTopLeftRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius) */
     borderTopRightRadius: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-style) */
     borderTopStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-width) */
     borderTopWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-width) */
     borderWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/bottom) */
     bottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break) */
     boxDecorationBreak: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-shadow) */
     boxShadow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-sizing) */
     boxSizing: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-after) */
     breakAfter: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-before) */
     breakBefore: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-inside) */
     breakInside: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/caption-side) */
     captionSide: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/caret-color) */
     caretColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clear) */
     clear: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip)
      */
     clip: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip-path) */
     clipPath: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip-rule) */
     clipRule: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color) */
     color: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-interpolation) */
     colorInterpolation: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-interpolation-filters) */
     colorInterpolationFilters: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-scheme) */
     colorScheme: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-count) */
     columnCount: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-fill) */
     columnFill: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-gap) */
     columnGap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule) */
     columnRule: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-color) */
     columnRuleColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-style) */
     columnRuleStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-width) */
     columnRuleWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-span) */
     columnSpan: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-width) */
     columnWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/columns) */
     columns: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain) */
     contain: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size) */
     containIntrinsicBlockSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height) */
     containIntrinsicHeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size) */
     containIntrinsicInlineSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size) */
     containIntrinsicSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width) */
     containIntrinsicWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container) */
     container: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container-name) */
     containerName: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container-type) */
     containerType: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/content) */
     content: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/content-visibility) */
     contentVisibility: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-increment) */
     counterIncrement: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-reset) */
     counterReset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-set) */
     counterSet: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/cssFloat) */
     cssFloat: string;
+
     /**
      * The **`cssText`** property of the CSSStyleDeclaration interface returns or sets the text of the element's **inline** style declaration only.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/cssText)
      */
     cssText: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cursor) */
     cursor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cx) */
     cx: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cy) */
     cy: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/d) */
     d: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/direction) */
     direction: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/display) */
     display: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/dominant-baseline) */
     dominantBaseline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/empty-cells) */
     emptyCells: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill) */
     fill: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill-opacity) */
     fillOpacity: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill-rule) */
     fillRule: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/filter) */
     filter: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex) */
     flex: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-basis) */
     flexBasis: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-direction) */
     flexDirection: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-flow) */
     flexFlow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-grow) */
     flexGrow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-shrink) */
     flexShrink: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-wrap) */
     flexWrap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/float) */
     float: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flood-color) */
     floodColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flood-opacity) */
     floodOpacity: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font) */
     font: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-family) */
     fontFamily: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-feature-settings) */
     fontFeatureSettings: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-kerning) */
     fontKerning: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing) */
     fontOpticalSizing: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-palette) */
     fontPalette: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-size) */
     fontSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-size-adjust) */
     fontSizeAdjust: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-stretch)
      */
     fontStretch: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-style) */
     fontStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis) */
     fontSynthesis: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps) */
     fontSynthesisSmallCaps: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style) */
     fontSynthesisStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight) */
     fontSynthesisWeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant) */
     fontVariant: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates) */
     fontVariantAlternates: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps) */
     fontVariantCaps: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian) */
     fontVariantEastAsian: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures) */
     fontVariantLigatures: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric) */
     fontVariantNumeric: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-position) */
     fontVariantPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variation-settings) */
     fontVariationSettings: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-weight) */
     fontWeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust) */
     forcedColorAdjust: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/gap) */
     gap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid) */
     grid: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-area) */
     gridArea: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns) */
     gridAutoColumns: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow) */
     gridAutoFlow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-rows) */
     gridAutoRows: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column) */
     gridColumn: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column-end) */
     gridColumnEnd: string;
+
     /** @deprecated This is a legacy alias of `columnGap`. */
     gridColumnGap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column-start) */
     gridColumnStart: string;
+
     /** @deprecated This is a legacy alias of `gap`. */
     gridGap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row) */
     gridRow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row-end) */
     gridRowEnd: string;
+
     /** @deprecated This is a legacy alias of `rowGap`. */
     gridRowGap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row-start) */
     gridRowStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template) */
     gridTemplate: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-areas) */
     gridTemplateAreas: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-columns) */
     gridTemplateColumns: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-rows) */
     gridTemplateRows: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/height) */
     height: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphenate-character) */
     hyphenateCharacter: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphenate-limit-chars) */
     hyphenateLimitChars: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphens) */
     hyphens: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/image-orientation)
      */
     imageOrientation: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/image-rendering) */
     imageRendering: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inline-size) */
     inlineSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset) */
     inset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block) */
     insetBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block-end) */
     insetBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block-start) */
     insetBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline) */
     insetInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline-end) */
     insetInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline-start) */
     insetInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/isolation) */
     isolation: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-content) */
     justifyContent: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-items) */
     justifyItems: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-self) */
     justifySelf: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/left) */
     left: string;
+
     /**
      * The read-only property returns an integer that represents the number of style declarations in this CSS declaration block.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/length)
      */
     readonly length: number;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/letter-spacing) */
     letterSpacing: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/lighting-color) */
     lightingColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-break) */
     lineBreak: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-height) */
     lineHeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style) */
     listStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-image) */
     listStyleImage: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-position) */
     listStylePosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-type) */
     listStyleType: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin) */
     margin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block) */
     marginBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block-end) */
     marginBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block-start) */
     marginBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-bottom) */
     marginBottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline) */
     marginInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline-end) */
     marginInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline-start) */
     marginInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-left) */
     marginLeft: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-right) */
     marginRight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-top) */
     marginTop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker) */
     marker: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-end) */
     markerEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-mid) */
     markerMid: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-start) */
     markerStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask) */
     mask: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-clip) */
     maskClip: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-composite) */
     maskComposite: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-image) */
     maskImage: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-mode) */
     maskMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-origin) */
     maskOrigin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-position) */
     maskPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-repeat) */
     maskRepeat: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-size) */
     maskSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-type) */
     maskType: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/math-depth) */
     mathDepth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/math-style) */
     mathStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-block-size) */
     maxBlockSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-height) */
     maxHeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-inline-size) */
     maxInlineSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-width) */
     maxWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-block-size) */
     minBlockSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-height) */
     minHeight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-inline-size) */
     minInlineSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-width) */
     minWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode) */
     mixBlendMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/object-fit) */
     objectFit: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/object-position) */
     objectPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset) */
     offset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-anchor) */
     offsetAnchor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-distance) */
     offsetDistance: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-path) */
     offsetPath: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-position) */
     offsetPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-rotate) */
     offsetRotate: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/opacity) */
     opacity: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/order) */
     order: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/orphans) */
     orphans: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline) */
     outline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-color) */
     outlineColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-offset) */
     outlineOffset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-style) */
     outlineStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-width) */
     outlineWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow) */
     overflow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-anchor) */
     overflowAnchor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-block) */
     overflowBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin) */
     overflowClipMargin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-inline) */
     overflowInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap) */
     overflowWrap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-x) */
     overflowX: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-y) */
     overflowY: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior) */
     overscrollBehavior: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block) */
     overscrollBehaviorBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline) */
     overscrollBehaviorInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x) */
     overscrollBehaviorX: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y) */
     overscrollBehaviorY: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding) */
     padding: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block) */
     paddingBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block-end) */
     paddingBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block-start) */
     paddingBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-bottom) */
     paddingBottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline) */
     paddingInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline-end) */
     paddingInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline-start) */
     paddingInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-left) */
     paddingLeft: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-right) */
     paddingRight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-top) */
     paddingTop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page) */
     page: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-after)
      */
     pageBreakAfter: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-before)
      */
     pageBreakBefore: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-inside)
      */
     pageBreakInside: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/paint-order) */
     paintOrder: string;
+
     /**
      * The **CSSStyleDeclaration.parentRule** read-only property returns a CSSRule that is the parent of this style block, e.g., a CSSStyleRule representing the style for a CSS selector.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/parentRule)
      */
     readonly parentRule: CSSRule | null;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective) */
     perspective: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective-origin) */
     perspectiveOrigin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-content) */
     placeContent: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-items) */
     placeItems: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-self) */
     placeSelf: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/pointer-events) */
     pointerEvents: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/position) */
     position: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/print-color-adjust) */
     printColorAdjust: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/quotes) */
     quotes: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/r) */
     r: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/resize) */
     resize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/right) */
     right: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/rotate) */
     rotate: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/row-gap) */
     rowGap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ruby-align) */
     rubyAlign: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ruby-position) */
     rubyPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/rx) */
     rx: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ry) */
     ry: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scale) */
     scale: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior) */
     scrollBehavior: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin) */
     scrollMargin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block) */
     scrollMarginBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end) */
     scrollMarginBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start) */
     scrollMarginBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom) */
     scrollMarginBottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline) */
     scrollMarginInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end) */
     scrollMarginInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start) */
     scrollMarginInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left) */
     scrollMarginLeft: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right) */
     scrollMarginRight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-top) */
     scrollMarginTop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding) */
     scrollPadding: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block) */
     scrollPaddingBlock: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end) */
     scrollPaddingBlockEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start) */
     scrollPaddingBlockStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-bottom) */
     scrollPaddingBottom: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline) */
     scrollPaddingInline: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end) */
     scrollPaddingInlineEnd: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start) */
     scrollPaddingInlineStart: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-left) */
     scrollPaddingLeft: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right) */
     scrollPaddingRight: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top) */
     scrollPaddingTop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align) */
     scrollSnapAlign: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop) */
     scrollSnapStop: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type) */
     scrollSnapType: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-color) */
     scrollbarColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter) */
     scrollbarGutter: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-width) */
     scrollbarWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold) */
     shapeImageThreshold: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-margin) */
     shapeMargin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-outside) */
     shapeOutside: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-rendering) */
     shapeRendering: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stop-color) */
     stopColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stop-opacity) */
     stopOpacity: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke) */
     stroke: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-dasharray) */
     strokeDasharray: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-dashoffset) */
     strokeDashoffset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-linecap) */
     strokeLinecap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-linejoin) */
     strokeLinejoin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-miterlimit) */
     strokeMiterlimit: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-opacity) */
     strokeOpacity: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-width) */
     strokeWidth: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/tab-size) */
     tabSize: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/table-layout) */
     tableLayout: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-align) */
     textAlign: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-align-last) */
     textAlignLast: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-anchor) */
     textAnchor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box) */
     textBox: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box-edge) */
     textBoxEdge: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box-trim) */
     textBoxTrim: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-combine-upright) */
     textCombineUpright: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration) */
     textDecoration: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-color) */
     textDecorationColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line) */
     textDecorationLine: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink) */
     textDecorationSkipInk: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style) */
     textDecorationStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness) */
     textDecorationThickness: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis) */
     textEmphasis: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color) */
     textEmphasisColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position) */
     textEmphasisPosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style) */
     textEmphasisStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-indent) */
     textIndent: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-orientation) */
     textOrientation: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-overflow) */
     textOverflow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-rendering) */
     textRendering: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-shadow) */
     textShadow: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-transform) */
     textTransform: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset) */
     textUnderlineOffset: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-underline-position) */
     textUnderlinePosition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap) */
     textWrap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap-mode) */
     textWrapMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap-style) */
     textWrapStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/top) */
     top: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/touch-action) */
     touchAction: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform) */
     transform: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-box) */
     transformBox: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-origin) */
     transformOrigin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-style) */
     transformStyle: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition) */
     transition: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-behavior) */
     transitionBehavior: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-delay) */
     transitionDelay: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-duration) */
     transitionDuration: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-property) */
     transitionProperty: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-timing-function) */
     transitionTimingFunction: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/translate) */
     translate: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/unicode-bidi) */
     unicodeBidi: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/user-select) */
     userSelect: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/vector-effect) */
     vectorEffect: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/vertical-align) */
     verticalAlign: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/view-transition-class) */
     viewTransitionClass: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/view-transition-name) */
     viewTransitionName: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/visibility) */
     visibility: string;
+
     /**
      * @deprecated This is a legacy alias of `alignContent`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content)
      */
     webkitAlignContent: string;
+
     /**
      * @deprecated This is a legacy alias of `alignItems`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-items)
      */
     webkitAlignItems: string;
+
     /**
      * @deprecated This is a legacy alias of `alignSelf`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-self)
      */
     webkitAlignSelf: string;
+
     /**
      * @deprecated This is a legacy alias of `animation`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation)
      */
     webkitAnimation: string;
+
     /**
      * @deprecated This is a legacy alias of `animationDelay`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-delay)
      */
     webkitAnimationDelay: string;
+
     /**
      * @deprecated This is a legacy alias of `animationDirection`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-direction)
      */
     webkitAnimationDirection: string;
+
     /**
      * @deprecated This is a legacy alias of `animationDuration`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-duration)
      */
     webkitAnimationDuration: string;
+
     /**
      * @deprecated This is a legacy alias of `animationFillMode`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode)
      */
     webkitAnimationFillMode: string;
+
     /**
      * @deprecated This is a legacy alias of `animationIterationCount`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count)
      */
     webkitAnimationIterationCount: string;
+
     /**
      * @deprecated This is a legacy alias of `animationName`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-name)
      */
     webkitAnimationName: string;
+
     /**
      * @deprecated This is a legacy alias of `animationPlayState`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-play-state)
      */
     webkitAnimationPlayState: string;
+
     /**
      * @deprecated This is a legacy alias of `animationTimingFunction`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-timing-function)
      */
     webkitAnimationTimingFunction: string;
+
     /**
      * @deprecated This is a legacy alias of `appearance`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/appearance)
      */
     webkitAppearance: string;
+
     /**
      * @deprecated This is a legacy alias of `backfaceVisibility`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backface-visibility)
      */
     webkitBackfaceVisibility: string;
+
     /**
      * @deprecated This is a legacy alias of `backgroundClip`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-clip)
      */
     webkitBackgroundClip: string;
+
     /**
      * @deprecated This is a legacy alias of `backgroundOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-origin)
      */
     webkitBackgroundOrigin: string;
+
     /**
      * @deprecated This is a legacy alias of `backgroundSize`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-size)
      */
     webkitBackgroundSize: string;
+
     /**
      * @deprecated This is a legacy alias of `borderBottomLeftRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius)
      */
     webkitBorderBottomLeftRadius: string;
+
     /**
      * @deprecated This is a legacy alias of `borderBottomRightRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius)
      */
     webkitBorderBottomRightRadius: string;
+
     /**
      * @deprecated This is a legacy alias of `borderRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-radius)
      */
     webkitBorderRadius: string;
+
     /**
      * @deprecated This is a legacy alias of `borderTopLeftRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius)
      */
     webkitBorderTopLeftRadius: string;
+
     /**
      * @deprecated This is a legacy alias of `borderTopRightRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius)
      */
     webkitBorderTopRightRadius: string;
+
     /**
      * @deprecated This is a legacy alias of `boxAlign`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-align)
      */
     webkitBoxAlign: string;
+
     /**
      * @deprecated This is a legacy alias of `boxFlex`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-flex)
      */
     webkitBoxFlex: string;
+
     /**
      * @deprecated This is a legacy alias of `boxOrdinalGroup`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group)
      */
     webkitBoxOrdinalGroup: string;
+
     /**
      * @deprecated This is a legacy alias of `boxOrient`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-orient)
      */
     webkitBoxOrient: string;
+
     /**
      * @deprecated This is a legacy alias of `boxPack`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-pack)
      */
     webkitBoxPack: string;
+
     /**
      * @deprecated This is a legacy alias of `boxShadow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-shadow)
      */
     webkitBoxShadow: string;
+
     /**
      * @deprecated This is a legacy alias of `boxSizing`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-sizing)
      */
     webkitBoxSizing: string;
+
     /**
      * @deprecated This is a legacy alias of `filter`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/filter)
      */
     webkitFilter: string;
+
     /**
      * @deprecated This is a legacy alias of `flex`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex)
      */
     webkitFlex: string;
+
     /**
      * @deprecated This is a legacy alias of `flexBasis`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-basis)
      */
     webkitFlexBasis: string;
+
     /**
      * @deprecated This is a legacy alias of `flexDirection`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-direction)
      */
     webkitFlexDirection: string;
+
     /**
      * @deprecated This is a legacy alias of `flexFlow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-flow)
      */
     webkitFlexFlow: string;
+
     /**
      * @deprecated This is a legacy alias of `flexGrow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-grow)
      */
     webkitFlexGrow: string;
+
     /**
      * @deprecated This is a legacy alias of `flexShrink`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-shrink)
      */
     webkitFlexShrink: string;
+
     /**
      * @deprecated This is a legacy alias of `flexWrap`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-wrap)
      */
     webkitFlexWrap: string;
+
     /**
      * @deprecated This is a legacy alias of `justifyContent`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-content)
      */
     webkitJustifyContent: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-clamp) */
     webkitLineClamp: string;
+
     /**
      * @deprecated This is a legacy alias of `mask`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask)
      */
     webkitMask: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorder`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border)
      */
     webkitMaskBoxImage: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorderOutset`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-outset)
      */
     webkitMaskBoxImageOutset: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorderRepeat`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-repeat)
      */
     webkitMaskBoxImageRepeat: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorderSlice`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-slice)
      */
     webkitMaskBoxImageSlice: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorderSource`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-source)
      */
     webkitMaskBoxImageSource: string;
+
     /**
      * @deprecated This is a legacy alias of `maskBorderWidth`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-width)
      */
     webkitMaskBoxImageWidth: string;
+
     /**
      * @deprecated This is a legacy alias of `maskClip`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
      */
     webkitMaskClip: string;
+
     /**
      * @deprecated This is a legacy alias of `maskComposite`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-composite)
      */
     webkitMaskComposite: string;
+
     /**
      * @deprecated This is a legacy alias of `maskImage`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-image)
      */
     webkitMaskImage: string;
+
     /**
      * @deprecated This is a legacy alias of `maskOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-origin)
      */
     webkitMaskOrigin: string;
+
     /**
      * @deprecated This is a legacy alias of `maskPosition`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-position)
      */
     webkitMaskPosition: string;
+
     /**
      * @deprecated This is a legacy alias of `maskRepeat`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-repeat)
      */
     webkitMaskRepeat: string;
+
     /**
      * @deprecated This is a legacy alias of `maskSize`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-size)
      */
     webkitMaskSize: string;
+
     /**
      * @deprecated This is a legacy alias of `order`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/order)
      */
     webkitOrder: string;
+
     /**
      * @deprecated This is a legacy alias of `perspective`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective)
      */
     webkitPerspective: string;
+
     /**
      * @deprecated This is a legacy alias of `perspectiveOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective-origin)
      */
     webkitPerspectiveOrigin: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-fill-color) */
     webkitTextFillColor: string;
+
     /**
      * @deprecated This is a legacy alias of `textSizeAdjust`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-size-adjust)
      */
     webkitTextSizeAdjust: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke) */
     webkitTextStroke: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color) */
     webkitTextStrokeColor: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-width) */
     webkitTextStrokeWidth: string;
+
     /**
      * @deprecated This is a legacy alias of `transform`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform)
      */
     webkitTransform: string;
+
     /**
      * @deprecated This is a legacy alias of `transformOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-origin)
      */
     webkitTransformOrigin: string;
+
     /**
      * @deprecated This is a legacy alias of `transformStyle`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-style)
      */
     webkitTransformStyle: string;
+
     /**
      * @deprecated This is a legacy alias of `transition`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition)
      */
     webkitTransition: string;
+
     /**
      * @deprecated This is a legacy alias of `transitionDelay`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-delay)
      */
     webkitTransitionDelay: string;
+
     /**
      * @deprecated This is a legacy alias of `transitionDuration`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-duration)
      */
     webkitTransitionDuration: string;
+
     /**
      * @deprecated This is a legacy alias of `transitionProperty`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-property)
      */
     webkitTransitionProperty: string;
+
     /**
      * @deprecated This is a legacy alias of `transitionTimingFunction`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-timing-function)
      */
     webkitTransitionTimingFunction: string;
+
     /**
      * @deprecated This is a legacy alias of `userSelect`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/user-select)
      */
     webkitUserSelect: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/white-space) */
     whiteSpace: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/white-space-collapse) */
     whiteSpaceCollapse: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/widows) */
     widows: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/width) */
     width: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/will-change) */
     willChange: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/word-break) */
     wordBreak: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/word-spacing) */
     wordSpacing: string;
+
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap)
      */
     wordWrap: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/writing-mode) */
     writingMode: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/x) */
     x: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/y) */
     y: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/z-index) */
     zIndex: string;
+
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/zoom) */
     zoom: string;
   }
@@ -1446,55 +1952,67 @@ declare namespace CFDOM {
   interface AriaAttributes {
     /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
     "aria-activedescendant"?: string | undefined;
+
     /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
     "aria-atomic"?: Booleanish | undefined;
+
     /**
      * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
      * presented if they are made.
      */
     "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
+
     /**
      * Defines a string value that labels the current element, which is intended to be converted into Braille.
      * @see aria-label.
      */
     "aria-braillelabel"?: string | undefined;
+
     /**
      * Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.
      * @see aria-roledescription.
      */
     "aria-brailleroledescription"?: string | undefined;
+
     /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
     "aria-busy"?: Booleanish | undefined;
+
     /**
      * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
      * @see aria-pressed @see aria-selected.
      */
     "aria-checked"?: boolean | "false" | "mixed" | "true" | undefined;
+
     /**
      * Defines the total number of columns in a table, grid, or treegrid.
      * @see aria-colindex.
      */
     "aria-colcount"?: number | undefined;
+
     /**
      * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
      * @see aria-colcount @see aria-colspan.
      */
     "aria-colindex"?: number | undefined;
+
     /**
      * Defines a human readable text alternative of aria-colindex.
      * @see aria-rowindextext.
      */
     "aria-colindextext"?: string | undefined;
+
     /**
      * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-colindex @see aria-rowspan.
      */
     "aria-colspan"?: number | undefined;
+
     /**
      * Identifies the element (or elements) whose contents or presence are controlled by the current element.
      * @see aria-owns.
      */
     "aria-controls"?: string | undefined;
+
     /** Indicates the element that represents the current item within a container or set of related elements. */
     "aria-current"?:
       | boolean
@@ -1511,21 +2029,25 @@ declare namespace CFDOM {
      * @see aria-labelledby
      */
     "aria-describedby"?: string | undefined;
+
     /**
      * Defines a string value that describes or annotates the current element.
      * @see related aria-describedby.
      */
     "aria-description"?: string | undefined;
+
     /**
      * Identifies the element that provides a detailed, extended description for the object.
      * @see aria-describedby.
      */
     "aria-details"?: string | undefined;
+
     /**
      * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
      * @see aria-hidden @see aria-readonly.
      */
     "aria-disabled"?: Booleanish | undefined;
+
     /**
      * Indicates what functions can be performed when a dragged object is released on the drop target.
      * @deprecated in ARIA 1.1
@@ -1543,18 +2065,22 @@ declare namespace CFDOM {
      * @see aria-invalid @see aria-describedby.
      */
     "aria-errormessage"?: string | undefined;
+
     /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
     "aria-expanded"?: Booleanish | undefined;
+
     /**
      * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
      * allows assistive technology to override the general default of reading in document source order.
      */
     "aria-flowto"?: string | undefined;
+
     /**
      * Indicates an element's "grabbed" state in a drag-and-drop operation.
      * @deprecated in ARIA 1.1
      */
     "aria-grabbed"?: Booleanish | undefined;
+
     /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
     "aria-haspopup"?:
       | boolean
@@ -1571,6 +2097,7 @@ declare namespace CFDOM {
      * @see aria-disabled.
      */
     "aria-hidden"?: Booleanish | undefined;
+
     /**
      * Indicates the entered value does not conform to the format expected by the application.
      * @see aria-errormessage.
@@ -1584,54 +2111,68 @@ declare namespace CFDOM {
       | undefined;
     /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
     "aria-keyshortcuts"?: string | undefined;
+
     /**
      * Defines a string value that labels the current element.
      * @see aria-labelledby.
      */
     "aria-label"?: string | undefined;
+
     /**
      * Identifies the element (or elements) that labels the current element.
      * @see aria-describedby.
      */
     "aria-labelledby"?: string | undefined;
+
     /** Defines the hierarchical level of an element within a structure. */
     "aria-level"?: number | undefined;
+
     /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
     "aria-live"?: "off" | "assertive" | "polite" | undefined;
+
     /** Indicates whether an element is modal when displayed. */
     "aria-modal"?: Booleanish | undefined;
+
     /** Indicates whether a text box accepts multiple lines of input or only a single line. */
     "aria-multiline"?: Booleanish | undefined;
+
     /** Indicates that the user may select more than one item from the current selectable descendants. */
     "aria-multiselectable"?: Booleanish | undefined;
+
     /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
     "aria-orientation"?: "horizontal" | "vertical" | undefined;
+
     /**
      * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
      * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
      * @see aria-controls.
      */
     "aria-owns"?: string | undefined;
+
     /**
      * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
      * A hint could be a sample value or a brief description of the expected format.
      */
     "aria-placeholder"?: string | undefined;
+
     /**
      * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-setsize.
      */
     "aria-posinset"?: number | undefined;
+
     /**
      * Indicates the current "pressed" state of toggle buttons.
      * @see aria-checked @see aria-selected.
      */
     "aria-pressed"?: boolean | "false" | "mixed" | "true" | undefined;
+
     /**
      * Indicates that the element is not editable, but is otherwise operable.
      * @see aria-disabled.
      */
     "aria-readonly"?: Booleanish | undefined;
+
     /**
      * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
      * @see aria-atomic.
@@ -1650,49 +2191,61 @@ declare namespace CFDOM {
       | undefined;
     /** Indicates that user input is required on the element before a form may be submitted. */
     "aria-required"?: Booleanish | undefined;
+
     /** Defines a human-readable, author-localized description for the role of an element. */
     "aria-roledescription"?: string | undefined;
+
     /**
      * Defines the total number of rows in a table, grid, or treegrid.
      * @see aria-rowindex.
      */
     "aria-rowcount"?: number | undefined;
+
     /**
      * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
      * @see aria-rowcount @see aria-rowspan.
      */
     "aria-rowindex"?: number | undefined;
+
     /**
      * Defines a human readable text alternative of aria-rowindex.
      * @see aria-colindextext.
      */
     "aria-rowindextext"?: string | undefined;
+
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-rowindex @see aria-colspan.
      */
     "aria-rowspan"?: number | undefined;
+
     /**
      * Indicates the current "selected" state of various widgets.
      * @see aria-checked @see aria-pressed.
      */
     "aria-selected"?: Booleanish | undefined;
+
     /**
      * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-posinset.
      */
     "aria-setsize"?: number | undefined;
+
     /** Indicates if items in a table or grid are sorted in ascending or descending order. */
     "aria-sort"?: "none" | "ascending" | "descending" | "other" | undefined;
+
     /** Defines the maximum allowed value for a range widget. */
     "aria-valuemax"?: number | undefined;
+
     /** Defines the minimum allowed value for a range widget. */
     "aria-valuemin"?: number | undefined;
+
     /**
      * Defines the current value for a range widget.
      * @see aria-valuetext.
      */
     "aria-valuenow"?: number | undefined;
+
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
     "aria-valuetext"?: string | undefined;
   }
@@ -1853,10 +2406,12 @@ declare namespace CFDOM {
     popoverTarget?: string | undefined;
 
     // Living Standard
+
     /**
      * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
      */
     inert?: boolean | undefined;
+
     /**
      * Hints at the type of data that might be entered by the user while editing the element or its contents
      * @see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}
@@ -1876,10 +2431,12 @@ declare namespace CFDOM {
      * @see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}
      */
     is?: string | undefined;
+
     /**
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts}
      */
     exportparts?: string | undefined;
+
     /**
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/part}
      */
@@ -2134,17 +2691,21 @@ declare namespace CFDOM {
     allow?: string | undefined;
     allowFullScreen?: boolean | undefined;
     allowTransparency?: boolean | undefined;
+
     /** @deprecated */
     frameBorder?: number | string | undefined;
     height?: number | string | undefined;
     loading?: "eager" | "lazy" | undefined;
+
     /** @deprecated */
     marginHeight?: number | undefined;
+
     /** @deprecated */
     marginWidth?: number | undefined;
     name?: string | undefined;
     referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
     sandbox?: string | undefined;
+
     /** @deprecated */
     scrolling?: string | undefined;
     seamless?: boolean | undefined;
@@ -2437,6 +2998,7 @@ declare namespace CFDOM {
   interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
     async?: boolean | undefined;
     blocking?: "render" | (string & {}) | undefined;
+
     /** @deprecated */
     charSet?: string | undefined;
     crossOrigin?: CrossOrigin;
@@ -3224,6 +3786,7 @@ interface CFPromptInputAttributes<T> extends CFHTMLAttributes<T> {
   "autoResize"?: boolean;
   "pending"?: boolean;
   "voice"?: boolean;
+
   /** Upload File/Blob attachments to the blob store on add (default off). */
   "uploadAttachments"?: boolean;
   "oncf-send"?: EventHandler<{
@@ -3233,6 +3796,7 @@ interface CFPromptInputAttributes<T> extends CFHTMLAttributes<T> {
       name: string;
       type: "file" | "clipboard";
       data?: unknown;
+
       /** Blob-store URL once uploaded (when uploadAttachments is set). */
       url?: string;
       mediaType?: string;
@@ -3324,16 +3888,22 @@ type TailwindNumberType =
 interface CFStackAttributes<T> extends CFHTMLAttributes<T> {
   "gap"?: TailwindNumberType;
   "padding"?: TailwindNumberType;
+
   /** Horizontal (left/right) padding; overrides `padding` on those sides. */
   "px"?: TailwindNumberType;
+
   /** Vertical (top/bottom) padding; overrides `padding` on those sides. */
   "py"?: TailwindNumberType;
+
   /** Padding-top; overrides `padding`/`py` on that side. */
   "pt"?: TailwindNumberType;
+
   /** Padding-right; overrides `padding`/`px` on that side. */
   "pr"?: TailwindNumberType;
+
   /** Padding-bottom; overrides `padding`/`py` on that side. */
   "pb"?: TailwindNumberType;
+
   /** Padding-left; overrides `padding`/`px` on that side. */
   "pl"?: TailwindNumberType;
   "align"?: "start" | "center" | "end" | "stretch" | "baseline";
@@ -3655,6 +4225,7 @@ interface CFLoaderAttributes<T> extends CFHTMLAttributes<T> {
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | "sm" | "md" | "lg";
   "show-elapsed"?: boolean;
   "show-stop"?: boolean;
+
   /** Fired when stop button is clicked */
   "oncf-stop"?: EventHandler<{}>;
 }
@@ -3965,6 +4536,7 @@ interface CFToolsChipAttributes<T> extends CFHTMLAttributes<T> {
   "open-on-hover"?: boolean;
   "toggle-on-click"?: boolean;
   "close-delay"?: number;
+
   /**
    * Accepts either:
    * - Array: { name, description?, schema? }[]
@@ -4259,6 +4831,7 @@ interface CFTextAttributes<T> extends CFHTMLAttributes<T> {
       | "error"
     >;
   "block"?: boolean | CellLike<boolean>;
+
   /** Single-line ellipsis truncation. Implies block display. */
   "truncate"?: boolean | CellLike<boolean>;
 }
@@ -4286,6 +4859,7 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
   /** A cell containing a profile (ProfileHomeOutput): renders avatar + name. */
   "$profile"?: CellLike<any>;
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
+
   /**
    * Badge shape (CT-1761), all carrying the same generative seal (aura ring +
    * cursor glint — there is no shield icon): `full` (default) = avatar + name;
@@ -4294,6 +4868,7 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
    * page header (pair with `noNavigate`).
    */
   "variant"?: "full" | "chip" | "circle" | "hero" | CellLike<string>;
+
   /**
    * Suppress click-to-navigate. Set when the badge is bound to a derived view
    * of a profile (e.g. the self-badge on a profile-home page) rather than the
@@ -4307,6 +4882,7 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
 interface CFChipAttributes<T> extends CFHTMLAttributes<T> {
   "label"?: string | CellLike<string>;
   "color"?: "neutral" | "primary" | "accent" | "danger";
+
   /** @deprecated Use color instead */
   "variant"?:
     | "default"

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -105,1824 +105,1318 @@ declare namespace CFDOM {
   interface CSSStyleDeclaration {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/accent-color) */
     accentColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content) */
     alignContent: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-items) */
     alignItems: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-self) */
     alignSelf: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/alignment-baseline) */
     alignmentBaseline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/all) */
     all: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation) */
     animation: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-composition) */
     animationComposition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-delay) */
     animationDelay: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-direction) */
     animationDirection: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-duration) */
     animationDuration: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode) */
     animationFillMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count) */
     animationIterationCount: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-name) */
     animationName: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-play-state) */
     animationPlayState: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-timing-function) */
     animationTimingFunction: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/appearance) */
     appearance: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/aspect-ratio) */
     aspectRatio: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backdrop-filter) */
     backdropFilter: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backface-visibility) */
     backfaceVisibility: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background) */
     background: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-attachment) */
     backgroundAttachment: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-blend-mode) */
     backgroundBlendMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-clip) */
     backgroundClip: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-color) */
     backgroundColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-image) */
     backgroundImage: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-origin) */
     backgroundOrigin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position) */
     backgroundPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position-x) */
     backgroundPositionX: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-position-y) */
     backgroundPositionY: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-repeat) */
     backgroundRepeat: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-size) */
     backgroundSize: string;
     baselineShift: string;
     baselineSource: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/block-size) */
     blockSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border) */
     border: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block) */
     borderBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-color) */
     borderBlockColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end) */
     borderBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-color) */
     borderBlockEndColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-style) */
     borderBlockEndStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-end-width) */
     borderBlockEndWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start) */
     borderBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-color) */
     borderBlockStartColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-style) */
     borderBlockStartStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-start-width) */
     borderBlockStartWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-style) */
     borderBlockStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-block-width) */
     borderBlockWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom) */
     borderBottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-color) */
     borderBottomColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius) */
     borderBottomLeftRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius) */
     borderBottomRightRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-style) */
     borderBottomStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-width) */
     borderBottomWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-collapse) */
     borderCollapse: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-color) */
     borderColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius) */
     borderEndEndRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius) */
     borderEndStartRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image) */
     borderImage: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-outset) */
     borderImageOutset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-repeat) */
     borderImageRepeat: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-slice) */
     borderImageSlice: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-source) */
     borderImageSource: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-image-width) */
     borderImageWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline) */
     borderInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-color) */
     borderInlineColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end) */
     borderInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color) */
     borderInlineEndColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style) */
     borderInlineEndStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width) */
     borderInlineEndWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start) */
     borderInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color) */
     borderInlineStartColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style) */
     borderInlineStartStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width) */
     borderInlineStartWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-style) */
     borderInlineStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-inline-width) */
     borderInlineWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left) */
     borderLeft: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-color) */
     borderLeftColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-style) */
     borderLeftStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-left-width) */
     borderLeftWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-radius) */
     borderRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right) */
     borderRight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-color) */
     borderRightColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-style) */
     borderRightStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-right-width) */
     borderRightWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-spacing) */
     borderSpacing: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius) */
     borderStartEndRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius) */
     borderStartStartRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-style) */
     borderStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top) */
     borderTop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-color) */
     borderTopColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius) */
     borderTopLeftRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius) */
     borderTopRightRadius: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-style) */
     borderTopStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-width) */
     borderTopWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-width) */
     borderWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/bottom) */
     bottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-decoration-break) */
     boxDecorationBreak: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-shadow) */
     boxShadow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-sizing) */
     boxSizing: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-after) */
     breakAfter: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-before) */
     breakBefore: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/break-inside) */
     breakInside: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/caption-side) */
     captionSide: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/caret-color) */
     caretColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clear) */
     clear: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip)
      */
     clip: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip-path) */
     clipPath: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/clip-rule) */
     clipRule: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color) */
     color: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-interpolation) */
     colorInterpolation: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-interpolation-filters) */
     colorInterpolationFilters: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/color-scheme) */
     colorScheme: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-count) */
     columnCount: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-fill) */
     columnFill: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-gap) */
     columnGap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule) */
     columnRule: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-color) */
     columnRuleColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-style) */
     columnRuleStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-rule-width) */
     columnRuleWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-span) */
     columnSpan: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/column-width) */
     columnWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/columns) */
     columns: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain) */
     contain: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size) */
     containIntrinsicBlockSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height) */
     containIntrinsicHeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size) */
     containIntrinsicInlineSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size) */
     containIntrinsicSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width) */
     containIntrinsicWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container) */
     container: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container-name) */
     containerName: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/container-type) */
     containerType: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/content) */
     content: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/content-visibility) */
     contentVisibility: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-increment) */
     counterIncrement: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-reset) */
     counterReset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/counter-set) */
     counterSet: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/cssFloat) */
     cssFloat: string;
-
     /**
      * The **`cssText`** property of the CSSStyleDeclaration interface returns or sets the text of the element's **inline** style declaration only.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/cssText)
      */
     cssText: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cursor) */
     cursor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cx) */
     cx: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/cy) */
     cy: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/d) */
     d: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/direction) */
     direction: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/display) */
     display: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/dominant-baseline) */
     dominantBaseline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/empty-cells) */
     emptyCells: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill) */
     fill: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill-opacity) */
     fillOpacity: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/fill-rule) */
     fillRule: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/filter) */
     filter: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex) */
     flex: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-basis) */
     flexBasis: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-direction) */
     flexDirection: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-flow) */
     flexFlow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-grow) */
     flexGrow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-shrink) */
     flexShrink: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-wrap) */
     flexWrap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/float) */
     float: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flood-color) */
     floodColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flood-opacity) */
     floodOpacity: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font) */
     font: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-family) */
     fontFamily: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-feature-settings) */
     fontFeatureSettings: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-kerning) */
     fontKerning: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing) */
     fontOpticalSizing: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-palette) */
     fontPalette: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-size) */
     fontSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-size-adjust) */
     fontSizeAdjust: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-stretch)
      */
     fontStretch: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-style) */
     fontStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis) */
     fontSynthesis: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps) */
     fontSynthesisSmallCaps: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style) */
     fontSynthesisStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight) */
     fontSynthesisWeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant) */
     fontVariant: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates) */
     fontVariantAlternates: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-caps) */
     fontVariantCaps: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian) */
     fontVariantEastAsian: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures) */
     fontVariantLigatures: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric) */
     fontVariantNumeric: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variant-position) */
     fontVariantPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-variation-settings) */
     fontVariationSettings: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/font-weight) */
     fontWeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust) */
     forcedColorAdjust: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/gap) */
     gap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid) */
     grid: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-area) */
     gridArea: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns) */
     gridAutoColumns: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow) */
     gridAutoFlow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-auto-rows) */
     gridAutoRows: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column) */
     gridColumn: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column-end) */
     gridColumnEnd: string;
-
     /** @deprecated This is a legacy alias of `columnGap`. */
     gridColumnGap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-column-start) */
     gridColumnStart: string;
-
     /** @deprecated This is a legacy alias of `gap`. */
     gridGap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row) */
     gridRow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row-end) */
     gridRowEnd: string;
-
     /** @deprecated This is a legacy alias of `rowGap`. */
     gridRowGap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-row-start) */
     gridRowStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template) */
     gridTemplate: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-areas) */
     gridTemplateAreas: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-columns) */
     gridTemplateColumns: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/grid-template-rows) */
     gridTemplateRows: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/height) */
     height: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphenate-character) */
     hyphenateCharacter: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphenate-limit-chars) */
     hyphenateLimitChars: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/hyphens) */
     hyphens: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/image-orientation)
      */
     imageOrientation: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/image-rendering) */
     imageRendering: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inline-size) */
     inlineSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset) */
     inset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block) */
     insetBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block-end) */
     insetBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-block-start) */
     insetBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline) */
     insetInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline-end) */
     insetInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/inset-inline-start) */
     insetInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/isolation) */
     isolation: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-content) */
     justifyContent: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-items) */
     justifyItems: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-self) */
     justifySelf: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/left) */
     left: string;
-
     /**
      * The read-only property returns an integer that represents the number of style declarations in this CSS declaration block.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/length)
      */
     readonly length: number;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/letter-spacing) */
     letterSpacing: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/lighting-color) */
     lightingColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-break) */
     lineBreak: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-height) */
     lineHeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style) */
     listStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-image) */
     listStyleImage: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-position) */
     listStylePosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/list-style-type) */
     listStyleType: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin) */
     margin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block) */
     marginBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block-end) */
     marginBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-block-start) */
     marginBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-bottom) */
     marginBottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline) */
     marginInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline-end) */
     marginInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-inline-start) */
     marginInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-left) */
     marginLeft: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-right) */
     marginRight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/margin-top) */
     marginTop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker) */
     marker: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-end) */
     markerEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-mid) */
     markerMid: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/marker-start) */
     markerStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask) */
     mask: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-clip) */
     maskClip: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-composite) */
     maskComposite: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-image) */
     maskImage: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-mode) */
     maskMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-origin) */
     maskOrigin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-position) */
     maskPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-repeat) */
     maskRepeat: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-size) */
     maskSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-type) */
     maskType: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/math-depth) */
     mathDepth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/math-style) */
     mathStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-block-size) */
     maxBlockSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-height) */
     maxHeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-inline-size) */
     maxInlineSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/max-width) */
     maxWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-block-size) */
     minBlockSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-height) */
     minHeight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-inline-size) */
     minInlineSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/min-width) */
     minWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode) */
     mixBlendMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/object-fit) */
     objectFit: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/object-position) */
     objectPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset) */
     offset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-anchor) */
     offsetAnchor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-distance) */
     offsetDistance: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-path) */
     offsetPath: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-position) */
     offsetPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/offset-rotate) */
     offsetRotate: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/opacity) */
     opacity: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/order) */
     order: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/orphans) */
     orphans: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline) */
     outline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-color) */
     outlineColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-offset) */
     outlineOffset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-style) */
     outlineStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/outline-width) */
     outlineWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow) */
     overflow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-anchor) */
     overflowAnchor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-block) */
     overflowBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin) */
     overflowClipMargin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-inline) */
     overflowInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap) */
     overflowWrap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-x) */
     overflowX: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-y) */
     overflowY: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior) */
     overscrollBehavior: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block) */
     overscrollBehaviorBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline) */
     overscrollBehaviorInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x) */
     overscrollBehaviorX: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y) */
     overscrollBehaviorY: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding) */
     padding: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block) */
     paddingBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block-end) */
     paddingBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-block-start) */
     paddingBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-bottom) */
     paddingBottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline) */
     paddingInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline-end) */
     paddingInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-inline-start) */
     paddingInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-left) */
     paddingLeft: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-right) */
     paddingRight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/padding-top) */
     paddingTop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page) */
     page: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-after)
      */
     pageBreakAfter: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-before)
      */
     pageBreakBefore: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/page-break-inside)
      */
     pageBreakInside: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/paint-order) */
     paintOrder: string;
-
     /**
      * The **CSSStyleDeclaration.parentRule** read-only property returns a CSSRule that is the parent of this style block, e.g., a CSSStyleRule representing the style for a CSS selector.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/parentRule)
      */
     readonly parentRule: CSSRule | null;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective) */
     perspective: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective-origin) */
     perspectiveOrigin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-content) */
     placeContent: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-items) */
     placeItems: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/place-self) */
     placeSelf: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/pointer-events) */
     pointerEvents: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/position) */
     position: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/print-color-adjust) */
     printColorAdjust: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/quotes) */
     quotes: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/r) */
     r: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/resize) */
     resize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/right) */
     right: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/rotate) */
     rotate: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/row-gap) */
     rowGap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ruby-align) */
     rubyAlign: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ruby-position) */
     rubyPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/rx) */
     rx: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/ry) */
     ry: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scale) */
     scale: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-behavior) */
     scrollBehavior: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin) */
     scrollMargin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block) */
     scrollMarginBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end) */
     scrollMarginBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start) */
     scrollMarginBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom) */
     scrollMarginBottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline) */
     scrollMarginInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end) */
     scrollMarginInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start) */
     scrollMarginInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left) */
     scrollMarginLeft: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right) */
     scrollMarginRight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-margin-top) */
     scrollMarginTop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding) */
     scrollPadding: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block) */
     scrollPaddingBlock: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end) */
     scrollPaddingBlockEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start) */
     scrollPaddingBlockStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-bottom) */
     scrollPaddingBottom: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline) */
     scrollPaddingInline: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end) */
     scrollPaddingInlineEnd: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start) */
     scrollPaddingInlineStart: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-left) */
     scrollPaddingLeft: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right) */
     scrollPaddingRight: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top) */
     scrollPaddingTop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align) */
     scrollSnapAlign: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop) */
     scrollSnapStop: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type) */
     scrollSnapType: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-color) */
     scrollbarColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter) */
     scrollbarGutter: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/scrollbar-width) */
     scrollbarWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold) */
     shapeImageThreshold: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-margin) */
     shapeMargin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-outside) */
     shapeOutside: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/shape-rendering) */
     shapeRendering: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stop-color) */
     stopColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stop-opacity) */
     stopOpacity: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke) */
     stroke: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-dasharray) */
     strokeDasharray: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-dashoffset) */
     strokeDashoffset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-linecap) */
     strokeLinecap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-linejoin) */
     strokeLinejoin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-miterlimit) */
     strokeMiterlimit: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-opacity) */
     strokeOpacity: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/stroke-width) */
     strokeWidth: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/tab-size) */
     tabSize: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/table-layout) */
     tableLayout: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-align) */
     textAlign: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-align-last) */
     textAlignLast: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-anchor) */
     textAnchor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box) */
     textBox: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box-edge) */
     textBoxEdge: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-box-trim) */
     textBoxTrim: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-combine-upright) */
     textCombineUpright: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration) */
     textDecoration: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-color) */
     textDecorationColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-line) */
     textDecorationLine: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink) */
     textDecorationSkipInk: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-style) */
     textDecorationStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness) */
     textDecorationThickness: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis) */
     textEmphasis: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color) */
     textEmphasisColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position) */
     textEmphasisPosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style) */
     textEmphasisStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-indent) */
     textIndent: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-orientation) */
     textOrientation: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-overflow) */
     textOverflow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-rendering) */
     textRendering: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-shadow) */
     textShadow: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-transform) */
     textTransform: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-underline-offset) */
     textUnderlineOffset: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-underline-position) */
     textUnderlinePosition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap) */
     textWrap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap-mode) */
     textWrapMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-wrap-style) */
     textWrapStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/top) */
     top: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/touch-action) */
     touchAction: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform) */
     transform: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-box) */
     transformBox: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-origin) */
     transformOrigin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-style) */
     transformStyle: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition) */
     transition: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-behavior) */
     transitionBehavior: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-delay) */
     transitionDelay: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-duration) */
     transitionDuration: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-property) */
     transitionProperty: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-timing-function) */
     transitionTimingFunction: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/translate) */
     translate: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/unicode-bidi) */
     unicodeBidi: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/user-select) */
     userSelect: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/vector-effect) */
     vectorEffect: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/vertical-align) */
     verticalAlign: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/view-transition-class) */
     viewTransitionClass: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/view-transition-name) */
     viewTransitionName: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/visibility) */
     visibility: string;
-
     /**
      * @deprecated This is a legacy alias of `alignContent`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content)
      */
     webkitAlignContent: string;
-
     /**
      * @deprecated This is a legacy alias of `alignItems`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-items)
      */
     webkitAlignItems: string;
-
     /**
      * @deprecated This is a legacy alias of `alignSelf`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-self)
      */
     webkitAlignSelf: string;
-
     /**
      * @deprecated This is a legacy alias of `animation`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation)
      */
     webkitAnimation: string;
-
     /**
      * @deprecated This is a legacy alias of `animationDelay`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-delay)
      */
     webkitAnimationDelay: string;
-
     /**
      * @deprecated This is a legacy alias of `animationDirection`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-direction)
      */
     webkitAnimationDirection: string;
-
     /**
      * @deprecated This is a legacy alias of `animationDuration`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-duration)
      */
     webkitAnimationDuration: string;
-
     /**
      * @deprecated This is a legacy alias of `animationFillMode`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode)
      */
     webkitAnimationFillMode: string;
-
     /**
      * @deprecated This is a legacy alias of `animationIterationCount`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count)
      */
     webkitAnimationIterationCount: string;
-
     /**
      * @deprecated This is a legacy alias of `animationName`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-name)
      */
     webkitAnimationName: string;
-
     /**
      * @deprecated This is a legacy alias of `animationPlayState`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-play-state)
      */
     webkitAnimationPlayState: string;
-
     /**
      * @deprecated This is a legacy alias of `animationTimingFunction`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/animation-timing-function)
      */
     webkitAnimationTimingFunction: string;
-
     /**
      * @deprecated This is a legacy alias of `appearance`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/appearance)
      */
     webkitAppearance: string;
-
     /**
      * @deprecated This is a legacy alias of `backfaceVisibility`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/backface-visibility)
      */
     webkitBackfaceVisibility: string;
-
     /**
      * @deprecated This is a legacy alias of `backgroundClip`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-clip)
      */
     webkitBackgroundClip: string;
-
     /**
      * @deprecated This is a legacy alias of `backgroundOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-origin)
      */
     webkitBackgroundOrigin: string;
-
     /**
      * @deprecated This is a legacy alias of `backgroundSize`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/background-size)
      */
     webkitBackgroundSize: string;
-
     /**
      * @deprecated This is a legacy alias of `borderBottomLeftRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius)
      */
     webkitBorderBottomLeftRadius: string;
-
     /**
      * @deprecated This is a legacy alias of `borderBottomRightRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius)
      */
     webkitBorderBottomRightRadius: string;
-
     /**
      * @deprecated This is a legacy alias of `borderRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-radius)
      */
     webkitBorderRadius: string;
-
     /**
      * @deprecated This is a legacy alias of `borderTopLeftRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius)
      */
     webkitBorderTopLeftRadius: string;
-
     /**
      * @deprecated This is a legacy alias of `borderTopRightRadius`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius)
      */
     webkitBorderTopRightRadius: string;
-
     /**
      * @deprecated This is a legacy alias of `boxAlign`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-align)
      */
     webkitBoxAlign: string;
-
     /**
      * @deprecated This is a legacy alias of `boxFlex`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-flex)
      */
     webkitBoxFlex: string;
-
     /**
      * @deprecated This is a legacy alias of `boxOrdinalGroup`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group)
      */
     webkitBoxOrdinalGroup: string;
-
     /**
      * @deprecated This is a legacy alias of `boxOrient`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-orient)
      */
     webkitBoxOrient: string;
-
     /**
      * @deprecated This is a legacy alias of `boxPack`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-pack)
      */
     webkitBoxPack: string;
-
     /**
      * @deprecated This is a legacy alias of `boxShadow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-shadow)
      */
     webkitBoxShadow: string;
-
     /**
      * @deprecated This is a legacy alias of `boxSizing`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/box-sizing)
      */
     webkitBoxSizing: string;
-
     /**
      * @deprecated This is a legacy alias of `filter`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/filter)
      */
     webkitFilter: string;
-
     /**
      * @deprecated This is a legacy alias of `flex`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex)
      */
     webkitFlex: string;
-
     /**
      * @deprecated This is a legacy alias of `flexBasis`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-basis)
      */
     webkitFlexBasis: string;
-
     /**
      * @deprecated This is a legacy alias of `flexDirection`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-direction)
      */
     webkitFlexDirection: string;
-
     /**
      * @deprecated This is a legacy alias of `flexFlow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-flow)
      */
     webkitFlexFlow: string;
-
     /**
      * @deprecated This is a legacy alias of `flexGrow`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-grow)
      */
     webkitFlexGrow: string;
-
     /**
      * @deprecated This is a legacy alias of `flexShrink`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-shrink)
      */
     webkitFlexShrink: string;
-
     /**
      * @deprecated This is a legacy alias of `flexWrap`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/flex-wrap)
      */
     webkitFlexWrap: string;
-
     /**
      * @deprecated This is a legacy alias of `justifyContent`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/justify-content)
      */
     webkitJustifyContent: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/line-clamp) */
     webkitLineClamp: string;
-
     /**
      * @deprecated This is a legacy alias of `mask`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask)
      */
     webkitMask: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorder`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border)
      */
     webkitMaskBoxImage: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorderOutset`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-outset)
      */
     webkitMaskBoxImageOutset: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorderRepeat`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-repeat)
      */
     webkitMaskBoxImageRepeat: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorderSlice`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-slice)
      */
     webkitMaskBoxImageSlice: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorderSource`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-source)
      */
     webkitMaskBoxImageSource: string;
-
     /**
      * @deprecated This is a legacy alias of `maskBorderWidth`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-border-width)
      */
     webkitMaskBoxImageWidth: string;
-
     /**
      * @deprecated This is a legacy alias of `maskClip`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-clip)
      */
     webkitMaskClip: string;
-
     /**
      * @deprecated This is a legacy alias of `maskComposite`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-composite)
      */
     webkitMaskComposite: string;
-
     /**
      * @deprecated This is a legacy alias of `maskImage`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-image)
      */
     webkitMaskImage: string;
-
     /**
      * @deprecated This is a legacy alias of `maskOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-origin)
      */
     webkitMaskOrigin: string;
-
     /**
      * @deprecated This is a legacy alias of `maskPosition`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-position)
      */
     webkitMaskPosition: string;
-
     /**
      * @deprecated This is a legacy alias of `maskRepeat`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-repeat)
      */
     webkitMaskRepeat: string;
-
     /**
      * @deprecated This is a legacy alias of `maskSize`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/mask-size)
      */
     webkitMaskSize: string;
-
     /**
      * @deprecated This is a legacy alias of `order`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/order)
      */
     webkitOrder: string;
-
     /**
      * @deprecated This is a legacy alias of `perspective`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective)
      */
     webkitPerspective: string;
-
     /**
      * @deprecated This is a legacy alias of `perspectiveOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/perspective-origin)
      */
     webkitPerspectiveOrigin: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-fill-color) */
     webkitTextFillColor: string;
-
     /**
      * @deprecated This is a legacy alias of `textSizeAdjust`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/text-size-adjust)
      */
     webkitTextSizeAdjust: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke) */
     webkitTextStroke: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color) */
     webkitTextStrokeColor: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-width) */
     webkitTextStrokeWidth: string;
-
     /**
      * @deprecated This is a legacy alias of `transform`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform)
      */
     webkitTransform: string;
-
     /**
      * @deprecated This is a legacy alias of `transformOrigin`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-origin)
      */
     webkitTransformOrigin: string;
-
     /**
      * @deprecated This is a legacy alias of `transformStyle`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transform-style)
      */
     webkitTransformStyle: string;
-
     /**
      * @deprecated This is a legacy alias of `transition`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition)
      */
     webkitTransition: string;
-
     /**
      * @deprecated This is a legacy alias of `transitionDelay`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-delay)
      */
     webkitTransitionDelay: string;
-
     /**
      * @deprecated This is a legacy alias of `transitionDuration`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-duration)
      */
     webkitTransitionDuration: string;
-
     /**
      * @deprecated This is a legacy alias of `transitionProperty`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-property)
      */
     webkitTransitionProperty: string;
-
     /**
      * @deprecated This is a legacy alias of `transitionTimingFunction`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/transition-timing-function)
      */
     webkitTransitionTimingFunction: string;
-
     /**
      * @deprecated This is a legacy alias of `userSelect`.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/user-select)
      */
     webkitUserSelect: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/white-space) */
     whiteSpace: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/white-space-collapse) */
     whiteSpaceCollapse: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/widows) */
     widows: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/width) */
     width: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/will-change) */
     willChange: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/word-break) */
     wordBreak: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/word-spacing) */
     wordSpacing: string;
-
     /**
      * @deprecated
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/overflow-wrap)
      */
     wordWrap: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/writing-mode) */
     writingMode: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/x) */
     x: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/y) */
     y: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/z-index) */
     zIndex: string;
-
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/zoom) */
     zoom: string;
   }
@@ -1952,67 +1446,55 @@ declare namespace CFDOM {
   interface AriaAttributes {
     /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
     "aria-activedescendant"?: string | undefined;
-
     /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
     "aria-atomic"?: Booleanish | undefined;
-
     /**
      * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
      * presented if they are made.
      */
     "aria-autocomplete"?: "none" | "inline" | "list" | "both" | undefined;
-
     /**
      * Defines a string value that labels the current element, which is intended to be converted into Braille.
      * @see aria-label.
      */
     "aria-braillelabel"?: string | undefined;
-
     /**
      * Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille.
      * @see aria-roledescription.
      */
     "aria-brailleroledescription"?: string | undefined;
-
     /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */
     "aria-busy"?: Booleanish | undefined;
-
     /**
      * Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
      * @see aria-pressed @see aria-selected.
      */
     "aria-checked"?: boolean | "false" | "mixed" | "true" | undefined;
-
     /**
      * Defines the total number of columns in a table, grid, or treegrid.
      * @see aria-colindex.
      */
     "aria-colcount"?: number | undefined;
-
     /**
      * Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
      * @see aria-colcount @see aria-colspan.
      */
     "aria-colindex"?: number | undefined;
-
     /**
      * Defines a human readable text alternative of aria-colindex.
      * @see aria-rowindextext.
      */
     "aria-colindextext"?: string | undefined;
-
     /**
      * Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-colindex @see aria-rowspan.
      */
     "aria-colspan"?: number | undefined;
-
     /**
      * Identifies the element (or elements) whose contents or presence are controlled by the current element.
      * @see aria-owns.
      */
     "aria-controls"?: string | undefined;
-
     /** Indicates the element that represents the current item within a container or set of related elements. */
     "aria-current"?:
       | boolean
@@ -2029,25 +1511,21 @@ declare namespace CFDOM {
      * @see aria-labelledby
      */
     "aria-describedby"?: string | undefined;
-
     /**
      * Defines a string value that describes or annotates the current element.
      * @see related aria-describedby.
      */
     "aria-description"?: string | undefined;
-
     /**
      * Identifies the element that provides a detailed, extended description for the object.
      * @see aria-describedby.
      */
     "aria-details"?: string | undefined;
-
     /**
      * Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
      * @see aria-hidden @see aria-readonly.
      */
     "aria-disabled"?: Booleanish | undefined;
-
     /**
      * Indicates what functions can be performed when a dragged object is released on the drop target.
      * @deprecated in ARIA 1.1
@@ -2065,22 +1543,18 @@ declare namespace CFDOM {
      * @see aria-invalid @see aria-describedby.
      */
     "aria-errormessage"?: string | undefined;
-
     /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
     "aria-expanded"?: Booleanish | undefined;
-
     /**
      * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
      * allows assistive technology to override the general default of reading in document source order.
      */
     "aria-flowto"?: string | undefined;
-
     /**
      * Indicates an element's "grabbed" state in a drag-and-drop operation.
      * @deprecated in ARIA 1.1
      */
     "aria-grabbed"?: Booleanish | undefined;
-
     /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
     "aria-haspopup"?:
       | boolean
@@ -2097,7 +1571,6 @@ declare namespace CFDOM {
      * @see aria-disabled.
      */
     "aria-hidden"?: Booleanish | undefined;
-
     /**
      * Indicates the entered value does not conform to the format expected by the application.
      * @see aria-errormessage.
@@ -2111,68 +1584,54 @@ declare namespace CFDOM {
       | undefined;
     /** Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element. */
     "aria-keyshortcuts"?: string | undefined;
-
     /**
      * Defines a string value that labels the current element.
      * @see aria-labelledby.
      */
     "aria-label"?: string | undefined;
-
     /**
      * Identifies the element (or elements) that labels the current element.
      * @see aria-describedby.
      */
     "aria-labelledby"?: string | undefined;
-
     /** Defines the hierarchical level of an element within a structure. */
     "aria-level"?: number | undefined;
-
     /** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
     "aria-live"?: "off" | "assertive" | "polite" | undefined;
-
     /** Indicates whether an element is modal when displayed. */
     "aria-modal"?: Booleanish | undefined;
-
     /** Indicates whether a text box accepts multiple lines of input or only a single line. */
     "aria-multiline"?: Booleanish | undefined;
-
     /** Indicates that the user may select more than one item from the current selectable descendants. */
     "aria-multiselectable"?: Booleanish | undefined;
-
     /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
     "aria-orientation"?: "horizontal" | "vertical" | undefined;
-
     /**
      * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
      * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
      * @see aria-controls.
      */
     "aria-owns"?: string | undefined;
-
     /**
      * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
      * A hint could be a sample value or a brief description of the expected format.
      */
     "aria-placeholder"?: string | undefined;
-
     /**
      * Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-setsize.
      */
     "aria-posinset"?: number | undefined;
-
     /**
      * Indicates the current "pressed" state of toggle buttons.
      * @see aria-checked @see aria-selected.
      */
     "aria-pressed"?: boolean | "false" | "mixed" | "true" | undefined;
-
     /**
      * Indicates that the element is not editable, but is otherwise operable.
      * @see aria-disabled.
      */
     "aria-readonly"?: Booleanish | undefined;
-
     /**
      * Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
      * @see aria-atomic.
@@ -2191,61 +1650,49 @@ declare namespace CFDOM {
       | undefined;
     /** Indicates that user input is required on the element before a form may be submitted. */
     "aria-required"?: Booleanish | undefined;
-
     /** Defines a human-readable, author-localized description for the role of an element. */
     "aria-roledescription"?: string | undefined;
-
     /**
      * Defines the total number of rows in a table, grid, or treegrid.
      * @see aria-rowindex.
      */
     "aria-rowcount"?: number | undefined;
-
     /**
      * Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
      * @see aria-rowcount @see aria-rowspan.
      */
     "aria-rowindex"?: number | undefined;
-
     /**
      * Defines a human readable text alternative of aria-rowindex.
      * @see aria-colindextext.
      */
     "aria-rowindextext"?: string | undefined;
-
     /**
      * Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
      * @see aria-rowindex @see aria-colspan.
      */
     "aria-rowspan"?: number | undefined;
-
     /**
      * Indicates the current "selected" state of various widgets.
      * @see aria-checked @see aria-pressed.
      */
     "aria-selected"?: Booleanish | undefined;
-
     /**
      * Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
      * @see aria-posinset.
      */
     "aria-setsize"?: number | undefined;
-
     /** Indicates if items in a table or grid are sorted in ascending or descending order. */
     "aria-sort"?: "none" | "ascending" | "descending" | "other" | undefined;
-
     /** Defines the maximum allowed value for a range widget. */
     "aria-valuemax"?: number | undefined;
-
     /** Defines the minimum allowed value for a range widget. */
     "aria-valuemin"?: number | undefined;
-
     /**
      * Defines the current value for a range widget.
      * @see aria-valuetext.
      */
     "aria-valuenow"?: number | undefined;
-
     /** Defines the human readable text alternative of aria-valuenow for a range widget. */
     "aria-valuetext"?: string | undefined;
   }
@@ -2406,12 +1853,10 @@ declare namespace CFDOM {
     popoverTarget?: string | undefined;
 
     // Living Standard
-
     /**
      * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
      */
     inert?: boolean | undefined;
-
     /**
      * Hints at the type of data that might be entered by the user while editing the element or its contents
      * @see {@link https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute}
@@ -2431,12 +1876,10 @@ declare namespace CFDOM {
      * @see {@link https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is}
      */
     is?: string | undefined;
-
     /**
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts}
      */
     exportparts?: string | undefined;
-
     /**
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/part}
      */
@@ -2691,21 +2134,17 @@ declare namespace CFDOM {
     allow?: string | undefined;
     allowFullScreen?: boolean | undefined;
     allowTransparency?: boolean | undefined;
-
     /** @deprecated */
     frameBorder?: number | string | undefined;
     height?: number | string | undefined;
     loading?: "eager" | "lazy" | undefined;
-
     /** @deprecated */
     marginHeight?: number | undefined;
-
     /** @deprecated */
     marginWidth?: number | undefined;
     name?: string | undefined;
     referrerPolicy?: HTMLAttributeReferrerPolicy | undefined;
     sandbox?: string | undefined;
-
     /** @deprecated */
     scrolling?: string | undefined;
     seamless?: boolean | undefined;
@@ -2998,7 +2437,6 @@ declare namespace CFDOM {
   interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
     async?: boolean | undefined;
     blocking?: "render" | (string & {}) | undefined;
-
     /** @deprecated */
     charSet?: string | undefined;
     crossOrigin?: CrossOrigin;
@@ -3786,7 +3224,6 @@ interface CFPromptInputAttributes<T> extends CFHTMLAttributes<T> {
   "autoResize"?: boolean;
   "pending"?: boolean;
   "voice"?: boolean;
-
   /** Upload File/Blob attachments to the blob store on add (default off). */
   "uploadAttachments"?: boolean;
   "oncf-send"?: EventHandler<{
@@ -3796,7 +3233,6 @@ interface CFPromptInputAttributes<T> extends CFHTMLAttributes<T> {
       name: string;
       type: "file" | "clipboard";
       data?: unknown;
-
       /** Blob-store URL once uploaded (when uploadAttachments is set). */
       url?: string;
       mediaType?: string;
@@ -3888,22 +3324,16 @@ type TailwindNumberType =
 interface CFStackAttributes<T> extends CFHTMLAttributes<T> {
   "gap"?: TailwindNumberType;
   "padding"?: TailwindNumberType;
-
   /** Horizontal (left/right) padding; overrides `padding` on those sides. */
   "px"?: TailwindNumberType;
-
   /** Vertical (top/bottom) padding; overrides `padding` on those sides. */
   "py"?: TailwindNumberType;
-
   /** Padding-top; overrides `padding`/`py` on that side. */
   "pt"?: TailwindNumberType;
-
   /** Padding-right; overrides `padding`/`px` on that side. */
   "pr"?: TailwindNumberType;
-
   /** Padding-bottom; overrides `padding`/`py` on that side. */
   "pb"?: TailwindNumberType;
-
   /** Padding-left; overrides `padding`/`px` on that side. */
   "pl"?: TailwindNumberType;
   "align"?: "start" | "center" | "end" | "stretch" | "baseline";
@@ -4225,7 +3655,6 @@ interface CFLoaderAttributes<T> extends CFHTMLAttributes<T> {
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | "sm" | "md" | "lg";
   "show-elapsed"?: boolean;
   "show-stop"?: boolean;
-
   /** Fired when stop button is clicked */
   "oncf-stop"?: EventHandler<{}>;
 }
@@ -4536,7 +3965,6 @@ interface CFToolsChipAttributes<T> extends CFHTMLAttributes<T> {
   "open-on-hover"?: boolean;
   "toggle-on-click"?: boolean;
   "close-delay"?: number;
-
   /**
    * Accepts either:
    * - Array: { name, description?, schema? }[]
@@ -4831,7 +4259,6 @@ interface CFTextAttributes<T> extends CFHTMLAttributes<T> {
       | "error"
     >;
   "block"?: boolean | CellLike<boolean>;
-
   /** Single-line ellipsis truncation. Implies block display. */
   "truncate"?: boolean | CellLike<boolean>;
 }
@@ -4859,7 +4286,6 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
   /** A cell containing a profile (ProfileHomeOutput): renders avatar + name. */
   "$profile"?: CellLike<any>;
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
-
   /**
    * Badge shape (CT-1761), all carrying the same generative seal (aura ring +
    * cursor glint — there is no shield icon): `full` (default) = avatar + name;
@@ -4868,7 +4294,6 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
    * page header (pair with `noNavigate`).
    */
   "variant"?: "full" | "chip" | "circle" | "hero" | CellLike<string>;
-
   /**
    * Suppress click-to-navigate. Set when the badge is bound to a derived view
    * of a profile (e.g. the self-badge on a profile-home page) rather than the
@@ -4882,7 +4307,6 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
 interface CFChipAttributes<T> extends CFHTMLAttributes<T> {
   "label"?: string | CellLike<string>;
   "color"?: "neutral" | "primary" | "accent" | "danger";
-
   /** @deprecated Use color instead */
   "variant"?:
     | "default"

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -78,8 +78,10 @@ export class DomApplicator {
     number,
     Map<string, EventListener>
   >();
+
   /** Parent tracking: childId → parentId for O(1) descendant lookup */
   private readonly nodeParents = new Map<number, number>();
+
   /** Children tracking: parentId → Set<childId> for O(n) descendant cleanup */
   private readonly nodeChildren = new Map<number, Set<number>>();
   private readonly document: Document;

--- a/packages/html/src/main/events.ts
+++ b/packages/html/src/main/events.ts
@@ -19,6 +19,7 @@ import {
 export interface SerializedEvent {
   /** Event type (e.g., "click", "input", "change") */
   type: string;
+
   /** Internal provenance hint from the renderer */
   provenance?: EventProvenance;
 
@@ -56,6 +57,7 @@ export type { EventProvenance };
  */
 export interface SerializedEventTarget {
   name?: string;
+
   /**
    * The element's current value. A `FabricValue` rather than a string: a custom
    * element chooses what its `value` is, and a `cf-input`, a `cf-tabs` and a
@@ -63,6 +65,7 @@ export interface SerializedEventTarget {
    * arrives here as the sigil link the conversion resolved it to.
    */
   value?: FabricValue;
+
   /**
    * Whether the element is checked -- or, where the element chose to expose
    * something else, what it chose. `cf-checkbox` and `cf-switch` each declare

--- a/packages/html/src/render.ts
+++ b/packages/html/src/render.ts
@@ -25,6 +25,7 @@ export function getActiveRenders(): ReadonlyMap<HTMLElement, ActiveRender> {
 export interface RenderOptions {
   setProp?: SetPropHandler;
   document?: Document;
+
   /** Optional error handler */
   onError?: (error: Error) => void;
 }

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -24,6 +24,7 @@ export type CreateElementOp = {
   op: "create-element";
   nodeId: number;
   tagName: string;
+
   /**
    * The space of the cell whose render produced this element, present
    * only when it differs from the nearest ancestor element that
@@ -59,6 +60,7 @@ export type SetPropOp = {
   op: "set-prop";
   nodeId: number;
   key: string;
+
   /**
    * The value to set, which is whatever a pattern put on a render node and so
    * is a `FabricValue` entire. `transformPropValue()` in

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -80,8 +80,10 @@ export function isWorkerVNode(value: unknown): value is WorkerVNode {
 export interface PropState {
   /** The Cell being subscribed to (if reactive), or undefined for static props */
   cell: Cell<unknown> | undefined;
+
   /** Cancel function for this prop's subscription */
   cancel: Cancel;
+
   /** The specific value bound (for equality checking of static props/handlers) */
   currentValue?: unknown;
 }
@@ -92,6 +94,7 @@ export interface PropState {
 export interface ChildrenState {
   /** The Cell being subscribed to (if reactive), or undefined for static children */
   cell: Cell<unknown> | undefined;
+
   /** Cancel function for the children subscription */
   cancel: Cancel;
 }
@@ -128,6 +131,7 @@ export interface RenderPolicy {
   textIntegrity?: {
     requiredIntegrity: readonly CfcAtom[];
     allowLiteralText: boolean;
+
     /**
      * The enclosing text-integrity boundaries this policy applies to, innermost
      * included. A block under this policy is attributed to every id in the set

--- a/packages/js-compiler/interface.ts
+++ b/packages/js-compiler/interface.ts
@@ -10,6 +10,7 @@ export type Source = {
 export type ProgramResolver = {
   main(): Promise<Source>;
   resolveSource(identifier: string): Promise<Source | undefined>;
+
   /**
    * Reads a data file the program's source declares, by the root-relative name
    * a `dataFile()` call gives it. Undefined when this resolver holds no such
@@ -28,6 +29,7 @@ export type ProgramResolver = {
 export type Program = {
   main: string;
   files: Source[];
+
   /**
    * Names of entries in `files` that carry data rather than code. A data file
    * travels with the source package and is never transformed, compiled, or

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -286,6 +286,7 @@ export type BeforeTransformersResult =
 export interface TypeScriptCompilerOptions {
   // Skip type checking.
   noCheck?: boolean;
+
   /**
    * The program is DURABLE STORED pattern source being reloaded — bytes
    * nobody can re-author, recompiled by a toolchain newer than the one that
@@ -301,6 +302,7 @@ export interface TypeScriptCompilerOptions {
   // Optional mapping of runtime module name e.g. `"@commonfabric/framework"`,
   // and its corresponding type definitions.
   runtimeModules?: string[];
+
   /**
    * Maps an import specifier (verbatim text) to a program file name. Used for
    * scheme-prefixed specifiers that the path-join and runtime-module rules

--- a/packages/js-compiler/typescript/diagnostics/checker.ts
+++ b/packages/js-compiler/typescript/diagnostics/checker.ts
@@ -7,6 +7,7 @@ import {
 
 export interface CheckerOptions {
   messageTransformer?: DiagnosticMessageTransformer;
+
   /**
    * Compiling durable STORED pattern source (see
    * `TypeScriptCompilerOptions.storedSource`): authoring-hygiene-only codes

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -38,6 +38,7 @@ export type SchemaHints = WeakMap<ts.Node, SchemaHint>;
 /** Options that affect schema generation without changing the authored type. */
 export interface SchemaGenerationOptions {
   readonly widenLiterals?: boolean;
+
   /**
    * Resolves a TypeScript source-file name to the writer identity that should
    * be embedded in `WriteAuthorizedBy` metadata. Transformer callers use this
@@ -54,42 +55,57 @@ export interface SchemaGenerationOptions {
  */
 export interface GenerationContext {
   // Immutable context (set once)
+
   /** TypeScript type checker */
   readonly typeChecker: ts.TypeChecker;
+
   /** Pre-computed cyclic type set */
   readonly cyclicTypes: ReadonlySet<ts.Type>;
+
   /** Pre-computed cyclic name set */
   readonly cyclicNames: ReadonlySet<string>;
 
   // Accumulating state (grows during generation)
+
   /** Named type definitions for $refs */
   definitions: Record<string, SchemaDefinition>;
+
   /** Which $refs have been emitted */
   emittedRefs: Set<string>;
 
   // Stack state (push/pop during recursion)
+
   /** Current recursion path for cycle detection */
   definitionStack: Set<string | ts.Type>;
+
   /** Currently building these named types */
   inProgressNames: Set<string>;
 
   // Optional context
+
   /** Type node for additional context */
   typeNode?: ts.TypeNode;
+
   /** Source file name for authoring metadata that needs stable file identity */
   sourceFileName?: string;
+
   /** Source file for resolving names from synthetic type nodes */
   sourceFile?: ts.SourceFile;
+
   /** Optional type registry for synthetic nodes */
   typeRegistry?: WeakMap<ts.Node, ts.Type>;
+
   /** Widen literal types to base types during schema generation */
   widenLiterals?: boolean;
+
   /** Resolve writer-claim file spelling and optional mint-time identity. */
   writerIdentityForSourceFile?: (
     fileName: string,
   ) => WriterSourceIdentity;
+
   /** Schema hints for overriding default behavior (keyed by TypeNode) */
   schemaHints?: SchemaHints;
+
   /** Override for array items schema, propagated from wrapper types */
   arrayItemsOverride?: JSONSchema;
 }

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -45,8 +45,10 @@ export class SchemaGenerator {
     new PrimitiveFormatter(),
     new ObjectFormatter(this),
   ];
+
   /** Synthetic names for anonymous recursive types */
   private anonymousNames: WeakMap<ts.Type, string> = new WeakMap();
+
   /** Counter to generate stable synthetic identifiers */
   private anonymousNameCounter: number = 0;
 

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -415,6 +415,7 @@ export function getNativeTypeSchema(
 
   return resolve(type);
 }
+
 /**
  * Return a public/stable named key for a type if and only if it has a useful
  * symbol name. Filters out anonymous ("__type") and wrapper/container names

--- a/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
@@ -2,6 +2,7 @@
 interface SchemaRoot {
   /** The note body. */
   content: string;
+
   /** Linked #annotation entries. */
   annotations: string[];
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-index-ambiguous.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-index-ambiguous.input.ts
@@ -1,6 +1,7 @@
 interface SchemaRoot {
   /** Doc for string index */
   [key: string]: number;
+
   /** Doc for number index */
   [index: number]: number;
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-same.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-same.input.ts
@@ -6,6 +6,7 @@ interface A {
 interface B {
   /** Name doc */
   name: string;
+
   /** Age */
   age: number;
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-nested.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-nested.input.ts
@@ -1,8 +1,10 @@
 interface ChildNode {
   /** The main text content of the child node */
   body: string;
+
   /** Children of the child node */
   children: any[];
+
   /** Attachments associated with the child node */
   attachments: any[];
 }
@@ -11,10 +13,13 @@ interface ChildNode {
 type SchemaRoot = {
   /** The main text content of the node */
   body: string;
+
   /** Child nodes of this node */
   children: ChildNode[];
+
   /** Attachments associated with this node */
   attachments: any[];
+
   /** Version of document */
   version: number;
 };

--- a/packages/schema-generator/test/fixtures/schema/descriptions-optional-union.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-optional-union.input.ts
@@ -1,6 +1,7 @@
 interface SchemaRoot {
   /** maybe label */
   label?: string;
+
   /** maybe flag */
   flag: boolean | undefined;
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-recursive.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-recursive.input.ts
@@ -1,6 +1,7 @@
 interface SchemaRoot {
   /** node name */
   name: string;
+
   /** Child nodes */
   children: SchemaRoot[];
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-wrappers.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-wrappers.input.ts
@@ -3,8 +3,10 @@ type Default<T, V extends T = T> = T;
 interface SchemaRoot {
   /** Titles in a cell */
   titles: Cell<string[]>;
+
   /** Count as stream */
   count: Stream<number>;
+
   /** Level with default */
   level: Default<number, 3>;
 }

--- a/packages/schema-generator/test/fixtures/schema/stream-deprecated-mark.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/stream-deprecated-mark.input.ts
@@ -6,8 +6,10 @@
 interface SchemaRoot {
   /** @deprecated Compatibility mutation for callers of the previous board. */
   setLegacyName: Stream<string>;
+
   /** Current verb beside it, unmarked. */
   rename: Stream<string>;
+
   /** @deprecated Compatibility shadow, mirrored for old consumers — but data,
    * so no mark. */
   legacyName: string;

--- a/packages/schema-generator/test/object-formatter.test.ts
+++ b/packages/schema-generator/test/object-formatter.test.ts
@@ -49,6 +49,7 @@ interface OpenEvent {
 interface SchemaRoot {
   /** Opens the composer panel. */
   openComposer: () => Stream<OpenEvent>;
+
   /** The board's visible title. */
   title: string;
 }

--- a/packages/test-support/src/fixture-runner.ts
+++ b/packages/test-support/src/fixture-runner.ts
@@ -29,15 +29,18 @@ type MaybePromise<T> = T | Promise<T>;
 
 export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
   suiteName: string;
+
   /**
    * Root directory containing fixture files. Resolved relative to the current
    * working directory of the test process.
    */
   rootDir: string;
+
   /**
    * Pattern for identifying input fixtures. Defaults to `/\.input\.(ts|tsx)$/i`.
    */
   inputPattern?: RegExp;
+
   /**
    * Computes the path to the expected output relative to the fixture root.
    */
@@ -46,26 +49,32 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     extension: string;
     relativeInputPath: string;
   }) => string;
+
   /**
    * Optional filter to skip fixtures.
    */
   skip?: (fixture: Fixture) => boolean;
+
   /**
    * Optional grouping for nested describe blocks.
    */
   groupBy?: (fixture: Fixture) => string | undefined;
+
   /**
    * Custom comparator for fixture ordering.
    */
   sortFixtures?: (a: Fixture, b: Fixture) => number;
+
   /**
    * Friendly test name formatter. Defaults to the fixture stem.
    */
   formatTestName?: (fixture: Fixture) => string;
+
   /**
    * Optional warmup hook executed once before tests run.
    */
   warmup?: () => MaybePromise<Warmup>;
+
   /**
    * Optional hook executed before each fixture test.
    */
@@ -73,6 +82,7 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     fixture: Fixture,
     ctx: FixtureContext<Warmup>,
   ) => MaybePromise<void>;
+
   /**
    * Produce the actual output for a fixture.
    */
@@ -80,6 +90,7 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     fixture: Fixture,
     ctx: FixtureContext<Warmup>,
   ) => MaybePromise<Actual>;
+
   /**
    * Load the expected output for a fixture.
    */
@@ -87,6 +98,7 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     fixture: Fixture,
     ctx: FixtureContext<Warmup>,
   ) => MaybePromise<Expected>;
+
   /**
    * Compare actual vs expected values.
    */
@@ -96,6 +108,7 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     fixture: Fixture,
     ctx: FixtureContext<Warmup>,
   ) => MaybePromise<void>;
+
   /**
    * Optional determinism check for executions that should be stable across
    * multiple invocations (e.g., schema generation).
@@ -105,6 +118,7 @@ export interface FixtureSuiteConfig<Actual, Expected, Warmup = void> {
     fixture: Fixture,
     ctx: FixtureContext<Warmup>,
   ) => MaybePromise<void>;
+
   /**
    * Handle golden updates when `UPDATE_GOLDENS=1`.
    */

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -10,6 +10,7 @@ export interface DenoCommandWithTemporaryLockOptions {
 
 export interface DenoCheckWithTemporaryConfigOptions {
   root: string;
+
   /**
    * A copy of the root config with the same workspace dependency graph.
    * Compiler options may differ for the check.
@@ -22,12 +23,14 @@ export interface DenoCheckWithTemporaryConfigOptions {
 export interface FrozenDriftCheckOptions {
   /** Import map the baseline lockfile is generated from. */
   baselineImports: Record<string, string>;
+
   /**
    * Import map the frozen check runs against. It must differ from
    * `baselineImports`, and the entry module must only import specifiers that it
    * still maps.
    */
   driftedImports: Record<string, string>;
+
   /** Source of the entry module the checks type-check. */
   entrySource: string;
 }
@@ -35,6 +38,7 @@ export interface FrozenDriftCheckOptions {
 export interface FrozenDriftCheckResult {
   /** Output of generating the baseline lockfile from `baselineImports`. */
   generate: Deno.CommandOutput;
+
   /** Output of the frozen check run against `driftedImports`. */
   check: Deno.CommandOutput;
 }

--- a/packages/test-support/src/records/gcp-auth.ts
+++ b/packages/test-support/src/records/gcp-auth.ts
@@ -8,6 +8,7 @@
 
 export interface ServiceAccountKey {
   client_email: string;
+
   /** PEM, PKCS#8. */
   private_key: string;
   token_uri: string;

--- a/packages/test-support/src/records/junit.ts
+++ b/packages/test-support/src/records/junit.ts
@@ -253,6 +253,7 @@ export function isRelativeSourcePath(classname: string): boolean {
 export interface IngestJUnitOptions {
   kind: string;
   scope: string;
+
   /**
    * Repository path of the test process's working directory, "" when it ran
    * at the repository root. Joined onto relative classnames to produce

--- a/packages/test-support/src/records/schema.ts
+++ b/packages/test-support/src/records/schema.ts
@@ -18,10 +18,13 @@ export interface TestIdentity {
   /** Class of check: "unit", "browser", "pattern", "integration",
    * "typecheck", "lint", "format", or "gate". */
   k: string;
+
   /** Owning workspace member, or "repo". */
   s: string;
+
   /** Name as reported by the test's own runner. */
   n: string;
+
   /** Non-default configuration under which the test ran. */
   v?: string;
 }
@@ -41,6 +44,7 @@ export interface TestRecord {
   test: TestIdentity;
   outcome: "pass" | "fail" | "skip";
   durationMs: number;
+
   /** Repository-relative source file, when reliably known. Metadata, not
    * identity. */
   file?: string;
@@ -52,14 +56,19 @@ export interface CiContext {
   workflowRunId: string;
   runAttempt: number;
   workflow: string;
+
   /** Job identity including the matrix leg, as in "Test (3/8)". */
   job: string;
+
   /** Shard label like "3/8" when the job is sharded. */
   shard?: string;
+
   /** Pull request head commit; `commit` is the ephemeral merge commit. */
   headCommit?: string;
+
   /** Triggering event, from the trusted payload: "push", "pull_request". */
   event?: string;
+
   /**
    * True when the run's head repository differs from the base repository.
    * Stamped from the trusted payload, never from job artifacts: record
@@ -73,17 +82,22 @@ export interface CiContext {
 export interface RunContext {
   schema: typeof RECORD_SCHEMA_VERSION;
   line: "context";
+
   /** ULID; unique per uploaded object. */
   reportId: string;
+
   /** Canonical repository name, as in "commontoolsinc/labs". */
   repo: string;
+
   /** Full hash of the commit the tests ran against. */
   commit: string;
+
   /** True when the working tree had uncommitted changes. */
   dirty: boolean;
   branch?: string;
   env: "ci" | "local";
   ci?: CiContext;
+
   /**
    * Opaque label for the operating agent: CF_TEST_AGENT, or the
    * harness a run was started under when that variable is unset.
@@ -92,6 +106,7 @@ export interface RunContext {
   os: string;
   arch: string;
   denoVersion: string;
+
   /** ISO 8601 UTC. */
   startedAt: string;
 }

--- a/packages/test-support/src/records/spool.ts
+++ b/packages/test-support/src/records/spool.ts
@@ -37,6 +37,7 @@ export const SPOOL_STAGING_PREFIX = "staging-";
 /** A spool this process owns or has adopted; the lock is held until close. */
 export interface HeldSpool {
   dir: string;
+
   /** Releases the lock and closes the lock file. */
   close(): void;
 }

--- a/packages/test-support/src/records/store.ts
+++ b/packages/test-support/src/records/store.ts
@@ -24,13 +24,16 @@ export async function gunzipToText(bytes: Uint8Array): Promise<string> {
 
 export interface CreateObjectOptions {
   bucket: string;
+
   /** Full object name, prefix included. */
   name: string;
   body: Uint8Array;
   token: string;
   contentType?: string;
+
   /** Set to "gzip" so plain HTTPS readers receive NDJSON via transcoding. */
   contentEncoding?: string;
+
   /** Injectable for tests. */
   fetch?: typeof fetch;
 }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 126 doc comments across 34 files had no blank line above them; each
gets one. Covered: `packages/schema-generator`, `packages/test-support`,
`packages/html`, `packages/fuse`, and `packages/js-compiler`.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Two files handled specially

`packages/html/src/jsx.d.ts` is **not** swept. It is derived from the upstream
DOM typings — its property documentation is the `[MDN Reference]` line
TypeScript's own `lib.dom.d.ts` carries — and
`packages/static/assets/types/jsx.d.ts` is a symlink to it, sitting beside the
`dom.d.ts` and `es2023.d.ts` that are upstream verbatim. Those two are out of
scope for this whole series, and this one belongs with them: the 576 blank lines
would be lost the next time the file is re-derived. The second commit takes it
back out.

Eight `schema-generator` fixture files are in `deno.jsonc`'s `fmt.exclude`, so
the formatter cannot settle the parenthesized-list and union carve-outs for
them. Each was copied to a scratch path, formatted there, and came back
byte-identical. The package's suite also passes against the existing goldens: a
doc comment's *text* is what becomes a schema `description`, and the space above
it does not reach that.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, all five packages' own test
tasks, and `packages/static`'s three generated-asset checks pass locally.
GitHub Actions is in an outage as this is opened, so these are local runs rather
than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
