### PR TITLE
docs(patterns): blank lines above doc comments in `google`, `integration`, and the top level

### DIFF
--- a/packages/patterns/address.tsx
+++ b/packages/patterns/address.tsx
@@ -37,12 +37,16 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface AddressModuleInput {
   /** Label for this address (Home, Work, Billing, etc.) */
   label: string | Default<"Home">;
+
   /** Street address */
   street: string | Default<"">;
+
   /** City */
   city: string | Default<"">;
+
   /** State/Province */
   state: string | Default<"">;
+
   /** ZIP/Postal code */
   zip: string | Default<"">;
 }

--- a/packages/patterns/annotation.tsx
+++ b/packages/patterns/annotation.tsx
@@ -1,4 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
+
 /**
  * Annotation - A pattern for annotating existing cells/pieces.
  *

--- a/packages/patterns/birthday.tsx
+++ b/packages/patterns/birthday.tsx
@@ -70,8 +70,10 @@ const getMonthName = (month: string): string => {
 export interface BirthdayModuleInput {
   /** Birth month (1-12 as string) */
   birthMonth: string | Default<"">;
+
   /** Birth day (1-31 as string) */
   birthDay: string | Default<"">;
+
   /** Birth year (e.g., "1990") */
   birthYear: string | Default<"">;
 }

--- a/packages/patterns/custom-field.tsx
+++ b/packages/patterns/custom-field.tsx
@@ -86,8 +86,10 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface CustomFieldModuleInput {
   /** Field name (e.g., "Employee ID", "SKU") */
   name: string | Default<"">;
+
   /** Field value (stored as string, parsed by UI) */
   value: string | Default<"">;
+
   /** Value type determines input UI */
   valueType: CustomFieldValueType | Default<"text">;
 }

--- a/packages/patterns/email.tsx
+++ b/packages/patterns/email.tsx
@@ -34,6 +34,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface EmailModuleInput {
   /** Label for this email (Personal, Work, School, etc.) */
   label: string | Default<"Personal">;
+
   /** Email address */
   address: string | Default<"">;
 }

--- a/packages/patterns/giftprefs.tsx
+++ b/packages/patterns/giftprefs.tsx
@@ -48,8 +48,10 @@ type GiftTier = "always" | "occasions" | "reciprocal" | "none";
 export interface GiftPrefsModuleInput {
   /** Gift giving tier */
   giftTier: GiftTier | "" | Default<"">;
+
   /** Favorite things (interests, hobbies, brands) */
   favorites: string[] | Default<[]>;
+
   /** Things to avoid (allergies, dislikes) */
   avoid: string[] | Default<[]>;
 }

--- a/packages/patterns/google/core/bill-extractor/index.tsx
+++ b/packages/patterns/google/core/bill-extractor/index.tsx
@@ -202,6 +202,7 @@ export interface BillExtractorOutput {
     summaryStatsUI: JSX.Element;
     overdueAlertUI: JSX.Element;
     websiteLinkUI: JSX.Element;
+
     /** Banner shown when supportsAutoDetect is false */
     manualTrackingBannerUI: JSX.Element;
   };

--- a/packages/patterns/google/core/bill-extractor/types.ts
+++ b/packages/patterns/google/core/bill-extractor/types.ts
@@ -99,26 +99,37 @@ export type BillStatus = "unpaid" | "paid" | "overdue" | "likely_paid";
 export interface TrackedBill {
   /** Unique key for deduplication (identifier|dueDate) */
   key: string;
+
   /** Generic identifier (card last 4, account number, etc.) */
   identifier: string;
+
   /** Bill amount in dollars */
   amount: number;
+
   /** Due date in ISO format */
   dueDate: string;
+
   /** Current status */
   status: BillStatus;
+
   /** Whether the bill is considered paid */
   isPaid: boolean;
+
   /** Date the bill was paid (if known) */
   paidDate?: string;
+
   /** Date the email was received */
   emailDate: string;
+
   /** Gmail message ID */
   emailId: string;
+
   /** Whether user manually marked as paid */
   isManuallyPaid: boolean;
+
   /** Whether assumed paid due to age (>45 days overdue) */
   isLikelyPaid: boolean;
+
   /** Days until due (negative = overdue) */
   daysUntilDue: number;
 }

--- a/packages/patterns/google/core/experimental/calendar-event-manager.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.tsx
@@ -50,16 +50,22 @@ type CalendarOperation = "create" | "update" | "delete" | "rsvp";
 type EventDraft = {
   /** Event title/summary */
   summary: string | Default<"">;
+
   /** Start datetime (ISO or datetime-local format) */
   start: string | Default<"">;
+
   /** End datetime (ISO or datetime-local format) */
   end: string | Default<"">;
+
   /** Calendar ID (primary for main calendar) */
   calendarId: string | Default<"primary">;
+
   /** Event description */
   description: string | Default<"">;
+
   /** Event location */
   location: string | Default<"">;
+
   /** Attendee emails (comma-separated) */
   attendeesText: string | Default<"">;
 };
@@ -67,8 +73,10 @@ type EventDraft = {
 type ExistingEvent = {
   /** Event ID for update/delete/rsvp */
   id: string;
+
   /** Calendar ID */
   calendarId: string;
+
   /** Event summary for display */
   summary?: string;
 } | null;
@@ -109,6 +117,7 @@ interface Input {
       location: "";
       attendeesText: "";
     }>;
+
   /** Existing event for update/delete/rsvp operations */
   existingEvent: ExistingEvent | Default<null>;
 }

--- a/packages/patterns/google/core/experimental/gmail-label-manager.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.tsx
@@ -51,10 +51,13 @@ import {
 type LabelOperation = {
   /** Message IDs to modify */
   messageIds: string[];
+
   /** Label IDs to add */
   addLabelIds: string[];
+
   /** Label IDs to remove */
   removeLabelIds: string[];
+
   /** Human-readable label names (for display) */
   addLabelNames: string[];
   removeLabelNames: string[];
@@ -70,8 +73,10 @@ type OperationResult = {
 interface Input {
   /** Message ID(s) to manage labels for - can be single string or array */
   messageIds: string[] | Default<[]>;
+
   /** Labels to add (by ID) */
   labelsToAdd: string[] | Default<[]>;
+
   /** Labels to remove (by ID) */
   labelsToRemove: string[] | Default<[]>;
 }
@@ -83,6 +88,7 @@ export interface Output {
   labelsToAdd: string[];
   labelsToRemove: string[];
   result: OperationResult | null;
+
   /** Available labels (fetched from Gmail) */
   availableLabels: GmailLabel[];
 }

--- a/packages/patterns/google/core/experimental/gmail-sender.tsx
+++ b/packages/patterns/google/core/experimental/gmail-sender.tsx
@@ -40,16 +40,22 @@ import { type Auth, createGoogleAuth } from "../util/google-auth-manager.tsx";
 type EmailDraft = {
   /** Recipient email address */
   to: string | Default<"">;
+
   /** Email subject line */
   subject: string | Default<"">;
+
   /** Plain text body */
   body: string | Default<"">;
+
   /** CC recipients (comma-separated) */
   cc: string | Default<"">;
+
   /** BCC recipients (comma-separated) */
   bcc: string | Default<"">;
+
   /** Message ID to reply to (for threading) */
   replyToMessageId: string | Default<"">;
+
   /** Thread ID to reply to (for threading) */
   replyToThreadId: string | Default<"">;
 };

--- a/packages/patterns/google/core/gmail-extractor.tsx
+++ b/packages/patterns/google/core/gmail-extractor.tsx
@@ -110,6 +110,7 @@ export interface GmailExtractorInput {
      * - {{email.snippet}} - Brief preview
      */
     promptTemplate: string;
+
     /**
      * JSON Schema for the extraction result.
      * The LLM will generate objects conforming to this schema.
@@ -149,8 +150,10 @@ export interface AnalysisItem<T = unknown> {
 export interface GmailExtractorOutput {
   /** Raw emails from Gmail */
   emails: Email[];
+
   /** Count of emails fetched */
   emailCount: number;
+
   /** Analysis results (empty when extraction not provided) */
   rawAnalyses: Array<{
     email: Email;
@@ -161,18 +164,24 @@ export interface GmailExtractorOutput {
     pending: boolean;
     error: unknown;
   }>;
+
   /** Count of pending analyses */
   pendingCount: number;
+
   /** Count of completed analyses */
   completedCount: number;
+
   /** Whether Gmail is connected */
   isConnected: boolean;
 
   // Operations (Streams, not functions)
+
   /** Refresh emails from Gmail */
   refresh: Stream<unknown>;
+
   /** Add labels to a message */
   addLabels: Stream<{ messageId: string; labels: string[] }>;
+
   /** Remove labels from a message */
   removeLabels: Stream<{ messageId: string; labels: string[] }>;
 

--- a/packages/patterns/google/core/gmail-importer.tsx
+++ b/packages/patterns/google/core/gmail-importer.tsx
@@ -122,18 +122,25 @@ type Settings = {
 export interface Output {
   [NAME]: string;
   [UI]: VNode;
+
   /** Array of imported emails */
   emails: Email[];
+
   /** Mentionables — email cards with NAME and summary for search indexing */
   mentionable: { [NAME]: string; summary: string; [UI]: VNode }[];
+
   /** Number of emails imported */
   emailCount: number;
+
   /** Summary of container-level emails for hierarchical indexing */
   summary: string;
+
   /** Auth UI component for managing Google OAuth connection */
   authUI: VNode;
+
   /** Handler to trigger email fetch from external patterns */
   bgUpdater: Stream<void>;
+
   /** Whether auth is ready (has valid token) */
   isReady: boolean;
   // /** Search emails by query string (searches subject, from, snippet) */

--- a/packages/patterns/google/core/google-auth-personal.tsx
+++ b/packages/patterns/google/core/google-auth-personal.tsx
@@ -48,6 +48,7 @@ export interface Output {
   [UI]: VNode;
   auth: Writable<Auth>;
   accountType: "personal";
+
   /** Minimal preview for picker display with PERSONAL badge */
   [TILE_UI]: VNode;
 }

--- a/packages/patterns/google/core/google-auth-work.tsx
+++ b/packages/patterns/google/core/google-auth-work.tsx
@@ -48,6 +48,7 @@ export interface Output {
   [UI]: VNode;
   auth: Writable<Auth>;
   accountType: "work";
+
   /** Minimal preview for picker display with WORK badge */
   [TILE_UI]: VNode;
 }

--- a/packages/patterns/google/core/google-auth.tsx
+++ b/packages/patterns/google/core/google-auth.tsx
@@ -271,14 +271,18 @@ export interface Output {
   auth: GoogleAuthCell;
   scopes: string[];
   selectedScopes: SelectedScopes;
+
   /** Compact user display with avatar, name, and email */
   userChip: VNode;
+
   /** Minimal preview for picker display with scope summary */
   [TILE_UI]: VNode;
+
   /**
    * Refresh the OAuth token. Call this from other pieces when the token expires.
    */
   refreshToken: Stream<Record<string, never>>;
+
   /** Background updater for proactive token refresh via background-piece-service */
   bgUpdater: Stream<Record<string, never>>;
 }

--- a/packages/patterns/google/core/google-calendar-importer.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.tsx
@@ -522,8 +522,10 @@ export interface Output {
   [UI]: VNode;
   events: CalendarEvent[];
   calendars: Calendar[];
+
   /** Number of events imported */
   eventCount: number;
+
   /** Summary of container-level events for hierarchical indexing */
   summary: string;
 }

--- a/packages/patterns/google/core/util/agentic-tools.ts
+++ b/packages/patterns/google/core/util/agentic-tools.ts
@@ -101,10 +101,13 @@ export function defineItemSchema<T extends Record<string, PropertyDef>>(
 export interface ListToolConfig<Fields extends string> {
   /** Cell containing the list of items */
   items: any; // Accepts pattern input cells (OpaqueCell, etc.)
+
   /** Fields that make up the dedup key - MUST be valid field names from schema */
   dedupe: Fields[];
+
   /** Prefix for generated IDs (default: "item") */
   idPrefix?: string;
+
   /** Field name for the timestamp - MUST be a valid field name or new field */
   timestamp?: string;
 }

--- a/packages/patterns/google/core/util/calendar-export-types.ts
+++ b/packages/patterns/google/core/util/calendar-export-types.ts
@@ -40,6 +40,7 @@ export type DayOfWeek =
 export interface SemesterDates {
   /** Start date in YYYY-MM-DD format */
   startDate: string;
+
   /** End date in YYYY-MM-DD format */
   endDate: string;
 }
@@ -51,12 +52,16 @@ export interface SemesterDates {
 export interface RecurrenceRule {
   /** Frequency of recurrence */
   frequency: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+
   /** Interval between occurrences (e.g., 2 = every 2 weeks) */
   interval?: number;
+
   /** Days of week for WEEKLY frequency (e.g., "MO", "MO,WE,FR") */
   byDay?: string;
+
   /** End date in YYYY-MM-DD format */
   until?: string;
+
   /** Number of occurrences (alternative to until) */
   count?: number;
 }
@@ -76,12 +81,16 @@ export type ExportTarget = "google" | "apple" | "ics";
 export interface ExportTargetInfo {
   /** Target identifier */
   id: ExportTarget;
+
   /** Display label */
   label: string;
+
   /** Icon (emoji) */
   icon: string;
+
   /** Whether this target is available */
   available: boolean;
+
   /** Reason why unavailable (if applicable) */
   unavailableReason?: string;
 }
@@ -96,8 +105,10 @@ export interface ExportTargetInfo {
 export interface EventTimeSlot {
   /** Day of the week */
   day: DayOfWeek;
+
   /** Start time in HH:MM (24-hour) format */
   startTime: string;
+
   /** End time in HH:MM (24-hour) format */
   endTime: string;
 }
@@ -173,20 +184,28 @@ export interface ExportableEvent {
 export interface CalendarOutboxEvent {
   /** Unique event identifier */
   id: string;
+
   /** Event title */
   title: string;
+
   /** Target calendar name in Apple Calendar */
   calendarName: string;
+
   /** Start date in YYYY-MM-DD format */
   startDate: string;
+
   /** Start time in HH:MM format */
   startTime: string;
+
   /** End time in HH:MM format */
   endTime: string;
+
   /** Event location */
   location?: string;
+
   /** Event notes/description */
   notes?: string;
+
   /** Recurrence rule for repeating events */
   recurrence?: RecurrenceRule;
 }
@@ -198,6 +217,7 @@ export interface CalendarOutboxEvent {
 export interface UserConfirmation {
   /** ISO timestamp when user confirmed */
   timestamp: string;
+
   /** What was displayed in the dialog */
   dialogContent: {
     displayedTitle: string;
@@ -207,6 +227,7 @@ export interface UserConfirmation {
     displayedClasses: string[];
     warningMessage: string;
   };
+
   /** Source pattern information */
   sourcePattern: {
     name: string;
@@ -220,12 +241,16 @@ export interface UserConfirmation {
 export interface ExecutionResult {
   /** Current status */
   status: "pending" | "processing" | "completed" | "failed";
+
   /** When processing started */
   startedAt?: string;
+
   /** When processing completed */
   completedAt?: string;
+
   /** Error message if failed */
   error?: string;
+
   /** IDs of events created in Apple Calendar */
   createdEventIds?: string[];
 }
@@ -236,12 +261,16 @@ export interface ExecutionResult {
 export interface CalendarOutboxEntry {
   /** Unique entry identifier */
   id: string;
+
   /** Events to create */
   events: CalendarOutboxEvent[];
+
   /** User confirmation metadata (audit trail) */
   confirmation: UserConfirmation;
+
   /** Execution status (updated by CLI) */
   execution: ExecutionResult;
+
   /** ISO timestamp when entry was created */
   createdAt: string;
 }
@@ -253,8 +282,10 @@ export interface CalendarOutboxEntry {
 export interface CalendarOutbox {
   /** Outbox entries */
   entries: CalendarOutboxEntry[];
+
   /** ISO timestamp of last update */
   lastUpdated: string;
+
   /** Schema version */
   version: string; // "1.0"
 }
@@ -296,14 +327,19 @@ export interface ExportConfig {
 export interface EventExportResult {
   /** ID of the event */
   eventId: string;
+
   /** Whether export succeeded */
   success: boolean;
+
   /** External ID assigned by target system */
   externalId?: string;
+
   /** Error message if failed */
   error?: string;
+
   /** Whether this was skipped as duplicate */
   skipped?: boolean;
+
   /** Reason for skipping */
   skipReason?: string;
 }
@@ -314,26 +350,37 @@ export interface EventExportResult {
 export interface ExportResult {
   /** Overall success */
   success: boolean;
+
   /** Export target */
   target: ExportTarget;
+
   /** Human-readable message */
   message: string;
+
   /** ISO timestamp when completed */
   timestamp: string;
+
   /** Number of events exported */
   exportedCount: number;
+
   /** Number of events that failed */
   failedCount?: number;
+
   /** Number of duplicates skipped */
   skippedCount?: number;
+
   /** Per-event results (for detailed reporting) */
   eventResults?: EventExportResult[];
+
   /** Whether events were added to outbox (Apple) */
   addedToOutbox?: boolean;
+
   /** Outbox entry ID (Apple) */
   outboxEntryId?: string;
+
   /** ICS content (for download target) */
   icsContent?: string;
+
   /** ICS filename (for download target) */
   icsFilename?: string;
 }
@@ -344,18 +391,25 @@ export interface ExportResult {
 export interface PendingExport {
   /** Export target */
   target: ExportTarget;
+
   /** Events to export */
   events: ExportableEvent[];
+
   /** Export configuration */
   config: ExportConfig;
+
   /** Number of events (excluding duplicates) */
   eventCount: number;
+
   /** Number of duplicates detected */
   duplicateCount: number;
+
   /** Items that will be skipped */
   skippedItems: Array<{ name: string; reason: string }>;
+
   /** Pre-generated ICS content (for Apple fallback) */
   icsContent?: string;
+
   /** Converted outbox events (for Apple) */
   outboxEvents?: CalendarOutboxEvent[];
 }
@@ -370,18 +424,25 @@ export interface PendingExport {
 export interface ExportProgress {
   /** Current phase */
   phase: "preparing" | "exporting" | "completing" | "done" | "error";
+
   /** Total events to export */
   total: number;
+
   /** Events processed so far */
   processed: number;
+
   /** Events successfully exported */
   succeeded: number;
+
   /** Events that failed */
   failed: number;
+
   /** Percentage complete (0-100) */
   percentComplete: number;
+
   /** Current event being processed */
   currentEvent?: string;
+
   /** Error message if phase is "error" */
   error?: string;
 }

--- a/packages/patterns/google/core/util/calendar-write-client.ts
+++ b/packages/patterns/google/core/util/calendar-write-client.ts
@@ -68,22 +68,31 @@ export interface CalendarWriteClientConfig {
 export interface CreateEventParams {
   /** Calendar ID (use "primary" for main calendar) */
   calendarId: string;
+
   /** Event title/summary (required) */
   summary: string;
+
   /** Start time - ISO datetime string or Date object */
   start: string | Date;
+
   /** End time - ISO datetime string or Date object */
   end: string | Date;
+
   /** Event description (optional) */
   description?: string;
+
   /** Location (optional) */
   location?: string;
+
   /** Attendee email addresses (optional) */
   attendees?: string[];
+
   /** Whether to send email updates to attendees */
   sendUpdates?: "all" | "externalOnly" | "none";
+
   /** For all-day events, use date instead of dateTime */
   isAllDay?: boolean;
+
   /**
    * Recurrence rules in RFC 5545 RRULE format.
    * Example: ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20240531T235959Z"]
@@ -94,16 +103,22 @@ export interface CreateEventParams {
 export interface UpdateEventParams {
   /** Event title/summary */
   summary?: string;
+
   /** Start time - ISO datetime string or Date object */
   start?: string | Date;
+
   /** End time - ISO datetime string or Date object */
   end?: string | Date;
+
   /** Event description */
   description?: string;
+
   /** Location */
   location?: string;
+
   /** Attendee email addresses (replaces existing) */
   attendees?: string[];
+
   /** For all-day events */
   isAllDay?: boolean;
 }
@@ -120,14 +135,19 @@ export type RSVPStatus = "accepted" | "declined" | "tentative";
 export interface BatchProgress {
   /** Total events to process */
   total: number;
+
   /** Events processed so far */
   processed: number;
+
   /** Events successfully created */
   succeeded: number;
+
   /** Events that failed */
   failed: number;
+
   /** Percentage complete (0-100) */
   percentComplete: number;
+
   /** Current event being processed */
   currentEvent?: string;
 }
@@ -138,10 +158,13 @@ export interface BatchProgress {
 export interface BatchEventResult {
   /** Client-provided event ID (for correlation) */
   clientId: string;
+
   /** Whether the event was created successfully */
   success: boolean;
+
   /** The created event (if successful) */
   event?: CalendarEventResult;
+
   /** Error message (if failed) */
   error?: string;
 }
@@ -152,33 +175,46 @@ export interface BatchEventResult {
 export interface BatchCreateEventsParams {
   /** Calendar ID (use "primary" for main calendar) */
   calendarId: string;
+
   /** Events to create */
   events: Array<{
     /** Client-provided ID for correlation in results */
     clientId: string;
+
     /** Event title/summary */
     summary: string;
+
     /** Start time - ISO datetime string or Date object */
     start: string | Date;
+
     /** End time - ISO datetime string or Date object */
     end: string | Date;
+
     /** Event description */
     description?: string;
+
     /** Location */
     location?: string;
+
     /** Attendee email addresses */
     attendees?: string[];
+
     /** For all-day events */
     isAllDay?: boolean;
+
     /** Recurrence rules in RFC 5545 RRULE format */
     recurrence?: string[];
   }>;
+
   /** Whether to send email updates to attendees */
   sendUpdates?: "all" | "externalOnly" | "none";
+
   /** Batch size (default: 10, max: 50) */
   batchSize?: number;
+
   /** Delay between batches in ms (default: 100) */
   batchDelayMs?: number;
+
   /** Progress callback */
   onProgress?: (progress: BatchProgress) => void;
 }
@@ -189,10 +225,13 @@ export interface BatchCreateEventsParams {
 export interface BatchCreateEventsResult {
   /** Total events processed */
   total: number;
+
   /** Number of events successfully created */
   succeeded: number;
+
   /** Number of events that failed */
   failed: number;
+
   /** Per-event results */
   results: BatchEventResult[];
 }
@@ -200,28 +239,36 @@ export interface BatchCreateEventsResult {
 export interface CalendarEventResult {
   /** Event ID */
   id: string;
+
   /** Event status */
   status: string;
+
   /** HTML link to the event */
   htmlLink: string;
+
   /** Event summary/title */
   summary?: string;
+
   /** Event description */
   description?: string;
+
   /** Event location */
   location?: string;
+
   /** Start time */
   start?: {
     dateTime?: string;
     date?: string;
     timeZone?: string;
   };
+
   /** End time */
   end?: {
     dateTime?: string;
     date?: string;
     timeZone?: string;
   };
+
   /** Attendees */
   attendees?: Array<{
     email: string;

--- a/packages/patterns/google/core/util/gmail-client.ts
+++ b/packages/patterns/google/core/util/gmail-client.ts
@@ -28,8 +28,10 @@ import type { Auth } from "../gmail-importer.tsx";
 export interface GmailClientConfig {
   /** How many times the client will retry after an HTTP failure */
   retries?: number;
+
   /** Enable verbose console logging */
   debugMode?: boolean;
+
   /**
    * External refresh callback for cross-piece token refresh.
    * Use this when the auth cell belongs to a different piece - direct cell updates

--- a/packages/patterns/google/core/util/gmail-send-client.ts
+++ b/packages/patterns/google/core/util/gmail-send-client.ts
@@ -120,16 +120,22 @@ export interface GmailSendClientConfig {
 export interface SendEmailParams {
   /** Recipient email address (required) */
   to: string;
+
   /** Email subject line (required) */
   subject: string;
+
   /** Plain text body (required) */
   body: string;
+
   /** CC recipients (optional, comma-separated) */
   cc?: string;
+
   /** BCC recipients (optional, comma-separated) */
   bcc?: string;
+
   /** Message ID to reply to (for threading) */
   replyToMessageId?: string;
+
   /** Thread ID to reply to (for threading) */
   replyToThreadId?: string;
 }
@@ -137,8 +143,10 @@ export interface SendEmailParams {
 export interface SendEmailResult {
   /** Gmail message ID */
   id: string;
+
   /** Gmail thread ID */
   threadId: string;
+
   /** Labels applied to the message */
   labelIds: string[];
 }
@@ -146,6 +154,7 @@ export interface SendEmailResult {
 export interface ModifyLabelsParams {
   /** Label IDs to add (max 100 per request) */
   addLabelIds?: string[];
+
   /** Label IDs to remove (max 100 per request) */
   removeLabelIds?: string[];
 }
@@ -153,8 +162,10 @@ export interface ModifyLabelsParams {
 export interface ModifyLabelsResult {
   /** Gmail message ID */
   id: string;
+
   /** Gmail thread ID */
   threadId: string;
+
   /** Labels now on the message */
   labelIds: string[];
 }
@@ -162,12 +173,16 @@ export interface ModifyLabelsResult {
 export interface GmailLabel {
   /** Label ID (use this for API calls) */
   id: string;
+
   /** Label name (human readable) */
   name: string;
+
   /** Label type: system, user */
   type: "system" | "user";
+
   /** Message list visibility */
   messageListVisibility?: "show" | "hide";
+
   /** Label list visibility */
   labelListVisibility?: "labelShow" | "labelShowIfUnread" | "labelHide";
 }

--- a/packages/patterns/google/core/util/google-docs-client.ts
+++ b/packages/patterns/google/core/util/google-docs-client.ts
@@ -37,8 +37,10 @@ export type { GoogleComment, GoogleDocsDocument };
 export interface GoogleDocsClientConfig {
   /** How many times to refresh an expired token and retry before giving up. */
   retries?: number;
+
   /** Enable verbose console logging */
   debugMode?: boolean;
+
   /**
    * External refresh callback for cross-piece token refresh.
    * Use this when the auth cell belongs to a different piece - direct cell updates

--- a/packages/patterns/google/core/util/google-docs-markdown.ts
+++ b/packages/patterns/google/core/util/google-docs-markdown.ts
@@ -446,8 +446,10 @@ function getListMarker(
 export interface ConversionOptions {
   /** Include comments as blockquotes (default: true) */
   includeComments?: boolean;
+
   /** Download and embed images as base64 (default: true) */
   embedImages?: boolean;
+
   /** OAuth token for image downloads */
   token?: string;
 }

--- a/packages/patterns/google/extractors/email-pattern-launcher.tsx
+++ b/packages/patterns/google/extractors/email-pattern-launcher.tsx
@@ -54,6 +54,7 @@ import UnitedFlightTrackerPattern from "./united-flight-tracker.tsx";
 interface RegistryEntry {
   /** Path to the pattern file (relative to /api/patterns/) */
   patternUri: string;
+
   /** Glob-style email patterns (e.g., "*@usps.com") */
   emailPatterns: string[];
 }
@@ -62,8 +63,10 @@ interface RegistryEntry {
 interface PatternMatchInfo {
   /** Path to the pattern file */
   patternUri: string;
+
   /** The full registry entry */
   entry: RegistryEntry;
+
   /** Email addresses that triggered this pattern */
   matchedEmails: string[];
 }

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -134,6 +134,7 @@ interface TrackedThread {
   settings: ThreadSettings;
   isDue: boolean;
   shouldGiveUp: boolean;
+
   /** Most recent message ID (for threading replies) */
   lastMessageId: string;
 }

--- a/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
@@ -104,6 +104,7 @@ type MembershipRecord = InferItem<typeof MembershipSchema> & {
 /** One hotel brand the scan found more than one membership number for. */
 interface MultiAccountBrand {
   brand: string;
+
   /** One entry per distinct membership number, with the tier it was found at. */
   accounts: { membershipNumber: string; tier?: string }[];
 }

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -53,8 +53,10 @@ export interface User {
    */
   name: string;
   joinedAt: number;
+
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
+
   /**
    * Link to the joiner's profile cell — the stable identity key (optional so
    * rosters written before the profile migration still load).

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1054,6 +1054,7 @@ type ClickAim =
  */
 type ClickLanding = {
   verdict: "pending" | "hit" | "missed";
+
   /** The innermost few elements the interaction did reach, outward. */
   path: string;
 };
@@ -1110,6 +1111,7 @@ const aimAtMarkedTarget = async (
 
   type Landing = {
     verdict: "pending" | "hit" | "missed";
+
     /** Whether the interaction's first event carried the mark. */
     onTarget: boolean | undefined;
     path: string;
@@ -1940,43 +1942,55 @@ export interface TimingStatRow {
 export interface ChurnCounters {
   /** Total computation/effect runs (`scheduler/run/action`). */
   actionRuns: number;
+
   /** Commit conflicts — stale-seq-basis rejections (`storage.v2/commit-conflict`). */
   commitConflicts: number;
+
   /** Reverts emitted after a rejected commit (`storage.v2/commit-revert`). */
   commitReverts: number;
+
   /** Non-conflict commit rejections (`storage.v2/commit-rejected`). */
   commitRejected: number;
+
   /** Reactive-action commit errors that triggered a retry (`scheduler/schedule-run-error`). */
   scheduleRunErrors: number;
+
   /** Event handlers that lost the receipt race permanently (`scheduler/event-lost-race`). */
   eventLostRaces: number;
+
   /** Server-execution v2 stage C tuning T2 (flag-ON clients only, else 0):
    * event-handler echoes dropped at seal because their intent was already
    * terminal (`speculation-overlay/late-echo-dropped`) — the late-echo
    * class the two-browsers lockdown stall belonged to. */
   overlayLateEchoDrops: number;
+
   /** Stage C tuning T2: overlay sweeps the replica's arrival wake ran
    * (`speculation-overlay/arrival-sweep`) — served values arriving
    * decoupled from a watermark advance. */
   overlayArrivalSweeps: number;
+
   /** Stage C design (e): intent checks the overlay's storage-notification
    * listener ran (`speculation-overlay/intent-check`) — one per fire plus
    * one per coalesced sidecar change while intents are outstanding; never
    * a scheduler run. */
   overlayIntentChecks: number;
+
   /** Stage C design (e): intents resolved by their tracked entry's own
    * consequence mark (`speculation-overlay/intent-retired-by-consequence-of`)
    * — the sanctioned `consequenceOf` carrier. */
   overlayIntentsByConsequenceOf: number;
+
   /** Stage C design (e): intent-origin echoes retired by the watermark
    * BACKSTOP instead (`speculation-overlay/intent-echo-retired-by-backstop`). */
   overlayIntentEchoBackstops: number;
+
   /** Stage C W2.1: client CASCADE-child echoes retired because an ancestor
    * intent's terminal consequence arrived (`speculation-overlay/
    * cascade-echo-retired`) — the W0 l3 "duplicate join" class: the join is
    * the click handler's cascade child, its echo carries a client-minted id
    * no mark ever names and writes an entity doc the server never writes. */
   overlayCascadeEchoRetired: number;
+
   /** Stage C W2.1: the subset retired on a consequenced parent's mark
    * while NO doc the echo wrote held a confirmed value at or after the
    * MARK frame's seq (`speculation-overlay/cascade-echo-retired-
@@ -1999,18 +2013,21 @@ export interface ChurnCounters {
 
 export interface BrowserLoadSummary {
   label: string;
+
   /**
    * Main-thread `runtime-client` IPC round-trip timing. p95/max here ballooning
    * (and approaching the 60s request timeout) is the multi-browser-slowness
    * signal: the main thread is waiting on a saturated worker.
    */
   ipc: TimingStatRow[];
+
   /**
    * Requests still in flight on the main thread when the summary was taken
    * ({ type, ageMs }). The completed-timing rows above cannot show a request
    * that never came back; this names it.
    */
   pendingIpc: Array<{ type: string; ageMs: number }>;
+
   /**
    * Worker-side request ledger (`runtime-worker.ipc` counts): how many
    * requests of each type the worker received and answered. A main-side
@@ -2019,10 +2036,13 @@ export interface BrowserLoadSummary {
    * in both means the response was lost in transit.
    */
   workerIpc: Record<string, number>;
+
   /** Worker-side scheduler/runner/storage timing — where the work happens. */
   worker: TimingStatRow[];
+
   /** Conflict / re-run counters — see {@link ChurnCounters}. */
   churn: ChurnCounters;
+
   /**
    * Send/settle timeline of the first IPC requests (the boot window), offsets
    * in ms from the runtime connection's construction. The aggregate rows say a
@@ -2271,12 +2291,16 @@ export async function collectBrowserLoadSummary(
 export type SenderEchoSample = {
   label: string;
   text: string;
+
   /** performance.now() of the last trusted click seen while armed. */
   clickMs: number;
+
   /** performance.now() when the armed text was first observed in the DOM. */
   renderMs: number;
+
   /** renderMs − clickMs: the sender-side speculative echo latency. */
   echoMs: number;
+
   /** Trusted clicks observed while armed (a re-aimed click re-stamps). */
   clicks: number;
 };
@@ -2793,10 +2817,13 @@ type CfInputProbe = {
   readOnly: boolean;
   visible: boolean;
   hostTagName: string;
+
   /** Whether the host custom element's definition was registered/upgraded. */
   hostUpgraded?: boolean;
+
   /** Whether the host exposes `commit()` (a cell-committing form field). */
   hostHasCommit?: boolean;
+
   /**
    * The host's `value` property: `{ kind: "cell", id, space, path }` for a
    * bound cell handle, otherwise `{ kind: typeof value }`. A fill that stalls
@@ -2804,14 +2831,19 @@ type CfInputProbe = {
    * bound cell it points at the cell:set round-trip.
    */
   hostValueBinding?: unknown;
+
   /** Progress ledger left by fillAndVerify for this selector (see there). */
   fill?: unknown;
+
   /** In-flight runtime IPC requests at probe time ({ type, ageMs }). */
   pendingIpc?: unknown;
+
   /** Completed runtime IPC round-trips at probe time ({ count, maxMs }). */
   completedIpc?: unknown;
+
   /** Cell subscription totals (active instances, backend subscribes). */
   subscriptionTotals?: unknown;
+
   /** Bounded tail of the page's console messages (see Page wrapper). */
   consoleTail?: unknown;
 };

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -59,11 +59,13 @@ export type { RuntimeDiagnosticsSnapshot };
 export interface MultiRuntimeSessionSpec {
   /** Label used in error messages and as the identity passphrase seed. */
   label: string;
+
   /**
    * Identity for this session. Pass the same Identity in two specs to model
    * one user with two concurrent sessions (e.g. two browser tabs).
    */
   identity?: Identity;
+
   /**
    * Test-only network shaping: delay every storage WebSocket frame (both
    * directions) in this session's realm by this many milliseconds. Reproduces
@@ -76,8 +78,10 @@ export interface MultiRuntimeSessionSpec {
 export interface MultiRuntimeHarnessOptions {
   /** Path to the pattern entry file (e.g. `<dir>/main.tsx`). */
   programPath: string;
+
   /** Module-resolution root, usually the `packages/patterns` directory. */
   rootPath: string;
+
   /**
    * Data files to store with the pattern, as paths on disk. A file the pattern
    * reads with `dataFile()` is attached from that call alone and needs no
@@ -86,12 +90,15 @@ export interface MultiRuntimeHarnessOptions {
    * request rather than being attached here.
    */
   dataFilePaths?: readonly string[];
+
   /** Optional initial pattern input for the bootstrap-created piece. */
   input?: Record<string, FabricValue>;
+
   /** Enable scheduler graph/stats/action diagnostics for this harness run. */
   diagnostics?: boolean;
   sessions: (string | MultiRuntimeSessionSpec)[];
   spaceName?: string;
+
   /**
    * When set, sessions talk to a running toolshed at this URL instead of the
    * self-hosted in-process storage server.
@@ -101,6 +108,7 @@ export interface MultiRuntimeHarnessOptions {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const RPC_TIMEOUT_MS = 120_000;
+
 /** Total event-consequence quiescence budget per `settle()` call on a
  * toolshed-backed harness (see `settle`): generous against the measured
  * ~2–3 s serving drain of a 40-event pipelined storm, small against the

--- a/packages/patterns/integration/multi-runtime-ipc.ts
+++ b/packages/patterns/integration/multi-runtime-ipc.ts
@@ -38,6 +38,7 @@ export type WorkerResponse =
 export type TrustedUiDescriptor = {
   /** `data-ui-pattern` / `data-ui-event-integrity` of the trusted surface. */
   surface: string;
+
   /** `data-ui-action` of the control inside the surface. */
   action: string;
 };

--- a/packages/patterns/integration/sx2-events.test.ts
+++ b/packages/patterns/integration/sx2-events.test.ts
@@ -53,6 +53,7 @@ const FLAG_ON = Deno.env.get("EXPERIMENTAL_SERVER_EXECUTION") === undefined
 
 type EventStats = {
   derivedCommits: number;
+
   /** Per-space attribution (#6158): lets the logged ratio name THIS
    * test's space instead of the host-global total. */
   derivedCommitsBySpace?: Record<string, number>;
@@ -75,6 +76,7 @@ describe("sx2 events (Phase 3 gates)", () => {
   let piece: PieceController;
   let sinkCancel: (() => void) | undefined;
   let latestValue: number | undefined;
+
   /** Sink-driven value waits (round-2 thread T9): the sink callback IS
    * the delivery channel, so value conditions resolve from it directly
    * — no polling loop, and a paused/slow worker only delays the

--- a/packages/patterns/integration/sx2-serving-loop.test.ts
+++ b/packages/patterns/integration/sx2-serving-loop.test.ts
@@ -60,6 +60,7 @@ type ServingLoopStats = {
   effectAcks: number;
   derivedCommits: number;
   structureLoadFailures: number;
+
   /** S1 (RULED 2026-08-19): drain-settle quiescence advances — the
    * advance-only waves the budgets below subtract. */
   settleAdvances: { count: number };

--- a/packages/patterns/integration/topic-board-fixture.ts
+++ b/packages/patterns/integration/topic-board-fixture.ts
@@ -33,8 +33,10 @@ export interface SeededTopic {
 export interface TopicBoardFixture {
   /** The space the board lives in. */
   spaceName: string;
+
   /** The board piece, for the shell's `/spaceName/pieceId` route. */
   boardId: string;
+
   /** Seeded topics in creation order. */
   topics: SeededTopic[];
 }
@@ -43,20 +45,25 @@ export interface SeedTopicBoardOptions {
   apiUrl: URL;
   spaceName: string;
   identity: Identity;
+
   /** How many topics the board carries. */
   topicCount: number;
+
   /**
    * How many earlier topics a citing body cites. Every citation is an edge the
    * board's crossref join has to find, and a link its cards render.
    */
   crossrefsPerTopic?: number;
+
   /**
    * How many of the topics cite anything, counted back from the newest. See
    * {@link DEFAULT_CITING_TOPICS} for why this is not every topic.
    */
   citingTopics?: number;
+
   /** Words of prose in each topic body. */
   bodyWords?: number;
+
   /** Called after each topic lands, with its index. */
   onTopic?: (index: number) => void;
 }
@@ -279,12 +286,14 @@ export async function seedTopicBoard(
 export interface SeedTopicBoardOutOfProcessOptions {
   apiUrl: URL;
   spaceName: string;
+
   /** Passphrase the child derives the seeding identity from. */
   passphrase: string;
   topicCount: number;
   crossrefsPerTopic?: number;
   citingTopics?: number;
   bodyWords?: number;
+
   /** Heap ceiling for the child, in megabytes. */
   heapMegabytes?: number;
 }

--- a/packages/patterns/integration/topic-board-seed.ts
+++ b/packages/patterns/integration/topic-board-seed.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S deno run -A
+
 /**
  * Seeds one synthetic topic board and writes the fixture describing it.
  *

--- a/packages/patterns/integration/topic-board-session.ts
+++ b/packages/patterns/integration/topic-board-session.ts
@@ -23,6 +23,7 @@ import { type TopicBoardFixture, topicTitle } from "./topic-board-fixture.ts";
 
 export interface BoardSessionTarget {
   fixture: TopicBoardFixture;
+
   /** The identity the board was seeded under, and is read back with. */
   identity: Identity;
 }

--- a/packages/patterns/link.tsx
+++ b/packages/patterns/link.tsx
@@ -24,8 +24,10 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface LinkModuleInput {
   /** URL */
   url: string | Default<"">;
+
   /** Link title */
   linkTitle: string | Default<"">;
+
   /** Description */
   description: string | Default<"">;
 }

--- a/packages/patterns/location-track.tsx
+++ b/packages/patterns/location-track.tsx
@@ -34,20 +34,28 @@ import type { ModuleMetadata } from "./container-protocol.ts";
 export interface LocationPoint {
   /** Unique ID for this point */
   id: string;
+
   /** Latitude in decimal degrees */
   latitude: number;
+
   /** Longitude in decimal degrees */
   longitude: number;
+
   /** Accuracy in meters */
   accuracy: number;
+
   /** Altitude in meters (if available) */
   altitude?: number;
+
   /** Altitude accuracy in meters (if available) */
   altitudeAccuracy?: number;
+
   /** Heading in degrees 0-360 (if available) */
   heading?: number;
+
   /** Speed in m/s (if available) */
   speed?: number;
+
   /** Unix timestamp in milliseconds */
   timestamp: number;
 }
@@ -82,6 +90,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface LocationTrackModuleInput {
   /** Array of captured location points */
   locations: LocationPoint[] | Default<[]>;
+
   /** Optional label for this track (e.g., "Morning run", "Commute") */
   label: string | Default<"">;
 }

--- a/packages/patterns/location.tsx
+++ b/packages/patterns/location.tsx
@@ -24,8 +24,10 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface LocationModuleInput {
   /** Location name (e.g., venue, landmark) */
   locationName: string | Default<"">;
+
   /** Full address */
   locationAddress: string | Default<"">;
+
   /** Coordinates in lat,lng format */
   coordinates: string | Default<"">;
 }

--- a/packages/patterns/phone.tsx
+++ b/packages/patterns/phone.tsx
@@ -34,6 +34,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface PhoneModuleInput {
   /** Label for this phone (Mobile, Home, Work, etc.) */
   label: string | Default<"Mobile">;
+
   /** Phone number (preserve original formatting) */
   number: string | Default<"">;
 }

--- a/packages/patterns/photo.tsx
+++ b/packages/patterns/photo.tsx
@@ -38,6 +38,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface PhotoModuleInput {
   /** The uploaded image data (null if no image) */
   image: ImageData | null | Default<null>;
+
   /** User-defined label for the photo */
   label: string | Default<"">;
 }

--- a/packages/patterns/profile-roster-live-demo.tsx
+++ b/packages/patterns/profile-roster-live-demo.tsx
@@ -40,6 +40,7 @@ export type ParticipantProfileCell = Cell<
 export interface Participant {
   /** Live link to the contributor's profile cell — stable identity + live data. */
   profile: ParticipantProfileCell;
+
   /** Display name, snapshotted at join time (durable label; survives even if the live cell is momentarily unresolved on first render). */
   name: string;
   joinedAt: number;

--- a/packages/patterns/record-icon.tsx
+++ b/packages/patterns/record-icon.tsx
@@ -35,6 +35,7 @@ export interface RecordIconModuleInput {
 export interface RecordIconModuleOutput {
   /** The palette emoji, then the chosen icon, or `(auto)` when none is set. */
   [NAME]: string;
+
   /** Custom emoji/icon */
   icon: string;
 }

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -56,16 +56,20 @@ export interface RecordOutput {
   title?: string | Default<"">;
   subPieces?: SubPieceEntry[] | Default<[]>;
   trashedSubPieces?: TrashedSubPieceEntry[] | Default<[]>;
+
   /** Self-reference for sub-pieces to access their parent Record */
   parentRecord?: RecordOutput | null;
+
   /** Adds a module of the named type to this record's sub-pieces. */
   addModule?: Stream<{
     type: string;
     initialData?: { label?: string; [key: string]: unknown };
     result?: Writable<unknown>;
   }>;
+
   /** Writes a structured summary of every module into the result cell. */
   getSummary?: Stream<{ result?: Writable<unknown> }>;
+
   /** Sets a directly-settable field on the module at the given index. The
    * value is written into that field, so it is declared as the scalars a
    * module field holds rather than as `unknown`, which declares a reference. */
@@ -75,10 +79,13 @@ export interface RecordOutput {
     value: string | number | boolean | null;
     result?: Writable<unknown>;
   }>;
+
   /** Moves the module at the given index to the trash. */
   removeModule?: Stream<{ index: number; result?: Writable<unknown> }>;
+
   /** Sets this record's title. */
   setTitle?: Stream<{ newTitle: string; result?: Writable<unknown> }>;
+
   /** Writes the list of addable module types into the result cell. */
   listModuleTypes?: Stream<{ result?: Writable<unknown> }>;
 }
@@ -153,10 +160,13 @@ const seedRecord = lift<{
 interface SubPieceDisplayFields {
   /** The module type, carried through so a reader can pick modules by it. */
   type: string;
+
   /** Instance label, e.g. the email module's "Personal" or "Work". */
   label?: string;
+
   /** Icon chosen in a record-icon module. */
   icon?: string;
+
   /** Alias held by a nickname module. */
   nickname?: string;
 }

--- a/packages/patterns/relationship.tsx
+++ b/packages/patterns/relationship.tsx
@@ -45,10 +45,13 @@ type ClosenessLevel = "intimate" | "close" | "casual" | "distant";
 export interface RelationshipModuleInput {
   /** Relationship types (e.g., friend, family, colleague) */
   relationTypes: string[] | Default<[]>;
+
   /** Closeness level */
   closeness: ClosenessLevel | "" | Default<"">;
+
   /** How we met */
   howWeMet: string | Default<"">;
+
   /** Inner circle member */
   innerCircle: boolean | Default<false>;
 }

--- a/packages/patterns/social.tsx
+++ b/packages/patterns/social.tsx
@@ -51,8 +51,10 @@ type SocialPlatform =
 export interface SocialModuleInput {
   /** Social platform (normalize: Insta→instagram, X→twitter) */
   platform: SocialPlatform | "" | Default<"">;
+
   /** Username/handle without @ prefix */
   handle: string | Default<"">;
+
   /** Profile URL */
   profileUrl: string | Default<"">;
 }

--- a/packages/patterns/text-import.tsx
+++ b/packages/patterns/text-import.tsx
@@ -37,6 +37,7 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface TextImportModuleInput {
   /** The text content from the uploaded file */
   content: string | Default<"">;
+
   /** The original filename */
   filename: string | Default<"">;
 }

--- a/packages/patterns/timeline.tsx
+++ b/packages/patterns/timeline.tsx
@@ -32,8 +32,10 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface TimelineModuleInput {
   /** Start date (ISO format YYYY-MM-DD) */
   startDate: string | Default<"">;
+
   /** Target completion date (ISO format YYYY-MM-DD) */
   targetDate: string | Default<"">;
+
   /** Actual completion date (ISO format YYYY-MM-DD) */
   completedDate: string | Default<"">;
 }

--- a/packages/patterns/timing.tsx
+++ b/packages/patterns/timing.tsx
@@ -24,8 +24,10 @@ export const MODULE_METADATA: ModuleMetadata = {
 export interface TimingModuleInput {
   /** Prep time in minutes */
   prepTime: number | null | Default<null>;
+
   /** Cook time in minutes */
   cookTime: number | null | Default<null>;
+
   /** Rest time in minutes */
   restTime: number | null | Default<null>;
 }


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 300 doc comments across 49 files had no blank line above them; each
gets one.

Covered: `packages/patterns/google`, `packages/patterns/integration`, and the
package's top-level pattern files. The remaining subdirectories follow in their
own PR.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## The pattern guards

Pattern source is compiled and content-addressed, and the automatic updater
performs no structural check before swapping a pattern onto a running piece, so
a whitespace sweep here is not a prose-only sweep. The guards that would catch a
moved contract were run and are green:

- `deno task cfcheck` — the authoritative pattern type-check
- `deno task pattern-compat`, all three `PATTERN_COMPAT_SHARD` shards
- `deno task pattern-vintage`
- `deno task check-baselines-append-only`

That is the substantive result: a blank line above a doc comment does not reach
`argumentSchema` or `resultSchema`. What a doc comment *says* becomes a schema
`description`; the space above it does not.

## Gates

`deno fmt --check`, `deno lint`, `deno task check`, `packages/patterns`' own
test task, and `packages/static`'s three generated-asset checks also pass.
GitHub Actions is in an outage as this is opened, so these are local runs rather
than CI.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

