### PR TITLE
fix(runner): settle a builtin whose staged request is abandoned

### DIFF
--- a/docs/features/committed-write-backpressure.md
+++ b/docs/features/committed-write-backpressure.md
@@ -216,8 +216,10 @@ every attempt re-subscribes so the action recovers when its inputs next change.
 Whichever way a run ends, the moment the scheduler stops attempting a commit is
 the moment it calls `abandonStagedWork` on that transaction. Every stop does
 so, on both paths: a permanent or terminal rejection, an exhausted retry
-budget, an exhausted name resolution, a handler that threw, a caller that opted
-out of retrying, and a seal that was refused. Work staged there
+budget, an exhausted name resolution, a handler that threw, and a caller that
+opted out of retrying. A refused late seal is the one refusal that is not a
+stop: the durable entry is still the truth and the drain delivers it, so a
+further attempt is coming and the staged work is waiting for something. Work staged there
 and waiting for the commit hears it as its effect's `abandon`.
 That decision is the scheduler's, because the number of attempts is not a
 property of the rejection. A CFC refusal whose every reason is a verdict on the

--- a/docs/features/committed-write-backpressure.md
+++ b/docs/features/committed-write-backpressure.md
@@ -212,6 +212,30 @@ conflict whose triggering write was already delivered.) A conflict there is a
 wait for catch-up, not a failure, and consumes no budget. Only non-conflict
 transient errors fall back to the bounded `MAX_RETRIES_FOR_REACTIVE` retry, and
 every attempt re-subscribes so the action recovers when its inputs next change.
+
+Whichever way a run ends, the moment the scheduler stops attempting a commit is
+the moment it calls `abandonStagedWork` on that transaction. Every stop does
+so, on both paths: a permanent or terminal rejection, an exhausted retry
+budget, an exhausted name resolution, a handler that threw, a caller that opted
+out of retrying, and a seal that was refused. Work staged there
+and waiting for the commit hears it as its effect's `abandon`.
+That decision is the scheduler's, because the number of attempts is not a
+property of the rejection. A CFC refusal whose every reason is a verdict on the
+committed data arrives as a terminal class and stops on the first attempt; a
+refusal naming something prepare could not evaluate keeps the retryable class,
+because the attempt that reads it decides differently. Either way the builtin
+waiting on the commit sees a rejection and cannot tell how many follow it, and a
+builtin that guesses either reports an error for work that is about to happen or
+waits forever for work that will not.
+
+A write CFC enforcement refused and nothing will retry is reported through
+`reportDroppedCfcRejectedWrite`, on the reactive path as well as the event path,
+so it is visible rather than dropped in silence. A builtin that staged a request
+on the abandoned transaction settles its result with the error through the
+`onRejected` hook of `enqueueSinkRequestPostCommitEffect`; without that its
+request is staged but never sent, and its result stays pending with nothing
+coming. Every builtin that stages a sink request passes the hook, and `sqlite*` gives
+its effect an `abandon` directly, since it enqueues that effect by hand.
 The backpressure rework targets the event-handler path instead, where a one-shot
 write *is* the user's intent and cannot be re-derived from inputs, so a conflict
 must be actively retried rather than recovered by re-derivation.

--- a/docs/specs/server-side-execution/builtins.md
+++ b/docs/specs/server-side-execution/builtins.md
@@ -37,6 +37,27 @@ hit ⇒ stored result is the value; miss ⇒ outbox; result + key in one
 derived commit; error results advance the same way; in-flight dedupe by
 key; client speculation reads through (speculation.md §2).
 
+A request reaches the outbox only if the commit that staged it succeeds. A
+rejected commit clears the outbox, so nothing is sent and no receipt stands for
+a request that never ran, and the action is attempted again. When the scheduler
+stops attempting it, the transaction is abandoned and the builtin settles its
+result with the refusal as its error, recording the request hash so the same
+request is not staged afresh. `enqueueSinkRequestPostCommitEffect` carries that
+as its `onRejected` hook, and every builtin on this table settles through it:
+`llm` and its two siblings, `fetch`, `fetch-program`, `llm-dialog` and
+`stream-data`. `sqlite*` reaches the same ending without the seam, giving its
+effect an `abandon` directly, because it enqueues that effect by hand rather
+than as a sink request.
+
+The settled shape differs by builtin, and each writes what its own result
+surface reads: an error beside a pending flag for `fetch` and `stream-data`, an
+`error` cache entry for `fetch-program`, a settled `QueryState` for `sqlite*`.
+`llm-dialog` is the one that settles by leaving the conversation alone: the
+turn's user message, pending flag and request id all rode the abandoned
+transaction, so an assistant error message would answer a turn no reader can
+see. It takes the pending flag down and re-announces, and the refusal is
+reported rather than written into the conversation.
+
 | built-in | request inputs (memo key basis) | result cell | authority | notes |
 | --- | --- | --- | --- | --- |
 | `fetch` (`fetchData`) | url, method, headers (allowlisted), body, response schema | `{ result?, error?, pending, requestHash }` — today the hash lives in an internal cell `{requestId, lastActivity, inputHash}` (`fetch.ts:427-472`); the "migrate it onto the result doc" move was DEFERRED at stage G (deliberate): the internal-cell hash is functionally equivalent committed state (T10.Q1 — §4's memo rule reads it the same), and the migration is an OFF-arm cell-shape change, so it waits for an OFF-arm ruling batch that wants it (plausibly never) | capability handle bound at wiring (README §3.8) | redirects/deadlines per existing `fetch-request-deadlines` doc; today's outbox id `` `${kind.name}:${inputHash}` `` is the memo+outbox-dedupe precedent |

--- a/docs/specs/server-side-execution/runtime-mapping.md
+++ b/docs/specs/server-side-execution/runtime-mapping.md
@@ -51,9 +51,9 @@ Status legend:
 | --- | --- | --- | --- | --- |
 | 14 | `RetryImmediately`: abort + immediate re-run after `inSpace("name")` DID resolution | `scheduler/retry-immediately.ts:11`, `runner.ts:4933-4943`, event path `scheduler/events.ts:955-983` | protocol §2b (provisioning kept) | COVERED |
 | 15 | Reactive stale-basis retry: off-budget re-queue on conflict / local inconsistency, `readyToRetry` catch-up | `scheduler/run.ts:122-214` | serving-loop §3d (mid-wave CAS drop) | CHANGED |
-| 16 | Bounded retry for non-conflict reactive failures (MAX_RETRIES_FOR_REACTIVE = 10) | `scheduler/run.ts:239-253`, `scheduler/constants.ts:40` | serving-loop §3d (per-action failure isolation) | COVERED |
+| 16 | Bounded retry for non-conflict reactive failures (MAX_RETRIES_FOR_REACTIVE = 10); the permanent and terminal classes take no attempt, and every stop — including an exhausted name-resolution retry — abandons the transaction's staged work | `scheduler/run.ts` (`abandonAction`), `scheduler/constants.ts:40`, `storage/extended-storage-transaction.ts` (`abandonStagedWork`) | serving-loop §3d (per-action failure isolation) | COVERED |
 | 17 | Event-commit backpressure: capped exponential backoff window, `CommitConvergenceError`, disposition classes (permanent / terminal / give-up / backoff) | `scheduler/backpressure.ts:22-57`, `scheduler/events.ts:1096-1210`, `events.ts:1335-1387` | events §5 partially | CHANGED |
-| 18 | CFC-rejected-write loud drop | `scheduler/events.ts:63-75` | serving-loop §3c (named explicitly) | COVERED |
+| 18 | CFC-rejected-write loud drop, on the event path and the reactive-action path alike | `scheduler/cfc-rejection-report.ts`, called from `scheduler/events.ts` and `scheduler/run.ts` | serving-loop §3c (named explicitly) | COVERED |
 
 ### 1c. Events and handlers
 

--- a/packages/runner/src/builtins/abandoned-request.ts
+++ b/packages/runner/src/builtins/abandoned-request.ts
@@ -16,29 +16,23 @@ const logger = getLogger("builtins", { enabled: true, level: "warn" });
  * error — and announces those cells again, because the announcement rode the
  * abandoned transaction and a reader has nothing to look at without it.
  *
- * One transaction for both, attributed to the builtin, and carrying the served
- * effect's completion key where there is one: a writeback that names neither is
- * refused under the serving posture, which would leave the pattern pointing at
- * nothing — the state this exists to prevent.
+ * One transaction for both, attributed to the builtin and carrying the served
+ * effect's completion key: a writeback naming neither is refused under the
+ * serving posture, which would leave the pattern pointing at nothing — the
+ * state this exists to prevent. Every request staged on the outbox has such a
+ * key, so it is required rather than defaulted.
  */
 export async function settleAbandonedRequest(
   runtime: Runtime,
   builtinId: string,
-  effectKey: string | undefined,
+  effectKey: string,
   write: (tx: IExtendedStorageTransaction) => void,
 ): Promise<void> {
   const { error } = await runtime.editWithRetry((tx) => {
     if (runtime.cfcEnforcementMode !== "disabled") {
       tx.setCfcImplementationIdentity({ kind: "builtin", builtinId });
     }
-    if (effectKey !== undefined) {
-      markEffectCompletion(tx, effectKey);
-    } else {
-      runtime.stampServerRun(tx, {
-        actionId: `${builtinId}/abandoned`,
-        kind: "bookkeeping",
-      });
-    }
+    markEffectCompletion(tx, effectKey);
     write(tx);
   });
   if (error) {

--- a/packages/runner/src/builtins/abandoned-request.ts
+++ b/packages/runner/src/builtins/abandoned-request.ts
@@ -1,0 +1,55 @@
+import { getLogger } from "@commonfabric/utils/logger";
+
+import { markEffectCompletion } from "../executor/effect-completion.ts";
+import type { Runtime } from "../runtime.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+
+const logger = getLogger("builtins", { enabled: true, level: "warn" });
+
+/**
+ * Write the ending of a request whose staging transaction was abandoned.
+ *
+ * A builtin stages its request in the transaction that schedules the work and
+ * does the work once that transaction commits, so an abandoned one means the
+ * request will never be sent and nothing else will say so. `write` puts that on
+ * the builtin's own result cells — the pending flag down, the refusal as the
+ * error — and announces those cells again, because the announcement rode the
+ * abandoned transaction and a reader has nothing to look at without it.
+ *
+ * One transaction for both, attributed to the builtin, and carrying the served
+ * effect's completion key where there is one: a writeback that names neither is
+ * refused under the serving posture, which would leave the pattern pointing at
+ * nothing — the state this exists to prevent.
+ */
+export async function settleAbandonedRequest(
+  runtime: Runtime,
+  builtinId: string,
+  effectKey: string | undefined,
+  write: (tx: IExtendedStorageTransaction) => void,
+): Promise<void> {
+  const { error } = await runtime.editWithRetry((tx) => {
+    if (runtime.cfcEnforcementMode !== "disabled") {
+      tx.setCfcImplementationIdentity({ kind: "builtin", builtinId });
+    }
+    if (effectKey !== undefined) {
+      markEffectCompletion(tx, effectKey);
+    } else {
+      runtime.stampServerRun(tx, {
+        actionId: `${builtinId}/abandoned`,
+        kind: "bookkeeping",
+      });
+    }
+    write(tx);
+  });
+  if (error) {
+    // The ending had nowhere to land, so a reader of these cells sees
+    // something other than this failure. Report it here, since nothing
+    // downstream can.
+    console.error(
+      `[${builtinId}] Writing the abandoned request's error to its result ` +
+        `cells was rejected.`,
+      { rejection: error.message },
+    );
+    logger.warn("builtins", "abandoned-request writeback rejected", { error });
+  }
+}

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -384,13 +384,27 @@ export function fetchProgram(
                 (settleTx) => {
                   // The claim this run staged rode the abandoned transaction,
                   // so the entry reads `idle` and a reader waits on a fetch
-                  // nobody is running. Record the refusal in its place.
+                  // nobody is running. Record the refusal in its place — but
+                  // read the entry at write time first: a later request for
+                  // the same inputs claims it or answers it, and that state is
+                  // the newer request's, not this one's to overwrite.
+                  const entry = cache.withTx(settleTx).get()?.[inputHash];
+                  if (entry !== undefined && entry.state.type !== "idle") {
+                    return;
+                  }
                   cache.withTx(settleTx).update({
                     [inputHash]: {
                       inputHash,
                       state: { type: "error", message: rejection.message },
                     },
                   });
+                  // A run derives these from the entry above and announces
+                  // them at its end. No run follows this one, so the ending
+                  // does both itself.
+                  sendResult(settleTx, { pending, result, error });
+                  pending.withTx(settleTx).set(false);
+                  result.withTx(settleTx).set(undefined);
+                  error.withTx(settleTx).set(rejection.message);
                 },
               ),
               parentCell,

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -5,6 +5,7 @@ import type { CellScope } from "../builder/types.ts";
 import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { settleAbandonedRequest } from "./abandoned-request.ts";
 import {
   effectTargetKey,
   markEffectCompletion,
@@ -372,7 +373,30 @@ export function fetchProgram(
             parentCell,
           );
         },
-        { idempotencyKey: effectKey },
+        {
+          idempotencyKey: effectKey,
+          onRejected: (rejection) => {
+            runtime.trackAsyncWork(
+              settleAbandonedRequest(
+                runtime,
+                "fetchProgram",
+                effectKey,
+                (settleTx) => {
+                  // The claim this run staged rode the abandoned transaction,
+                  // so the entry reads `idle` and a reader waits on a fetch
+                  // nobody is running. Record the refusal in its place.
+                  cache.withTx(settleTx).update({
+                    [inputHash]: {
+                      inputHash,
+                      state: { type: "error", message: rejection.message },
+                    },
+                  });
+                },
+              ),
+              parentCell,
+            );
+          },
+        },
       );
     }
 

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -13,6 +13,7 @@ import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { validateAgainstSchema } from "../cfc/schema-sanitization.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { settleAbandonedRequest } from "./abandoned-request.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
 import type { Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
@@ -595,7 +596,25 @@ function fetchBuiltin(kind: FetchKind) {
             );
             runtime.trackAsyncWork(work, parentCell);
           },
-          { idempotencyKey: effectKey },
+          {
+            idempotencyKey: effectKey,
+            onRejected: (rejection) => {
+              runtime.trackAsyncWork(
+                settleAbandonedRequest(
+                  runtime,
+                  kind.name,
+                  effectKey,
+                  (settleTx) => {
+                    sendResult(settleTx, { pending, result, error });
+                    pending.withTx(settleTx).set(false);
+                    result.withTx(settleTx).set(undefined);
+                    error.withTx(settleTx).set(rejection.message);
+                  },
+                ),
+                parentCell,
+              );
+            },
+          },
         );
       }
     };

--- a/packages/runner/src/builtins/fetch.ts
+++ b/packages/runner/src/builtins/fetch.ts
@@ -605,7 +605,20 @@ function fetchBuiltin(kind: FetchKind) {
                   kind.name,
                   effectKey,
                   (settleTx) => {
+                    // The announcement rode the abandoned transaction, so it
+                    // is made again whoever owns the answer now.
                     sendResult(settleTx, { pending, result, error });
+                    // Decided here rather than when this callback ran: a newer
+                    // request can start in between and claim these cells, and
+                    // its claim id is what says so.
+                    const claim = internal.withTx(settleTx).key("requestId")
+                      .get();
+                    if (
+                      claim !== undefined && claim !== "" &&
+                      claim !== newRequestId
+                    ) {
+                      return;
+                    }
                     pending.withTx(settleTx).set(false);
                     result.withTx(settleTx).set(undefined);
                     error.withTx(settleTx).set(rejection.message);

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -67,6 +67,7 @@ import {
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { settleAbandonedRequest } from "./abandoned-request.ts";
 import { markEffectCompletion } from "../executor/effect-completion.ts";
 import { createTrustResolver } from "../cfc/trust.ts";
 import {
@@ -3583,6 +3584,31 @@ export function llmDialog(
                 }),
                 parentCell,
               );
+            },
+            {
+              onRejected: (rejection) => {
+                // The turn is not in the conversation: the user's message, the
+                // pending flag and the request id all rode the transaction
+                // that was abandoned, so appending an assistant error message
+                // here would answer a turn no reader can see. What is left to
+                // do is put the announcement back, since it rode that
+                // transaction too, and take the pending flag down so nothing
+                // waits on a turn that will not run. The seam reports the
+                // refusal itself.
+                if (requestId !== nextRequestId) return;
+                runtime.trackAsyncWork(
+                  settleAbandonedRequest(
+                    runtime,
+                    "llmDialog",
+                    `llmDialog:${nextRequestId}`,
+                    (settleTx) => {
+                      sendResult(settleTx, result);
+                      pending.withTx(settleTx).set(false);
+                    },
+                  ),
+                  parentCell,
+                );
+              },
             },
           );
         },

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -3586,7 +3586,7 @@ export function llmDialog(
               );
             },
             {
-              onRejected: (rejection) => {
+              onRejected: () => {
                 // The turn is not in the conversation: the user's message, the
                 // pending flag and the request id all rode the transaction
                 // that was abandoned, so appending an assistant error message
@@ -3595,14 +3595,23 @@ export function llmDialog(
                 // transaction too, and take the pending flag down so nothing
                 // waits on a turn that will not run. The seam reports the
                 // refusal itself.
-                if (requestId !== nextRequestId) return;
                 runtime.trackAsyncWork(
                   settleAbandonedRequest(
                     runtime,
                     "llmDialog",
                     `llmDialog:${nextRequestId}`,
                     (settleTx) => {
+                      // The announcement rode the abandoned transaction, so it
+                      // is made again whoever owns the turn now.
                       sendResult(settleTx, result);
+                      // Decided here rather than when this callback ran: a
+                      // newer turn can start in between, and taking its
+                      // pending flag down would report it as finished.
+                      const claim = internal.withTx(settleTx).key("requestId")
+                        .get();
+                      if (claim !== undefined && claim !== nextRequestId) {
+                        return;
+                      }
                       pending.withTx(settleTx).set(false);
                     },
                   ),

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -507,23 +507,27 @@ async function handleLLMError<T, P>(
    * make it again. */
   announce?: (tx: IExtendedStorageTransaction) => void,
 ): Promise<void> {
-  const superseded = thisRun !== getCurrentRun();
-  if (superseded && announce === undefined) return;
+  if (thisRun !== getCurrentRun() && announce === undefined) return;
 
   const message = error instanceof Error ? error.message : String(error);
-  if (!superseded) {
+  if (thisRun === getCurrentRun()) {
     console.warn(`[LLM Error] ${message}`);
     logger.warn("llm", "Error in LLM request", { error });
   }
 
   await runtime.idle();
 
+  let wrote = false;
   const { error: writeError } = await runtime.editWithRetry((tx) => {
     if (effectKey !== undefined) markEffectCompletion(tx, effectKey);
     announce?.(tx);
-    // A newer request owns the answer, so only the announcement above is
-    // this run's to make.
-    if (superseded) return;
+    // Read at write time rather than from a decision taken before the wait
+    // above: a newer request can start while this one waits for the
+    // scheduler, and from then on the answer is that request's to give. The
+    // announcement still stands, because it says where the answer appears and
+    // is the same either way.
+    if (thisRun !== getCurrentRun()) return;
+    wrote = true;
     pendingCell.withTx(tx).set(false);
     errorCell.withTx(tx).set(message);
     resultCell.withTx(tx).set(undefined as T);
@@ -540,7 +544,7 @@ async function handleLLMError<T, P>(
     );
   }
 
-  if (superseded) return;
+  if (!wrote) return;
   resetPreviousHash();
 }
 
@@ -888,6 +892,11 @@ export function llm(
         effectKey,
       );
 
+    // This request's own result cell. A later run that finds a different output
+    // scope builds a new one and leaves this variable pointing at that, so the
+    // ending below has to write the cell this request announced.
+    const requestResultCell = resultCell;
+
     // The abandoned request's ending. It carries the announcement because the
     // one this run made rode the transaction that was abandoned, and the
     // `cellsInitialized` latch means no later run makes it again.
@@ -895,11 +904,11 @@ export function llm(
       handleLLMError(
         error,
         runtime,
-        resultCell.key("pending"),
-        resultCell.key("result"),
-        resultCell.key("error"),
-        resultCell.key("partial"),
-        resultCell.key("requestHash"),
+        requestResultCell.key("pending"),
+        requestResultCell.key("result"),
+        requestResultCell.key("error"),
+        requestResultCell.key("partial"),
+        requestResultCell.key("requestHash"),
         hash,
         () => currentRun,
         thisRun,
@@ -907,7 +916,7 @@ export function llm(
           if (hash === previousCallHash) previousCallHash = undefined;
         },
         effectKey,
-        (announceTx) => sendResult(announceTx, resultCell),
+        (announceTx) => sendResult(announceTx, requestResultCell),
       );
 
     // Build tool catalog if tools are present, then start execution after the
@@ -1295,6 +1304,11 @@ export function generateText(
         effectKey,
       );
 
+    // This request's own result cell. A later run that finds a different output
+    // scope builds a new one and leaves this variable pointing at that, so the
+    // ending below has to write the cell this request announced.
+    const requestResultCell = resultCell;
+
     // The abandoned request's ending. It carries the announcement because the
     // one this run made rode the transaction that was abandoned, and the
     // `cellsInitialized` latch means no later run makes it again.
@@ -1302,11 +1316,11 @@ export function generateText(
       handleLLMError(
         error,
         runtime,
-        resultCell.key("pending"),
-        resultCell.key("result"),
-        resultCell.key("error"),
-        resultCell.key("partial"),
-        resultCell.key("requestHash"),
+        requestResultCell.key("pending"),
+        requestResultCell.key("result"),
+        requestResultCell.key("error"),
+        requestResultCell.key("partial"),
+        requestResultCell.key("requestHash"),
         hash,
         () => currentRun,
         thisRun,
@@ -1314,7 +1328,7 @@ export function generateText(
           if (hash === previousCallHash) previousCallHash = undefined;
         },
         effectKey,
-        (announceTx) => sendResult(announceTx, resultCell),
+        (announceTx) => sendResult(announceTx, requestResultCell),
       );
 
     enqueuePostCommitLLMWork(
@@ -1763,6 +1777,12 @@ export function generateObject<T extends Record<string, unknown>>(
         );
       };
 
+      // This request's own result cell. A later run that finds a different
+      // output scope builds a new one and leaves this variable pointing at
+      // that, so the ending below has to write the cell this request
+      // announced.
+      const requestResultCell = resultCell;
+
       // The abandoned request's ending. It carries the announcement because
       // the one this run made rode the transaction that was abandoned, and the
       // `cellsInitialized` latch means no later run makes it again.
@@ -1770,11 +1790,11 @@ export function generateObject<T extends Record<string, unknown>>(
         handleLLMError(
           error,
           runtime,
-          resultCell.key("pending"),
-          resultCell.key("result"),
-          resultCell.key("error"),
-          resultCell.key("partial"),
-          resultCell.key("requestHash"),
+          requestResultCell.key("pending"),
+          requestResultCell.key("result"),
+          requestResultCell.key("error"),
+          requestResultCell.key("partial"),
+          requestResultCell.key("requestHash"),
           hash,
           () => currentRun,
           thisRun,
@@ -1782,7 +1802,7 @@ export function generateObject<T extends Record<string, unknown>>(
             previousCallHash = undefined;
           },
           effectKey,
-          (announceTx) => sendResult(announceTx, resultCell),
+          (announceTx) => sendResult(announceTx, requestResultCell),
         );
 
       logGenerateObject("enqueue", toolsRequestSummary);
@@ -2159,6 +2179,12 @@ export function generateObject<T extends Record<string, unknown>>(
         );
       };
 
+      // This request's own result cell. A later run that finds a different
+      // output scope builds a new one and leaves this variable pointing at
+      // that, so the ending below has to write the cell this request
+      // announced.
+      const requestResultCell = resultCell;
+
       // The abandoned request's ending. It carries the announcement because
       // the one this run made rode the transaction that was abandoned, and the
       // `cellsInitialized` latch means no later run makes it again.
@@ -2166,11 +2192,11 @@ export function generateObject<T extends Record<string, unknown>>(
         handleLLMError(
           error,
           runtime,
-          resultCell.key("pending"),
-          resultCell.key("result"),
-          resultCell.key("error"),
-          resultCell.key("partial"),
-          resultCell.key("requestHash"),
+          requestResultCell.key("pending"),
+          requestResultCell.key("result"),
+          requestResultCell.key("error"),
+          requestResultCell.key("partial"),
+          requestResultCell.key("requestHash"),
           hash,
           () => currentRun,
           thisRun,
@@ -2178,7 +2204,7 @@ export function generateObject<T extends Record<string, unknown>>(
             previousCallHash = undefined;
           },
           effectKey,
-          (announceTx) => sendResult(announceTx, resultCell),
+          (announceTx) => sendResult(announceTx, requestResultCell),
         );
 
       logGenerateObject("enqueue", directRequestSummary);

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -469,6 +469,16 @@ async function executeWithToolsLoop(params: {
 }
 
 /**
+ * Announce the builtin's result cell again, in a transaction of its own.
+ *
+ * The announcement rides the same transaction as the request it belongs to, so
+ * a refused request takes the announcement with it and the pattern is left
+ * pointing at nothing — including at the error the refusal is about to record.
+ * Writing it again puts the result cell back where a reader looks for it. The
+ * value is the one the refused transaction carried, so on the runs that kept
+ * their announcement this writes what is already there.
+ */
+/**
  * Common error handler for LLM requests.
  * Resets state and allows retry on next invocation.
  */
@@ -490,24 +500,47 @@ async function handleLLMError<T, P>(
    * (server-execution v2 stage G, serving-loop.md §4's error-shaped
    * results); inert everywhere else. */
   effectKey?: string,
+  /** Announces the builtin's result cell, for the caller whose announcement
+   * rode a transaction that was abandoned. It runs whether or not a newer
+   * request has taken over, because the announcement says where the answer
+   * appears and is the same either way, and the run that took over will not
+   * make it again. */
+  announce?: (tx: IExtendedStorageTransaction) => void,
 ): Promise<void> {
-  if (thisRun !== getCurrentRun()) return;
+  const superseded = thisRun !== getCurrentRun();
+  if (superseded && announce === undefined) return;
 
   const message = error instanceof Error ? error.message : String(error);
-  console.warn(`[LLM Error] ${message}`);
-  logger.warn("llm", "Error in LLM request", { error });
+  if (!superseded) {
+    console.warn(`[LLM Error] ${message}`);
+    logger.warn("llm", "Error in LLM request", { error });
+  }
 
   await runtime.idle();
 
-  await runtime.editWithRetry((tx) => {
+  const { error: writeError } = await runtime.editWithRetry((tx) => {
     if (effectKey !== undefined) markEffectCompletion(tx, effectKey);
+    announce?.(tx);
+    // A newer request owns the answer, so only the announcement above is
+    // this run's to make.
+    if (superseded) return;
     pendingCell.withTx(tx).set(false);
     errorCell.withTx(tx).set(message);
     resultCell.withTx(tx).set(undefined as T);
     partialCell.withTx(tx).set(undefined as P);
     requestHashCell.withTx(tx).set(requestHash);
   });
+  if (writeError) {
+    // The error had nowhere to land, so a reader of this result cell sees
+    // something other than this failure. Report it here, since nothing
+    // downstream can.
+    console.error(
+      "[LLM] Writing the request's error to its result cell was rejected.",
+      { requestHash, cause: message, rejection: writeError.message },
+    );
+  }
 
+  if (superseded) return;
   resetPreviousHash();
 }
 
@@ -575,6 +608,18 @@ function buildContextDocumentation(
     );
 }
 
+/**
+ * Start `start` once the transaction staging this request commits, and call
+ * `onRefused` instead when the commit is rejected in a way that re-running
+ * cannot resolve. A refused request never reaches the model, so the builtin
+ * settles on the refusal rather than leaving `pending` true forever.
+ *
+ * The settled error is recorded against the request hash, so this request is
+ * over and the builtin waits for a different one. A refusal that turns on
+ * something other than the request — the ceiling its result store declares,
+ * say — outlives the change that resolves it, because that change leaves the
+ * hash where it was. Editing the pattern is what moves it.
+ */
 function enqueuePostCommitLLMWork(
   tx: IExtendedStorageTransaction,
   sink: string,
@@ -586,6 +631,7 @@ function enqueuePostCommitLLMWork(
   kind: string,
   request: any,
   start: () => void,
+  onRefused: (error: Error) => void,
 ): void {
   enqueueSinkRequestPostCommitEffect(
     tx,
@@ -596,7 +642,7 @@ function enqueuePostCommitLLMWork(
     () => {
       start();
     },
-    { idempotencyKey },
+    { idempotencyKey, onRejected: onRefused },
   );
 }
 
@@ -818,9 +864,54 @@ export function llm(
         thisRun,
       );
 
+    const effectKey = effectTargetKey(`llm:${hash}`, resultCell);
+
+    // The one way this request ends badly, whether the model call failed or the
+    // request never went out at all.
+    const settleWithError = (error: unknown) =>
+      handleLLMError(
+        error,
+        runtime,
+        resultCell.key("pending"),
+        resultCell.key("result"),
+        resultCell.key("error"),
+        resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
+        getRunForCancellation,
+        thisRun,
+        () => {
+          // Only clear if this is still the current request; a newer request
+          // may have already set previousCallHash to its own hash.
+          if (hash === previousCallHash) previousCallHash = undefined;
+        },
+        effectKey,
+      );
+
+    // The abandoned request's ending. It carries the announcement because the
+    // one this run made rode the transaction that was abandoned, and the
+    // `cellsInitialized` latch means no later run makes it again.
+    const settleAbandoned = (error: unknown) =>
+      handleLLMError(
+        error,
+        runtime,
+        resultCell.key("pending"),
+        resultCell.key("result"),
+        resultCell.key("error"),
+        resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
+        () => currentRun,
+        thisRun,
+        () => {
+          if (hash === previousCallHash) previousCallHash = undefined;
+        },
+        effectKey,
+        (announceTx) => sendResult(announceTx, resultCell),
+      );
+
     // Build tool catalog if tools are present, then start execution after the
     // transaction commits.
-    const effectKey = effectTargetKey(`llm:${hash}`, resultCell);
     enqueuePostCommitLLMWork(
       tx,
       "llm",
@@ -907,28 +998,13 @@ export function llm(
         // `runtime.settledFor(parentCell)` both wait for the result to land;
         // `idle()` does not, so the handler never blocks on the LLM call.
         runtime.trackAsyncWork(
-          resultPromise.catch((e) =>
-            handleLLMError(
-              e,
-              runtime,
-              resultCell.key("pending"),
-              resultCell.key("result"),
-              resultCell.key("error"),
-              resultCell.key("partial"),
-              resultCell.key("requestHash"),
-              hash,
-              getRunForCancellation,
-              thisRun,
-              () => {
-                // Only clear if this is still the current request; a newer request
-                // may have already set previousCallHash to its own hash.
-                if (hash === previousCallHash) previousCallHash = undefined;
-              },
-              effectKey,
-            )
-          ),
+          resultPromise.catch(settleWithError),
           parentCell,
         );
+      },
+      (error) => {
+        cleanupPartial();
+        runtime.trackAsyncWork(settleAbandoned(error), parentCell);
       },
     );
   };
@@ -1196,6 +1272,51 @@ export function generateText(
       );
 
     const effectKey = effectTargetKey(`generateText:${hash}`, resultCell);
+
+    // The one way this request ends badly, whether the model call failed or the
+    // request never went out at all.
+    const settleWithError = (error: unknown) =>
+      handleLLMError(
+        error,
+        runtime,
+        resultCell.key("pending"),
+        resultCell.key("result"),
+        resultCell.key("error"),
+        resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
+        getRunForCancellation,
+        thisRun,
+        () => {
+          // Only clear if this is still the current request; a newer request
+          // may have already set previousCallHash to its own hash.
+          if (hash === previousCallHash) previousCallHash = undefined;
+        },
+        effectKey,
+      );
+
+    // The abandoned request's ending. It carries the announcement because the
+    // one this run made rode the transaction that was abandoned, and the
+    // `cellsInitialized` latch means no later run makes it again.
+    const settleAbandoned = (error: unknown) =>
+      handleLLMError(
+        error,
+        runtime,
+        resultCell.key("pending"),
+        resultCell.key("result"),
+        resultCell.key("error"),
+        resultCell.key("partial"),
+        resultCell.key("requestHash"),
+        hash,
+        () => currentRun,
+        thisRun,
+        () => {
+          if (hash === previousCallHash) previousCallHash = undefined;
+        },
+        effectKey,
+        (announceTx) => sendResult(announceTx, resultCell),
+      );
+
     enqueuePostCommitLLMWork(
       tx,
       "generateText",
@@ -1277,28 +1398,13 @@ export function generateText(
         // `runtime.settledFor(parentCell)` both wait for the result to land;
         // `idle()` does not, so the handler never blocks on the LLM call.
         runtime.trackAsyncWork(
-          resultPromise.catch((e) =>
-            handleLLMError(
-              e,
-              runtime,
-              resultCell.key("pending"),
-              resultCell.key("result"),
-              resultCell.key("error"),
-              resultCell.key("partial"),
-              resultCell.key("requestHash"),
-              hash,
-              getRunForCancellation,
-              thisRun,
-              () => {
-                // Only clear if this is still the current request; a newer request
-                // may have already set previousCallHash to its own hash.
-                if (hash === previousCallHash) previousCallHash = undefined;
-              },
-              effectKey,
-            )
-          ),
+          resultPromise.catch(settleWithError),
           parentCell,
         );
+      },
+      (error) => {
+        cleanupPartial();
+        runtime.trackAsyncWork(settleAbandoned(error), parentCell);
       },
     );
   };
@@ -1632,6 +1738,53 @@ export function generateObject<T extends Record<string, unknown>>(
         ? () => false
         : () => thisRun !== currentRun;
 
+      // The one way this request ends badly, whether the tools loop failed or
+      // the request never went out at all.
+      const settleWithError = (error: unknown) => {
+        logGenerateObject("error", {
+          ...toolsRequestSummary,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return handleLLMError(
+          error,
+          runtime,
+          resultCell.key("pending"),
+          resultCell.key("result"),
+          resultCell.key("error"),
+          resultCell.key("partial"),
+          resultCell.key("requestHash"),
+          hash,
+          queueName ? () => thisRun : () => currentRun,
+          thisRun,
+          () => {
+            previousCallHash = undefined;
+          },
+          effectKey,
+        );
+      };
+
+      // The abandoned request's ending. It carries the announcement because
+      // the one this run made rode the transaction that was abandoned, and the
+      // `cellsInitialized` latch means no later run makes it again.
+      const settleAbandoned = (error: unknown) =>
+        handleLLMError(
+          error,
+          runtime,
+          resultCell.key("pending"),
+          resultCell.key("result"),
+          resultCell.key("error"),
+          resultCell.key("partial"),
+          resultCell.key("requestHash"),
+          hash,
+          () => currentRun,
+          thisRun,
+          () => {
+            previousCallHash = undefined;
+          },
+          effectKey,
+          (announceTx) => sendResult(announceTx, resultCell),
+        );
+
       logGenerateObject("enqueue", toolsRequestSummary);
 
       enqueuePostCommitLLMWork(
@@ -1868,30 +2021,13 @@ export function generateObject<T extends Record<string, unknown>>(
           // both span it; `idle()` does not, so the handler never blocks on the
           // LLM call.
           runtime.trackAsyncWork(
-            resultPromise.catch((e) => {
-              logGenerateObject("error", {
-                ...toolsRequestSummary,
-                error: e instanceof Error ? e.message : String(e),
-              });
-              return handleLLMError(
-                e,
-                runtime,
-                resultCell.key("pending"),
-                resultCell.key("result"),
-                resultCell.key("error"),
-                resultCell.key("partial"),
-                resultCell.key("requestHash"),
-                hash,
-                queueName ? () => thisRun : () => currentRun,
-                thisRun,
-                () => {
-                  previousCallHash = undefined;
-                },
-                effectKey,
-              );
-            }),
+            resultPromise.catch(settleWithError),
             parentCell,
           );
+        },
+        (error) => {
+          cleanupPartial();
+          runtime.trackAsyncWork(settleAbandoned(error), parentCell);
         },
       );
     } else {
@@ -1997,6 +2133,53 @@ export function generateObject<T extends Record<string, unknown>>(
       const isRunCancelled = queueName
         ? () => false
         : () => thisRun !== currentRun;
+
+      // The one way this request ends badly, whether the model call failed or
+      // the request never went out at all.
+      const settleWithError = (error: unknown) => {
+        logGenerateObject("error", {
+          ...directRequestSummary,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return handleLLMError(
+          error,
+          runtime,
+          resultCell.key("pending"),
+          resultCell.key("result"),
+          resultCell.key("error"),
+          resultCell.key("partial"),
+          resultCell.key("requestHash"),
+          hash,
+          queueName ? () => thisRun : () => currentRun,
+          thisRun,
+          () => {
+            previousCallHash = undefined;
+          },
+          effectKey,
+        );
+      };
+
+      // The abandoned request's ending. It carries the announcement because
+      // the one this run made rode the transaction that was abandoned, and the
+      // `cellsInitialized` latch means no later run makes it again.
+      const settleAbandoned = (error: unknown) =>
+        handleLLMError(
+          error,
+          runtime,
+          resultCell.key("pending"),
+          resultCell.key("result"),
+          resultCell.key("error"),
+          resultCell.key("partial"),
+          resultCell.key("requestHash"),
+          hash,
+          () => currentRun,
+          thisRun,
+          () => {
+            previousCallHash = undefined;
+          },
+          effectKey,
+          (announceTx) => sendResult(announceTx, resultCell),
+        );
 
       logGenerateObject("enqueue", directRequestSummary);
 
@@ -2137,30 +2320,12 @@ export function generateObject<T extends Record<string, unknown>>(
                 });
                 logGenerateObject("write-complete", directRequestSummary);
               })
-              .catch((e) => {
-                logGenerateObject("error", {
-                  ...directRequestSummary,
-                  error: e instanceof Error ? e.message : String(e),
-                });
-                return handleLLMError(
-                  e,
-                  runtime,
-                  resultCell.key("pending"),
-                  resultCell.key("result"),
-                  resultCell.key("error"),
-                  resultCell.key("partial"),
-                  resultCell.key("requestHash"),
-                  hash,
-                  queueName ? () => thisRun : () => currentRun,
-                  thisRun,
-                  () => {
-                    previousCallHash = undefined;
-                  },
-                  effectKey,
-                );
-              }),
+              .catch(settleWithError),
             parentCell,
           );
+        },
+        (error) => {
+          runtime.trackAsyncWork(settleAbandoned(error), parentCell);
         },
       );
     }

--- a/packages/runner/src/builtins/navigate-to.ts
+++ b/packages/runner/src/builtins/navigate-to.ts
@@ -404,6 +404,10 @@ export function navigateTo(
         ])
       }`,
       kind: "navigateTo",
+      // No `abandon`: nothing waits on a result cell here, and the `navigated`
+      // flag is restored by the commit callback above, so a later attempt
+      // navigates. An effect whose work simply does not happen has nothing to
+      // record.
       // The convergence key (protocol.md §5): the overlay destination
       // BEGINS it on the effects channel before this flush's callback
       // runs, and the channel acks the authoritative intent without

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -899,6 +899,15 @@ export function sqliteQuery(
             effectKey,
             (settleTx) => {
               sendResult(settleTx, result);
+              // Read the stored claim at write time: a newer request commits
+              // its own hash, and from then on the result is that request's
+              // to write, exactly as `failQuery` decides it.
+              const stored = result.withTx(settleTx).get();
+              if (
+                stored?.requestHash !== undefined && stored.requestHash !== hash
+              ) {
+                return;
+              }
               result.withTx(settleTx).set({
                 pending: false,
                 error: (rejection as { message?: string })?.message,

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -21,6 +21,7 @@
 
 import type { CfcAtom } from "@commonfabric/api/cfc";
 import { parseLink } from "../link-utils.ts";
+import { settleAbandonedRequest } from "./abandoned-request.ts";
 import {
   computeRowLabelRead,
   resolveCeilingPlaceholders,
@@ -886,6 +887,33 @@ export function sqliteQuery(
       id: `sqliteQuery:${hash}`,
       idempotencyKey: effectKey,
       kind: "sqlite-query",
+      // The claim above rides this transaction, and so does this effect. When
+      // the scheduler stops attempting the commit neither landed and no read
+      // is coming, so a reader of the claim would wait on a query nobody is
+      // running.
+      abandon: (rejection) => {
+        runtime.trackAsyncWork(
+          settleAbandonedRequest(
+            runtime,
+            "sqliteQuery",
+            effectKey,
+            (settleTx) => {
+              sendResult(settleTx, result);
+              result.withTx(settleTx).set({
+                pending: false,
+                error: (rejection as { message?: string })?.message,
+                requestHash: hash,
+              });
+            },
+          ),
+          parentCell,
+        );
+      },
+      // The flush awaits the query and its writeback, so the transaction's own
+      // commit promise spans them and the scheduler registers that promise for
+      // every commit carrying post-commit effects. Nothing here is handed to
+      // `trackAsyncWork` for that reason; the abandonment settle above is
+      // separate work with its own completion, and is registered.
       async flush() {
         inFlightIssues.add(hash);
         // The requesting RUN's identity, applied to every writeback

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -262,14 +262,19 @@ export function streamData(
       {
         idempotencyKey: effectKey,
         onRejected: (rejection) => {
-          if (thisRun !== status.run) return;
           runtime.trackAsyncWork(
             settleAbandonedRequest(
               runtime,
               "streamData",
               effectKey,
               (settleTx) => {
+                // The announcement rode the abandoned transaction, so it is
+                // made again whoever owns the answer now.
                 sendResult(settleTx, { pending, result, error });
+                // Decided here rather than when this callback ran: a newer
+                // request can start in between, and the stream it opens owns
+                // these cells from then on.
+                if (thisRun !== status.run) return;
                 pending.withTx(settleTx).set(false);
                 result.withTx(settleTx).set(undefined);
                 error.withTx(settleTx).set(rejection.message);

--- a/packages/runner/src/builtins/stream-data.ts
+++ b/packages/runner/src/builtins/stream-data.ts
@@ -5,6 +5,8 @@ import type { CellScope } from "../builder/types.ts";
 import { type Cell } from "../cell.ts";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
+import { effectTargetKey } from "../executor/effect-completion.ts";
+import { settleAbandonedRequest } from "./abandoned-request.ts";
 import { setPatternCell, setResultCell } from "../result-utils.ts";
 import type { Runtime } from "../runtime.ts";
 import { type Action } from "../scheduler.ts";
@@ -152,6 +154,11 @@ export function streamData(
 
     const thisRun = ++status.run;
     const requestId = hashOf(requestSnapshot).toString();
+    // The outbox key is the request widened by THIS node's result-cell
+    // identity, so two distinct nodes streaming the same url each keep their
+    // own effect and their own ending, rather than sharing one under the bare
+    // request id.
+    const effectKey = effectTargetKey(`streamData:${requestId}`, result);
 
     enqueueSinkRequestPostCommitEffect(
       tx,
@@ -159,6 +166,10 @@ export function streamData(
       `streamData:${requestId}`,
       requestSnapshot,
       "streamData-start",
+      // The read loop below lives until the stream ends or is aborted, so it
+      // is not handed to `trackAsyncWork`: a barrier waiting on it would never
+      // return while a stream is connected. The abandonment settle below is
+      // separate work with its own completion, and is registered.
       () => {
         if (thisRun !== status.run) {
           return;
@@ -247,6 +258,26 @@ export function streamData(
             // Allow retrying the same request.
             previousCall = "";
           });
+      },
+      {
+        idempotencyKey: effectKey,
+        onRejected: (rejection) => {
+          if (thisRun !== status.run) return;
+          runtime.trackAsyncWork(
+            settleAbandonedRequest(
+              runtime,
+              "streamData",
+              effectKey,
+              (settleTx) => {
+                sendResult(settleTx, { pending, result, error });
+                pending.withTx(settleTx).set(false);
+                result.withTx(settleTx).set(undefined);
+                error.withTx(settleTx).set(rejection.message);
+              },
+            ),
+            parentCell,
+          );
+        },
       },
     );
   };

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -88,23 +88,6 @@ export function verifySinkRequestRelease(
 }
 
 /**
- * The keys each transaction has already registered an abandon callback under.
- *
- * Keyed by the INNER transaction, the one the outbox and the callback
- * registries live on, because a caller may hand this function a wrapper around
- * it. Two stagings that reach the same inner transaction share one outbox
- * entry, so they share one abandonment; keyed by the wrapper they would each
- * register, and one refusal would be reported twice.
- */
-const abandonCallbackKeys = new WeakMap<object, Set<string>>();
-
-/** The inner transaction a wrapper forwards to, or the transaction itself. */
-function transactionIdentity(tx: object): object {
-  const inner = (tx as { tx?: object }).tx;
-  return inner ?? tx;
-}
-
-/**
  * Stage a sink request on `tx` and run `flush` once that transaction commits.
  *
  * The work happens after the commit because the request's own state — the

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -87,6 +87,55 @@ export function verifySinkRequestRelease(
   return undefined;
 }
 
+/**
+ * The keys each transaction has already registered an abandon callback under.
+ *
+ * Keyed by the INNER transaction, the one the outbox and the callback
+ * registries live on, because a caller may hand this function a wrapper around
+ * it. Two stagings that reach the same inner transaction share one outbox
+ * entry, so they share one abandonment; keyed by the wrapper they would each
+ * register, and one refusal would be reported twice.
+ */
+const abandonCallbackKeys = new WeakMap<object, Set<string>>();
+
+/** The inner transaction a wrapper forwards to, or the transaction itself. */
+function transactionIdentity(tx: object): object {
+  const inner = (tx as { tx?: object }).tx;
+  return inner ?? tx;
+}
+
+/**
+ * Stage a sink request on `tx` and run `flush` once that transaction commits.
+ *
+ * The work happens after the commit because the request's own state — the
+ * pending flag, the request hash a later run recognizes — has to be durable
+ * before anything is sent. So the commit failing means the work never starts.
+ * Usually that is right: the action runs again, stages the request again, and
+ * a later attempt sends it. When the code that owns those attempts stops
+ * making them, the caller is left with a request that was staged, never sent,
+ * and never answered. `onRejected` is where a caller settles that. It is
+ * called once, when the transaction is abandoned, and never on a rejection
+ * another attempt still follows — the scheduler decides which is which, since
+ * no rejection says so on its own.
+ *
+ * What it is handed says the request was refused and names the sink, and stops
+ * there. A caller records that error where a pattern reads it, and the refusal
+ * detail — the document the rule named, the confidentiality atoms that did not
+ * fit, and with them the `source` of each caveat, the principal that introduced
+ * it — is precisely what the pattern-facing surface withholds (inv-12 / audit
+ * 28b, the rule `redactCaveatSourcesForDisplay` applies to label views). It
+ * would be a strange bargain to refuse the write and then hand its reason to
+ * the writer. The detail travels on `cause` and to the log below, both of which
+ * face the operator. A deployment that wants a pattern to read some of the
+ * reason declassifies the fields it chooses through an error exchange rule,
+ * which names each field and the confidentiality it is released to.
+ *
+ * A rejected request has no receipt and no partial send. The refusal happens
+ * before the transaction reaches storage, which clears the post-commit outbox,
+ * so `flush` — and with it the release check below that would mint one — never
+ * runs. `onRejected` reports what did not happen; it must not write anything
+ * that stands for a completed request.
+ */
 export function enqueueSinkRequestPostCommitEffect(
   tx: Pick<
     IExtendedStorageTransaction,
@@ -106,13 +155,33 @@ export function enqueueSinkRequestPostCommitEffect(
      * its cells pending forever (the stage-G round-2 headline). The
      * CFC policy-input `effectId` stays unscoped either way. */
     idempotencyKey?: string;
+    /** Called once, with an error naming the refusal, when the transaction
+     * staging this request is abandoned — no further attempt at it is
+     * coming, so the request will never be sent. */
+    onRejected?: (error: Error) => void;
   },
 ): void {
   const policyInput = createSinkRequestPolicyInput(sink, effectId, request);
   tx.recordCfcWritePolicyInput(policyInput);
+  const onRejected = options?.onRejected;
   tx.enqueuePostCommitEffect({
     id: effectId,
     idempotencyKey: options?.idempotencyKey ?? effectId,
+    // The other half of this effect's outcome. The outbox drops a second
+    // effect staged under a key it is already holding, and drops this with it,
+    // so one request is abandoned once however many times it is staged.
+    abandon: onRejected === undefined ? undefined : (error) => {
+      console.error(
+        `[cfc] ${kind} was abandoned before it started; the request is not ` +
+          `sent.`,
+        { sink, effectId, rejection: (error as { message?: string })?.message },
+      );
+      onRejected(
+        new Error(`${sink} request was refused before it started`, {
+          cause: error,
+        }),
+      );
+    },
     kind,
     flush: async (committedTx) => {
       const reason = verifySinkRequestRelease(

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -545,6 +545,17 @@ export type PostCommitSideEffect = {
    * on it instead of re-enacting (T2.Q7). Absent everywhere else. */
   nonce?: string;
   flush(tx: unknown): void | Promise<void>;
+  /**
+   * Called instead of {@link flush} when the work this effect stands for will
+   * not happen: the transaction carrying it was rejected and whoever owns its
+   * retries has stopped. Exactly one of the two runs, so this is where a
+   * builtin ends a request that was staged and never sent.
+   *
+   * Not called when the effect is handed to a seal destination, which runs it
+   * elsewhere — that clears the outbox too, and it is a handover rather than
+   * an ending.
+   */
+  abandon?(error: unknown): void;
 };
 
 export type CfcPrepareState =

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -116,6 +116,7 @@ import {
   schedulerDependencyRead,
 } from "./storage/reactivity-log.ts";
 import {
+  isCfcEnforcementRejection,
   isConflictRejection,
   isStaleReadConflict,
   isStorageTransactionInconsistent,
@@ -1683,7 +1684,7 @@ export class Runner {
           if (
             (error.name === "CfcCommitRefusalError" ||
               error.name === "StorageTransactionAborted") &&
-            error.message.startsWith("CFC enforcement rejected commit")
+            isCfcEnforcementRejection(error)
           ) {
             // The two rejections carry their diagnostic differently: the
             // boundary refusal carries every prepare reason as `reasons`,

--- a/packages/runner/src/scheduler/cfc-rejection-report.ts
+++ b/packages/runner/src/scheduler/cfc-rejection-report.ts
@@ -1,0 +1,45 @@
+/**
+ * Whether a commit error is CFC enforcement's DETERMINISTIC pre-storage
+ * rejection (`rejectCommitBeforeStorage` in extended-storage-transaction.ts):
+ * every reason behind it is a verdict on the committed data, so re-running
+ * recomputes the identical refused write. The served give-up arm and
+ * {@link reportDroppedCfcRejectedWrite} key on this one predicate, so the
+ * sealed error consequence and the loss report cover exactly the same class.
+ *
+ * The class is the test, not the message. A refusal naming something prepare
+ * could not evaluate keeps the retryable name and carries the same message
+ * prefix, and reporting that one as a dropped write would name a write a later
+ * attempt still lands.
+ */
+export function isCfcRejectedCommitError(
+  error: { name?: string; message?: string } | undefined,
+): error is { name: "CfcCommitRefusalError"; message: string } {
+  return error?.name === "CfcCommitRefusalError" &&
+    typeof error.message === "string";
+}
+
+/**
+ * Report a write that CFC enforcement refused and that nothing will retry.
+ *
+ * The refusal is a deterministic verdict on the committed data, so the write
+ * never lands however many times the code that made it runs again. Both commit
+ * paths — the event handler path in events.ts and the reactive action path in
+ * run.ts — stop on one, and stopping without a word loses whatever the write
+ * carried. Report through `console.error` rather than the scheduler logger,
+ * which is opt-in and disabled in deployed workers; the logger call each caller
+ * makes alongside carries the rest of the disposition.
+ *
+ * `writerId` names the code whose write was refused: a handler id on the event
+ * path, an action id on the reactive path.
+ */
+export function reportDroppedCfcRejectedWrite(
+  error: { name?: string; message?: string } | undefined,
+  writerId: unknown,
+): void {
+  if (!isCfcRejectedCommitError(error)) return;
+  console.error(
+    "[cfc] Owner-protected write dropped: CFC enforcement rejected the " +
+      "commit and re-running cannot resolve it.",
+    { error: error.message, writerId },
+  );
+}

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -10,6 +10,7 @@ import {
 import type { Runtime } from "../runtime.ts";
 import type { ScopeKeyIdentity } from "@commonfabric/memory/v2";
 import type {
+  CommitError,
   IExtendedStorageTransaction,
   IPreconditionFailedError,
   MemorySpace,
@@ -42,6 +43,10 @@ import {
   txToReactivityLog,
 } from "./reactivity.ts";
 import {
+  isCfcRejectedCommitError,
+  reportDroppedCfcRejectedWrite,
+} from "./cfc-rejection-report.ts";
+import {
   type Action,
   type EventHandler,
   type EventPreflightTraceContext,
@@ -62,6 +67,20 @@ type EventCommitError = {
   readonly message: string;
   readonly precondition?: IPreconditionFailedError["precondition"];
 };
+
+/**
+ * The error handed to work staged on an event's transaction when the event ends
+ * without a commit verdict at all — the handler threw, the caller opted out of
+ * retrying, or the seal was refused. There is no rejection to pass on in those
+ * cases, and the staged work needs to hear that none is coming.
+ */
+function eventAbandonError(reason: string): CommitError {
+  return {
+    name: "StorageTransactionAborted",
+    message: `event abandoned before it committed: ${reason}`,
+    reason: new Error(reason),
+  } as CommitError;
+}
 
 function normalizeEventCommitRejection(reason: unknown): EventCommitError {
   if (reason instanceof Error) {
@@ -85,42 +104,6 @@ function normalizeEventCommitRejection(reason: unknown): EventCommitError {
     reason
       ? String(reason)
       : "Storage commit promise rejected without a reason",
-  );
-}
-
-/**
- * Whether a commit error is CFC enforcement's DETERMINISTIC pre-storage
- * rejection (`rejectCommitBeforeStorage` in extended-storage-transaction.ts):
- * the transaction was refused before it reached storage, and re-running
- * recomputes the identical refused write. The served give-up arm and
- * {@link reportDroppedCfcRejectedWrite} key on this one predicate, so the
- * sealed error consequence and the loss report cover exactly the same class.
- */
-export function isCfcRejectedCommitError(
-  error: { name?: string; message?: string } | undefined,
-): error is { name: "CfcCommitRefusalError"; message: string } {
-  return error?.name === "CfcCommitRefusalError" &&
-    typeof error.message === "string";
-}
-
-/**
- * A CFC-enforcement-rejected commit on a give-up disposition is silent data
- * loss of user intent — the UI's write simply never lands (labs#4772 shipped
- * that way for weeks behind the opt-in scheduler logger, which is disabled in
- * deployed workers). Report it unconditionally; the opt-in `logger.warn`
- * alongside still carries the full disposition detail.
- */
-export function reportDroppedCfcRejectedWrite(
-  error: { name?: string; message?: string } | undefined,
-  handlerId: unknown,
-): void {
-  if (!isCfcRejectedCommitError(error)) {
-    return;
-  }
-  console.error(
-    "[cfc] Owner-protected write dropped: CFC enforcement rejected the " +
-      "commit and re-running cannot resolve it.",
-    { error: error.message, handlerId },
   );
 }
 
@@ -1498,6 +1481,7 @@ export async function dispatchQueuedEvent(state: {
           { handlerId },
         );
         runFinalCommitCallback();
+        tx.abandonStagedWork(eventAbandonError("retry opted out"));
       }
       return;
     }
@@ -1524,6 +1508,7 @@ export async function dispatchQueuedEvent(state: {
         // commit callback (with the aborted tx) instead of leaving callers
         // that await it hanging.
         runFinalCommitCallback();
+        tx.abandonStagedWork(eventAbandonError("handler threw"));
       }
       return;
     }
@@ -1563,6 +1548,9 @@ export async function dispatchQueuedEvent(state: {
           `LT1 in-process copy of ${queuedEvent.id} sealed outside its ` +
           "appending wave and was refused; the drain delivers the entry",
         ]);
+        // No abandonment: the durable entry is still the truth and the drain
+        // delivers it, so a further attempt at this event is coming and work
+        // staged on it is waiting for something rather than nothing.
         runFinalCommitCallback();
         return;
       }
@@ -1696,6 +1684,10 @@ export async function dispatchQueuedEvent(state: {
           sealCfcRefusalConsequence();
           runFinalCommitCallback();
           reportDroppedCfcRejectedWrite(error, handlerId);
+          // No further attempt at this event is coming, so anything staged on
+          // the transaction and waiting for it to commit is waiting for
+          // nothing.
+          tx.abandonStagedWork(error as CommitError);
           logger.warn(
             "scheduler",
             disposition.reason === "non-retryable"
@@ -1738,6 +1730,7 @@ export async function dispatchQueuedEvent(state: {
           sealCfcRefusalConsequence();
           runFinalCommitCallback();
           reportDroppedCfcRejectedWrite(error, handlerId);
+          tx.abandonStagedWork(error as CommitError);
           logger.warn(
             "scheduler",
             "Event handler commit terminally rejected (deterministic refusal); " +
@@ -1747,6 +1740,7 @@ export async function dispatchQueuedEvent(state: {
           break;
         case "permanent":
           runFinalCommitCallback();
+          tx.abandonStagedWork(error as CommitError);
           if (permanentRejection === "receipt-exists") {
             logger.warn(
               "event-lost-race",
@@ -1764,6 +1758,7 @@ export async function dispatchQueuedEvent(state: {
           break;
         case "convergence-failed": {
           runFinalCommitCallback();
+          tx.abandonStagedWork(error as CommitError);
           logger.error(
             "commit-convergence-failed",
             () => [

--- a/packages/runner/src/scheduler/run.ts
+++ b/packages/runner/src/scheduler/run.ts
@@ -4,6 +4,7 @@ import type { Runtime } from "../runtime.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type {
   ChangeGroup,
+  CommitError,
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
@@ -25,6 +26,7 @@ import {
   type DiagnosisRecord,
   runIdempotencyRecheck,
 } from "./diagnosis.ts";
+import { reportDroppedCfcRejectedWrite } from "./cfc-rejection-report.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
 import {
   getSchedulerActionName,
@@ -301,6 +303,7 @@ export function watchReactiveActionCommit(state: {
           toTerminalRejectionError(error, state.action),
         );
       }
+      abandonAction(state, error);
       return;
     }
 
@@ -325,6 +328,14 @@ export function watchReactiveActionCommit(state: {
     } else {
       // WATCH(scheduler-v2): exhausted retries can leave a piece registered
       // against rolled-back data (accepted zombie — spec §15 decision 9).
+      // The counters stay set, unlike the success and permanent arms. A spent
+      // budget is spent until this action commits something: clearing it here
+      // would hand every later failure a fresh budget, which under a failure
+      // that persists is a retry loop with no bound at all. So a run that a
+      // later input change triggers gets one attempt, and abandoning here is
+      // what an action that has not committed through a whole budget has
+      // earned.
+      abandonAction(state, error);
     }
   };
   return state.commitPromise.then(
@@ -340,6 +351,32 @@ export function watchReactiveActionCommit(state: {
       error,
     );
   });
+}
+
+/**
+ * Tell the work staged on this run's transaction that no further attempt at it
+ * is coming, and report the write if CFC enforcement is what refused it.
+ *
+ * The scheduler is the only party that knows this. A rejection does not say
+ * whether another attempt would fare better — CFC enforcement refuses a commit
+ * both for a verdict on the data and for metadata this replica has not read
+ * yet, and only the second converges by re-running — so a builtin waiting on
+ * the commit cannot tell a pause from an ending. This is the ending.
+ */
+function abandonAction(
+  state: {
+    readonly action: Action;
+    readonly tx: IExtendedStorageTransaction;
+    readonly getActionId: (action: Action) => string;
+  },
+  error: unknown,
+): void {
+  const actionId = state.getActionId(state.action);
+  reportDroppedCfcRejectedWrite(
+    error as { name?: string; message?: string },
+    actionId,
+  );
+  state.tx.abandonStagedWork(error as CommitError);
 }
 
 export function appendActionRunTrace(state: {
@@ -837,6 +874,11 @@ function rescheduleActionForImmediateRetry(
     // it runs again on the node's next real invalidation, with a fresh
     // budget — the same "until its input data changes" shape as OFF's.
     state.retries.delete(args.action);
+    abandonAction({
+      action: args.action,
+      tx: args.tx,
+      getActionId: state.getActionId,
+    }, args.error);
     logger.error(
       "schedule-error",
       `Action ${args.actionId} exhausted retries resolving inSpace names`,

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -109,6 +109,7 @@ import {
 import { ignoreReadForScheduling } from "../scheduler.ts";
 import { normalizeCellScope, scopeRank } from "../scope.ts";
 import type { MergeableOpDelta } from "./mergeable-ops.ts";
+import { CFC_ENFORCEMENT_REJECTION_PREFIX } from "./rejection.ts";
 import {
   clearSchemaRefusalTx,
   isInternalVerifierRead,
@@ -306,6 +307,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     ) => void
   >();
   private verdictCallbacksDispatched = false;
+  // Post-commit effects this transaction staged and then discarded, held for
+  // the moment the code that owns its retries stops retrying it — a decision no
+  // rejection carries on its own, since a refusal one attempt cannot get past
+  // is often one a later attempt can. Effects handed to a seal destination are
+  // not here: that clears the outbox too, and it is a handover rather than an
+  // ending.
+  #abandonableEffects: PostCommitSideEffect[] = [];
+  private abandonDispatched = false;
+  // Set when a commit of this transaction succeeded. Abandonment is what the
+  // staged work hears instead of a commit, so a transaction that committed has
+  // nothing to abandon, and saying otherwise would report a request as never
+  // sent after the outbox flushed it.
+  private committed = false;
   // The verdict-time effect run of the current commit(): verdict callbacks
   // plus the CFC outbox flush. What settled()-style barriers wait on in
   // place of the commit promise, whose resolution additionally waits for
@@ -2265,8 +2279,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   abort(reason?: any): Result<any, InactiveTransactionError> {
     this.assertWritable("abort()");
     this.statusOverride = undefined;
-    this.#cfcState.outbox = [];
-    this.outboxIdempotencyKeys.clear();
+    this.clearPostCommitOutbox();
     this.#cfcState.prepare = { status: "unprepared" };
     this.#cfcState.dereferenceTraces = [];
     this.#cfcState.structureContainers = [];
@@ -2284,6 +2297,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (this.commitCallbacksDispatched) {
       return;
     }
+    if (!result.error) this.committed = true;
     // Verdict callbacks never fire after commit callbacks: on the async
     // path the effect chain dispatched them at the verdict already (this is
     // a no-op then); on synchronous fates (abort, pre-storage rejection)
@@ -2322,7 +2336,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.verdictCallbacks.clear();
   }
 
-  private clearPostCommitOutbox(): void {
+  /**
+   * Drop the staged effects. `handedOff` says another runner has taken them,
+   * so they are not held for abandonment: exactly one of `flush` and `abandon`
+   * runs per effect, and a handed-off effect will be flushed elsewhere.
+   */
+  private clearPostCommitOutbox(handedOff = false): void {
+    if (!handedOff) {
+      this.#abandonableEffects.push(...this.#cfcState.outbox);
+    }
     this.#cfcState.outbox = [];
     this.outboxIdempotencyKeys.clear();
   }
@@ -2441,7 +2463,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
           : [];
         const detail = reasons.length > 0 ? `: ${plainReason(reasons[0])}` : "";
         const message =
-          `CFC enforcement rejected commit: relevant transaction was not prepared${detail}`;
+          `${CFC_ENFORCEMENT_REJECTION_PREFIX}: relevant transaction was not prepared${detail}`;
         // WATCH(cfc-verdict): a refusal is terminal only when EVERY reason is
         // a VERDICT on this transaction's data. Anything else — an input
         // prepare could not evaluate, or a prepared state a caller disturbed
@@ -2478,7 +2500,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
               error: {
                 name: "StorageTransactionAborted",
                 message:
-                  "CFC enforcement rejected commit: prepared digest changed",
+                  `${CFC_ENFORCEMENT_REJECTION_PREFIX}: prepared digest changed`,
                 reason: new Error("cfc-prepared-digest-mismatch"),
               },
             });
@@ -2546,7 +2568,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
                 [...this.#cfcState.outbox],
               ) === true;
           if (deferred) {
-            this.clearPostCommitOutbox();
+            this.clearPostCommitOutbox(true);
             return;
           }
           for (const effect of this.#cfcState.outbox) {
@@ -2641,6 +2663,29 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   ): void {
     this.assertWritable("addVerdictCallback()");
     this.verdictCallbacks.add(callback);
+  }
+
+  abandonStagedWork(error: CommitError): void {
+    if (this.committed || this.abandonDispatched) return;
+    this.abandonDispatched = true;
+    // Everything this transaction staged and did not flush: the effects a
+    // discard path moved aside, and any still on the outbox because the
+    // transaction ended without reaching one. A handover empties the outbox
+    // without adding to either, so handed-off effects are in neither.
+    const effects = [...this.#abandonableEffects, ...this.#cfcState.outbox];
+    this.#abandonableEffects = [];
+    this.#cfcState.outbox = [];
+    for (const effect of effects) {
+      try {
+        effect.abandon?.(error);
+      } catch (abandonError) {
+        logger.error(
+          "storage-error",
+          "Post-commit side effect's abandon failed:",
+          { effect, error: abandonError },
+        );
+      }
+    }
   }
 }
 
@@ -3128,6 +3173,14 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   ): void {
     if (this.options.discardSettleCallbacks === true) return;
     return this.wrapped.addVerdictCallback(callback);
+  }
+
+  abandonStagedWork(error: CommitError): void {
+    // A wrapper that discards settle callbacks stands for work whose outcome
+    // nobody acts on — duplicate work run only to compare its writes — so it
+    // does not end the staged work of the transaction it wraps.
+    if (this.options.discardSettleCallbacks === true) return;
+    return this.wrapped.abandonStagedWork(error);
   }
 }
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1988,6 +1988,21 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   ): void;
 
   /**
+   * Tell the post-commit effects this transaction staged and lost that no
+   * further attempt at its commit is coming, by calling each one's `abandon`.
+   * Exactly one of an effect's `flush` and `abandon` runs.
+   *
+   * Called by whoever owns the retries for this transaction, because a commit
+   * rejection does not say whether another attempt would fare better and the
+   * effect cannot tell. CFC enforcement refuses a commit both for a verdict on
+   * the data — a shape its rules do not support — and for metadata this replica
+   * has not read yet, and only the second converges when a later attempt sees
+   * more. Dispatched at most once, and never after a commit of this
+   * transaction succeeded.
+   */
+  abandonStagedWork(error: CommitError): void;
+
+  /**
    * Reads a value from a (local) memory address and throws on error, except for
    * `NotFoundError` which is returned as undefined.
    *

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -269,6 +269,47 @@ export function isTransientCommitRejection(
 }
 
 /**
+ * The opening words of the message on every commit CFC enforcement refuses
+ * before the transaction reaches storage (`rejectCommitBeforeStorage` in
+ * extended-storage-transaction.ts). The refusal travels as a
+ * `StorageTransactionAborted` whose message carries the detail, so the prefix
+ * is what tells one apart from an ordinary `tx.abort()`. Minted and matched
+ * from this one constant.
+ */
+export const CFC_ENFORCEMENT_REJECTION_PREFIX =
+  "CFC enforcement rejected commit";
+
+/**
+ * CFC enforcement refused this commit before it reached storage: the
+ * transaction was relevant to enforcement and did not come out of prepare in a
+ * prepared state, or the prepared digest changed under it. The refusal names
+ * the rule that produced it — a writer-fit confidentiality misfit, a
+ * writeAuthorizedBy failure, an egress ceiling violation.
+ *
+ * A refusal does not say whether another attempt would fare better, and the
+ * reasons behind one differ on exactly that. A rule's verdict on the data — a
+ * shape its rules do not support — recurs on every attempt. A reason naming
+ * metadata prepare could not read, a `cid:` schema document or a link source
+ * this replica does not hold yet, is answered by the attempt that reads it.
+ * So this classifies the refusal and not its prospects: it says CFC enforcement
+ * refused the commit, which is what makes a dropped write worth reporting, and
+ * the decision to stop attempting belongs to whoever owns the retries.
+ *
+ * The refusal travels as a `StorageTransactionAborted` whose message opens with
+ * the prefix, and the prefix is what the test reads. A commit error normalized
+ * on its way here can lose its class and keep its message, so testing the
+ * message is what covers both shapes of the same refusal.
+ */
+export function isCfcEnforcementRejection<
+  T extends { message?: string },
+>(
+  error: T | undefined | null,
+): error is T & { message: string } {
+  return typeof error?.message === "string" &&
+    error.message.startsWith(CFC_ENFORCEMENT_REJECTION_PREFIX);
+}
+
+/**
  * The attempt was discarded before it ever reached storage, so there is no
  * server verdict to respect: the `editWithRetry` callback called `tx.abort()`
  * to throw this attempt away, asking for a fresh one. Re-running produces a

--- a/packages/runner/test/async-work-registration.test.ts
+++ b/packages/runner/test/async-work-registration.test.ts
@@ -59,19 +59,12 @@ enableMockMode();
  * Builtin source files that enqueue a post-commit side effect and deliberately
  * do not hand a promise to `trackAsyncWork`, with the reason. Anything absent
  * from this list has to register, and the source scan names it when it does not.
+ *
+ * Empty: every builtin that enqueues one registers work of its own. Two of them
+ * register the settle for an abandoned request rather than the flush, and say
+ * at the flush itself why that one is not registered.
  */
-const POST_COMMIT_WITHOUT_TRACKED_WORK: Record<string, string> = {
-  // The query RPC and its writeback are awaited inside the flush, so the
-  // transaction's own commit promise spans them, and the scheduler registers
-  // that promise for every commit carrying post-commit effects.
-  "sqlite-builtins.ts":
-    "the flush awaits the query and its writeback, so the commit promise spans it",
-  // A subscription rather than a request: the read loop lives until the stream
-  // ends or is aborted, so registering it would mean `settled()` never returns
-  // while a stream is connected.
-  "stream-data.ts":
-    "an open-ended stream subscription, with no completion for a barrier to wait for",
-};
+const POST_COMMIT_WITHOUT_TRACKED_WORK: Record<string, string> = {};
 
 const OK_SCHEMA = {
   type: "object",

--- a/packages/runner/test/builtin-abandoned-request.test.ts
+++ b/packages/runner/test/builtin-abandoned-request.test.ts
@@ -1,0 +1,134 @@
+/**
+ * What a builtin leaves behind when the transaction staging its request is
+ * abandoned.
+ *
+ * Each of these stages its request in the transaction that schedules the work
+ * and does the work once that transaction commits, so an abandoned one means
+ * the request is never sent. The settled shape differs per builtin, but the
+ * property is the same everywhere: the result cells the pattern reads are
+ * announced and say the request will not be answered, rather than staying as
+ * they were with nothing coming.
+ */
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import type { Cell } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { MAX_ENFORCEMENT_CFC_OPTIONS } from "../src/runtime-presets.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { waitForCellValue } from "@commonfabric/integration/wait-for-cell-value";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// A caveat the result store does not declare. The builtin reads the input
+// carrying it, so its writes derive that confidentiality, and the undeclared
+// store resolves to the empty ceiling — the writer-fit misfit, which rejects
+// at `enforce-strict`.
+const PROMPT_INFLUENCE = {
+  type: "https://commonfabric.org/cfc/atom/Caveat",
+  kind: "https://commonfabric.org/cfc/concepts/prompt-influence",
+  source: "of:hostile",
+} as const;
+
+describe("a builtin whose staged request is abandoned", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let commonfabric: ReturnType<typeof createBuilder>["commonfabric"];
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      ...MAX_ENFORCEMENT_CFC_OPTIONS,
+      // The bundle pins every staged dial; the enforcement mode is the
+      // per-session raise on top of it, and the bundle's persisted flow labels
+      // are what make that raise conform.
+      cfcEnforcementMode: "enforce-strict",
+    });
+    tx = runtime.edit();
+    ({ commonfabric } = createTrustedBuilder(runtime));
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.idle();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /** Resolve once the cell reports an error, at a quiescent moment. */
+  // deno-lint-ignore no-explicit-any
+  function waitForError(cell: Cell<any>): Promise<{ error?: string }> {
+    return waitForCellValue<{ error?: string }>(
+      runtime,
+      cell,
+      (value) => typeof value?.error === "string" && value.error.length > 0,
+    );
+  }
+
+  it("reports the refusal on streamData's error cell", async () => {
+    const { pattern, streamData, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const url = BuilderCell.of("https://example.invalid/events", {
+        type: "string",
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      // deno-lint-ignore no-explicit-any
+      return streamData({ url } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "streamData-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    // The rule's own reason names the document it matched on and the source of
+    // each caveat, which the pattern-facing surface withholds.
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("reports the refusal on fetchJson's error cell", async () => {
+    const { pattern, fetchJson, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const url = BuilderCell.of("https://example.invalid/data.json", {
+        type: "string",
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      // deno-lint-ignore no-explicit-any
+      return fetchJson({ url } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "fetchJson-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+});

--- a/packages/runner/test/builtin-abandoned-request.test.ts
+++ b/packages/runner/test/builtin-abandoned-request.test.ts
@@ -104,6 +104,48 @@ describe("a builtin whose staged request is abandoned", () => {
     expect(result.withTx().key("pending").get()).toBe(false);
   });
 
+  it("reports the refusal on generateObject's error cell with no tools", async () => {
+    // The tools path and the direct path build and settle their requests
+    // separately, so a request with no tools reaches the second of them.
+    const { pattern, generateObject, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const messages = BuilderCell.of([{
+        role: "user",
+        content: "a briefing the result store does not declare",
+      }], {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      return generateObject({
+        messages,
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "generateObject-direct-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
   it("reports the refusal on generateText's error cell", async () => {
     const { pattern, generateText, Cell: BuilderCell } = commonfabric;
     const testPattern = pattern<Record<string, never>>(() => {

--- a/packages/runner/test/builtin-abandoned-request.test.ts
+++ b/packages/runner/test/builtin-abandoned-request.test.ts
@@ -104,6 +104,100 @@ describe("a builtin whose staged request is abandoned", () => {
     expect(result.withTx().key("pending").get()).toBe(false);
   });
 
+  it("reports the refusal on generateText's error cell", async () => {
+    const { pattern, generateText, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const messages = BuilderCell.of([{
+        role: "user",
+        content: "a briefing the result store does not declare",
+      }], {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      // deno-lint-ignore no-explicit-any
+      return generateText({ messages } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "generateText-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("reports the refusal on llm's error cell", async () => {
+    const { pattern, llm, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const messages = BuilderCell.of([{
+        role: "user",
+        content: "a briefing the result store does not declare",
+      }], {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      // deno-lint-ignore no-explicit-any
+      return llm({ messages } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "llm-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
+  it("reports the refusal on fetchProgram's error cell", async () => {
+    const { pattern, fetchProgram, Cell: BuilderCell } = commonfabric;
+    const testPattern = pattern<Record<string, never>>(() => {
+      const url = BuilderCell.of("https://example.invalid/program.js", {
+        type: "string",
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      // deno-lint-ignore no-explicit-any
+      return fetchProgram({ url } as any);
+    });
+    const resultCell = runtime.getCell(
+      space,
+      "fetchProgram-abandoned",
+      testPattern.resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, testPattern, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    // A run derives these cells from its cache entry, and an abandoned
+    // request has no following run to do it.
+    const settled = await waitForError(result);
+    await runtime.settled();
+
+    expect(settled.error).toContain("was refused before it started");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(result.withTx().key("pending").get()).toBe(false);
+  });
+
   it("reports the refusal on fetchJson's error cell", async () => {
     const { pattern, fetchJson, Cell: BuilderCell } = commonfabric;
     const testPattern = pattern<Record<string, never>>(() => {

--- a/packages/runner/test/cfc-writer-claim-correspondence.test.ts
+++ b/packages/runner/test/cfc-writer-claim-correspondence.test.ts
@@ -5,7 +5,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { writerClaimFilesCorrespond } from "../src/cfc/writer-claim-correspondence.ts";
 import { mergeCfcSchemaEnvelopes } from "../src/cfc/schema-merge.ts";
-import { reportDroppedCfcRejectedWrite } from "../src/scheduler/events.ts";
+import { reportDroppedCfcRejectedWrite } from "../src/scheduler/cfc-rejection-report.ts";
 import type { JSONSchema, JSONSchemaObj } from "../src/builder/types.ts";
 
 /**
@@ -489,6 +489,6 @@ describe("reportDroppedCfcRejectedWrite", () => {
     }
     expect(seen.length).toBe(1);
     expect(String(seen[0]![0])).toContain("Owner-protected write dropped");
-    expect(seen[0]![1]).toMatchObject({ handlerId: "handler-1" });
+    expect(seen[0]![1]).toMatchObject({ writerId: "handler-1" });
   });
 });

--- a/packages/runner/test/generate-object-cfc-refusal.test.ts
+++ b/packages/runner/test/generate-object-cfc-refusal.test.ts
@@ -1,0 +1,219 @@
+/**
+ * A generateObject request whose staging commit CFC refuses.
+ *
+ * The builtin stages its request state — the pending flag, the request hash a
+ * later run recognizes — in the transaction that schedules the work, and sends
+ * the request once that transaction commits. Under the strict dials a refusal
+ * of that commit is an ordinary runtime event, and these tests pin what the
+ * builtin does with one: it settles, once, with the refusal as its error, and
+ * the request it could not send is staged once rather than once per retry.
+ */
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import type { BuiltInLLMTool } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import {
+  clearMockResponses,
+  enableMockMode,
+  setMockResponseGate,
+} from "@commonfabric/llm/client";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { createBuilder } from "../src/builder/factory.ts";
+import type { Cell, JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { MAX_ENFORCEMENT_CFC_OPTIONS } from "../src/runtime-presets.ts";
+import { MAX_RETRIES_FOR_REACTIVE } from "../src/scheduler/constants.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { waitForLlmSettled } from "./support/llm-result.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+enableMockMode();
+
+// A caveat the pattern's own result store does not declare. The builtin reads
+// the messages carrying it, so its writes derive that confidentiality, and the
+// undeclared store resolves to the empty ceiling — the writer-fit misfit of
+// §8.12.4, which rejects at `enforce-strict`.
+const PROMPT_INFLUENCE = {
+  type: "https://commonfabric.org/cfc/atom/Caveat",
+  kind: "https://commonfabric.org/cfc/concepts/prompt-influence",
+  source: "of:hostile",
+} as const;
+
+const RESULT_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: { ok: { type: "boolean" } },
+  required: ["ok"],
+  additionalProperties: false,
+};
+
+describe("generateObject under a refused commit", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let commonfabric: ReturnType<typeof createBuilder>["commonfabric"];
+  let requestsSent: number;
+
+  beforeEach(() => {
+    clearMockResponses();
+    requestsSent = 0;
+    setMockResponseGate(() => {
+      requestsSent += 1;
+      return Promise.resolve();
+    });
+    storageManager = StorageManager.emulate({ as: signer });
+    // The max-enforcement posture, raised to strict — the posture the
+    // writer-fit rule rejects under.
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      ...MAX_ENFORCEMENT_CFC_OPTIONS,
+      // The bundle pins every staged dial; the enforcement mode is the
+      // per-session raise on top of it, and the bundle's persisted flow labels
+      // are what make that raise conform.
+      cfcEnforcementMode: "enforce-strict",
+    });
+    tx = runtime.edit();
+    ({ commonfabric } = createTrustedBuilder(runtime));
+  });
+
+  afterEach(async () => {
+    setMockResponseGate(undefined);
+    await tx.commit();
+    await runtime.idle();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  /**
+   * Run a generateObject with one pattern tool over messages carrying
+   * {@link PROMPT_INFLUENCE}, and hand back the cell the pattern exposes.
+   */
+  // deno-lint-ignore no-explicit-any
+  function runRefusedRequest(cause: string): Cell<any> {
+    const { pattern, generateObject, patternTool, Cell: BuilderCell } =
+      commonfabric;
+    const helperPattern = pattern(
+      () => ({ ok: true }),
+      { type: "object", additionalProperties: false },
+      {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
+      },
+    );
+    const testPattern = pattern<Record<string, never>>(() => {
+      const briefing = BuilderCell.of([{
+        role: "user",
+        content: "a briefing the result store does not declare",
+      }], {
+        type: "array",
+        items: { type: "object", additionalProperties: true },
+        ifc: { confidentiality: [PROMPT_INFLUENCE] },
+      });
+      return generateObject({
+        messages: briefing,
+        schema: RESULT_SCHEMA,
+        tools: {
+          helper: {
+            description: "A tool the model never gets to call.",
+            ...(patternTool(helperPattern) as unknown as BuiltInLLMTool),
+          },
+        },
+        // deno-lint-ignore no-explicit-any
+      } as any);
+    });
+
+    const resultCell = runtime.getCell(
+      space,
+      cause,
+      testPattern.resultSchema,
+      tx,
+    );
+    return runtime.run(tx, testPattern, {}, resultCell);
+  }
+
+  it("settles with a refusal error that withholds the rule's detail", async () => {
+    const result = runRefusedRequest("generateObject-cfc-refusal-settles");
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    await waitForLlmSettled(runtime, result);
+    // The settle writeback is tracked async builtin work, which `idle()` — and
+    // so the wait above — deliberately does not span. Reading after it lands
+    // asserts the durable state rather than an optimistic local write whose
+    // commit is still racing the teardown.
+    await runtime.settled();
+    const settled = result.withTx().get() as {
+      pending?: boolean;
+      error?: string;
+      result?: unknown;
+      messages?: unknown;
+    };
+
+    expect(settled.pending).toBe(false);
+    expect(settled.error).toBe(
+      "generateObject request was refused before it started",
+    );
+    // The pattern is the writer whose write was refused, and the reason names
+    // the document the rule matched on, the confidentiality that did not fit,
+    // and the `source` of each caveat — the principal that introduced it, which
+    // the pattern-facing surface withholds (inv-12 / audit 28b). The refusal
+    // reaches the operator through the log instead.
+    expect(settled.error).not.toContain("writer-fit");
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.source);
+    expect(settled.error).not.toContain(PROMPT_INFLUENCE.kind);
+    // A refused request produces no answer and no record of a conversation:
+    // the post-commit outbox is cleared by the refusal, so nothing was sent and
+    // no receipt stands for a request that never ran.
+    expect(settled.result).toBeUndefined();
+    expect(settled.messages).toBeUndefined();
+    expect(requestsSent).toBe(0);
+  });
+
+  it("reports the abandoned request once however many attempts are made", async () => {
+    runtime.scheduler.setActionRunTraceEnabled(true);
+    const abandoned: string[] = [];
+    const realConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      if (String(args[0]).includes("was abandoned before it started")) {
+        abandoned.push(String(args[0]));
+        return;
+      }
+      // Everything else still reaches the console, including the two reports
+      // this path adds, so a real failure here is not swallowed by the capture.
+      realConsoleError(...args);
+    };
+    try {
+      const result = runRefusedRequest("generateObject-cfc-refusal-run-count");
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+
+      await waitForLlmSettled(runtime, result);
+      await runtime.settled();
+
+      const builtinRuns = runtime.scheduler.getActionRunTrace().filter((
+        entry,
+      ) => entry.actionId.includes("generateObject"));
+      // The scheduler keeps attempting a refused commit, because a refusal
+      // does not say whether the next attempt would fare better: CFC
+      // enforcement refuses one both for a verdict on the data and for
+      // metadata this replica has not read yet. So the action runs more than
+      // once here, and the bound on how many times is the scheduler's retry
+      // budget rather than anything this builtin decides.
+      expect(builtinRuns.length).toBeGreaterThan(1);
+      expect(builtinRuns.length).toBeLessThanOrEqual(
+        MAX_RETRIES_FOR_REACTIVE + 2,
+      );
+      // The request is one request across all of those attempts, so it is
+      // abandoned once, not once per attempt.
+      expect(abandoned.length).toBe(1);
+    } finally {
+      console.error = realConsoleError;
+    }
+  });
+});

--- a/packages/runner/test/scheduler-diagnosis.test.ts
+++ b/packages/runner/test/scheduler-diagnosis.test.ts
@@ -2,6 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
+  captureCommittedReads,
+  captureTransactionWrites,
+  detectCausalCycles,
   type DiagnosisRecord,
   findDifferingWriteKeys,
   findNonIdempotentPair,
@@ -170,6 +173,201 @@ describe("scheduler-diagnosis", () => {
       // second run produced no writes at all.
       expect(violations).toEqual([]);
       expect(tx2.wasAborted()).toBe(true);
+    });
+  });
+
+  describe("captureTransactionWrites", () => {
+    it("records only the addresses the transaction has novelty for", () => {
+      const written = address("of:written", ["value"]);
+      const touched = address("of:touched", ["value"]);
+      const tx = fakeTransaction([{ address: written, value: "new" }]);
+
+      const values = captureTransactionWrites(tx, [written, touched]);
+
+      // A write log entry with no novelty behind it is a no-op write or a
+      // materialization touch, and recording it would read as a differing
+      // write when the computation's output did not change.
+      expect([...values.keys()]).toEqual([makeAddressKey(written)]);
+      expect(values.get(makeAddressKey(written))).toBe("new");
+    });
+
+    it("reads each space's write details once for many addresses", () => {
+      const first = address("of:first", ["value"]);
+      const second = address("of:second", ["value"]);
+      let detailReads = 0;
+      const tx = {
+        getWriteDetails: (space: IMemorySpaceAddress["space"]) => {
+          detailReads++;
+          return [
+            { address: first, value: "a" },
+            { address: second, value: "b" },
+          ].filter((write) => write.address.space === space);
+        },
+      } as unknown as IExtendedStorageTransaction;
+
+      const values = captureTransactionWrites(tx, [first, second]);
+
+      expect(values.size).toBe(2);
+      expect(detailReads).toBe(1);
+    });
+
+    it("substitutes the error value for a space it cannot read", () => {
+      const target = address("of:unreadable", ["value"]);
+      const tx = {
+        getWriteDetails: () => {
+          throw new Error("details unavailable");
+        },
+      } as unknown as IExtendedStorageTransaction;
+
+      const values = captureTransactionWrites(tx, [target], {
+        errorValue: "[write-error]",
+      });
+
+      expect(values.get(makeAddressKey(target))).toBe("[write-error]");
+    });
+
+    it("rethrows when no error value is offered", () => {
+      const target = address("of:unreadable", ["value"]);
+      const tx = {
+        getWriteDetails: () => {
+          throw new Error("details unavailable");
+        },
+      } as unknown as IExtendedStorageTransaction;
+
+      expect(() => captureTransactionWrites(tx, [target])).toThrow(
+        "details unavailable",
+      );
+    });
+  });
+
+  describe("captureCommittedReads", () => {
+    /** A read-only transaction stand-in that answers one address. */
+    function readerFor(
+      answer: (path: readonly string[]) => { ok?: { value: FabricValue } },
+      onAbort: () => void,
+    ): IExtendedStorageTransaction {
+      return {
+        tx: {
+          read: (addr: { path: readonly string[] }) => answer(addr.path),
+        },
+        abort: onAbort,
+      } as unknown as IExtendedStorageTransaction;
+    }
+
+    it("returns the value each address read", () => {
+      const target = address("of:read", ["value"]);
+      const values = captureCommittedReads(
+        [target],
+        () => readerFor(() => ({ ok: { value: "committed" } }), () => {}),
+      );
+
+      expect(values.get(makeAddressKey(target))).toBe("committed");
+    });
+
+    it("marks an address whose read threw", () => {
+      const target = address("of:throws", ["value"]);
+      const values = captureCommittedReads(
+        [target],
+        () =>
+          readerFor(() => {
+            throw new Error("read failed");
+          }, () => {}),
+      );
+
+      expect(values.get(makeAddressKey(target))).toBe("[read-error]");
+    });
+
+    it("aborts every transaction it opened, including one that threw", () => {
+      const ok = address("of:ok", ["value"]);
+      const bad = address("of:bad", ["value"]);
+      let aborts = 0;
+      captureCommittedReads([ok, bad], () =>
+        readerFor((path) => {
+          if (path[0] === "value" && aborts === 1) throw new Error("read");
+          return { ok: { value: "v" } };
+        }, () => {
+          aborts++;
+        }));
+
+      expect(aborts).toBe(2);
+    });
+
+    it("records an absent read as undefined rather than skipping it", () => {
+      const target = address("of:absent", ["value"]);
+      const values = captureCommittedReads(
+        [target],
+        () => readerFor(() => ({}), () => {}),
+      );
+
+      expect(values.has(makeAddressKey(target))).toBe(true);
+      expect(values.get(makeAddressKey(target))).toBe(undefined);
+    });
+  });
+
+  describe("detectCausalCycles", () => {
+    const edge = (writer: string, triggered: string, cell: string) => ({
+      writer,
+      triggered,
+      cell,
+    });
+
+    it("returns nothing for a graph that does not come back on itself", () => {
+      expect(detectCausalCycles([
+        edge("a", "b", "of:x"),
+        edge("b", "c", "of:y"),
+      ])).toEqual([]);
+    });
+
+    it("returns nothing for no edges at all", () => {
+      expect(detectCausalCycles([])).toEqual([]);
+    });
+
+    it("reports an action that triggers itself", () => {
+      const cycles = detectCausalCycles([edge("a", "a", "of:self")]);
+
+      expect(cycles.length).toBe(1);
+      expect(cycles[0].cycle).toEqual([{
+        actionId: "a",
+        writesCell: "of:self",
+      }]);
+    });
+
+    it("reports a cycle across two actions, naming the cell each writes", () => {
+      const cycles = detectCausalCycles([
+        edge("a", "b", "of:x"),
+        edge("b", "a", "of:y"),
+      ]);
+
+      expect(cycles.length).toBe(1);
+      expect(cycles[0].cycle).toEqual([
+        { actionId: "a", writesCell: "of:x" },
+        { actionId: "b", writesCell: "of:y" },
+      ]);
+    });
+
+    it("reports a cycle reached through a node outside it", () => {
+      // `entry` leads into the loop without being part of it, so the reported
+      // cycle starts where the loop closes rather than where the walk began.
+      const cycles = detectCausalCycles([
+        edge("entry", "a", "of:in"),
+        edge("a", "b", "of:x"),
+        edge("b", "a", "of:y"),
+      ]);
+
+      expect(cycles.length).toBe(1);
+      expect(cycles[0].cycle.map((step) => step.actionId)).toEqual(["a", "b"]);
+    });
+
+    it("reports each of two independent cycles", () => {
+      const cycles = detectCausalCycles([
+        edge("a", "b", "of:x"),
+        edge("b", "a", "of:y"),
+        edge("c", "d", "of:p"),
+        edge("d", "c", "of:q"),
+      ]);
+
+      expect(cycles.length).toBe(2);
+      expect(cycles.map((c) => c.cycle[0].actionId).sort()).toEqual(["a", "c"]);
     });
   });
 });

--- a/packages/runner/test/transaction-abandon-callbacks.test.ts
+++ b/packages/runner/test/transaction-abandon-callbacks.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Abandoning the post-commit effects a transaction staged and lost.
+ *
+ * A post-commit effect has two outcomes and runs exactly one of them: `flush`
+ * when its transaction commits, `abandon` when no further attempt at that
+ * commit is coming. The decision belongs to whoever owns the retries, so the
+ * transaction's part is narrow: dispatch once, never after a commit succeeded,
+ * and never through a wrapper standing for work whose outcome nobody acts on.
+ */
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+import { Runtime } from "../src/runtime.ts";
+import { createDuplicateWorkTransaction } from "../src/storage/extended-storage-transaction.ts";
+import type { CommitError } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+const refusal = {
+  name: "StorageTransactionAborted",
+  message: "CFC enforcement rejected commit: relevant transaction was not " +
+    "prepared: writer-fit confidentiality misfit",
+} as CommitError;
+
+describe("transaction abandon", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  /** Stage an effect that records which of its two outcomes ran. */
+  function stageEffect(
+    tx: ReturnType<Runtime["edit"]>,
+    id: string,
+    seen: string[],
+    options: { throws?: boolean } = {},
+  ): void {
+    tx.enqueuePostCommitEffect({
+      id,
+      kind: "test-effect",
+      flush: () => {
+        seen.push(`flush:${id}`);
+      },
+      abandon: (error) => {
+        if (options.throws) throw new Error("abandon failed");
+        seen.push(`abandon:${id}:${(error as { message?: string })?.message}`);
+      },
+    });
+  }
+
+  it("abandons each staged effect once, with the error", () => {
+    const tx = runtime.edit();
+    const seen: string[] = [];
+    stageEffect(tx, "a", seen);
+    stageEffect(tx, "b", seen);
+    tx.abort(new Error("rejected before storage"));
+
+    tx.abandonStagedWork(refusal);
+    tx.abandonStagedWork(refusal);
+
+    expect(seen).toEqual([
+      `abandon:a:${refusal.message}`,
+      `abandon:b:${refusal.message}`,
+    ]);
+  });
+
+  it("abandons the remaining effects when one throws", () => {
+    const tx = runtime.edit();
+    const seen: string[] = [];
+    stageEffect(tx, "a", seen, { throws: true });
+    stageEffect(tx, "b", seen);
+    tx.abort(new Error("rejected before storage"));
+
+    tx.abandonStagedWork(refusal);
+
+    expect(seen).toEqual([`abandon:b:${refusal.message}`]);
+  });
+
+  it("abandons one effect per outbox key, however often it is staged", () => {
+    const tx = runtime.edit();
+    const seen: string[] = [];
+    stageEffect(tx, "a", seen);
+    stageEffect(tx, "a", seen);
+    tx.abort(new Error("rejected before storage"));
+
+    tx.abandonStagedWork(refusal);
+
+    expect(seen).toEqual([`abandon:a:${refusal.message}`]);
+  });
+
+  it("abandons nothing once a commit of the transaction succeeded", async () => {
+    const tx = runtime.edit();
+    const cell = runtime.getCell<string>(space, "abandon-after-commit", {
+      type: "string",
+    }, tx);
+    cell.withTx(tx).set("written");
+    const seen: string[] = [];
+    stageEffect(tx, "a", seen);
+
+    runtime.prepareTxForCommit(tx);
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+    tx.abandonStagedWork(refusal);
+
+    // The effect flushed, so its request was sent; reporting it as never sent
+    // would be a lie about a commit that landed, and would run the second of
+    // two outcomes that admit only one.
+    expect(seen).toEqual(["flush:a"]);
+  });
+
+  it("does not abandon the wrapped transaction through duplicate work", () => {
+    const tx = runtime.edit();
+    const seen: string[] = [];
+    stageEffect(tx, "a", seen);
+    tx.abort(new Error("rejected before storage"));
+    const duplicate = createDuplicateWorkTransaction(tx);
+
+    duplicate.abandonStagedWork(refusal);
+
+    expect(seen).toEqual([]);
+    tx.abandonStagedWork(refusal);
+    expect(seen).toEqual([`abandon:a:${refusal.message}`]);
+  });
+});

--- a/packages/runner/test/traverse-recorder.test.ts
+++ b/packages/runner/test/traverse-recorder.test.ts
@@ -1,0 +1,227 @@
+/**
+ * The recorder behind traverse capture.
+ *
+ * It exists to turn a run's traversals into a replayable fixture, so what it
+ * owes is a faithful record: every invocation in order, each doc snapshotted
+ * once, repeated selectors and links shared rather than copied, and a bound on
+ * how much one run may accumulate.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  fixtureDocKey,
+  TraverseCaptureRecorder,
+} from "../src/traverse-recorder.ts";
+import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+import type { NormalizedFullLink } from "../src/link-types.ts";
+import type { SchemaPathSelector } from "../src/traverse.ts";
+
+const SPACE = "did:key:zTraverse" as IMemorySpaceAddress["space"];
+
+function address(
+  id: string,
+  path: string[] = [],
+  extra: { type?: string; scope?: string } = {},
+): IMemorySpaceAddress {
+  return {
+    space: SPACE,
+    id: id as IMemorySpaceAddress["id"],
+    path,
+    ...extra,
+  } as IMemorySpaceAddress;
+}
+
+const selector = (path: string[]): SchemaPathSelector =>
+  ({ path, schemaContext: undefined }) as unknown as SchemaPathSelector;
+
+describe("traverse-recorder", () => {
+  describe("fixtureDocKey", () => {
+    it("fills in the default scope and type", () => {
+      expect(fixtureDocKey({ space: "s", id: "of:x" })).toBe(
+        "s|space|of:x|application/json",
+      );
+    });
+
+    it("keeps a scope and type the address carries", () => {
+      expect(
+        fixtureDocKey({
+          space: "s",
+          id: "of:x",
+          scope: "user",
+          type: "text/plain",
+        }),
+      ).toBe("s|user|of:x|text/plain");
+    });
+
+    it("separates two docs that differ only in scope", () => {
+      const a = fixtureDocKey({ space: "s", id: "of:x", scope: "space" });
+      const b = fixtureDocKey({ space: "s", id: "of:x", scope: "user" });
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("recordInvocation", () => {
+    it("records an invocation with its address, selector and meta flag", () => {
+      const recorder = new TraverseCaptureRecorder();
+      recorder.recordInvocation(
+        { address: address("of:doc", ["a"]) },
+        selector(["a"]),
+        undefined,
+        { includeMeta: true },
+        undefined,
+      );
+
+      const fixture = recorder.toFixture("name", "source");
+      expect(fixture.invocations.length).toBe(1);
+      const only = fixture.invocations[0];
+      expect(only.address.id).toBe("of:doc");
+      expect(only.address.path).toEqual(["a"]);
+      expect(only.address.type).toBe("application/json");
+      expect(only.includeMeta).toBe(true);
+    });
+
+    it("copies the address path rather than aliasing the caller's", () => {
+      const recorder = new TraverseCaptureRecorder();
+      const path = ["a"];
+      recorder.recordInvocation(
+        { address: address("of:doc", path) },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        undefined,
+      );
+      path.push("mutated");
+
+      expect(recorder.toFixture("n", "s").invocations[0].address.path).toEqual(
+        ["a"],
+      );
+    });
+
+    it("gives one context object one id across invocations", () => {
+      const recorder = new TraverseCaptureRecorder();
+      const context = { includeMeta: false };
+      for (let i = 0; i < 3; i++) {
+        recorder.recordInvocation(
+          { address: address(`of:doc${i}`) },
+          selector(["a"]),
+          undefined,
+          context,
+          undefined,
+        );
+      }
+
+      const ids = recorder.toFixture("n", "s").invocations.map((i) =>
+        i.context
+      );
+      expect(new Set(ids).size).toBe(1);
+    });
+
+    it("gives distinct context objects distinct ids", () => {
+      const recorder = new TraverseCaptureRecorder();
+      recorder.recordInvocation(
+        { address: address("of:a") },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        undefined,
+      );
+      recorder.recordInvocation(
+        { address: address("of:b") },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        undefined,
+      );
+
+      const ids = recorder.toFixture("n", "s").invocations.map((i) =>
+        i.context
+      );
+      expect(new Set(ids).size).toBe(2);
+    });
+
+    it("records a memo only when the traversal had one", () => {
+      const recorder = new TraverseCaptureRecorder();
+      recorder.recordInvocation(
+        { address: address("of:with") },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        {},
+      );
+      recorder.recordInvocation(
+        { address: address("of:without") },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        undefined,
+      );
+
+      const [withMemo, withoutMemo] = recorder.toFixture("n", "s").invocations;
+      expect(withMemo.memo).not.toBe(undefined);
+      expect("memo" in withoutMemo).toBe(false);
+    });
+
+    it("records a link only when the traversal followed one", () => {
+      const recorder = new TraverseCaptureRecorder();
+      const link = {
+        space: SPACE,
+        id: "of:target",
+        path: [],
+      } as unknown as NormalizedFullLink;
+      recorder.recordInvocation(
+        { address: address("of:doc") },
+        selector(["a"]),
+        link,
+        { includeMeta: false },
+        undefined,
+      );
+      recorder.recordInvocation(
+        { address: address("of:doc2") },
+        selector(["a"]),
+        undefined,
+        { includeMeta: false },
+        undefined,
+      );
+
+      const [followed, plain] = recorder.toFixture("n", "s").invocations;
+      expect(followed.link).not.toBe(undefined);
+      expect("link" in plain).toBe(false);
+    });
+
+    it("stops recording at the cap and keeps what it already had", () => {
+      const recorder = new TraverseCaptureRecorder(2);
+      for (let i = 0; i < 5; i++) {
+        recorder.recordInvocation(
+          { address: address(`of:doc${i}`) },
+          selector(["a"]),
+          undefined,
+          { includeMeta: false },
+          undefined,
+        );
+      }
+
+      const fixture = recorder.toFixture("n", "s");
+      expect(fixture.invocations.length).toBe(2);
+      expect(fixture.invocations.map((i) => i.address.id)).toEqual([
+        "of:doc0",
+        "of:doc1",
+      ]);
+    });
+  });
+
+  describe("toFixture", () => {
+    it("carries the name and source it is given, and when it captured", () => {
+      const fixture = new TraverseCaptureRecorder().toFixture("fx", "src.ts");
+      expect(fixture.meta.name).toBe("fx");
+      expect(fixture.meta.source).toBe("src.ts");
+      expect(typeof fixture.meta.capturedAt).toBe("string");
+      expect(fixture.version).toBe(1);
+    });
+
+    it("describes a run that traversed nothing", () => {
+      const fixture = new TraverseCaptureRecorder().toFixture("fx", "src.ts");
+      expect(fixture.invocations).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
A builtin that calls out to the world stages its request in the transaction that schedules the work — a pending flag, the announcement of the result cell, a request hash a later run recognizes — and does the work once that transaction commits. When the commit is rejected the work never starts, and nothing told the builtin. Its result stayed as it was and nothing settled it, so a caller waiting on that result waited forever and the runtime reported a leaked promise at exit.

Under the strict CFC dials this is easy to reach. A generateObject with a tool call over messages carrying a prompt-influence caveat derives that confidentiality onto its writes, its result store declares no ceiling, and the writer-fit rule refuses the commit. The scheduler re-ran the action across its whole retry budget, staging the same request ten times and sending none of them, and the builtin never settled.

The number of attempts is not a property of the rejection. A CFC refusal whose every reason is a verdict on the committed data arrives as a terminal class and stops on the first attempt. A refusal naming something prepare could not evaluate — a link source or a schema document this replica does not hold yet — keeps the retryable class, because the attempt that reads it decides differently; the wish resolver's own commit is refused that way and converges later. A builtin waiting on the commit sees a rejection either way and cannot tell how many follow it.

The scheduler can, because it is what decides. A post-commit effect already carries the request's identity, its dedupe key and the work to do; it gains the other half of its outcome, `abandon`, and runs exactly one of the two. A transaction holds the effects it staged and did not flush, and `abandonStagedWork` hands each one its ending. The reactive commit path calls that wherever it stops — a precondition failure, a deterministic commit-rule refusal, a retry budget that has run out, an exhausted name resolution — and the event commit path calls it on each of its give-up arms, including the two that end an event with no commit verdict at all. A refused late seal is not among them: the durable entry is still the truth there and the drain delivers it, so a further attempt is coming. Nothing classifies a rejection as hopeless; the component that gives up is the one that says so.

Pairing the ending with the effect is what keeps "abandoned once" from needing bookkeeping of its own. The outbox already drops a second effect staged under a key it holds, and now drops that effect's ending with it, so a request staged twice on one transaction is abandoned once. An effect handed to a seal destination is neither flushed nor abandoned here: that clears the outbox too, and it is a handover rather than an ending.

The exhausted arm does not clear the retry counters, unlike the success and permanent arms, and that is deliberate: a spent budget stays spent until the action commits something. Clearing it there would hand every later failure a fresh budget, which under a failure that persists is a retry loop with no bound. So a run a later input change triggers gets one attempt, and abandoning the request it staged is what an action that has not committed through a whole budget has earned.

Two invariants sit under the new hook. A transaction that committed has nothing to abandon, so abandoning one afterwards does nothing rather than reporting a sent request as never sent. And a wrapper standing for work whose outcome nobody acts on does not abandon the transaction it wraps.

`enqueueSinkRequestPostCommitEffect` gives the effect it stages an `abandon` when its caller passes `onRejected`, so the contract reaches every builtin that stages a sink request. All of them pass one: the three llm builtins, fetch, fetch-program, llm-dialog and stream-data. sqliteQuery gives its effect an `abandon` directly, because it enqueues that effect by hand rather than as a sink request. stream-data also gains the per-target outbox key its siblings already had, so two nodes streaming the same url keep their own ending rather than sharing one.

Each builtin writes what its own result surface reads: an error beside a lowered pending flag for the llm builtins, fetch and stream-data, an error cache entry for fetch-program, a settled query state for sqliteQuery. llm-dialog settles by leaving the conversation alone — the turn's user message, pending flag and request id all rode the abandoned transaction, so an assistant error message would answer a turn no reader can see.

All of them announce their result cells again in the settling transaction. That announcement rode the transaction that was abandoned, and for the llm builtins a latch means no later run makes it again, so without this the pattern points at nothing — including at the error about to be written. It happens even when a newer request has superseded this one, because the announcement says where the answer appears and is the same either way, while the answer is now the newer request's to give. One transaction carries both, attributed to the builtin and naming the served effect it completes: a writeback that names neither is refused under the serving posture, which would leave the pattern pointing at nothing all the same.

What the pattern reads is that its request was refused, and not why. The reason names the document the rule matched on, the confidentiality that did not fit, and the source of each caveat, which is the principal that introduced it — none of which the pattern-facing surface exposes. A deployment that wants part of the reason read declassifies chosen fields through an error exchange rule. The full detail goes to the log, along with two write rejections that were previously swallowed.

A write CFC enforcement refused and nothing will retry is now reported on the reactive path as well as the event path, which had it already. The report and the predicate behind it move to one module both paths call.

The exemption list for builtins that enqueue a post-commit effect without registering async work is now empty. The two builtins on it register their abandonment settle, and each says at its own flush why that one is not registered.

No dial default changes here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

