### PR TITLE
The worker's error reply survives a message with no `msgId`

### DIFF
--- a/packages/runtime-client/src/backends/web-worker/index.ts
+++ b/packages/runtime-client/src/backends/web-worker/index.ts
@@ -10,12 +10,14 @@ import "core-js/proposals/async-explicit-resource-management";
 
 import { getLogger } from "@commonfabric/utils/logger";
 import { unrefTimer } from "@commonfabric/utils/sleep";
+import { isObjectNotArray } from "@commonfabric/utils/types";
 
 import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
   IPCRemoteResponse,
   isIPCClientMessage,
   isIPCClientNotification,
+  NotificationType,
   RequestType,
   RuntimeErrorCode,
   TransportNotificationType,
@@ -246,8 +248,26 @@ self.addEventListener("message", async (event: MessageEvent) => {
     const code = error instanceof CompilerStackLoadError
       ? RuntimeErrorCode.CompilerStackLoadFailed
       : undefined;
+    // A reply is addressed by `msgId`, and what reaches here need not have
+    // one: `message` is whatever was posted, which is why the line above asks
+    // `isIPCClientMessage()` rather than trusting it, and `Invalid IPC
+    // request` is thrown precisely for what is no message at all. Reading
+    // `msgId` off that throws from inside this `catch`, which is the one place
+    // a throw has nowhere to go -- out of an async listener it surfaces as an
+    // unhandled rejection, taking the report it was making with it.
+    const msgId = isObjectNotArray(message) && typeof message.msgId === "number"
+      ? message.msgId
+      : undefined;
+    if (msgId === undefined) {
+      postToClient({
+        type: NotificationType.ErrorReport,
+        message: `Malformed message from the client: ${describeFailure(error)}`,
+      });
+      return;
+    }
+
     postToClient({
-      msgId: message.msgId,
+      msgId,
       error: describeFailure(error),
       ...(code ? { code } : {}),
     });

--- a/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
+++ b/packages/runtime-client/test/backends/web-worker-console-bridge.test.ts
@@ -9,6 +9,7 @@ import { CompilerStackLoadError } from "@commonfabric/runner";
 import {
   ClientNotificationType,
   isWorkerConsoleNotification,
+  NotificationType,
   RequestType,
   RuntimeErrorCode,
   TransportNotificationType,
@@ -431,6 +432,40 @@ describe("web-worker-console-bridge", () => {
           (globalThis as { postMessage?: unknown }).postMessage =
             originalPostMessage;
         }
+      }
+    });
+
+    it("reports a message that carries no `msgId` to reply under", async () => {
+      // `message` is whatever was posted, and a reply is addressed by
+      // `msgId`. `null` has none: the entry throws `Invalid IPC request` for
+      // it, and reading `msgId` off it inside the `catch` would throw from the
+      // one place a throw has nowhere to go -- out of this async listener it
+      // is an unhandled rejection, and the report never gets posted at all.
+      const posted: Posted[] = [];
+      const originalPostMessage =
+        (globalThis as { postMessage?: unknown }).postMessage;
+      (globalThis as { postMessage: (m: Posted) => void }).postMessage = (
+        m: Posted,
+      ) => {
+        posted.push(m);
+      };
+      const realConsoleError = console.error;
+      console.error = () => {};
+
+      try {
+        await import("@/backends/web-worker/index.ts");
+        posted.length = 0;
+
+        await dispatch(null);
+
+        expect(posted).toHaveLength(1);
+        expect(posted[0].type).toBe(NotificationType.ErrorReport);
+        expect(posted[0].message).toContain("Malformed message");
+        expect(Object.hasOwn(posted[0], "msgId")).toBe(false);
+      } finally {
+        console.error = realConsoleError;
+        (globalThis as { postMessage?: unknown }).postMessage =
+          originalPostMessage;
       }
     });
 


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Prep for the IPC envelope work (#6323), on the pattern #6330 and #6339 set.
This one is a live bug on `main`, found by cubic's review of that PR and
independent of it.

## The error reply could destroy itself

The worker entry's top-level `catch` exists so a failed request still gets an
answer and the client's promise settles. It addressed that answer with
`message.msgId` — where `message` is `event.data`, whatever was posted. Two
lines above, the same block asks `isIPCClientMessage(message)` rather than
trusting it, and `Invalid IPC request` is thrown precisely for what is no
message at all. Then it dereferences it anyway.

Reading `msgId` off a non-object throws, and it throws from inside the one
`catch` that has nowhere to put a throw: out of an async listener it is an
unhandled rejection. So the report is lost along with the failure it was
reporting, and the request it belonged to never settles at all. A client that
posts `null` reaches it.

Where there is no `msgId` to reply under, the failure now goes out as an
`ErrorReport`.

## The test was ablated, and the ablation is the interesting part

With the guard removed the new test does not merely fail — it fails with

```
error: (in promise) TypeError: Cannot read properties of null (reading 'msgId')
Uncaught error from ./test/backends/web-worker-console-bridge.test.ts FAILED
```

taking its whole test file down with it. That is the shape of the bug rather
than an approximation of it: an exception with nowhere to go, destroying more
than the thing that raised it.

## Verification

- `deno fmt --check`, `deno lint`, `deno task check`: green, repo-wide.
- `runtime-client`: 14 passed / 321 steps / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ukZJG1bVUK194EAJhtLNu


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

