### PR TITLE
The walks that meet a fabric class

### DIFF
--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -3,8 +3,11 @@
  */
 
 import {
+  FabricInstance,
+  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { DID } from "@commonfabric/identity";
 import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
@@ -19,6 +22,7 @@ import {
   linkRefFrom,
   linkRefPayload,
   linkRefPayloadToString,
+  refuseFabricInstance,
   type SigilLink,
 } from "@commonfabric/runner/shared";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -466,7 +470,7 @@ export class CellHandle<T = unknown> {
       this.#value,
       this as CellHandle<unknown>,
     ) as T;
-    const valueChanged = !valuesEqual(applied, this.#value);
+    const valueChanged = !valuesOrCellsEqual(applied, this.#value);
     // A label-only change (value identical) still fires label-aware subscribers.
     // `labelUpdate` is present only on notifications that carried a label, so a
     // value-only notification never spuriously churns the label.
@@ -502,6 +506,25 @@ export class CellHandle<T = unknown> {
 
     if (Array.isArray(value)) {
       return value.map((item) => CellHandle.deserialize(base, item));
+    }
+
+    // A `FabricPrimitive` is a leaf, so a walk that stops at it has already
+    // done the right thing -- and this goes _before_ the record branch, which
+    // rebuilds from enumerable own properties a fabric class does not have and
+    // would put `{}` here in place of the value.
+    if (value instanceof FabricPrimitive) return value;
+
+    // An instance is a container, reached by its codec contents rather than by
+    // property name, so a sigil link can sit inside one where this walk cannot
+    // see it -- and a value handed back unhydrated would carry that link where
+    // a `CellHandle` belongs.
+    //
+    // Nothing reaches this today, de facto rather than by construction: the
+    // connection carries a value by structured cloning, which strips a fabric
+    // class before it arrives, and `CellHandle.serialize()` refuses one on the
+    // way out.
+    if (value instanceof FabricInstance) {
+      refuseFabricInstance(value, "when hydrating a value off the connection");
     }
 
     if (isObjectOrArray(value)) {
@@ -638,6 +661,20 @@ function applyValue(
     );
   }
 
+  // A leaf, carried through whole as `deserialize()` hydrates one: the record
+  // branch below would rebuild it from enumerable own properties it does not
+  // have.
+  if (current instanceof FabricPrimitive) {
+    return current;
+  }
+
+  // A container this walk cannot descend, so it cannot preserve a handle
+  // inside one against the incoming value the way it does for a record.
+  // Unreachable for the same reason as in `deserialize()`.
+  if (current instanceof FabricInstance) {
+    refuseFabricInstance(current, "when applying a delivered value");
+  }
+
   // For plain objects, recursively apply to each property
   if (isObjectOrArray(current)) {
     const prevRecord = (isObjectNotArray(previous))
@@ -667,10 +704,18 @@ function cellRefsEqual(a: CellRef, b: CellRef): boolean {
 }
 
 /**
- * Deep equality check for cell values.
- * Handles primitives, arrays, objects, and CellHandles.
+ * Compares two values a cell can hold, deciding whether a delivered update is
+ * a change this handle's subscribers hear about.
+ *
+ * Distinct from `valueEqual()`, which it calls: that settles a `FabricValue`
+ * by content, and this also knows about cells. A `CellHandle` compares by the
+ * cell it names rather than by what that cell holds, so two handles on one
+ * cell are equal and a handle is equal to nothing else.
+ *
+ * @throws If either side is a `FabricInstance`, whose outgoing references this
+ *   walk cannot reach.
  */
-function valuesEqual(a: unknown, b: unknown): boolean {
+function valuesOrCellsEqual(a: unknown, b: unknown): boolean {
   // `Object.is`, not `===`: an unchanged `NaN` leaf must compare equal (else
   // every delivery of a NaN-bearing value re-notifies all subscribers), and a
   // `0` -> `-0` change must compare unequal (else the update is dropped).
@@ -678,14 +723,41 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   if (a == null || b == null) return a === b;
   if (typeof a !== typeof b) return false;
   if (typeof a !== "object") return false;
-  if (isCellHandle(a) && isCellHandle(b)) {
-    return a.equals(b);
+  // Either side being a handle is enough to ask. A handle holds its state
+  // privately, so the record branch below would read `{}` off it and call it
+  // equal to anything else without enumerable own keys -- `{}` itself among
+  // them, so replacing a handle with a record would be judged a no-change and
+  // reach no subscriber. A handle is a reference to a cell and equals only
+  // another reference to the same cell.
+  if (isCellHandle(a) || isCellHandle(b)) {
+    return isCellHandle(a) && isCellHandle(b) && a.equals(b);
+  }
+
+  // A `FabricPrimitive` is compared by the data model rather than by this
+  // walk, and _before_ the record branch, for the same reason: two
+  // `FabricBytes` over different bytes both present as `{}` there and would
+  // compare equal. A primitive is a leaf, so comparing its content is the
+  // whole comparison.
+  if (a instanceof FabricPrimitive || b instanceof FabricPrimitive) {
+    return valueEqual(a as FabricValue, b as FabricValue);
+  }
+
+  // An instance is not a leaf, and `valueEqual()` would settle its outgoing
+  // references by the data model's rules where this walk has its own -- a
+  // handle compares by the cell it names, not by content. Rather than answer
+  // with a comparison that is right for one of those and wrong for the other,
+  // this refuses. Unreachable for the same reason as in `deserialize()`.
+  if (a instanceof FabricInstance || b instanceof FabricInstance) {
+    refuseFabricInstance(
+      (a instanceof FabricInstance ? a : b) as FabricInstance,
+      "when comparing a delivered value against the cached one",
+    );
   }
   if (Array.isArray(a)) {
     if (!Array.isArray(b)) return false;
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (!valuesEqual(a[i], b[i])) return false;
+      if (!valuesOrCellsEqual(a[i], b[i])) return false;
     }
     return true;
   }
@@ -698,7 +770,7 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   for (const key of aKeys) {
     if (!(key in (b as object))) return false;
     if (
-      !valuesEqual(
+      !valuesOrCellsEqual(
         (a as Record<string, unknown>)[key],
         (b as Record<string, unknown>)[key],
       )

--- a/packages/runtime-client/src/cell-handle.ts
+++ b/packages/runtime-client/src/cell-handle.ts
@@ -711,9 +711,6 @@ function cellRefsEqual(a: CellRef, b: CellRef): boolean {
  * by content, and this also knows about cells. A `CellHandle` compares by the
  * cell it names rather than by what that cell holds, so two handles on one
  * cell are equal and a handle is equal to nothing else.
- *
- * @throws If either side is a `FabricInstance`, whose outgoing references this
- *   walk cannot reach.
  */
 function valuesOrCellsEqual(a: unknown, b: unknown): boolean {
   // `Object.is`, not `===`: an unchanged `NaN` leaf must compare equal (else
@@ -738,20 +735,13 @@ function valuesOrCellsEqual(a: unknown, b: unknown): boolean {
   // `FabricBytes` over different bytes both present as `{}` there and would
   // compare equal. A primitive is a leaf, so comparing its content is the
   // whole comparison.
+  //
+  // There is no arm for a `FabricInstance`. `applyValue()` is this function's
+  // only caller and refuses one before it returns, so neither argument can
+  // hold one -- an arm here would be unreachable rather than defensive, and
+  // untestable with it.
   if (a instanceof FabricPrimitive || b instanceof FabricPrimitive) {
     return valueEqual(a as FabricValue, b as FabricValue);
-  }
-
-  // An instance is not a leaf, and `valueEqual()` would settle its outgoing
-  // references by the data model's rules where this walk has its own -- a
-  // handle compares by the cell it names, not by content. Rather than answer
-  // with a comparison that is right for one of those and wrong for the other,
-  // this refuses. Unreachable for the same reason as in `deserialize()`.
-  if (a instanceof FabricInstance || b instanceof FabricInstance) {
-    refuseFabricInstance(
-      (a instanceof FabricInstance ? a : b) as FabricInstance,
-      "when comparing a delivered value against the cached one",
-    );
   }
   if (Array.isArray(a)) {
     if (!Array.isArray(b)) return false;

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 
+import { FabricLink } from "@commonfabric/data-model/fabric-instances";
 import {
   FabricBytes,
   FabricEpochNsec,
@@ -592,6 +593,59 @@ describe("cell-handle", () => {
       const after = calls.length;
       cell[$onCellUpdate]({ x: NaN });
       expect(calls.length).toBe(after);
+    });
+
+    it("notifies when a special object's contents change", () => {
+      // Two `FabricBytes` over different bytes are different values, and their
+      // state is private -- so a walk over enumerable own properties sees `{}`
+      // on both sides and would call them equal.
+      const cell = new CellHandle<FabricBytes>(makeRuntime(), ref);
+      const calls: Array<unknown> = [];
+      cell.subscribe((value) => {
+        calls.push(value);
+      });
+
+      cell[$onCellUpdate](new FabricBytes(new Uint8Array([1])));
+      const after = calls.length;
+      cell[$onCellUpdate](new FabricBytes(new Uint8Array([2])));
+
+      expect(calls.length).toBe(after + 1);
+    });
+
+    it("refuses a `FabricInstance` rather than compare one", () => {
+      // A tripwire: nothing delivers an instance today, the transport striping
+      // a fabric class before it arrives. Reached here directly, because a
+      // walk that cannot descend a container must say so rather than answer.
+      const cell = new CellHandle<unknown>(makeRuntime(), ref);
+      cell.subscribe(() => {});
+      const link = new FabricLink(
+        Object.freeze({ id: "of:fid1:refusal", path: [] }),
+      );
+
+      expect(() => cell[$onCellUpdate](link)).toThrow(
+        "Cannot yet handle `FabricLink` (a `FabricInstance`)",
+      );
+    });
+
+    it("notifies when a handle is replaced by a record", () => {
+      // A handle holds its state privately, so a walk over enumerable own
+      // properties reads `{}` off it -- equal to any other key-less object,
+      // `{}` included, which would drop the update and tell no subscriber.
+      const cell = new CellHandle<{ a: unknown }>(makeRuntime(), ref);
+      const calls: Array<unknown> = [];
+      cell.subscribe((value) => {
+        calls.push(value);
+      });
+      const inner = new CellHandle(makeRuntime(), {
+        ...ref,
+        id: "of:other-cell" as CellRef["id"],
+      });
+
+      cell[$onCellUpdate]({ a: inner });
+      const after = calls.length;
+      cell[$onCellUpdate]({ a: {} });
+
+      expect(calls.length).toBe(after + 1);
     });
 
     it("notifies on a 0 -> -0 change", () => {

--- a/packages/runtime-client/test/cell-handle.test.ts
+++ b/packages/runtime-client/test/cell-handle.test.ts
@@ -612,10 +612,11 @@ describe("cell-handle", () => {
       expect(calls.length).toBe(after + 1);
     });
 
-    it("refuses a `FabricInstance` rather than compare one", () => {
-      // A tripwire: nothing delivers an instance today, the transport striping
-      // a fabric class before it arrives. Reached here directly, because a
-      // walk that cannot descend a container must say so rather than answer.
+    it("refuses a `FabricInstance` rather than apply one", () => {
+      // A tripwire: nothing delivers an instance today, the transport
+      // stripping a fabric class before it arrives. This is `applyValue()`'s
+      // refusal -- it runs first, which is why the comparison after it needs
+      // no arm of its own.
       const cell = new CellHandle<unknown>(makeRuntime(), ref);
       cell.subscribe(() => {});
       const link = new FabricLink(
@@ -820,6 +821,51 @@ describe("cell-handle", () => {
       cell[$onCellUpdate]("not an array" as unknown as number[]);
       expect(() => cell.push(1)).toThrow(
         "push() can only be used on array cells",
+      );
+    });
+  });
+
+  describe("CellHandle hydration meets a fabric class", () => {
+    const makeRuntime = () =>
+      ({
+        [$conn]: () => ({
+          request: () => Promise.resolve({ value: undefined }),
+          subscribe: () => Promise.resolve(),
+          unsubscribe: () => Promise.resolve(),
+        }),
+      }) as unknown as RuntimeClient;
+    const makeHandle = () =>
+      new CellHandle(makeRuntime(), {
+        id: "of:hydration-cell" as CellRef["id"],
+        space: "did:key:test" as CellRef["space"],
+        scope: "space",
+        path: [],
+      });
+
+    it("hydrates a `FabricPrimitive` as itself, not as a record", () => {
+      // A leaf: stopping at it is the whole job, and it must be stopped at
+      // before the record branch, which would rebuild it from enumerable own
+      // properties it does not have and yield `{}`.
+      const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+      expect(CellHandle.deserialize(makeHandle(), bytes)).toBe(bytes);
+      expect(
+        (CellHandle.deserialize(makeHandle(), { a: [bytes] }) as {
+          a: unknown[];
+        }).a[0],
+      ).toBe(bytes);
+    });
+
+    it("refuses a `FabricInstance` rather than hydrate one", () => {
+      // A container, reached by its codec contents rather than by property
+      // name, so a sigil link can sit inside one where this walk cannot see
+      // it. Nothing delivers one today; this is the tripwire.
+      const link = new FabricLink(
+        Object.freeze({ id: "of:fid1:hydration-refusal", path: [] }),
+      );
+
+      expect(() => CellHandle.deserialize(makeHandle(), link)).toThrow(
+        "Cannot yet handle `FabricLink` (a `FabricInstance`)",
       );
     });
   });


### PR DESCRIPTION
From: Agent working on behalf of @danfuzz (Claude Opus 5, 1M context)

Prep for the IPC envelope work (#6323), on the pattern #6330, #6339 and #6369
set. One live bug plus the tripwires that belong with it; nothing here depends
on that change landing.

## A handle replaced by a record was judged a no-change

`valuesOrCellsEqual()` in `cell-handle.ts` decides whether a delivered update
reaches subscribers. Its handle arm asked `isCellHandle(a) && isCellHandle(b)`,
so a handle compared against anything *else* fell through to the record branch
— which compares enumerable own properties, and a `CellHandle` holds its state
privately. It therefore read `{}` off the handle and compared it equal to every
other key-less object, `{}` among them.

So a cell whose field goes from a link to a plain record is judged unchanged:
the cache keeps the old handle and no subscriber fires. A primitive is caught
by the `typeof` check, `null` by the null check and an array by the array
check, so key-less objects are the specific leak.

Either side being a handle is enough to ask now, and a handle equals only
another handle for the same cell. **The test is ablated against the exact prior
code**: restore `&&` and it fails.

## And the leaf/container split those walks were missing

The same three walks treated every fabric class alike. Only half of them earn
it. A `FabricPrimitive` is a leaf, so a walk that stops at one has already done
the whole job. A `FabricInstance` is a container, reached by its codec contents
rather than by property name — so a cell can sit inside one where these walks
cannot see it, and passing one through unexamined is the silent misbehavior
they exist to prevent. `refuseFabricInstance()`'s own doc states exactly this
distinction; these walks now follow it.

`deserialize()`, `applyValue()` and the comparison carry the leaf and refuse
the container, through the helper the rest of the repository refuses with.

**These are tripwires, not fixes.** Nothing delivers an instance today: the
connection carries values by structured cloning, which strips a fabric class
before it arrives, and `CellHandle.serialize()` refuses one on the way out.
Each comment says so, de facto rather than by construction, per the obligation
in `docs/development/EXPERIMENTAL_OPTIONS.md`.

Deliberately **not** included: the matching split in `CellHandle.serialize()`
(`cell-handle.ts:559` here). That one currently throws for *any*
`FabricSpecialObject`, and letting a `FabricPrimitive` through is only correct
once the transport can carry one — which is #6323's business, not this PR's.

## And a rename

`valuesEqual()` is one character from `valueEqual()`, and now calls it. It is
`valuesOrCellsEqual()`, which names the difference: this one also knows about
cells, where the data model's settles a `FabricValue` by content alone. Its doc
states the contract and the refusal rather than listing the shapes it walks.
Module-private, so it reaches four call sites in one file. The unrelated
module-private `valuesEqual()` in `packages/state-inspector/timetravel.ts` sits
nowhere near `valueEqual()` and is left alone.

## Verification

- `deno fmt --check`, `deno lint`, `deno task check`: green, repo-wide.
- Package suites green: `runtime-client` (14/324), `html`, `lib-shell`, `shell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ukZJG1bVUK194EAJhtLNu


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

