### PR TITLE
feat(runner): opaque cells refuse value reads

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -916,6 +916,23 @@ export class CellImpl<T extends FabricValue>
     return this._kind === "cell" || this._kind === "readonly";
   }
 
+  /**
+   * Throws when this cell is an opaque handle (`asCell: ["opaque"]`) about to
+   * materialize the value behind it. An opaque handle carries identity and
+   * forwards as a link; the value it names is out of reach by contract.
+   * `getRaw()` under its default `lastNode: "top"` stays allowed — it returns
+   * the reference itself, which is what an opaque handle holds.
+   */
+  private refuseOpaqueRead(op: string): void {
+    if (this._kind !== "opaque") return;
+    throw new Error(
+      `Cannot read through an opaque cell: ${op} would materialize the ` +
+        `value, and an opaque handle (asCell: ["opaque"]) grants identity ` +
+        `and forwarding only. Read this location under a schema that does ` +
+        `not mark it opaque.`,
+    );
+  }
+
   [cfcLabelViewSymbol](): CfcLabelView | undefined {
     return cloneCfcLabelView(this._cfcLabelView);
   }
@@ -1151,6 +1168,7 @@ export class CellImpl<T extends FabricValue>
   }
 
   get(options?: { traverseCells?: boolean }): Readonly<StripDefaultBrand<T>> {
+    this.refuseOpaqueRead("get()");
     if (!this.synced) this.sync(); // No await, just kicking this off
 
     // Per-transaction read cache: within one ready transaction, repeatedly
@@ -2900,6 +2918,7 @@ export class CellImpl<T extends FabricValue>
     path?: Readonly<Path>,
     tx?: IExtendedStorageTransaction,
   ): CellResult<DeepKeyLookup<T, Path>> {
+    this.refuseOpaqueRead("getAsQueryResult()");
     if (!this.synced) this.sync(); // No await, just kicking this off
     const subPath = path || [];
     return createQueryResultProxy(
@@ -2977,6 +2996,9 @@ export class CellImpl<T extends FabricValue>
     options?: RawCellReadOptions & { frozen?: boolean },
   ): FabricValue {
     const { frozen = true, lastNode = "top", ...readOptions } = options ?? {};
+    if (lastNode !== "top") {
+      this.refuseOpaqueRead(`getRaw() with lastNode "${lastNode}"`);
+    }
     if (!this.synced) this.sync(); // No await, just kicking this off
     const tx = this.runtime.readTx(this.tx);
     // Resolve all links ON THE WAY to the target, but don't resolve the final

--- a/packages/runner/test/opaque-cell-read-refusal.test.ts
+++ b/packages/runner/test/opaque-cell-read-refusal.test.ts
@@ -1,0 +1,105 @@
+// An opaque cell (`asCell: ["opaque"]`) is a reference, not a readable view:
+// reads that would materialize the value behind it throw, while identity
+// operations and the reference-only `getRaw()` default stay available.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("opaque cell read refusal test");
+const space = signer.did();
+
+const SCHEMA = {
+  type: "object",
+  properties: {
+    opaque: { type: "number", asCell: ["opaque"] },
+    plain: { type: "number" },
+  },
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+describe("opaque cell read refusal", () => {
+  const mintRoot = (rt: Runtime, t: IExtendedStorageTransaction) =>
+    rt.getCell(space, "opaque-cell-read-refusal", SCHEMA, t);
+  const mintOpaque = (r: ReturnType<typeof mintRoot>) => r.key("opaque");
+
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+  let root: ReturnType<typeof mintRoot>;
+  let opaque: ReturnType<typeof mintOpaque>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+    runtime.getCell(space, "opaque-cell-read-refusal", undefined, tx)
+      .setRawUntyped({ opaque: 5, plain: 7 });
+    root = mintRoot(runtime, tx);
+    opaque = mintOpaque(root);
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  describe("get()", () => {
+    it("throws on an opaque cell", () => {
+      expect(() => opaque.get()).toThrow(
+        "Cannot read through an opaque cell",
+      );
+    });
+
+    it("returns the value for a sibling the schema does not mark opaque", () => {
+      expect(root.key("plain").get()).toBe(7);
+    });
+  });
+
+  describe("getRaw()", () => {
+    it('returns the stored value under the default `lastNode: "top"`', () => {
+      expect(opaque.getRaw()).toBe(5);
+    });
+
+    it('throws under `lastNode: "value"`', () => {
+      expect(() => opaque.getRaw({ lastNode: "value" })).toThrow(
+        "Cannot read through an opaque cell",
+      );
+    });
+
+    it('throws under `lastNode: "writeRedirect"`', () => {
+      expect(() => opaque.getRaw({ lastNode: "writeRedirect" })).toThrow(
+        "Cannot read through an opaque cell",
+      );
+    });
+  });
+
+  describe("getAsQueryResult()", () => {
+    it("throws on an opaque cell", () => {
+      expect(() => opaque.getAsQueryResult()).toThrow(
+        "Cannot read through an opaque cell",
+      );
+    });
+  });
+
+  describe("identity operations", () => {
+    it("equals() compares two handles to the same location as equal", () => {
+      expect(opaque.equals(root.key("opaque"))).toBe(true);
+    });
+
+    it("getAsNormalizedFullLink() returns the reference", () => {
+      const link = opaque.getAsNormalizedFullLink();
+      expect(link.id).toBe(root.getAsNormalizedFullLink().id);
+      expect(link.path).toEqual(["opaque"]);
+    });
+  });
+});

--- a/packages/runner/test/pattern-node-alias-schema.test.ts
+++ b/packages/runner/test/pattern-node-alias-schema.test.ts
@@ -136,7 +136,7 @@ describe("compiled pattern node alias schemas", () => {
     ).toEqual(["cell"]);
   });
 
-  it("reads recursive node arguments shallowly through the alias schema", async () => {
+  it("refuses value reads through the opaque alias and reads shallowly through the module argument schema", async () => {
     const { live, serialized } = await compileSource(PURE_RECURSIVE_SOURCE);
     const aliasSchema = nodeAliasSchema(serialized);
 
@@ -152,9 +152,14 @@ describe("compiled pattern node alias schemas", () => {
       children: [{ title: "child" }],
     });
 
+    // The alias schema marks the forwarded argument opaque, so the read
+    // stops at a handle that refuses to materialize the value behind it.
+    // The value read belongs to the module argument schema below.
     const directRoot = root.get();
     expect(isCell(directRoot)).toBe(true);
-    expect(isCell(directRoot.get().children[0])).toBe(true);
+    expect(() => directRoot.get()).toThrow(
+      "Cannot read through an opaque cell",
+    );
 
     const resultCell = runtime.getCell<any>(
       space,
@@ -171,6 +176,16 @@ describe("compiled pattern node alias schemas", () => {
     )!;
     const childRoot = childArgument.get();
     expect(isCell(childRoot)).toBe(true);
-    expect(isCell(childRoot.get().children[0])).toBe(true);
+    expect(() => childRoot.get()).toThrow(
+      "Cannot read through an opaque cell",
+    );
+
+    // The sanctioned value read drops the opaque wrapper from the schema and
+    // materializes one level, with recursive children still held as cells.
+    const { asCell: _asCell, ...readableSchema } =
+      serialized.nodes[0].module.implementation.argumentSchema;
+    const readable = childArgument.asSchema(readableSchema).get();
+    expect(readable.title).toBe("root");
+    expect(isCell(readable.children[0])).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

An `asCell: ["opaque"]` handle grants identity and forwarding only — the value behind it is out of reach by contract (`docs/specs/json_schema.md` already describes it as pass-through-only). Until now nothing enforced that: `createCell` unwraps the `asCell` entry into `_kind`, and `isReadableCell()` was purely advisory, so `get()` on an opaque cell read through normally.

`CellImpl` now refuses reads that would materialize the value on an opaque-kind cell:

- `get()` and `getAsQueryResult()` throw.
- `getRaw()` throws unless it runs under its default `lastNode: "top"`, which returns the reference itself — exactly what an opaque handle holds.

Identity operations (`equals`, `getAsNormalizedFullLink`, link serialization) are unchanged. `key()` children inherit the opaque kind, and `asSchema` only recomputes kind from an explicit `asCell` entry, so a plain-schema `asSchema` cannot launder a handle back to readable. The error message names the sanctioned route: read the location under a schema that does not mark it opaque.

This is the first cut of the enforcement surface; `sink()` and the reactive-proxy leaf reads are deliberately left for a follow-up.

## What the suite turned up

One existing test read through an opaque handle: `pattern-node-alias-schema.test.ts`. A pattern's top-level `Writable<T>` argument compiles (in pattern-argument position, via `wrapperKindToBrand`'s `Reactive → "opaque"`) to a root `asCell: ["opaque"]`, and the test read through that handle to verify shallow materialization of a recursive argument. No runtime path does — every other step of the runner suite passed unmodified — so the test is re-pinned to the new contract: the handle refuses `get()`, and the sanctioned read (drop the opaque wrapper from the schema, then `get()`) still materializes one level with recursive children held as cells.

## Test plan

- New `packages/runner/test/opaque-cell-read-refusal.test.ts` covers the refusals, the allowed `getRaw()` default, a non-opaque sibling reading normally, and the surviving identity surface.
- `packages/runner` `deno task test`: 1287 passed (7436 steps), 0 failed.
- `deno task check`, repo-wide `deno lint`, and `deno fmt --check` on touched files pass locally (under Deno 2.8.2; CI holds the 2.9.4 pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

