### PR TITLE
docs(patterns): blank lines above doc comments in the remaining subdirectories

### DIFF
--- a/packages/patterns/agent/schemas.tsx
+++ b/packages/patterns/agent/schemas.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Shared types for the Agent pattern.
  *

--- a/packages/patterns/airtable/core/airtable-auth.tsx
+++ b/packages/patterns/airtable/core/airtable-auth.tsx
@@ -207,12 +207,16 @@ export interface Output {
   auth: Writable<AirtableAuth>;
   scopes: string[];
   selectedScopes: SelectedScopes;
+
   /** Compact user display */
   userChip: VNode;
+
   /** Minimal preview for picker display */
   [TILE_UI]: VNode;
+
   /** Refresh the OAuth token from other pieces */
   refreshToken: Stream<Record<string, never>>;
+
   /** Background updater for proactive token refresh */
   bgUpdater: Stream<Record<string, never>>;
 }

--- a/packages/patterns/airtable/core/util/airtable-client.ts
+++ b/packages/patterns/airtable/core/util/airtable-client.ts
@@ -23,6 +23,7 @@ export interface AirtableClientConfig {
   /** How many times to refresh an expired token and retry before giving up. */
   retries?: number;
   debugMode?: boolean;
+
   /** External refresh callback for cross-piece token refresh */
   onRefresh?: () => Promise<void>;
 }

--- a/packages/patterns/auth/auth-manager-descriptor.ts
+++ b/packages/patterns/auth/auth-manager-descriptor.ts
@@ -9,16 +9,22 @@ import type { AuthState } from "./auth-types.ts";
 export interface AuthManagerDescriptor {
   /** Internal name, e.g. "google", "airtable" */
   name: string;
+
   /** Display name, e.g. "Google", "Airtable" */
   displayName: string;
+
   /** Brand color hex, e.g. "#4285f4", "#18BFFF" */
   brandColor: string;
+
   /** Primary wish tag, e.g. "#googleAuth", "#airtableAuth" */
   wishTag: string;
+
   /** Variant wish tags for multi-account support, e.g. { personal: "#googleAuthPersonal" } */
   variantWishTags?: Record<string, string>;
+
   /** Token field name on the auth object */
   tokenField: "token" | "accessToken";
+
   /**
    * Unified scope registry. Each key is a short scope identifier (e.g. "gmail",
    * "data.records:read"). `description` is the human-readable label shown in UI.
@@ -26,6 +32,7 @@ export interface AuthManagerDescriptor {
    * Airtable this equals the key, for Google it's the full URL.
    */
   scopes: Record<string, { description: string; scopeString: string }>;
+
   /** Whether the provider supports user avatar images (Google: true, Airtable: false) */
   hasAvatarSupport: boolean;
 }

--- a/packages/patterns/base/contact-types.tsx
+++ b/packages/patterns/base/contact-types.tsx
@@ -18,6 +18,7 @@ import { type Default, NAME, UI, type VNode } from "commonfabric";
 export interface PersonLike {
   firstName: string;
   lastName: string;
+
   /** Optional link to same entity in another context (e.g., work vs personal) */
   sameAs?: PersonLike;
 }

--- a/packages/patterns/battleship/multiplayer/multi-user.test.tsx
+++ b/packages/patterns/battleship/multiplayer/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for the battleship multiplayer lobby.
  *

--- a/packages/patterns/battleship/multiplayer/repro-minimal.tsx
+++ b/packages/patterns/battleship/multiplayer/repro-minimal.tsx
@@ -83,6 +83,7 @@ interface Container {
 interface ChildInput {
   /** Cell set by THIS session - works correctly */
   myData: Writable<Container | null>;
+
   /** Cell set by OTHER session - BUG: nested array elements are undefined */
   otherData: Writable<Container | null>;
   whichPlayer: 1 | 2;

--- a/packages/patterns/battleship/multiplayer/schemas.tsx
+++ b/packages/patterns/battleship/multiplayer/schemas.tsx
@@ -61,6 +61,7 @@ import { createEmptyGrid } from "../shared/index.tsx";
 
 export interface PlayerData {
   name: string;
+
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
   ships: Ship[];
@@ -163,6 +164,7 @@ export interface RoomOutput {
   [UI]: PerSession<VNode>;
   myName: string;
   myPlayerNumber: 1 | 2 | null;
+
   /** Fire a shot at the enemy board - exported for testing */
   fireShot: Stream<{ row: number; col: number }>;
 }

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for the CFC group chat demo.
  *

--- a/packages/patterns/cozy-poll/main.tsx
+++ b/packages/patterns/cozy-poll/main.tsx
@@ -37,6 +37,7 @@ import {
 
 export interface User {
   name: string;
+
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
   color: string;

--- a/packages/patterns/cozy-poll/multi-user.test.tsx
+++ b/packages/patterns/cozy-poll/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for cozy poll.
  *

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -56,8 +56,10 @@ export interface DoListOutput {
     }>
   >;
   // LLM-friendly handlers (use title matching)
+
   /** Remove a task and its subtasks by title */
   removeItemByTitle: Reactive<Stream<{ title: string }>>;
+
   /** Update a task by title. Set done to mark complete, newTitle to rename, attachments to add references. */
   updateItemByTitle: Reactive<
     Stream<{

--- a/packages/patterns/examples/clock.tsx
+++ b/packages/patterns/examples/clock.tsx
@@ -48,8 +48,10 @@ function formatDate(ms: number): string {
 export interface ClockOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** "HH:MM:SS" once #now resolves, "--:--:--" during the load window. */
   time: string;
+
   /** "Wed 9 Jul 2026" once #now resolves, "" during the load window. */
   date: string;
 }

--- a/packages/patterns/examples/phonetic-speller.tsx
+++ b/packages/patterns/examples/phonetic-speller.tsx
@@ -54,8 +54,10 @@ interface PhoneticSpellerInput {
 export interface PhoneticSpellerOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** `text` spelled out, one code word per letter it recognizes. */
   spelled: string;
+
   /** Every code word the file holds, in the order the file stores them. */
   codeWords: string[];
 }

--- a/packages/patterns/examples/reactive-now.tsx
+++ b/packages/patterns/examples/reactive-now.tsx
@@ -70,24 +70,34 @@ const setTyped = handler<{ value: string }, { typed: Writable<string> }>(
 export interface ReactiveNowOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** The piece's first-load time, "HH:MM:SS" (or "…" before #now resolves). */
   loadedAt: string;
+
   /** The ticking current time, "HH:MM:SS" (or "…"). */
   now: string;
+
   /** Whole seconds since load, e.g. "12s ago" (or "…"). */
   sinceLoad: string;
+
   /** How many times the tap handler has actually been delivered. */
   taps: number;
+
   /** Coarse time the last tap was delivered ("—" before the first). */
   lastTapAt: string;
+
   /** The tap event stream (also driven by the button). */
   tap: Stream<Record<string, never>>;
+
   /** The current text of the bound `$value` box. */
   typed: string;
+
   /** Length of `typed`, derived — updates as the keystroke write propagates. */
   charCount: number;
+
   /** `typed` upper-cased, derived — a second observer of the same cell flip. */
   echo: string;
+
   /** Test-only stream to set the text box (the browser uses the `$value` bind). */
   type: Stream<{ value: string }>;
 }

--- a/packages/patterns/experimental/chat-note.tsx
+++ b/packages/patterns/experimental/chat-note.tsx
@@ -43,10 +43,13 @@ type Input = {
   content?: Writable<string | Default<"">>;
   isHidden?: boolean | Default<false>;
   noteId?: string | Default<"">;
+
   /** Pattern JSON for [[wiki-links]]. Defaults to creating new ChatNotes. */
   linkPattern?: Writable<string | Default<"">>;
+
   /** Parent notebook reference (passed via SELF from notebook.tsx) */
   parentNotebook?: any;
+
   /** Selected model for generation. Defaults to Sonnet 4.5 */
   model?: Writable<string | Default<"anthropic:claude-sonnet-4-5">>;
 };

--- a/packages/patterns/experimental/folksonomy-demo.tsx
+++ b/packages/patterns/experimental/folksonomy-demo.tsx
@@ -34,10 +34,13 @@ import { FolksonomyTags } from "./folksonomy-tags.tsx";
 interface Input {
   /** Tags for item A (scope: demo-shared) */
   itemATags: string[] | Default<[]>;
+
   /** Tags for item B (scope: demo-shared - same as A) */
   itemBTags: string[] | Default<[]>;
+
   /** Tags for item C (scope: demo-isolated - different scope) */
   itemCTags: string[] | Default<[]>;
+
   /** Custom scope name */
   customScope: string | Default<"demo-shared">;
 }

--- a/packages/patterns/experimental/folksonomy-tags.tsx
+++ b/packages/patterns/experimental/folksonomy-tags.tsx
@@ -72,8 +72,10 @@ interface AggregatorPiece {
 interface FolksonomyTagsInput {
   /** Namespace key (e.g., GitHub URL of the pattern using it) */
   scope: Writable<string | Default<"">>;
+
   /** User's tags for this scope - bidirectional binding */
   tags: Writable<string[] | Default<[]>>;
+
   /** Optional: Direct reference to aggregator (bypasses wish() discovery) */
   aggregator?: AggregatorPiece;
 }

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -124,8 +124,10 @@ export interface User {
    * so its person can re-join with a profile and appear as themselves.
    */
   profile?: LunchProfileCell;
+
   /** Display name at join time — cosmetic, may duplicate another participant. */
   name: string;
+
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
   color: string;
@@ -153,6 +155,7 @@ export const DEFAULT_HOST: PollHost = {};
  */
 export interface ViewerOverride {
   readonly profile?: LunchProfileCell;
+
   /** Stands in for `#profileName` / `#profileAvatar`, which also need a wish. */
   readonly name?: string;
   readonly avatar?: string;
@@ -174,6 +177,7 @@ export interface Option {
   id: string;
   title: string;
   addedByName: string;
+
   /**
    * Persisted generated-art data URL (`""` until the host's client generates
    * and syncs it). Every viewer renders this stored value; generation only
@@ -194,6 +198,7 @@ export interface Vote {
   voter?: LunchProfileCell;
   optionId: string;
   voteType: VoteColor;
+
   /**
    * When the vote was cast (ms epoch), stamped by `castVote`. Optional for
    * votes stored before this field existed — those count as not-today, so the
@@ -246,6 +251,7 @@ export type ResetVotesEvent = Record<PropertyKey, never>;
 export interface VoteSnapshot {
   /** Display name at snapshot time — cosmetic; the profile below is identity. */
   voter: string;
+
   /**
    * Live identity link, so a badge stays right even after a rename. Optional
    * only for snapshots stored by the name-keyed predecessor.
@@ -265,16 +271,19 @@ export interface VoteSnapshot {
 export interface HistoryEntry {
   id: string;
   title: string;
+
   /**
    * Display name at log time — cosmetic. Defaulted so entries stored by the
    * name-keyed predecessor (which had no such field) read back as `""`.
    */
   loggedByName: string | Default<"">;
+
   /**
    * Live identity link to whoever logged it. Optional only for entries
    * stored by the name-keyed predecessor, which recorded no identity link.
    */
   loggedBy?: LunchProfileCell;
+
   /**
    * Both defaulted so entries stored by the SQL-era predecessor (separate
    * tables, text timestamps) read back — a zero `wentAt` sorts a legacy row
@@ -291,6 +300,7 @@ export interface HistoryEntry {
  */
 export interface PlaceStat {
   title: string;
+
   /**
    * Counts are defaulted so rows stored by the SQL-era predecessor (whose
    * derived stat rows carried different fields) read back as zeros instead
@@ -323,6 +333,7 @@ type QuestionCell = Writable<string | Default<"Where should we eat?">>;
 type OptionsCell = Writable<Option[] | Default<[]>>;
 type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
+
 /** Free-text drafts (option title, visit date) — never identity. */
 type DraftCell = Writable<string | Default<"">>;
 type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
@@ -946,6 +957,7 @@ interface OptionTally {
     voteType: VoteColor;
     color: string;
     initials: string;
+
     /**
      * Whether this vote is the viewer's own, decided by profile cell.
      * Resolved here rather than in the view, which has only a display name
@@ -1033,8 +1045,10 @@ export interface CozyPollInput {
   options?: PerSpace<Option[] | Default<[]>>;
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
+
   /** Which participant hosts the poll — the first to join, transferable. */
   host?: PerSpace<HostValue>;
+
   /**
    * Allocation site for the viewer-identity override slot — per-user, so ONE
    * shared piece holds a separate override per viewer (a multi-user test
@@ -1061,8 +1075,10 @@ export interface CozyPollOutput {
   // only `todaysVotes` — see the current-day filter note in the file header.
   votes: readonly Vote[];
   users: readonly User[];
+
   /** The host's display name, resolved from the roster ("" when unhosted). */
   hostName: string;
+
   /** This viewer's display name from their profile ("" before it resolves). */
   myName: string;
   userCount: number;
@@ -1089,6 +1105,7 @@ export interface CozyPollOutput {
   placeStats: readonly PlaceStat[];
   isJoined: boolean;
   isAdmin: boolean;
+
   /**
    * Why this viewer's last join attempt was rejected, or "" — the join
    * gate's loud counterpart. The deploy doc's CLI smoke test reads this.
@@ -1096,6 +1113,7 @@ export interface CozyPollOutput {
   joinMessage: string;
   joinAs: Stream<JoinEvent>;
   claimHost: Stream<ClaimHostEvent>;
+
   /** Test seam: claim this viewer's identity (see the handler's doc). */
   overrideViewer: Stream<ViewerOverride>;
   addOption: Stream<AddOptionEvent>;

--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for the lunch poll.
  *

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -178,10 +178,13 @@ export interface ParticipantIdentityCardInput {
 export interface ParticipantIdentityCardOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** Whether the viewer has joined this poll. */
   isJoined: boolean;
+
   /** Whether the viewer hosts this poll. */
   isAdmin: boolean;
+
   /**
    * Why this viewer's last join attempt was rejected, or "" — the loud
    * counterpart of the join gate. Headless callers read it (a CLI smoke test

--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -31,20 +31,28 @@ const handleBacklinkClick = handler<
 export interface NoteMdOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** Passthrough note reference */
   note: NotePiece;
+
   /** Hidden from default-app piece list */
   isHidden: true;
+
   /** Excluded from mentions autocomplete (notes in notebooks may be hidden but still mentionable) */
   isMentionable: false;
+
   /** Tile variant (CT-1764): minimal embedded UI for `<cf-render variant="tile">`. */
   [TILE_UI]: VNode;
+
   /** Processed content with wiki-links converted to markdown links */
   processedContent: string;
+
   /** Stream to toggle checkboxes in content */
   checkboxToggle: Stream<{ detail: { index: number; checked: boolean } }>;
+
   /** Whether backlinks section should be visible */
   hasBacklinks: boolean;
+
   /** Stream to navigate back to source note for editing */
   goToEdit: Stream<void>;
 }

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -58,6 +58,7 @@ export const bareMentionId = (uri: string): string => {
 export interface NoteOutput extends NotePiece {
   [NAME]: string;
   [UI]: VNode;
+
   /** A note is always markdown, so it declares that arm rather than the whole
    * `FsProjection` union: the open arm types every field loosely, and a reader
    * of this projection wants `content` as the string it is. */
@@ -71,6 +72,7 @@ export interface NoteOutput extends NotePiece {
   summary: string;
   mentioned: MentionablePiece[] | Default<[]>;
   backlinks: MentionablePiece[];
+
   /**
    * Where this note's `[Label][key]` mentions point. The default matches the
    * input's; see `NoteInput.references` for why they have to.
@@ -81,13 +83,16 @@ export interface NoteOutput extends NotePiece {
   grep: PatternToolResult<{ content: string }>;
   translate: PatternToolResult<{ content: string }>;
   editContent: Stream<{ detail: { value: string } }>;
+
   /** Take an edited filesystem projection, definitions and all. */
   editProjection: Stream<{ body: string }>;
   setTitle: Stream<string>;
   appendLink: Stream<{ piece: Writable<MentionablePiece> }>;
   createNewNote: Stream<void>;
+
   /** Parent notebook reference, null if not in a notebook */
   parentNotebook: NotebookPiece | null;
+
   /** Tile variant (CT-1764): the minimal embedded UI used when a container
    * (e.g. Record) renders this note via `<cf-render variant="tile">`. */
   [TILE_UI]: VNode;

--- a/packages/patterns/notes/reference-block.ts
+++ b/packages/patterns/notes/reference-block.ts
@@ -23,8 +23,10 @@ export interface ReferenceDefinition {
 export interface SplitBody {
   /** The prose, with no trailing definition block and no trailing blank run. */
   content: string;
+
   /** The definitions that were attached to it, in the order they appeared. */
   definitions: ReferenceDefinition[];
+
   /**
    * Lines in the trailing block that are not definitions. A block holding one
    * is not a generated block, so the whole run stays prose — dropping a line

--- a/packages/patterns/notes/schemas.tsx
+++ b/packages/patterns/notes/schemas.tsx
@@ -97,10 +97,13 @@ export interface NoteInput {
   title?: Writable<string | Default<"Untitled Note">>;
   content?: Writable<string | Default<"">>;
   isHidden?: boolean | Default<false>;
+
   /** Pattern JSON for [[wiki-links]]. Defaults to creating new Notes. */
   linkPattern?: Writable<string | Default<"">>;
+
   /** Parent notebook reference. Set at creation, can be updated for moves. */
   parentNotebook?: Writable<NotebookPiece | null | Default<null>>;
+
   /**
    * The note's mentions in reference form. Stored beside `content` because it
    * has to stay in lockstep with it: the text carries keys, and this is what
@@ -125,6 +128,7 @@ export interface NotebookInput {
   notes?: Writable<NotePiece[] | Default<[]>>;
   isNotebook?: boolean | Default<true>;
   isHidden?: boolean | Default<false>;
+
   /** Parent notebook reference. Set at creation, can be updated for moves. */
   parentNotebook?: Writable<NotebookPiece | null | Default<null>>;
 }
@@ -156,10 +160,13 @@ export type MentionRefMap = Record<string, MentionRef>;
 export interface NoteMdInput {
   /** Cell reference to note data (title + content + backlinks) */
   note?: NotePiece | Default<{ title: ""; content: ""; backlinks: [] }>;
+
   /** Direct reference to source note for Edit navigation */
   sourceNoteRef?: NotePiece;
+
   /** Writable content cell for checkbox updates */
   content?: Writable<string>;
+
   /** The note's mentions, for resolving `[Label][key]` in its content */
   references?: Writable<MentionRefMap>;
 }

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -46,8 +46,10 @@ export type ChatProfileCell = Cell<{ name?: string; avatar?: string }>;
 export interface ChatMessage {
   /** Sender's live profile cell — rendered first-class via cf-profile-badge. */
   authorProfile: ChatProfileCell;
+
   /** Sender's profile name, snapshotted at send time (durable fallback label). */
   author: string;
+
   /** Sender's profile avatar (URL or glyph), snapshotted at send time. */
   avatar: string;
   body: string;
@@ -91,6 +93,7 @@ const sendMessage = handler<SendEvent, {
 export interface ProfileGroupChatInput {
   /** Shared message log — every user in the space reads & appends to this. */
   messages?: PerSpace<ChatMessage[] | Default<typeof DEFAULT_MESSAGES>>;
+
   /** Current viewer's message draft — follows the user, not broadcast. */
   draft?: PerUser<string | Default<"">>;
 }

--- a/packages/patterns/scrabble/multi-user.test.tsx
+++ b/packages/patterns/scrabble/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for scrabble.
  *

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -45,8 +45,10 @@ export type ScrabbleProfileCell = Cell<{ name?: string; avatar?: string }>;
 
 export interface Player {
   name: string;
+
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
+
   /**
    * Live profile cell — present for profile-joined players (the scoreboard
    * renders it via `<cf-profile-badge>`), absent for headless name-only joins

--- a/packages/patterns/shared-profile-roster/main.tsx
+++ b/packages/patterns/shared-profile-roster/main.tsx
@@ -56,8 +56,10 @@ export interface Participant {
    * participants are "the same" iff `equals()` matches on this, never on name.
    */
   profile: ParticipantProfileCell;
+
   /** Display name, snapshotted from the joiner's profile at join time. */
   name: string;
+
   /** Avatar URL or glyph, snapshotted from the joiner's profile (may be ""). */
   avatar: string;
   joinedAt: number;
@@ -71,6 +73,7 @@ export interface Roster {
 export interface ViewerState {
   /** Set once this viewer has contributed their entry to the shared roster. */
   joined?: boolean;
+
   /** The display name shown on the join button after joining (cosmetic only). */
   joinedName?: string;
 }
@@ -125,6 +128,7 @@ const join = handler<JoinEvent, {
 export interface RosterDemoInput {
   /** Shared roster — every user in the space reads & appends to this. */
   roster?: PerSpace<Roster | Default<typeof DEFAULT_ROSTER>>;
+
   /** Current viewer's join marker — follows the user, not broadcast directly. */
   viewer?: PerUser<ViewerState | Default<typeof EMPTY_VIEWER>>;
 }

--- a/packages/patterns/system/common-fabric.tsx
+++ b/packages/patterns/system/common-fabric.tsx
@@ -26,6 +26,7 @@ import { type MentionablePiece } from "./backlinks-index.tsx";
 type CalculatorRequest = {
   /** The mathematical expression to evaluate. */
   expression: string;
+
   /** The base to use for the calculation. */
   base?: number;
 };
@@ -279,12 +280,16 @@ export const readWebpage = pattern<
 type BashRequest = {
   /** The bash command to execute. */
   command: string;
+
   /** Working directory for the command. */
   workingDirectory?: string;
+
   /** Timeout in milliseconds. Defaults to 60000. */
   timeout?: number;
+
   /** Additional environment variables as key-value pairs. */
   environment?: Record<string, string>;
+
   /** Sandbox identifier. Automatically provided — do not set. */
   sandboxId: FrameworkProvided<string>;
 };

--- a/packages/patterns/topics/main.tsx
+++ b/packages/patterns/topics/main.tsx
@@ -58,6 +58,7 @@ export interface TopicsInput {
    * are legitimate but unattributed, and a whole-array write forfeits the
    * mergeability the verb's append keeps. */
   topics?: Writable<TopicPiece[] | Default<[]>>;
+
   /** @deprecated Retained while pre-Profile callers still use the old
    * `setMyName` + unsigned-event contract. New callers use `agentName`. */
   myName?: PerUser<Writable<string | Default<"">>>;
@@ -66,11 +67,13 @@ export interface TopicsInput {
 export interface AddTopicEvent {
   /** The topic's title, trimmed before it is stored. Must be non-empty. */
   title: string;
+
   /** The topic's initial living-document body. A topic born with a body
    * appears with it atomically — no reader observes the title-only halfway
    * state, and no follow-up `setBody` call is needed to finish a create
    * (verb contract: the atomic-unit rule). */
   body?: string;
+
   /** The agent making this mutation. The authenticated principal remains the
    * human whose identity key invoked the stream; this is the agent's explicit
    * content-level signature under that shared principal. Optional only so
@@ -105,11 +108,13 @@ export interface AddTopicResult {
 export interface TopicIndexRow {
   title: string;
   createdAt: number;
+
   /** Who filed the topic. A topic written without structured authorship
    * materializes the declared default — the inert legacy sentinel
    * `{ kind: "person", name: "" }` — so a blank name here means "unsigned";
    * the display string then comes from the topic's own `createdByName`. */
   createdBy?: TopicAuthor | Default<{ kind: "person"; name: "" }> | undefined;
+
   /** Coalesced to 0 for a cold or older topic whose derived path is absent,
    * so the row itself never carries the mixed-version undefined. */
   commentCount: number | Default<0> | undefined;
@@ -264,37 +269,47 @@ const cardsByActivity = lift(
 export interface TopicsOutput {
   [NAME]: string;
   [UI]: VNode;
+
   /** The board's topics, in filing order, as complete pieces — bodies,
    * threads, and verbs included. Survey through `index` instead; read this
    * when you already know which topic you are expanding. */
   topics: TopicPiece[];
+
   /** The same list, under the name the topic pattern's editor autocompletes
    * over — what `addTopic` wires into each child as its mention universe. */
   mentionable: TopicPiece[] | Default<[]>;
+
   /** How many topics the board holds, nulls included. */
   topicCount: number;
+
   /** The board's mention pivot, one row per topic: the topic, and the topics
    * that mention it. Published so a topic composed outside `addTopic` can be
    * wired to the same table the board's own children read — the graph is
    * derived once, here, and never per topic. */
   crossrefs: TopicCrossrefRow[] | Default<[]>;
+
   /** The full-board survey surface: one bounded row per topic, carrying the
    * scalars a survey reads. A row IS its topic, so a row's own address is the
    * topic's — `--select index[].@` reads it, and an index into this array is
    * not a stable address. */
   index: TopicIndexRow[] | Default<[]>;
+
   /** Session-local draft for the footer composer (exposed for embedding and
    * headless driving, like the chat exemplar's drafts). */
   newTitle?: PerSession<Writable<string>>;
+
   /** File a topic. The atomic unit takes the initial body with the title, so
    * no reader observes a title-only halfway state and no follow-up `setBody`
    * finishes a create. Returns the created topic as its survey row — the
    * reference plus the write-time facts the pattern resolved. */
   addTopic: Stream<AddTopicEvent, AddTopicResult>;
+
   /** @deprecated Compatibility view for callers of the previous board. */
   myName: string;
+
   /** @deprecated Compatibility mutation for callers of the previous board. */
   setMyName: Stream<{ name: string }>;
+
   /** Submit the footer composer as the current viewer's canonical Profile. */
   submitTopic: Stream<void>;
 }
@@ -305,6 +320,7 @@ export interface TopicsOutput {
 export const submitProfileTopic = handler<void, {
   topics: Writable<TopicPiece[] | Default<[]>>;
   mentionable: Writable<TopicPiece[] | Default<[]>>;
+
   /** `Writable` only because that is what the factory boundary accepts: the
    * input this is handed straight to declares `ReadonlyCell`, and a
    * `ReadonlyCell` held in handler state is not assignable to it — handler

--- a/packages/patterns/topics/multi-user.test.tsx
+++ b/packages/patterns/topics/multi-user.test.tsx
@@ -1,4 +1,5 @@
 /// <cts-enable />
+
 /**
  * Multi-user pattern test for Topics (CT-1878).
  *

--- a/packages/patterns/topics/topic.tsx
+++ b/packages/patterns/topics/topic.tsx
@@ -52,10 +52,12 @@ export interface AddLinkEvent extends AgentAuthoredEvent {
    * result direction, where required-to-optional is refused, so relaxing
    * this rides the next acknowledged break rather than an ordinary deploy. */
   kind: TopicLinkKind;
+
   /** The link target. Must be http(s): anything else rejects, because a
    * user-supplied scheme on a shared surface is script execution in every
    * viewer's session. */
   url: string;
+
   /** Display label. A blank label falls back to the URL; required to be
    * present for the same gate reason as `kind`. */
   label: string;
@@ -71,6 +73,7 @@ export interface SetBodyEvent extends AgentAuthoredEvent {
 export interface SetTitleEvent {
   /** The new title, trimmed before it is stored. Must be non-empty. */
   title: string;
+
   /** The agent making this mutation, stored as structured attribution beside
    * the write time. Required: this verb postdates the unsigned-caller era,
    * so it carries no legacy fallback. */
@@ -144,6 +147,7 @@ export interface SetBodyResult {
   /** The body as persisted — verbatim, so a caller can confirm that
    * whitespace-sensitive Markdown survived the round trip. */
   body: string;
+
   /** Attribution written for this save. Both are absent when the caller sent
    * no `agentName`: an unattributed save leaves the previous attribution
    * standing rather than overwriting it. */
@@ -154,6 +158,7 @@ export interface SetBodyResult {
 export interface SetTitleResult {
   /** The title as persisted, after trimming. */
   title: string;
+
   /** Attribution written for this rename — always present, because the verb
    * requires `agentName`. */
   titleUpdatedBy: TopicAuthor;
@@ -166,6 +171,7 @@ export interface TopicComment {
    * array elements have stable entity identity; future editing addresses
    * elements by reference (`equals()`), not by a synthetic key. */
   author?: TopicAuthor;
+
   /** @deprecated Compatibility shadow for consumers of the previous result
    * schema. New callers must use `author`; the pattern mirrors this field. */
   authorName: string | Default<"">;
@@ -183,6 +189,7 @@ export interface TopicLink {
 
 export interface TopicInput {
   title?: Writable<string | Default<"">>;
+
   /** The topic's living document: durable conclusions get folded up into the
    * body; the comment thread below holds the deliberation. */
   body?: Writable<string | Default<"">>;
@@ -190,8 +197,10 @@ export interface TopicInput {
   links?: Writable<TopicLink[] | Default<[]>>;
   createdAt?: number | Default<0>;
   createdBy?: TopicAuthor;
+
   /** @deprecated Compatibility shadow for the previous result contract. */
   createdByName?: string | Default<"">;
+
   /** @deprecated Retained only for callers of the previous unsigned mutation
    * streams. New callers use Profile authorship or an atomic `agentName`. */
   myName?: PerUser<Writable<string | Default<"">>>;
@@ -199,17 +208,20 @@ export interface TopicInput {
     TopicAuthor | Default<{ kind: "person"; name: "" }>
   >;
   bodyUpdatedAt?: Writable<number | Default<0>>;
+
   /** Attribution of the last rename, stamped by `setTitle` — the same pair
    * the body keeps, because a title is the other editable scalar. */
   titleUpdatedBy?: Writable<
     TopicAuthor | Default<{ kind: "person"; name: "" }>
   >;
   titleUpdatedAt?: Writable<number | Default<0>>;
+
   /** The board's own topics list — the mention universe the body editor
    * autocompletes over. A reference to the tracker's array, wired at creation
    * like `myName` (and backfillable as a one-time link-bind on pieces created
    * before it existed). Absent, the editor simply offers no completions. */
   mentionable?: Writable<TopicPiece[] | Default<[]>>;
+
   /** Where this topic's `[Label][key]` mentions point, keyed by the token that
    * appears in the body. The editor owns the contents; this pattern owns the
    * cell, which is what makes a mention durable and — because each entry holds
@@ -220,6 +232,7 @@ export interface TopicInput {
    * under a different default than its input carries cannot be materialized. */
   // deno-lint-ignore ban-types
   references?: Writable<TopicMentionRefMap | Default<{}>>;
+
   /** Pieces this topic references outside its prose — what `mention` records.
    *
    * Its own list rather than an entry in `references`, because that map belongs
@@ -229,6 +242,7 @@ export interface TopicInput {
    * key by, because there is nothing to point back at from the prose — a
    * reference outside a sentence is just a link in a list. */
   mentioned?: Writable<unknown[] | Default<[]>>;
+
   /** The board's mention pivot, one row per topic. A topic reads its own row
    * out of it and nothing else; see `backlinksOf`. Absent, a topic simply shows
    * no inbound references.
@@ -325,6 +339,7 @@ export interface TopicSummary {
    * `deno task pattern-vintage` is what catches it, by replaying a real
    * deployed board. */
   title: string | Default<"">;
+
   /** When the topic was filed (epoch milliseconds), stamped at create. */
   createdAt: number;
   createdBy?:
@@ -353,17 +368,22 @@ export interface TopicPiece extends TopicSummary {
    * retained topic may not have produced this path yet; its persisted title
    * remains authoritative until it does. */
   [NAME]: string | Default<""> | undefined;
+
   /** @deprecated Compatibility shadow for consumers of the previous result
    * schema. New callers must use `createdBy`; the pattern mirrors this field. */
   createdByName: string | Default<"">;
+
   /** The living document, verbatim Markdown. `setBody` replaces it whole. */
   body: string | Default<"">;
+
   /** The thread, in arrival order: append-only point-in-time records, each
    * carrying its author snapshot and `sentAt`. */
   comments: TopicComment[];
+
   /** Typed outbound links, in arrival order, each carrying its author
    * snapshot and `addedAt`. */
   links: TopicLink[];
+
   /** Every piece this topic's prose and links point at, as references.
    *
    * The board's pivot is declared over this and nothing else, so what one topic
@@ -381,13 +401,16 @@ export interface TopicPiece extends TopicSummary {
    * and the default is what a topic deployed before this path existed
    * materializes against. */
   mentions: unknown[] | Default<[]>;
+
   /** Where this topic's `[Label][key]` mentions point. Durable content, like
    * `links`. The body editor works on a session copy of this map, which a save
    * publishes here whole, beside the prose whose tokens name its entries. */
   // deno-lint-ignore ban-types
   references: TopicMentionRefMap | Default<{}>;
+
   /** Pieces referenced outside the prose, recorded by `mention`. */
   mentioned: unknown[] | Default<[]>;
+
   /** The topics that mention this one, read out of the board's pivot.
    *
    * Declared through `TopicSummary` rather than `TopicPiece`, and that is
@@ -398,19 +421,23 @@ export interface TopicPiece extends TopicSummary {
   referencedBy: TopicSummary[] | Default<[]>;
   bodyUpdatedBy?: TopicAuthor | undefined;
   bodyUpdatedAt?: number | undefined;
+
   /** Append to the thread — a point-in-time record of progress or
    * deliberation; durable conclusions belong in the body. Returns the
    * comment as recorded, resolved author and `sentAt` included. */
   addComment: Stream<AddCommentEvent, AddCommentResult>;
+
   /** Attach a typed outbound link — a PR, an agent session, a web page.
    * Returns the link as recorded, resolved `addedBy` and `addedAt`
    * included. Appends merge and nothing dedupes: a repeated URL is two
    * entries. */
   addLink: Stream<AddLinkEvent, AddLinkResult>;
+
   /** Replace the living document whole — read it, revise it, write it back
    * complete; the body is one value with whole-value conflict semantics.
    * Returns the persisted body and any attribution written. */
   setBody: Stream<SetBodyEvent, SetBodyResult>;
+
   /** Reference another piece from this topic — the payload is the piece
    * itself, stored as a reference. The browser equivalent is picking a
    * completion in the body editor, which writes the same map.
@@ -421,6 +448,7 @@ export interface TopicPiece extends TopicSummary {
    * outright. The older verbs predate every deployed generation, so they can
    * stay required; these cannot. */
   mention?: Stream<MentionEvent>;
+
   /** Stop referencing a piece: removes every `mention`-made entry naming it.
    * References made in the prose are retracted by editing the prose, not by
    * this. Optional on the projection for the same reason as `mention`. */
@@ -443,6 +471,7 @@ export interface TopicPiece extends TopicSummary {
  */
 export interface TopicOutput extends TopicPiece {
   [UI]: VNode;
+
   /**
    * Session-local composer/edit state. These controls belong to a direct Topic
    * instance, not the shared TopicPiece projection used by the tracker's list.
@@ -455,6 +484,7 @@ export interface TopicOutput extends TopicPiece {
   linkUrlDraft: PerSession<Writable<string>>;
   linkLabelDraft: PerSession<Writable<string>>;
   linkKindDraft: PerSession<Writable<TopicLinkKind>>;
+
   /**
    * The body draft's mention map, staged so Cancel can discard it.
    *
@@ -468,6 +498,7 @@ export interface TopicOutput extends TopicPiece {
    * this gives them one.
    */
   referencesDraft: PerSession<Writable<TopicMentionRefMap>>;
+
   /** Rename the topic. Lives on the direct interface rather than the shared
    * `TopicPiece` projection, and the placement is the contract: a holder's
    * required demands are write-once, so a required verb added to the
@@ -477,32 +508,41 @@ export interface TopicOutput extends TopicPiece {
    * all.) Requires `agentName` and returns the persisted title with the
    * attribution written. */
   setTitle: Stream<SetTitleEvent, SetTitleResult>;
+
   /** Attribution of the last rename; unset until the first `setTitle`.
    * Beside `setTitle` rather than on the projection, for the same reason. */
   titleUpdatedBy?: TopicAuthor | undefined;
   titleUpdatedAt?: number | undefined;
+
   /** UI wrapper: open the rename editor, seeding the session draft from the
    * durable title. */
   startEditTitle: Stream<void>;
+
   /** UI wrapper: save the session title draft under the viewer's Profile —
    * the contract verb is `setTitle`, and both land through the same core, so
    * a browser rename stamps the same attribution and moves the same activity
    * clock. */
   saveTitle: Stream<void>;
+
   /** UI wrapper: close the rename editor; the session draft is the discard. */
   cancelEditTitle: Stream<void>;
+
   /** UI wrapper: append the session comment draft under the viewer's
    * Profile. Reads session-local state, so it is a silent no-op headless —
    * the contract verb is `addComment`. */
   submitComment: Stream<void>;
+
   /** UI wrapper: open the body editor, seeding the session drafts from the
    * durable body and mention map. */
   startEditBody: Stream<void>;
+
   /** UI wrapper: publish the session body and mention-map drafts whole,
    * attributed to the viewer's Profile — the contract verb is `setBody`. */
   saveBody: Stream<void>;
+
   /** UI wrapper: close the body editor; the session drafts are the discard. */
   cancelEditBody: Stream<void>;
+
   /** UI wrapper: append the session link drafts under the viewer's Profile —
    * the contract verb is `addLink`. */
   submitLink: Stream<void>;

--- a/packages/patterns/topics/topics.test.tsx
+++ b/packages/patterns/topics/topics.test.tsx
@@ -96,6 +96,7 @@ const propValue = (value: any): unknown =>
 // runtime: a declared result adds nothing to the generated schema (C3
 // withdrawn — results flow schema-free through receipts), so the stored
 // schema a legacy piece is validated against is unchanged.
+
 /**
  * What a topic pattern deployed before the current paths existed publishes.
  *


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Conformance sweep for "The blank line above" in `code-comment-style.md`, which
#6350 adds. 162 doc comments across 34 files had no blank line above them; each
gets one. Together with #6362 this finishes `packages/patterns`, apart from the
two files below.

The diff removes no line and adds no non-blank one — checked as a property of
the whole diff, not a sample.

## Two patterns a blank line cannot be added to

`lobby/main.tsx` and `factory-outputs/parking-coordinator/main.tsx` are left
alone, because sweeping them makes `deno task pattern-compat` fail with
`contract … is not recorded`.

The mechanism is worth writing down, because it applies to any change to these
files, not just this one. Both wrap a value in `TrustedActionWrite<…, typeof
someHandler, …>`, and the schema that lowers to carries the handler's
`moduleIdentity` — a content hash of the module. A single blank line anywhere in
the module changes that hash, so the pattern's contract changes, so it is not
one of the recorded baselines.

Measured rather than reasoned:

- Control: both failing shards are green at the branch's exact base commit with
  a clean tree.
- Isolation: copying **one** of the 34 swept files, whose whole diff is a single
  blank line inside an `interface` body, onto that clean tree reproduces
  `contract r81vFLwS-CMIQTWM is not recorded`.
- Mechanism: `cf check --show-transformed` before and after that one insertion
  differs in nothing but the `fid1:` source hash and nine `moduleIdentity`
  values. No schema field, no `description`, no `ifc` label changes.

So the honest options for those two are to leave them non-conforming or to
append a baseline, and appending a baseline for a cosmetic change is not a call
this sweep should make.

## Guards

All three `PATTERN_COMPAT_SHARD` shards of `deno task pattern-compat`, plus
`deno task cfcheck`, `deno task pattern-vintage`, `deno task
check-baselines-append-only`, `deno fmt --check`, `deno lint`, `deno task
check`, and `packages/patterns`' own test task are green over what remains.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

