### PR TITLE
fix(piece,patterns): adding an endorsement is not a contract change

### DIFF
--- a/packages/patterns/baselines/cfc-group-chat-demo/main.tsx/20260821T064855Z-7vNcdzNpQKWFJXVr.json
+++ b/packages/patterns/baselines/cfc-group-chat-demo/main.tsx/20260821T064855Z-7vNcdzNpQKWFJXVr.json
@@ -1,0 +1,1123 @@
+{
+  "argumentSchema": {
+    "$defs": {
+      "ChatAdminBootstrapRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ],
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSetAdmin",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatAdminSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatAdminSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedAdminToggle"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatAdminRole"
+        },
+        "type": "array"
+      },
+      "ChatAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ChatAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/ChatAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/ChatEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "ChatAdminRegistryValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ChatAdminRegistryStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyAdminRegistryValue"
+          }
+        ]
+      },
+      "ChatAdminRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ChatEveryoneAdminFlag": {
+        "anyOf": [
+          {
+            "enum": [
+              true
+            ],
+            "ifc": {
+              "addIntegrity": [
+                "group-chat-admin"
+              ],
+              "requiredIntegrity": [
+                "group-chat-admin"
+              ],
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              }
+            },
+            "type": "boolean"
+          },
+          {
+            "enum": [
+              false
+            ],
+            "ifc": {
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+                  "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+                  "path": [
+                    "commitTrustedAdminToggle"
+                  ]
+                }
+              }
+            },
+            "type": "boolean"
+          }
+        ]
+      },
+      "ChatProfile": {
+        "properties": {
+          "accentColor": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "accentColor"
+        ],
+        "type": "object"
+      },
+      "ChatRoom": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/$defs/SharedChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "EmptyAdminRegistryValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptyMyProfileValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptySharedRoomsValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ImportedClaimedChatMessage": {
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "undefined"
+                  },
+                  {
+                    "$ref": "#/$defs/ChatProfile"
+                  }
+                ],
+                "asCell": [
+                  "cell"
+                ]
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "imported"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "MyProfileCellValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/MyProfileStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyMyProfileValue"
+          }
+        ]
+      },
+      "MyProfileStoredValue": {
+        "properties": {
+          "profile": {
+            "$ref": "#/$defs/ChatProfile"
+          }
+        },
+        "type": "object"
+      },
+      "SharedChatMessage": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TrustedSentChatMessage"
+          },
+          {
+            "$ref": "#/$defs/ImportedClaimedChatMessage"
+          }
+        ]
+      },
+      "SharedMessagesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedChatMessage"
+        },
+        "type": "array"
+      },
+      "SharedProfileEntry": {
+        "properties": {
+          "profile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          }
+        },
+        "required": [
+          "profile"
+        ],
+        "type": "object"
+      },
+      "SharedProfilesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedProfileEntry"
+        },
+        "type": "array"
+      },
+      "SharedRoomList": {
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ],
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatAddRoom",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatRoomSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatRoomSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedRoomAdd"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatRoom"
+        },
+        "type": "array"
+      },
+      "SharedRoomsStoredValue": {
+        "properties": {
+          "list": {
+            "$ref": "#/$defs/SharedRoomList"
+          }
+        },
+        "type": "object"
+      },
+      "SharedRoomsValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SharedRoomsStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptySharedRoomsValue"
+          }
+        ]
+      },
+      "TrustedSentChatMessage": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "authored-by",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSendMessage",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatSendSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatSendSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedMessageSend"
+              ]
+            }
+          }
+        },
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ],
+            "asCell": [
+              "cell"
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "sent"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "authorProfile",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "adminRegistry": {
+        "$ref": "#/$defs/ChatAdminRegistryValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "hostMessageDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "messageDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "messages": {
+        "$ref": "#/$defs/SharedMessagesValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "myProfile": {
+        "$ref": "#/$defs/MyProfileCellValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ]
+      },
+      "profileDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "user"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "profiles": {
+        "$ref": "#/$defs/SharedProfilesValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      },
+      "roomDraft": {
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "session"
+          }
+        ],
+        "default": "",
+        "type": "string"
+      },
+      "rooms": {
+        "$ref": "#/$defs/SharedRoomsValue",
+        "asCell": [
+          {
+            "kind": "cell",
+            "scope": "space"
+          }
+        ]
+      }
+    },
+    "type": "object"
+  },
+  "pattern": "cfc-group-chat-demo/main.tsx",
+  "resultSchema": {
+    "$defs": {
+      "ChatAdminBootstrapRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminList": {
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ],
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSetAdmin",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatAdminSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatAdminSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedAdminToggle"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatAdminRole"
+        },
+        "type": "array"
+      },
+      "ChatAdminRegistryStoredValue": {
+        "properties": {
+          "admins": {
+            "$ref": "#/$defs/ChatAdminList"
+          },
+          "bootstrapAdmin": {
+            "$ref": "#/$defs/ChatAdminBootstrapRole"
+          },
+          "everyoneIsAdmin": {
+            "$ref": "#/$defs/ChatEveryoneAdminFlag"
+          }
+        },
+        "type": "object"
+      },
+      "ChatAdminRegistryValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ChatAdminRegistryStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyAdminRegistryValue"
+          }
+        ]
+      },
+      "ChatAdminRole": {
+        "$ref": "#/$defs/ChatAdminRoleAssignment",
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ]
+        }
+      },
+      "ChatAdminRoleAssignment": {
+        "properties": {
+          "displayName": {
+            "type": "string"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          }
+        },
+        "required": [
+          "subject",
+          "displayName"
+        ],
+        "type": "object"
+      },
+      "ChatEveryoneAdminFlag": {
+        "anyOf": [
+          {
+            "enum": [
+              true
+            ],
+            "ifc": {
+              "addIntegrity": [
+                "group-chat-admin"
+              ],
+              "requiredIntegrity": [
+                "group-chat-admin"
+              ],
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              }
+            },
+            "type": "boolean"
+          },
+          {
+            "enum": [
+              false
+            ],
+            "ifc": {
+              "uiContract": {
+                "action": "TrustedGroupChatSetAdmin",
+                "helper": "UiAction",
+                "requiredEventIntegrity": [
+                  "TrustedGroupChatAdminSurface"
+                ],
+                "trustedPattern": "TrustedGroupChatAdminSurface"
+              },
+              "writeAuthorizedBy": {
+                "__ctWriterIdentityOf": {
+                  "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+                  "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+                  "path": [
+                    "commitTrustedAdminToggle"
+                  ]
+                }
+              }
+            },
+            "type": "boolean"
+          }
+        ]
+      },
+      "ChatProfile": {
+        "properties": {
+          "accentColor": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "accentColor"
+        ],
+        "type": "object"
+      },
+      "ChatRoom": {
+        "properties": {
+          "createdAt": {
+            "type": "number"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/$defs/SharedChatMessage"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "messages",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "EmptyAdminRegistryValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptyMyProfileValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "EmptySharedRoomsValue": {
+        "additionalProperties": false,
+        "properties": {},
+        "type": "object"
+      },
+      "ImportedClaimedChatMessage": {
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "undefined"
+                  },
+                  {
+                    "$ref": "#/$defs/ChatProfile"
+                  }
+                ]
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "imported"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "MyProfileCellValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/MyProfileStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptyMyProfileValue"
+          }
+        ]
+      },
+      "MyProfileStoredValue": {
+        "properties": {
+          "profile": {
+            "$ref": "#/$defs/ChatProfile"
+          }
+        },
+        "type": "object"
+      },
+      "SharedChatMessage": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/TrustedSentChatMessage"
+          },
+          {
+            "$ref": "#/$defs/ImportedClaimedChatMessage"
+          }
+        ]
+      },
+      "SharedMessagesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedChatMessage"
+        },
+        "type": "array"
+      },
+      "SharedProfileEntry": {
+        "properties": {
+          "profile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          }
+        },
+        "required": [
+          "profile"
+        ],
+        "type": "object"
+      },
+      "SharedProfilesValue": {
+        "default": [],
+        "items": {
+          "$ref": "#/$defs/SharedProfileEntry"
+        },
+        "type": "array"
+      },
+      "SharedRoomList": {
+        "ifc": {
+          "addIntegrity": [
+            "group-chat-admin"
+          ],
+          "requiredIntegrity": [
+            "group-chat-admin"
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatAddRoom",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatRoomSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatRoomSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedRoomAdd"
+              ]
+            }
+          }
+        },
+        "items": {
+          "$ref": "#/$defs/ChatRoom"
+        },
+        "type": "array"
+      },
+      "SharedRoomsStoredValue": {
+        "properties": {
+          "list": {
+            "$ref": "#/$defs/SharedRoomList"
+          }
+        },
+        "type": "object"
+      },
+      "SharedRoomsValue": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SharedRoomsStoredValue"
+          },
+          {
+            "$ref": "#/$defs/EmptySharedRoomsValue"
+          }
+        ]
+      },
+      "TrustedAdminPolicyEvent": {
+        "properties": {
+          "detail": {
+            "properties": {
+              "checked": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "everyoneIsAdmin": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "properties": {
+              "dataset": {
+                "properties": {
+                  "adminName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TrustedSentChatMessage": {
+        "ifc": {
+          "addIntegrity": [
+            {
+              "kind": "authored-by",
+              "subject": {
+                "__ctCurrentPrincipal": true
+              }
+            }
+          ],
+          "uiContract": {
+            "action": "TrustedGroupChatSendMessage",
+            "helper": "UiAction",
+            "requiredEventIntegrity": [
+              "TrustedGroupChatSendSurface"
+            ],
+            "trustedPattern": "TrustedGroupChatSendSurface"
+          },
+          "writeAuthorizedBy": {
+            "__ctWriterIdentityOf": {
+              "file": "/packages/patterns/cfc-group-chat-demo/trusted.tsx",
+              "moduleIdentity": "c_UI6KamSwOcrZmEz0kRJphzweIoLyAzDnf6tlS3wWQ",
+              "path": [
+                "commitTrustedMessageSend"
+              ]
+            }
+          }
+        },
+        "properties": {
+          "authorName": {
+            "type": "string"
+          },
+          "authorProfile": {
+            "anyOf": [
+              {
+                "type": "undefined"
+              },
+              {
+                "$ref": "#/$defs/ChatProfile"
+              }
+            ]
+          },
+          "body": {
+            "type": "string"
+          },
+          "origin": {
+            "enum": [
+              "sent"
+            ],
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "origin",
+          "authorName",
+          "authorProfile",
+          "body",
+          "timestamp"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": true,
+      "addRandomMessages": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "addTrustedRoom": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "adminRegistry": {
+        "$ref": "#/$defs/ChatAdminRegistryValue"
+      },
+      "currentProfileName": {
+        "type": "string"
+      },
+      "currentUserCanManageAdmins": {
+        "type": "boolean"
+      },
+      "currentUserIsAdmin": {
+        "type": "boolean"
+      },
+      "hostLookalikeSend": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "hostMessageDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "messageDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "messages": {
+        "$ref": "#/$defs/SharedMessagesValue"
+      },
+      "myProfile": {
+        "$ref": "#/$defs/MyProfileCellValue"
+      },
+      "profileDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "profiles": {
+        "$ref": "#/$defs/SharedProfilesValue"
+      },
+      "roomDraft": {
+        "default": "",
+        "type": "string"
+      },
+      "rooms": {
+        "$ref": "#/$defs/SharedRoomsValue"
+      },
+      "saveProfile": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "sendTrustedMessage": {
+        "asCell": [
+          "stream",
+          "opaque"
+        ]
+      },
+      "setHostMessageDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setMessageDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setProfileDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "setRoomDraft": {
+        "asCell": [
+          "stream"
+        ],
+        "type": "string"
+      },
+      "toggleCurrentUserAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleEveryoneAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "asCell": [
+          "stream"
+        ]
+      },
+      "toggleParticipantAdmin": {
+        "$ref": "#/$defs/TrustedAdminPolicyEvent",
+        "asCell": [
+          "stream"
+        ]
+      }
+    },
+    "required": [
+      "myProfile",
+      "profiles",
+      "messages",
+      "rooms",
+      "adminRegistry",
+      "profileDraft",
+      "messageDraft",
+      "hostMessageDraft",
+      "roomDraft",
+      "setProfileDraft",
+      "setMessageDraft",
+      "setHostMessageDraft",
+      "setRoomDraft",
+      "currentProfileName",
+      "currentUserIsAdmin",
+      "currentUserCanManageAdmins",
+      "saveProfile",
+      "toggleCurrentUserAdmin",
+      "toggleParticipantAdmin",
+      "toggleEveryoneAdmin",
+      "sendTrustedMessage",
+      "addTrustedRoom",
+      "hostLookalikeSend",
+      "addRandomMessages",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -110,11 +110,14 @@ export type SharedProfilesCell = Writable<SharedProfilesValue>;
 export type TrustedChatRoom = ChatRoom<SharedChatMessage>;
 
 export type ChatAdminList = RequiresIntegrity<
-  TrustedActionWrite<
-    ChatAdminRole[],
-    typeof commitTrustedAdminToggle,
-    typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
-    typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+  AddIntegrity<
+    TrustedActionWrite<
+      ChatAdminRole[],
+      typeof commitTrustedAdminToggle,
+      typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+      typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
   >,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
@@ -156,11 +159,14 @@ export type ChatAdminRegistryValue =
 export type ChatAdminRegistryCell = Writable<ChatAdminRegistryValue>;
 
 export type SharedRoomList = RequiresIntegrity<
-  TrustedActionWrite<
-    TrustedChatRoom[],
-    typeof commitTrustedRoomAdd,
-    typeof TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION,
-    typeof TRUSTED_GROUP_CHAT_ROOM_SURFACE
+  AddIntegrity<
+    TrustedActionWrite<
+      TrustedChatRoom[],
+      typeof commitTrustedRoomAdd,
+      typeof TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION,
+      typeof TRUSTED_GROUP_CHAT_ROOM_SURFACE
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
   >,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -7,6 +7,7 @@ import {
 } from "@commonfabric/runner";
 import {
   cfcSchemaChildRoot,
+  type IfcKey,
   resolveCfcSchemaRefRoot,
   resolveCfcSchemaRefs,
   validateSchemaDefinition,
@@ -219,26 +220,213 @@ const WRITER_IDENTITY_VOLATILE_KEYS: ReadonlySet<string> = new Set([
  * `not`) is compared by whole-value equality instead, so its volatile identity
  * still participates and a recompile there is reported as a change.
  */
-const ifcWithoutVolatileWriterIdentity = (ifc: unknown): unknown => {
-  if (typeof ifc !== "object" || ifc === null) return ifc;
-  const claim = (ifc as Record<string, unknown>).writeAuthorizedBy;
+const writerClaimWithoutVolatileIdentity = (claim: unknown): unknown => {
   if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
-    return ifc;
+    return claim;
   }
   const identity = (claim as Record<string, unknown>).__ctWriterIdentityOf;
-  if (typeof identity !== "object" || identity === null) return ifc;
+  if (typeof identity !== "object" || identity === null) return claim;
   const strippedIdentity: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(identity)) {
     if (WRITER_IDENTITY_VOLATILE_KEYS.has(key)) continue;
     strippedIdentity[key] = value;
   }
   return {
-    ...(ifc as Record<string, unknown>),
-    writeAuthorizedBy: {
-      ...(claim as Record<string, unknown>),
-      __ctWriterIdentityOf: strippedIdentity,
-    },
+    ...(claim as Record<string, unknown>),
+    __ctWriterIdentityOf: strippedIdentity,
   };
+};
+
+/**
+ * What each `ifc` key contributes to this comparison.
+ *
+ * `declared` is the store policy a caller depends on: a claim about what the
+ * store holds, or a requirement on who may write or read it. A change to one is
+ * a change to the contract, and the values are compared as they stand.
+ *
+ * `derived` describes the label a write produces rather than the policy the
+ * store declares. CFC §8.12.8 gives a persisted path three label components and
+ * a discipline for each: the declared store policy is monotone, while the
+ * derived per-value component is replace-on-overwrite, and that section states
+ * that a runtime must not apply the monotone constraint to the derived one.
+ * This comparison is that monotone constraint, so it drops these keys — except
+ * for the part of a mint that an `ownerPrincipal` beside it turns into
+ * authorization evidence, which `comparableIfc` keeps.
+ *
+ * `writerIdentity` is the write authorization, compared except for the parts of
+ * its claim that move without the authorization moving.
+ */
+type IfcKeyRole = "declared" | "derived" | "writerIdentity";
+
+/**
+ * A role for every key of {@link IFC_KEYS}. The mapped type is the point: a new
+ * `ifc` key in the runtime fails to type-check here until someone decides what
+ * it means for two contracts to differ in it. A key this table does not name at
+ * all — an unrecognized extension — is compared as it stands, which is the
+ * fail-closed direction.
+ */
+const IFC_KEY_ROLES: { readonly [K in IfcKey]: IfcKeyRole } = {
+  confidentiality: "declared",
+  integrity: "declared",
+  requiredIntegrity: "declared",
+  maxConfidentiality: "declared",
+  ownerPrincipal: "declared",
+  exactCopyOf: "declared",
+  projection: "declared",
+  collection: "declared",
+  flowPrecisionClaim: "declared",
+  uiContract: "declared",
+  writeAuthorizedBy: "writerIdentity",
+  // `addIntegrity` is the lowered form of the spec's `addedIntegrity`
+  // transition annotation, and of the `RepresentsCurrentUser` and
+  // `AuthoredByCurrentUser` spellings that expand to it. It names atoms the
+  // runtime attaches to the integrity of the value a write produces (CFC
+  // §8.9.3's output labels), which is the derived component of §8.12.8.
+  //
+  // Dropping it is what lets a path repair a floor it cannot satisfy. A schema
+  // can require that anything written to one of its locations already carry a
+  // named atom, and that floor is tested against the value the write produces.
+  // An `addIntegrity` on the entries below the location does not reach a floor
+  // declared on the location itself, so a schema that requires an atom and
+  // attaches none refuses every write to that location. The repair is to attach
+  // the atom the same declaration asks for, and comparing this key for equality
+  // would report that repair as an incompatible successor.
+  //
+  // Dropping the key cuts both ways: losing a mint is not a contract change
+  // either. A pattern whose own writes stop satisfying its own floor is a
+  // defect its own tests catch, at the path where the write happens. A reader
+  // elsewhere whose floor rested on atoms this path minted fails at that
+  // reader's own check, which is where `docs/specs/piece-source-lifecycle.md`
+  // places a result contract's drift. Neither is a statement about the contract
+  // between two versions of this pattern, which is what this comparison
+  // decides.
+  addIntegrity: "derived",
+};
+
+/**
+ * Copy one key onto the reduced extension.
+ *
+ * Uses `defineProperty` rather than `kept[key] = value`, the same way
+ * `stripUndefinedProps` in `@commonfabric/utils` does, so that a key named
+ * `"__proto__"` lands as a plain own data property rather than reaching the
+ * prototype setter. A schema read off the wire can carry such a key, because
+ * `JSON.parse` makes it an own property, and a key this comparison does not
+ * recognize is one it has to keep comparing.
+ */
+const keep = (
+  kept: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void => {
+  Object.defineProperty(kept, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+};
+
+/**
+ * The parts of a mint that an `ownerPrincipal` check consults: the atoms
+ * claiming to represent a principal. Everything else is a label the runtime
+ * attaches and no authorization reads.
+ *
+ * The search walks arrays and object values, because
+ * `literalDidSubjectsForPrincipalClaim` (runner `cfc/prepare.ts`) does: an atom
+ * nested inside another structure still authorizes a write, so a flat scan
+ * would drop evidence the runtime acts on.
+ *
+ * Every such atom is kept, not only one whose subject reads as the owner. The
+ * runtime resolves a current-principal placeholder against the acting principal
+ * of a live trust snapshot before it matches, and this comparison has neither,
+ * so which atom will match cannot be decided here. Keeping all of them refuses
+ * a few updates that would in fact have been safe, which is the direction to
+ * err in.
+ */
+const representsPrincipalAtoms = (value: unknown): readonly unknown[] => {
+  if (Array.isArray(value)) return value.flatMap(representsPrincipalAtoms);
+  if (typeof value !== "object" || value === null) return [];
+  const record = value as Record<string, unknown>;
+  if (record.kind === "represents-principal") return [value];
+  return Object.values(record).flatMap(representsPrincipalAtoms);
+};
+
+/**
+ * Return an `ifc` extension reduced to what this comparison decides: the
+ * derived per-value keys dropped, and a write authorization's volatile identity
+ * normalized. Returns the input unchanged when neither applies.
+ *
+ * This runs where `ifc` is compared as a semantic-extension key, which the
+ * per-node recursion reaches for a node written directly on a property, behind
+ * a `$defs` reference, or in an `anyOf` branch. An `ifc` reached only through a
+ * composite keyword (`allOf`, `oneOf`, `if`/`then`, `not`) is compared by whole
+ * value instead, so a mint there still reads as a change — the same scope the
+ * writer-identity normalization has.
+ *
+ * An extension with no keys left comes back as `undefined`, the same as no
+ * extension at all, and so does one that arrived empty. A path that carried no
+ * `ifc` and gains only a mint therefore compares equal to what it was, and so
+ * does one whose last mint is removed. Without that, the reduced `{}` would differ
+ * from the absent one and the update would be refused for the very change this
+ * reduction exists to allow.
+ */
+const comparableIfc = (ifc: unknown): unknown => {
+  if (typeof ifc !== "object" || ifc === null || Array.isArray(ifc)) return ifc;
+  const source = ifc as Record<string, unknown>;
+  // Beside an `ownerPrincipal`, part of the mint is not a derived label at all.
+  // `currentPrincipalIntegrityReason` (runner `cfc/prepare.ts`) reads the
+  // `represents-principal` atoms out of `addIntegrity` and requires one whose
+  // subject is the owner before it authorizes the write, so losing those
+  // refuses writes the node used to accept. Every other atom in the array is
+  // still a label the runtime attaches and nothing consults, so only the
+  // owner-matching evidence is held to the contract.
+  const ownerAuthorizesWrites = source.ownerPrincipal !== undefined;
+  // Most `ifc` nodes carry only declared keys and come back untouched. Scanning
+  // for a key that needs handling walks the keys without building anything, so
+  // that common node costs no allocation at all.
+  let handled = false;
+  let empty = true;
+  for (const key in source) {
+    empty = false;
+    const role: IfcKeyRole | undefined = IFC_KEY_ROLES[key as IfcKey] as
+      | IfcKeyRole
+      | undefined;
+    if (role === "derived" || role === "writerIdentity") {
+      handled = true;
+      break;
+    }
+  }
+  // An extension with nothing in it says the same as no extension, whether it
+  // arrived that way or is what the reduction below leaves behind. Both come
+  // back as `undefined`, so the two compare equal either way round.
+  if (empty) return undefined;
+  if (!handled) return ifc;
+  const kept: Record<string, unknown> = {};
+  let changed = false;
+  for (const key in source) {
+    const value = source[key];
+    const role: IfcKeyRole | undefined = IFC_KEY_ROLES[key as IfcKey] as
+      | IfcKeyRole
+      | undefined;
+    if (role === "derived") {
+      const evidence = ownerAuthorizesWrites
+        ? representsPrincipalAtoms(value)
+        : [];
+      changed = true;
+      if (evidence.length > 0) keep(kept, key, evidence);
+      continue;
+    }
+    if (role === "writerIdentity") {
+      const normalized = writerClaimWithoutVolatileIdentity(value);
+      if (normalized !== value) changed = true;
+      keep(kept, key, normalized);
+      continue;
+    }
+    keep(kept, key, value);
+  }
+  if (!changed) return ifc;
+  for (const _key in kept) return kept;
+  return undefined;
 };
 
 /**
@@ -293,10 +481,17 @@ const ifcWithoutVolatileWriterIdentity = (ifc: unknown): unknown => {
  * write on `moduleIdentity` plus the binding `path` and never on `file`, and it
  * re-verifies the live writer's `moduleIdentity` against the claim at write
  * time, so holding those fields fixed here would reject a recompile or a
- * cross-resolver rebuild of an unchanged authorization (see
- * `ifcWithoutVolatileWriterIdentity`). The binding `path` and the whole
- * `uiContract` are still compared, and the runtime enforcement is untouched, so
- * this narrows nothing.
+ * cross-resolver rebuild of an unchanged authorization. The binding `path` and
+ * the whole `uiContract` are still compared, and the runtime enforcement is
+ * untouched, so this narrows nothing.
+ *
+ * The `ifc` comparison drops one key as well. `addIntegrity` names the derived
+ * per-value label rather than the store's declared policy, so a path gaining or
+ * losing a mint is not a change to the contract between two versions of the
+ * pattern — except beside an `ownerPrincipal`, where the atoms of that mint
+ * claiming to represent a principal are what authorizes the write, and those
+ * are compared. `comparableIfc` performs both reductions, and
+ * {@link IfcKeyRole} states which keys take part in each.
  */
 export function assertPatternSchemasBackwardCompatible(
   previous: Pattern,
@@ -529,13 +724,15 @@ function schemaSubsetIssue(
     for (const key of SEMANTIC_EXTENSION_KEYS) {
       // The `ifc` extension is compared for exact equality except for a
       // `writeAuthorizedBy` writer claim's volatile identity — its content hash
-      // and its resolver-dependent file spelling — which the runtime does not
-      // hold fixed either (see ifcWithoutVolatileWriterIdentity).
+      // and its resolver-dependent file spelling, which the runtime does not
+      // hold fixed either — and the derived per-value label annotations, which
+      // describe the label a write produces rather than the policy the store
+      // declares. `comparableIfc` removes both.
       const sourceValue = key === "ifc"
-        ? ifcWithoutVolatileWriterIdentity(source[key])
+        ? comparableIfc(source[key])
         : source[key];
       const targetValue = key === "ifc"
-        ? ifcWithoutVolatileWriterIdentity(target[key])
+        ? comparableIfc(target[key])
         : target[key];
       if (!fabricAwareEqual(sourceValue, targetValue)) {
         return `${path}: ${key} changed`;

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -173,6 +173,247 @@ describe("piece schema compatibility", () => {
     ).not.toThrow();
   });
 
+  // A floored path is authored to mint the atom it floors, because the write
+  // floor tests the integrity of the value being written and a mint on the
+  // entries below the path does not reach a floor declared on the path itself.
+  // A pattern that declares a floor and mints nothing has to gain the mint
+  // before any write to it can conform. The mint names the derived per-value
+  // component (CFC §8.12.8), which the monotone constraint behind this
+  // comparison does not govern, so gaining one is not a contract change.
+  const flooredList = (ifc: Record<string, unknown>): JSONSchema => ({
+    type: "object",
+    properties: {
+      admins: { type: "array", items: { type: "string" }, ifc },
+    },
+  });
+  const floorOnly = { requiredIntegrity: ["group-chat-admin"] };
+  const floorAndMint = {
+    requiredIntegrity: ["group-chat-admin"],
+    addIntegrity: ["group-chat-admin"],
+  };
+
+  it("accepts a floored path that gains the mint its own floor names", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flooredList(floorOnly), { type: "object" }),
+        pattern(flooredList(floorAndMint), { type: "object" }),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts a floored path that loses its mint", () => {
+    // The derived component is replace-on-overwrite, not a ratchet, so this
+    // comparison has no opinion either way. A pattern whose writes stop
+    // satisfying its own floor fails at the write, where its tests are.
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flooredList(floorAndMint), { type: "object" }),
+        pattern(flooredList(floorOnly), { type: "object" }),
+      )
+    ).not.toThrow();
+  });
+
+  it("compares a writeAuthorizedBy claim carrying no writer identity whole", () => {
+    // Normalization reaches inside `__ctWriterIdentityOf`. A claim without one
+    // has nothing volatile to remove, so two such claims compare equal.
+    // The two sides differ by a mint, which is dropped, so what is left to
+    // compare is the claim itself. Comparing two schemas that are equal all
+    // the way down would settle before reaching it.
+    const claimWith = (mint: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        flag: {
+          type: "boolean",
+          ifc: {
+            writeAuthorizedBy: {},
+            ...(mint ? { addIntegrity: ["reviewed"] } : {}),
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object" }, claimWith(true)),
+        pattern({ type: "object" }, claimWith(false)),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts a claim that gains only the volatile identity fields", () => {
+    // Same binding path, same uiContract, and a content hash and file spelling
+    // the runtime re-derives rather than holds fixed. That is a recompile of
+    // one authorization, so it is accepted.
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(
+          { type: "object" },
+          trustedWriteResult({ path: ["setFlag"] }, baselineUiContract),
+        ),
+        pattern(
+          { type: "object" },
+          trustedWriteResult(baselineIdentity, baselineUiContract),
+        ),
+      )
+    ).not.toThrow();
+  });
+
+  it("finds owner evidence nested inside a mint, as the runtime does", () => {
+    // `literalDidSubjectsForPrincipalClaim` walks arrays and object values, so
+    // an atom nested inside another structure still authorizes the write.
+    // Losing it has to read as a change here rather than slip through.
+    const ownerNode = (withEvidence: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            ownerPrincipal: { __ctCurrentPrincipal: true },
+            addIntegrity: [
+              {
+                kind: "delegated",
+                via: withEvidence
+                  ? {
+                    kind: "represents-principal",
+                    subject: { __ctCurrentPrincipal: true },
+                  }
+                  : { kind: "unrelated" },
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(ownerNode(true), { type: "object" }),
+        pattern(ownerNode(false), { type: "object" }),
+      )
+    ).toThrow(/ifc changed/);
+  });
+
+  it("reads no owner evidence out of a mint that is not a list of atoms", () => {
+    // A malformed mint carries no represents-principal atom, so there is
+    // nothing for the owner check to match and nothing for this comparison to
+    // hold. It reduces the same as a node that mints nothing at all.
+    const ownerNode = (withMint: boolean): JSONSchema =>
+      JSON.parse(
+        `{"type":"object","properties":{"bio":{"type":"string","ifc":{` +
+          `"ownerPrincipal":{"__ctCurrentPrincipal":true}` +
+          (withMint ? `,"addIntegrity":"not-a-list"` : "") +
+          `}}}}`,
+      );
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(ownerNode(true), { type: "object" }),
+        pattern(ownerNode(false), { type: "object" }),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts dropping an atom the owner check does not read", () => {
+    // Only `represents-principal` evidence feeds the owner check. An atom
+    // beside it is a label nothing consults, so losing it leaves the write
+    // authorized exactly as before and is not a contract change.
+    const ownerNode = (extra: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            ownerPrincipal: { __ctCurrentPrincipal: true },
+            addIntegrity: [
+              {
+                kind: "represents-principal",
+                subject: { __ctCurrentPrincipal: true },
+              },
+              ...(extra ? ["profile-reviewed"] : []),
+            ],
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(ownerNode(true), { type: "object" }),
+        pattern(ownerNode(false), { type: "object" }),
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts losing the last mint into an empty ifc", () => {
+    // The reduction leaves nothing behind on one side and finds an already
+    // empty extension on the other. Both say the same thing, so they compare
+    // equal rather than reading as a change.
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flooredList({ addIntegrity: ["group-chat-admin"] }), {
+          type: "object",
+        }),
+        pattern(flooredList({}), { type: "object" }),
+      )
+    ).not.toThrow();
+  });
+
+  it("still compares the mint on a node that authorizes by owner principal", () => {
+    // Beside an `ownerPrincipal`, the mint supplies the represents-principal
+    // atom the runtime matches against the owner before authorizing a write.
+    // Losing it there refuses writes that used to be accepted, so the mint is
+    // part of the contract on such a node rather than a derived label.
+    const ownerNode = (mint: boolean): JSONSchema => ({
+      type: "object",
+      properties: {
+        bio: {
+          type: "string",
+          ifc: {
+            ownerPrincipal: { __ctCurrentPrincipal: true },
+            ...(mint
+              ? {
+                addIntegrity: [{
+                  kind: "represents-principal",
+                  subject: { __ctCurrentPrincipal: true },
+                }],
+              }
+              : {}),
+          },
+        },
+      },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(ownerNode(true), { type: "object" }),
+        pattern(ownerNode(false), { type: "object" }),
+      )
+    ).toThrow(/ifc changed/);
+  });
+
+  it("still rejects a change to the floor the path requires", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flooredList(floorAndMint), { type: "object" }),
+        pattern(
+          flooredList({
+            requiredIntegrity: ["group-chat-owner"],
+            addIntegrity: ["group-chat-admin"],
+          }),
+          { type: "object" },
+        ),
+      )
+    ).toThrow(/ifc changed/);
+  });
+
+  it("still rejects a change to the integrity a path declares it holds", () => {
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(flooredList({ integrity: ["group-chat-admin"] }), {
+          type: "object",
+        }),
+        pattern(flooredList({ integrity: ["group-chat-owner"] }), {
+          type: "object",
+        }),
+      )
+    ).toThrow(/ifc changed/);
+  });
+
   it("still rejects a writeAuthorizedBy binding path change", () => {
     expect(() =>
       assertPatternSchemasBackwardCompatible(

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -238,7 +238,7 @@ export type {
 } from "./prepare.ts";
 export { readStoredCfcMetadata } from "./metadata.ts";
 export { cfcSchemaMergeIssue } from "./schema-merge.ts";
-export type { CfcSchemaMergeIssue } from "./schema-merge.ts";
+export type { CfcSchemaMergeIssue, IfcKey } from "./schema-merge.ts";
 export {
   createSinkRequestPolicyInput,
   recordSinkRequestPolicyInput,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -3434,7 +3434,7 @@ const isNonEndorsementProvenanceAtom = (atom: unknown): boolean =>
 // provenance reads that could have fed the write. Provenance-only reads still
 // count as "the write had labeled input" for the #14 empty-prefix arm — the
 // group-chat admin-grant shape (provenance lookup + protected write, no
-// endorsed read, no mint) must keep committing.
+// endorsed read) must keep committing.
 const isProvenanceOnlyConsumedLabel = (label: IFCLabel): boolean => {
   if ((label.confidentiality?.length ?? 0) > 0) return false;
   const integrity = label.integrity ?? [];

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -14,6 +14,7 @@ import { normalizeClause } from "./clause.ts";
 import { CfcSchemaMigrationError } from "./migration-reason.ts";
 import { writerClaimFilesCorrespond } from "./writer-claim-correspondence.ts";
 
+/** Every `ifc` key the runtime understands. {@link IfcKey} names one of them. */
 const IFC_KEYS = [
   "confidentiality",
   "integrity",
@@ -32,6 +33,16 @@ const IFC_KEYS = [
   "flowPrecisionClaim",
   "uiContract",
 ] as const;
+
+/**
+ * One of the `ifc` keys the runtime understands.
+ *
+ * A consumer that has to treat the keys differently from one another states a
+ * decision for each of them, and a mapped type over this union does not compile
+ * until it has. Adding a key here is what tells such a consumer that a new one
+ * arrived.
+ */
+export type IfcKey = typeof IFC_KEYS[number];
 
 const asSchemaObject = (
   schema: JSONSchema,

--- a/packages/runner/test/cfc-write-floor.test.ts
+++ b/packages/runner/test/cfc-write-floor.test.ts
@@ -219,6 +219,66 @@ describe("CFC write-side requiredIntegrity floor (D3, §8.12.4.1)", () => {
     }
   });
 
+  it("a mint on an array's items does not satisfy a floor on the array path", async () => {
+    // The shape a pattern reaches for when a list of endorsed entries is
+    // stored behind a floor: each entry mints the atom, the list path
+    // declares it. The floor is checked at the path it is declared on, and
+    // the items' mints sit below that path, so the list write is unendorsed
+    // until the list path mints too. Both halves run here — the item-only
+    // shape rejects, the same shape with a path mint commits.
+    const items = {
+      type: "object",
+      properties: {
+        subject: { type: "string" },
+        displayName: { type: "string" },
+      },
+      required: ["subject", "displayName"],
+      ifc: { addIntegrity: [ADMIN_ATOM] },
+    } as const;
+    const itemMintOnly = {
+      type: "object",
+      properties: {
+        admins: {
+          type: "array",
+          items,
+          ifc: { requiredIntegrity: [ADMIN_ATOM] },
+        },
+      },
+      required: ["admins"],
+    } as const satisfies JSONSchema;
+    const alsoPathMint = {
+      type: "object",
+      properties: {
+        admins: {
+          type: "array",
+          items,
+          ifc: { requiredIntegrity: [ADMIN_ATOM], addIntegrity: [ADMIN_ATOM] },
+        },
+      },
+      required: ["admins"],
+    } as const satisfies JSONSchema;
+
+    const writeAdmins = async (schema: JSONSchema, id: string) => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });
+      try {
+        const tx = runtime.edit();
+        const sink = runtime.getCell(signer.did(), id, schema, tx);
+        sink.set({ admins: [{ subject: "alice", displayName: "Alice" }] });
+        tx.prepareCfc();
+        return String((await tx.commit()).error?.message ?? "");
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    };
+
+    expect(await writeAdmins(itemMintOnly, "wf-item-mint-sink")).toContain(
+      "write floor failed",
+    );
+    expect(await writeAdmins(alsoPathMint, "wf-path-mint-sink")).toBe("");
+  });
+
   it("the floor is a minimum: extra minted integrity is fine", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = makeRuntime({ storageManager, cfcWriteFloor: "enforce" });

--- a/tasks/pattern-compat-accepted-breaks.ts
+++ b/tasks/pattern-compat-accepted-breaks.ts
@@ -187,31 +187,6 @@ export const ACCEPTED_CONTRACT_BREAKS: readonly AcceptedContractBreak[] = [
     record: "docs/history/parking-admin-floor-contract-break.md",
   },
   {
-    // The lobby's admin roster declared a `requiredIntegrity` floor on the
-    // `lobby-admin` atom that nothing minted at that path: the roles inside
-    // the roster carry the atom, and an endorsement on an array's entries
-    // does not reach a floor declared on the array path. Under
-    // `cfcWriteFloor: "enforce"` every write to the roster is refused, so the
-    // floor had to gain the mint that satisfies it. The registry's other four
-    // rules already held — one atom throughout, endorsed entries, no
-    // self-granted credential, and a `writeAuthorizedBy` binding to
-    // `commitTrustedLobbyAction` — so the mint is the whole correction.
-    pattern: "lobby/main.tsx",
-    baselines: ["20260729T022742Z-GhLFnf8OCmke_Jje"],
-    // `ifc` is compared for exact equality, so adding the mint that makes an
-    // unsatisfiable floor satisfiable reads as a break. The registry is not
-    // part of the pattern's result, so only the argument role is blamed.
-    paths: ["argument.adminRegistry.admins"],
-    reason:
-      "The admin roster's integrity floor was unsatisfiable, so no write to " +
-      "it could be accepted once the write floor is enforced. Minting the " +
-      "atom the floor names at the path the floor sits on is the only thing " +
-      "that satisfies it, and that changes the `ifc` at that path. A piece " +
-      "holding a roster keeps its stored roles; what it loses is the ability " +
-      "to be updated in place to the corrected contract.",
-    record: "docs/history/lobby-admin-floor-contract-break.md",
-  },
-  {
     // The lunch poll's identity moved from display names to profile cells
     // (see docs/history/lunch-poll-identity-break.md). The proof reports two
     // paths here: the published name-keyed admin result went away, and the


### PR DESCRIPTION
A schema can require that anything written to one of its locations already carry a named integrity atom. That rule is `requiredIntegrity`, and it is a floor: the runtime tests the value a write produces and refuses the write when the value does not carry the atom. A schema can also say that a write through it attaches an atom to the value it produces, which is `addIntegrity`, and which the codebase calls minting.

A location that declares the floor and attaches nothing refuses every write to itself. The floor is checked at the location that declares it, and an endorsement on the entries below that location does not reach it, so a list of endorsed entries still fails a floor on the list. The repair is to attach the atom the same declaration asks for.

The backward-compatibility comparison refused that repair. It compares a schema's `ifc` for exact equality, so the added key read the same as a rewritten store policy, and the refusal reached the runtime as well: `cf piece setsrc` calls this function, so a released pattern could not take the repair on a running piece. Two patterns have already paid an accepted contract break to get past it — the parking coordinator, and the lobby a day ago — and each break costs the pieces holding that data the ability to be updated in place.

A mint is not a store policy. It is the lowered form of the spec's `addedIntegrity` transition annotation, naming atoms the runtime attaches to the integrity of the value a write produces — CFC §8.9.3's output labels, which §8.12.8 calls the derived per-value component and holds to replace-on-overwrite. The monotone constraint that makes a label change incompatible governs the declared store-policy component, and §8.12.8 says a runtime must not apply that constraint to the derived one. §8.12.4.1 settles the floor beside it the same way: a `requiredIntegrity` is a requirement on writers, tightening is the allowed direction for a requirement, and raising a floor asserts nothing about values already stored.

So the comparison now states a role for every `ifc` key the runtime understands, rather than growing another exception each time one turns out not to belong. `declared` keys are the store policy a caller depends on and are compared as they stand: `integrity` and `confidentiality` claim what the store holds, `requiredIntegrity` and `maxConfidentiality` constrain who may write and read it. `writeAuthorizedBy` is compared except for the parts of its claim that move without the authorization moving. `addIntegrity` is the one derived key, and it is dropped.

The roles live in a table typed over the runtime's own list of `ifc` keys, which is now exported for it. A key added there fails to compile here until someone decides what it means for two contracts to differ in it, which is the same discipline the wrapper-name tables use in the schema generator. A key the table does not name at all is compared as it stands, so an unrecognized extension stays fail-closed. The scan for a key that needs handling walks the keys without building anything, so a node carrying only declared keys is returned as it stands and costs no allocation.

Two things follow. The group-chat demo's `SharedRoomList` and `ChatAdminList` gain the mints their own floors name, and record the contracts that produces, with no break to pay. And the lobby's exemption, granted a day ago for exactly this repair, no longer forgives anything: the gate reports it as an exemption outliving its break, so it goes. Its history record stands as the account of what was decided at the time. The parking coordinator's entry stays, because that break also changed the floor atom and added a writer binding, and both are declared keys this comparison still holds.

Two tests pin the mechanism. Under an enforcing floor, a list whose entries each mint the atom is still rejected when the list path itself mints nothing, and the same write commits once the path mints. In the compatibility suite, a location gaining or losing a mint is accepted while a changed floor and a changed declared integrity are still refused.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

