### PR TITLE
Add collaborative note co-presence example

### DIFF
--- a/packages/patterns/baselines/collaborative-note/main.tsx/20260826T203142Z-V1afJ3y0leJe99Mu.json
+++ b/packages/patterns/baselines/collaborative-note/main.tsx/20260826T203142Z-V1afJ3y0leJe99Mu.json
@@ -1,0 +1,52 @@
+{
+  "argumentSchema": {
+    "properties": {
+      "note": {
+        "default": "# Collaborative note\n\nStart writing together.",
+        "description": "Note body shared by every viewer of this piece.",
+        "scope": "space",
+        "type": "string"
+      },
+      "presenceRoom": {
+        "description": "Opaque high-entropy room shared by this piece's co-presence sessions.",
+        "scope": "space",
+        "type": "string"
+      }
+    },
+    "required": [
+      "presenceRoom"
+    ],
+    "type": "object"
+  },
+  "pattern": "collaborative-note/main.tsx",
+  "resultSchema": {
+    "properties": {
+      "$NAME": {
+        "type": "string"
+      },
+      "$UI": {
+        "$ref": "https://commonfabric.org/schemas/vnode.json"
+      },
+      "note": {
+        "default": "# Collaborative note\n\nStart writing together.",
+        "scope": "space",
+        "type": "string"
+      },
+      "participantName": {
+        "type": "string"
+      },
+      "presenceRoom": {
+        "scope": "space",
+        "type": "string"
+      }
+    },
+    "required": [
+      "note",
+      "presenceRoom",
+      "participantName",
+      "$NAME",
+      "$UI"
+    ],
+    "type": "object"
+  }
+}

--- a/packages/patterns/baselines/collaborative-note/main.tsx/20260826T210950Z-NOf7pbg53SlXT96I.json
+++ b/packages/patterns/baselines/collaborative-note/main.tsx/20260826T210950Z-NOf7pbg53SlXT96I.json
@@ -6,16 +6,8 @@
         "description": "Note body shared by every viewer of this piece.",
         "scope": "space",
         "type": "string"
-      },
-      "presenceRoom": {
-        "description": "Opaque high-entropy room shared by this piece's co-presence sessions.",
-        "scope": "space",
-        "type": "string"
       }
     },
-    "required": [
-      "presenceRoom"
-    ],
     "type": "object"
   },
   "pattern": "collaborative-note/main.tsx",
@@ -34,15 +26,10 @@
       },
       "participantName": {
         "type": "string"
-      },
-      "presenceRoom": {
-        "scope": "space",
-        "type": "string"
       }
     },
     "required": [
       "note",
-      "presenceRoom",
       "participantName",
       "$NAME",
       "$UI"

--- a/packages/patterns/collaborative-note/main.test.tsx
+++ b/packages/patterns/collaborative-note/main.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Test: Collaborative Note
+ *
+ * Verifies the example's shared editor contract: the note is writable, the
+ * room is forwarded to co-presence, and profile setup is visible while the
+ * viewer's profile wishes are unresolved in the headless test runtime.
+ *
+ * Run: deno task cf test packages/patterns/collaborative-note/main.test.tsx
+ */
+
+import { action, assert, pattern, TESTS, UI, Writable } from "commonfabric";
+import {
+  findElement,
+  findNodeById,
+  propsOf,
+  readValue,
+} from "../test/vnode-helpers.ts";
+import CollaborativeNote from "./main.tsx";
+
+const ROOM = "collaborative_note_room_01";
+
+export default pattern(() => {
+  const note = Writable.of("Starting point");
+  const subject = CollaborativeNote({ note, presenceRoom: ROOM });
+
+  const assert_editor_contract = assert(() => {
+    const editorProps = propsOf(findElement(subject[UI], "cf-code-editor"));
+    return editorProps !== undefined &&
+      readValue(editorProps.collaborative) === true &&
+      readValue(editorProps.presenceRoom) === ROOM &&
+      readValue(editorProps.participantName) === "" &&
+      readValue(editorProps.mode) === "prose" &&
+      readValue(editorProps["$value"]) === "Starting point";
+  });
+  const assert_profile_setup_visible = assert(() =>
+    findNodeById(subject[UI], "collaborative-note-profile-setup") !== undefined
+  );
+  const action_edit = action(() => note.set("Edited together"));
+  const assert_edit_visible = assert(() => {
+    const editorProps = propsOf(findElement(subject[UI], "cf-code-editor"));
+    return readValue(editorProps?.["$value"]) === "Edited together";
+  });
+
+  return {
+    [TESTS]: [
+      { assertion: assert_editor_contract },
+      { assertion: assert_profile_setup_visible },
+      { action: action_edit },
+      { assertion: assert_edit_visible },
+    ],
+    subject,
+  };
+});

--- a/packages/patterns/collaborative-note/main.test.tsx
+++ b/packages/patterns/collaborative-note/main.test.tsx
@@ -15,7 +15,9 @@ import {
   propsOf,
   readValue,
 } from "../test/vnode-helpers.ts";
-import CollaborativeNote from "./main.tsx";
+import CollaborativeNote, {
+  normalizePresenceParticipantName,
+} from "./main.tsx";
 
 const ROOM = "collaborative_note_room_01";
 
@@ -35,6 +37,13 @@ export default pattern(() => {
   const assert_profile_setup_visible = assert(() =>
     findNodeById(subject[UI], "collaborative-note-profile-setup") !== undefined
   );
+  const assert_profile_name_is_safe_for_presence = assert(() =>
+    normalizePresenceParticipantName("  Ada\u0000\u0085 Lovelace  ") ===
+      "Ada Lovelace" &&
+    normalizePresenceParticipantName("a".repeat(81)) === "a".repeat(80) &&
+    normalizePresenceParticipantName("😀".repeat(65)) === "😀".repeat(64) &&
+    normalizePresenceParticipantName("\ud800") === ""
+  );
   const action_edit = action(() => note.set("Edited together"));
   const assert_edit_visible = assert(() => {
     const editorProps = propsOf(findElement(subject[UI], "cf-code-editor"));
@@ -45,6 +54,7 @@ export default pattern(() => {
     [TESTS]: [
       { assertion: assert_editor_contract },
       { assertion: assert_profile_setup_visible },
+      { assertion: assert_profile_name_is_safe_for_presence },
       { action: action_edit },
       { assertion: assert_edit_visible },
     ],

--- a/packages/patterns/collaborative-note/main.test.tsx
+++ b/packages/patterns/collaborative-note/main.test.tsx
@@ -1,9 +1,11 @@
 /**
  * Test: Collaborative Note
  *
- * Verifies the example's shared editor contract: the note is writable, the
- * room is forwarded to co-presence, and profile setup is visible while the
- * viewer's profile wishes are unresolved in the headless test runtime.
+ * Verifies the example's shared editor contract: the note is writable, no room
+ * override is required, profile setup is visible while wishes are unresolved,
+ * and the profile-name sanitizer obeys the co-presence wire bounds. The
+ * headless runtime does not resolve viewer identity, so live `#profileName`
+ * propagation remains browser-integration coverage.
  *
  * Run: deno task cf test packages/patterns/collaborative-note/main.test.tsx
  */
@@ -19,17 +21,15 @@ import CollaborativeNote, {
   normalizePresenceParticipantName,
 } from "./main.tsx";
 
-const ROOM = "collaborative_note_room_01";
-
 export default pattern(() => {
   const note = Writable.of("Starting point");
-  const subject = CollaborativeNote({ note, presenceRoom: ROOM });
+  const subject = CollaborativeNote({ note });
 
   const assert_editor_contract = assert(() => {
     const editorProps = propsOf(findElement(subject[UI], "cf-code-editor"));
     return editorProps !== undefined &&
       readValue(editorProps.collaborative) === true &&
-      readValue(editorProps.presenceRoom) === ROOM &&
+      editorProps.presenceRoom === undefined &&
       readValue(editorProps.participantName) === "" &&
       readValue(editorProps.mode) === "prose" &&
       readValue(editorProps["$value"]) === "Starting point";

--- a/packages/patterns/collaborative-note/main.tsx
+++ b/packages/patterns/collaborative-note/main.tsx
@@ -50,26 +50,22 @@ export function normalizePresenceParticipantName(value: string): string {
 export interface CollaborativeNoteInput {
   /** Note body shared by every viewer of this piece. */
   note?: PerSpace<string | Default<typeof DEFAULT_NOTE>>;
-
-  /** Opaque high-entropy room shared by this piece's co-presence sessions. */
-  presenceRoom: PerSpace<string>;
 }
 
 export interface CollaborativeNoteOutput {
   [NAME]: string;
   [UI]: VNode;
   note: PerSpace<string | Default<typeof DEFAULT_NOTE>>;
-  presenceRoom: PerSpace<string>;
   participantName: string;
 }
 
 /**
  * A minimal shared note that pairs Memory-backed text with ephemeral cursors.
- * The host supplies the co-presence service URL; this pattern supplies the
- * shared room and derives each viewer's label from their Fabric profile.
+ * The editor derives its room from the shared field, the host supplies the
+ * service URL, and the pattern derives each viewer's label from their profile.
  */
 export default pattern<CollaborativeNoteInput, CollaborativeNoteOutput>(
-  ({ note, presenceRoom }) => {
+  ({ note }) => {
     // `#profile` owns the create/pick UI and live profile identity. The field
     // wish is the profile-backed plain-text label expected by cf-code-editor.
     const profileWish = wish<{ name?: string; avatar?: string }>({
@@ -114,7 +110,6 @@ export default pattern<CollaborativeNoteInput, CollaborativeNoteOutput>(
             <cf-code-editor
               $value={note}
               collaborative
-              presenceRoom={presenceRoom}
               participantName={participantName}
               language="text/markdown"
               mode="prose"
@@ -126,7 +121,6 @@ export default pattern<CollaborativeNoteInput, CollaborativeNoteOutput>(
         </cf-screen>
       ),
       note,
-      presenceRoom,
       participantName,
     };
   },

--- a/packages/patterns/collaborative-note/main.tsx
+++ b/packages/patterns/collaborative-note/main.tsx
@@ -1,0 +1,98 @@
+import {
+  computed,
+  Default,
+  ifElse,
+  NAME,
+  pattern,
+  type PerSpace,
+  UI,
+  type VNode,
+  wish,
+} from "commonfabric";
+
+const DEFAULT_NOTE = "# Collaborative note\n\nStart writing together.";
+
+export interface CollaborativeNoteInput {
+  /** Note body shared by every viewer of this piece. */
+  note?: PerSpace<string | Default<typeof DEFAULT_NOTE>>;
+
+  /** Opaque high-entropy room shared by this piece's co-presence sessions. */
+  presenceRoom: PerSpace<string>;
+}
+
+export interface CollaborativeNoteOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  note: PerSpace<string | Default<typeof DEFAULT_NOTE>>;
+  presenceRoom: PerSpace<string>;
+  participantName: string;
+}
+
+/**
+ * A minimal shared note that pairs Memory-backed text with ephemeral cursors.
+ * The host supplies the co-presence service URL; this pattern supplies the
+ * shared room and derives each viewer's label from their Fabric profile.
+ */
+export default pattern<CollaborativeNoteInput, CollaborativeNoteOutput>(
+  ({ note, presenceRoom }) => {
+    // `#profile` owns the create/pick UI and live profile identity. The field
+    // wish is the profile-backed plain-text label expected by cf-code-editor.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const participantName = computed(() =>
+      Array.from((profileNameWish.result ?? "").trim()).slice(0, 80).join("")
+    );
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== "" &&
+      profileWish.result !== undefined
+    );
+
+    return {
+      [NAME]: "Collaborative note",
+      [UI]: (
+        <cf-screen>
+          <cf-vstack
+            gap="4"
+            style={{ padding: "1rem", maxWidth: "760px", margin: "0 auto" }}
+          >
+            <cf-hstack justify="between" align="center" gap="4">
+              <cf-vstack gap="1">
+                <cf-heading level={2}>Collaborative note</cf-heading>
+                <cf-text tone="muted">
+                  The note is durable; names and live selections are ephemeral.
+                </cf-text>
+              </cf-vstack>
+              {ifElse(
+                hasProfile,
+                <cf-profile-badge
+                  variant="chip"
+                  $profile={profileWish.result}
+                />,
+                <div id="collaborative-note-profile-setup">
+                  {profileWish[UI]}
+                </div>,
+              )}
+            </cf-hstack>
+
+            <cf-code-editor
+              $value={note}
+              collaborative
+              presenceRoom={presenceRoom}
+              participantName={participantName}
+              language="text/markdown"
+              mode="prose"
+              wordWrap
+              placeholder="Write something together…"
+              style={{ minHeight: "24rem" }}
+            />
+          </cf-vstack>
+        </cf-screen>
+      ),
+      note,
+      presenceRoom,
+      participantName,
+    };
+  },
+);

--- a/packages/patterns/collaborative-note/main.tsx
+++ b/packages/patterns/collaborative-note/main.tsx
@@ -11,6 +11,41 @@ import {
 } from "commonfabric";
 
 const DEFAULT_NOTE = "# Collaborative note\n\nStart writing together.";
+const MAXIMUM_PRESENCE_NAME_CODE_POINTS = 80;
+const MAXIMUM_PRESENCE_NAME_BYTES = 256;
+
+function isPresenceNameCodePoint(codePoint: number): boolean {
+  return !(codePoint <= 0x1f ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    (codePoint >= 0xd800 && codePoint <= 0xdfff));
+}
+
+/** Returns a profile name that satisfies the co-presence wire contract. */
+export function normalizePresenceParticipantName(value: string): string {
+  const filtered = Array.from(value)
+    .filter((character) => isPresenceNameCodePoint(character.codePointAt(0)!))
+    .join("")
+    .trim();
+  const encoder = new TextEncoder();
+  let bytes = 0;
+  let result = "";
+  let codePoints = 0;
+
+  for (const character of filtered) {
+    const characterBytes = encoder.encode(character).length;
+    if (
+      codePoints === MAXIMUM_PRESENCE_NAME_CODE_POINTS ||
+      bytes + characterBytes > MAXIMUM_PRESENCE_NAME_BYTES
+    ) {
+      break;
+    }
+    result += character;
+    codePoints++;
+    bytes += characterBytes;
+  }
+
+  return result;
+}
 
 export interface CollaborativeNoteInput {
   /** Note body shared by every viewer of this piece. */
@@ -42,10 +77,10 @@ export default pattern<CollaborativeNoteInput, CollaborativeNoteOutput>(
     });
     const profileNameWish = wish<string>({ query: "#profileName" });
     const participantName = computed(() =>
-      Array.from((profileNameWish.result ?? "").trim()).slice(0, 80).join("")
+      normalizePresenceParticipantName(profileNameWish.result ?? "")
     );
     const hasProfile = computed(() =>
-      (profileNameWish.result ?? "").trim() !== "" &&
+      normalizePresenceParticipantName(profileNameWish.result ?? "") !== "" &&
       profileWish.result !== undefined
     );
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -882,6 +882,42 @@ interface Output {
 }
 ```
 
+## `collaborative-note/main.tsx`
+
+A minimal multiplayer note built on `cf-code-editor`. The note body is durable
+per-space state synchronized through Memory's operation protocol. Names, carets,
+and selections travel separately as ephemeral co-presence data. Each viewer
+selects or creates a Fabric profile with `wish({ query: "#profile" })`; the
+editor uses that profile's `#profileName` field as its participant label. The
+host provides the WebSocket endpoint, while the caller supplies an opaque,
+high-entropy room identifier unique to the note.
+
+**Keywords:** multiplayer, collaborative editor, note, profile, wish,
+co-presence, CodeMirror
+
+### Input Schema
+
+```ts
+interface CollaborativeNoteInput {
+  note?: PerSpace<
+    string | Default<"# Collaborative note\n\nStart writing together.">
+  >;
+  presenceRoom: PerSpace<string>;
+}
+```
+
+### Output Schema
+
+```ts
+interface CollaborativeNoteOutput {
+  note: PerSpace<
+    string | Default<"# Collaborative note\n\nStart writing together.">
+  >;
+  presenceRoom: PerSpace<string>;
+  participantName: string;
+}
+```
+
 ## `cfc-agent-prompt-injection-demo/main.tsx`
 
 Interactive side-by-side chatbot demo for the new observation ceiling and

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -889,8 +889,8 @@ per-space state synchronized through Memory's operation protocol. Names, carets,
 and selections travel separately as ephemeral co-presence data. Each viewer
 selects or creates a Fabric profile with `wish({ query: "#profile" })`; the
 editor uses that profile's `#profileName` field as its participant label. The
-host provides the WebSocket endpoint, while the caller supplies an opaque,
-high-entropy room identifier unique to the note.
+host provides the WebSocket endpoint, while `cf-code-editor` derives an opaque
+room identifier from the shared note field.
 
 **Keywords:** multiplayer, collaborative editor, note, profile, wish,
 co-presence, CodeMirror
@@ -902,7 +902,6 @@ interface CollaborativeNoteInput {
   note?: PerSpace<
     string | Default<"# Collaborative note\n\nStart writing together.">
   >;
-  presenceRoom: PerSpace<string>;
 }
 ```
 
@@ -913,7 +912,6 @@ interface CollaborativeNoteOutput {
   note: PerSpace<
     string | Default<"# Collaborative note\n\nStart writing together.">
   >;
-  presenceRoom: PerSpace<string>;
   participantName: string;
 }
 ```


### PR DESCRIPTION
## Why

Give the co-presence stack a small end-to-end pattern example that uses the same shared-profile identity flow as the multiplayer patterns.

## What

- adds a per-space collaborative Markdown note backed by `cf-code-editor`
- relies on the editor's field-derived room and the host's default WebSocket endpoint, so the pattern only supplies a nonempty participant name to enable presence
- resolves `#profile` for create/pick UI and normalizes `#profileName` to the co-presence wire limits for the live participant label
- adds focused pattern coverage, a compatibility baseline, and catalog documentation

## Test

- `deno task cf test packages/patterns/collaborative-note/main.test.tsx`
- `deno task pattern-compat --only collaborative-note`
- `deno task check-baselines-append-only`
- `deno task cfcheck` (421 pattern files)
- `cd packages/patterns && deno task test` (110 tests)
- `deno fmt --check`
- `deno lint`
- independent pattern/adversarial review

Stack: depends on #6377.

