### PR TITLE
feat(repo): gate a CLI command nobody documented, and write the five it named

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -195,7 +195,7 @@ jobs:
           deno task run-recorded gate repo check-completion-slots --
           deno task check-completion-slots
 
-      - name: 📖 Guard against a CLI command nobody documented
+      - name: 🚧 Guard against a CLI command nobody documented
         timeout-minutes: *work-timeout
         run: >-
           deno task run-recorded gate repo check-command-docs --

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -195,6 +195,12 @@ jobs:
           deno task run-recorded gate repo check-completion-slots --
           deno task check-completion-slots
 
+      - name: 📖 Guard against a CLI command nobody documented
+        timeout-minutes: *work-timeout
+        run: >-
+          deno task run-recorded gate repo check-command-docs --
+          deno task check-command-docs
+
       - name: 🔎 Check generated commonfabric/cfc types are up to date
         timeout-minutes: *work-timeout
         working-directory: packages/static

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,11 @@ Each of these gates fails CI on its own, and none of them run as part of
   hand-maintained tables, and a slot missing from both is silent: it offers
   nothing, exactly as an unreachable fabric does. Give it candidates, or record
   in the task why it has none
+- `deno task check-command-docs` — a `cf` command no live document names. The
+  obligation to update a document when behavior changes cannot fire for a
+  command no document describes, so a command ships and its prose does not.
+  Describe it in a live document — the README of the package that implements it
+  is the usual home — or record in the task why it needs none
 - `deno task check-local-program` — a program built from local files by hand
   rather than through `resolveLocalProgram`, which silently drops any data files
   the caller attached

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,9 @@ Each of these gates fails CI on its own, and none of them run as part of
   obligation to update a document when behavior changes cannot fire for a
   command no document describes, so a command ships and its prose does not.
   Describe it in a live document — the README of the package that implements it
-  is the usual home — or record in the task why it needs none
+  is the usual home — or record in the task why it needs none. It fails the
+  other way round too, on a recorded reason naming a command the tree no longer
+  accepts: a command removed takes its entry with it
 - `deno task check-local-program` — a program built from local files by hand
   rather than through `resolveLocalProgram`, which silently drops any data files
   the caller attached

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -71,6 +71,7 @@
     // resolves the whole CLI — including the SQLite library `cf inspect`
     // opens spaces with, which is why this needs --allow-ffi.
     "check-completion-slots": "deno run --allow-read --allow-env --allow-sys --allow-ffi ./tasks/check-completion-slots.ts",
+    "check-command-docs": "deno run --allow-read --allow-env --allow-sys --allow-ffi ./tasks/check-command-docs.ts",
     "check-tripwires": "deno run --allow-read ./tasks/check-tripwires.ts",
     // Reports the docs/ link graph; --allow-write serves its --out flag.
     "docs-links": "deno run --allow-read --allow-write ./scripts/docs-links.ts",

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,19 @@ live document describes, update that document in the same change.** A live
 document that no longer matches the code is a bug. This applies to human and
 AI contributors alike.
 
+That obligation reaches only behavior some document already describes, so new
+surface needs the other half of it: **a capability a caller can reach is
+described somewhere a caller can find.** The two are not the same rule — nothing
+is out of date when a command ships with no prose, because nothing claimed to
+cover it, and the absence is visible only to someone who already knows the
+command exists.
+
+For the `cf` command surface that half is mechanical: `deno task check-command-docs`
+fails when a command the CLI accepts is named in no live document, and takes a
+recorded reason instead where a command genuinely needs none. Prose belongs with
+the code it describes — the README of the package that implements the command,
+or the feature document that owns the surface — which is where the gate looks.
+
 ## Historical documentation
 
 [`docs/history/`](history/README.md) holds point-in-time records: audit

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -89,6 +89,7 @@ on the Common Fabric runtime.
 - [workflows/development.md](workflows/development.md) — `cf` CLI loop: check, deploy, setsrc, inspect, link
 - [workflows/pattern-testing.md](workflows/pattern-testing.md) — writing and running pattern tests
 - [workflows/handlers-cli-testing.md](workflows/handlers-cli-testing.md) — invoking mounted callables from the CLI
+- [workflows/bulk-operations.md](workflows/bulk-operations.md) — surveying, repairing and retargeting a collection of deployed pieces: the plan as the unit of work, dry-by-default applies, and why the verdict is a second survey
 
 ### verbs/ — driving a deployed piece through `cf`
 

--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -89,7 +89,7 @@ on the Common Fabric runtime.
 - [workflows/development.md](workflows/development.md) — `cf` CLI loop: check, deploy, setsrc, inspect, link
 - [workflows/pattern-testing.md](workflows/pattern-testing.md) — writing and running pattern tests
 - [workflows/handlers-cli-testing.md](workflows/handlers-cli-testing.md) — invoking mounted callables from the CLI
-- [workflows/bulk-operations.md](workflows/bulk-operations.md) — surveying, repairing and retargeting a collection of deployed pieces: the plan as the unit of work, dry-by-default applies, and why the verdict is a second survey
+- [workflows/bulk-operations.md](workflows/bulk-operations.md) — the tour of surveying, repairing and retargeting a collection of deployed pieces, walked act by act against the demo that runs it; the contract these operations hold is [features/piece-bulk-operations.md](../features/piece-bulk-operations.md)
 
 ### verbs/ — driving a deployed piece through `cf`
 

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -206,6 +206,15 @@ A verb decides what it returns; the caller decides how much of it to look at.
 `cf wish` and `cf exec` take, with the same grammar — shape the `result` before
 it reaches stdout, and go before the callable name:
 
+Where they go depends on whether a callable's own vocabulary stands between the
+command and them. `cf get` and `cf wish` have none, so the three flags sit on
+the line like any others. `cf call` and `cf exec` do, so the flags precede the
+name that opens it — the callable name on `call`, the mounted file on `exec` —
+and everything after that name belongs to the callable. `--` is what ends the
+callable's section, which is why it is written on those two and refused on
+`cf get`, `cf set` and `cf wish`: there is no section for it to close, and a
+marker on one of those would set aside words nothing reads.
+
 ```bash
 cf call --piece <topic> --select comment.writtenAt addComment \
   '{"body":"first","agentName":"Sol"}'

--- a/docs/common/verbs/over-the-cli.md
+++ b/docs/common/verbs/over-the-cli.md
@@ -210,10 +210,17 @@ Where they go depends on whether a callable's own vocabulary stands between the
 command and them. `cf get` and `cf wish` have none, so the three flags sit on
 the line like any others. `cf call` and `cf exec` do, so the flags precede the
 name that opens it — the callable name on `call`, the mounted file on `exec` —
-and everything after that name belongs to the callable. `--` is what ends the
-callable's section, which is why it is written on those two and refused on
-`cf get`, `cf set` and `cf wish`: there is no section for it to close, and a
-marker on one of those would set aside words nothing reads.
+and everything after that name belongs to the callable.
+
+The two spell that boundary differently today. `cf exec` takes the callable's
+arguments straight after the mounted file with nothing between them, while
+`cf call` wants `--` before the same words in the same position. A caller who
+learns one has not learned the other, and closing that gap is what step 10 of
+[CLI surface shape](../../plans/cli-surface-shape.md) is for.
+
+Where a command has no callable section at all, `--` closes nothing: it is
+refused on `cf get`, `cf set` and `cf wish` rather than silently setting aside
+words that nothing reads.
 
 ```bash
 cf call --piece <topic> --select comment.writtenAt addComment \

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -1,0 +1,232 @@
+# Bulk piece operations
+
+*What is this, and why is it shaped this way?* A tour of surveying, repairing
+and retargeting a collection of deployed pieces, walked act by act against a
+board of 113 members. It assumes you can deploy a piece and call a verb; it
+assumes nothing about the bulk surface.
+
+## What this is for
+
+A pattern ships, and the pieces already running it do not change. Their stored
+documents were written by an older version of the source, against an older
+shape, and nothing about a new deployment reaches back to them. So the work is
+not "deploy the fix" but "carry every existing piece to it" — a hundred
+documents to rewrite, or a hundred pieces to move onto a new source, one at a
+time, without losing track of which ones were done.
+
+Every failure mode that work has is a failure of bookkeeping rather than of
+transformation. A run stops halfway and nobody knows where. A piece is missed
+because the enumeration that found the others never held it. A write lands on a
+document that changed since it was read. An apply exits zero and the caller
+believes it.
+
+The surface is shaped around those four, and three ideas carry the whole of it.
+
+### Three ideas, and then the commands make sense
+
+**The plan is the unit of work, not the command line.** A survey emits a
+line-oriented JSON file: a header accounting for the selection, then one row per
+piece. Each row records the identity that piece runs today, whether that source
+is still retained in the space, and the hash of the document a verdict was
+computed from. The plan is what a later stage consumes, so what was decided is
+written down before anything is written to.
+
+**Dry is the default, and the apply is driven by the plan.** Every write stage
+runs first as a report — the exact per-piece change, and nothing written. The
+apply then takes that plan as its input and works through its rows in its order,
+each row's recorded precondition proved inside the same transaction that writes
+it. A document that moved since the plan was taken fails its own row rather than
+being overwritten.
+
+**The verdict is a second survey, never the apply's exit code.** An apply that
+exits zero says the writes it attempted returned success. Whether the collection
+now holds what you wanted is a different question, and it is answered by
+surveying again and holding the result against the plan the run was made from.
+The two stay separate invocations on purpose.
+
+## The session, act by act
+
+The demo deploys a board, files 113 members through its verb, and works the
+collection from there. `$SPACE` is a throwaway space and `$WORK` a scratch
+directory; every other value is one a previous command printed.
+
+### Acts 1–2 · A collection the registry cannot enumerate
+
+The board holds its members in its own `items` collection. `cf piece ls` reads
+the space's piece registry, which is a different set — a handler-created piece
+appears there only if something sent it to `addPiece`. So the enumeration the
+bulk stages need is the holder's own, and reaching it means asking the holder.
+
+### Act 3 · The survey
+
+```bash
+cf piece survey -s "$SPACE" --piece board --path items --out "$WORK/plan.jsonl"
+```
+
+One process, the whole collection: a plan row per member, the holder last, and a
+tally that answers *do these pieces all agree?* without a reader having to walk
+every row.
+
+The header accounts for the selection — what was asked for, and how many pieces
+that turned out to be. Each member row records the identity the piece runs today
+and whether that source is retained in the space. That second field is the
+rollback question, and the survey answers it before any write is planned rather
+than after one has failed.
+
+### Act 4 · One piece's pin, without running it
+
+```bash
+cf piece inspect -s "$SPACE" --piece board --pattern-identity
+```
+
+The same identity fact the survey reads per member, as a single lookup: no piece
+started, no input or result pulled. This is what makes a board-sized survey one
+cheap read per member rather than one execution per member.
+
+### Acts 5–6 · A plan that carries the operation, from a live read
+
+A survey can carry the work as well as the record. A retarget stamped onto every
+row whose phase matches is pinned to the identity the on-disk source produces —
+not to a path, which could drift between the plan and the apply.
+
+```bash
+cf piece survey -s "$SPACE" --piece board --path items \
+  --retarget "items=$RETARGET_FIXTURE@v2" --main-export Member \
+  --out "$WORK/retarget.jsonl"
+```
+
+Each row then carries both halves: `expect` is where the piece stands, `op` is
+where this plan will take it.
+
+The survey is a live read, so filing one more member and surveying again moves
+the count. There is no cache to invalidate and nothing to refresh.
+
+### Act 7 · A repair, where the fixer is the work
+
+A **fixer** is a TypeScript module whose default export is a pure transform from
+a piece's stored document to the document it should hold. That is the whole of
+what a caller writes. Selection, ordering, the write, the stop and the resume
+belong to the tooling.
+
+```bash
+cf piece repair -s "$SPACE" --piece board --path items \
+  --fixer "$WORK/fix-titles.ts" --out "$WORK/repair.jsonl"
+```
+
+Dry: the exact per-piece diff, and no write at all. Every row records the
+document hash its verdict was computed from — the precondition the apply will
+prove — and the fixer it was evaluated for.
+
+```bash
+cf piece repair -s "$SPACE" --piece board --path items \
+  --fixer "$WORK/fix-titles.ts" --plan "$WORK/repair.jsonl" --apply \
+  --out "$WORK/applied.jsonl"
+```
+
+The plan drives the apply: its rows, in its order, each checked against its
+recorded hash in the same transaction that writes it.
+
+**Resume is the same command again.** A repaired document is one the fixer no
+longer changes, so a completed plan re-runs as landed and writes nothing. That
+property is what makes a run that stopped partway safe to simply re-issue: there
+is no separate resume mode to get wrong, and no bookkeeping the caller has to
+keep.
+
+### Act 8 · The retarget, applied over grouped sessions
+
+Where a repair rewrites documents, a retarget moves pieces onto a new source.
+The plan is the whole input — it names the pieces, the reference each must still
+be on, and the source each moves to — so the command carries no selection of its
+own.
+
+```bash
+cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
+  --out "$WORK/dry.json"
+```
+
+Dry again: every row classified against its own reference pair, nothing written.
+
+```bash
+cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
+  --group-size 25 --apply --out "$WORK/applied.json"
+```
+
+Sessions are grouped rather than opened per piece or held open for the whole
+run. The warm-up amortizes across a group while the pieces live at once stay
+bounded by it, and a group boundary is a resume point. Every row carries what it
+cost, because a run whose cost per piece is unknown cannot be improved.
+
+Re-invoking is the resume, on the same principle the repair uses: a piece
+already on its row's target reads as landed and is not rewritten.
+
+### Act 9 · The verification is a second survey
+
+```bash
+cf piece survey -s "$SPACE" --piece board --path items \
+  --diff "$WORK/retarget.jsonl"
+```
+
+A planned piece lands in one of three outcomes — moved as planned, still
+outstanding, or moved to something the plan did not ask for — and the third is
+what an upgrade that half-converged looks like. The command exits nonzero unless
+every planned row converged.
+
+A member filed after the plan was taken is none of the three. It is named as
+held by the space and not by the plan, rather than counted as though the plan
+had asked for it.
+
+### Act 10 · The refusal the survey exists to make
+
+A silent subset is the failure bulk operations die of: a run reports success
+over the pieces it knew about, and the ones it never enumerated stay behind at
+the old shape with nothing recording that they were missed.
+
+So when the registry knows a piece on an in-scope identity that the collection
+does not hold, the survey stops and names it rather than emitting a plan that
+quietly misses it. The plan the later stages consume is therefore complete by
+construction: an incomplete survey refuses to produce one, and a serialized plan
+carries the incompleteness so no write stage can consume it either.
+
+### Act 11 · A list survey claims only what it read
+
+```bash
+cf piece survey -s "$SPACE" --list board --out "$WORK/list.jsonl"
+```
+
+Naming pieces directly skips the containment check — and says so. The header
+records the selector, so a reader of the plan knows no containment claim was
+made. The orphan is still out there; this survey simply never claimed otherwise.
+
+## How the story is kept honest
+
+Every command above is one `packages/cli/integration/bulk-ops-demo.sh` runs.
+The demo narrates each act and then executes it, and each act re-parses its own
+displayed line and compares the words against the argv that ran — so a line a
+reader retypes is the line that executed, checked rather than asserted.
+`deno task check-verb-session-sync` holds this document to that script: a `cf`
+line here either quotes a command the demo runs or carries a `# not in the demo`
+comment saying why it cannot.
+
+`packages/cli/integration/bulk-survey-drill.sh` asserts the same surface as
+pass/fail in CI, which is what keeps the demo from drifting into a transcript
+nobody runs.
+
+## Running it yourself
+
+```bash
+API_URL=http://localhost:8000 packages/cli/integration/bulk-ops-demo.sh
+```
+
+The transcript is the artifact. Acts the mechanism does not yet cover appear at
+the end marked pending, so what the surface will grow stays visible beside what
+it does today.
+
+## Where to read further
+
+- [`docs/plans/piece-bulk-operations.md`](../../plans/piece-bulk-operations.md)
+  — the design: what each stage owes, and what the later ones wait on
+- [`packages/cli/README.md`](../../../packages/cli/README.md) — the reference
+  for `survey`, `repair` and `retarget`, and the reference forms their
+  selections take
+- [The Verb Session](../verbs/the-verb-session.md) — the tour of the surface a
+  collection is built through in the first place

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -44,42 +44,38 @@ stage writes without `--apply`, and what the dry run reports differs: a repair
 prints the exact per-piece document diff, a retarget prints where each piece
 stands against its own row's reference pair.
 
-The precondition differs too, and the difference decides what happens when
-something else is writing at the same time.
+The precondition differs too — each stage pins what its own write moves — and
+in both the write is what proves it.
 
-A repair row's precondition is the hash of the document its dry run read, and
-the write is what proves it: the check runs inside the edit closure, which
-re-runs against fresh state on a commit conflict, so a document that moved fails
-its own row rather than being overwritten.
+A repair row's precondition is the hash of the document its dry run read. The
+check runs inside the edit closure, which re-runs against fresh state on a
+commit conflict, so a document that moved fails its own row rather than being
+overwritten.
 
-A retarget row's precondition is the reference pair it records, and the write
-does not prove it. A row runs as a sequence — read the piece's current
-reference, classify it against the pair, resolve the row's source from disk,
-recompute the identity that source produces, then call `setPattern`, which loads
-the current reference for itself and holds its own commit to that and never to
-the pair the row recorded. The classification is a read taken some way before
-the write, not a condition on it.
+A retarget row's precondition is the reference pair it records. A row runs as a
+sequence: read the piece's current reference, classify it against the pair,
+resolve the row's source from disk, recompute the identity that source produces,
+then write. The read classifies and does not guard — a writer landing after it
+is invisible to it — so the reference that read proved rides into the write as
+its own precondition, checked against the snapshot the write takes and again
+inside the transaction that commits it. A piece something else moved is refused
+by name and stops the run, rather than being written over.
 
-What the classification catches is a piece standing on neither of the row's two
-references. At the preflight that reads every row before the first write, such
-a piece keeps the run from starting at all; in a row's own read it stops the run
-there, and every piece after it is named unattempted. What it absorbs instead is
-a piece something else moved onto the row's own target: that classifies as
-landed — the same verdict a resume produces — so the run leaves it alone and
-rewrites nothing. Both outcomes are pinned in
-`packages/piece/test/ops/bulk-retarget.test.ts`, which races a writer against a
-group session and asserts the skip in one run and the stop in the other.
+The classification's own outcomes stand either side of that. A piece on neither
+of the row's references stops the run too: at the preflight that reads every row
+before the first write it keeps the run from starting at all, and in a row's own
+read it stops there, with every piece after it named unattempted. A piece
+another writer moved onto the row's own target classifies as landed — the
+verdict a resumed row carries — so the run skips it without a write. That one
+case is absorbed rather than named, and it is the benign one: the piece is
+where the plan wanted it, though `landed` says only that it is there, never
+that this run put it there.
 
-Between them one window stays open: a move landing after the row's
-classification returns and before `setPattern` reads the piece for itself. A
-piece moved there is carried to the row's target from the reference the other
-writer left it on, the row's pair never being consulted again. Past that read it
-is covered once more — `runSynced` reasserts the identity `setPattern` loaded
-inside every transaction attempt, so a move landing later is rejected with
-"piece pattern changed while the source update was compiling" rather than
-written over. The window is narrow, but it is open, so a retarget plan is a
-record of what a run intended and a check on what it finds, not an interlock
-against a second writer working the same pieces.
+Each of those outcomes is pinned in
+`packages/piece/test/ops/bulk-retarget.test.ts`, which races a writer into the
+classification read in one test and into the gap before the write in another.
+The [bulk operations contract](../../features/piece-bulk-operations.md) is where
+every refusal and the moment it fires are written down.
 
 **The verdict is a second look, never the apply's exit code.** An apply that
 exits zero says the writes it attempted returned success, which is not the same
@@ -121,6 +117,16 @@ that turned out to be. Each member row records the identity the piece runs today
 and whether that source is retained in the space. That second field is the
 rollback question, and the survey answers it before any write is planned rather
 than after one has failed.
+
+What the survey does not do is report as it goes. Nothing reaches stdout, the
+`--out` file, or the hint stream until every piece has been read and the plan is
+whole; the plan is written in one piece at the end, which is what lets the next
+stage consume the file without asking whether it is finished. The cost is that
+silence carries no information: a caller watching a survey that has printed
+nothing has no way to tell a large collection from a read that will not finish,
+because the command offers nothing to tell them apart with. An apply is the
+other way about — given neither `--json` nor `--out`, it prints a line per row
+as it settles them.
 
 ### Act 4 · One piece's pin, without running it
 
@@ -298,9 +304,12 @@ nobody runs.
 API_URL=http://localhost:8000 packages/cli/integration/bulk-ops-demo.sh
 ```
 
-The transcript is the artifact. Acts the mechanism does not yet cover appear at
-the end marked pending, so what the surface will grow stays visible beside what
-it does today.
+The transcript is the artifact, and every act in it runs. Each one makes a
+claim the demo counts: an unmarked act says the command works, a REFUSED act
+says the surface turns it down, and a displayed line that would not re-parse to
+the argv that ran is counted too. A transcript that reads clean is one where
+every one of those claims held, because a run that got any of them wrong cannot
+exit zero.
 
 ## Where to read further
 

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -1,4 +1,4 @@
-# Bulk piece operations
+# The bulk operations session
 
 *What is this, and why is it shaped this way?* A tour of surveying, repairing
 and retargeting a collection of deployed pieces, walked act by act against a

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -268,6 +268,16 @@ Naming pieces directly skips the containment check — and says so. The header
 records the selector, so a reader of the plan knows no containment claim was
 made. The orphan is still out there; this survey simply never claimed otherwise.
 
+### Past act 11 · Undoing it
+
+The demo does not stop there. Acts 12 through 14 walk the reversal — a retarget
+undone from the plan that made it, one piece returned to a revision of its own
+source log, and a piece that cannot be brought back at all. They are the same
+spine as the acts above, applied in the other direction, and what each one
+proves is written down in the
+[bulk operations contract](../../features/piece-bulk-operations.md) rather than
+narrated here.
+
 ## How the story is kept honest
 
 Every command above is one `packages/cli/integration/bulk-ops-demo.sh` runs.
@@ -294,6 +304,9 @@ it does today.
 
 ## Where to read further
 
+- [The bulk operations contract](../../features/piece-bulk-operations.md) —
+  what a plan row means, what is proved and when, and every moment one of these
+  operations refuses
 - [`docs/plans/piece-bulk-operations.md`](../../plans/piece-bulk-operations.md)
   — the design: what each stage owes, and what the later ones wait on
 - [`packages/cli/README.md`](../../../packages/cli/README.md) — the reference

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -14,13 +14,19 @@ not "deploy the fix" but "carry every existing piece to it" — a hundred
 documents to rewrite, or a hundred pieces to move onto a new source, one at a
 time, without losing track of which ones were done.
 
-Every failure mode that work has is a failure of bookkeeping rather than of
-transformation. A run stops halfway and nobody knows where. A piece is missed
-because the enumeration that found the others never held it. A write lands on a
-document that changed since it was read. An apply exits zero and the caller
-believes it.
+The failures worth building against are the ones that leave no trace. A fixer
+that throws, an answer the store cannot hold, a source that resolves to
+something other than the identity a row recorded — those announce themselves,
+and the surface names the row and stops. These four announce nothing on their
+own. A run stops halfway and nobody knows where. A piece is missed because the
+enumeration that found the others never held it. A write lands on a document
+that changed since it was read. An apply exits zero and the caller believes it.
+What they have in common is the ending they reach when nothing is built to stop
+them: a caller who thinks the work is done, and a collection that says otherwise
+weeks later, with nothing written down that would have said which pieces.
 
-The surface is shaped around those four, and three ideas carry the whole of it.
+The surface is shaped around making that silent class loud, and three ideas
+carry the whole of it.
 
 ### Three ideas, and then the commands make sense
 
@@ -38,22 +44,33 @@ stage writes without `--apply`, and what the dry run reports differs: a repair
 prints the exact per-piece document diff, a retarget prints where each piece
 stands against its own row's reference pair.
 
-The precondition differs too, and the difference is what matters when something
-else is writing at the same time. A repair row's precondition is the hash of the
-document its dry run read, and it is proved *inside* the transaction that
-writes: the check runs in the edit closure, which re-runs against fresh state on
-a commit conflict, so a document that moved fails its own row rather than being
-overwritten. A retarget row's precondition is the reference pair it records, and
-it is proved by a read in the same session immediately *before* the write rather
-than by the write itself — `setPattern` conditions its commit on the reference
-it reads for itself, not on the one the row recorded. The two reads are not
-adjacent — the run resolves the row's source from disk and recomputes its
-identity in between — and a piece that something else moves inside that gap is
-carried to the row's target rather than refused, so a retarget plan is not a
-defense against a second writer working the same pieces at the same time. What
-the recorded pair does buy is that a piece already moved when the run reaches it
-stops the run: once at the preflight that classifies every row before the first
-write, and again in the read taken immediately before that row's own write.
+The precondition differs too, and the difference decides what happens when
+something else is writing at the same time.
+
+A repair row's precondition is the hash of the document its dry run read, and
+the write is what proves it: the check runs inside the edit closure, which
+re-runs against fresh state on a commit conflict, so a document that moved fails
+its own row rather than being overwritten.
+
+A retarget row's precondition is the reference pair it records, and the write
+does not prove it. A row runs as a sequence — read the piece's current
+reference, classify it against the pair, resolve the row's source from disk,
+recompute the identity that source produces, then call `setPattern`, which loads
+the current reference for itself and holds its own commit to that and never to
+the pair the row recorded. The classification is a read taken some way before
+the write, not a condition on it.
+
+What the classification catches is a piece standing on neither of the row's two
+references. At the preflight that reads every row before the first write, such a
+piece keeps the run from starting at all; in a row's own read it stops the run
+there, and every piece after it is named unattempted. What it does not catch has
+two shapes, and a reader should assume neither is caught. A piece that something
+else moved onto the row's own target classifies as landed — the same verdict a
+resume produces — so the run leaves it alone and reports nothing unusual about
+it. And a piece moved during the sequence above is carried to the row's target
+from wherever it had been taken, because the row's pair is never consulted
+again. A retarget plan is a record of what a run intended and a check on what it
+finds, not an interlock against a second writer working the same pieces.
 
 **The verdict is a second look, never the apply's exit code.** An apply that
 exits zero says the writes it attempted returned success, which is not the same

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -26,29 +26,52 @@ The surface is shaped around those four, and three ideas carry the whole of it.
 
 **The plan is the unit of work, not the command line.** A survey emits a
 line-oriented JSON file: a header accounting for the selection, then one row per
-piece. Each row records the identity that piece runs today, whether that source
-is still retained in the space, and the hash of the document a verdict was
-computed from. The plan is what a later stage consumes, so what was decided is
-written down before anything is written to.
+piece, in the order a run must work through them. Each row records the identity
+that piece runs today and whether that source is still retained in the space —
+the rollback question. A row carries no operation unless a stage put one there:
+a survey's rows are a pre-state record until it is asked to stamp a retarget, or
+until a repair's dry run emits rows of its own. The plan is what a later stage
+consumes, so what was decided is written down before anything is written to.
 
-**Dry is the default, and the apply is driven by the plan.** Every write stage
-runs first as a report — the exact per-piece change, and nothing written. The
-apply then takes that plan as its input and works through its rows in its order,
-each row's recorded precondition proved inside the same transaction that writes
-it. A document that moved since the plan was taken fails its own row rather than
-being overwritten.
+**Dry is the default, and what an apply proves is per operation.** Neither write
+stage writes without `--apply`, and what the dry run reports differs: a repair
+prints the exact per-piece document diff, a retarget prints where each piece
+stands against its own row's reference pair.
 
-**The verdict is a second survey, never the apply's exit code.** An apply that
-exits zero says the writes it attempted returned success. Whether the collection
-now holds what you wanted is a different question, and it is answered by
-surveying again and holding the result against the plan the run was made from.
-The two stay separate invocations on purpose.
+The precondition differs too, and the difference is what matters when something
+else is writing at the same time. A repair row's precondition is the hash of the
+document its dry run read, and it is proved *inside* the transaction that
+writes: the check runs in the edit closure, which re-runs against fresh state on
+a commit conflict, so a document that moved fails its own row rather than being
+overwritten. A retarget row's precondition is the reference pair it records, and
+it is proved by a read in the same session immediately *before* the write rather
+than by the write itself — `setPattern` conditions its commit on the reference
+it reads for itself, not on the one the row recorded. The two reads are not
+adjacent — the run resolves the row's source from disk and recomputes its
+identity in between — and a piece that something else moves inside that gap is
+carried to the row's target rather than refused, so a retarget plan is not a
+defense against a second writer working the same pieces at the same time. What
+the recorded pair does buy is that a piece already moved when the run reaches it
+stops the run: once at the preflight that classifies every row before the first
+write, and again in the read taken immediately before that row's own write.
+
+**The verdict is a second look, never the apply's exit code.** An apply that
+exits zero says the writes it attempted returned success, which is not the same
+question as whether the collection now holds what you wanted. For a retarget the
+second look is a survey, held against the plan the run was made from, and the
+two stay separate invocations on purpose. For a repair it is the fixer: a
+reference diff is refused outright for a plan carrying repair rows, because a
+repair moves the document and not the reference, so a diff would answer
+`unchanged` about work it cannot see. Re-running the fixer is what verifies a
+repair, and a document it no longer changes is a repaired one.
 
 ## The session, act by act
 
 The demo deploys a board, files 113 members through its verb, and works the
 collection from there. `$SPACE` is a throwaway space and `$WORK` a scratch
-directory; every other value is one a previous command printed.
+directory the session writes its plans into. `$RETARGET_FIXTURE` is a pattern
+source in this repository, `board` is the slug the holder was deployed under,
+and `fix-titles.ts` is a file Act 7 writes.
 
 ### Acts 1–2 · A collection the registry cannot enumerate
 
@@ -107,18 +130,27 @@ the count. There is no cache to invalidate and nothing to refresh.
 ### Act 7 · A repair, where the fixer is the work
 
 A **fixer** is a TypeScript module whose default export is a pure transform from
-a piece's stored document to the document it should hold. That is the whole of
-what a caller writes. Selection, ordering, the write, the stop and the resume
-belong to the tooling.
+a piece's stored input document to the document it should hold. That is the
+whole of what a caller writes. Selection, ordering, the write, the stop and the
+resume belong to the tooling.
+
+Purity is checked rather than assumed: the run evaluates the fixer twice over
+one document and refuses it by name if the two answers differ. Four more
+answers are refused the same way, before anything is written: one that is not a
+document, one holding a value the store cannot keep, one that drops a field the
+write would then zero — the write replaces the document whole — and one that
+rewrote or dropped a link.
 
 ```bash
 cf piece repair -s "$SPACE" --piece board --path items \
   --fixer "$WORK/fix-titles.ts" --out "$WORK/repair.jsonl"
 ```
 
-Dry: the exact per-piece diff, and no write at all. Every row records the
-document hash its verdict was computed from — the precondition the apply will
-prove — and the fixer it was evaluated for.
+Dry: the exact per-piece diff, and no write at all. The plan it emits holds one
+row per member — a repair works the members and not the holder — and a row whose
+document the fixer could evaluate records the hash that verdict was computed
+from, the precondition the apply will prove, beside the fixer it was evaluated
+for.
 
 ```bash
 cf piece repair -s "$SPACE" --piece board --path items \
@@ -147,7 +179,10 @@ cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
   --out "$WORK/dry.json"
 ```
 
-Dry again: every row classified against its own reference pair, nothing written.
+Dry again: every row that carries an op classified against its own reference
+pair, and nothing written. A row without one is not work — the holder's row is
+the usual case — so the report leaves it out rather than reporting a verdict
+about a piece this run will not touch.
 
 ```bash
 cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
@@ -170,14 +205,17 @@ cf piece survey -s "$SPACE" --piece board --path items \
   --diff "$WORK/retarget.jsonl"
 ```
 
-A planned piece lands in one of three outcomes — moved as planned, still
-outstanding, or moved to something the plan did not ask for — and the third is
-what an upgrade that half-converged looks like. The command exits nonzero unless
-every planned row converged.
+A row that carried an op lands in one of three outcomes — moved as planned,
+still outstanding, or moved to something the plan did not ask for — and the
+third is what an upgrade that half-converged looks like. A row the plan recorded
+without one is not measured against a target it never had: it reads as unchanged
+or as changed, the holder's row among them. A row whose piece the after-survey
+no longer holds reads as gone from the selection. The command exits nonzero
+unless every row is landed or unchanged, which is what "converged" means here.
 
-A member filed after the plan was taken is none of the three. It is named as
-held by the space and not by the plan, rather than counted as though the plan
-had asked for it.
+A member filed after the plan was taken is none of those. It is named as held by
+the space and not by the plan, rather than counted as though the plan had asked
+for it.
 
 ### Act 10 · The refusal the survey exists to make
 

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -271,9 +271,9 @@ Naming pieces directly skips the containment check — and says so. The header
 records the selector, so a reader of the plan knows no containment claim was
 made. The orphan is still out there; this survey simply never claimed otherwise.
 
-### Past act 11 · Undoing it
+### Acts 12–14 · Undoing it, where this tour stops
 
-The demo does not stop there. Acts 12 through 14 walk the reversal — a retarget
+The demo does not stop at act 11. These three walk the reversal — a retarget
 undone from the plan that made it, one piece returned to a revision of its own
 source log, and a piece that cannot be brought back at all. They are the same
 spine as the acts above, applied in the other direction, and what each one

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -61,16 +61,25 @@ the pair the row recorded. The classification is a read taken some way before
 the write, not a condition on it.
 
 What the classification catches is a piece standing on neither of the row's two
-references. At the preflight that reads every row before the first write, such a
-piece keeps the run from starting at all; in a row's own read it stops the run
-there, and every piece after it is named unattempted. What it does not catch has
-two shapes, and a reader should assume neither is caught. A piece that something
-else moved onto the row's own target classifies as landed — the same verdict a
-resume produces — so the run leaves it alone and reports nothing unusual about
-it. And a piece moved during the sequence above is carried to the row's target
-from wherever it had been taken, because the row's pair is never consulted
-again. A retarget plan is a record of what a run intended and a check on what it
-finds, not an interlock against a second writer working the same pieces.
+references. At the preflight that reads every row before the first write, such
+a piece keeps the run from starting at all; in a row's own read it stops the run
+there, and every piece after it is named unattempted. What it absorbs instead is
+a piece something else moved onto the row's own target: that classifies as
+landed — the same verdict a resume produces — so the run leaves it alone and
+rewrites nothing. Both outcomes are pinned in
+`packages/piece/test/ops/bulk-retarget.test.ts`, which races a writer against a
+group session and asserts the skip in one run and the stop in the other.
+
+Between them one window stays open: a move landing after the row's
+classification returns and before `setPattern` reads the piece for itself. A
+piece moved there is carried to the row's target from the reference the other
+writer left it on, the row's pair never being consulted again. Past that read it
+is covered once more — `runSynced` reasserts the identity `setPattern` loaded
+inside every transaction attempt, so a move landing later is rejected with
+"piece pattern changed while the source update was compiling" rather than
+written over. The window is narrow, but it is open, so a retarget plan is a
+record of what a run intended and a check on what it finds, not an interlock
+against a second writer working the same pieces.
 
 **The verdict is a second look, never the apply's exit code.** An apply that
 exits zero says the writes it attempted returned success, which is not the same

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -85,9 +85,12 @@ cheap read per member rather than one execution per member.
 
 ### Acts 5–6 · A plan that carries the operation, from a live read
 
-A survey can carry the work as well as the record. A retarget stamped onto every
-row whose phase matches is pinned to the identity the on-disk source produces —
-not to a path, which could drift between the plan and the apply.
+A survey can carry the work as well as the record. A retarget stamps an `op`
+onto the rows whose phase matches it, and pins that op to the identity the
+on-disk source produces — not to a path, which could drift between the plan and
+the apply. A row is exempt when its piece already stands on the reference the op
+names: there is nothing to do for that piece, and a row claiming otherwise could
+not be verified afterward, landed and never-ran reading alike.
 
 ```bash
 cf piece survey -s "$SPACE" --piece board --path items \
@@ -95,8 +98,8 @@ cf piece survey -s "$SPACE" --piece board --path items \
   --out "$WORK/retarget.jsonl"
 ```
 
-Each row then carries both halves: `expect` is where the piece stands, `op` is
-where this plan will take it.
+A row that carries an op carries both halves: `expect` is where the piece
+stands, `op` is where this plan will take it.
 
 The survey is a live read, so filing one more member and surveying again moves
 the count. There is no cache to invalidate and nothing to refresh.
@@ -153,8 +156,9 @@ cf piece retarget -s "$SPACE" --plan "$WORK/retarget.jsonl" \
 
 Sessions are grouped rather than opened per piece or held open for the whole
 run. The warm-up amortizes across a group while the pieces live at once stay
-bounded by it, and a group boundary is a resume point. Every row carries what it
-cost, because a run whose cost per piece is unknown cannot be improved.
+bounded by it, and a group boundary is a resume point. Every row an apply
+session worked on carries what it cost, because a run whose cost per piece is
+unknown cannot be improved.
 
 Re-invoking is the resume, on the same principle the repair uses: a piece
 already on its row's target reads as landed and is not rewritten.
@@ -182,10 +186,13 @@ over the pieces it knew about, and the ones it never enumerated stay behind at
 the old shape with nothing recording that they were missed.
 
 So when the registry knows a piece on an in-scope identity that the collection
-does not hold, the survey stops and names it rather than emitting a plan that
-quietly misses it. The plan the later stages consume is therefore complete by
-construction: an incomplete survey refuses to produce one, and a serialized plan
-carries the incompleteness so no write stage can consume it either.
+does not hold, the survey names it and exits nonzero. The plan is still emitted
+— to `--out`, or to stdout — because what was read is worth keeping; what it is
+not is consumable. Its header carries the pieces the survey could not account
+for, encoding and decoding preserve them, and every write stage refuses a plan
+whose header names any. The incompleteness therefore rides the artifact rather
+than the exit code: a plan that reached a write stage by another route, or was
+kept and supplied later, refuses there just the same.
 
 ### Act 11 · A list survey claims only what it read
 

--- a/docs/common/workflows/bulk-operations.md
+++ b/docs/common/workflows/bulk-operations.md
@@ -161,17 +161,15 @@ the count. There is no cache to invalidate and nothing to refresh.
 
 ### Act 7 · A repair, where the fixer is the work
 
-A **fixer** is a TypeScript module whose default export is a pure transform from
-a piece's stored input document to the document it should hold. That is the
-whole of what a caller writes. Selection, ordering, the write, the stop and the
-resume belong to the tooling.
+The work here is a **fixer**, and it is the only part a caller writes:
+selection, ordering, the write, the stop and the resume all belong to the
+tooling. What a fixer must be, and every answer it is refused for, is the
+[bulk operations contract](../../features/piece-bulk-operations.md)'s to say.
 
-Purity is checked rather than assumed: the run evaluates the fixer twice over
-one document and refuses it by name if the two answers differ. Four more
-answers are refused the same way, before anything is written: one that is not a
-document, one holding a value the store cannot keep, one that drops a field the
-write would then zero — the write replaces the document whole — and one that
-rewrote or dropped a link.
+What matters at this act is that the requirement is probed rather than trusted.
+A fixer is asked the same question twice and refused by name if it answers
+differently, so a transform that is not the function it claims to be is caught
+before a single document is written rather than after a hundred are.
 
 ```bash
 cf piece repair -s "$SPACE" --piece board --path items \
@@ -237,17 +235,16 @@ cf piece survey -s "$SPACE" --piece board --path items \
   --diff "$WORK/retarget.jsonl"
 ```
 
-A row that carried an op lands in one of three outcomes — moved as planned,
-still outstanding, or moved to something the plan did not ask for — and the
-third is what an upgrade that half-converged looks like. A row the plan recorded
-without one is not measured against a target it never had: it reads as unchanged
-or as changed, the holder's row among them. A row whose piece the after-survey
-no longer holds reads as gone from the selection. The command exits nonzero
-unless every row is landed or unchanged, which is what "converged" means here.
+Each row comes back with a verdict, and the
+[bulk operations contract](../../features/piece-bulk-operations.md) is where
+those verdicts are defined. What the act is for is the shape of the question:
+a row the plan gave no operation is not measured against a target it never had,
+a row whose piece the after-survey no longer holds is reported gone rather than
+outstanding, and the command exits nonzero unless every row converged.
 
-A member filed after the plan was taken is none of those. It is named as held by
-the space and not by the plan, rather than counted as though the plan had asked
-for it.
+A member filed after the plan was taken gets no verdict at all, because the plan
+never carried a row for it. It is named as held by the space and not by the
+plan, rather than counted as though the plan had asked for it.
 
 ### Act 10 · The refusal the survey exists to make
 

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -254,7 +254,7 @@ otherwise force arbitrary allocation with a garbage signature.
 
 ### Client
 
-`cf ingest mint|list|rotate|revoke`, alongside `cf acl`. `cf ingest rotate <id>`
+`cf ingest mint|ls|rotate|revoke`, alongside `cf acl`. `cf ingest rotate <id>`
 mints a new token for a channel the caller owns, leaving the channel and its
 grants in place — the spelling for a token that leaked or aged, where revoking
 would take the channel down with it. The CLI is the only client that can sign

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -254,7 +254,7 @@ otherwise force arbitrary allocation with a garbage signature.
 
 ### Client
 
-`cf ingest mint|list|rotate|revoke`, alongside `cf acl`. The CLI is the only
+`cf ingest mint|list|rotate|revoke`, alongside `cf acl`. `cf ingest rotate <id>` mints a new token for a channel the caller owns, leaving the channel and its grants in place — the spelling for a token that leaked or aged, where revoking would take the channel down with it. The CLI is the only
 client that can sign today — the shell cannot sign at all (zero references to
 `toolshed-http-auth` across `packages/shell`, `packages/lib-shell`,
 `packages/runtime-client`), and the in-pattern `fetch` builtin is bound to the

--- a/docs/features/self-serve-ingest-channels.md
+++ b/docs/features/self-serve-ingest-channels.md
@@ -254,11 +254,13 @@ otherwise force arbitrary allocation with a garbage signature.
 
 ### Client
 
-`cf ingest mint|list|rotate|revoke`, alongside `cf acl`. `cf ingest rotate <id>` mints a new token for a channel the caller owns, leaving the channel and its grants in place — the spelling for a token that leaked or aged, where revoking would take the channel down with it. The CLI is the only
-client that can sign today — the shell cannot sign at all (zero references to
-`toolshed-http-auth` across `packages/shell`, `packages/lib-shell`,
-`packages/runtime-client`), and the in-pattern `fetch` builtin is bound to the
-three-entry allowlist above.
+`cf ingest mint|list|rotate|revoke`, alongside `cf acl`. `cf ingest rotate <id>`
+mints a new token for a channel the caller owns, leaving the channel and its
+grants in place — the spelling for a token that leaked or aged, where revoking
+would take the channel down with it. The CLI is the only client that can sign
+today — the shell cannot sign at all (zero references to `toolshed-http-auth`
+across `packages/shell`, `packages/lib-shell`, `packages/runtime-client`), and
+the in-pattern `fetch` builtin is bound to the three-entry allowlist above.
 
 **This is a real limitation, stated plainly:** CLI signing needs a plaintext
 PKCS#8 key file on disk (`packages/cli/lib/identity.ts:33-37`), while a shell

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,6 +112,14 @@ arguments cell the way `--input` does. Only commands that take `--input` accept
 it; `#` is reserved for the suffix, so a path key containing `#` needs the
 positional path spelling.
 
+`cf piece apply` replaces a piece's whole input rather than one path within it.
+It validates the document against the pattern's `argumentSchema` and re-executes
+the pattern with it, so a field the schema requires and the document omits is
+refused before anything is written. `cf set` writes at one path and validates
+only that path, which makes the two different operations on the same cell: reach
+for `apply` when the new input is a whole document, and for `set` when it is one
+value in a document that is otherwise correct.
+
 ## Piece discovery
 
 `cf piece ls` lists the pieces in the selected space's piece registry. It reads
@@ -902,6 +910,14 @@ Every registered top-level command appears in `cf --help`. The direct
 launchers use them. Shell completion is the exception: it drops commands whose
 description opens with `Internal:`, because those are spawned by `cf fuse` and
 never typed at a prompt.
+
+## Evaluating patterns from another tool
+
+`cf init` writes a TypeScript environment an external tool can evaluate patterns
+in: the configuration and type declarations an editor, a scratch checkout, or a
+generated workspace needs to resolve `commonfabric` the way this repository
+does. It touches nothing in a space, so it is safe to run anywhere and to run
+again.
 
 ## Installing `cf` on PATH
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -273,6 +273,26 @@ value. An `observes` update is rejected when it would combine with an existing
 observation class instead of preserving the requested class. Omitting `observes`
 from a later update preserves an existing unambiguous class.
 
+## Invocation sessions
+
+An invocation id is the caller's own word for one call, and another caller can
+choose the same one. What separates them is the session it was chosen within:
+the pair decides which outcome a replay reads, and it is what keeps an outcome's
+address unguessable. `cf invocation-session` is where a session comes from.
+
+```bash
+export CF_INVOCATION_SESSION=$(cf invocation-session new)
+```
+
+`new` prints one id on stdout and nothing else, so a command substitution
+captures exactly it. Mint one per agent run and carry it in the environment
+rather than in `--invocation-session <id>`, which every `cf call` also accepts:
+an environment variable stays out of the process listing an argument shows up
+in. A call naming an invocation id with no session in scope is refused: an id is
+replayable only within the session it was chosen in, and a session minted on the
+spot would make the replay name a different invocation. A call naming neither
+gets both, minted for that one call.
+
 ## Output Conventions
 
 - stdout carries command output only; hints and diagnostics go to stderr.
@@ -916,8 +936,20 @@ never typed at a prompt.
 `cf init` writes a TypeScript environment an external tool can evaluate patterns
 in: the configuration and type declarations an editor, a scratch checkout, or a
 generated workspace needs to resolve `commonfabric` the way this repository
-does. It touches nothing in a space, so it is safe to run anywhere and to run
-again.
+does. It reaches no space — everything it does is to the current directory,
+where it writes three things:
+
+- `.cf-types/`, holding the declarations for `commonfabric`, `turndown`,
+  `cf-env` and the JSX runtime, one `index.d.ts` each.
+- `.cf-docs/`, holding a copy of the top-level pattern documentation.
+- `tsconfig.json` — **written whole, over whatever was already there.**
+
+The configuration is generated from the runtime's own compiler options and is
+not merged with the file it replaces, so a directory that is already a
+TypeScript project loses its `compilerOptions`, its `include`, and everything
+else it had, without a prompt and without a backup. A second run replaces the
+generated one in turn, discarding any edit made to it. Run it in a directory
+that exists for patterns, or in a copy.
 
 ## Installing `cf` on PATH
 

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -130,6 +130,7 @@ deno task cf inspect summary  z6Mkqa41
 deno task cf inspect entities z6Mkqa41 [--kind piece] [--limit 5000] [--require-complete]
 deno task cf inspect piece    z6Mkqa41 of:fid1:… [--code]   # pattern source, input, owned cells
 deno task cf inspect hot      z6Mkqa41 --limit 10
+deno task cf inspect commits  z6Mkqa41 [--limit 20]   # recent commits: who, ops, reads
 deno task cf inspect churn    z6Mkqa41 [--bucket 60] [--since '2026-07-22 10:00:00'] [--top 10]
 deno task cf inspect history  z6Mkqa41 of:fid1:…
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count [--seq N]

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -145,8 +145,11 @@ answer composes into the next command.
   positional instead of on `--piece`: an address begins with `/` and a relative
   path never does, so the two cannot collide.
 - A canonical reference ending `#argument` selects the piece's arguments cell —
-  the same selection `--input` makes. The suffix needs the canonical form, so
-  with `--url` or a bare id, `--input` is the spelling that reaches it.
+  the same selection `--input` makes, and it is accepted exactly where `--input`
+  is: `cf get`, `cf set`, and `cf piece get-label|set-label`. A command that
+  takes no `--input` refuses the suffix rather than ignoring it, `cf call` among
+  them. The suffix also needs the canonical form, so with `--url` or a bare id,
+  `--input` is the spelling that reaches it.
 
 `cf piece get|set|call` name the same commands under a deprecated spelling: they
 work and warn on stderr with the date they stop working. That date lives once,

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -128,6 +128,50 @@ See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 **Local servers**: See `docs/development/LOCAL_DEV_SERVERS.md`
 
+## Naming a target
+
+Every read and every call names a target, and the spelling decides whether the
+answer composes into the next command.
+
+- `--piece <id|slug>` — the alias form. Convenient for a target you already
+  know; it carries no space, so `--space` rides beside it.
+- `/[@did:.../]of:fid1:<id>[@scope][/path]` — the canonical reference, the one
+  syntax the whole fabric shares. A space embedded in it supplies `--space` when
+  the flag is absent, and must agree with it when both are given. **An address
+  printed by one command is accepted by the next with no flag beside it.** The
+  alias form cannot do that, which is the reason to prefer the canonical one
+  whenever you are chaining commands rather than typing one.
+- On `cf get`, `cf set` and `cf call` a canonical reference may sit in the first
+  positional instead of on `--piece`: an address begins with `/` and a relative
+  path never does, so the two cannot collide.
+- A canonical reference ending `#argument` selects the piece's arguments cell —
+  the same selection `--input` makes. The suffix needs the canonical form, so
+  with `--url` or a bare id, `--input` is the spelling that reaches it.
+
+`cf piece get|set|call` name the same commands under a deprecated spelling: they
+work and warn on stderr with the date they stop working. That date lives once,
+as `PIECE_DATA_SPELLING_END_DATE` in `packages/cli/commands/piece.ts`. Prefer
+the top-level spellings.
+
+## Where the read options go
+
+`--select`, `--schema` and `--filter` shape what a read returns, and every
+command that returns data carries all three: `cf get`, `cf wish`, `cf call`,
+`cf exec`. `--select` takes a field list, `--schema` a full JSON Schema, and
+naming both on one line is refused rather than resolved.
+
+Their position depends on whether a callable's own vocabulary is on the line.
+`cf get` and `cf wish` have none, so the flags sit anywhere. `cf call` and
+`cf exec` do, so the flags precede the name that opens that section — the verb,
+or the mounted file — and everything after it belongs to the callable. `--` is
+what ends the callable's section, which is why it appears on those two and is
+**refused** on `cf get`, `cf set` and `cf wish`: there is no section to close,
+and the words after it would be set aside unread.
+
+**Resolving a wish writes.** `cf wish` commits a cell to the space as part of
+resolving the query, so it is not a free read and not safe to issue
+speculatively against a space you do not intend to touch.
+
 ## Quick Command Reference
 
 | Operation          | Command                                                                                                                      |
@@ -508,6 +552,8 @@ mounts; auto-discovered spaces may appear writable but silently drop writes.
 - `docs/common/verbs/agents-over-the-cli.md` - Reaching a piece with no id in
   hand: what bounds each discovery surface, and what an empty answer does not
   prove
+- `packages/cli/README.md` - Piece references: the two reference forms, what
+  each carries, and where a canonical address may be written
 - `docs/common/verbs/over-the-cli.md` - The verb walkthrough: invocation ids and
   sessions, receipts, retries, and shaped reads, each step runnable
 - `packages/patterns/system/default-app.tsx` - System pieces (pieceRegistry

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -5,6 +5,7 @@ import {
   declaredCommands,
   describeCommandDocFailures,
   documentedCommands,
+  isLiveDoc,
   main,
   NO_PROSE,
   reportCommandDocs,
@@ -43,6 +44,21 @@ describe("check-command-docs", () => {
         new Command().description("d"),
       );
       expect(declaredCommands(tree)).not.toContain("help");
+    });
+  });
+
+  describe("isLiveDoc()", () => {
+    it("reads a path spelled with either separator", () => {
+      // The rules are written in slashes and the path arrives in the host's
+      // separator, so a Windows spelling has to reach the same verdict.
+      expect(isLiveDoc("docs/guide.md")).toBe(true);
+      expect(isLiveDoc("docs\\guide.md")).toBe(true);
+      expect(isLiveDoc("docs/history/report.md")).toBe(false);
+      expect(isLiveDoc("docs\\history\\report.md")).toBe(false);
+      expect(isLiveDoc("docs\\plans\\later.md")).toBe(false);
+      expect(isLiveDoc("packages\\oven\\brew.ts")).toBe(false);
+      expect(isLiveDoc("packages\\oven\\docs\\guide.md")).toBe(false);
+      expect(isLiveDoc("packages\\oven\\README.md")).toBe(true);
     });
   });
 
@@ -103,6 +119,18 @@ describe("check-command-docs", () => {
         "docs/plans/later.md": "`cf brew` will gain a flag.",
       }, async (root) => {
         expect([...await documentedCommands(root, ["brew"])]).toEqual([]);
+      });
+    });
+
+    it("does not take an instruction written for an agent as documentation", async () => {
+      // `.claude/` addresses one agent mid-task. A command it is told to run
+      // is still a command no caller can look up, so it covers nothing.
+      await withDocs({
+        ".claude/agents/baker.md": "Run `cf brew` before you glaze.",
+        "skills/baking/SKILL.md": "`cf glaze set` picks the flavor.",
+      }, async (root) => {
+        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        expect([...found]).toEqual(["glaze set"]);
       });
     });
 

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Command } from "@cliffy/command";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
   commandPattern,
   declaredCommands,
@@ -12,6 +14,79 @@ import {
   readPackageDocs,
   reportCommandDocs,
 } from "./check-command-docs.ts";
+
+const REPO_ROOT = dirname(dirname(fromFileUrl(import.meta.url)));
+
+/** Run the gate the way its task does, and return what the process reported. */
+async function runAsProgram(
+  ...args: string[]
+): Promise<{ code: number; out: string }> {
+  const output = await runDenoCommandWithTemporaryLock({
+    root: REPO_ROOT,
+    args: (lockPath) => [
+      "run",
+      "--config",
+      join(REPO_ROOT, "deno.jsonc"),
+      "--lock",
+      lockPath,
+      // The permissions deno.jsonc grants the task, so a run that needs more
+      // than the task allows fails here rather than in CI.
+      "--allow-read",
+      "--allow-env",
+      "--allow-sys",
+      "--allow-ffi",
+      join(REPO_ROOT, "tasks/check-command-docs.ts"),
+      ...args,
+    ],
+  });
+  return { code: output.code, out: new TextDecoder().decode(output.stdout) };
+}
+
+/** What a run printed, either side of the exit code it returned. */
+async function captureConsole(
+  body: () => Promise<number>,
+): Promise<{ code: number; out: string; err: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args) => out.push(args.map(String).join(" "));
+  console.error = (...args) => err.push(args.map(String).join(" "));
+  try {
+    return { code: await body(), out: out.join("\n"), err: err.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}
+
+/**
+ * A repository root holding a config and no documents at all, so every
+ * command the CLI declares is undocumented and the failure directions are
+ * reachable without inventing a command tree.
+ */
+async function withEmptyRoot(
+  body: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "workspace": [] }`);
+    await body(root);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+}
+
+/** The gate's own failure verdict, run against a root with no documents. */
+async function withFailure(): Promise<
+  { code: number; out: string; err: string }
+> {
+  let captured = { code: -1, out: "", err: "" };
+  await withEmptyRoot(async (root) => {
+    captured = await captureConsole(() => main([], root));
+  });
+  return captured;
+}
 
 /** A small tree in the shape the CLI's own is: nested commands under a root. */
 function fixtureTree() {
@@ -65,6 +140,19 @@ describe("check-command-docs", () => {
       expect(isLiveDoc("packages\\oven\\README.md", packageDocs)).toBe(true);
     });
 
+    it("takes nothing vendored under node_modules as documentation", () => {
+      // A dependency's own README travels with the dependency. Without this
+      // rule a vendored copy under `docs/` would read as live documentation,
+      // and a command named in it would satisfy the gate.
+      expect(isLiveDoc("docs/node_modules/dep/README.md", packageDocs))
+        .toBe(false);
+      expect(isLiveDoc("skills/cf/node_modules/dep/guide.md", packageDocs))
+        .toBe(false);
+      // The rule is the path segment, not the word: a document about the
+      // directory is still a document.
+      expect(isLiveDoc("docs/node_modules-and-you.md", packageDocs)).toBe(true);
+    });
+
     it("takes a README under a package to be the package's own or nothing", () => {
       // A fixture corpus and a test directory keep READMEs of their own, and
       // neither is somewhere a caller is sent to read.
@@ -99,6 +187,37 @@ describe("check-command-docs", () => {
         );
         expect([...await readPackageDocs(root)].sort()).toEqual([
           "packages/mixers/whisk/README.md",
+          "packages/oven/README.md",
+        ]);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    });
+
+    it("takes no README from a config that lists no workspace", async () => {
+      // A config without the key is not a config with an empty one by
+      // accident: no member means no package README counts, and the walk
+      // simply finds nothing under `packages/`.
+      const root = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "tasks": {} }`);
+        expect([...await readPackageDocs(root)]).toEqual([]);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    });
+
+    it("skips a member that is not a path", async () => {
+      // The member list is data from a file, so a malformed entry is a
+      // possibility rather than a type error. It contributes no README
+      // instead of a `[object Object]/README.md` that matches nothing.
+      const root = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(
+          `${root}/deno.jsonc`,
+          `{ "workspace": ["./packages/oven", 7, { "path": "./packages/x" }] }`,
+        );
+        expect([...await readPackageDocs(root)]).toEqual([
           "packages/oven/README.md",
         ]);
       } finally {
@@ -223,6 +342,23 @@ describe("check-command-docs", () => {
       });
     });
 
+    it("raises a doc root that cannot be walked rather than reading past it", async () => {
+      // A missing root contributes no documents, which is how a partial
+      // checkout behaves. A root that exists and cannot be walked is a
+      // different fact: reading past it would silently drop every document
+      // it holds and report the commands they name as undocumented.
+      const root = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(`${root}/deno.jsonc`, `{ "workspace": [] }`);
+        await Deno.writeTextFile(`${root}/docs`, "a file where a tree goes");
+        await expect(documentedCommands(root, ["brew"])).rejects.toThrow(
+          /Not a directory/,
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    });
+
     it("reads the package's own README and not an internal one", async () => {
       // A fixture corpus documents the fixtures, for whoever maintains them.
       await withDocs({
@@ -297,6 +433,65 @@ describe("check-command-docs", () => {
         expect(reason.trim().length, `${command} has no reason`)
           .toBeGreaterThan(0);
       }
+    });
+
+    it("fails a command no document names, printing the finding and the remedy", async () => {
+      // Against a root holding no documents at all, every command the CLI
+      // declares is undocumented — which is the shape of the failure a real
+      // one takes, one command at a time.
+      const { code, err } = await withFailure();
+      expect(code).toBe(1);
+      expect(err).toContain("Command documentation check failed.");
+      expect(err).toContain("are named in no live document");
+      expect(err).toContain("NO_PROSE");
+      // The offending commands by name, not a count an operator cannot act
+      // on, and the remedy beside them.
+      expect(err).toContain("cf get");
+      expect(err).toContain("cf piece survey");
+      expect(err).toContain("Either describe the command in a live document");
+      expect(err).toContain("tasks/check-command-docs.ts");
+    });
+
+    it("lists the undocumented commands and succeeds when asked for the list", async () => {
+      // `--list` is the working view: it answers what is undocumented
+      // without failing, so the list can be read while it is worked through.
+      let captured = { code: -1, out: "", err: "" };
+      await withEmptyRoot(async (root) => {
+        captured = await captureConsole(() => main(["--list"], root));
+      });
+      expect(captured.code).toBe(0);
+      expect(captured.out).toContain("cf get");
+      expect(captured.out).toContain("cf piece survey");
+      // The list is the whole of what it prints: no verdict line, because
+      // the run passed and the list is not a failure report.
+      expect(captured.out).not.toContain("Command documentation OK");
+      expect(captured.err).toBe("");
+      // A command the allowance covers is decided, so it is not undecided.
+      for (const command of NO_PROSE.keys()) {
+        expect(captured.out).not.toContain(`cf ${command}`);
+      }
+    });
+  });
+
+  describe("as the task runs it", () => {
+    // Calling main() above would still pass if the entry point never ran it,
+    // or if the permissions the task declares were too narrow to walk the
+    // tree. This is the promise the CI job makes: the command exits 0, having
+    // done the work.
+    it("exits 0 reporting the commands it walked", async () => {
+      const { code, out } = await runAsProgram();
+      expect(code).toBe(0);
+      expect(out).toContain("Command documentation OK");
+      expect(out).toMatch(/\d+ command\(s\)/);
+      expect(out).toMatch(/\d+ deliberately without prose/);
+    });
+
+    it("exits 0 printing nothing to list when every command is documented", async () => {
+      // The gate is green on this repository, so the working view is empty —
+      // and an empty list is a result, not a silence to be read as an error.
+      const { code, out } = await runAsProgram("--list");
+      expect(code).toBe(0);
+      expect(out.trim()).toBe("");
     });
   });
 });

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -2,12 +2,14 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Command } from "@cliffy/command";
 import {
+  commandPattern,
   declaredCommands,
   describeCommandDocFailures,
   documentedCommands,
   isLiveDoc,
   main,
   NO_PROSE,
+  readPackageDocs,
   reportCommandDocs,
 } from "./check-command-docs.ts";
 
@@ -48,17 +50,88 @@ describe("check-command-docs", () => {
   });
 
   describe("isLiveDoc()", () => {
+    /** One package, the way the root config names its members. */
+    const packageDocs = new Set(["packages/oven/README.md"]);
+
     it("reads a path spelled with either separator", () => {
       // The rules are written in slashes and the path arrives in the host's
       // separator, so a Windows spelling has to reach the same verdict.
-      expect(isLiveDoc("docs/guide.md")).toBe(true);
-      expect(isLiveDoc("docs\\guide.md")).toBe(true);
-      expect(isLiveDoc("docs/history/report.md")).toBe(false);
-      expect(isLiveDoc("docs\\history\\report.md")).toBe(false);
-      expect(isLiveDoc("docs\\plans\\later.md")).toBe(false);
-      expect(isLiveDoc("packages\\oven\\brew.ts")).toBe(false);
-      expect(isLiveDoc("packages\\oven\\docs\\guide.md")).toBe(false);
-      expect(isLiveDoc("packages\\oven\\README.md")).toBe(true);
+      expect(isLiveDoc("docs/guide.md", packageDocs)).toBe(true);
+      expect(isLiveDoc("docs\\guide.md", packageDocs)).toBe(true);
+      expect(isLiveDoc("docs/history/report.md", packageDocs)).toBe(false);
+      expect(isLiveDoc("docs\\history\\report.md", packageDocs)).toBe(false);
+      expect(isLiveDoc("docs\\plans\\later.md", packageDocs)).toBe(false);
+      expect(isLiveDoc("packages\\oven\\brew.ts", packageDocs)).toBe(false);
+      expect(isLiveDoc("packages\\oven\\README.md", packageDocs)).toBe(true);
+    });
+
+    it("takes a README under a package to be the package's own or nothing", () => {
+      // A fixture corpus and a test directory keep READMEs of their own, and
+      // neither is somewhere a caller is sent to read.
+      expect(isLiveDoc("packages/oven/README.md", packageDocs)).toBe(true);
+      expect(isLiveDoc("packages/oven/test/README.md", packageDocs))
+        .toBe(false);
+      expect(isLiveDoc("packages/oven/test/fixtures/README.md", packageDocs))
+        .toBe(false);
+      // A member the config names below the first level is still a package.
+      expect(
+        isLiveDoc("packages/mixers/whisk/README.md", packageDocs),
+      ).toBe(false);
+      expect(
+        isLiveDoc(
+          "packages/mixers/whisk/README.md",
+          new Set(["packages/mixers/whisk/README.md"]),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("readPackageDocs()", () => {
+    it("names one README per workspace member, however deep", async () => {
+      const root = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(
+          `${root}/deno.jsonc`,
+          `{
+  // The member list is what says a directory is a package.
+  "workspace": ["./packages/oven", "./packages/mixers/whisk"]
+}`,
+        );
+        expect([...await readPackageDocs(root)].sort()).toEqual([
+          "packages/mixers/whisk/README.md",
+          "packages/oven/README.md",
+        ]);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    });
+  });
+
+  describe("commandPattern()", () => {
+    const commands = ["brew", "glaze", "glaze set", "glaze setsrc"];
+
+    it("needs a boundary before the command as well as after it", () => {
+      // Otherwise a word ending in the command's letters names it.
+      expect(commandPattern("brew", commands).test("Run `cf brew`.")).toBe(
+        true,
+      );
+      expect(commandPattern("brew", commands).test("Run scf brew.")).toBe(
+        false,
+      );
+      expect(commandPattern("brew", commands).test("Run my-cf brew.")).toBe(
+        false,
+      );
+    });
+
+    it("does not let a child stand in for the parent it hangs under", () => {
+      // A reader looking up `cf glaze` finds nothing about it in a document
+      // that only ever writes `cf glaze set`.
+      const glaze = commandPattern("glaze", commands);
+      expect(glaze.test("Run `cf glaze set` first.")).toBe(false);
+      expect(glaze.test("Run `cf glaze setsrc` first.")).toBe(false);
+      expect(glaze.test("`cf glaze` applies one.")).toBe(true);
+      // An argument is not a child, so it still reads as naming the parent.
+      expect(glaze.test("Run `cf glaze cherry`.")).toBe(true);
     });
   });
 
@@ -70,6 +143,12 @@ describe("check-command-docs", () => {
     ): Promise<void> {
       const root = await Deno.makeTempDir();
       try {
+        // The package rule reads its member list from the root config, so a
+        // throwaway tree needs one the way the repository has one.
+        await Deno.writeTextFile(
+          `${root}/deno.jsonc`,
+          `{ "workspace": ["./packages/oven"] }`,
+        );
         for (const [path, text] of Object.entries(files)) {
           const full = `${root}/${path}`;
           await Deno.mkdir(full.slice(0, full.lastIndexOf("/")), {
@@ -138,6 +217,17 @@ describe("check-command-docs", () => {
       await withDocs({
         "packages/oven/README.md": "`cf brew` heats the glaze.",
         "packages/oven/brew.ts": "// `cf glaze set` in a comment",
+      }, async (root) => {
+        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        expect([...found]).toEqual(["brew"]);
+      });
+    });
+
+    it("reads the package's own README and not an internal one", async () => {
+      // A fixture corpus documents the fixtures, for whoever maintains them.
+      await withDocs({
+        "packages/oven/README.md": "`cf brew` heats the glaze.",
+        "packages/oven/test/fixtures/README.md": "`cf glaze set` here too.",
       }, async (root) => {
         const found = await documentedCommands(root, ["brew", "glaze set"]);
         expect([...found]).toEqual(["brew"]);

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -122,6 +122,40 @@ describe("check-command-docs", () => {
       );
       expect(declaredCommands(tree)).not.toContain("help");
     });
+
+    it("names a hidden command, which a caller reaches like any other", () => {
+      // Hidden decides what `--help` prints, not what the CLI accepts: the
+      // real tree hides `completion complete` and every installed completion
+      // function invokes it on every Tab. A gate that walked past it would
+      // report a count having never asked about the last command.
+      const tree = new Command()
+        .name("cf")
+        .command("brew", new Command().description("make a glaze"))
+        .command(
+          "sift",
+          new Command().description("an entry point nobody types").hidden(),
+        );
+      expect(declaredCommands(tree)).toEqual(["brew", "sift"]);
+    });
+
+    it("walks into a hidden command's own subcommands", () => {
+      // The hidden one is a group in the real tree, and its child is the
+      // command that actually runs.
+      const tree = new Command().name("cf").command(
+        "completion",
+        new Command()
+          .description("shell completion")
+          .command(
+            "complete",
+            new Command().description("what the shell calls").hidden(),
+          )
+          .hidden(),
+      );
+      expect(declaredCommands(tree)).toEqual([
+        "completion",
+        "completion complete",
+      ]);
+    });
   });
 
   describe("isLiveDoc()", () => {

--- a/tasks/check-command-docs.test.ts
+++ b/tasks/check-command-docs.test.ts
@@ -1,0 +1,184 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Command } from "@cliffy/command";
+import {
+  declaredCommands,
+  describeCommandDocFailures,
+  documentedCommands,
+  main,
+  NO_PROSE,
+  reportCommandDocs,
+} from "./check-command-docs.ts";
+
+/** A small tree in the shape the CLI's own is: nested commands under a root. */
+function fixtureTree() {
+  return new Command()
+    .name("cf")
+    .command("brew", new Command().description("make a donut glaze"))
+    .command(
+      "glaze",
+      new Command()
+        .description("apply one")
+        .command("set", new Command().description("choose a flavor"))
+        .command("setsrc", new Command().description("a different command")),
+    );
+}
+
+describe("check-command-docs", () => {
+  describe("declaredCommands()", () => {
+    it("names every command by the path a caller types", () => {
+      expect(declaredCommands(fixtureTree())).toEqual([
+        "brew",
+        "glaze",
+        "glaze set",
+        "glaze setsrc",
+      ]);
+    });
+
+    it("returns no entry for the help cliffy propagates to every command", () => {
+      // It is generated onto every descendant, so it is nobody's command and
+      // no document owes it prose.
+      const tree = new Command().name("cf").command(
+        "brew",
+        new Command().description("d"),
+      );
+      expect(declaredCommands(tree)).not.toContain("help");
+    });
+  });
+
+  describe("documentedCommands()", () => {
+    /** A throwaway tree of documents, so the search runs against real files. */
+    async function withDocs(
+      files: Record<string, string>,
+      body: (root: string) => Promise<void>,
+    ): Promise<void> {
+      const root = await Deno.makeTempDir();
+      try {
+        for (const [path, text] of Object.entries(files)) {
+          const full = `${root}/${path}`;
+          await Deno.mkdir(full.slice(0, full.lastIndexOf("/")), {
+            recursive: true,
+          });
+          await Deno.writeTextFile(full, text);
+        }
+        await body(root);
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
+    }
+
+    it("finds a command a live document names", async () => {
+      await withDocs({ "docs/guide.md": "Run `cf glaze set` first." }, async (
+        root,
+      ) => {
+        expect([...await documentedCommands(root, ["glaze set"])])
+          .toEqual(["glaze set"]);
+      });
+    });
+
+    it("does not let a longer command satisfy a shorter one", async () => {
+      // `cf glaze setsrc` is its own command with its own obligation, so it
+      // must not stand in for `cf glaze set`.
+      await withDocs({ "docs/guide.md": "Run `cf glaze setsrc`." }, async (
+        root,
+      ) => {
+        expect([...await documentedCommands(root, ["glaze set"])]).toEqual([]);
+      });
+    });
+
+    it("reads a mention the document wrapped across lines", async () => {
+      await withDocs({ "docs/guide.md": "Run `cf glaze\nset` first." }, async (
+        root,
+      ) => {
+        expect([...await documentedCommands(root, ["glaze set"])])
+          .toEqual(["glaze set"]);
+      });
+    });
+
+    it("ignores a record of a moment rather than a description", async () => {
+      // A command named only in an archived report or a pending plan is not
+      // documented: neither describes a surface a reader can use today.
+      await withDocs({
+        "docs/history/report.md": "We ran `cf brew` in July.",
+        "docs/plans/later.md": "`cf brew` will gain a flag.",
+      }, async (root) => {
+        expect([...await documentedCommands(root, ["brew"])]).toEqual([]);
+      });
+    });
+
+    it("reads a package README and not the source beside it", async () => {
+      await withDocs({
+        "packages/oven/README.md": "`cf brew` heats the glaze.",
+        "packages/oven/brew.ts": "// `cf glaze set` in a comment",
+      }, async (root) => {
+        const found = await documentedCommands(root, ["brew", "glaze set"]);
+        expect([...found]).toEqual(["brew"]);
+      });
+    });
+  });
+
+  describe("reportCommandDocs()", () => {
+    const declared = ["brew", "glaze set"];
+
+    it("names a command no document covers and no allowance excuses", () => {
+      const report = reportCommandDocs(declared, new Set(), new Map());
+      expect(report.undocumented).toEqual(["brew", "glaze set"]);
+    });
+
+    it("returns no finding for a documented command", () => {
+      expect(
+        reportCommandDocs(declared, new Set(declared), new Map()).undocumented,
+      ).toEqual([]);
+    });
+
+    it("returns no finding for a command the allowance records a reason for", () => {
+      const allowed = new Map([["brew", "an internal entry point"]]);
+      expect(
+        reportCommandDocs(declared, new Set(["glaze set"]), allowed)
+          .undocumented,
+      ).toEqual([]);
+    });
+
+    it("names an allowance for a command the tree no longer accepts", () => {
+      // A recorded decision cannot outlive the thing it was about.
+      const allowed = new Map([["retired", "gone"]]);
+      expect(
+        reportCommandDocs(declared, new Set(declared), allowed).staleAllowance,
+      ).toEqual(["retired"]);
+    });
+  });
+
+  describe("describeCommandDocFailures()", () => {
+    it("returns nothing when the report is empty", () => {
+      expect(describeCommandDocFailures({
+        undocumented: [],
+        staleAllowance: [],
+      })).toEqual([]);
+    });
+
+    it("names the table to edit and the commands at fault", () => {
+      const text = describeCommandDocFailures({
+        undocumented: ["brew"],
+        staleAllowance: ["retired"],
+      }).join("\n");
+      expect(text).toContain("NO_PROSE");
+      expect(text).toContain("cf brew");
+      expect(text).toContain("cf retired");
+    });
+  });
+
+  describe("main()", () => {
+    it("returns 0 for the CLI's own command tree", async () => {
+      // The gate itself. Every command the CLI accepts is described in a live
+      // document, or recorded as deliberately without prose.
+      expect(await main()).toBe(0);
+    });
+
+    it("records a reason for every allowance, so none is a bare exemption", () => {
+      for (const [command, reason] of NO_PROSE) {
+        expect(reason.trim().length, `${command} has no reason`)
+          .toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env -S deno run --allow-read --allow-env --allow-sys --allow-ffi
+/**
+ * Fails when a command the CLI accepts is described in no live document.
+ *
+ * `docs/README.md` already obliges a change that alters documented behavior to
+ * update the document in the same change. That obligation cannot fire for a
+ * command no document describes: nothing is wrong, because nothing claimed to
+ * cover it. So a command ships, the prose does not, and the absence is visible
+ * only to someone who already knows the command exists.
+ *
+ * The command tree is walkable and the documents are greppable, so the question
+ * is machine-answerable: is this command named anywhere a reader would find it?
+ *
+ * What this cannot decide is whether a command SHOULD have prose. Plenty should
+ * not — an internal entry point exists for the packaged binary to call, and a
+ * forensics subcommand may be `--help`-discoverable by design. What it requires
+ * is that every command has been decided about, which is what {@link NO_PROSE}
+ * records. That turns the next command's documentation from something
+ * remembered into something the gate asks for.
+ *
+ * Usage: deno task check-command-docs
+ *        deno task check-command-docs --list   # every undocumented command
+ */
+
+import type { Command } from "@cliffy/command";
+import { main as cliRoot } from "../packages/cli/commands/main.ts";
+import { walk } from "@std/fs/walk";
+import { relative } from "@std/path";
+
+/**
+ * Commands deliberately left without prose, each with the reason.
+ *
+ * A reason here answers one question: why would a reader never need to find
+ * this from a document? An entry point the packaged binary calls on its own has
+ * no caller to inform; a subcommand whose whole surface is its `--help` page
+ * has nothing a document would add.
+ */
+export const NO_PROSE = new Map<string, string>([
+  [
+    "fuse-daemon",
+    "an internal entry point the packaged binary calls; no caller writes it",
+  ],
+  [
+    "fuse-supervisor",
+    "the same, for the process that supervises the FUSE child",
+  ],
+]);
+
+/** Where the gate looks for prose, relative to the repository root. */
+export const DOC_ROOTS: readonly string[] = [
+  "docs",
+  "skills",
+  ".claude",
+  "packages",
+];
+
+/** Documents that record a moment rather than describing the system. */
+function isLiveDoc(path: string): boolean {
+  if (!path.endsWith(".md")) return false;
+  if (path.startsWith("docs/history/")) return false;
+  // A plan describes work that is intended, not a surface a reader can use
+  // today, so naming a command there is not documenting it.
+  if (path.startsWith("docs/plans/")) return false;
+  if (path.includes("/node_modules/")) return false;
+  // Under `packages/`, only the package's own README is documentation; the
+  // rest is source, fixtures and generated output.
+  if (path.startsWith("packages/") && !path.endsWith("README.md")) return false;
+  return true;
+}
+
+/** Every command path the tree accepts, deepest last. */
+export function declaredCommands(
+  // deno-lint-ignore no-explicit-any
+  root: Command<any>,
+): string[] {
+  const paths: string[] = [];
+  // deno-lint-ignore no-explicit-any
+  const visit = (command: Command<any>, path: readonly string[]): void => {
+    if (path.length > 0) paths.push(path.join(" "));
+    for (const child of command.getCommands(false)) {
+      // Cliffy propagates its generated `help` to every descendant, so it is
+      // nobody's command and no document owes it prose.
+      if (child.getName() === "help") continue;
+      visit(child, [...path, child.getName()]);
+    }
+  };
+  visit(root, []);
+  return paths;
+}
+
+/**
+ * The command paths some live document names.
+ *
+ * A document names a command by writing it the way a caller types it, so the
+ * search is for `cf <path>` followed by a boundary. `cf piece set` must not be
+ * satisfied by `cf piece setsrc`, which is a different command with its own
+ * prose obligation.
+ */
+export async function documentedCommands(
+  root: string,
+  commands: readonly string[],
+): Promise<Set<string>> {
+  const found = new Set<string>();
+  const patterns = commands.map((command) => ({
+    command,
+    // A boundary is anything that cannot continue the command's last word.
+    pattern: new RegExp(`cf ${command.replace(/ /g, "\\s+")}(?![\\w-])`),
+  }));
+  for (const dir of DOC_ROOTS) {
+    // `walk` reports a missing directory when it is iterated rather than when
+    // it is constructed, so the guard has to wrap the loop. A root a checkout
+    // does not have contributes no documents rather than failing the run.
+    try {
+      const entries = walk(`${root}/${dir}`, {
+        exts: [".md"],
+        includeDirs: false,
+      });
+      for await (const entry of entries) {
+        const path = relative(root, entry.path);
+        if (!isLiveDoc(path)) continue;
+        const text = await Deno.readTextFile(entry.path);
+        for (const { command, pattern } of patterns) {
+          if (!found.has(command) && pattern.test(text)) found.add(command);
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+  }
+  return found;
+}
+
+/** What the check found, in the two directions it looks. */
+export interface CommandDocReport {
+  /** Commands no live document names and no allowance covers. */
+  readonly undocumented: string[];
+  /** Allowances naming a command the tree no longer accepts. */
+  readonly staleAllowance: string[];
+}
+
+/** Subtract what the documents cover from what the tree accepts. */
+export function reportCommandDocs(
+  declared: readonly string[],
+  documented: ReadonlySet<string>,
+  allowed: ReadonlyMap<string, string>,
+): CommandDocReport {
+  const undocumented = declared
+    .filter((command) => !documented.has(command) && !allowed.has(command))
+    .sort();
+  const declaredSet = new Set(declared);
+  const staleAllowance = [...allowed.keys()]
+    .filter((command) => !declaredSet.has(command))
+    .sort();
+  return { undocumented, staleAllowance };
+}
+
+/** The failures a report describes, one paragraph each. */
+export function describeCommandDocFailures(
+  report: CommandDocReport,
+): string[] {
+  const failures: string[] = [];
+  const block = (lines: readonly string[]) =>
+    lines.map((line) => `  cf ${line}`).join("\n");
+  if (report.undocumented.length > 0) {
+    failures.push(
+      `${report.undocumented.length} command(s) are named in no live ` +
+        `document and have no entry in NO_PROSE:\n` +
+        block(report.undocumented),
+    );
+  }
+  if (report.staleAllowance.length > 0) {
+    failures.push(
+      `${report.staleAllowance.length} NO_PROSE entr(ies) name a command the ` +
+        `tree no longer accepts:\n` + block(report.staleAllowance),
+    );
+  }
+  return failures;
+}
+
+/** Run the check against the real CLI tree. Returns the process exit code. */
+export async function main(
+  args: readonly string[] = [],
+  root = new URL("..", import.meta.url).pathname,
+): Promise<number> {
+  const declared = declaredCommands(cliRoot);
+  const documented = await documentedCommands(root, declared);
+  const report = reportCommandDocs(declared, documented, NO_PROSE);
+
+  if (args.includes("--list")) {
+    for (const command of report.undocumented) console.log(`cf ${command}`);
+    return 0;
+  }
+
+  const failures = describeCommandDocFailures(report);
+  if (failures.length > 0) {
+    console.error("Command documentation check failed.\n");
+    console.error(failures.join("\n\n"));
+    console.error(
+      "\nEither describe the command in a live document, or record why it " +
+        "needs none in tasks/check-command-docs.ts.",
+    );
+    return 1;
+  }
+
+  console.log(
+    `Command documentation OK (${declared.length} command(s), ` +
+      `${NO_PROSE.size} deliberately without prose).`,
+  );
+  return 0;
+}
+
+if (import.meta.main) Deno.exit(await main(Deno.args));

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -26,7 +26,7 @@ import type { Command } from "@cliffy/command";
 import { main as cliRoot } from "../packages/cli/commands/main.ts";
 import { walk } from "@std/fs/walk";
 import { parse as parseJsonc } from "@std/jsonc";
-import { join, relative } from "@std/path";
+import { dirname, fromFileUrl, join, relative } from "@std/path";
 
 /**
  * Commands deliberately left without prose, each with the reason.
@@ -262,7 +262,7 @@ export function describeCommandDocFailures(
 /** Run the check against the real CLI tree. Returns the process exit code. */
 export async function main(
   args: readonly string[] = [],
-  root = new URL("..", import.meta.url).pathname,
+  root = dirname(dirname(fromFileUrl(import.meta.url))),
 ): Promise<number> {
   const declared = declaredCommands(cliRoot);
   const documented = await documentedCommands(root, declared);

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -111,7 +111,16 @@ export function isLiveDoc(
   return true;
 }
 
-/** Every command path the tree accepts, deepest last. */
+/**
+ * Every command path the tree accepts, deepest last.
+ *
+ * Hidden commands are walked with the rest. Hidden is a fact about `--help`,
+ * not about whether the CLI accepts the words: `cf completion complete` is
+ * hidden and every installed completion function invokes it on every Tab. A
+ * command a caller can reach is a command this gate has to ask about, and one
+ * that genuinely needs no prose says so in {@link NO_PROSE} rather than by
+ * being invisible here.
+ */
 export function declaredCommands(
   // deno-lint-ignore no-explicit-any
   root: Command<any>,
@@ -120,7 +129,7 @@ export function declaredCommands(
   // deno-lint-ignore no-explicit-any
   const visit = (command: Command<any>, path: readonly string[]): void => {
     if (path.length > 0) paths.push(path.join(" "));
-    for (const child of command.getCommands(false)) {
+    for (const child of command.getCommands(true)) {
       // Cliffy propagates its generated `help` to every descendant, so it is
       // nobody's command and no document owes it prose.
       if (child.getName() === "help") continue;

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -25,7 +25,8 @@
 import type { Command } from "@cliffy/command";
 import { main as cliRoot } from "../packages/cli/commands/main.ts";
 import { walk } from "@std/fs/walk";
-import { relative } from "@std/path";
+import { parse as parseJsonc } from "@std/jsonc";
+import { join, relative } from "@std/path";
 
 /**
  * Commands deliberately left without prose, each with the reason.
@@ -61,8 +62,40 @@ export const DOC_ROOTS: readonly string[] = [
   "packages",
 ];
 
-/** Documents that record a moment rather than describing the system. */
-export function isLiveDoc(path: string): boolean {
+/**
+ * The README of each workspace package, as a repository-relative path.
+ *
+ * A package is what the root config says it is, rather than what the shape of
+ * a path suggests: `packages/connectors/agents` is a package and
+ * `packages/ts-transformers/test/fixtures` is not, and only the member list
+ * tells the two apart. The path a member yields need not exist — one that
+ * does not simply never turns up in the walk.
+ */
+export async function readPackageDocs(root: string): Promise<Set<string>> {
+  const config = parseJsonc(
+    await Deno.readTextFile(join(root, "deno.jsonc")),
+  ) as { workspace?: unknown } | null;
+  const members = Array.isArray(config?.workspace) ? config.workspace : [];
+  const docs = new Set<string>();
+  for (const member of members) {
+    if (typeof member !== "string") continue;
+    docs.add(`${member.replace(/^\.\//, "").replace(/\/+$/, "")}/README.md`);
+  }
+  return docs;
+}
+
+/**
+ * Documents that record a moment rather than describing the system.
+ *
+ * `packageDocs` is {@link readPackageDocs}: under `packages/` the
+ * documentation is a package's own README, and an internal one — a fixture
+ * corpus, a test directory, a sub-example — is no more somewhere a caller is
+ * sent to read than the source beside it.
+ */
+export function isLiveDoc(
+  path: string,
+  packageDocs: ReadonlySet<string>,
+): boolean {
   // A repository-relative path arrives spelled with the host's separator and
   // every rule below is written in slashes, so the path is read in slashes
   // whichever it arrives in. Untranslated, a Windows `docs\history\report.md`
@@ -74,9 +107,7 @@ export function isLiveDoc(path: string): boolean {
   // today, so naming a command there is not documenting it.
   if (doc.startsWith("docs/plans/")) return false;
   if (doc.includes("/node_modules/")) return false;
-  // Under `packages/`, only the package's own README is documentation; the
-  // rest is source, fixtures and generated output.
-  if (doc.startsWith("packages/") && !doc.endsWith("README.md")) return false;
+  if (doc.startsWith("packages/") && !packageDocs.has(doc)) return false;
   return true;
 }
 
@@ -100,23 +131,53 @@ export function declaredCommands(
   return paths;
 }
 
+/** Nothing in a pattern's own text may be read as regex syntax. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
- * The command paths some live document names.
+ * The expression that decides whether a document names one command.
  *
- * A document names a command by writing it the way a caller types it, so the
- * search is for `cf <path>` followed by a boundary. `cf piece set` must not be
- * satisfied by `cf piece setsrc`, which is a different command with its own
- * prose obligation.
+ * A document names a command by writing it the way a caller types it, which
+ * is the whole command path between boundaries. Three things look like that
+ * and are not it. `cf piece setsrc` is a different command with its own prose
+ * obligation, so it cannot stand in for `cf piece set`. `scf brew` is a word
+ * that happens to end in the command's letters. And `cf piece ls` names the
+ * child: a reader looking up `cf piece` finds nothing about `cf piece` there,
+ * so the parent still owes prose of its own — which is why the next segment
+ * of every command this one is a prefix of ends the match.
  */
+export function commandPattern(
+  command: string,
+  commands: readonly string[],
+): RegExp {
+  const path = command.split(" ");
+  const children = new Set<string>();
+  for (const other of commands) {
+    const parts = other.split(" ");
+    if (parts.length === path.length + 1 && other.startsWith(`${command} `)) {
+      children.add(parts.at(-1)!);
+    }
+  }
+  const child = children.size === 0
+    ? ""
+    : `(?!\\s+(?:${[...children].map(escapeRegExp).join("|")})(?![\\w-]))`;
+  return new RegExp(
+    `(?<![\\w-])cf\\s+${path.map(escapeRegExp).join("\\s+")}${child}(?![\\w-])`,
+  );
+}
+
+/** The command paths some live document names. */
 export async function documentedCommands(
   root: string,
   commands: readonly string[],
 ): Promise<Set<string>> {
   const found = new Set<string>();
+  const packageDocs = await readPackageDocs(root);
   const patterns = commands.map((command) => ({
     command,
-    // A boundary is anything that cannot continue the command's last word.
-    pattern: new RegExp(`cf ${command.replace(/ /g, "\\s+")}(?![\\w-])`),
+    pattern: commandPattern(command, commands),
   }));
   for (const dir of DOC_ROOTS) {
     // `walk` reports a missing directory when it is iterated rather than when
@@ -129,7 +190,7 @@ export async function documentedCommands(
       });
       for await (const entry of entries) {
         const path = relative(root, entry.path);
-        if (!isLiveDoc(path)) continue;
+        if (!isLiveDoc(path, packageDocs)) continue;
         const text = await Deno.readTextFile(entry.path);
         for (const { command, pattern } of patterns) {
           if (!found.has(command) && pattern.test(text)) found.add(command);

--- a/tasks/check-command-docs.ts
+++ b/tasks/check-command-docs.ts
@@ -46,25 +46,37 @@ export const NO_PROSE = new Map<string, string>([
   ],
 ]);
 
-/** Where the gate looks for prose, relative to the repository root. */
+/**
+ * Where the gate looks for prose, relative to the repository root.
+ *
+ * Each root is somewhere a caller is sent to read: the documentation tree, the
+ * authored skills that people and agents share, and the README of the package
+ * implementing the command. Instructions addressed to one agent are not that —
+ * a command told to an agent mid-task is still a command no caller can look up
+ * — so `.claude/` is no more a root than the source is.
+ */
 export const DOC_ROOTS: readonly string[] = [
   "docs",
   "skills",
-  ".claude",
   "packages",
 ];
 
 /** Documents that record a moment rather than describing the system. */
-function isLiveDoc(path: string): boolean {
-  if (!path.endsWith(".md")) return false;
-  if (path.startsWith("docs/history/")) return false;
+export function isLiveDoc(path: string): boolean {
+  // A repository-relative path arrives spelled with the host's separator and
+  // every rule below is written in slashes, so the path is read in slashes
+  // whichever it arrives in. Untranslated, a Windows `docs\history\report.md`
+  // satisfies no rule here, so every one of them passes it through.
+  const doc = path.replaceAll("\\", "/");
+  if (!doc.endsWith(".md")) return false;
+  if (doc.startsWith("docs/history/")) return false;
   // A plan describes work that is intended, not a surface a reader can use
   // today, so naming a command there is not documenting it.
-  if (path.startsWith("docs/plans/")) return false;
-  if (path.includes("/node_modules/")) return false;
+  if (doc.startsWith("docs/plans/")) return false;
+  if (doc.includes("/node_modules/")) return false;
   // Under `packages/`, only the package's own README is documentation; the
   // rest is source, fixtures and generated output.
-  if (path.startsWith("packages/") && !path.endsWith("README.md")) return false;
+  if (doc.startsWith("packages/") && !doc.endsWith("README.md")) return false;
   return true;
 }
 

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -17,10 +17,13 @@ import { expect } from "@std/expect";
 import { dirname, fromFileUrl, join } from "@std/path";
 import {
   actReferences,
+  BULK_DEMO_PATH,
+  BULK_TOUR_PATH,
   commandMatches,
   DEMO_PATH,
   demoActs,
   demoCommands,
+  demoFor,
   findViolations,
   joinContinuations,
   main,
@@ -204,7 +207,14 @@ describe("check-verb-session-sync", () => {
           "```bash\ncf frobnicate --nothing-like-this\n```\n",
         );
         const errors: string[] = [];
-        expect(await main({ mdPath, error: (l) => errors.push(l) })).toBe(1);
+        // A document the table does not name says which demo it is held to.
+        expect(
+          await main({
+            mdPath,
+            shPath: DEMO_PATH,
+            error: (l) => errors.push(l),
+          }),
+        ).toBe(1);
         expect(errors.length).toBeGreaterThanOrEqual(2);
       } finally {
         await Deno.remove(mdPath);
@@ -229,7 +239,9 @@ describe("check-verb-session-sync", () => {
         const lines: string[] = [];
         expect(await main({ mdPath, shPath, log: (l) => lines.push(l) }))
           .toBe(0);
-        expect(await main({ mdPath, error: () => {} })).toBe(1);
+        // The same document against the verb demo, which does not run it.
+        expect(await main({ mdPath, shPath: DEMO_PATH, error: () => {} }))
+          .toBe(1);
       } finally {
         await Deno.remove(dir, { recursive: true });
       }
@@ -240,6 +252,26 @@ describe("check-verb-session-sync", () => {
       // the demo they passed.
       await expect(main({ shPath: "/nowhere/demo.sh" })).rejects.toThrow(
         /pass both/,
+      );
+    });
+
+    it("gives a named document the demo the table pairs it with", async () => {
+      // Not a default: the bulk tour quotes commands the verb demo never
+      // runs, so defaulting would report every one of them as invented.
+      const lines: string[] = [];
+      expect(
+        await main({ mdPath: BULK_TOUR_PATH, log: (l) => lines.push(l) }),
+      ).toBe(0);
+      expect(lines.join("\n")).toContain("1 document(s)");
+      expect(demoFor(BULK_TOUR_PATH)).toBe(BULK_DEMO_PATH);
+      expect(demoFor(TOUR_PATH)).toBe(DEMO_PATH);
+    });
+
+    it("refuses a document no demo is paired with", async () => {
+      // The other half of the same rule: half a pairing that names nothing
+      // is refused rather than sent to whichever demo happens to be first.
+      await expect(main({ mdPath: "docs/nowhere.md" })).rejects.toThrow(
+        /No demo is paired with/,
       );
     });
 

--- a/tasks/check-verb-session-sync.test.ts
+++ b/tasks/check-verb-session-sync.test.ts
@@ -211,6 +211,38 @@ describe("check-verb-session-sync", () => {
       }
     });
 
+    it("holds a document to the demo shPath names", async () => {
+      // The pairing is the injectable unit: the same document is a violation
+      // against the default demo and clean against the demo that runs it.
+      const dir = await Deno.makeTempDir();
+      try {
+        const mdPath = `${dir}/tour.md`;
+        const shPath = `${dir}/demo.sh`;
+        await Deno.writeTextFile(
+          mdPath,
+          "```bash\ncf frobnicate --nothing-like-this\n```\n",
+        );
+        await Deno.writeTextFile(
+          shPath,
+          "#!/usr/bin/env bash\nrun cf frobnicate --nothing-like-this\n",
+        );
+        const lines: string[] = [];
+        expect(await main({ mdPath, shPath, log: (l) => lines.push(l) }))
+          .toBe(0);
+        expect(await main({ mdPath, error: () => {} })).toBe(1);
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
+    });
+
+    it("refuses a demo that names no document to check against it", async () => {
+      // Silently ignoring it would leave the caller believing the run used
+      // the demo they passed.
+      await expect(main({ shPath: "/nowhere/demo.sh" })).rejects.toThrow(
+        /pass both/,
+      );
+    });
+
     it("does not let a reasonless marker exempt anything", () => {
       const block = [
         "```bash",

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -41,7 +41,24 @@ export const TOUR_PATH = "docs/common/verbs/the-verb-session.md";
 
 /** Every document held to the demo. Both quote commands and name acts, and a
  * command invented in either is wrong the same way. */
-export const DOC_PATHS = [TOUR_PATH, WALKTHROUGH_PATH];
+export const BULK_DEMO_PATH = "packages/cli/integration/bulk-ops-demo.sh";
+export const BULK_TOUR_PATH = "docs/common/workflows/bulk-operations.md";
+
+/**
+ * Each document, paired with the demo that runs the session it describes.
+ *
+ * A document is held to its own demo and no other: the verb tour and its
+ * walkthrough describe one session, and the bulk tour describes a different
+ * one. Pairing them here is what lets a second story be added without either
+ * demo having to grow commands the other document quotes.
+ */
+export const DOC_DEMOS: ReadonlyArray<{ doc: string; demo: string }> = [
+  { doc: TOUR_PATH, demo: DEMO_PATH },
+  { doc: WALKTHROUGH_PATH, demo: DEMO_PATH },
+  { doc: BULK_TOUR_PATH, demo: BULK_DEMO_PATH },
+];
+
+export const DOC_PATHS = DOC_DEMOS.map((pair) => pair.doc);
 
 /** The comment that exempts the next `cf` line in a walkthrough bash block.
  * The marker alone is not enough: an exemption without a reason is one
@@ -134,9 +151,10 @@ function extractCf(line: string): string | null {
   return span.trim();
 }
 
-/** Every command the demo runs, as normalized token lists: `run`, `refused`,
- * and `broken` lines execute theirs, and a `pending` line's first argument is
- * the command it promises. */
+/** Every command a demo runs, as normalized token lists: `run`, `run_loud`,
+ * `refused` and `broken` lines execute theirs, and a `pending` line's first
+ * argument is the command it promises. `run_loud` differs from `run` only in
+ * how much of the output it shows, so both are commands the demo ran. */
 export function demoCommands(shText: string): string[][] {
   const commands: string[][] = [];
   for (const line of joinContinuations(shText)) {
@@ -144,7 +162,10 @@ export function demoCommands(shText: string): string[][] {
     const tokens = tokenize(trimmed);
     if (tokens.length === 0) continue;
     const head = tokens[0]!;
-    if (head === "run" || head === "refused" || head === "broken") {
+    if (
+      head === "run" || head === "run_loud" || head === "refused" ||
+      head === "broken"
+    ) {
       const at = tokens.indexOf("cf");
       if (at !== -1) commands.push(dropSpaceFlag(tokens.slice(at)));
       continue;
@@ -331,16 +352,26 @@ export async function main(deps: {
 } = {}): Promise<number> {
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
-  const shText = await Deno.readTextFile(
-    deps.shPath ?? join(REPO_ROOT, DEMO_PATH),
-  );
-  const docPaths = deps.mdPath === undefined ? DOC_PATHS : [deps.mdPath];
+  // An override names one pairing; otherwise every document is read against
+  // the demo it was written from.
+  const pairs = deps.mdPath === undefined
+    ? DOC_DEMOS
+    : [{ doc: deps.mdPath, demo: deps.shPath ?? DEMO_PATH }];
+  const demoText = new Map<string, string>();
   const violations: string[] = [];
-  for (const docPath of docPaths) {
+  for (const { doc, demo } of pairs) {
+    if (!demoText.has(demo)) {
+      demoText.set(
+        demo,
+        await Deno.readTextFile(
+          demo.startsWith("/") ? demo : join(REPO_ROOT, demo),
+        ),
+      );
+    }
     const mdText = await Deno.readTextFile(
-      docPath.startsWith("/") ? docPath : join(REPO_ROOT, docPath),
+      doc.startsWith("/") ? doc : join(REPO_ROOT, doc),
     );
-    violations.push(...findViolations(shText, mdText, docPath));
+    violations.push(...findViolations(demoText.get(demo)!, mdText, doc));
   }
   if (violations.length > 0) {
     error(`verb-session sync: ${violations.length} violation(s)\n`);
@@ -348,7 +379,7 @@ export async function main(deps: {
     return 1;
   }
   log(
-    `Commands and act references in ${docPaths.length} document(s) all ` +
+    `Commands and act references in ${pairs.length} document(s) all ` +
       `match the demo.`,
   );
   return 0;

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -341,9 +341,16 @@ export function findViolations(
   return violations;
 }
 
-/** Runs the check and returns the process exit code. The file paths and the
- * printers are injectable so a test can drive both verdicts; the defaults are
- * the repository's own files and the console. */
+/**
+ * Runs the check and returns the process exit code.
+ *
+ * The printers are injectable so a test can drive both verdicts, and so is
+ * the pairing: `mdPath` names the document to check and `shPath` the demo to
+ * hold it to, defaulting to the verb demo. A demo alone names no document, so
+ * it is refused rather than quietly dropped — the caller that passes one means
+ * to check something against it. The default is every pairing in
+ * {@link DOC_DEMOS} and the console.
+ */
 export async function main(deps: {
   shPath?: string;
   mdPath?: string;
@@ -352,6 +359,11 @@ export async function main(deps: {
 } = {}): Promise<number> {
   const log = deps.log ?? console.log;
   const error = deps.error ?? console.error;
+  if (deps.shPath !== undefined && deps.mdPath === undefined) {
+    throw new Error(
+      "shPath names the demo to hold mdPath's document to; pass both.",
+    );
+  }
   // An override names one pairing; otherwise every document is read against
   // the demo it was written from.
   const pairs = deps.mdPath === undefined

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -39,8 +39,6 @@ export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
 export const WALKTHROUGH_PATH = "docs/common/verbs/session-walkthrough.md";
 export const TOUR_PATH = "docs/common/verbs/the-verb-session.md";
 
-/** Every document held to the demo. Both quote commands and name acts, and a
- * command invented in either is wrong the same way. */
 export const BULK_DEMO_PATH = "packages/cli/integration/bulk-ops-demo.sh";
 export const BULK_TOUR_PATH = "docs/common/workflows/bulk-operations.md";
 
@@ -58,7 +56,27 @@ export const DOC_DEMOS: ReadonlyArray<{ doc: string; demo: string }> = [
   { doc: BULK_TOUR_PATH, demo: BULK_DEMO_PATH },
 ];
 
+/** Every document held to a demo. Each quotes commands and names acts, and a
+ * command invented in any of them is wrong the same way. */
 export const DOC_PATHS = DOC_DEMOS.map((pair) => pair.doc);
+
+/**
+ * The demo a document is held to, by the table rather than by a default.
+ *
+ * A document the table does not name has no demo to pick — every demo runs a
+ * different session, so choosing one for it would check it against a story it
+ * never described — and saying so is the whole of what this does.
+ */
+export function demoFor(doc: string): string {
+  const pair = DOC_DEMOS.find((entry) => entry.doc === doc);
+  if (pair === undefined) {
+    throw new Error(
+      `No demo is paired with ${doc}; name one as shPath, or add the ` +
+        `pairing to DOC_DEMOS.`,
+    );
+  }
+  return pair.demo;
+}
 
 /** The comment that exempts the next `cf` line in a walkthrough bash block.
  * The marker alone is not enough: an exemption without a reason is one
@@ -345,11 +363,12 @@ export function findViolations(
  * Runs the check and returns the process exit code.
  *
  * The printers are injectable so a test can drive both verdicts, and so is
- * the pairing: `mdPath` names the document to check and `shPath` the demo to
- * hold it to, defaulting to the verb demo. A demo alone names no document, so
- * it is refused rather than quietly dropped — the caller that passes one means
- * to check something against it. The default is every pairing in
- * {@link DOC_DEMOS} and the console.
+ * the pairing. With neither path, every pairing in {@link DOC_DEMOS} runs.
+ * With both, they are the pairing. With `mdPath` alone, the document supplies
+ * its own demo from {@link DOC_DEMOS} — a document declared there is never
+ * held to another story's demo. Half a pairing that names nothing is refused
+ * rather than defaulted: a demo with no document to check, and a document the
+ * table does not know, each say what to pass.
  */
 export async function main(deps: {
   shPath?: string;
@@ -365,10 +384,13 @@ export async function main(deps: {
     );
   }
   // An override names one pairing; otherwise every document is read against
-  // the demo it was written from.
-  const pairs = deps.mdPath === undefined
-    ? DOC_DEMOS
-    : [{ doc: deps.mdPath, demo: deps.shPath ?? DEMO_PATH }];
+  // the demo it was written from. A named document that the table knows
+  // brings its own demo, so an override of the document alone cannot hold
+  // one story's document to another story's demo.
+  const pairs = deps.mdPath === undefined ? DOC_DEMOS : [{
+    doc: deps.mdPath,
+    demo: deps.shPath ?? demoFor(deps.mdPath),
+  }];
   const demoText = new Map<string, string>();
   const violations: string[] = [];
   for (const { doc, demo } of pairs) {

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -3,12 +3,12 @@
 /**
  * Fails when a verb-session document drifts from the demo that runs it.
  *
- * Two documents describe the same session — the tour
- * (`docs/common/verbs/the-verb-session.md`) and the walkthrough
- * (`docs/common/verbs/session-walkthrough.md`) — and each may QUOTE commands
- * but never compose them: every `cf` line in one of their command blocks must
- * be a command `packages/cli/integration/verb-session-demo.sh` actually runs,
- * or sit under a `# not in the demo` comment saying why it cannot be. Nothing
+ * Each document is paired with the demo that runs the session it describes —
+ * the tour and the walkthrough with `verb-session-demo.sh`, the bulk tour with
+ * `bulk-ops-demo.sh` — and a document may QUOTE its demo's commands but never
+ * compose them: every `cf` line in one of its command blocks must be a command
+ * that demo actually runs, or sit under a `# not in the demo` comment saying
+ * why it cannot be. Nothing
  * executes a command block in a document, so a composed example can be wrong
  * from the day it is written and stay wrong through every editing pass — one
  * shipped that way and survived four of them. Both documents also name demo

--- a/tasks/check-verb-session-sync.ts
+++ b/tasks/check-verb-session-sync.ts
@@ -39,7 +39,10 @@ export const DEMO_PATH = "packages/cli/integration/verb-session-demo.sh";
 export const WALKTHROUGH_PATH = "docs/common/verbs/session-walkthrough.md";
 export const TOUR_PATH = "docs/common/verbs/the-verb-session.md";
 
+/** The demo that runs the bulk piece operations, act by act. */
 export const BULK_DEMO_PATH = "packages/cli/integration/bulk-ops-demo.sh";
+
+/** The tour written from that demo, and held to it below. */
 export const BULK_TOUR_PATH = "docs/common/workflows/bulk-operations.md";
 
 /**


### PR DESCRIPTION
## Why

`docs/README.md` obliges a change that alters documented behavior to update the
document in the same change. That obligation cannot fire for a command no
document describes: nothing is out of date, because nothing claimed to cover it.
So a command ships, its prose does not, and the absence is visible only to
someone who already knows the command exists.

Five commands had reached that state — `cf piece retarget` (merged the day
before this branch), `cf piece apply`, `cf init`, `cf ingest rotate`, and
`cf inspect commits`. Nothing was wrong with any document; the surface had simply
grown past them.

This is the completion arc's defect one level up. There, a slot with no provider
was indistinguishable from a slot whose fabric was unreachable, and #6254 made
every slot be *decided about*. A command with no prose is the same shape, and the
same machinery answers it: the tree is walkable and the documents are greppable.

## What Changed

**The gate.** `deno task check-command-docs` fails when a command the CLI accepts
is named in no live document, and takes a recorded reason instead where one
genuinely needs none — the two FUSE entry points the packaged binary calls on its
own. It also fails on an allowance for a command the tree no longer accepts, so a
recorded decision cannot outlive its subject. Wired into `deno.jsonc`, CI and
`AGENTS.md`.

Documentation lives with the code it describes, so the gate reads package READMEs
as well as `docs/` and `skills/`. That is not incidental: the `cf inspect` family
is documented in `packages/state-inspector/README.md`, and a search of `docs/`
alone would call 22 commands undocumented that are not.

**The five commands**, each written up where its siblings live.

**The grammar a caller writes**, which was reachable but not written down:

- Where the read options go on each of the four commands that carry them, and
  why `--` appears on two of them and is refused on the others.
- How a target is named, in `skills/cf/SKILL.md`. It taught `--piece ID` and
  nothing else, so an agent could not compose an address one command printed into
  the next — the property the canonical reference exists to provide.

**The policy.** `docs/README.md` gains the half of the obligation that was
missing: a capability a caller can reach is described somewhere a caller can
find. The existing rule covers changed behavior; this one covers new surface.

## Test plan

- `deno task check-command-docs` — 92 commands, 2 deliberately without prose.
  Mutation-checked: renaming the `retarget` mention makes the gate name it.
- `tasks/check-command-docs.test.ts` — 20 steps, including that a longer command
  never satisfies a shorter one (`cf glaze setsrc` must not cover `cf glaze set`),
  that a plan or an archived report does not count as documentation, and that a
  package README counts while the source beside it does not. The suite caught a
  real bug: `walk()` reports a missing directory on iteration rather than
  construction, so the original guard never fired.
- `deno fmt --check`, `deno lint`, `check-docs` (568 blocks), `check-skill-facts`
  (46 documents), `check-verb-session-sync` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

