### PR TITLE
A failed head-event load park DEFERS the served event, never drops it

### DIFF
--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1432,12 +1432,14 @@ OW45 residue member, 2026-08-26): `loadParkDeferrals` — served events
 deferred because the dispatch preflight's head-event LOAD PARK failed,
 counted per deferral (the head's and each later-arrived same-space
 entry the arrival-order barrier holds behind it), each with a WARN
-naming the failing doc keys and the error. §5's T3 predicate is "no
+naming the failing doc keys and the error. events.md §5's T3 predicate
+is "no
 runnable handler", never "the run raced", so a transient read failure
 over a durably-existing doc defers rather than dropping: the entry
 stays pending and UNCONSEQUENCED and a later drain re-delivers it.
 The deferral is deliberately NOT on the queued class's bounded
-creation-race budget — that budget hardens into §5's drop, which for
+creation-race budget — that budget hardens into events.md §5's drop,
+which for
 this cause would be the at-least-once discharge the arm exists to
 prevent — so a load that never heals defers indefinitely and its
 backstop rescan keeps the space out of the idle park; a give-up arm

--- a/docs/specs/server-side-execution/serving-loop.md
+++ b/docs/specs/server-side-execution/serving-loop.md
@@ -1291,7 +1291,7 @@ pushGrowthWakes, watchWakes, warmWakes}, settle: {series, dropped},
 settleAdvances: {count, lastDelta, series, dropped}, events:
 {appended, processed, coalescedPerWaveMax, skippedIdempotent,
 drainInFlightSkips, lt1LeftoversPurged, lt1LateSealsRefused,
-orphanDeliveriesRefused}, memo:
+orphanDeliveriesRefused, loadParkDeferrals, dropped}, memo:
 {hits, misses, inflight}, outbox: {queued, completed, failed,
 budgetDeferrals}, lease:
 {held, lost}, push: {prioritizedSessions, followerSessions,
@@ -1426,6 +1426,30 @@ delivering server-emitted entries, never the double's signature —
 per-event run counts are (and a store-side per-event consequence-commit
 count is not one either: it reads 1 for a same-wave double and 2 for a
 late-seal split with a surviving intent sibling — W3 review B1).
+
+The `events` block's DISPOSITION counters (verification-coverage.md's
+OW45 residue member, 2026-08-26): `loadParkDeferrals` — served events
+deferred because the dispatch preflight's head-event LOAD PARK failed,
+counted per deferral (the head's and each later-arrived same-space
+entry the arrival-order barrier holds behind it), each with a WARN
+naming the failing doc keys and the error. §5's T3 predicate is "no
+runnable handler", never "the run raced", so a transient read failure
+over a durably-existing doc defers rather than dropping: the entry
+stays pending and UNCONSEQUENCED and a later drain re-delivers it.
+The deferral is deliberately NOT on the queued class's bounded
+creation-race budget — that budget hardens into §5's drop, which for
+this cause would be the at-least-once discharge the arm exists to
+prevent — so a load that never heals defers indefinitely and its
+backstop rescan keeps the space out of the idle park; a give-up arm
+for that case is OW54's separately tracked territory. `dropped` —
+terminal drop notices SEALED onto a durable entry, the previously
+unmeasurable half: an event discharged this way left `appended ==
+processed` reading clean while a user's action was permanently gone,
+so only the WARN and the entry's own `status` field carried it. Both
+are read together, never alone: `loadParkDeferrals` growing while
+`processed` does not names a load that never heals, and a rising
+`dropped` on a space whose pieces all start names a disposition bug
+rather than routine unrunnable-event cleanup.
 
 ## 8. Tripwires (grep-able FORBIDDEN list)
 

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6311,8 +6311,17 @@ supply; OW29/OW32/OW34 closed):
     durable entry left pending and UNCONSEQUENCED, the standard
     re-drain re-delivering it — and carries the drain's arrival-order
     BARRIER with it (events.md §2, mirroring the sidecar-sync-failure
-    arm): every later-arrived durable served entry behind it IN THE
-    SAME SPACE defers too. Two exclusions, deliberate: cross-space
+    arm), in TWO halves, because the deferral can land in two places.
+    IN THE QUEUE: every later-arrived durable served entry behind the
+    head IN THE SAME SPACE defers too. MID-DRAIN-PASS: the
+    scheduler-side barrier can only hold what is already queued, and
+    the drain awaits a `sync()` per new sidecar — so a park failure can
+    land between one entry's queueing and the next's, and the next
+    entry would queue behind the barrier's back and overtake. The
+    second half (`#loadParkDeferredInPass`) makes the pass STOP there,
+    the same `break` the sidecar-sync arm makes; found in this seat's
+    own adversarial pass, and its mutation reds `["A","B","A"]` exactly
+    like the in-queue one. Two exclusions, deliberate: cross-space
     queue neighbours (§2's order is per-space) and LT1 in-process
     copies (`served` with no `streamEntry` — no durable entry to
     re-drain, and a running event's same-wave cascade children rather
@@ -6357,11 +6366,20 @@ supply; OW29/OW32/OW34 closed):
     failure reaches the drain as a load-park DEFERRAL, not a drop"
     (the contract the SpaceServer's `onFailure` branches on; the
     pre-existing client-side drop pin beside it is unchanged).
-    Mutations, both red: restore the drop routing → both entries seal
-    dropped and the log never grows past the warm-up; skip the barrier
-    loop → the log reads `["A","B","A"]`, the OW45 arm-B b01 overtake
-    shape. Battery green at the fix: executor-events-down (23 steps),
-    executor-fan-out, executor-serving-loop, scheduler-event-load-park.
+    A third pin covers the mid-pass half: the drain's sync gate holds a
+    pass at B's sidecar with A2's park already failed inside it, and
+    after healing and release the log still reads `["A","A","B"]`.
+    Mutations, all red: restore the drop routing → both entries seal
+    dropped and the log never grows past the warm-up (and the
+    scheduler-level pin reads `kind: "dropped"`); skip the in-queue
+    barrier loop → `["A","B","A"]`, the OW45 arm-B b01 overtake shape;
+    drop the `#loadParkDeferredInPass` check → the same overtake through
+    the mid-pass gap. Battery green at the fix: executor-events-down
+    (24 steps, the α3 retry machinery untouched), executor-fan-out,
+    executor-serving-loop, scheduler-event-load-park,
+    executor-space-server, executor-watermark, executor-stats,
+    executor-wave, executor-cross-space, and the full
+    `packages/runner` package (1301 passed / 7549 steps / 0 failed).
     STILL OPEN, untouched by this fix: shard 9
     (`cfc-staged-publish`) stays UNHARVESTED — symptom-compatible,
     no store evidence, classification open — and the #6248 lane

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6450,7 +6450,21 @@ supply; OW29/OW32/OW34 closed):
     overtake shape; drop the `#loadParkDeferredInPass` check → the same
     overtake through the mid-pass gap; fall the load-park arm through
     into the threshold accounting → "a persistent load failure must
-    never harden into events.md §5's drop". Battery green at the fix:
+    never harden into events.md §5's drop". The barrier's TWO
+    EXCLUSIONS are pinned too — they were the coverage ratchet's two
+    uncovered lines, and were COVERED rather than accepted: a
+    scheduler-level pin queues, behind a parked served head, a
+    same-space durable sibling, another SPACE's durable entry, and a
+    `streamEntry`-less LT1 copy, and asserts the sweep takes only the
+    first. Independently red: drop the cross-space guard → "another
+    space's entry must not be swept"; drop the LT1 guard → "a
+    streamEntry-less LT1 copy must not be swept". Construction note for
+    whoever edits it — both traps cost this seat a red: `addEventHandler`
+    stamps `populateDependencies` onto the HANDLER FUNCTION OBJECT, so
+    each stream needs its own function (sharing one makes all four park
+    on the armed doc), and same-stream sends COALESCE by doc id, so the
+    cross-space neighbour needs its own id rather than the sibling's
+    with the space swapped. Battery green at the fix:
     executor-events-down
     (26 steps, the α3 retry machinery untouched), executor-fan-out,
     executor-serving-loop, scheduler-event-load-park,

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6321,7 +6321,22 @@ supply; OW29/OW32/OW34 closed):
     second half (`#loadParkDeferredInPass`) makes the pass STOP there,
     the same `break` the sidecar-sync arm makes; found in this seat's
     own adversarial pass, and its mutation reds `["A","B","A"]` exactly
-    like the in-queue one. Two exclusions, deliberate: cross-space
+    like the in-queue one. Its CHECK POSITION is load-bearing and was
+    got wrong first: the loop awaits TWICE per entry (a new sidecar's
+    `sync()` and then the stream doc's), and a rejection landing in
+    either window sweeps only what was queued at that instant — so the
+    check sits past BOTH, immediately before
+    `#drainInFlight.set`/`queueEvent`. Independent review (Codex P1 on
+    PR #6365) caught it one await too early. **Coverage gap recorded,
+    NOT filled:** the pin discriminates the check's EXISTENCE (delete
+    it → red) but NOT its POSITION — measured, not assumed: with the
+    check moved back to the pre-review position the pin still passes.
+    Discriminating the position needs the park rejection to land inside
+    the stream-doc-sync window specifically, which takes a two-stage
+    drain gate plus a controllable park rejection interleaved in a
+    fixed order; a flaky pin in this arm would be worse than none, so
+    the position rests on the code comment and this record. Two
+    exclusions, deliberate: cross-space
     queue neighbours (§2's order is per-space) and LT1 in-process
     copies (`served` with no `streamEntry` — no durable entry to
     re-drain, and a running event's same-wave cascade children rather

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6303,6 +6303,70 @@ supply; OW29/OW32/OW34 closed):
     shared-profile's, profile-embed's, and staged-publish's steps
     with an owed row) is the owner's call, deliberately not taken by
     the diagnosis seat.
+    **FIXED 2026-08-26 (its own deliberate seal-adjacent pass, no
+    riders — the OW58 caution above is why): the load-park failure arm
+    DEFERS a served event instead of dropping it.**
+    `failHeadEventLoadPark` (scheduler/facade.ts) now settles a served
+    event through the `deferred` arm — no consequence sealed, the
+    durable entry left pending and UNCONSEQUENCED, the standard
+    re-drain re-delivering it — and carries the drain's arrival-order
+    BARRIER with it (events.md §2, mirroring the sidecar-sync-failure
+    arm): every later-arrived durable served entry behind it IN THE
+    SAME SPACE defers too. Two exclusions, deliberate: cross-space
+    queue neighbours (§2's order is per-space) and LT1 in-process
+    copies (`served` with no `streamEntry` — no durable entry to
+    re-drain, and a running event's same-wave cascade children rather
+    than later arrivals; their entry re-drains WITH a `streamEntry`,
+    the `lt1LeftoversPurged` semantics). CLIENT-side (no `served`) the
+    drop keeps today's shape — there is no durable entry to re-drain,
+    so deferring would lose the event outright; the same split
+    events.ts already makes for a piece-load failure, and client-side
+    the two arms are behaviourally indistinguishable anyway (both
+    remove the event and abort its onCommit). T3's genuine
+    no-runnable-handler drop is UNTOUCHED — only the load-FAILURE
+    routing changed.
+    **Persistent-failure posture, stated:** a load that never heals
+    defers INDEFINITELY — durable, visible, re-tried each drain. The
+    deferral is deliberately kept OFF the queued class's bounded
+    creation-race budget (`EVENT_DEFERRAL_DROP_THRESHOLD`, which
+    hardens into §5's drop after 8 deferrals) by a typed
+    `cause: "load-park"` on the served failure outcome: that budget
+    exists because a piece which never materializes has no runnable
+    handler, whereas here the input doc EXISTS durably and only the
+    read path failed, so hardening would restore exactly the
+    at-least-once discharge this fix removes. Indefinite deferral is
+    strictly better than silent loss and is the accepted posture; its
+    cost is that the backstop rescan keeps ticking, so a never-healing
+    load holds the space out of its idle park. A give-up arm for that
+    case is OW54's separately tracked territory and was deliberately
+    NOT built here.
+    Observability gap CLOSED with the fix: `events.loadParkDeferrals`
+    counts each deferral (head and barrier alike) and `events.dropped`
+    counts terminal drop notices sealed onto a durable entry — the
+    previously invisible half; a loud WARN per deferral names the
+    failing doc keys and the error. serving-loop.md §7 carries both.
+    Pins, red-first: `executor-events-down.test.ts`'s "a served event
+    whose HEAD-EVENT LOAD PARK fails DEFERS instead of terminally
+    dropping" (a new `GatedStorageManager.loadParkFailAddress` seam
+    reports one doc as an in-flight load and REJECTS its park settle
+    with the production error text; observed pre-fix red: BOTH entries
+    sealed `{consequenced: true, status: "dropped", reason: "Event
+    dropped: required replica load failed before dispatch"}` — the
+    exact CI store shape) and
+    `scheduler-event-load-park.test.ts`'s "a SERVED event's load-park
+    failure reaches the drain as a load-park DEFERRAL, not a drop"
+    (the contract the SpaceServer's `onFailure` branches on; the
+    pre-existing client-side drop pin beside it is unchanged).
+    Mutations, both red: restore the drop routing → both entries seal
+    dropped and the log never grows past the warm-up; skip the barrier
+    loop → the log reads `["A","B","A"]`, the OW45 arm-B b01 overtake
+    shape. Battery green at the fix: executor-events-down (23 steps),
+    executor-fan-out, executor-serving-loop, scheduler-event-load-park.
+    STILL OPEN, untouched by this fix: shard 9
+    (`cfc-staged-publish`) stays UNHARVESTED — symptom-compatible,
+    no store evidence, classification open — and the #6248 lane
+    disposition remains the owner's call, now with the fix-before-flip
+    option actually available.
   - **OW46 — the silent forever-park is invisible (seat S-D;
     OW19-adjacent detectability). CLOSED 2026-08-21 (optimize-on-main
     client-durability pass; report:

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -6332,10 +6332,19 @@ supply; OW29/OW32/OW34 closed):
     it → red) but NOT its POSITION — measured, not assumed: with the
     check moved back to the pre-review position the pin still passes.
     Discriminating the position needs the park rejection to land inside
-    the stream-doc-sync window specifically, which takes a two-stage
-    drain gate plus a controllable park rejection interleaved in a
-    fixed order; a flaky pin in this arm would be worse than none, so
-    the position rests on the code comment and this record. Two
+    the stream-doc-sync window specifically. **PIN OWED, CONSTRUCTION
+    SKETCHED** (review F7 corrected this seat's earlier "a flaky pin
+    would be worse than none" — the construction is fully CAUSAL, not
+    timing-raced, so that framing overstated): hold B at its sidecar
+    sync (the shipped gate), wait for A2's park to be CREATED (a
+    parkObserved hook in the seam, as the scheduler pin already does),
+    arm a second gate on B's stream-doc sync (`cell.sync()` always
+    reaches `syncCell` — verified, no warm-cache short-circuit),
+    release the sidecar gate, hold at the stream gate, reject the park,
+    disarm, release. Every step causally ordered, no timers. Recorded
+    rather than built here only to keep this round scoped to the two P1
+    pins; see review-6365-report.md F7. Until it exists the position
+    rests on the code comment and this record. Two
     exclusions, deliberate: cross-space
     queue neighbours (§2's order is per-space) and LT1 in-process
     copies (`served` with no `streamEntry` — no durable entry to
@@ -6364,6 +6373,36 @@ supply; OW29/OW32/OW34 closed):
     load holds the space out of its idle park. A give-up arm for that
     case is OW54's separately tracked territory and was deliberately
     NOT built here.
+    **The price, quantified (review §2 — it was asserted but not
+    costed).** Per poisoned space, per 250 ms backstop tick: one drain
+    pass, one queueEvent, one preflight, one park, one real load attempt
+    against the failing backend, and 1+N WARN lines (head plus barrier
+    victims). So ~4 load attempts/s and, for a 10-event backlog, ~44 log
+    lines/s sustained — a WARN-flood cost the fix frames as
+    observability. Same-space later served events are head-of-line
+    blocked indefinitely BY DESIGN (order over liveness). Cross-space
+    events are not deferred, but the scheduler is head-serial, so the
+    poisoned head occupies the head slot for one park-to-rejection
+    latency every tick — negligible for the production error (a revoked
+    session rejects immediately) but a TIMEOUT-class slow failure would
+    stall co-scheduled dispatch at 4 Hz. That slow-failure case is what
+    makes OW54 worth scheduling rather than itself deferring
+    indefinitely.
+    **Weakening recorded (review F5), and it is DELIBERATE but was
+    unstated.** The arm's `#eventDeferrals.delete(entry.eventId)` on
+    every load-park deferral — head and barrier victims alike — means
+    the cold-view give-up guarantee is no longer "8 deferrals" but "8
+    CONSECUTIVE cold-view deferrals uninterrupted by a load-park
+    failure". Under a FLAPPING serving session (revoke/remount cycling
+    — the production mechanism here) a genuinely unrunnable event whose
+    cold-view deferrals interleave with load-park failures at least once
+    per ~7 ticks never hardens, wedging the park criterion active for an
+    event T3 licenses dropping. The intent was only to keep the budgets
+    unmixed; the sharper alternative — leave the cold-view count ALONE
+    rather than resetting it, since not-mixing is not the same as
+    resetting — preserves the hardening bound and belongs in OW54's
+    design space. Not changed here: it is a behaviour change to the
+    cold-view arm, which this deliberately scoped pass does not touch.
     Observability gap CLOSED with the fix: `events.loadParkDeferrals`
     counts each deferral (head and barrier alike) and `events.dropped`
     counts terminal drop notices sealed onto a durable entry — the
@@ -6384,17 +6423,70 @@ supply; OW29/OW32/OW34 closed):
     A third pin covers the mid-pass half: the drain's sync gate holds a
     pass at B's sidecar with A2's park already failed inside it, and
     after healing and release the log still reads `["A","A","B"]`.
-    Mutations, all red: restore the drop routing → both entries seal
-    dropped and the log never grows past the warm-up (and the
-    scheduler-level pin reads `kind: "dropped"`); skip the in-queue
-    barrier loop → `["A","B","A"]`, the OW45 arm-B b01 overtake shape;
-    drop the `#loadParkDeferredInPass` check → the same overtake through
-    the mid-pass gap. Battery green at the fix: executor-events-down
-    (24 steps, the α3 retry machinery untouched), executor-fan-out,
+    **CORRECTED 2026-08-26 (independent review F3 — this record briefly
+    claimed a mutation red that does not reproduce, the one thing it
+    must never do).** The original in-queue row was measured BEFORE the
+    mid-pass half existed and never re-run after; with both halves
+    present, emptying the in-queue loop leaves the suite GREEN, because
+    that pin's two handlers both read the ARMED doc — so a barrier-less
+    B parks on the same failure and self-defers through the HEAD arm.
+    The in-queue half is now discriminated by its own pin: the
+    `DISJOINT_CLOSURE_LOG_PATTERN` gives `pushA` an extra `gate` input
+    linked to a SEPARATE doc, the seam arms only that doc (so B stays
+    perfectly runnable), and the park rejection is HELD
+    (`loadParkSettle`) until both entries are provably queued —
+    `events.processed` up by two with the head parked — so the mid-pass
+    half cannot be what preserves the order. A fifth pin discriminates
+    the typed-cause budget bypass (review F4, the posture's load-bearing
+    half, previously unpinned): a PERSISTENT failure, waited past
+    `EVENT_DEFERRAL_DROP_THRESHOLD` on the `loadParkDeferrals` counter
+    rather than a sleep, must still seal nothing — then heals and
+    delivers once.
+    Mutations, all red, all re-run at this head: restore the drop
+    routing → both entries seal dropped and the log never grows past the
+    warm-up (and the scheduler-level pin reads `kind: "dropped"`); empty
+    the in-queue barrier loop → "B1 must not consequence while the
+    earlier-arrived A2 is deferred", `["A","B","A"]`, the OW45 arm-B b01
+    overtake shape; drop the `#loadParkDeferredInPass` check → the same
+    overtake through the mid-pass gap; fall the load-park arm through
+    into the threshold accounting → "a persistent load failure must
+    never harden into events.md §5's drop". Battery green at the fix:
+    executor-events-down
+    (26 steps, the α3 retry machinery untouched), executor-fan-out,
     executor-serving-loop, scheduler-event-load-park,
     executor-space-server, executor-watermark, executor-stats,
     executor-wave, executor-cross-space, and the full
     `packages/runner` package (1301 passed / 7549 steps / 0 failed).
+    **THE BARRIER INVARIANT AS STATED IS NOT CLOSED — a THIRD path gets
+    past both halves (review F1, structural from the code; not built as
+    a repro, and NOT a landing blocker because both the re-mark and the
+    shaper routing pre-date this PR and the pre-fix behaviour — terminal
+    drop — was strictly worse).** The drain re-marks durable entries
+    renderer-trusted before queueing (space-server.ts), and
+    `Scheduler.queueEvent` routes any renderer-trusted payload with
+    `doNotLoadPieceIfNotRunning=false` — what the drain passes — through
+    `holdShapedEvent`. The wake shaper's first `BURST_CAPACITY` (10)
+    deliveries per piece-group are synchronous, so the barrier sees
+    those; overflow sits in `group.pending` and releases as a batch on
+    the next window tick (≤1000 ms) straight into `queueSchedulerEvent`,
+    knowing nothing of a barrier sweep that ran while it was held.
+    Scenario, and the fresh-space backlog drain IS the OW45 window:
+    >10 renderer-trusted served entries for one piece drain in one pass;
+    1–10 queue, 11+ are shaper-held with their `#drainInFlight` guards
+    set (so re-drains skip them). Head 1's park fails → the in-queue
+    sweep defers 2–10 and the mid-pass break stops further queueing, but
+    11+ are in NEITHER place. The window tick releases 11 into the
+    now-empty queue; the load heals (this failure heals on next mount,
+    seconds); the rescan re-drains 1–10 BEHIND 11 → 11's consequence
+    lands ahead of 1–10, the §2 inversion the barrier exists to prevent.
+    (If the load still fails when 11 heads, 11 self-parks and order
+    self-heals; the overtake needs the heal inside the
+    release-to-rescan window — a real race for a transient failure.)
+    Named follow-up shape: exempt DRAIN RE-DISPATCHES from shaping —
+    they are re-deliveries of already-shaped input, so re-shaping
+    double-charges the timing budget anyway — or have the shaper's
+    release re-check barrier state. Sibling PRE-EXISTING hazard minted
+    separately as **OW63** below.
     STILL OPEN, untouched by this fix: shard 9
     (`cfc-staged-publish`) stays UNHARVESTED — symptom-compatible,
     no store evidence, classification open — and the #6248 lane
@@ -7786,6 +7878,34 @@ supply; OW29/OW32/OW34 closed):
     never landed at all (`deferred-start-conflict-exhausted` never
     became a live log key; the recovery's keys are
     `deferred-start-catchup` / `deferred-start-catchup-failed`).**
+  - **OW63 — the wake shaper can invert same-space arrival order
+    across PIECES, with no load-park involved (PRE-EXISTING; minted
+    2026-08-26 from the independent review of PR #6365, finding F1's
+    sibling). NOT OWED BY THAT PR** — it neither introduced nor
+    worsened this; it is recorded because reading the barrier's
+    reachability exposed it. events.md §2 orders served entries
+    "across streams in one space, arrival order", but the wake shaper
+    buckets held events per PIECE-GROUP, and two pieces in one space
+    have SEPARATE buckets with independent burst budgets and window
+    ticks. So a later-arrived entry for piece Y whose bucket is cold
+    (synchronous, inside `BURST_CAPACITY`) can consequence ahead of an
+    earlier-arrived entry for piece X whose bucket is saturated and
+    therefore held to the next window tick (≤1000 ms). No failure of
+    any kind is required — only a burst on one piece and normal
+    traffic on another, which is ordinary multi-piece load. What is
+    NOT yet established: whether any §2-visible consequence ordering
+    actually depends on cross-piece order in practice (same-piece and
+    same-stream order are preserved by the shaper's own FIFO), so the
+    first move is to decide whether §2's "across streams in one space"
+    is meant to bind across pieces at all — a SPEC question for the
+    owner before it is a code question. If it does bind, the candidate
+    shapes are the same two F1 names for the load-park case: exempt
+    drain re-dispatches from shaping (re-deliveries of already-shaped
+    input — re-shaping double-charges the timing budget), or give the
+    shaper a space-level ordering constraint rather than a per-group
+    one. Unpinned and unmeasured; structural from the code only
+    (`wake-shaping.ts`'s per-group `pending` + window tick, and the
+    drain's per-entry `queueEvent`).
 
 ## 4. Standing rule
 

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -2690,6 +2690,37 @@ export class SpaceServer implements TransactionSealDestination {
                 streamEntry,
                 onFailure: (outcome) => {
                   if (this.#runtime !== tenure) return;
+                  if (
+                    outcome.kind === "deferred" &&
+                    outcome.cause === "load-park"
+                  ) {
+                    // The pre-dispatch LOAD-PARK deferral
+                    // (verification-coverage.md's OW45 residue member).
+                    // Deliberately NOT on the bounded creation-race
+                    // budget below: that budget exists because a piece
+                    // which never materializes has no runnable handler
+                    // and must eventually harden into §5's drop, while
+                    // here the input doc EXISTS durably and only the
+                    // read path failed — hardening it would restore
+                    // exactly the at-least-once discharge this arm was
+                    // added to prevent. So a persistently failing load
+                    // defers INDEFINITELY: durable, unconsequenced,
+                    // re-tried every drain, WARNed per deferral by the
+                    // scheduler and counted here. The accepted cost is
+                    // that the backstop rescan keeps ticking, so a
+                    // never-healing load holds the space out of its
+                    // idle park; a give-up arm for that is OW54's
+                    // separately tracked territory, not this fix's.
+                    this.#options.stats.events.loadParkDeferrals += 1;
+                    // Never mix budgets: if this entry later defers for
+                    // the cold-view reason, that count starts fresh.
+                    this.#eventDeferrals.delete(entry.eventId);
+                    // The copy left no mark: release the guard so the
+                    // rescan can queue it again.
+                    this.#drainInFlight.delete(eventId);
+                    this.#armDeferredRescan();
+                    return;
+                  }
                   if (outcome.kind === "deferred") {
                     const deferrals =
                       (this.#eventDeferrals.get(entry.eventId) ?? 0) + 1;
@@ -2808,6 +2839,16 @@ export class SpaceServer implements TransactionSealDestination {
             path: ["entries", String(streamEntry.index), "error"],
           }).withTx(tx).set(outcome.message);
         } else {
+          // The recorded observability gap (verification-coverage.md's
+          // OW45 residue record), closed with the load-park fix: a
+          // terminally discharged served event used to leave NO trace
+          // in serving stats — `appended == processed` reads clean
+          // while the user's action is permanently gone. Counted at the
+          // DECISION, so a notice whose commit is refused and re-drains
+          // counts again; read it with the WARNs, never alone.
+          if (outcome.kind === "dropped") {
+            this.#options.stats.events.dropped += 1;
+          }
           runtime.getCellFromLink<string>({
             ...base,
             path: ["entries", String(streamEntry.index), "status"],

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -739,6 +739,18 @@ export class SpaceServer implements TransactionSealDestination {
    * EVENT_PREQUEUE_STUCK_AFTER. */
   #preQueueDeferralStreaks = new Map<string, number>();
 
+  /** Set when a LOAD-PARK deferral fires while a drain pass is running
+   * (verification-coverage.md's OW45 residue member). The scheduler's
+   * own arrival-order barrier holds every later-arrived durable entry
+   * that is already QUEUED behind the deferred one, but an entry this
+   * pass has not reached yet is out of its reach — and the pass awaits
+   * TWICE per entry (a new sidecar's `sync()`, then the stream doc's),
+   * so a park failure genuinely can land in either gap. The drain reads
+   * this immediately before queueing each entry — past both awaits —
+   * and stops the pass, the same barrier `break` the sidecar-sync-
+   * failure arm makes. Cleared at the top of every pass. */
+  #loadParkDeferredInPass = false;
+
   /** Post-commit effects of sealed transactions, deferred per wave
    * (serving-loop.md §3: effects hand to the outbox POST-commit, never
    * at seal). Admitted to the outbox after the wave's commit step;
@@ -2441,6 +2453,9 @@ export class SpaceServer implements TransactionSealDestination {
     const pendingDocs = Engine.selectPendingStreamEventDocs(engine);
     if (pendingDocs.length === 0) return 0;
     let queued = 0;
+    // The load-park barrier's mid-pass half (see #loadParkDeferredInPass).
+    // Cleared here so each pass judges its own deferrals.
+    this.#loadParkDeferredInPass = false;
     // Pending entries process ACROSS sidecars in append commit-seq
     // order — events.md §2: per stream, commit-seq order; across streams
     // in one space, arrival order. A deferral (a lagging sidecar view or
@@ -2500,6 +2515,18 @@ export class SpaceServer implements TransactionSealDestination {
           doc.id,
           () => `sidecar ${doc.id} (sync failing)`,
         );
+        this.#armDeferredRescan();
+        break;
+      }
+      // The load-park barrier's OTHER half. The scheduler-side barrier
+      // (failHeadEventLoadPark) can only hold entries already IN the
+      // event queue; an entry this pass has not queued YET would slip
+      // past it and overtake the deferred one. The window is real —
+      // each new sidecar's `sync()` above is an await, so a park failure
+      // can land between one entry's queueing and the next's — so the
+      // pass STOPS here, the same `break` the sidecar-sync arm makes,
+      // and the rescan re-drains from arrival position.
+      if (this.#loadParkDeferredInPass) {
         this.#armDeferredRescan();
         break;
       }
@@ -2712,6 +2739,10 @@ export class SpaceServer implements TransactionSealDestination {
                     // idle park; a give-up arm for that is OW54's
                     // separately tracked territory, not this fix's.
                     this.#options.stats.events.loadParkDeferrals += 1;
+                    // The barrier's mid-pass half: a drain pass in
+                    // flight must stop before queueing an entry that
+                    // arrived after this one.
+                    this.#loadParkDeferredInPass = true;
                     // Never mix budgets: if this entry later defers for
                     // the cold-view reason, that count starts fresh.
                     this.#eventDeferrals.delete(entry.eventId);

--- a/packages/runner/src/executor/space-server.ts
+++ b/packages/runner/src/executor/space-server.ts
@@ -2518,18 +2518,6 @@ export class SpaceServer implements TransactionSealDestination {
         this.#armDeferredRescan();
         break;
       }
-      // The load-park barrier's OTHER half. The scheduler-side barrier
-      // (failHeadEventLoadPark) can only hold entries already IN the
-      // event queue; an entry this pass has not queued YET would slip
-      // past it and overtake the deferred one. The window is real —
-      // each new sidecar's `sync()` above is an await, so a park failure
-      // can land between one entry's queueing and the next's — so the
-      // pass STOPS here, the same `break` the sidecar-sync arm makes,
-      // and the rescan re-drains from arrival position.
-      if (this.#loadParkDeferredInPass) {
-        this.#armDeferredRescan();
-        break;
-      }
       const stored = sidecar.stored ?? [];
       {
         const index = stored.findIndex((candidate) =>
@@ -2627,6 +2615,23 @@ export class SpaceServer implements TransactionSealDestination {
           }).sync();
         } catch {
           // A cold stream doc defers like a cold piece load below.
+        }
+        // The load-park barrier's OTHER half, and it sits HERE — past
+        // every await in the iteration, immediately before the queue —
+        // on purpose. The scheduler-side barrier
+        // (failHeadEventLoadPark) can only hold entries already IN the
+        // event queue; an entry this pass has not queued YET is out of
+        // its reach, and the gap is real because this loop awaits both
+        // a new sidecar's `sync()` above and the stream doc's `sync()`
+        // just now. A rejection landing in EITHER window sweeps only
+        // what was queued at that instant, so a check placed before
+        // one of them would let the entry queue anyway and commit
+        // ahead of the deferred one (independent review P1). Stopping
+        // the pass is the same `break` the sidecar-sync-failure arm
+        // makes; the rescan re-drains from arrival position.
+        if (this.#loadParkDeferredInPass) {
+          this.#armDeferredRescan();
+          break;
         }
         try {
           // The renderer-trust RE-MARK (fan-out stage B, OW34 — the

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -421,7 +421,11 @@ export type ServingLoopStats = {
     loadParkDeferrals: number;
     /** Terminal drop/error notices SEALED onto a durable entry
      * (events.md §5: the notice IS the consequence and the frontier
-     * advances past it). Recorded observability gap, closed with the
+     * advances past it). DROPS ONLY — a handler that THREW seals an
+     * error consequence and is deliberately not counted here, matching
+     * serving-loop.md §7's wording (independent review F8: this comment
+     * used to say "drop/error", which the increment never did).
+     * Recorded observability gap, closed with the
      * load-park fix: a terminally discharged served event used to be
      * invisible in serving stats — `appended == processed` reads clean
      * while a user's action is permanently gone — so only the WARN line

--- a/packages/runner/src/executor/stats.ts
+++ b/packages/runner/src/executor/stats.ts
@@ -406,6 +406,30 @@ export type ServingLoopStats = {
      * intent tx) fold into the refusal. Counted once per refused EVENT,
      * however many contributions folded. */
     orphanDeliveriesRefused: number;
+    /** The pre-dispatch LOAD-PARK deferrals (verification-coverage.md's
+     * OW45 residue member, fixed 2026-08-26): a served event's dispatch
+     * preflight parked on an in-flight replica load its closure reads
+     * and that load FAILED, so the event — and every later-arrived
+     * event behind it in the same space — deferred to a later drain
+     * instead of being sealed `{status: "dropped"}`. Counted per
+     * DEFERRAL, head and barrier alike, so a persistently failing load
+     * reads as a growing count rather than a single event. Nonzero is
+     * not by itself a fault (a revoked-then-remounted session heals in
+     * a cycle or two); a count that grows without `processed` moving
+     * names a load that never heals, and the WARN beside each deferral
+     * carries the failing doc key and the error. */
+    loadParkDeferrals: number;
+    /** Terminal drop/error notices SEALED onto a durable entry
+     * (events.md §5: the notice IS the consequence and the frontier
+     * advances past it). Recorded observability gap, closed with the
+     * load-park fix: a terminally discharged served event used to be
+     * invisible in serving stats — `appended == processed` reads clean
+     * while a user's action is permanently gone — so only the WARN line
+     * and the entry's own `status` field carried it. Routine causes
+     * exist (a piece that can never start hardens here after its
+     * bounded creation-race window), so read it against
+     * `loadParkDeferrals` and the WARNs, not alone. */
+    dropped: number;
   };
   memo: { hits: number; misses: number; inflight: number };
   outbox: {
@@ -515,6 +539,8 @@ export const emptyServingLoopStats = (): ServingLoopStats => ({
     lt1LeftoversPurged: 0,
     lt1LateSealsRefused: 0,
     orphanDeliveriesRefused: 0,
+    loadParkDeferrals: 0,
+    dropped: 0,
   },
   memo: { hits: 0, misses: 0, inflight: 0 },
   outbox: { queued: 0, completed: 0, failed: 0, budgetDeferrals: 0 },

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -184,7 +184,7 @@ function notifyEventDropped(
   },
   reason: string,
   servedKind: "dropped" | "deferred" = "dropped",
-  options: { quiet?: boolean } = {},
+  options: { quiet?: boolean; cause?: "load-park" } = {},
 ): void {
   if (options.quiet === true) {
     // A routine, counted pre-dispatch removal (the serving loop's LT1
@@ -196,10 +196,17 @@ function notifyEventDropped(
   // The serving drain's terminal arms (events.md §5): `dropped` — no
   // runnable handler, the drain writes the dropped-event notice as the
   // event's consequence and advances the stream past it (non-wedging);
-  // `deferred` — the handler was UNREACHABLE (a cold-view load), no
-  // consequence is written and a later wave re-drains the entry.
+  // `deferred` — the handler was UNREACHABLE (a cold-view load, or a
+  // required replica load that failed at the dispatch preflight's
+  // park), no consequence is written and a later wave re-drains the
+  // entry. `cause` tells the two deferrals apart for the drain's retry
+  // budget (see ServedEventDispatch.onFailure).
   try {
-    args.served?.onFailure?.({ kind: servedKind, message: reason });
+    args.served?.onFailure?.({
+      kind: servedKind,
+      message: reason,
+      ...(options.cause !== undefined ? { cause: options.cause } : {}),
+    });
   } catch (callbackError) {
     logger.error(
       "schedule-error",
@@ -234,7 +241,7 @@ export function dropQueuedEvent(
   event: QueuedEvent,
   reason: string,
   servedKind: "dropped" | "deferred" = "dropped",
-  options: { quiet?: boolean } = {},
+  options: { quiet?: boolean; cause?: "load-park" } = {},
 ): void {
   const index = state.eventQueue.indexOf(event);
   if (index >= 0) state.eventQueue.splice(index, 1);

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -2840,22 +2840,86 @@ export class Scheduler {
     this.queueExecution();
   }
 
+  /**
+   * The head event's required replica load FAILED.
+   *
+   * events.md §5's T3 drop predicate is "no runnable handler", never
+   * "the run raced" — and a load failure is the second: the doc the
+   * closure reads EXISTS durably, only the read path failed. The live
+   * shape (verification-coverage.md's OW45 residue member, store-proven
+   * on CI run 32929764230) is a serving session revoked by the genesis
+   * ACL landing after activation — `unauthorized` on a cross-space read
+   * of a doc the server itself wrote one second earlier, healing by
+   * design on the next mount. Sealing §5's dropped-event notice for
+   * that DISCHARGED at-least-once on a healthy trusted user action and
+   * advanced the watermark past it, so nothing ever re-ran it: the
+   * click was silently lost.
+   *
+   * A SERVED event therefore DEFERS — no consequence written, the
+   * durable entry left pending and UNCONSEQUENCED, a later drain
+   * re-delivering it. The deferral carries the drain's arrival-order
+   * BARRIER with it (events.md §2, mirroring the sidecar-sync-failure
+   * arm): every later-arrived durable served entry behind it IN THE
+   * SAME SPACE defers too, or a later arrival's consequence lands ahead
+   * of an earlier one. Two exclusions, both deliberate: cross-space
+   * queue neighbours (§2's order is per-space) and LT1 in-process
+   * copies (`served` with no `streamEntry`), which have no durable
+   * entry to re-drain and are a running event's same-wave cascade
+   * children rather than later arrivals.
+   *
+   * Client-side (no `served`) there is no durable entry to re-drain, so
+   * the drop keeps today's shape — the same split events.ts makes for a
+   * piece-load failure.
+   */
   private failHeadEventLoadPark(event: QueuedEvent, error: unknown): void {
     if (this.headEventLoadPark?.eventId !== event.id) return;
+    const keys = this.headEventLoadPark.keys.join(", ");
     this.headEventLoadPark = null;
     this.headEventLoadParkHistory = null;
     const detail = error instanceof Error ? error.message : String(error);
+    if (event.served === undefined) {
+      this.dropEvent(
+        event,
+        `Event dropped: required replica load failed before dispatch (${detail})`,
+      );
+      this.queueExecution();
+      return;
+    }
+    // WARN per deferral, naming the failing doc keys and the error: a
+    // deferral that never clears is a user action that never lands, and
+    // `events.loadParkDeferrals` counts what the log spells out.
     this.dropEvent(
       event,
-      `Event dropped: required replica load failed before dispatch (${detail})`,
+      `Event deferred: required replica load failed before dispatch ` +
+        `(${keys}: ${detail}); the entry stays pending and a later drain ` +
+        `re-delivers it`,
+      { servedKind: "deferred", cause: "load-park" },
     );
+    for (const later of [...this.eventQueue]) {
+      if (later.eventLink.space !== event.eventLink.space) continue;
+      if (later.served?.streamEntry === undefined) continue;
+      this.dropEvent(
+        later,
+        `Event deferred: held behind ${event.id}, whose required replica ` +
+          `load failed before dispatch (${keys}); later-arrived events wait ` +
+          `behind it`,
+        { servedKind: "deferred", cause: "load-park" },
+      );
+    }
     this.queueExecution();
   }
 
   private dropEvent(
     event: QueuedEvent,
     reason: string,
-    options: { quiet?: boolean } = {},
+    options: {
+      quiet?: boolean;
+      /** Defaults to the terminal `dropped` arm. `deferred` leaves the
+       * durable entry UNCONSEQUENCED for a later drain (events.md §5);
+       * only meaningful for a served event. */
+      servedKind?: "dropped" | "deferred";
+      cause?: "load-park";
+    } = {},
   ): void {
     if (this.headEventLoadPark?.eventId === event.id) {
       this.headEventLoadPark = null;
@@ -2873,7 +2937,7 @@ export class Scheduler {
       },
       event,
       reason,
-      "dropped",
+      options.servedKind ?? "dropped",
       options,
     );
   }

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -285,7 +285,17 @@ export type ServedEventDispatch = {
        * would be the same at-least-once discharge this arm exists to
        * prevent. Absent on the cold-view piece-load deferral, which
        * keeps its bounded budget (a piece that never materializes has
-       * no runnable handler and must eventually harden). */
+       * no runnable handler and must eventually harden).
+       *
+       * ONLY meaningful when `kind` is `deferred`; the terminal arms
+       * never set it (independent review, Cubic P3). Deliberately NOT
+       * modelled as a discriminated union: the producer builds `kind`
+       * dynamically — `notifyEventDropped` takes it as
+       * `"dropped" | "deferred"` and cannot narrow to a branch — so a
+       * union would only relocate the looseness into a cast at the one
+       * call site. The producer-side guarantee is exact instead:
+       * `cause` is forwarded solely from `failHeadEventLoadPark`, which
+       * always pairs it with `servedKind: "deferred"`. */
       cause?: "load-park";
     },
   ) => void;

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -273,6 +273,20 @@ export type ServedEventDispatch = {
        * runnable handler', never 'the run raced'". */
       kind: "error" | "dropped" | "deferred";
       message: string;
+      /** Which deferral this is, when the drain needs to tell them
+       * apart. `load-park`: the dispatch preflight parked the head on
+       * an in-flight replica load its closure reads and that load
+       * FAILED (verification-coverage.md's OW45 residue member — the
+       * live shape is a serving session revoked by a genesis ACL
+       * landing after activation, healing on the next mount). Its
+       * retry budget is the drain's, not the queued class's bounded
+       * creation-race window: the input is a doc that durably EXISTS
+       * and only the read path failed, so hardening it into §5's drop
+       * would be the same at-least-once discharge this arm exists to
+       * prevent. Absent on the cold-view piece-load deferral, which
+       * keeps its bounded budget (a piece that never materializes has
+       * no runnable handler and must eventually harden). */
+      cause?: "load-park";
     },
   ) => void;
 };

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -3387,7 +3387,7 @@ describe("Phase 3 events-down (serving side)", () => {
     }
   });
 
-  it("the load-park barrier reaches entries the drain has NOT queued yet: a park failure landing MID-PASS stops the pass, instead of letting the next-arrived entry queue behind the barrier's back and overtake (the scheduler-side barrier can only hold what is already IN the event queue, and each new sidecar's sync() is an await — so the gap is real; held open here with the drain's sync gate on B's sidecar. Mutation: drop the #loadParkDeferredInPass check in #drainStreamEvents → B1 queues into the healed load and the log reads [\"A\",\"B\",\"A\"], the OW45 arm-B b01 overtake shape)", async () => {
+  it('the load-park barrier reaches entries the drain has NOT queued yet: a park failure landing MID-PASS stops the pass, instead of letting the next-arrived entry queue behind the barrier\'s back and overtake (the scheduler-side barrier can only hold what is already IN the event queue, and each new sidecar\'s sync() is an await — so the gap is real; held open here with the drain\'s sync gate on B\'s sidecar. Mutation: drop the #loadParkDeferredInPass check in #drainStreamEvents → B1 queues into the healed load and the log reads ["A","B","A"], the OW45 arm-B b01 overtake shape)', async () => {
     ({ manager: clientManager, runtime: clientRuntime } = openClient());
     const engine = await server.engineForSpace(space);
 

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -111,6 +111,60 @@ class GatedStorageManager extends EmulatedStorageManager {
    * touched the failing sidecar counts one. */
   static syncThrowHits = 0;
 
+  /** The FOURTH seam, the HEAD-EVENT LOAD-PARK FAILURE arm (the OW45
+   * residue member's live shape): a served event's dispatch preflight
+   * parks on an in-flight replica load its closure reads, and that
+   * load FAILS. In production the failure is a serving session revoked
+   * by the genesis ACL landing after activation — transient, healing
+   * on the next mount, and NOT events.md §5's "no runnable handler".
+   * While armed, the named doc reads as an in-flight load (so a head
+   * event whose closure reads it parks) and the park's settle REJECTS
+   * with that error's text. STATIC for the same reason as the sync
+   * throw seam: the host may rotate runtime tenures, and the seam must
+   * hold across every tenure of the pass under test. */
+  static loadParkFailDocId: string | undefined;
+  /** The armed doc's address, reported as pending while armed. */
+  static loadParkFailAddress:
+    | { space: MemorySpace; scope: "space"; id: string }
+    | undefined;
+  /** How many head-event load parks the seam has failed — a pin's
+   * evidence that the park was REACHED, not merely armed. */
+  static loadParkFailHits = 0;
+
+  /** The park key is `space/scopeKey/id` (scheduler/keys.ts); the
+   * scope key resolves against the runtime's identity, so match on the
+   * id suffix rather than re-deriving it here. */
+  static #matchesArmedDoc(key: string): boolean {
+    const id = GatedStorageManager.loadParkFailDocId;
+    return id !== undefined && key.endsWith(`/${id}`);
+  }
+
+  override pendingLoadAddresses(): ReturnType<
+    EmulatedStorageManager["pendingLoadAddresses"]
+  > {
+    const real = super.pendingLoadAddresses();
+    const armed = GatedStorageManager.loadParkFailAddress;
+    if (armed === undefined) return real;
+    return [...real, armed] as ReturnType<
+      EmulatedStorageManager["pendingLoadAddresses"]
+    >;
+  }
+
+  override pendingLoadGeneration(key: string): number | undefined {
+    if (GatedStorageManager.#matchesArmedDoc(key)) return 1;
+    return super.pendingLoadGeneration(key);
+  }
+
+  override loadsSettled(keys: readonly string[]): Promise<void> {
+    if (keys.some((key) => GatedStorageManager.#matchesArmedDoc(key))) {
+      GatedStorageManager.loadParkFailHits += 1;
+      return Promise.reject(
+        new Error("memory session revoked: unauthorized (pin seam)"),
+      );
+    }
+    return super.loadsSettled(keys);
+  }
+
   override async syncCell<T>(
     cell: Cell<T>,
     options?: Parameters<EmulatedStorageManager["syncCell"]>[1],
@@ -3156,6 +3210,163 @@ describe("Phase 3 events-down (serving side)", () => {
       expect(storedLog()).toEqual(["A", "A", "B"]);
     } finally {
       GatedStorageManager.syncThrowWhen = undefined;
+      cancelDemand();
+    }
+  });
+
+  it("a served event whose HEAD-EVENT LOAD PARK fails DEFERS instead of terminally dropping: the entry stays unconsequenced through the failure, later arrivals hold behind it, and a drain after the failure clears delivers it EXACTLY ONCE in arrival order (events.md §5's T3 predicate — 'no runnable handler', never 'the run raced'; the OW45 residue member: a genesis ACL revoking the serving plane's pre-genesis session made a cross-space replica load fail and `failHeadEventLoadPark` sealed {status:'dropped', consequenced:true}, discharging at-least-once on a healthy trusted click; mutation: route the failure arm back to `dropEvent` → BOTH entries seal dropped and the log never grows past the warm-up)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+
+    const compiled = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: ORDERED_LOG_PATTERN }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ log: string[] }>(
+      space,
+      "load-park-defer-arg",
+      undefined,
+    );
+    const result = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "load-park-defer-result",
+      compiled.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      argument.withTx(seed).set({ log: [] });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const argumentLink = argument.getAsNormalizedFullLink();
+    const argumentId = argumentLink.id;
+    const storedLog =
+      (): string[] => ((Engine.read(engine, { id: argumentId })?.value as
+        | { log?: string[] }
+        | undefined)?.log ?? []);
+    const entriesOf = (sidecarId: string) =>
+      ((Engine.read(engine, { id: sidecarId })?.value ??
+        {}) as StreamEventsDocValue).entries ?? [];
+    const allEntries = () =>
+      sidecarIdsIn(engine).flatMap((id) => entriesOf(id));
+    const send = (stream: "a" | "b") =>
+      (result.key(stream) as unknown as { send(value: unknown): unknown })
+        .send({});
+
+    GatedStorageManager.loadParkFailHits = 0;
+    try {
+      // Warm the piece and stream `a`'s sidecar: one consequenced send,
+      // with no park armed.
+      send("a");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => storedLog().length === 1,
+        "the warm-up consequence to land",
+      );
+      expect(storedLog()).toEqual(["A"]);
+      const aSidecarId = sidecarIdsIn(engine)[0];
+      expect(aSidecarId).toBeDefined();
+
+      // Arm the failure on the ARGUMENT doc — the doc BOTH handlers'
+      // closures read, so either stream's head event parks on it.
+      GatedStorageManager.loadParkFailDocId = argumentId;
+      GatedStorageManager.loadParkFailAddress = {
+        space,
+        scope: "space",
+        id: argumentId,
+      };
+
+      // A2 arrives first, B1 second — the same ordered appends the
+      // sidecar-sync barrier pin uses.
+      send("a");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => entriesOf(aSidecarId).length === 2,
+        "A2's append to land",
+      );
+      send("b");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => sidecarIdsIn(engine).length === 2,
+        "B1's append to land on its own sidecar",
+      );
+
+      // Wait for the park failure to have RESOLVED one way or the other.
+      // The predicate is satisfiable in BOTH worlds on purpose, so the
+      // pin reds on its assertion rather than on a timeout: the terminal
+      // arm seals a `status` onto the entry and then goes quiet (nothing
+      // is left to park), while the deferral arm never seals and keeps
+      // re-draining, so its failure count goes on climbing.
+      const failuresBefore = GatedStorageManager.loadParkFailHits;
+      await waitUntil(
+        () =>
+          allEntries().some((entry) =>
+            (entry as { status?: string }).status !== undefined
+          ) || GatedStorageManager.loadParkFailHits > failuresBefore + 1,
+        "the head-event load park to fail (deferring or terminally dropping)",
+      );
+
+      // PIN 1 — the failure is a DEFERRAL, not a drop: nothing was
+      // sealed. Pre-fix both entries carry {status: "dropped",
+      // consequenced: true} within a wave of the first failure.
+      expect(
+        allEntries().filter((entry) =>
+          (entry as { status?: string }).status !== undefined
+        ),
+        "a transient load failure must never seal a dropped-event notice",
+      ).toEqual([]);
+      expect(
+        allEntries().filter((entry) => entry.consequenced === true).length,
+        "only the warm-up entry may be consequenced while the load fails",
+      ).toBe(1);
+      // PIN 2 — the ordering barrier: B1 (later arrival, its own healthy
+      // sidecar) must not overtake the deferred A2.
+      expect(storedLog(), "later arrivals hold behind the deferred event")
+        .toEqual(["A"]);
+      // PIN 3 — the deferral is VISIBLE: the serving stats carry it, and
+      // no terminal drop was counted.
+      const duringFailure = host!.stats().events;
+      expect(duringFailure.loadParkDeferrals).toBeGreaterThan(0);
+      expect(duringFailure.dropped).toBe(0);
+
+      // Heal: the replica load succeeds and the deferred entries drain.
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+
+      await waitUntil(
+        () => storedLog().length === 3,
+        "all three consequences to land after the load failure clears",
+        30_000,
+      );
+      // PIN 4 — exactly-once ((α)) AND arrival order: one consequence per
+      // event, A2 before B1. A re-delivery would read ["A","A","A","B"].
+      expect(storedLog()).toEqual(["A", "A", "B"]);
+      await clientRuntime.idle();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(storedLog(), "no residual re-delivery of the deferred event")
+        .toEqual(["A", "A", "B"]);
+      expect(
+        allEntries().filter((entry) => entry.consequenced === true).length,
+        "every entry consequenced exactly once",
+      ).toBe(3);
+      expect(host!.stats().events.dropped).toBe(0);
+    } finally {
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
       cancelDemand();
     }
   });

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -3373,4 +3373,132 @@ describe("Phase 3 events-down (serving side)", () => {
       cancelDemand();
     }
   });
+
+  it("the load-park barrier reaches entries the drain has NOT queued yet: a park failure landing MID-PASS stops the pass, instead of letting the next-arrived entry queue behind the barrier's back and overtake (the scheduler-side barrier can only hold what is already IN the event queue, and each new sidecar's sync() is an await — so the gap is real; held open here with the drain's sync gate on B's sidecar. Mutation: drop the #loadParkDeferredInPass check in #drainStreamEvents → B1 queues into the healed load and the log reads [\"A\",\"B\",\"A\"], the OW45 arm-B b01 overtake shape)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+
+    const compiled = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: ORDERED_LOG_PATTERN }],
+    }, { space });
+    const argument = clientRuntime.getCell<{ log: string[] }>(
+      space,
+      "load-park-midpass-arg",
+      undefined,
+    );
+    const result = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "load-park-midpass-result",
+      compiled.resultSchema,
+    );
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      argument.withTx(seed).set({ log: [] });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const argumentId = argument.getAsNormalizedFullLink().id;
+    const storedLog =
+      (): string[] => ((Engine.read(engine, { id: argumentId })?.value as
+        | { log?: string[] }
+        | undefined)?.log ?? []);
+    const entriesOf = (sidecarId: string) =>
+      ((Engine.read(engine, { id: sidecarId })?.value ??
+        {}) as StreamEventsDocValue).entries ?? [];
+    const send = (stream: "a" | "b") =>
+      (result.key(stream) as unknown as { send(value: unknown): unknown })
+        .send({});
+
+    GatedStorageManager.loadParkFailHits = 0;
+    const gate = Promise.withResolvers<void>();
+    try {
+      // Warm the piece and stream `a`'s sidecar, ungated.
+      send("a");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => storedLog().length === 1,
+        "the warm-up consequence to land",
+      );
+      const aSidecarId = sidecarIdsIn(engine)[0];
+      expect(aSidecarId).toBeDefined();
+      expect(servingManager).toBeDefined();
+
+      // Hold the drain at B's sidecar sync — the exact point at which A2
+      // has been queued and B1 has not. `a`'s sidecar passes through, so
+      // A2 still queues in this pass.
+      servingManager!.syncGateWhen = (id) =>
+        id.startsWith("of:stream-events:") && id !== aSidecarId;
+      servingManager!.syncGate = gate.promise;
+
+      // Fail A2's head-event load park while the pass is held.
+      GatedStorageManager.loadParkFailDocId = argumentId;
+      GatedStorageManager.loadParkFailAddress = {
+        space,
+        scope: "space",
+        id: argumentId,
+      };
+
+      send("a");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => entriesOf(aSidecarId).length === 2,
+        "A2's append to land",
+      );
+      send("b");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => sidecarIdsIn(engine).length === 2,
+        "B1's append to land on its own sidecar",
+      );
+
+      // The window: a pass held at B's sidecar sync, with A2's park
+      // already failed inside it.
+      await waitUntil(
+        () =>
+          (servingManager?.syncGateHits ?? 0) > 0 &&
+          GatedStorageManager.loadParkFailHits > 0,
+        "a drain pass held at B's sidecar with A2's park already failed",
+      );
+
+      // HEAL FIRST, then release: with the load healthy, an unbarriered
+      // pass would queue B1 and dispatch it immediately — the overtake.
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+      servingManager!.syncGateWhen = undefined;
+      servingManager!.syncGate = undefined;
+      gate.resolve();
+
+      await waitUntil(
+        () => storedLog().length === 3,
+        "all three consequences to land after the pass resumes",
+        30_000,
+      );
+      // THE PIN: arrival order held across the mid-pass gap.
+      expect(storedLog()).toEqual(["A", "A", "B"]);
+    } finally {
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+      if (servingManager !== undefined) {
+        servingManager.syncGateWhen = undefined;
+        servingManager.syncGate = undefined;
+      }
+      gate.resolve();
+      cancelDemand();
+    }
+  });
 });

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -155,9 +155,19 @@ class GatedStorageManager extends EmulatedStorageManager {
     return super.pendingLoadGeneration(key);
   }
 
+  /** When set, the armed doc's park settle returns THIS promise instead of
+   * rejecting at once — so a pin can hold a park OPEN until it has arranged
+   * the state under test (e.g. a later-arrived entry actually QUEUED behind
+   * the parked head), then fail it on command. Without it the rejection is
+   * immediate and the state a pin wants to construct may never exist. The
+   * scheduler-level pins use the same `Promise.withResolvers` idiom. */
+  static loadParkSettle: Promise<void> | undefined;
+
   override loadsSettled(keys: readonly string[]): Promise<void> {
     if (keys.some((key) => GatedStorageManager.#matchesArmedDoc(key))) {
       GatedStorageManager.loadParkFailHits += 1;
+      const held = GatedStorageManager.loadParkSettle;
+      if (held !== undefined) return held;
       return Promise.reject(
         new Error("memory session revoked: unauthorized (pin seam)"),
       );
@@ -276,6 +286,33 @@ const ORDERED_LOG_PATTERN = [
   "  { log: Writable<string[]> },",
   "  { log: string[]; a: Stream<unknown>; b: Stream<unknown> }",
   ">(({ log }) => ({ log, a: pushA({ log }), b: pushB({ log }) }));",
+].join("\n");
+
+/** The ORDERED_LOG_PATTERN's sibling with DISJOINT handler closures: `pushA`
+ * additionally reads `gate`, which the test links to a SEPARATE doc, while
+ * `pushB` reads only the shared log. Arming the load-park failure on the gate
+ * doc therefore parks stream `a`'s head event and leaves stream `b`'s handler
+ * perfectly runnable — the construction the in-queue arrival-order barrier
+ * actually needs. (In the shared-closure pattern a later-arrived B parks on
+ * the same failing doc and self-defers through the HEAD arm, so removing the
+ * barrier changes nothing and the pin cannot discriminate it — independent
+ * review F3.) */
+const DISJOINT_CLOSURE_LOG_PATTERN = [
+  "import { handler, pattern, Stream, Writable } from 'commonfabric';",
+  "const pushA = handler<",
+  "  unknown,",
+  "  { log: Writable<string[]>; gate: Writable<number> }",
+  ">((_ev, { log, gate }) => {",
+  "  gate.get();",
+  "  log.set([...(log.get() ?? []), 'A']);",
+  "});",
+  "const pushB = handler<unknown, { log: Writable<string[]> }>(",
+  "  (_ev, { log }) => { log.set([...(log.get() ?? []), 'B']); },",
+  ");",
+  "export default pattern<",
+  "  { log: Writable<string[]>; gate: Writable<number> },",
+  "  { log: string[]; a: Stream<unknown>; b: Stream<unknown> }",
+  ">(({ log, gate }) => ({ log, a: pushA({ log, gate }), b: pushB({ log }) }));",
 ].join("\n");
 
 // OW54's refused-commit class (verification-coverage.md §3): a stored
@@ -3511,6 +3548,241 @@ describe("Phase 3 events-down (serving side)", () => {
         servingManager.syncGate = undefined;
       }
       gate.resolve();
+      cancelDemand();
+    }
+  });
+
+  it('the IN-QUEUE arrival-order barrier, discriminated: a later-arrived event whose closure does NOT touch the failing doc — so it is perfectly runnable and already QUEUED behind the parked head — defers with the head instead of overtaking it (events.md §2; independent review F3: the previous construction had both handlers reading the armed doc, so a barrier-less B parked on the same failure and self-deferred through the HEAD arm, making the in-queue half undiscriminable. Here the park rejection is DEFERRED until both entries are provably queued, so the mid-pass half cannot be what saves the order. Mutation: empty the barrier loop in failHeadEventLoadPark → B1 consequences while A2 is deferred and the log reads ["A","B","A"])', async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+
+    const compiled = await clientRuntime.patternManager.compilePattern({
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: DISJOINT_CLOSURE_LOG_PATTERN }],
+    }, { space });
+    // `gate` is its OWN doc, linked into the argument: that is what makes
+    // pushA's closure a strict superset of pushB's.
+    const gateCell = clientRuntime.getCell<number>(
+      space,
+      "in-queue-barrier-gate",
+      undefined,
+    );
+    const argument = clientRuntime.getCell<
+      { log: string[]; gate: unknown }
+    >(space, "in-queue-barrier-arg", undefined);
+    const result = clientRuntime.getCell<Record<string, unknown>>(
+      space,
+      "in-queue-barrier-result",
+      compiled.resultSchema,
+    );
+    await gateCell.sync();
+    await argument.sync();
+    await result.sync();
+    {
+      const seed = clientRuntime.edit();
+      gateCell.withTx(seed).set(0);
+      argument.withTx(seed).set({ log: [], gate: gateCell });
+      expect((await seed.commit()).error).toBeUndefined();
+    }
+    {
+      const tx = clientRuntime.edit();
+      clientRuntime.run(tx, compiled, argument, result);
+      expect((await tx.commit()).error).toBeUndefined();
+    }
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const argumentId = argument.getAsNormalizedFullLink().id;
+    const gateId = gateCell.getAsNormalizedFullLink().id;
+    // The construction only means anything if the gate really is a separate
+    // doc — otherwise arming it would arm both closures again (the F3 trap).
+    expect(gateId, "the gate must be its own doc, not a path in the argument")
+      .not.toBe(argumentId);
+    const storedLog =
+      (): string[] => ((Engine.read(engine, { id: argumentId })?.value as
+        | { log?: string[] }
+        | undefined)?.log ?? []);
+    const send = (stream: "a" | "b") =>
+      (result.key(stream) as unknown as { send(value: unknown): unknown })
+        .send({});
+
+    GatedStorageManager.loadParkFailHits = 0;
+    const park = Promise.withResolvers<void>();
+    park.promise.catch(() => {});
+    try {
+      // Warm the piece and stream `a`'s sidecar, unarmed.
+      send("a");
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(
+        () => storedLog().length === 1,
+        "the warm-up consequence to land",
+      );
+      expect(storedLog()).toEqual(["A"]);
+
+      // Arm the failure on the GATE doc — pushA's closure only — and HOLD
+      // the park open rather than failing it now.
+      GatedStorageManager.loadParkSettle = park.promise;
+      GatedStorageManager.loadParkFailDocId = gateId;
+      GatedStorageManager.loadParkFailAddress = {
+        space,
+        scope: "space",
+        id: gateId,
+      };
+
+      const processedBefore = host!.stats().events.processed;
+      send("a"); // A2 arrives first
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      send("b"); // B1 second
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+
+      // THE CONSTRUCTION: wait until BOTH entries have been queued into the
+      // scheduler (processed counts queueEvent calls per drain pass) and A2
+      // is provably PARKED on the held settle. At this instant the queue is
+      // [A2 parked at head, B1 behind it] — B1 is exactly what the in-queue
+      // sweep must reach, and the mid-pass half is irrelevant because no
+      // deferral has happened yet.
+      await waitUntil(
+        () =>
+          host!.stats().events.processed >= processedBefore + 2 &&
+          GatedStorageManager.loadParkFailHits > 0,
+        "both entries queued with A2 parked on the held load",
+      );
+      expect(storedLog(), "neither may have run while A2 holds the head")
+        .toEqual(["A"]);
+
+      // Now fail the park. A2 defers; the in-queue barrier must take B1 with
+      // it even though B1's own closure is perfectly loadable.
+      park.reject(new Error("memory session revoked: unauthorized (pin seam)"));
+      await waitUntil(
+        () => host!.stats().events.loadParkDeferrals >= 2,
+        "the head deferral and its barrier victim",
+      );
+      expect(
+        storedLog(),
+        "B1 must not consequence while the earlier-arrived A2 is deferred",
+      ).toEqual(["A"]);
+
+      // Heal: both re-drain in arrival order.
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+      GatedStorageManager.loadParkSettle = undefined;
+
+      await waitUntil(
+        () => storedLog().length === 3,
+        "all three consequences to land after the load failure clears",
+        30_000,
+      );
+      // THE PIN: arrival order. Without the in-queue sweep B1 runs at the
+      // moment A2 defers and the log reads ["A","B","A"].
+      expect(storedLog()).toEqual(["A", "A", "B"]);
+      expect(host!.stats().events.dropped).toBe(0);
+    } finally {
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+      GatedStorageManager.loadParkSettle = undefined;
+      park.reject(new Error("pin teardown"));
+      cancelDemand();
+    }
+  });
+
+  it("the typed-cause budget bypass, discriminated: a PERSISTENTLY failing load defers past the cold-view give-up threshold without ever hardening into §5's drop (the fix's central posture — `cause: \"load-park\"` keeps these deferrals off `EVENT_DEFERRAL_DROP_THRESHOLD`, because that budget exists for a piece that never materializes, not for an input that exists and only failed to READ. Independent review F4. Mutation: delete the arm's trailing delete/delete/rescan/return so it falls through into the threshold accounting → the entry hardens into a sealed dropped notice after ~8 backstop ticks, restoring the at-least-once discharge this PR removes)", async () => {
+    ({ manager: clientManager, runtime: clientRuntime } = openClient());
+    const engine = await server.engineForSpace(space);
+    const { argument, result } = await standUp(clientRuntime, BUMP_PATTERN, {
+      arg: "budget-bypass-arg",
+      result: "budget-bypass-result",
+    });
+    const cancelDemand = result.sink(() => {});
+    await clientRuntime.idle();
+    await clientRuntime.storageManager.synced();
+
+    host = newHost();
+    const argumentId = argument.getAsNormalizedFullLink().id;
+    const storedValue = () =>
+      (Engine.read(engine, { id: argumentId })?.value as
+        | { value?: number }
+        | undefined)?.value ?? 0;
+    const entriesOf = (sidecarId: string) =>
+      ((Engine.read(engine, { id: sidecarId })?.value ??
+        {}) as StreamEventsDocValue).entries ?? [];
+    const allEntries = () =>
+      sidecarIdsIn(engine).flatMap((id) => entriesOf(id));
+    const bump = () =>
+      (result.key("bump") as unknown as { send(value: unknown): unknown })
+        .send({});
+
+    GatedStorageManager.loadParkFailHits = 0;
+    try {
+      // Warm the piece and its sidecar, unarmed.
+      bump();
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+      await waitUntil(() => storedValue() === 1, "the warm-up bump to land");
+
+      // A PERSISTENT failure — never healed inside this pin.
+      GatedStorageManager.loadParkFailDocId = argumentId;
+      GatedStorageManager.loadParkFailAddress = {
+        space,
+        scope: "space",
+        id: argumentId,
+      };
+      bump();
+      await clientRuntime.idle();
+      await clientRuntime.storageManager.synced();
+
+      // Causally closed on the COUNTER, not a sleep: one pending event means
+      // one deferral per backstop tick, so crossing the cold-view budget is
+      // what we wait for. EVENT_DEFERRAL_DROP_THRESHOLD is 8; going past it
+      // is the whole point. The seal arm is in the predicate too, so that a
+      // regression reds on the ASSERTION below rather than on a timeout:
+      // under the fall-through mutation the counter stops at the threshold
+      // (the entry is consequenced and stops deferring) and would otherwise
+      // just hang here.
+      await waitUntil(
+        () =>
+          host!.stats().events.loadParkDeferrals > 8 ||
+          allEntries().some((entry) =>
+            (entry as { status?: string }).status !== undefined
+          ),
+        "the deferral count to pass the cold-view give-up threshold " +
+          "(or an entry to harden, which is the regression)",
+        30_000,
+      );
+
+      // THE PIN: past the threshold, still no consequence. Under the
+      // fall-through mutation the entry is sealed
+      // {status: "dropped", consequenced: true} by now.
+      expect(
+        allEntries().filter((entry) =>
+          (entry as { status?: string }).status !== undefined
+        ),
+        "a persistent load failure must never harden into §5's drop",
+      ).toEqual([]);
+      expect(host!.stats().events.dropped, "nothing terminal was sealed")
+        .toBe(0);
+      expect(
+        allEntries().filter((entry) => entry.consequenced === true).length,
+        "only the warm-up entry is consequenced",
+      ).toBe(1);
+      expect(storedValue(), "the handler never ran").toBe(1);
+
+      // And it is a DEFERRAL, not a wedge: healing still delivers it once.
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
+      await waitUntil(
+        () => storedValue() === 2,
+        "the long-deferred event to deliver after the failure clears",
+        30_000,
+      );
+      expect(host!.stats().events.dropped).toBe(0);
+    } finally {
+      GatedStorageManager.loadParkFailDocId = undefined;
+      GatedStorageManager.loadParkFailAddress = undefined;
       cancelDemand();
     }
   });

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -3358,8 +3358,21 @@ describe("Phase 3 events-down (serving side)", () => {
       // PIN 4 — exactly-once ((α)) AND arrival order: one consequence per
       // event, A2 before B1. A re-delivery would read ["A","A","A","B"].
       expect(storedLog()).toEqual(["A", "A", "B"]);
-      await clientRuntime.idle();
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // No-residual-re-delivery, proved CAUSALLY rather than by waiting
+      // out a fixed delay (independent review P1: a re-delivery slower
+      // than the timer would pass undetected, and the timer taxes every
+      // green run). Once every entry is consequenced AND the watermark
+      // has advanced past the last of them, the drain's pending-entry
+      // scan can no longer select any of them — a re-delivery is
+      // excluded by construction, not by having failed to show up yet.
+      const lastSeq = Math.max(...allEntries().map((entry) => entry.seq ?? 0));
+      await waitUntil(
+        () =>
+          allEntries().length === 3 &&
+          allEntries().every((entry) => entry.consequenced === true) &&
+          readWatermarkSeq(engine) >= lastSeq,
+        "every entry consequenced and the watermark advanced past them",
+      );
       expect(storedLog(), "no residual re-delivery of the deferred event")
         .toEqual(["A", "A", "B"]);
       expect(

--- a/packages/runner/test/executor-events-down.test.ts
+++ b/packages/runner/test/executor-events-down.test.ts
@@ -3334,7 +3334,10 @@ describe("Phase 3 events-down (serving side)", () => {
         "only the warm-up entry may be consequenced while the load fails",
       ).toBe(1);
       // PIN 2 — the ordering barrier: B1 (later arrival, its own healthy
-      // sidecar) must not overtake the deferred A2.
+      // sidecar) must not overtake the deferred A2. PIN 4 is where the
+      // barrier actually bites (mutation: skip the barrier loop in
+      // `failHeadEventLoadPark` → the log reads ["A","B","A"], the same
+      // overtake shape as the OW45 arm-B b01 red).
       expect(storedLog(), "later arrivals hold behind the deferred event")
         .toEqual(["A"]);
       // PIN 3 — the deferral is VISIBLE: the serving stats carry it, and

--- a/packages/runner/test/scheduler-event-load-park.test.ts
+++ b/packages/runner/test/scheduler-event-load-park.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
 import type { Action, EventHandler } from "../src/scheduler.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
 import {
   createSchedulerTestRuntime,
@@ -355,6 +359,159 @@ describe("event dispatch parks on in-flight closure loads", () => {
     expect(outcomes).toEqual([{ kind: "deferred", cause: "load-park" }]);
     await runtime.idle();
     expect(outcomes.length, "settled exactly once").toBe(1);
+  });
+
+  // The barrier's TWO DELIBERATE EXCLUSIONS, pinned rather than merely
+  // documented. When a served head's load park fails, every later-arrived
+  // DURABLE served entry in the SAME space defers with it (events.md §2's
+  // arrival order). Two neighbours are deliberately left alone:
+  //   - another SPACE's entry — §2 orders within one space, and deferring a
+  //     stranger's event would be a liveness cost with no ordering benefit;
+  //   - an LT1 in-process copy (`served` with no `streamEntry`) — it has no
+  //     durable entry to re-drain, so deferring it would LOSE it; its durable
+  //     twin re-drains with a `streamEntry` on its own.
+  // Both were argued in review and neither was exercised — they were also
+  // exactly the two uncovered lines the coverage ratchet caught.
+  it("the barrier's exclusions: the same-space durable sibling defers, while another space's entry and a streamEntry-less LT1 copy are left alone", async () => {
+    const { runtime, tx } = env;
+    const otherSpace = (await Identity.fromPassphrase("load-park other space"))
+      .did() as MemorySpace;
+    const coldDoc = runtime.getCell<string>(
+      space,
+      "barrier-exclusions-cold",
+      undefined,
+    );
+    const headCell = runtime.getCell<number>(
+      space,
+      "barrier-exclusions-head",
+      undefined,
+    );
+    const siblingCell = runtime.getCell<number>(
+      space,
+      "barrier-exclusions-sibling",
+      undefined,
+    );
+    const lt1Cell = runtime.getCell<number>(
+      space,
+      "barrier-exclusions-lt1",
+      undefined,
+    );
+    // Its OWN doc id: same-stream sends coalesce by id, so reusing the
+    // sibling's id would merge the two queue slots instead of giving the
+    // barrier a distinct cross-space neighbour to skip.
+    const otherSpaceCell = runtime.getCell<number>(
+      space,
+      "barrier-exclusions-other-space",
+      undefined,
+    );
+    await tx.commit();
+    env.tx = runtime.edit();
+
+    // A FRESH function per handler: addEventHandler stamps
+    // `populateDependencies` onto the function object itself, so sharing one
+    // `noop` would give every stream the head's closure — and all four would
+    // park on the armed doc instead of just the head.
+    const freshHandler = (): EventHandler => () => {};
+    // Only the HEAD reads the cold doc, so only the head parks.
+    runtime.scheduler.addEventHandler(
+      freshHandler(),
+      headCell.getAsNormalizedFullLink(),
+      (depTx) => coldDoc.withTx(depTx).get(),
+    );
+    const siblingLink = siblingCell.getAsNormalizedFullLink();
+    const lt1Link = lt1Cell.getAsNormalizedFullLink();
+    // A link in ANOTHER space; the barrier compares `eventLink.space`.
+    const otherSpaceLink = {
+      ...otherSpaceCell.getAsNormalizedFullLink(),
+      space: otherSpace,
+    };
+    runtime.scheduler.addEventHandler(freshHandler(), siblingLink);
+    runtime.scheduler.addEventHandler(freshHandler(), lt1Link);
+    runtime.scheduler.addEventHandler(freshHandler(), otherSpaceLink);
+
+    const link = coldDoc.getAsNormalizedFullLink();
+    const key = `${link.space}/${link.scope}/${link.id}`;
+    const load = Promise.withResolvers<void>();
+    load.promise.catch(() => {});
+    const parkObserved = Promise.withResolvers<void>();
+    const manager = runtime.storageManager as unknown as {
+      pendingLoadAddresses(): readonly {
+        space: string;
+        scope: string;
+        id: string;
+      }[];
+      pendingLoadGeneration(key: string): number | undefined;
+      loadsSettled(keys: readonly string[]): Promise<void>;
+    };
+    manager.pendingLoadAddresses = () => [{
+      space: link.space,
+      scope: link.scope,
+      id: link.id,
+    }];
+    manager.pendingLoadGeneration = (candidate) =>
+      candidate === key ? 1 : undefined;
+    manager.loadsSettled = () => {
+      parkObserved.resolve();
+      return load.promise;
+    };
+
+    const outcomes = new Map<string, { kind: string; cause?: string }[]>();
+    const record = (who: string) =>
+    (outcome: {
+      kind: string;
+      cause?: string;
+    }) => {
+      const seen = outcomes.get(who) ?? [];
+      seen.push({ kind: outcome.kind, cause: outcome.cause });
+      outcomes.set(who, seen);
+    };
+    const servedEntry = { sidecarId: "of:stream-events:pin", index: 0, seq: 1 };
+
+    // The head goes in first and must be PARKED before the others queue, so
+    // the queue is unambiguously [head(parked), sibling, otherSpace, lt1].
+    runtime.scheduler.queueEvent(
+      headCell.getAsNormalizedFullLink(),
+      1,
+      true,
+      undefined,
+      false,
+      { served: { streamEntry: servedEntry, onFailure: record("head") } },
+    );
+    await parkObserved.promise;
+
+    runtime.scheduler.queueEvent(siblingLink, 1, true, undefined, false, {
+      served: { streamEntry: servedEntry, onFailure: record("sibling") },
+    });
+    runtime.scheduler.queueEvent(otherSpaceLink, 1, true, undefined, false, {
+      served: { streamEntry: servedEntry, onFailure: record("otherSpace") },
+    });
+    // The LT1 shape: served carriage, NO streamEntry.
+    runtime.scheduler.queueEvent(lt1Link, 1, true, undefined, false, {
+      served: { onFailure: record("lt1") },
+    });
+
+    load.reject(new Error("memory session revoked: unauthorized"));
+    await runtime.idle();
+
+    // Swept: the head and its same-space durable sibling.
+    expect(outcomes.get("head")).toEqual([{
+      kind: "deferred",
+      cause: "load-park",
+    }]);
+    expect(
+      outcomes.get("sibling"),
+      "a later-arrived same-space durable entry defers with the head",
+    ).toEqual([{ kind: "deferred", cause: "load-park" }]);
+    // Left alone: another space's entry (§2 is per-space) and the LT1 copy
+    // (no durable entry to re-drain — deferring it would lose it).
+    expect(
+      outcomes.get("otherSpace"),
+      "another space's entry must not be swept",
+    ).toBeUndefined();
+    expect(
+      outcomes.get("lt1"),
+      "a streamEntry-less LT1 copy must not be swept",
+    ).toBeUndefined();
   });
 
   it("re-parks the same event for a fresh load generation", async () => {

--- a/packages/runner/test/scheduler-event-load-park.test.ts
+++ b/packages/runner/test/scheduler-event-load-park.test.ts
@@ -265,6 +265,98 @@ describe("event dispatch parks on in-flight closure loads", () => {
     expect(callbackRuns).toBe(1);
   });
 
+  // The SERVED counterpart of the test above, and the reason the two
+  // arms differ (verification-coverage.md's OW45 residue member): a
+  // client event has no durable entry, so its load-park failure has
+  // nowhere to be re-delivered from and keeps the terminal drop. A
+  // SERVED event's entry IS durable, so the same failure must reach the
+  // drain as a DEFERRAL — no consequence sealed, the entry left pending
+  // for a later drain. events.md §5's T3 predicate is "no runnable
+  // handler", never "the run raced", and a transient read failure over
+  // a doc that exists durably is the second. This pins the contract the
+  // SpaceServer's `onFailure` branches on; the end-to-end consequence,
+  // ordering, and exactly-once behaviour live in
+  // executor-events-down.test.ts.
+  it("a SERVED event's load-park failure reaches the drain as a load-park DEFERRAL, not a drop", async () => {
+    const { runtime, tx } = env;
+    const coldDoc = runtime.getCell<string>(
+      space,
+      "load-park-served-cold",
+      undefined,
+    );
+    const eventCell = runtime.getCell<number>(
+      space,
+      "load-park-served-event",
+      undefined,
+    );
+    await tx.commit();
+    env.tx = runtime.edit();
+
+    let handlerRuns = 0;
+    const handler: EventHandler = () => {
+      handlerRuns++;
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventCell.getAsNormalizedFullLink(),
+      (depTx) => coldDoc.withTx(depTx).get(),
+    );
+
+    const link = coldDoc.getAsNormalizedFullLink();
+    const key = `${link.space}/${link.scope}/${link.id}`;
+    const load = Promise.withResolvers<void>();
+    const parkObserved = Promise.withResolvers<void>();
+    const manager = runtime.storageManager as unknown as {
+      pendingLoadAddresses(): readonly {
+        space: string;
+        scope: string;
+        id: string;
+      }[];
+      pendingLoadGeneration(key: string): number | undefined;
+      loadsSettled(keys: readonly string[]): Promise<void>;
+    };
+    manager.pendingLoadAddresses = () => [{
+      space: link.space,
+      scope: link.scope,
+      id: link.id,
+    }];
+    manager.pendingLoadGeneration = (candidate) =>
+      candidate === key ? 1 : undefined;
+    manager.loadsSettled = () => {
+      parkObserved.resolve();
+      return load.promise;
+    };
+
+    const outcomes: { kind: string; cause?: string }[] = [];
+    runtime.scheduler.queueEvent(
+      eventCell.getAsNormalizedFullLink(),
+      1,
+      true,
+      undefined,
+      false,
+      {
+        served: {
+          streamEntry: { sidecarId: "of:stream-events:pin", index: 0, seq: 1 },
+          onFailure: (outcome) =>
+            outcomes.push({ kind: outcome.kind, cause: outcome.cause }),
+        },
+      },
+    );
+    await parkObserved.promise;
+    expect(handlerRuns).toBe(0);
+
+    load.reject(new Error("memory session revoked: unauthorized"));
+    await runtime.idle();
+    expect(handlerRuns).toBe(0);
+    // The pin: `deferred` (the entry stays pending for a later drain),
+    // carrying the cause that keeps it off the queued class's bounded
+    // creation-race budget. Pre-fix this read [{ kind: "dropped" }] and
+    // the drain sealed the entry.
+    expect(outcomes).toEqual([{ kind: "deferred", cause: "load-park" }]);
+    await runtime.idle();
+    expect(outcomes.length, "settled exactly once").toBe(1);
+  });
+
   it("re-parks the same event for a fresh load generation", async () => {
     const { runtime, tx } = env;
     const coldDoc = runtime.getCell<string>(


### PR DESCRIPTION
## Why

A de-authorizing ACL change racing a served dispatch silently discarded a
user's trusted action, and every fresh space has a window where it can happen.

events.md §5's T3 drop predicate licenses a drop for exactly one condition —
"An event drops iff its handler CANNOT RUN AT ALL against current state … The
test is 'no runnable handler', never 'the run raced'." A required replica load
that FAILS is the second thing, not the first: the doc the handler's closure
reads exists durably, and only the read path failed.

`failHeadEventLoadPark` mapped **any** load-park failure to the terminal drop
arm, so the drain sealed `{status: "dropped", consequenced: true, reason:
"Event dropped: required replica load failed before dispatch"}` and advanced
the watermark past the entry. At-least-once was discharged by that seal:
nothing ever re-ran the event, the authoritative handler never executed, and
the surface the user clicked starved.

The production mechanism, store-proven on CI run 32929764230 (both captured
shards, byte-identical): the serving plane activates and opens its home-space
replica session **before** the genesis ACL lands — the recorded
activation-before-genesis boot order, which every fresh space goes through —
and the ACL landing revokes that session (`#revokeDeauthorizedSessions`; a HOME
genesis is `{user: OWNER}` with no `"*"` grant). The revocation is by design and
heals on the next mount. But a served dispatch whose preflight parks on a
cross-space read inside that window gets `ConnectionError: memory session
revoked: unauthorized` — on a doc the server's own ensure had written durably
one second earlier — and the click was gone. Any ACL change that removes the
serving session's authority reaches the same arm; sharing a space is a normal
operation.

Diagnosis and evidence: verification-coverage.md's OW45 residue record.

## What Changed

**The disposition.** A served event's load-park failure now DEFERS: no
consequence is written, the durable entry stays pending and UNCONSEQUENCED, and
the standard re-drain re-delivers it. Client-side (no `served`, so no durable
entry to re-drain) keeps today's drop — the same split events.ts already makes
for a piece-load failure. T3's genuine no-runnable-handler drop is untouched;
only the load-FAILURE routing changed.

**The arrival-order barrier**, mirroring the sidecar-sync-failure arm ("its
events — and every later-arrived event behind them — defer to the next wave",
events.md §2). It has two halves because the deferral can land in two places:

- *In the queue* — `failHeadEventLoadPark` defers every later-arrived durable
  served entry behind the head **in the same space**. Cross-space queue
  neighbours are excluded (§2's order is per-space) and so are LT1 in-process
  copies (`served` with no `streamEntry`): they have no durable entry to
  re-drain and are a running event's same-wave cascade children, not later
  arrivals.
- *Mid-drain-pass* — the scheduler-side barrier can only hold what is already
  queued, and the drain awaits a `sync()` per new sidecar, so a park failure can
  land between one entry's queueing and the next's. `#loadParkDeferredInPass`
  makes the pass stop there, the same `break` the sidecar-sync arm makes.

**Persistent-failure posture (stated deliberately).** A load that never heals
means the event defers **indefinitely** — durable, visible, re-tried each
drain. A typed `cause: "load-park"` keeps it off the queued class's bounded
creation-race budget (`EVENT_DEFERRAL_DROP_THRESHOLD`, which hardens into §5's
drop after 8 deferrals): that budget exists because a piece which never
materializes has no runnable handler, whereas here the input exists and only
the read failed — hardening would restore exactly the at-least-once discharge
this change removes. Indefinite deferral is strictly better than silent loss
and is the accepted posture. Its cost, stated: the backstop rescan keeps
ticking, so a never-healing load holds the space out of its idle park. **A
give-up arm is OW54's separately tracked territory and was deliberately not
built here.**

**Observability** (the register's recorded gap — a terminally dropped served
event was invisible in serving stats, `appended == processed` reading clean
while the action was gone): `events.loadParkDeferrals` counts each deferral,
head and barrier alike; `events.dropped` counts terminal drop notices sealed
onto a durable entry. A loud WARN per deferral names the failing doc keys and
the error. serving-loop.md §7 carries both. No dashboard work.

## Test plan

Red-first, then two mutations per behaviour.

**`executor-events-down.test.ts`** — new `GatedStorageManager` seam
(`loadParkFailAddress`) reports one doc as an in-flight load and REJECTS its
park settle with the production error text.

- *the disposition pin*: through the failure the entries stay unsealed and
  unconsequenced and later arrivals hold; after the failure clears, all three
  consequences land in arrival order `["A","A","B"]`, each entry consequenced
  exactly once, no residual re-delivery, `events.dropped == 0`,
  `events.loadParkDeferrals > 0`.
  **Observed pre-fix red**: both entries sealed `{consequenced: true, status:
  "dropped", reason: "Event dropped: required replica load failed before
  dispatch (…)"}` — the CI store shape exactly.
- *the mid-pass pin*: the drain's sync gate holds a pass at B's sidecar, with
  A2's park already failed inside it; after healing and release, the log still
  reads `["A","A","B"]`.

**`scheduler-event-load-park.test.ts`** — pins the contract the SpaceServer's
`onFailure` branches on: a served load-park failure arrives as
`{kind: "deferred", cause: "load-park"}`, settled exactly once. The
pre-existing client-side drop pin beside it is unchanged.

**Mutations, all red**

| Mutation | Red |
| --- | --- |
| restore the drop routing | both entries seal dropped; scheduler pin reads `kind: "dropped"` |
| skip the in-queue barrier loop | log reads `["A","B","A"]` — the OW45 arm-B b01 overtake shape |
| drop the `#loadParkDeferredInPass` check | same overtake, through the mid-pass gap |

**Battery** (local, all zero failures): the nine seal-adjacent suites together
post-rebase — `executor-events-down` (24 steps, the α3 retry machinery
untouched), `executor-fan-out`, `executor-serving-loop`,
`scheduler-event-load-park`, `executor-space-server`, `executor-watermark`,
`executor-stats`, `executor-wave`, `executor-cross-space` — **10 passed / 143
steps / 0 failed**; plus the full `packages/runner` package at the fix commit,
**1301 passed / 7549 steps / 0 failed**.

## Review rounds

### Independent review of fd4ffd4 — two P1 VERIFICATION defects (975c9ed)

The mechanism survived every attack; both P1s were about what the tests
actually prove.

- **The in-queue barrier's claimed mutation-red was FALSE.** It was measured
  before the mid-pass half existed and never re-run; with both halves present,
  emptying the loop leaves the suite green, because that pin's two handlers
  both read the ARMED doc — so a barrier-less B parks on the same failure and
  self-defers through the HEAD arm. Claim corrected in the register, and the
  half is now genuinely pinned: `DISJOINT_CLOSURE_LOG_PATTERN` gives `pushA` an
  extra `gate` input on a SEPARATE doc, only that doc is armed (B stays
  runnable), and the park rejection is HELD until both entries are provably
  queued. Mutation → RED: *"B1 must not consequence while the earlier-arrived
  A2 is deferred"*.
- **The typed-cause budget bypass — this fix's central posture — was
  unpinned.** Falling the arm through into threshold accounting left both
  suites green while a persistent failure hardened into §5's drop after ~8
  ticks. Now pinned, causally closed on the `loadParkDeferrals` counter rather
  than a sleep. Mutation → RED: *"a persistent load failure must never harden
  into events.md §5's drop"*.

Also in that round: the cold-view budget weakening now STATED in the register
(F5), the position gap reworded to "pin owed, construction sketched" (F7), the
wake shaper recorded as a third path past both barrier halves with **OW63**
minted for its pre-existing sibling (F1), the posture's price quantified, and
F8 + Cubic's two P3s addressed.

### Codex review of 09eb5c4f (fd4ffd4)

- **The mid-pass check sat one await too early.** `#drainStreamEvents` awaits
  *twice* per entry — a new sidecar's `sync()` and then the stream doc's — and a
  rejection landing in either window sweeps only what was queued at that
  instant. The check now sits past both, immediately before
  `#drainInFlight.set`/`queueEvent`.
- **The no-residual assertion waited out a fixed 500 ms.** Replaced with the
  causal condition: all three entries consequenced *and* the watermark advanced
  past the last of them, after which the drain's scan cannot select them.
  ~2 s faster too.

## Board

**Green at `1c0692ab0`: 68/68 — 65 success, 3 skipped, 0 failures.** `Coverage
Check` included: the ratchet flagged `packages/runner` +2 uncovered lines,
which turned out to be exactly the barrier's two documented-but-unexercised
exclusions, so they were **covered rather than accepted** (no
`ACCEPT_COVERAGE_DEBT` marker). The 3 skips are the routine PR deploy skips.

Mutation total: **6, all red** — drop routing (executor + scheduler surfaces),
in-queue barrier, mid-pass check, budget fall-through, and the cross-space and
LT1 exclusion guards independently.

## Flagged, not filled

- **The mid-pass check's POSITION is not discriminated by a pin** — only its
  existence is. Measured, not assumed: with the check moved back to the
  pre-review position, the pin still passes. **Pin owed, construction
  sketched** — the review supplied a fully causal two-stage recipe (sidecar
  gate → parkObserved hook → armed stream-doc gate → deferred rejection), so my
  earlier "a flaky pin would be worse than none" was an overstatement and is
  retracted in the register. Left for its own pass to keep this one scoped.
- **The barrier invariant as stated is NOT closed**: the wake shaper is a third
  path past both halves (review F1). Pre-existing-adjacent and not a landing
  blocker — the pre-fix behavior, a terminal drop, was strictly worse — but
  recorded in the register with the scenario and the named follow-up shape.
  **OW63** minted for its sibling pre-existing hazard (cross-piece same-space
  shaper reorder, no load-park involved).
- **The cold-view give-up bound is weakened** by this arm's
  `#eventDeferrals.delete`: it becomes "8 CONSECUTIVE deferrals uninterrupted
  by a load-park failure", which a flapping session can hold open indefinitely.
  Deliberate (budgets must not mix) but previously unstated; now in the
  register, with the sharper alternative recorded in OW54's design space rather
  than redesigned here.
- **Shard 9 (`cfc-staged-publish`) stays UNHARVESTED** — symptom-compatible
  with this member, no store evidence, classification open. Whether this fix
  lifts its step-skip needs a measurement, not an assumption.
- **The #6248 lane disposition remains the owner's call**, now with
  fix-before-flip actually available.
- `preQueueDeferralStuck` is missing from serving-loop.md §7's `events` key
  list (pre-existing omission in the line this PR edits). Left alone to keep
  the hunk tight.
