### PR TITLE
fix(runner): reserved CFC documents are not value-write targets

### DIFF
--- a/docs/specs/cfc-enforcement-matrix.md
+++ b/docs/specs/cfc-enforcement-matrix.md
@@ -225,7 +225,21 @@ The strict-only delta is:
   their audience a person rather than the container and so narrower than the
   set of principals a space grants reader roles to; and the ungrantable
   read-failed marker sits outside every ceiling, the residency clause
-  included, so a poisoned measurement never proves fit. Implementation in
+  included, so a poisoned measurement never proves fit. The reserved policy
+  namespaces are outside the check too: the durable policy manifests
+  (`of:cfc-policy-manifest:<digest>`) and the release grants and single-use
+  consumption receipts (`grant:cfc:<digest>`) hold policy state the runtime
+  persists through its own privileged writers, gated at the transaction write
+  chokepoint, so they are not value-write targets any of the write-side checks
+  measure. The spec settles this rather than leaving it to implementation
+  taste. A grant record is "a content-addressed record at a reserved location
+  in the granting owner's space, written only by a trusted policy writer",
+  whose "stored label never changes" (spec §4.3.5, and §8.12.7 route 2a).
+  Policy manifests live in "a separate immutable store" and are "public
+  artifacts", and a transaction MUST NOT persist a module-policy reference
+  unless that same transaction create-only installs the byte-verified manifest
+  (spec §4.4.2) — which the writer-fit reject would otherwise make impossible
+  at this level. Implementation in
   [prepare.ts](../../packages/runner/src/cfc/prepare.ts) (`prepareBoundaryCommit`
   flow-persist stamping), asserted both ways in
   [cfc-writer-fit.test.ts](../../packages/runner/test/cfc-writer-fit.test.ts).

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1372,12 +1372,14 @@ const schemaEnvelopeForTargetPath = (
 // and it is not a user value write for schema write policy, flow labels, or
 // writer-fit to measure.
 //
-// A recorded write holds its document out of the exemption, so a forged write
-// is measured like any other value write and carries the join. The recording
-// arms differ: the manifest arm throws, while a forged grant write reaches
-// storage under the non-rejecting modes, and the label it carries is what ties
-// a later read of it back to what the forging transaction observed. Reads of
-// these documents are measured for the same reason.
+// A write the chokepoint recorded as unprivileged holds its document out of
+// the exemption, so a forged write is measured like any other value write and
+// carries the join. Which namespace that matters for follows from the two
+// arms. A forged manifest write throws, so no such document reaches the
+// boundary. A forged grant write is recorded and still reaches storage under
+// the modes that do not reject, and the label it carries there is what ties a
+// later read of the document back to what the forging transaction observed.
+// Reads of these documents stay measured for the same reason.
 const isReservedCfcDocumentId = (id: string): boolean =>
   id.startsWith(CFC_POLICY_MANIFEST_ID_PREFIX) ||
   id.startsWith(CFC_GRANT_ID_PREFIX);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -81,6 +81,7 @@ import {
 } from "./exchange-eval.ts";
 import { externalIngestStamp } from "./external-ingest.ts";
 import {
+  CFC_GRANT_ID_PREFIX,
   createTxCfcGrantResolver,
   flushCfcGrantConsumptionClaims,
 } from "./grants.ts";
@@ -111,6 +112,7 @@ import {
   cfcIntegritySatisfiesFloorCoherently,
   uniqueCfcAtoms,
 } from "./observation.ts";
+import { CFC_POLICY_MANIFEST_ID_PREFIX } from "./policy.ts";
 import { createTxCfcModulePolicyResolver } from "./policy-resolver.ts";
 import { cfcSchemaEntries } from "./schema-label-view.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
@@ -1361,6 +1363,25 @@ const schemaEnvelopeForTargetPath = (
   return envelope;
 };
 
+// The reserved CFC document namespaces: the durable policy manifests a
+// consultation installs, and the release grants `writeCfcGrant` authors along
+// with the receipts that spend them. Both hold policy state, and the
+// transaction write chokepoint gates every unprivileged write to them — a
+// manifest write throws, a grant write is recorded and becomes a fail-closed
+// prepare reason. The runtime's own privileged persistence is what remains,
+// and it is not a user value write for schema write policy, flow labels, or
+// writer-fit to measure.
+//
+// A recorded write holds its document out of the exemption, so a forged write
+// is measured like any other value write and carries the join. The recording
+// arms differ: the manifest arm throws, while a forged grant write reaches
+// storage under the non-rejecting modes, and the label it carries is what ties
+// a later read of it back to what the forging transaction observed. Reads of
+// these documents are measured for the same reason.
+const isReservedCfcDocumentId = (id: string): boolean =>
+  id.startsWith(CFC_POLICY_MANIFEST_ID_PREFIX) ||
+  id.startsWith(CFC_GRANT_ID_PREFIX);
+
 const valueWriteTargets = (
   tx: IExtendedStorageTransaction,
 ): Map<
@@ -1411,6 +1432,7 @@ const valueWriteTargets = (
     }
   >();
   const log = tx.getReactivityLog?.();
+  const forgedSystemWrites = tx.getCfcState().unprivilegedSystemWrites ?? [];
   const seenWriteSpaces = new Set<MemorySpace>(
     [...(log?.writes ?? []), ...(log?.attemptedWrites ?? [])].map((write) =>
       write.space
@@ -1432,6 +1454,12 @@ const valueWriteTargets = (
       // carry their labels via the link-write machinery, not here.
       if (
         write.address.id.startsWith("cid:") ||
+        (
+          isReservedCfcDocumentId(write.address.id) &&
+          !forgedSystemWrites.some((recorded) =>
+            recorded.startsWith(`${write.address.id}/`)
+          )
+        ) ||
         rawPath[0] === "cfc" ||
         rawPath[0] === "source" ||
         (

--- a/packages/runner/test/cfc-grant-records.test.ts
+++ b/packages/runner/test/cfc-grant-records.test.ts
@@ -467,6 +467,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
     opts: {
       policyEvaluation?: "off" | "observe" | "enforce";
       enforcement?: "enforce-explicit" | "observe" | "disabled";
+      flowLabels?: "off" | "observe" | "persist";
       storageManager?: ReturnType<typeof StorageManager.emulate>;
     },
     body: (
@@ -480,6 +481,7 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
       apiUrl: new URL("https://example.com"),
       storageManager,
       cfcEnforcementMode: opts.enforcement ?? "enforce-explicit",
+      cfcFlowLabels: opts.flowLabels ?? "off",
       cfcSinkMaxConfidentiality: { fetchJson: [userBob] },
       cfcPolicyRecords: [{ id: "share-policy", rules: [sinkShareRule] }],
       cfcPolicyEvaluation: opts.policyEvaluation ?? "enforce",
@@ -693,6 +695,56 @@ describe("CFC grant records (§8.12.7 route 2a)", () => {
         expect(String((result.error as Error).message).toLowerCase())
           .toContain("cfc");
       });
+    });
+
+    // Under a non-rejecting mode the forged write reaches storage, so the
+    // flow stage must still measure it. The reserved namespaces are held out
+    // of value-write targeting because the runtime persists policy state
+    // through them; a document some transaction forged is not that, and the
+    // label it carries is what ties a later read of the stash back to what
+    // the forging transaction observed.
+    it("labels an unprivileged write to a grant document under observe", async () => {
+      await withRuntime(
+        { enforcement: "observe", flowLabels: "persist" },
+        async (runtime, storageManager) => {
+          await seedLabeledCell(runtime, "forged-stash-source", {
+            confidentiality: ["never-fits"],
+          });
+
+          const tx = runtime.edit();
+          const source = runtime.getCell(
+            signer.did(),
+            "forged-stash-source",
+            SECRET_SCHEMA.schema,
+            tx,
+          );
+          expect(source.key("secret").get()).toBe("rosebud");
+          const forgedId = `${CFC_GRANT_ID_PREFIX}forged-stash`;
+          tx.writeOrThrow({
+            space: signer.did(),
+            id: forgedId as URI,
+            type: "application/json",
+            path: ["value"],
+          }, { stashed: source.key("secret").get() });
+          tx.prepareCfc();
+          expect((await tx.commit()).ok).toBeDefined();
+
+          const replica = storageManager.open(signer.did())
+            .replica as unknown as {
+              getDocument(id: string): {
+                cfc?: { labelMap?: { entries: { label: IFCLabel }[] } };
+              } | undefined;
+            };
+          const entries =
+            replica.getDocument(forgedId)?.cfc?.labelMap?.entries ?? [];
+          expect(entries.length).toBeGreaterThan(0);
+          expect(
+            entries.every((entry) =>
+              (entry.label.confidentiality ?? []).includes("never-fits")
+            ),
+          ).toBe(true);
+        },
+      );
     });
 
     // The mergeable-op path (push/increment/…) cannot bypass the gate: the

--- a/packages/runner/test/cfc-policy-manifest-consultation.test.ts
+++ b/packages/runner/test/cfc-policy-manifest-consultation.test.ts
@@ -6,8 +6,14 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import {
   buildCfcPolicyArtifactManifest,
+  CFC_POLICY_MANIFEST_ID_PREFIX,
   cfcPolicyManifestDocId,
 } from "../src/cfc/policy.ts";
+import { parseLink } from "../src/link-utils.ts";
+import {
+  SEED_ENVELOPE_SCHEMA_HASH,
+  writeSeedEnvelopeDoc,
+} from "./cfc-seed-envelope.ts";
 import {
   createTxCfcModulePolicyResolver,
   preparedDigestFor,
@@ -32,6 +38,134 @@ const base: PreparedDigestInput = {
   dereferenceTraces: [],
   triggerReads: [],
   writePolicyInputs: [],
+};
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  origin?: string;
+};
+
+const storedDocument = (
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+  id: string,
+):
+  | { value?: unknown; cfc?: { labelMap?: { entries: StoredEntry[] } } }
+  | undefined => {
+  const replica = storageManager.open(signer.did()).replica as unknown as {
+    getDocument(id: string): {
+      value?: unknown;
+      cfc?: { labelMap?: { entries: StoredEntry[] } };
+    } | undefined;
+  };
+  return replica.getDocument(id);
+};
+
+// Seed a source doc whose `secret` field carries a confidentiality label, so
+// a transaction that reads it derives a tainted per-tx flow join.
+const seedSecretSource = async (runtime: Runtime, name: string) => {
+  const seed = runtime.edit();
+  const sourceCell = runtime.getCell(
+    signer.did(),
+    name,
+    {
+      type: "object",
+      properties: { secret: { type: "string" } },
+    },
+  );
+  const sourceId = parseLink(sourceCell.getAsLink()).id!;
+  writeSeedEnvelopeDoc(seed, signer.did());
+  seed.writeOrThrow({
+    space: signer.did(),
+    scope: "space",
+    id: sourceId,
+    path: [],
+  }, {
+    value: { secret: "s3cr3t" },
+    cfc: {
+      version: 1,
+      schemaHash: SEED_ENVELOPE_SCHEMA_HASH,
+      labelMap: {
+        version: 1,
+        entries: [{
+          path: ["secret"],
+          label: { confidentiality: ["secret"] },
+        }],
+      },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+const persistenceArtifact = (moduleIdentity: string) =>
+  buildCfcPolicyArtifactManifest({
+    formatVersion: 1,
+    moduleIdentity,
+    symbol: "rules",
+    template: {
+      templateVersion: 1,
+      exchangeRules: [],
+      dependencies: { authorityOnly: [], dataBearing: [] },
+      integrityRequirements: {},
+    },
+  });
+
+// Run the consultation flow that persists a manifest inside a tainted
+// transaction: read the labeled source, write a derived value whose declared
+// store policy covers the join and carries the module-policy reference, and
+// prepare twice — the first prepare installs the manifest document (a
+// privileged write now in the journal), the recorded consultation invalidates
+// the prepared state, and the second prepare re-measures the journal with the
+// manifest write present.
+const runTaintedManifestPersistence = async (
+  runtime: Runtime,
+  artifact: ReturnType<typeof buildCfcPolicyArtifactManifest>,
+  names: { source: string; derived: string },
+  escalate: "enforce-strict" | undefined,
+) => {
+  runtime.registerCfcPolicyManifests(undefined, [artifact]);
+  await seedSecretSource(runtime, names.source);
+
+  const tx = runtime.edit();
+  if (escalate !== undefined) {
+    tx.setCfcEnforcementMode(escalate);
+  }
+  const source = runtime.getCell(signer.did(), names.source, undefined, tx);
+  const raw = source.getRaw() as { secret?: string };
+  expect(raw.secret).toBe("s3cr3t");
+  const derived = runtime.getCell(
+    signer.did(),
+    names.derived,
+    {
+      type: "object",
+      properties: { copied: { type: "string" } },
+      ifc: {
+        confidentiality: ["secret", {
+          type: CFC_ATOM_TYPE.Policy,
+          policyRefKind: "module",
+          moduleIdentity: artifact.manifest.moduleIdentity,
+          symbol: artifact.manifest.symbol,
+          policyDigest: artifact.policyDigest,
+          subject: { __ctOwningSpace: true },
+        }],
+      },
+    } as const,
+    tx,
+  );
+  derived.set({ copied: `${raw.secret}!` });
+  tx.prepareCfc();
+  tx.recordCfcConsultedPolicyManifest({
+    reference: cfcAtom.modulePolicyRef(
+      artifact.manifest.moduleIdentity,
+      artifact.manifest.symbol,
+      artifact.policyDigest,
+      "did:key:additional-subject",
+    ),
+    state: "absent",
+  });
+  expect(tx.prepareCfc()).not.toBe("");
+  expect((await tx.commit()).ok).toBeDefined();
+  return { tx, derivedId: derived.getAsNormalizedFullLink().id };
 };
 
 describe("module-policy manifest consultation", () => {
@@ -375,6 +509,93 @@ describe("module-policy manifest consultation", () => {
         )
       ).toThrow("storage cannot bind manifest consultation");
       binding.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  // Reserved manifest documents are not value-write targets: the privileged
+  // persistence during prepare is CFC machinery, so the strict writer-fit
+  // must not measure the manifest write against its own (undeclared) store
+  // policy, and the flagged modes must not attach flow labels or misfit
+  // flags to it.
+  it("commits a tainted flow that persists its manifest under enforce-strict", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    const artifact = persistenceArtifact("sha256:strict-persist-module");
+    try {
+      const { tx, derivedId } = await runTaintedManifestPersistence(
+        runtime,
+        artifact,
+        {
+          source: "manifest-strict-source",
+          derived: "manifest-strict-derived",
+        },
+        "enforce-strict",
+      );
+
+      const stored = storedDocument(
+        storageManager,
+        cfcPolicyManifestDocId(artifact.policyDigest),
+      );
+      expect(stored?.value).toEqual(artifact);
+      expect(stored?.cfc).toBeUndefined();
+      // The derived write itself was measured: the tainted join persisted a
+      // derived component onto the declared-covered target.
+      const derivedEntries =
+        storedDocument(storageManager, derivedId)?.cfc?.labelMap?.entries ?? [];
+      expect(derivedEntries.some((entry) => entry.origin === "derived")).toBe(
+        true,
+      );
+      expect(
+        tx.getCfcState().diagnostics.filter((diagnostic) =>
+          diagnostic.includes(CFC_POLICY_MANIFEST_ID_PREFIX)
+        ),
+      ).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("flags no writer-fit diagnostic naming a manifest document under enforce-explicit", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    const artifact = persistenceArtifact("sha256:explicit-flag-module");
+    try {
+      const { tx } = await runTaintedManifestPersistence(
+        runtime,
+        artifact,
+        {
+          source: "manifest-flag-source",
+          derived: "manifest-flag-derived",
+        },
+        undefined,
+      );
+
+      const stored = storedDocument(
+        storageManager,
+        cfcPolicyManifestDocId(artifact.policyDigest),
+      );
+      expect(stored?.value).toEqual(artifact);
+      expect(stored?.cfc).toBeUndefined();
+      expect(
+        tx.getCfcState().diagnostics.filter((diagnostic) =>
+          diagnostic.includes("writer-fit") &&
+          diagnostic.includes(CFC_POLICY_MANIFEST_ID_PREFIX)
+        ),
+      ).toEqual([]);
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-writer-fit.test.ts
+++ b/packages/runner/test/cfc-writer-fit.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/api";
 import { Identity } from "@commonfabric/identity";
+import { cfcAtom } from "@commonfabric/api/cfc";
 import {
   SEED_ENVELOPE_SCHEMA_HASH,
   writeSeedEnvelopeDoc,
@@ -859,6 +860,62 @@ describe("CFC writer-fit (canWrite, §8.12.4 / SC-18b)", () => {
         await storageManager.close();
       }
     });
+  });
+
+  // Reserved CFC documents (policy manifests, release grants) hold policy
+  // state the runtime persists through its privileged writers, so they are
+  // not value-write targets the fit measures. The grant document declares no
+  // store policy of its own, and the transaction that authors one has read
+  // the resource it releases — a tainted join.
+  it("admits a reserved grant document under enforce-strict", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = newRuntime(storageManager);
+    try {
+      await seedSecretSource(runtime, "writer-fit-grant-source");
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-strict");
+      const source = runtime.getCell(
+        signer.did(),
+        "writer-fit-grant-source",
+        undefined,
+        tx,
+      );
+      const raw = source.getRaw() as { secret?: string };
+      expect(raw.secret).toBe("s3cr3t");
+      // The trusted policy-writer authors under a builtin identity, the one
+      // sanctioned writer of the reserved grant namespace.
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "cfc-grant-writer",
+      });
+      const written = tx.writeCfcGrant({
+        kind: "ShareGrant",
+        owner: signer.did(),
+        resource: "of:writer-fit-grant-resource",
+        audience: [cfcAtom.user(
+          "did:key:z6MkfZ3gV6ZKqmyWLTPYnPYRUYQBqTHTNCJgqbCkNBzYqZ4H",
+        )],
+        grantedAt: 1000,
+      });
+      expect(tx.prepareCfc()).not.toBe("");
+      expect((await tx.commit()).ok).toBeDefined();
+
+      // The grant persisted, carrying no derived label of its own: a
+      // consultation reading it inherits nothing from the releasing
+      // transaction.
+      const stored = storedDocument(storageManager, written.id);
+      expect(stored?.value).toBeDefined();
+      expect(stored?.cfc).toBeUndefined();
+      expect(
+        tx.getCfcState().diagnostics.filter((diagnostic) =>
+          diagnostic.includes(written.id)
+        ),
+      ).toEqual([]);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
   });
 
   it("leaves untainted writes untouched under enforce-strict", async () => {


### PR DESCRIPTION
Two document namespaces hold CFC policy state rather than user data. The durable policy manifests a consultation installs are addressed `of:cfc-policy-manifest:<digest>`. The release grants the trusted policy writer authors are addressed `grant:cfc:<digest>`, and so are the single-use consumption receipts that spend them. Neither namespace is writable by ordinary code: the transaction write chokepoint gates every unprivileged write to them — a manifest write throws outright, a grant write is recorded and becomes a fail-closed prepare reason — so what reaches the commit boundary is the runtime's own privileged persistence.

The value-write targeting measured that persistence anyway. Everything schema write policy, flow labels, and the writer-fit check consume is keyed off `valueWriteTargets`, and all three privileged writers landed in it like any pattern-authored document. None of these documents declares a store policy of its own, so a transaction that read labeled data and then persisted one of them failed the fit against an undeclared store. Under `enforce-strict` that is a rejection: the consultation flow could not install the manifest that a label carrying a Policy atom requires, the trusted policy writer could not author a grant releasing data it had just read, and a single-use release could not stage its receipt — the operations most likely to run in a tainted transaction, refused at exactly the posture that relies on them. Under the flagged modes the same misfit produced diagnostics naming documents no author can write, and stamped derived labels onto policy state.

Exclude both namespaces through one `isReservedCfcDocumentId` predicate, beside the existing `cid:` schema-document exclusion. The exemption is for the runtime's own persistence, so a document the transaction also wrote outside the privileged scope is held out of it: the chokepoint already records those writes, and the two recording arms differ — the manifest arm throws, while a forged grant write reaches storage under the non-rejecting modes, where the label it carries is what ties a later read of the stash back to what the forging transaction observed. Reads of these documents stay measured for the same reason, so the read-side exclusions are deliberately not extended to match.

Nothing about the refusal path changes: a forged write under either prefix is still recorded and still surfaces as a fail-closed prepare reason, because that path reads the recorded write list rather than the value-write targets.

The writer-fit scope note in the enforcement matrix now names the reserved namespaces alongside the other categories the check does not measure.

The manifest case is covered in the consultation suite, which pins `enforce-strict` with flow labels persisting and proves a tainted consultation commits its manifest cleanly, and that no writer-fit diagnostic names a manifest under the flagged modes. The grant case is covered in the writer-fit suite, where a tainted strict transaction authors a release grant and the reserved document persists carrying no derived label of its own. The grant suite gains the paired negative case beside its existing chokepoint rejection: under `observe`, where the forged write commits, the forged document is still measured and carries the join.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

