### PR TITLE
docs(features): the bulk piece operations contract, in one findable place

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -91,6 +91,10 @@ Add a line for each new document to the index below.
 - [`host-embedding.md`](host-embedding.md) — the seams a host that is not the
   labs shell may bind to when it mounts our components and patterns, each one
   pinned by a test that goes red if the contract changes
+- [`piece-bulk-operations.md`](piece-bulk-operations.md) — retargeting,
+  repairing, and reversing many pieces in one space as one reviewable,
+  resumable operation: what a plan row means, what each write proves first,
+  what a stop leaves behind, and what a resume may claim
 
 ## Observability and testing
 

--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -1,0 +1,471 @@
+# Bulk piece operations
+
+Three write operations over many pieces in one space — retarget a piece's
+source, repair its stored document, and reverse either — share one spine and
+differ only in what they apply, with a read-only survey under all of them.
+This document is the contract they hold: what a plan row means, what is proved
+before a write, what a stop leaves behind, what a resume may claim, and which
+refusal fires at which moment.
+
+Command spellings, flags, and output modes are in
+[`packages/cli/README.md`](../../packages/cli/README.md). The operating loop
+for rehearsing a run against a copy of real data is
+[`space-clone-rehearsal.md`](../development/space-clone-rehearsal.md).
+
+## The spine
+
+```text
+survey → plan → preflight → apply serially → survey diff
+```
+
+Every operation walks it, and only the apply step differs.
+
+| operation | applies | its row's precondition | verified by | reversed by |
+| --- | --- | --- | --- | --- |
+| survey | nothing; it reads and reports | — | — | it writes nothing |
+| retarget | one local source package, resolved from disk | the `{identity, symbol}` pair the piece is on | the survey diff | rollback, derived from the same plan |
+| repair | a fixer's whole-document answer | the hash of the stored document | re-asking the fixer after the write | nothing derivable |
+| restore | a revision of the piece's own retained source log | the pair the retarget produced | the survey diff | a second retarget |
+
+Retarget and restore run on the shared engine in
+[`bulk-apply.ts`](../../packages/piece/src/ops/bulk-apply.ts), each supplying
+one write step. Repair runs its own pass over the same survey selection,
+because its rows are classified from a document rather than from a reference.
+
+## The plan artifact
+
+A plan is one header line and one row per piece, encoded as line-oriented
+JSON, and **line order is execution order** — the ordering constraint sits in
+the artifact a reviewer reads rather than in a shell history nothing can
+check.
+
+The header records the space every row's piece lives in, when the survey was
+taken, which selector produced the rows, and the enumeration the selection was
+cross-checked by: the number of pieces selected, the number the piece registry
+lists, and the number of registered in-scope pieces the selection lacks.
+Optional `problems` and `outside` lists name what the survey could not account
+for, so an incomplete survey rides the artifact rather than encoding as a
+clean one.
+
+A row carries the piece's canonical bare address, an optional `phase` label,
+the `expect` record the operation requires, and — once an operation is chosen
+— the `op` that performs it. `expect` holds the pattern identity the piece is
+on, the export symbol that identity runs, whether that source is verifiably
+retained in the space, the current source revision when the piece keeps a log,
+and the stored document's hash when a repair recorded one. An `op` is a
+retarget (a local source, the identity it produces, the symbol, and a per-row
+compatibility override), a restore (the reference to return to, and the
+revision when one was read), or a repair (the fixer's name and the content
+identity of its authored closure).
+
+`normalizePlan` is the one validator the decoder and every executor share, so
+an in-memory plan handed straight to a run receives exactly the scrutiny a
+decoded file receives. It refuses:
+
+- a first line that is not a `piece-plan` v1 header;
+- a header whose `registeredOutside` count disagrees with its `outside` list,
+  which is what keeps deleting the list from laundering an incomplete plan
+  into a complete one;
+- a plan listing one piece twice, the `of:` alias and the bare spelling
+  folding to one key before the check;
+- a reference row whose `op` pair equals its `expect` pair, which no diff
+  could tell landed from never-ran;
+- a retarget row whose `symbol` disagrees with its source's requested export,
+  or whose requested export is the empty string — the resolver drops a falsy
+  export and runs the default, so such a row would execute something its own
+  text does not say;
+- a repair row without a document hash, or a repair `op` without a fixer
+  identity: without either, nothing about the row can be checked.
+
+A retarget row's `rev` is a label for readers and for diffing two plans. It is
+never enforced. The pin is the identity, recomputed at the write.
+
+## What a survey reads, and what it refuses
+
+A collection selector names a holder piece and the path to a collection inside
+its stored input (or its result, when asked), and emits the members in stored
+order with the holder last under the phase `holder`. Children first, parent
+last is the selector's property rather than a step an operator performs. A
+list selector names pieces outright, under the phase `list`.
+
+The survey refuses, rather than surveying a subset silently: an empty
+collection path or an empty segment; a holder that stores nothing at the path,
+since a misspelled path and a never-written collection read identically; a
+value at the path that is not an array; a member slot that holds no piece
+link, named by its position; a collection whose last path segment is `holder`,
+which would share a phase label with the holder's own row; and a piece
+selected twice.
+
+Per piece it takes one synced read for the source pin and never runs the
+piece, plus one retained-source load per distinct identity, cached across the
+run — bare document existence would be cheaper and would lie, since a
+malformed entry document exists while nothing can restore from it. A supplied
+validator adds a second read per piece. Every read is live: a survey taken
+after a change reflects the change, with no snapshot to invalidate.
+
+The registry is read once, serving both the header count and the containment
+check, so the two can never describe different enumerations. Every registered
+piece the selection does not hold is read for its reference; one on an
+in-scope `{identity, symbol}` pair is reported as outside the selection, which
+is a stop and is recorded in the header. A list survey claims no containment
+and is not cross-checked.
+
+An operation supplied to the survey is keyed by phase and stamped onto that
+phase's rows. A phase no selected row carries is refused rather than dropped,
+because an operation resolved from disk and then silently discarded leaves a
+pre-state record the operator believes is a retarget plan. A piece already on
+the operation's reference gets no `op` at all: such a row would be
+unverifiable, and it stays a pre-state record.
+
+A validator is a JSON schema each piece's result is read under, and it names
+the pieces that fail it. The read uses ordinary read semantics, so a field a
+schema default rescues passes here exactly as it would for the holder. A
+validator failure is a finding, not an incompleteness: it does not make the
+plan incomplete and does not stop a later stage.
+
+## Classification, resume, and the stop
+
+Every comparison is on the full executable reference, `{identity, symbol}`.
+Two patterns exported by one module share an identity and differ only in
+symbol, so an identity-only match would call a retarget landed before it ran.
+
+One read of a piece classifies it against its row three ways: **landed** (on
+the pair the `op` produces), **outstanding** (on the pair `expect` records), or
+**moved-elsewhere** (on neither — nothing in the plan accounts for where it
+is).
+
+A run begins with a preflight: every row classified from one read, before the
+first write. A row that is moved-elsewhere, or that cannot be read at all,
+keeps the run from starting — every row reports where it stands, and nothing
+is applied. The serial pass then proves each row again in the session that
+writes it, the preflight's verdict deciding nothing there: a row proved landed
+is reported without a write, and a row another writer moved since preflight is
+caught by the same read that would have skipped it.
+
+Resume is therefore re-invocation of the same command, not a mode. It costs
+one read per piece, is decided before any write, and rewrites nothing that
+landed. What it may claim is bounded: a piece on the reference its row
+produces is known to have moved as planned, and is not thereby known to be
+healthy.
+
+A stop is designed rather than incidental. Every piece that landed keeps its
+change; the run stops at the first refusal, failure, or mid-run move; and
+every remaining row is reported by name as `unattempted`, never as a count. A
+report's verdicts are:
+
+| verdict | meaning |
+| --- | --- |
+| `landed` | already on the pair the row's operation produces |
+| `outstanding` | still on the pair the row recorded; on a dry run, not a defect |
+| `applied` | this run performed the row's operation |
+| `moved-elsewhere` | on neither pair; the run stops or never starts |
+| `refused` | the row must not apply, and nothing was written |
+| `failed` | an operational failure, state-checked after the fact |
+| `unattempted` | untouched, after a stop or a session that never opened |
+
+An operational failure is classified by a state check made *after* it, never
+by a wall-clock probe before it: a server slow to answer here may still be
+completing its writes, so a probe that gave up on one would abort a run that
+was working. The row's problem text says where the failure left the piece: on
+the target reference, still on its recorded one, on neither, or unreadable.
+
+A row's `problem` and its `warning` are different facts. A `problem` belongs
+to a row that did not apply. A `warning` belongs to a row that **did** —
+the source was saved and something after it complained — so a warned row is
+still complete, and the warning rides the report rather than a console nobody
+keeps.
+
+`complete` is true when every row reached what the run was for and no session
+boundary failed: under an apply, every row landed or applied; on a dry run,
+every row landed or outstanding. `stopReason` carries the run's own trouble as
+distinct from any piece's — a session that would not open, would not release,
+or opened onto another space — and its presence makes `complete` false
+whatever the rows say.
+
+Before any read, a run refuses: a plan whose header names pieces the survey
+did not account for; a plan carrying rows of another operation's kind, one run
+applying one kind; a plan with no rows of this kind, since an empty run reads
+as a completed one; and a group size that is not a positive integer.
+
+## The safety model
+
+Each refusal below fires at a named moment, and the moment is the point.
+
+**Selection, at the survey.** A registered in-scope piece the collection lacks
+stops the survey and is named. A run over a silent subset reports success over
+what it enumerated and leaves the rest behind with nothing recording that they
+were missed.
+
+**Reversibility, before the first write.** A retarget row whose prior source
+is not retained names a piece that cannot be returned once it moves. Under an
+apply, every such row must be accepted by name or the run refuses and names
+the ones that were not. Acceptance is per piece, with deliberately no blanket
+form: one flag covering every row would turn many decisions into one, a
+different risk from the same decision taken many times. An acceptance covering
+no unretained row of the plan is itself refused, because accounting for none
+looks exactly like accounting for one. A dry run is not gated — it moves
+nothing, and reporting where such a piece stands is how an operator learns
+there is something to decide.
+
+**Reversibility, at the derivation.** The rollback derivation holds the same
+rows to the same rule, in the same spelling: an unretained row is refused by
+name, and naming it as accepted leaves it out of the reversal. Asking after
+the forward run has already moved the piece is asking past the point of no
+return, which is why the gate exists at both moments rather than only at the
+one where the restore is missing.
+
+**The source's identity, at the write.** A retarget resolves its row's source
+from disk immediately before writing, recomputes the identity that source
+produces — without compiling it — and refuses the row when it differs from
+what the row recorded. A different checkout, an uncommitted edit, or a renamed
+export cannot slip through. No separate export check is needed: the codec
+refuses a row whose symbol disagrees with its source's requested export, and
+the resolver echoes that request, so a decoded row's symbol is the export the
+program runs by construction.
+
+**Compatibility, per row.** The override is a field on the row, stamped across
+a run at plan time and honored by the apply from the row and nowhere else. One
+operator decision, as a per-run flag would be — but the plan shows exactly
+which rows ran with the gate open, a reviewer can strip it from rows that
+should not, and the record afterwards is per row. A restore carries no
+override at all: getting one piece back over a compatibility refusal means
+retargeting it onto that source, where the row-level override already lives.
+
+**The space, at every session.** A piece address names a piece within a space,
+so the same address names a different piece elsewhere. The plan's space is
+held against the preflight session's and against every group's. A mismatch at
+preflight refuses the run outright; a mismatch later stops it with the
+remainder named, the rows untouched.
+
+**The reference, inside the transaction.** The engine's read can only
+classify; a writer landing between the classification and the write is
+invisible to it. So the reference the recheck proved is handed to the write as
+its own precondition — `expectedPattern` on the runtime's source-change and
+source-set calls — and that snapshot becomes the transition's precondition,
+checked again inside the transaction that commits it. A piece something else
+moved is refused by name and the row stops the run; it is never overwritten.
+The pin is a precondition and nothing else: it confirms no compatibility
+review and opens no gate the row's own override does not.
+
+**Session boundaries, once outcomes exist.** A session that cannot be opened
+leaves its group unattempted, its state known rather than unknown. A session
+that cannot be released after its group's writes committed stops the run with
+those rows standing. Neither is any piece's fault, so both are reported as the
+run's `stopReason` and never thrown away — the rows a partial migration
+produced are exactly what its operator needs.
+
+## The fixer contract
+
+A fixer is a TypeScript module the run imports, whose default export is a pure
+transform from a piece's stored input document to the document it should hold.
+The tooling owns selection, ordering, the write, the stop, and resume; the
+fixer owns only what the change is.
+
+The fixer is its own predicate, which collapses three questions into one
+mechanism: selection is the pieces it would change, resume is the pieces it no
+longer changes, and verification is re-asking it over the stored result. None
+of the three can drift from what the fixer does, because they are what the
+fixer does — and that is why purity is part of the contract rather than a
+style preference. Each evaluation therefore runs the fixer twice over
+independent copies of the document and refuses an answer that differs.
+
+The write is the wide one — the whole input document replaced — made safe by
+refusals rather than by narrowing. An evaluation is refused when the fixer
+throws, when it returns something that is not a document, when it returns a
+document the store cannot hold (a function, an accessor, or a class instance
+anywhere in it), when the answer is not pure, when the answer drops a field
+the input held at any depth, or when it rewrites or drops a sigil link the
+input carried. A document that lost fields the fixer never mentioned is a
+defect, not an intent, and a reference rewritten as a value is corrupted while
+a dropped one is destroyed.
+
+Each row's evaluation and write happen in one transaction, so on a commit
+conflict the closure re-runs against fresh state and the report describes the
+evaluation that committed. A supplied plan's recorded document hash is
+rechecked inside that same transaction: a row whose stored document still
+needs the repair but no longer hashes to what the plan recorded is `moved` — a
+stop, not an overwrite — while a row the fixer no longer changes is landed,
+whatever it hashes to now. After a write the document is read back and the
+fixer asked again, and a stored document that does not satisfy the fixer fails
+the row and stops the run. A repaired row's reported changes are measured
+between the stored documents rather than restated from the fixer's answer,
+since the write path hydrates schema defaults and an addition the report never
+mentioned is how a repair quietly widens.
+
+Repair's selection is the survey's, not a plan's. A supplied plan must agree
+with that selection exactly — same space, same fixer name, same pieces — and a
+disagreement regenerates the plan rather than reconciling silently. The fixer
+pin is held before the module is imported, because a dynamic import runs
+top-level code and an implementation the plan's reviewer never saw must not
+run even that much. On a collection selector the holder's own row is not
+repaired: a fixer is typed against the members' document shape, and a holder
+wanting repair is a one-piece list selection of its own.
+
+## Rollback and single-piece restore
+
+A rollback is derived from the retarget plan row by row, with no second
+artifact and nothing re-surveyed: each row's precondition becomes the
+reference the retarget produced, and its operation restores the retained
+revision carrying the reference the row recorded. Survey-only and restore rows
+are left out, a repair row is refused by name — its reversal is an inverse
+fixer nothing can derive — and a derivation that would produce no rows at all
+is refused, because an empty rollback reads as having one.
+
+The reversal is the runtime's own operation rather than a second retarget.
+Every source update appends a revision retaining the exact source closure it
+ran, and a piece with no log yet gets a baseline from the retarget itself,
+provided the source it was on is still retained. That is why a rollback row
+names the recorded reference rather than a revision the survey could not have
+read, and why a rollback needs no filesystem: it runs from what the space
+retains, which is what makes it the reversal available during an incident.
+
+Resolving a reference to a revision is shared by the bulk rollback and the
+single-piece restore, so the two cannot disagree about which revision a
+reference names or whether it can be restored at all. A recorded revision id
+must exist in the piece's log *and* carry the recorded reference; without one,
+the reference selects the most recent revision carrying it. A revision whose
+source is no longer retained is not a restore target, however it was selected.
+
+Restoring severs the origin the piece follows. So a piece is already where a
+restore would leave it only when it runs the revision's reference **and**
+follows no origin; a piece that runs the reference while still following an
+origin is written, and the run names the origin it cuts. A compatibility
+verdict against the piece as it now stands is a refusal naming the piece and
+the reason, and an argument the restored source cannot use at all is the
+runtime's hard refusal, which arrives as an operational failure instead. Both
+stop the run; they differ only in the verdict the row carries.
+
+## Verification is a separate pass
+
+An apply that exits zero is not a verdict. The verification of a reference
+operation is the survey diff: a survey taken afterwards, held against the plan
+the run was made from, as a separate invocation.
+
+Each planned row lands in one of three outcomes — moved as planned, still
+outstanding, or moved to something the plan did not ask for, the third being
+what an upgrade that half-converged looks like. A row that carries no
+operation is a pre-state record and diffs to unchanged or changed. Pieces the
+after-survey holds and the plan does not are reported as unplanned rather than
+dropped, so a selection that grew mid-run stays visible.
+
+The diff refuses three comparisons outright: a plan carrying repair rows,
+since a repair moves the document and not the reference and a reference diff
+would report unchanged about work it cannot see; two plans from different
+spaces, where matching addresses would read as landed while saying nothing
+about either space; and an incomplete side, whose unaccounted pieces would
+read as clean rather than as unknown.
+
+A repair's verification is its own: re-asking the fixer, row by row after each
+write inside the run, and as a whole-set dry run over the same selection
+afterwards. One that comes back all-conforming is the verification an operator
+runs on its own.
+
+## Sessions, groups, and cost
+
+Sessions are grouped: one session serves a bounded number of pieces and is
+then released, so the expensive warm-up is paid once per group while the
+pieces live at once stay bounded by the group size rather than by the length
+of the run. The size is a knob with a default of twenty-five, not a constant
+in the code. A group boundary is therefore a resume point — a run that dies
+inside a group loses at most that group's warm-up, because every landed row
+reads as landed on the next invocation.
+
+Serial order is a correctness constraint and not a limitation to optimize
+away: a parent recomputing over children mid-change is the failure the
+ordering exists to prevent. Whether siblings may be applied concurrently is
+open, and it is gated on measurement.
+
+That measurement is why every row an apply session began work on reports its
+own wall-clock cost. A row reclassified as landed, moved, or refused paid for
+the reads and resolution that reclassified it and reports that cost as an
+applied row reports its write; a preflight classification and an unattempted
+row report none, neither having been worked on. The cost rides each row rather
+than a run summary, so it is in hand while there is still a run to reason
+about — a run whose cost per piece is unknown cannot be improved.
+
+## What the drill guarantees
+
+[`bulk-survey-drill.sh`](../../packages/cli/integration/bulk-survey-drill.sh)
+runs in continuous integration under the CLI integration suite's `piece-call`
+section, against a fresh space with no prior state and no store access. It
+deploys a checked-in fixture pair — a trimmed prior-generation member pattern
+and a current one, with the board holding them — so it reds when bulk
+operations break rather than when a real pattern changes. A change that breaks
+this surface breaks the drill, which is what makes "does the migration tooling
+still work?" a CI result rather than an expedition.
+
+It holds, among the rest: a board-sized collection surveyed in one process;
+the header's enumeration and containment; members in order with the holder
+last, and the retarget stamp on member rows alone; the single-piece pin
+agreeing with the holder's row; a survey reflecting a change made since the
+last one; a repair run dry, applied from its own plan, resumed as all-landed
+writing nothing, and a field-dropping fixer refused by name; a retarget dry
+run writing nothing; an edited source refused with every unattempted piece
+named; an unretained move refused until accepted by name; a completed plan
+re-running without writes; a piece on neither of its row's references stopping
+the run by name; the after-survey telling the three outcomes apart; a
+registered in-scope orphan making the survey refuse; a list survey claiming no
+containment; a rollback derived from the retarget's own plan and putting the
+board back where the plan found it; and one piece returned on its own to a
+revision of its own log.
+
+Interruption is exercised rather than left to production, for both the
+retarget and the rollback, because it is the property most likely to rot
+silently. The drill reads the report's streamed rows, kills the run inside its
+second group — past one group boundary — and completes it by re-invoking the
+same command. The interruption itself is proved twice over: the killed run's
+exit status must be a signal death, and a read-only pass between the two
+invocations must find real work on both sides of the cut. A run that had
+finished on its own would satisfy every assertion about the second invocation
+while exercising none of what the step is for. A repair stopped midway — by a
+row whose fixed document the schema refuses — is completed the same way, by
+re-invoking with an amended fixer, and the rows that landed are not rewritten.
+
+[`bulk-ops-demo.sh`](../../packages/cli/integration/bulk-ops-demo.sh) shows the
+same surface live: it narrates each command and then runs it, and each act
+re-parses its own displayed line and compares the words against the argv that
+ran, so a line a reader retypes is the line that executed. Run it against any
+host:
+
+```bash
+API_URL=http://localhost:8000 packages/cli/integration/bulk-ops-demo.sh
+```
+
+## Where the code lives
+
+Under [`packages/piece/src/ops/`](../../packages/piece/src/ops/):
+
+- [`bulk-plan.ts`](../../packages/piece/src/ops/bulk-plan.ts) — the plan's
+  types, its codec and shared validator, the acceptance rule for unretained
+  rows, and the rollback derivation
+- [`bulk-survey.ts`](../../packages/piece/src/ops/bulk-survey.ts) — the
+  selectors, the per-piece pin read, the containment check, the validator
+  pass, and the tally
+- [`bulk-apply.ts`](../../packages/piece/src/ops/bulk-apply.ts) — the shared
+  engine: classification, preflight, grouped sessions, the stop, and the
+  report
+- [`bulk-retarget.deno.ts`](../../packages/piece/src/ops/bulk-retarget.deno.ts)
+  — the retarget's write step
+- [`bulk-local.deno.ts`](../../packages/piece/src/ops/bulk-local.deno.ts) —
+  resolving a row's source from disk and computing the identity it produces
+  without compiling it
+- [`bulk-rollback.ts`](../../packages/piece/src/ops/bulk-rollback.ts) — the
+  restore write step the reversal runs on
+- [`bulk-repair.ts`](../../packages/piece/src/ops/bulk-repair.ts) — the fixer
+  contract, its guards, and the transactional apply
+- [`bulk-diff.ts`](../../packages/piece/src/ops/bulk-diff.ts) — the survey
+  diff
+- [`piece-restore.ts`](../../packages/piece/src/ops/piece-restore.ts) —
+  reading a piece's restorable revisions and resolving a reference to one
+
+## Where to read further
+
+- [`docs/plans/piece-bulk-operations.md`](../plans/piece-bulk-operations.md) —
+  the design and build sequence, including the stage that is still gated on
+  measurement
+- [`docs/specs/piece-source-lifecycle.md`](../specs/piece-source-lifecycle.md)
+  — the append-only revision log a piece keeps and the restore built on it
+- [`packages/cli/README.md`](../../packages/cli/README.md) — the commands,
+  their flags, and the reference forms their selections take
+- [`space-clone-rehearsal.md`](../development/space-clone-rehearsal.md) — the
+  procedure for rehearsing a run against a writable copy of a real space

--- a/docs/plans/piece-bulk-operations.md
+++ b/docs/plans/piece-bulk-operations.md
@@ -716,6 +716,18 @@ first, and because it is the only stage gated on measurement.
 - [ ] A failure under the shared session degrades to the same stop report,
       with the same remainder named.
 
+### Documentation
+
+The stages deliver behavior; this is what states it outside the plan, so that
+archiving the plan does not take the description of a live feature with it.
+
+- [x] A feature document —
+      [bulk piece operations](../features/piece-bulk-operations.md) — carries
+      the spine, the plan artifact's semantics, the safety model with the
+      moment each refusal fires, the drill's standing guarantees, and the
+      session and timing contracts, and stands alone once this plan is
+      archived. Command and flag detail stays in `packages/cli/README.md`.
+
 ## The drill
 
 Every stage above is finished by a drill that runs in continuous integration


### PR DESCRIPTION
## Why

The bulk-operations family (stages 1–4, last landed in #6345) is essentially invisible: its command prose lives in `packages/cli/README.md` sections a reader must already know to look for, and its only concept-level description is `docs/plans/piece-bulk-operations.md` — a plan, due to archive to `docs/history/` when the arc closes. Nothing under `docs/` states the feature's guarantees where the features index would surface them. Mike asked for a documentation plan with this first pass slotted before the Topics rehearsal, so the rehearsal's operators have a reference that exists.

Coordinated with the in-flight #6370 (b11): that branch carries the *tour* of this family (`docs/common/workflows/bulk-operations.md`, act-by-act against the demo); this document is the *reference* — the same tour-versus-reference split the verbs tree documents for itself. The two state the family's three core ideas at different depths on purpose; this one carries no narrative, no command flags, and no migration procedure (those belong to the tour, the CLI README, and `space-clone-rehearsal.md` respectively). No link to the tour yet — it is unmerged; #6370 adds the cross-link when it rebases over this.

## What Changed

- `docs/features/piece-bulk-operations.md` (new, 471 lines): the contract — the spine and which operation applies what; the plan artifact's fields and its codec refusals; survey selection and its refusals; classification, resume, and stop semantics; the safety model as seven refusal moments ordered by when they fire; the fixer contract; rollback and restore including origin severing; verification as a separate pass; grouped sessions and the timing contract; what the drill guarantees in CI; a module map.
- `docs/features/README.md`: index entry.
- `docs/plans/piece-bulk-operations.md`: a Documentation subsection with this first pass ticked, so the doc is a tracked deliverable.

Claims deliberately not made, because they could not be verified against code: the plan's past server-latency measurement, a content-export reversal path for repair (no such wiring exists — the table says "nothing derivable"), and the grouped-session cost arithmetic stage 5 exists to measure.

## Test plan

`check-docs` (568 blocks), `check-skill-facts`, `docs-links --orphan` (no orphans), `check-docs-history-index`, `check-conflict-markers`, `check-verb-session-sync` all pass; all 16 relative link targets resolve. Prose-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

