### PR TITLE
docs(features): a plan checks what it finds, it does not interlock a writer

### DIFF
--- a/docs/features/piece-bulk-operations.md
+++ b/docs/features/piece-bulk-operations.md
@@ -139,8 +139,17 @@ first write. A row that is moved-elsewhere, or that cannot be read at all,
 keeps the run from starting — every row reports where it stands, and nothing
 is applied. The serial pass then proves each row again in the session that
 writes it, the preflight's verdict deciding nothing there: a row proved landed
-is reported without a write, and a row another writer moved since preflight is
-caught by the same read that would have skipped it.
+is reported without a write, and a row moved to something no row of the plan
+names stops the run by name. Past that read the write carries the reference
+the recheck proved, refused inside the transaction that would commit it, so a
+move landing between the two is refused rather than overwritten.
+
+One case is absorbed rather than caught, and the plan cannot see it: a second
+writer that moves a piece onto the very reference the row was going to write
+leaves it indistinguishable from a row this run had already landed, and it is
+reported landed and skipped. The general statement is the honest one — a plan
+is a record of what a run intended and a check on what it finds, not an
+interlock against another writer.
 
 Resume is therefore re-invocation of the same command, not a mode. It costs
 one read per piece, is decided before any write, and rewrites nothing that


### PR DESCRIPTION
## Why

The bulk-operations contract (merged in #6379) claimed that "a row another writer moved since preflight is caught by the same read that would have skipped it." One case is not caught but **absorbed**: `classify()` in `bulk-apply.ts` returns `landed` for any pin matching the row's `op`, whoever wrote it — so a second writer that moves a piece onto the very reference the row was going to write is indistinguishable from a row this run had already landed, and is reported landed and skipped in silence.

A guarantee stated too broadly in the document a reader consults *for* the guarantee is worse than no statement. Found by b11 (author of the companion tour in #6370) while comparing the two documents; their tour reached the same conclusion over three review rounds.

## What Changed

`docs/features/piece-bulk-operations.md`: the recheck paragraph now states what the recheck does catch (a move to something no row names stops the run) and what the write's own in-transaction pin covers (a move landing between the recheck and the commit is refused, not overwritten — from #6345), then names the absorbed case explicitly and ends on the general statement: a plan is a record of what a run intended and a check on what it finds, not an interlock against another writer.

Related: b11 also raised a pre-#6345 concern — that the write passed `setPattern`'s own loaded identity rather than the row's recorded pair. That window was closed by #6345, which passes `row.expect` as `expectedPattern`; verified at `packages/piece/src/ops/bulk-retarget.deno.ts:93` and the matching rollback write. No change needed for it.

## Test plan

Prose-only. `check-docs` (568 blocks) and `check-skill-facts` pass; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

